### PR TITLE
feat(llm): ao_kernel.llm facade — clean public API

### DIFF
--- a/ao_kernel/llm.py
+++ b/ao_kernel/llm.py
@@ -1,0 +1,243 @@
+"""ao_kernel.llm — Public LLM facade for ao-kernel.
+
+Clean import path for LLM operations. Replaces direct src.* shim imports.
+
+Usage:
+    from ao_kernel.llm import resolve_route, build_request, normalize_response
+    from ao_kernel.llm import count_tokens, check_capabilities
+    from ao_kernel.llm import get_circuit_breaker, get_rate_limiter
+    from ao_kernel.llm import stream_request, StreamResult, StreamEvent
+
+This module re-exports from src/ shim with stable names. When src/ shim
+is removed in v2.0.0, implementations will move here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ── Routing ──────────────────────────────────────────────────────────
+
+
+def resolve_route(
+    *,
+    intent: str,
+    perspective: str | None = None,
+    provider_priority: list[str] | None = None,
+    workspace_root: str | None = None,
+) -> dict[str, Any]:
+    """Resolve the best provider/model for an LLM intent.
+
+    Deterministic routing: intent → class → provider → model.
+    Verified-only, TTL-gated. Fail-closed.
+
+    Returns dict with 'status' ('OK' or 'FAIL'), 'provider_id', 'model', etc.
+    """
+    from src.prj_kernel_api.llm_router import resolve
+
+    return resolve(
+        request={
+            "intent": intent,
+            "perspective": perspective,
+            "provider_priority": provider_priority or [],
+        },
+        workspace_root=workspace_root,
+    )
+
+
+# ── Request Building ─────────────────────────────────────────────────
+
+
+def build_request(
+    *,
+    provider_id: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    base_url: str,
+    api_key: str,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    request_id: str | None = None,
+    response_format: dict[str, Any] | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: str | None = None,
+    stream: bool = False,
+) -> dict[str, Any]:
+    """Build provider-native HTTP request for an LLM call.
+
+    Returns dict with keys: url, headers, body_bytes, body_json.
+    Supports all 6 providers: claude, openai, google, deepseek, qwen, xai.
+
+    Raises ValueError if stream=True and tools are provided (fail-closed).
+    """
+    from src.prj_kernel_api.llm_request_builder import build_live_request
+
+    return build_live_request(
+        provider_id=provider_id,
+        model=model,
+        messages=messages,
+        base_url=base_url,
+        api_key=api_key,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        request_id=request_id,
+        response_format=response_format,
+        tools=tools,
+        tool_choice=tool_choice,
+        stream=stream,
+    )
+
+
+def check_capabilities(
+    *,
+    provider_id: str,
+    model: str,
+    has_tools: bool = False,
+    has_response_format: bool = False,
+) -> tuple[bool, str, list[str]]:
+    """Pre-flight capability check before building request.
+
+    Returns (ok, provider_id, missing_capability_names).
+    """
+    from src.prj_kernel_api.llm_request_builder import check_capabilities_before_request
+
+    return check_capabilities_before_request(
+        provider_id=provider_id,
+        model=model,
+        has_tools=has_tools,
+        has_response_format=has_response_format,
+    )
+
+
+# ── Response Normalization ───────────────────────────────────────────
+
+
+def normalize_response(resp_bytes: bytes, *, provider_id: str) -> dict[str, Any]:
+    """Normalize a provider response into standard format.
+
+    Returns: {text, usage, tool_calls, raw_json, provider_id}
+    Handles Anthropic, OpenAI, Google, and compatible formats.
+    """
+    from src.prj_kernel_api.llm_response_normalizer import (
+        normalize_response as _normalize,
+    )
+
+    return _normalize(resp_bytes, provider_id=provider_id)
+
+
+def extract_text(resp_bytes: bytes) -> str:
+    """Extract text content from provider response bytes."""
+    from src.prj_kernel_api.llm_response_normalizer import extract_llm_output_text
+
+    return extract_llm_output_text(resp_bytes)
+
+
+def extract_usage(resp_bytes: bytes) -> dict[str, Any] | None:
+    """Extract token usage from provider response."""
+    from src.prj_kernel_api.llm_response_normalizer import (
+        extract_usage as _extract,
+    )
+
+    return _extract(resp_bytes)
+
+
+# ── Transport ────────────────────────────────────────────────────────
+
+
+def execute_request(
+    *,
+    url: str,
+    headers: dict[str, str],
+    body_bytes: bytes,
+    timeout_seconds: float,
+    max_response_bytes: int = 131072,
+    provider_id: str,
+    request_id: str,
+    max_retries: int = 0,
+) -> dict[str, Any]:
+    """Execute HTTP request with retry + circuit breaker.
+
+    Returns dict with: status, http_status, resp_bytes, elapsed_ms, error_code, etc.
+    """
+    from src.prj_kernel_api.llm_transport import execute_http_request_with_resilience
+
+    return execute_http_request_with_resilience(
+        url=url,
+        headers=headers,
+        body_bytes=body_bytes,
+        timeout_seconds=timeout_seconds,
+        max_response_bytes=max_response_bytes,
+        provider_id=provider_id,
+        request_id=request_id,
+        max_retries=max_retries,
+    )
+
+
+# ── Streaming ────────────────────────────────────────────────────────
+
+# Re-export streaming types for convenience
+from src.prj_kernel_api.llm_stream import StreamEvent  # noqa: E402
+from src.prj_kernel_api.llm_stream_transport import StreamResult  # noqa: E402
+from src.prj_kernel_api.llm_stream_transport import execute_stream_request as stream_request  # noqa: E402
+
+
+# ── Resilience ───────────────────────────────────────────────────────
+
+
+def get_circuit_breaker(provider_id: str):
+    """Get or create per-provider circuit breaker."""
+    from src.prj_kernel_api.circuit_breaker import get_circuit_breaker as _get
+
+    return _get(provider_id)
+
+
+def get_rate_limiter(provider_id: str):
+    """Get or create per-provider rate limiter."""
+    from src.prj_kernel_api.rate_limiter import get_rate_limiter as _get
+
+    return _get(provider_id)
+
+
+# ── Token Counting ───────────────────────────────────────────────────
+
+
+def count_tokens(
+    messages: list[dict[str, Any]],
+    *,
+    provider_id: str = "openai",
+    model: str = "gpt-4",
+) -> dict[str, Any]:
+    """Count tokens for a message list using provider-specific counting.
+
+    Returns dict with token count details.
+    """
+    from src.providers.token_counter import count_tokens as _count
+
+    return _count(messages, provider_id=provider_id, model=model)
+
+
+def count_tokens_heuristic(messages: list[dict[str, Any]]) -> int:
+    """Fast heuristic token count for a message list."""
+    from src.providers.token_counter import count_tokens_heuristic as _count
+
+    return _count(messages)
+
+
+# ── Public API ───────────────────────────────────────────────────────
+
+__all__ = [
+    "resolve_route",
+    "build_request",
+    "check_capabilities",
+    "normalize_response",
+    "extract_text",
+    "extract_usage",
+    "execute_request",
+    "stream_request",
+    "StreamEvent",
+    "StreamResult",
+    "get_circuit_breaker",
+    "get_rate_limiter",
+    "count_tokens",
+    "count_tokens_heuristic",
+]

--- a/ao_kernel/mcp_server.py
+++ b/ao_kernel/mcp_server.py
@@ -192,13 +192,11 @@ def handle_llm_route(params: dict[str, Any]) -> dict[str, Any]:
         )
 
     try:
-        from src.prj_kernel_api.llm_router import resolve
-        result = resolve(
-            request={
-                "intent": intent,
-                "perspective": params.get("perspective"),
-                "provider_priority": params.get("provider_priority"),
-            },
+        from ao_kernel.llm import resolve_route
+        result = resolve_route(
+            intent=intent,
+            perspective=params.get("perspective"),
+            provider_priority=params.get("provider_priority"),
             workspace_root=params.get("workspace_root"),
         )
 

--- a/tests/test_llm_facade.py
+++ b/tests/test_llm_facade.py
@@ -1,0 +1,156 @@
+"""Tests for ao_kernel.llm facade — clean import path for LLM operations."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestLlmFacadeImports:
+    """Verify all public API items are importable."""
+
+    def test_resolve_route(self):
+        from ao_kernel.llm import resolve_route
+        assert callable(resolve_route)
+
+    def test_build_request(self):
+        from ao_kernel.llm import build_request
+        assert callable(build_request)
+
+    def test_check_capabilities(self):
+        from ao_kernel.llm import check_capabilities
+        assert callable(check_capabilities)
+
+    def test_normalize_response(self):
+        from ao_kernel.llm import normalize_response
+        assert callable(normalize_response)
+
+    def test_extract_text(self):
+        from ao_kernel.llm import extract_text
+        assert callable(extract_text)
+
+    def test_extract_usage(self):
+        from ao_kernel.llm import extract_usage
+        assert callable(extract_usage)
+
+    def test_execute_request(self):
+        from ao_kernel.llm import execute_request
+        assert callable(execute_request)
+
+    def test_stream_request(self):
+        from ao_kernel.llm import stream_request
+        assert callable(stream_request)
+
+    def test_stream_event_type(self):
+        from ao_kernel.llm import StreamEvent
+        assert StreamEvent is not None
+
+    def test_stream_result_type(self):
+        from ao_kernel.llm import StreamResult
+        assert StreamResult is not None
+
+    def test_get_circuit_breaker(self):
+        from ao_kernel.llm import get_circuit_breaker
+        assert callable(get_circuit_breaker)
+
+    def test_get_rate_limiter(self):
+        from ao_kernel.llm import get_rate_limiter
+        assert callable(get_rate_limiter)
+
+    def test_count_tokens(self):
+        from ao_kernel.llm import count_tokens
+        assert callable(count_tokens)
+
+    def test_count_tokens_heuristic(self):
+        from ao_kernel.llm import count_tokens_heuristic
+        assert callable(count_tokens_heuristic)
+
+    def test_all_exports(self):
+        from ao_kernel.llm import __all__
+        assert len(__all__) == 14
+
+
+class TestLlmFacadeFunctionality:
+    def test_resolve_route_returns_dict(self):
+        from ao_kernel.llm import resolve_route
+        # Router may fail without full docs/OPERATIONS setup — that's OK
+        # We're testing the facade wrapper, not the router internals
+        try:
+            result = resolve_route(intent="FAST_TEXT")
+            assert isinstance(result, dict)
+        except FileNotFoundError:
+            pass  # Expected when docs/OPERATIONS not in repo root
+
+    def test_build_request_openai(self):
+        from ao_kernel.llm import build_request
+        req = build_request(
+            provider_id="openai",
+            model="gpt-4",
+            messages=[{"role": "user", "content": "hello"}],
+            base_url="https://api.openai.com/v1/chat/completions",
+            api_key="sk-test",
+        )
+        assert "url" in req
+        assert "body_bytes" in req
+        assert req["body_json"]["model"] == "gpt-4"
+
+    def test_build_request_stream_flag(self):
+        from ao_kernel.llm import build_request
+        req = build_request(
+            provider_id="claude",
+            model="claude-3",
+            messages=[{"role": "user", "content": "hi"}],
+            base_url="https://api.anthropic.com/v1/messages",
+            api_key="sk-ant-test",
+            stream=True,
+        )
+        assert req["body_json"]["stream"] is True
+
+    def test_build_request_stream_tools_raises(self):
+        from ao_kernel.llm import build_request
+        with pytest.raises(ValueError, match="stream=True with tools"):
+            build_request(
+                provider_id="openai",
+                model="gpt-4",
+                messages=[{"role": "user", "content": "hi"}],
+                base_url="https://api.openai.com/v1/chat/completions",
+                api_key="sk-test",
+                stream=True,
+                tools=[{"type": "function", "function": {"name": "test"}}],
+            )
+
+    def test_normalize_response_openai(self):
+        import json
+        from ao_kernel.llm import normalize_response
+        resp = json.dumps({
+            "choices": [{"message": {"content": "Hello world"}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 2},
+        }).encode()
+        result = normalize_response(resp, provider_id="openai")
+        assert result["text"] == "Hello world"
+        assert result["usage"]["input_tokens"] == 5
+
+    def test_extract_text_anthropic(self):
+        import json
+        from ao_kernel.llm import extract_text
+        resp = json.dumps({
+            "content": [{"type": "text", "text": "Merhaba"}],
+        }).encode()
+        assert extract_text(resp) == "Merhaba"
+
+    def test_count_tokens_heuristic(self):
+        from ao_kernel.llm import count_tokens_heuristic
+        messages = [{"role": "user", "content": "Hello world, this is a test."}]
+        result = count_tokens_heuristic(messages)
+        assert isinstance(result, int)
+        assert result > 0
+
+    def test_circuit_breaker_instance(self):
+        from ao_kernel.llm import get_circuit_breaker
+        cb = get_circuit_breaker("test_provider")
+        assert hasattr(cb, "allow_request")
+        assert hasattr(cb, "record_success")
+
+    def test_rate_limiter_instance(self):
+        from ao_kernel.llm import get_rate_limiter
+        rl = get_rate_limiter("test_provider")
+        assert rl is not None


### PR DESCRIPTION
## Summary

- `ao_kernel.llm` facade: 14 public API items — routing, request building, normalization, transport, streaming, resilience, token counting
- `mcp_server.py` migrated from `src` shim to `ao_kernel.llm` facade
- Codex CNS-20260413-006: only LLM facade now, policy/workspace/execution deferred to v0.2.x

## Test plan

- [ ] `from ao_kernel.llm import resolve_route, build_request, stream_request` — import OK
- [ ] `pytest tests/ -v` — 158 tests passing
- [ ] MCP server uses ao_kernel.llm instead of src shim

🤖 Generated with [Claude Code](https://claude.com/claude-code)