### PR TITLE
fix: self-edit memory recall pattern consistency

### DIFF
--- a/ao_kernel/client.py
+++ b/ao_kernel/client.py
@@ -662,8 +662,8 @@ class AoKernelClient:
         from ao_kernel.context.self_edit_memory import forget as _forget
         return _forget(self._workspace_root, key=key)
 
-    def recall(self, pattern: str = "memory.*") -> list[dict[str, Any]]:
-        """Query self-stored memories."""
+    def recall(self, pattern: str = "*") -> list[dict[str, Any]]:
+        """Query self-stored memories. Pattern auto-prefixed with 'memory.'."""
         if not self._workspace_root:
             return []
 

--- a/ao_kernel/context/self_edit_memory.py
+++ b/ao_kernel/context/self_edit_memory.py
@@ -131,11 +131,21 @@ def forget(
 def recall(
     workspace_root: Path,
     *,
-    key_pattern: str = "memory.*",
+    key_pattern: str = "*",
 ) -> list[dict[str, Any]]:
-    """Agent queries its self-stored memories."""
+    """Agent queries its self-stored memories.
+
+    The key_pattern is automatically prefixed with "memory." to match
+    the prefix added by remember(). Glob patterns supported (fnmatch).
+
+    Examples:
+        recall(ws, key_pattern="*")          → all memories
+        recall(ws, key_pattern="test.*")     → memory.test.*
+        recall(ws, key_pattern="test.fact")  → memory.test.fact
+    """
     from ao_kernel.context.canonical_store import query
-    return query(workspace_root, key_pattern=key_pattern)
+    full_pattern = f"memory.{key_pattern}" if not key_pattern.startswith("memory.") else key_pattern
+    return query(workspace_root, key_pattern=full_pattern)
 
 
 __all__ = ["remember", "update", "forget", "recall"]


### PR DESCRIPTION
## Summary

- `remember(key='test.fact')` → key'i `memory.test.fact` olarak kaydediyordu
- `recall('test.*')` → pattern'ı olduğu gibi `test.*` olarak arıyordu → 0 sonuç

Düzeltme: `recall()` artık pattern'a otomatik `memory.` prefix ekliyor (remember ile tutarlı).

## Test plan

- [x] 643 test passing, 0 lint error
- [x] Canlı doğrulama: `remember → recall('test.*') → 1 item` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)