### PR TITLE
test: fix 4 ADV-002 advisory warnings

### DIFF
--- a/tests/test_llm_facade.py
+++ b/tests/test_llm_facade.py
@@ -244,7 +244,8 @@ class TestBuildRequestWithContext:
             )
             mock_compile.assert_called_once()
             mock_inject.assert_called_once()
-            assert result is not None
+            assert isinstance(result, dict)
+            assert result["body_json"]["messages"][0]["content"] == "Previous decisions: use Python 3.11"
 
     def test_without_session_falls_back_to_plain_build(self):
         from ao_kernel.llm import build_request_with_context, build_request
@@ -305,4 +306,5 @@ class TestProcessResponseWithContext:
                 request_id="req-002",
                 tool_results=[{"name": "test_tool", "output": {"status": "ok"}}],
             )
-            assert result is not None
+            assert result is session_ctx
+            assert result["session_id"] == "test-002"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -428,7 +428,10 @@ class TestToolRegistry:
     def test_every_definition_has_handler(self):
         for td in TOOL_DEFINITIONS:
             handler = TOOL_DISPATCH.get(td["name"])
-            assert handler is not None, f"Tool {td['name']} has no handler"
+            # Verify handler exists and returns a dict when called with empty params
+            result = handler({})
+            assert isinstance(result, dict), f"Tool {td['name']} handler should return dict"
+            assert "tool" in result, f"Tool {td['name']} handler response missing 'tool' field"
 
     def test_every_handler_has_definition(self):
         defined_names = {td["name"] for td in TOOL_DEFINITIONS}

--- a/tests/test_shim.py
+++ b/tests/test_shim.py
@@ -13,7 +13,7 @@ class TestInternalNamespace:
     def test_internal_importable(self):
         """v2.0.0: src.* removed, ao_kernel._internal is internal."""
         import ao_kernel._internal
-        assert ao_kernel._internal is not None
+        assert hasattr(ao_kernel._internal, "__path__"), "_internal should be a package with __path__"
 
 
 class TestSharedUtils:


### PR DESCRIPTION
## Summary
- 4 shallow assertion (ADV-002) düzeltildi → behavioral assertion'lara dönüştürüldü
- `test_llm_facade.py`: `assert result is not None` → response body content + session identity
- `test_mcp_server.py`: `assert handler is not None` → handler çağırıp response structure doğrulama
- `test_shim.py`: `assert module is not None` → `__path__` ile package doğrulama
- 643 test, 0 warning, 0 error

## Test plan
- [x] `pytest tests/ -x -q` → 643 passed, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)