### PR TITLE
feat: Faz 3 — ABC enforcement, MCP/distiller tests, CHANGELOG, README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to ao-kernel are documented here.
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Faz 3: SecretsProvider ABC enforcement, MCP HTTP transport tests, memory distiller edge case tests
+- Faz 2: Tool use graduation (build_tools_param integration, registry supported), evidence writer client integration, compaction edge case tests
+
+### Fixed
+- Streaming evidence was never written (keyword-only arg mismatch + missing model param)
+- Compaction tests used wrong context key (`decisions` → `ephemeral_decisions`)
+- Obsolete src/* shim references removed from llm.py docstrings
+
+## [2.1.1] - 2026-04-13
+
+### Fixed
+- CI: exclude `_internal` from coverage gate to unblock Faz 1-2 test additions
+
+## [2.1.0] - 2026-04-13
+
+### Added
+- `AoKernelClient` unified high-level SDK with full governed pipeline
+- Self-editing memory (Letta/MemGPT inspired): remember/update/forget/recall
+- Semantic vector retrieval with provider embedding + cosine similarity
+- Embedding-based groundedness check in eval harness
+- End-to-end integration tests (session roundtrip, client pipeline, MCP dispatch)
+- Tool use activation: capability loader fix + registry propagation
+
+### Fixed
+- 5 integration wiring issues (lifecycle hook, canonical injection, stream tools, MCP desc, vision registry)
+- Fail-closed enforcement + policy delegation
+- Self-edit memory recall auto-prefix pattern consistency
+- 4 ADV-002 advisory warning fixes
+
+### Changed
+- CLAUDE.md rewritten: 16 sections, comprehensive and stable
+
+## [2.0.0] - 2026-04-13
+
+### Changed
+- **BREAKING:** `src/` shim removed, all internals under `ao_kernel._internal` namespace
+
+### Added
+- Hot/warm/cold memory tier enforcement
+- MCP HTTP transport (starlette + uvicorn)
+- Durable checkpoint/resume for session context
+- Tool streaming support (v0.3.0 — tool call deltas reconstructed)
+- Chaos/failure smoke tests
+- Multi-agent coordination SDK hooks (revision tracking, stale detection)
+- Context pipeline: 3-lane compilation, profile routing, decision extraction
+
+## [0.2.0] - 2026-04-12
+
+### Added
+- `ao_kernel.llm` public facade: route, build, execute, normalize, stream
+- Context management pipeline (compile → inject → extract → promote)
+- Canonical decision store with temporal metadata
+- Context compiler with 6 profiles (STARTUP, TASK_EXECUTION, REVIEW, EMERGENCY, ASSESSMENT, PLANNING)
+- Memory pipeline with governed context loop
+- Backlog modules: evidence writer, session management, secrets providers, tool gateway
+
+## [0.1.0] - 2026-04-12
+
+### Added
+- Initial release: governed AI orchestration runtime
+- Policy engine: 4 types (autonomy, tool calling, provider guardrails, generic)
+- Fail-closed governance with JSONL evidence trail
+- LLM routing with 6 provider support (Claude, OpenAI, Google, DeepSeek, Qwen, xAI)
+- CLI: `ao-kernel init`, `doctor`, `migrate`, `mcp serve`, `version`
+- Workspace mode + library mode dual operation
+- 324 bundled JSON defaults (policies, schemas, registry, extensions)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,31 @@ stream_request = build_req(
 | `get_circuit_breaker(provider_id)` | Per-provider circuit breaker |
 | `count_tokens(messages, provider_id, model)` | Token counting |
 
-Supported providers: Claude, OpenAI, Google Gemini, DeepSeek, Qwen, xAI.
+### Supported Providers
+
+| Provider | Streaming | Tool Use | Embedding |
+|----------|-----------|----------|-----------|
+| Claude | Yes | Yes | No |
+| OpenAI | Yes | Yes | Yes |
+| Google Gemini | Yes | No | Yes |
+| DeepSeek | Yes | Yes | No |
+| Qwen | Yes | Yes | No |
+| xAI | Yes | Yes | No |
+
+### AoKernelClient — Unified SDK
+
+Full governed pipeline: route → capabilities → context → build → execute → normalize → decisions → eval → telemetry.
+
+```python
+from ao_kernel import AoKernelClient
+
+with AoKernelClient(workspace_root=".") as client:
+    result = client.llm_call(
+        messages=[{"role": "user", "content": "Hello"}],
+        intent="FAST_TEXT",
+    )
+    print(result["text"])
+```
 
 ## MCP Server
 
@@ -101,6 +125,7 @@ ao-kernel mcp serve  # stdio transport
 **Tools:**
 - `ao_policy_check` — Validate action against policy (allow/deny)
 - `ao_llm_route` — Resolve provider/model for intent
+- `ao_llm_call` — Execute governed LLM call
 - `ao_quality_gate` — Check output quality
 - `ao_workspace_status` — Workspace health
 
@@ -155,16 +180,26 @@ items = query_memory(ws, key_pattern="arch.*")
 ## Architecture
 
 ```
-ao_kernel/          <- Public facade (clean API)
-  cli.py            <- CLI commands
-  config.py         <- Workspace + defaults resolver
-  llm.py            <- LLM routing, building, normalization
-  mcp_server.py     <- MCP server (4 tools, 3 resources)
-  telemetry.py      <- OpenTelemetry (lazy no-op fallback)
-  defaults/         <- 338 bundled JSON (policies, schemas, registry, extensions, ops)
-
-src/                <- Compat shim (deprecated, use ao_kernel.*)
+ao_kernel/              <- Public facade (clean API)
+  client.py             <- AoKernelClient — unified SDK
+  llm.py                <- LLM routing, building, normalization
+  governance.py         <- Policy SSOT (4 policy types, fail-closed)
+  mcp_server.py         <- MCP server (5 tools, 3 resources)
+  context/              <- Context pipeline (compile, inject, extract, promote)
+  _internal/            <- Private implementation (do not import directly)
+  defaults/             <- 338 bundled JSON (policies, schemas, registry, extensions)
 ```
+
+## Development
+
+```bash
+pip install -e ".[dev,llm,mcp]"          # Dev environment
+pytest tests/ -x                          # Run tests
+ruff check ao_kernel/ tests/              # Lint
+mypy ao_kernel/ --ignore-missing-imports  # Type check
+```
+
+Coverage target: 70% branch coverage (excluding `_internal`).
 
 ## License
 

--- a/ao_kernel/_internal/secrets/provider.py
+++ b/ao_kernel/_internal/secrets/provider.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import abc
 
-class SecretsProvider:
-    def get(self, secret_id: str) -> str | None:
-        raise NotImplementedError
+
+class SecretsProvider(abc.ABC):
+    """Abstract base for secrets providers. Subclasses must implement get()."""
+
+    @abc.abstractmethod
+    def get(self, secret_id: str) -> str | None: ...
 

--- a/ao_kernel/llm.py
+++ b/ao_kernel/llm.py
@@ -1,6 +1,6 @@
 """ao_kernel.llm — Public LLM facade for ao-kernel.
 
-Clean import path for LLM operations. Replaces direct src.* shim imports.
+Clean import path for governed LLM operations.
 
 Usage:
     from ao_kernel.llm import resolve_route, build_request, normalize_response
@@ -8,8 +8,8 @@ Usage:
     from ao_kernel.llm import get_circuit_breaker, get_rate_limiter
     from ao_kernel.llm import stream_request, StreamResult, StreamEvent
 
-This module re-exports from src/ shim with stable names. When src/ shim
-is removed in v2.0.0, implementations will move here.
+All implementations live in ao_kernel._internal.prj_kernel_api.
+This module provides the stable public API surface.
 """
 
 from __future__ import annotations

--- a/tests/test_mcp_http_transport.py
+++ b/tests/test_mcp_http_transport.py
@@ -1,0 +1,44 @@
+"""MCP HTTP transport contract tests — serve_http function surface verification."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+class TestServeHttpContract:
+    def test_serve_http_is_async_function(self):
+        """serve_http is an async coroutine function (not sync)."""
+        from ao_kernel.mcp_server import serve_http
+        assert inspect.iscoroutinefunction(serve_http), "serve_http must be async"
+
+    def test_serve_http_default_params(self):
+        """serve_http defaults: host='127.0.0.1', port=8080."""
+        from ao_kernel.mcp_server import serve_http
+        sig = inspect.signature(serve_http)
+        assert sig.parameters["host"].default == "127.0.0.1"
+        assert sig.parameters["port"].default == 8080
+
+    def test_serve_http_import_error_message(self):
+        """Missing mcp-http deps raise ImportError with install hint."""
+        import asyncio
+        from unittest.mock import patch
+
+        original_import = __import__
+
+        def mock_import(name, *args, **kwargs):
+            if name in ("mcp.server.streamable_http", "starlette.applications", "uvicorn"):
+                raise ImportError(f"No module named '{name}'")
+            return original_import(name, *args, **kwargs)
+
+        import importlib
+        import ao_kernel.mcp_server as mod
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            importlib.reload(mod)
+            with pytest.raises(ImportError, match="starlette and uvicorn"):
+                asyncio.run(mod.serve_http())
+
+        # Restore module
+        importlib.reload(mod)

--- a/tests/test_memory_distiller_edge.py
+++ b/tests/test_memory_distiller_edge.py
@@ -1,0 +1,97 @@
+"""Edge case tests for memory distiller — cross-session fact promotion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _write_session(tmp_path: Path, session_id: str, decisions: list[dict]) -> None:
+    """Helper: create a valid session_context.v1.json with schema + SHA256."""
+    from ao_kernel.session import new_context
+    from ao_kernel._internal.session.context_store import save_context_atomic, SessionPaths
+
+    ctx = new_context(session_id=session_id, workspace_root=tmp_path)
+    ctx["ephemeral_decisions"] = decisions
+
+    sp = SessionPaths(workspace_root=tmp_path, session_id=session_id)
+    sp.context_path.parent.mkdir(parents=True, exist_ok=True)
+    save_context_atomic(sp.context_path, ctx)
+
+
+def _decision(key: str, value: str, created_at: str) -> dict:
+    """Build a schema-valid ephemeral decision."""
+    return {
+        "key": key,
+        "value": value,
+        "source": "agent",
+        "created_at": created_at,
+    }
+
+
+class TestDistillEdgeCases:
+    def test_empty_sessions_dir(self, tmp_path: Path):
+        """Empty sessions directory returns no distilled facts."""
+        from ao_kernel._internal.session.memory_distiller import distill_decisions_from_sessions
+
+        sessions_dir = tmp_path / ".cache" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        result = distill_decisions_from_sessions(workspace_root=tmp_path)
+        assert result == []
+
+    def test_threshold_boundary_min_occurrences(self, tmp_path: Path):
+        """Key in exactly min_occurrences sessions → promoted; fewer → excluded."""
+        from ao_kernel._internal.session.memory_distiller import distill_decisions_from_sessions
+
+        d = _decision("lang", "python", "2026-01-01T00:00:00Z")
+        _write_session(tmp_path, "s1", [d])
+        _write_session(tmp_path, "s2", [d])
+
+        # 2 sessions, min_occurrences=2 → should be promoted
+        result = distill_decisions_from_sessions(workspace_root=tmp_path, min_occurrences=2, min_stability=1)
+        keys = [r["key"] for r in result]
+        assert "lang" in keys
+
+        # 1 session below threshold
+        tmp2 = tmp_path / "workspace2"
+        tmp2.mkdir()
+        _write_session(tmp2, "s1", [d])
+        result2 = distill_decisions_from_sessions(workspace_root=tmp2, min_occurrences=2, min_stability=1)
+        assert result2 == []
+
+    def test_stability_exact_min_stability(self, tmp_path: Path):
+        """Exactly min_stability consecutive same values → promoted; fewer → excluded."""
+        from ao_kernel._internal.session.memory_distiller import distill_decisions_from_sessions
+
+        d1 = _decision("db", "postgres", "2026-01-01T00:00:00Z")
+        d2 = _decision("db", "postgres", "2026-01-02T00:00:00Z")
+        _write_session(tmp_path, "s1", [d1])
+        _write_session(tmp_path, "s2", [d2])
+
+        result = distill_decisions_from_sessions(workspace_root=tmp_path, min_occurrences=2, min_stability=2)
+        keys = [r["key"] for r in result]
+        assert "db" in keys
+
+        # Break stability: last value different → stability=1
+        tmp2 = tmp_path / "workspace2"
+        tmp2.mkdir()
+        d3 = _decision("db", "mysql", "2026-01-03T00:00:00Z")
+        _write_session(tmp2, "s1", [d1])
+        _write_session(tmp2, "s2", [d3])
+
+        result2 = distill_decisions_from_sessions(workspace_root=tmp2, min_occurrences=2, min_stability=2)
+        db_entries = [r for r in result2 if r["key"] == "db"]
+        assert db_entries == []
+
+    def test_alternating_values_excluded(self, tmp_path: Path):
+        """Alternating pattern [A, B, A] has stability=1 → excluded with min_stability=2."""
+        from ao_kernel._internal.session.memory_distiller import distill_decisions_from_sessions
+
+        _write_session(tmp_path, "s1", [_decision("fw", "flask", "2026-01-01T00:00:00Z")])
+        _write_session(tmp_path, "s2", [_decision("fw", "django", "2026-01-02T00:00:00Z")])
+        _write_session(tmp_path, "s3", [_decision("fw", "flask", "2026-01-03T00:00:00Z")])
+
+        result = distill_decisions_from_sessions(
+            workspace_root=tmp_path, min_occurrences=2, min_stability=2,
+        )
+        fw_entries = [r for r in result if r["key"] == "fw"]
+        assert fw_entries == []

--- a/tests/test_secrets_deep.py
+++ b/tests/test_secrets_deep.py
@@ -63,9 +63,20 @@ class TestEnvProviderEdgeCases:
 
 
 class TestSecretsProviderAbstract:
-    def test_abstract_base_raises_on_get(self):
+    def test_cannot_instantiate_abstract_base(self):
+        """SecretsProvider is ABC — direct instantiation raises TypeError."""
         from ao_kernel._internal.secrets.provider import SecretsProvider
-        provider = SecretsProvider()
         import pytest
-        with pytest.raises(NotImplementedError):
-            provider.get("ANY_KEY")
+        with pytest.raises(TypeError, match="abstract method"):
+            SecretsProvider()
+
+    def test_subclass_must_implement_get(self):
+        """Subclass without get() cannot be instantiated."""
+        from ao_kernel._internal.secrets.provider import SecretsProvider
+        import pytest
+
+        class IncompleteProvider(SecretsProvider):
+            pass
+
+        with pytest.raises(TypeError, match="abstract method"):
+            IncompleteProvider()


### PR DESCRIPTION
## Summary
- **3b** SecretsProvider ABC enforcement (abc.ABC + @abstractmethod)
- **3c** llm.py docstring cleanup (removed obsolete src/* shim references)
- **3d** MCP HTTP transport contract tests (3 new)
- **3h** Memory distiller edge case tests (4 new)
- **3a** CHANGELOG.md created (Keep a Changelog, v0.1.0 → v2.1.1)
- **3j** README.md updated (providers table, SDK section, dev section)
- **3e** Ertelendi (Codex istişaresi gerekli)

## Test plan
- [x] 723 test geçiyor (+8 yeni, +1 güncelleme)
- [x] SecretsProvider artık doğrudan instantiate edilemiyor (TypeError)
- [x] Subclass'lar (EnvSecretsProvider, VaultStubSecretsProvider) etkilenmedi
- [x] MCP serve_http contract doğrulandı (async, default params, import error)
- [x] Distiller: threshold boundary, stability boundary, alternating values test edildi

🤖 Generated with [Claude Code](https://claude.com/claude-code)