### PR TITLE
feat: 3e + Faz 4 — semantic flag, secrets factory, extension loader, vector store, roadmap checkpoint

### DIFF
--- a/ao_kernel/_internal/roadmap/roadmap_checkpoint.py
+++ b/ao_kernel/_internal/roadmap/roadmap_checkpoint.py
@@ -1,0 +1,158 @@
+"""Roadmap checkpoint/resume — workflow-level progress persistence.
+
+Saves checkpoint after each milestone, enabling resume from last completed point.
+Pattern follows session checkpoint (ao_kernel/context/checkpoint.py) with
+workflow-specific state.
+
+Storage: .cache/roadmap_checkpoints/{run_id}/progress.v1.json
+Audit:   .cache/roadmap_checkpoints/{run_id}/steps.log.jsonl
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ao_kernel._internal.shared.utils import write_json_atomic
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class RoadmapCheckpoint:
+    """Workflow progress checkpoint."""
+
+    run_id: str
+    plan_id: str
+    timestamp: str
+    completed_milestones: list[str]
+    completed_steps: list[str]
+    current_milestone_id: str | None = None
+    current_step_id: str | None = None
+    state_snapshot: dict[str, Any] = field(default_factory=dict)
+    errors: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class StepResult:
+    """Result of a single step execution."""
+
+    step_id: str
+    status: str  # OK | SKIP | FAIL
+    duration_ms: int = 0
+    output: dict[str, Any] = field(default_factory=dict)
+    error: dict[str, Any] | None = None
+    timestamp: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.timestamp:
+            self.timestamp = _now_iso()
+
+
+def _compute_hash(data: dict[str, Any]) -> str:
+    content = json.dumps(data, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(content.encode()).hexdigest()[:16]
+
+
+class RoadmapCheckpointManager:
+    """Manages workflow-level checkpoints for roadmap execution."""
+
+    def __init__(self, workspace_root: Path) -> None:
+        self._checkpoints_dir = workspace_root / ".cache" / "roadmap_checkpoints"
+
+    def save(
+        self,
+        run_id: str,
+        plan_id: str,
+        *,
+        completed_milestones: list[str],
+        completed_steps: list[str],
+        current_milestone_id: str | None = None,
+        current_step_id: str | None = None,
+        state_snapshot: dict[str, Any] | None = None,
+        errors: list[dict[str, Any]] | None = None,
+    ) -> Path:
+        """Save checkpoint atomically.
+
+        Returns path to checkpoint file.
+        """
+        run_dir = self._checkpoints_dir / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        cp = RoadmapCheckpoint(
+            run_id=run_id,
+            plan_id=plan_id,
+            timestamp=_now_iso(),
+            completed_milestones=completed_milestones,
+            completed_steps=completed_steps,
+            current_milestone_id=current_milestone_id,
+            current_step_id=current_step_id,
+            state_snapshot=state_snapshot or {},
+            errors=errors or [],
+        )
+
+        cp_dict = {
+            "run_id": cp.run_id,
+            "plan_id": cp.plan_id,
+            "timestamp": cp.timestamp,
+            "completed_milestones": cp.completed_milestones,
+            "completed_steps": cp.completed_steps,
+            "current_milestone_id": cp.current_milestone_id,
+            "current_step_id": cp.current_step_id,
+            "state_snapshot": cp.state_snapshot,
+            "errors": cp.errors,
+        }
+
+        data = {"checkpoint": cp_dict, "hash": _compute_hash(cp_dict)}
+        path = run_dir / "progress.v1.json"
+        write_json_atomic(path, data)
+        return path
+
+    def load(self, run_id: str) -> RoadmapCheckpoint | None:
+        """Load checkpoint if exists and valid. Returns None on missing/corrupt."""
+        path = self._checkpoints_dir / run_id / "progress.v1.json"
+        if not path.exists():
+            return None
+
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            cp_dict = data.get("checkpoint", {})
+            stored_hash = data.get("hash", "")
+
+            if _compute_hash(cp_dict) != stored_hash:
+                return None  # Corrupted
+
+            return RoadmapCheckpoint(**cp_dict)
+        except (json.JSONDecodeError, TypeError, KeyError):
+            return None
+
+    def log_step(self, run_id: str, result: StepResult) -> None:
+        """Append step result to JSONL audit log."""
+        run_dir = self._checkpoints_dir / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        log_path = run_dir / "steps.log.jsonl"
+        entry = {
+            "step_id": result.step_id,
+            "status": result.status,
+            "duration_ms": result.duration_ms,
+            "timestamp": result.timestamp,
+        }
+        if result.error:
+            entry["error"] = result.error
+
+        with log_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    def get_resume_skip_set(self, run_id: str) -> set[str]:
+        """Get set of completed step IDs for resume (steps to skip)."""
+        cp = self.load(run_id)
+        if cp is None:
+            return set()
+        return set(cp.completed_steps)

--- a/ao_kernel/_internal/secrets/factory.py
+++ b/ao_kernel/_internal/secrets/factory.py
@@ -1,0 +1,48 @@
+"""Secrets provider factory — create providers by type with lazy imports."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from ao_kernel._internal.secrets.provider import SecretsProvider
+
+
+def create_provider(provider_type: str, **kwargs: Any) -> SecretsProvider:
+    """Create a secrets provider by type.
+
+    Supported types:
+        "env"              — Environment variable provider (default)
+        "vault_stub"       — JSON file provider (requires secrets_path kwarg)
+        "hashicorp_vault"  — HashiCorp Vault KV v2 (requires VAULT_ADDR + VAULT_TOKEN)
+
+    Raises ValueError for unknown provider type.
+    """
+    if provider_type == "env":
+        from ao_kernel._internal.secrets.env_provider import EnvSecretsProvider
+        return EnvSecretsProvider(**kwargs)
+
+    if provider_type == "vault_stub":
+        from ao_kernel._internal.secrets.vault_stub_provider import VaultStubSecretsProvider
+        secrets_path = kwargs.get("secrets_path")
+        if secrets_path is None:
+            secrets_path = Path(".secrets/vault.json")
+        elif isinstance(secrets_path, str):
+            secrets_path = Path(secrets_path)
+        return VaultStubSecretsProvider(secrets_path=secrets_path)
+
+    if provider_type == "hashicorp_vault":
+        from ao_kernel._internal.secrets.hashicorp_vault_provider import HashiCorpVaultProvider
+        return HashiCorpVaultProvider(**kwargs)
+
+    raise ValueError(f"Unknown secrets provider type: {provider_type!r}")
+
+
+def create_provider_from_env() -> SecretsProvider:
+    """Auto-detect and create provider from SECRETS_PROVIDER env var.
+
+    Defaults to "env" if not configured.
+    """
+    provider_type = os.environ.get("SECRETS_PROVIDER", "env").strip().lower()
+    return create_provider(provider_type)

--- a/ao_kernel/_internal/secrets/hashicorp_vault_provider.py
+++ b/ao_kernel/_internal/secrets/hashicorp_vault_provider.py
@@ -1,0 +1,75 @@
+"""HashiCorp Vault secrets provider — KV v2 HTTP API integration.
+
+Reads secrets from HashiCorp Vault via HTTP. Requires:
+    VAULT_ADDR: Vault server address (e.g., https://vault.example.com)
+    VAULT_TOKEN: Authentication token
+
+secret_id format: "path/to/secret/key_name"
+    e.g., "openai/api-key" → GET /v1/secret/data/openai → data.data["api-key"]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from urllib.request import Request, urlopen
+from urllib.error import URLError
+
+from ao_kernel._internal.secrets.provider import SecretsProvider
+
+
+class HashiCorpVaultProvider(SecretsProvider):
+    """HashiCorp Vault KV v2 secrets provider."""
+
+    def __init__(
+        self,
+        *,
+        vault_addr: str = "",
+        vault_token: str = "",
+        secret_mount: str = "secret",
+        timeout_seconds: float = 5.0,
+    ) -> None:
+        self._vault_addr = (vault_addr or os.environ.get("VAULT_ADDR", "")).strip().rstrip("/")
+        self._vault_token = (vault_token or os.environ.get("VAULT_TOKEN", "")).strip()
+        self._secret_mount = secret_mount or os.environ.get("VAULT_SECRET_MOUNT", "secret")
+        self._timeout = timeout_seconds
+
+    def get(self, secret_id: str) -> str | None:
+        """Retrieve secret from Vault KV v2.
+
+        secret_id format: "path/key_name" where path is the secret path
+        and key_name is the JSON key within the secret data.
+        Returns None if not found, misconfigured, or on any error.
+        """
+        if not secret_id or "/" not in secret_id:
+            return None
+        if not self._vault_addr or not self._vault_token:
+            return None
+
+        path, key_name = secret_id.rsplit("/", 1)
+        if not path or not key_name:
+            return None
+
+        url = f"{self._vault_addr}/v1/{self._secret_mount}/data/{path}"
+        req = Request(url, method="GET")
+        req.add_header("X-Vault-Token", self._vault_token)
+        req.add_header("Accept", "application/json")
+
+        try:
+            with urlopen(req, timeout=self._timeout) as resp:
+                body: dict[str, Any] = json.loads(resp.read().decode("utf-8"))
+        except (URLError, json.JSONDecodeError, OSError):
+            return None
+
+        secret_data = body.get("data", {})
+        if isinstance(secret_data, dict):
+            secret_data = secret_data.get("data", secret_data)
+
+        if not isinstance(secret_data, dict):
+            return None
+
+        value = secret_data.get(key_name)
+        if isinstance(value, str):
+            return value.strip() or None
+        return None

--- a/ao_kernel/context/context_compiler.py
+++ b/ao_kernel/context/context_compiler.py
@@ -54,6 +54,7 @@ def compile_context(
     workspace_facts: dict[str, Any] | None = None,
     profile: str | None = None,
     messages: list[dict[str, Any]] | None = None,
+    enable_semantic_search: bool | None = None,
 ) -> CompiledContext:
     """Compile context from 3 lanes with relevance scoring and budget enforcement.
 
@@ -63,6 +64,8 @@ def compile_context(
         workspace_facts: Distilled workspace facts (from memory_distiller)
         profile: Explicit profile ID or None (auto-detect from messages)
         messages: Conversation messages (for profile auto-detection)
+        enable_semantic_search: Enable semantic reranking (None = use profile/env).
+            Default OFF. Set AO_SEMANTIC_SEARCH=1 env var to enable globally.
 
     Returns:
         CompiledContext with preamble, metrics, and selection log.
@@ -96,6 +99,9 @@ def compile_context(
 
     # Sort by relevance (highest first)
     items.sort(key=lambda x: x.relevance_score, reverse=True)
+
+    # Semantic reranking (opt-in, default OFF)
+    _apply_semantic_reranking(items, messages, profile_config, enable_semantic_search)
 
     # Budget enforcement
     budget = profile_config.max_tokens * 4  # ~4 chars per token
@@ -232,6 +238,88 @@ def _recency_score(created_at: str) -> float:
         return 0.2
     except (ValueError, TypeError):
         return 0.3
+
+
+def _apply_semantic_reranking(
+    items: list[ContextItem],
+    messages: list[dict[str, Any]] | None,
+    profile_config: ProfileConfig,
+    enable_override: bool | None,
+) -> None:
+    """Optionally rerank items by semantic similarity to user query.
+
+    Gate logic (short-circuit):
+        1. Explicit override wins (True/False)
+        2. Env var AO_SEMANTIC_SEARCH=1 enables globally
+        3. Profile config (default OFF for all profiles)
+
+    Modifies items in-place (blends semantic score into relevance_score).
+    Fails silently if embedding API unavailable — deterministic fallback preserved.
+    """
+    import os
+
+    # Resolve enable flag
+    if enable_override is not None:
+        enabled = enable_override
+    elif os.environ.get("AO_SEMANTIC_SEARCH", "").strip().lower() in ("1", "true", "yes"):
+        enabled = True
+    else:
+        enabled = profile_config.enable_semantic_search
+
+    if not enabled or not items or not messages:
+        return
+
+    # Extract query from first user message
+    query = ""
+    for msg in messages:
+        if msg.get("role") == "user":
+            content = msg.get("content", "")
+            if isinstance(content, str):
+                query = content
+            elif isinstance(content, list):
+                query = " ".join(c.get("text", "") for c in content if isinstance(c, dict))
+            break
+
+    if not query:
+        return
+
+    try:
+        from ao_kernel.context.semantic_retrieval import semantic_search
+
+        # Build decisions list from items for semantic_search
+        decisions_for_search = [
+            {"key": item.key, "value": item.value, "_embedding": None}
+            for item in items
+        ]
+
+        # semantic_search needs pre-embedded decisions or API key;
+        # if neither available, it returns [] — deterministic fallback
+        results = semantic_search(
+            query,
+            decisions_for_search,
+            top_k=len(items),
+            min_similarity=0.2,
+        )
+
+        if not results:
+            return  # No embeddings available — keep deterministic order
+
+        # Build similarity map
+        sim_map: dict[str, float] = {}
+        for r in results:
+            sim_map[r.get("key", "")] = r.get("_similarity", 0.0)
+
+        # Blend: new_score = 0.7 * deterministic + 0.3 * semantic
+        for item in items:
+            sim = sim_map.get(item.key, 0.0)
+            if sim > 0:
+                item.relevance_score = min(1.0, item.relevance_score * 0.7 + sim * 0.3)
+
+        # Re-sort after blending
+        items.sort(key=lambda x: x.relevance_score, reverse=True)
+
+    except Exception:
+        pass  # Fail-open: semantic search is non-critical
 
 
 def _build_preamble(items: list[ContextItem], profile: ProfileConfig) -> str:

--- a/ao_kernel/context/profile_router.py
+++ b/ao_kernel/context/profile_router.py
@@ -23,6 +23,7 @@ class ProfileConfig:
     priority_prefixes: tuple[str, ...]  # key prefixes to prioritize
     max_decisions: int                   # max decisions to inject
     max_tokens: int                      # token budget for context preamble
+    enable_semantic_search: bool = False  # opt-in semantic reranking (default OFF)
 
 
 PROFILES: dict[str, ProfileConfig] = {

--- a/ao_kernel/context/semantic_retrieval.py
+++ b/ao_kernel/context/semantic_retrieval.py
@@ -112,7 +112,7 @@ def embed_decision(
 
 def semantic_search(
     query: str,
-    decisions: list[dict[str, Any]],
+    decisions: list[dict[str, Any]] | None = None,
     *,
     top_k: int = 10,
     min_similarity: float = 0.3,
@@ -121,8 +121,12 @@ def semantic_search(
     model: str = "text-embedding-3-small",
     base_url: str = "https://api.openai.com/v1",
     api_key: str = "",
+    vector_store: Any | None = None,
 ) -> list[dict[str, Any]]:
     """Search decisions by semantic similarity.
+
+    If vector_store provided, delegates to backend (scales to large corpora).
+    Otherwise falls back to in-memory search over decisions list.
 
     If query_embedding not provided, generates it via API.
     Only considers decisions that have _embedding attached.
@@ -140,6 +144,20 @@ def semantic_search(
 
     if not query_embedding:
         return []  # No embedding = fallback to deterministic
+
+    # Use vector store backend if provided
+    if vector_store is not None:
+        raw_results = vector_store.search(
+            query_embedding, top_k=top_k, min_similarity=min_similarity,
+        )
+        return [
+            {"key": r["key"], "_similarity": round(r["similarity"], 4), **r.get("metadata", {})}
+            for r in raw_results
+        ]
+
+    # In-memory search (default)
+    if not decisions:
+        return []
 
     results = []
     for d in decisions:

--- a/ao_kernel/context/vector_store.py
+++ b/ao_kernel/context/vector_store.py
@@ -1,0 +1,87 @@
+"""Vector store abstraction — pluggable backends for embedding storage and search.
+
+Provides:
+    VectorStoreBackend — Abstract interface for vector storage
+    InMemoryVectorStore — Pure-Python in-memory implementation (default)
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import Any
+
+from ao_kernel.context.semantic_retrieval import cosine_similarity
+
+
+class VectorStoreBackend(abc.ABC):
+    """Abstract interface for vector storage backends."""
+
+    @abc.abstractmethod
+    def store(self, key: str, embedding: list[float], *, metadata: dict[str, Any] | None = None) -> None:
+        """Store embedding with optional metadata."""
+        ...
+
+    @abc.abstractmethod
+    def search(
+        self,
+        query_embedding: list[float],
+        *,
+        top_k: int = 10,
+        min_similarity: float = 0.3,
+    ) -> list[dict[str, Any]]:
+        """Search by embedding similarity.
+
+        Returns list of {key, similarity, metadata}.
+        """
+        ...
+
+    @abc.abstractmethod
+    def delete(self, key: str) -> bool:
+        """Delete embedding by key. Returns True if existed."""
+        ...
+
+    @abc.abstractmethod
+    def count(self) -> int:
+        """Return number of stored embeddings."""
+        ...
+
+
+class InMemoryVectorStore(VectorStoreBackend):
+    """Pure-Python in-memory vector store. Suitable for small corpora."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, dict[str, Any]] = {}
+
+    def store(self, key: str, embedding: list[float], *, metadata: dict[str, Any] | None = None) -> None:
+        self._store[key] = {
+            "embedding": embedding,
+            "metadata": metadata or {},
+        }
+
+    def search(
+        self,
+        query_embedding: list[float],
+        *,
+        top_k: int = 10,
+        min_similarity: float = 0.3,
+    ) -> list[dict[str, Any]]:
+        results = []
+        for key, entry in self._store.items():
+            sim = cosine_similarity(query_embedding, entry["embedding"])
+            if sim >= min_similarity:
+                results.append({
+                    "key": key,
+                    "similarity": round(sim, 4),
+                    "metadata": entry["metadata"],
+                })
+        results.sort(key=lambda x: x["similarity"], reverse=True)
+        return results[:top_k]
+
+    def delete(self, key: str) -> bool:
+        if key in self._store:
+            del self._store[key]
+            return True
+        return False
+
+    def count(self) -> int:
+        return len(self._store)

--- a/ao_kernel/context/vector_store_pgvector.py
+++ b/ao_kernel/context/vector_store_pgvector.py
@@ -1,0 +1,116 @@
+"""pgvector backend for vector store — PostgreSQL + pgvector extension.
+
+Requires: pip install ao-kernel[pgvector]
+    - pgvector
+    - psycopg2-binary
+
+Usage:
+    from ao_kernel.context.vector_store_pgvector import PgvectorBackend
+    store = PgvectorBackend(dsn="postgresql://user:pass@localhost/ao_kernel")
+    store.store("key1", [0.1, 0.2, ...], metadata={"source": "agent"})
+    results = store.search([0.1, 0.2, ...], top_k=5)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ao_kernel.context.vector_store import VectorStoreBackend
+
+
+class PgvectorBackend(VectorStoreBackend):
+    """PostgreSQL + pgvector vector store backend.
+
+    Uses cosine distance operator (<=>). Creates table and index on first use.
+    """
+
+    def __init__(
+        self,
+        *,
+        dsn: str = "",
+        table_name: str = "ao_embeddings",
+        dimension: int = 1536,
+    ) -> None:
+        try:
+            import psycopg2
+            from pgvector.psycopg2 import register_vector
+        except ImportError:
+            raise ImportError(
+                "pgvector backend requires psycopg2 and pgvector. "
+                "Install with: pip install ao-kernel[pgvector]"
+            ) from None
+
+        self._dsn = dsn
+        self._table = table_name
+        self._dim = dimension
+        self._conn = psycopg2.connect(dsn)
+        register_vector(self._conn)
+        self._ensure_table()
+
+    def _ensure_table(self) -> None:
+        """Create embeddings table and index if not exists."""
+        with self._conn.cursor() as cur:
+            cur.execute(f"""
+                CREATE TABLE IF NOT EXISTS {self._table} (
+                    key TEXT PRIMARY KEY,
+                    embedding vector({self._dim}),
+                    metadata JSONB DEFAULT '{{}}'::jsonb,
+                    created_at TIMESTAMPTZ DEFAULT NOW()
+                )
+            """)
+            cur.execute(f"""
+                CREATE INDEX IF NOT EXISTS idx_{self._table}_cosine
+                ON {self._table} USING ivfflat (embedding vector_cosine_ops)
+            """)
+            self._conn.commit()
+
+    def store(self, key: str, embedding: list[float], *, metadata: dict[str, Any] | None = None) -> None:
+        meta_json = json.dumps(metadata or {})
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""INSERT INTO {self._table} (key, embedding, metadata)
+                    VALUES (%s, %s, %s::jsonb)
+                    ON CONFLICT (key) DO UPDATE
+                    SET embedding = EXCLUDED.embedding, metadata = EXCLUDED.metadata""",
+                (key, embedding, meta_json),
+            )
+            self._conn.commit()
+
+    def search(
+        self,
+        query_embedding: list[float],
+        *,
+        top_k: int = 10,
+        min_similarity: float = 0.3,
+    ) -> list[dict[str, Any]]:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""SELECT key, 1 - (embedding <=> %s::vector) AS similarity, metadata
+                    FROM {self._table}
+                    WHERE 1 - (embedding <=> %s::vector) >= %s
+                    ORDER BY embedding <=> %s::vector
+                    LIMIT %s""",
+                (query_embedding, query_embedding, min_similarity, query_embedding, top_k),
+            )
+            return [
+                {"key": row[0], "similarity": round(float(row[1]), 4), "metadata": row[2]}
+                for row in cur.fetchall()
+            ]
+
+    def delete(self, key: str) -> bool:
+        with self._conn.cursor() as cur:
+            cur.execute(f"DELETE FROM {self._table} WHERE key = %s", (key,))
+            deleted = cur.rowcount > 0
+            self._conn.commit()
+            return deleted
+
+    def count(self) -> int:
+        with self._conn.cursor() as cur:
+            cur.execute(f"SELECT COUNT(*) FROM {self._table}")
+            return cur.fetchone()[0]
+
+    def close(self) -> None:
+        """Close database connection."""
+        if self._conn and not self._conn.closed:
+            self._conn.close()

--- a/ao_kernel/extensions/__init__.py
+++ b/ao_kernel/extensions/__init__.py
@@ -1,0 +1,1 @@
+"""ao_kernel.extensions — Runtime extension discovery and registry."""

--- a/ao_kernel/extensions/loader.py
+++ b/ao_kernel/extensions/loader.py
@@ -10,7 +10,7 @@ Manifests are JSON files: extension.manifest.v1.json
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 

--- a/ao_kernel/extensions/loader.py
+++ b/ao_kernel/extensions/loader.py
@@ -1,0 +1,127 @@
+"""Extension loader — discover and load extension manifests at runtime.
+
+Supports two sources:
+    1. Bundled defaults (ao_kernel/defaults/extensions/) — always available
+    2. Workspace extensions (.ao/extensions/) — workspace-mode override
+
+Manifests are JSON files: extension.manifest.v1.json
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ExtensionManifest:
+    """Parsed extension manifest."""
+
+    extension_id: str
+    version: str
+    semver: str
+    enabled: bool
+    origin: str
+    entrypoints: dict[str, list[str]]
+    gates: dict[str, list[str]]
+    layer_contract: dict[str, Any]
+    policies: list[str]
+
+
+def _parse_manifest(data: dict[str, Any]) -> ExtensionManifest:
+    """Parse raw JSON dict into ExtensionManifest."""
+    return ExtensionManifest(
+        extension_id=str(data.get("extension_id", "")),
+        version=str(data.get("version", "v1")),
+        semver=str(data.get("semver", "0.0.0")),
+        enabled=bool(data.get("enabled", False)),
+        origin=str(data.get("origin", "UNKNOWN")),
+        entrypoints=data.get("entrypoints", {}),
+        gates=data.get("gates", {}),
+        layer_contract=data.get("layer_contract", {}),
+        policies=data.get("policies", []),
+    )
+
+
+class ExtensionRegistry:
+    """Runtime registry of loaded extensions."""
+
+    def __init__(self) -> None:
+        self._extensions: dict[str, ExtensionManifest] = {}
+
+    def load_from_defaults(self) -> int:
+        """Load bundled extension manifests from ao_kernel/defaults/extensions/.
+
+        Returns number of manifests loaded.
+        """
+        try:
+            import importlib.resources as resources
+            extensions_pkg = resources.files("ao_kernel.defaults.extensions")
+        except (ImportError, ModuleNotFoundError):
+            return 0
+
+        count = 0
+        for item in extensions_pkg.iterdir():
+            if not item.is_dir():
+                continue
+            manifest_file = item / "extension.manifest.v1.json"
+            try:
+                text = manifest_file.read_text(encoding="utf-8")
+                data = json.loads(text)
+                if isinstance(data, dict):
+                    manifest = _parse_manifest(data)
+                    self._extensions[manifest.extension_id] = manifest
+                    count += 1
+            except (FileNotFoundError, json.JSONDecodeError, OSError):
+                continue
+        return count
+
+    def load_from_workspace(self, workspace_root: Path) -> int:
+        """Load workspace extension manifests (override bundled).
+
+        Returns number of manifests loaded.
+        """
+        extensions_dir = workspace_root / "extensions"
+        if not extensions_dir.is_dir():
+            return 0
+
+        count = 0
+        for ext_dir in sorted(extensions_dir.iterdir()):
+            if not ext_dir.is_dir():
+                continue
+            manifest_path = ext_dir / "extension.manifest.v1.json"
+            if not manifest_path.exists():
+                continue
+            try:
+                data = json.loads(manifest_path.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    manifest = _parse_manifest(data)
+                    self._extensions[manifest.extension_id] = manifest
+                    count += 1
+            except (json.JSONDecodeError, OSError):
+                continue
+        return count
+
+    def get(self, extension_id: str) -> ExtensionManifest | None:
+        """Get extension by ID."""
+        return self._extensions.get(extension_id)
+
+    def list_all(self) -> list[ExtensionManifest]:
+        """List all loaded extensions (enabled + disabled)."""
+        return sorted(self._extensions.values(), key=lambda m: m.extension_id)
+
+    def list_enabled(self) -> list[ExtensionManifest]:
+        """List only enabled extensions."""
+        return [m for m in self.list_all() if m.enabled]
+
+    def find_by_entrypoint(self, entrypoint_name: str) -> list[ExtensionManifest]:
+        """Find extensions that declare a specific entrypoint."""
+        results = []
+        for m in self._extensions.values():
+            for ep_list in m.entrypoints.values():
+                if isinstance(ep_list, list) and entrypoint_name in ep_list:
+                    results.append(m)
+                    break
+        return results

--- a/tests/test_extension_loader.py
+++ b/tests/test_extension_loader.py
@@ -1,0 +1,77 @@
+"""Tests for extension loader and registry."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ao_kernel.extensions.loader import ExtensionRegistry
+
+
+class TestExtensionRegistry:
+    def test_load_from_defaults(self):
+        """Bundled defaults contain 18 extension manifests."""
+        reg = ExtensionRegistry()
+        count = reg.load_from_defaults()
+        assert count >= 16  # at least 16 bundled manifests
+        all_ext = reg.list_all()
+        assert len(all_ext) >= 16
+
+    def test_get_known_extension(self):
+        """Can retrieve a specific extension by ID."""
+        reg = ExtensionRegistry()
+        reg.load_from_defaults()
+        ext = reg.get("PRJ-KERNEL-API")
+        assert ext is not None
+        assert ext.extension_id == "PRJ-KERNEL-API"
+        assert ext.version == "v1"
+
+    def test_list_enabled_filters_disabled(self):
+        """list_enabled only returns extensions with enabled=True."""
+        reg = ExtensionRegistry()
+        reg.load_from_defaults()
+        enabled = reg.list_enabled()
+        for ext in enabled:
+            assert ext.enabled is True
+
+    def test_find_by_entrypoint(self):
+        """find_by_entrypoint discovers extensions declaring a specific entrypoint."""
+        reg = ExtensionRegistry()
+        reg.load_from_defaults()
+        # PRJ-AIRUNNER declares ops entrypoints
+        results = reg.find_by_entrypoint("airunner-run")
+        ext_ids = [r.extension_id for r in results]
+        assert "PRJ-AIRUNNER" in ext_ids
+
+    def test_load_from_workspace(self, tmp_path: Path):
+        """Workspace extensions override bundled defaults."""
+        ext_dir = tmp_path / "extensions" / "MY-EXT"
+        ext_dir.mkdir(parents=True)
+        manifest = {
+            "extension_id": "MY-EXT",
+            "version": "v1",
+            "semver": "1.0.0",
+            "enabled": True,
+            "origin": "WORKSPACE",
+            "entrypoints": {"ops": ["my-op"]},
+            "gates": {"required": []},
+            "layer_contract": {},
+            "policies": [],
+        }
+        (ext_dir / "extension.manifest.v1.json").write_text(
+            json.dumps(manifest), encoding="utf-8",
+        )
+
+        reg = ExtensionRegistry()
+        count = reg.load_from_workspace(tmp_path)
+        assert count == 1
+
+        ext = reg.get("MY-EXT")
+        assert ext is not None
+        assert ext.origin == "WORKSPACE"
+        assert ext.semver == "1.0.0"
+
+    def test_get_unknown_returns_none(self):
+        """Unknown extension ID returns None."""
+        reg = ExtensionRegistry()
+        assert reg.get("NONEXISTENT") is None

--- a/tests/test_roadmap_checkpoint.py
+++ b/tests/test_roadmap_checkpoint.py
@@ -1,0 +1,87 @@
+"""Tests for roadmap checkpoint/resume."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ao_kernel._internal.roadmap.roadmap_checkpoint import (
+    RoadmapCheckpointManager,
+    StepResult,
+)
+
+
+class TestRoadmapCheckpointManager:
+    def test_save_and_load_roundtrip(self, tmp_path: Path):
+        """Save checkpoint and load it back with same data."""
+        mgr = RoadmapCheckpointManager(tmp_path)
+        mgr.save(
+            "run-001", "plan-abc",
+            completed_milestones=["m1"],
+            completed_steps=["s1", "s2"],
+            current_milestone_id="m2",
+            state_snapshot={"key": "value"},
+        )
+
+        cp = mgr.load("run-001")
+        assert cp is not None
+        assert cp.run_id == "run-001"
+        assert cp.plan_id == "plan-abc"
+        assert cp.completed_milestones == ["m1"]
+        assert cp.completed_steps == ["s1", "s2"]
+        assert cp.current_milestone_id == "m2"
+        assert cp.state_snapshot == {"key": "value"}
+
+    def test_load_missing_returns_none(self, tmp_path: Path):
+        """Loading nonexistent checkpoint returns None."""
+        mgr = RoadmapCheckpointManager(tmp_path)
+        assert mgr.load("nonexistent") is None
+
+    def test_corrupted_checkpoint_returns_none(self, tmp_path: Path):
+        """Tampered checkpoint (hash mismatch) returns None."""
+        mgr = RoadmapCheckpointManager(tmp_path)
+        mgr.save("run-002", "plan-x", completed_milestones=[], completed_steps=[])
+
+        # Tamper with checkpoint
+        cp_path = tmp_path / ".cache" / "roadmap_checkpoints" / "run-002" / "progress.v1.json"
+        data = json.loads(cp_path.read_text())
+        data["checkpoint"]["completed_steps"] = ["tampered"]
+        cp_path.write_text(json.dumps(data))
+
+        assert mgr.load("run-002") is None
+
+    def test_resume_skip_set(self, tmp_path: Path):
+        """get_resume_skip_set returns completed step IDs."""
+        mgr = RoadmapCheckpointManager(tmp_path)
+        mgr.save(
+            "run-003", "plan-y",
+            completed_milestones=["m1"],
+            completed_steps=["step-1", "step-2", "step-3"],
+        )
+
+        skip = mgr.get_resume_skip_set("run-003")
+        assert skip == {"step-1", "step-2", "step-3"}
+
+    def test_resume_skip_set_missing_returns_empty(self, tmp_path: Path):
+        """Missing checkpoint → empty skip set."""
+        mgr = RoadmapCheckpointManager(tmp_path)
+        assert mgr.get_resume_skip_set("missing") == set()
+
+    def test_log_step_creates_jsonl(self, tmp_path: Path):
+        """Step results are logged as JSONL."""
+        mgr = RoadmapCheckpointManager(tmp_path)
+        mgr.log_step("run-004", StepResult(step_id="s1", status="OK", duration_ms=100))
+        mgr.log_step("run-004", StepResult(step_id="s2", status="FAIL", error={"msg": "timeout"}))
+
+        log_path = tmp_path / ".cache" / "roadmap_checkpoints" / "run-004" / "steps.log.jsonl"
+        assert log_path.exists()
+        lines = log_path.read_text().strip().split("\n")
+        assert len(lines) == 2
+
+        first = json.loads(lines[0])
+        assert first["step_id"] == "s1"
+        assert first["status"] == "OK"
+
+        second = json.loads(lines[1])
+        assert second["step_id"] == "s2"
+        assert second["error"]["msg"] == "timeout"

--- a/tests/test_secrets_factory.py
+++ b/tests/test_secrets_factory.py
@@ -1,0 +1,90 @@
+"""Tests for secrets provider factory and HashiCorp Vault provider."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from ao_kernel._internal.secrets.factory import create_provider, create_provider_from_env
+
+
+class TestSecretsFactory:
+    def test_create_env_provider(self):
+        """Factory creates EnvSecretsProvider."""
+        from ao_kernel._internal.secrets.env_provider import EnvSecretsProvider
+        provider = create_provider("env")
+        assert isinstance(provider, EnvSecretsProvider)
+
+    def test_create_vault_stub_provider(self, tmp_path: Path):
+        """Factory creates VaultStubSecretsProvider with path."""
+        from ao_kernel._internal.secrets.vault_stub_provider import VaultStubSecretsProvider
+        provider = create_provider("vault_stub", secrets_path=tmp_path / "vault.json")
+        assert isinstance(provider, VaultStubSecretsProvider)
+
+    def test_create_hashicorp_vault_provider(self):
+        """Factory creates HashiCorpVaultProvider."""
+        from ao_kernel._internal.secrets.hashicorp_vault_provider import HashiCorpVaultProvider
+        provider = create_provider(
+            "hashicorp_vault",
+            vault_addr="https://vault.example.com",
+            vault_token="test-token",
+        )
+        assert isinstance(provider, HashiCorpVaultProvider)
+
+    def test_create_unknown_raises(self):
+        """Unknown provider type raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown secrets provider type"):
+            create_provider("nonexistent")
+
+    def test_create_from_env_defaults_to_env(self):
+        """Default SECRETS_PROVIDER → env provider."""
+        from ao_kernel._internal.secrets.env_provider import EnvSecretsProvider
+        with patch.dict("os.environ", {}, clear=False):
+            provider = create_provider_from_env()
+            assert isinstance(provider, EnvSecretsProvider)
+
+
+class TestHashiCorpVaultProvider:
+    def test_get_missing_config_returns_none(self):
+        """No VAULT_ADDR/VAULT_TOKEN → None."""
+        provider = create_provider("hashicorp_vault", vault_addr="", vault_token="")
+        assert provider.get("openai/api-key") is None
+
+    def test_get_invalid_secret_id_returns_none(self):
+        """secret_id without '/' → None."""
+        provider = create_provider(
+            "hashicorp_vault", vault_addr="https://v", vault_token="t",
+        )
+        assert provider.get("no-slash") is None
+
+    def test_get_success_mock_http(self):
+        """Successful Vault HTTP response returns secret value."""
+        provider = create_provider(
+            "hashicorp_vault", vault_addr="https://vault.example.com", vault_token="t",
+        )
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "data": {"data": {"api-key": "sk-test-123"}},
+        }).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("ao_kernel._internal.secrets.hashicorp_vault_provider.urlopen", return_value=mock_response):
+            result = provider.get("openai/api-key")
+            assert result == "sk-test-123"
+
+    def test_get_http_error_returns_none(self):
+        """HTTP error → None (fail-safe)."""
+        from urllib.error import URLError
+        provider = create_provider(
+            "hashicorp_vault", vault_addr="https://vault.example.com", vault_token="t",
+        )
+        with patch(
+            "ao_kernel._internal.secrets.hashicorp_vault_provider.urlopen",
+            side_effect=URLError("connection refused"),
+        ):
+            result = provider.get("openai/api-key")
+            assert result is None

--- a/tests/test_semantic_flag.py
+++ b/tests/test_semantic_flag.py
@@ -1,0 +1,96 @@
+"""Tests for semantic retrieval feature flag in context compiler."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+
+class TestSemanticRetrievalFlag:
+    def test_default_off_no_semantic_call(self):
+        """Default OFF: semantic_search is never called."""
+        from ao_kernel.context.context_compiler import compile_context
+
+        ctx = {
+            "ephemeral_decisions": [
+                {"key": "lang", "value": "python", "source": "agent", "created_at": "2026-01-01T00:00:00Z"},
+            ],
+        }
+
+        with patch("ao_kernel.context.semantic_retrieval.semantic_search") as mock_ss:
+            result = compile_context(
+                ctx,
+                messages=[{"role": "user", "content": "hello"}],
+            )
+            mock_ss.assert_not_called()
+            assert result.items_included >= 0  # compiles normally
+
+    def test_env_var_enables_semantic(self):
+        """AO_SEMANTIC_SEARCH=1 enables semantic reranking."""
+        from ao_kernel.context.context_compiler import compile_context
+
+        ctx = {
+            "ephemeral_decisions": [
+                {"key": "lang", "value": "python", "source": "agent", "created_at": "2026-01-01T00:00:00Z"},
+            ],
+        }
+
+        with (
+            patch.dict(os.environ, {"AO_SEMANTIC_SEARCH": "1"}),
+            patch("ao_kernel.context.semantic_retrieval.semantic_search", return_value=[]) as mock_ss,
+        ):
+            result = compile_context(
+                ctx,
+                messages=[{"role": "user", "content": "what language should I use?"}],
+            )
+            mock_ss.assert_called_once()
+            assert result.items_included >= 0
+
+    def test_explicit_param_overrides_env(self):
+        """enable_semantic_search=False overrides env var."""
+        from ao_kernel.context.context_compiler import compile_context
+
+        ctx = {
+            "ephemeral_decisions": [
+                {"key": "lang", "value": "python", "source": "agent", "created_at": "2026-01-01T00:00:00Z"},
+            ],
+        }
+
+        with (
+            patch.dict(os.environ, {"AO_SEMANTIC_SEARCH": "1"}),
+            patch("ao_kernel.context.semantic_retrieval.semantic_search") as mock_ss,
+        ):
+            result = compile_context(
+                ctx,
+                messages=[{"role": "user", "content": "hello"}],
+                enable_semantic_search=False,
+            )
+            mock_ss.assert_not_called()
+            assert result.items_included >= 0
+
+    def test_no_api_key_graceful_fallback(self):
+        """When semantic_search returns empty (no API key), deterministic order preserved."""
+        from ao_kernel.context.context_compiler import compile_context
+
+        decisions = [
+            {"key": "arch.pattern", "value": "microservices", "source": "agent",
+             "created_at": "2026-01-01T00:00:00Z", "confidence": 0.9},
+            {"key": "lang", "value": "python", "source": "agent",
+             "created_at": "2026-01-02T00:00:00Z", "confidence": 0.5},
+        ]
+        ctx = {"ephemeral_decisions": decisions}
+
+        # Without semantic: compile deterministically
+        result_off = compile_context(ctx, messages=[{"role": "user", "content": "hello"}])
+
+        # With semantic enabled but returning empty (no API key)
+        with patch("ao_kernel.context.semantic_retrieval.semantic_search", return_value=[]):
+            result_on = compile_context(
+                ctx,
+                messages=[{"role": "user", "content": "hello"}],
+                enable_semantic_search=True,
+            )
+
+        # Same result — deterministic fallback preserved
+        assert result_off.items_included == result_on.items_included
+        assert result_off.preamble == result_on.preamble

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,90 @@
+"""Tests for vector store abstraction and in-memory backend."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ao_kernel.context.vector_store import InMemoryVectorStore, VectorStoreBackend
+
+
+class TestInMemoryVectorStore:
+    def test_store_and_search_roundtrip(self):
+        """Store embeddings and search returns similar results."""
+        store = InMemoryVectorStore()
+        store.store("python", [1.0, 0.0, 0.0], metadata={"lang": "python"})
+        store.store("java", [0.0, 1.0, 0.0], metadata={"lang": "java"})
+        store.store("typescript", [0.9, 0.1, 0.0], metadata={"lang": "typescript"})
+
+        results = store.search([1.0, 0.0, 0.0], top_k=2, min_similarity=0.5)
+        assert len(results) == 2
+        assert results[0]["key"] == "python"
+        assert results[0]["similarity"] == 1.0
+        assert results[0]["metadata"]["lang"] == "python"
+        # typescript should be second (0.9 similarity)
+        assert results[1]["key"] == "typescript"
+
+    def test_delete_removes_entry(self):
+        """Delete removes embedding and returns True; missing returns False."""
+        store = InMemoryVectorStore()
+        store.store("key1", [1.0, 0.0])
+        assert store.count() == 1
+        assert store.delete("key1") is True
+        assert store.count() == 0
+        assert store.delete("key1") is False
+
+    def test_count_reflects_state(self):
+        """Count returns current number of stored embeddings."""
+        store = InMemoryVectorStore()
+        assert store.count() == 0
+        store.store("a", [1.0])
+        store.store("b", [0.0])
+        assert store.count() == 2
+
+    def test_search_min_similarity_filters(self):
+        """Results below min_similarity are excluded."""
+        store = InMemoryVectorStore()
+        store.store("similar", [1.0, 0.0])
+        store.store("different", [0.0, 1.0])
+
+        results = store.search([1.0, 0.0], min_similarity=0.9)
+        assert len(results) == 1
+        assert results[0]["key"] == "similar"
+
+
+class TestSemanticSearchWithBackend:
+    def test_semantic_search_delegates_to_vector_store(self):
+        """When vector_store provided, semantic_search uses it instead of in-memory."""
+        from ao_kernel.context.semantic_retrieval import semantic_search
+
+        mock_store = MagicMock(spec=VectorStoreBackend)
+        mock_store.search.return_value = [
+            {"key": "result1", "similarity": 0.95, "metadata": {"source": "test"}},
+        ]
+
+        results = semantic_search(
+            "test query",
+            query_embedding=[1.0, 0.0],
+            vector_store=mock_store,
+        )
+        mock_store.search.assert_called_once()
+        assert len(results) == 1
+        assert results[0]["key"] == "result1"
+        assert results[0]["_similarity"] == 0.95
+
+    def test_semantic_search_without_backend_unchanged(self):
+        """Without vector_store, semantic_search uses in-memory as before."""
+        from ao_kernel.context.semantic_retrieval import semantic_search
+
+        decisions = [
+            {"key": "lang", "value": "python", "_embedding": [1.0, 0.0, 0.0]},
+            {"key": "db", "value": "postgres", "_embedding": [0.0, 1.0, 0.0]},
+        ]
+
+        results = semantic_search(
+            "test",
+            decisions,
+            query_embedding=[1.0, 0.0, 0.0],
+            min_similarity=0.5,
+        )
+        assert len(results) == 1
+        assert results[0]["key"] == "lang"


### PR DESCRIPTION
## Summary
- **3e** Semantic retrieval feature flag (default OFF, `AO_SEMANTIC_SEARCH=1` env var, profile-based opt-in)
- **4.3** Secrets provider factory + HashiCorp Vault provider (KV v2 HTTP, urllib, fail-safe)
- **4.2** Extension loader + runtime registry (18 bundled manifests, workspace override)
- **4.1** Vector store abstraction (InMemoryVectorStore + PgvectorBackend) + `semantic_search(vector_store=...)` param
- **4.4** Roadmap checkpoint/resume (save/load with SHA256 integrity, JSONL step audit)

## Test plan
- [x] 754 test geçiyor (+31 yeni)
- [x] Ruff: 0 hata (değiştirilen dosyalarda)
- [x] Semantic flag: default OFF doğrulandı, env var + explicit param + graceful fallback
- [x] Secrets factory: 3 provider tipi + mock Vault HTTP
- [x] Extension loader: bundled defaults (18 manifest), workspace override, entrypoint search
- [x] Vector store: InMemory roundtrip, backend delegation, backward compat
- [x] Roadmap checkpoint: save/load roundtrip, corruption detection, JSONL logging

## New files (7)
- `ao_kernel/_internal/secrets/factory.py`
- `ao_kernel/_internal/secrets/hashicorp_vault_provider.py`
- `ao_kernel/extensions/__init__.py` + `loader.py`
- `ao_kernel/context/vector_store.py` + `vector_store_pgvector.py`
- `ao_kernel/_internal/roadmap/roadmap_checkpoint.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)