### PR TITLE
docs(plan): mark v2.2.0 shipped in FAZ5 plan (v1.1 → v1.2)

### DIFF
--- a/.claude/plans/FAZ5-MASTER-PLAN.md
+++ b/.claude/plans/FAZ5-MASTER-PLAN.md
@@ -213,9 +213,24 @@ Kod işine başlanmadan **tamamı** bitmiş olmalı.
 - **Ek:** `.gitignore`'a `/*.patch` ekle (yeni backup'lar köke düşmesin).
 - **Uygulanan:** 20 dosya `git mv` ile taşındı (rename olarak tracked), `.gitignore`'a `/*.patch` eklendi (yalnızca root), `.archive/patches/README.md` yazıldı.
 
-### 6.2 Tranş A — Hijyen & Honesty (v2.2.0 hedef)
+### 6.2 Tranş A — Hijyen & Honesty (v2.2.0 hedef) ✅ TAMAMLANDI (PR #57 @ 23b4302)
 
 Preflight bittikten sonra başlar. Her adım ayrı commit, bir PR içinde toplanır.
+
+**Tranş A commit zinciri:**
+- `a761956` A8 — release(v2.2.0): CHANGELOG + version bump + memory
+- `95f2074` A7 — fix(registry): downgrade unbacked capability flags + guard test
+- `242378e` A6 — feat(examples): add hello-llm quickstart
+- `f98be5c` A5 — docs(security): add SECURITY.md
+- `3640cf8` A4 — docs(readme): add SDK vs MCP capability matrix
+- `f43d5cc` A3 — fix(client): replace silent except-pass with structured warnings
+- `3207541` A2 — chore(release): bump PyPI classifier Alpha → Beta
+- `cafecf8` docs(plan): mark G1 + Tranş A kickoff
+
+**Release artifact'ları:**
+- PyPI: https://pypi.org/project/ao-kernel/2.2.0/ ✅
+- GitHub release: https://github.com/Halildeu/ao-kernel/releases/tag/v2.2.0 ✅
+- Main HEAD: `23b4302`
 
 #### A1 — `.patch` Arşivleme
 - P7 ile birleştirildi (yukarıda). İşaretleme: ✅ (Preflight'a taşındı).
@@ -604,7 +619,7 @@ Eğer preflight sonrası kritik bug bulunursa:
 |---|---|---|---|
 | G0 | Halil | Bu plan dosyası | Preflight P1'e başla |
 | G1 | Halil | Preflight sonu (P7 bitti) ✅ 2026-04-14 merge d9e86be | Tranş A başla |
-| G2 | Halil + Codex (CNS-opsiyonel) | Tranş A PR hazır | Merge + v2.2.0 tag |
+| G2 | Halil + Codex (CNS-opsiyonel) | Tranş A PR hazır ✅ 2026-04-14 merge 23b4302 → v2.2.0 tag → PyPI | Merge + v2.2.0 tag |
 | G3 | Halil | v2.2.0 release sonrası | Tranş B başla |
 | G4 | Codex (CNS-007) | B1 tasarımı | B1 implementasyonu |
 | G5 | Codex (CNS-008) | B3 tasarımı | B3 implementasyonu |
@@ -669,6 +684,7 @@ Bu plan değişirse:
 |---|---|---|---|
 | 2026-04-14 | v1.0 | İlk taslak oluşturuldu | CNS-005 + CNS-006 sonuçları |
 | 2026-04-14 | v1.1 | Preflight tamamlandı ve v2.2.0-track açıldı. Yol üstünde kazanıldı: mypy 131→0, typecheck gerçek gate, client.save_checkpoint/resume_checkpoint real-bug fix, 18 dead __init__.py sildi. G1 merged @ d9e86be. | PR #56 merge |
+| 2026-04-14 | v1.2 | Tranş A (A2-A8) tamamlandı. G2 merged @ 23b4302. v2.2.0 tag push → publish.yml OIDC → PyPI yayında (Development Status :: 4 - Beta). 758 test, mypy strict 0, 6 required CI check. GitHub release oluşturuldu. Sıradaki: Tranş B. | PR #57 merge + v2.2.0 release |
 
 ---
 

--- a/.claude/plans/SESSION-HANDOFF-2026-04-14.md
+++ b/.claude/plans/SESSION-HANDOFF-2026-04-14.md
@@ -1,0 +1,156 @@
+# Oturum Kapanış Raporu — 2026-04-14
+
+## TL;DR
+
+**ao-kernel v2.2.0 PyPI'da yayında.** Faz 5 Preflight + Tranş A kapandı. Sıradaki oturum **Tranş B** (v2.3.0 — Faz 4 wiring) ile devam eder. Plan hazır, memory güncel, repo tertemiz, yarım iş yok.
+
+---
+
+## Bu Oturumda Yapılanlar
+
+### 2 release hedefinden 1'i tamam (v2.2.0 shipped)
+
+| Safha | Tamamlandı mı? | PR | Sonuç |
+|---|---|---|---|
+| Faz 5 plan (v1.0) | ✅ | — | `.claude/plans/FAZ5-MASTER-PLAN.md` |
+| CNS-20260414-005 plan review | ✅ | — | Verdict D, D0 gereklilik |
+| CNS-20260414-006 A0 safety net | ✅ | — | Verdict C, 3 Claude önerisi çürütüldü |
+| Preflight (P1-P7) | ✅ | #56 → d9e86be | Branch/tag protection + hooks + workflow split |
+| Bonus: mypy 131→0, typecheck gerçek gate, checkpoint real-bug fix, 18 dead init.py | ✅ | #56 dahil | — |
+| Tranş A (A2-A8) | ✅ | #57 → 23b4302 | classifier Beta, exception fix, README matrix, SECURITY, examples, registry fix, version 2.2.0 |
+| v2.2.0 tag + PyPI release | ✅ | — | https://pypi.org/project/ao-kernel/2.2.0/ |
+| GitHub release notes | ✅ | — | https://github.com/Halildeu/ao-kernel/releases/tag/v2.2.0 |
+| Plan v1.2 docs sync | ⏳ | #58 | Oturum sonunda kapanıyor |
+
+### Ölçülebilir değişimler
+
+| Metric | v2.1.1 | v2.2.0 |
+|---|---|---|
+| Test | 754 | **758** |
+| Mypy strict | 131 err (`\|\| true` yut) | **0** (gerçek gate) |
+| Required CI check | 5 | **6** |
+| Branch protection | yok | aktif (admin dahil) |
+| Tag protection | yok | `v*` (ruleset 15043973) |
+| `.githooks/` | yok | pre-commit + pre-push (versioned) |
+| `examples/` | — | hello-llm |
+| `SECURITY.md` | — | ✅ |
+| Registry overclaim | 6 flag | **0** (guard test) |
+| PyPI classifier | Alpha | **Beta** |
+
+### Sayılarla
+
+- **Merged PR:** 2 (#56 Preflight, #57 Tranş A) + 1 kapanıyor (#58 plan docs)
+- **Commit (bu oturum):** ~25 (Preflight 8 + Tranş A 8 + plan docs 1 + lint/typecheck fix commit'leri)
+- **CNS (bu oturum):** 2 (#005 Verdict D, #006 Verdict C)
+- **Yol üstünde bulunan bug:** 1 (`client.save_checkpoint` / `resume_checkpoint` API mismatch — tip check yakaladı)
+- **Repo hijyen:** 20 `.patch` dosyası arşive taşındı, 18 dead `__init__.py` silindi
+
+---
+
+## Sıradaki Oturum Başlama Kılavuzu
+
+### 1. İlk önce oku (sırasıyla)
+
+```
+~/.claude/projects/-Users-halilkocoglu-Documents-ao-kernel/memory/MEMORY.md
+~/.claude/projects/-Users-halilkocoglu-Documents-ao-kernel/memory/project_origin.md
+~/.claude/projects/-Users-halilkocoglu-Documents-ao-kernel/memory/project_p3_candidates.md
+~/.claude/projects/-Users-halilkocoglu-Documents-ao-kernel/memory/feedback_codex_consultations.md
+.claude/plans/FAZ5-MASTER-PLAN.md    ← plan v1.2, tam güncel
+.claude/plans/SESSION-HANDOFF-2026-04-14.md  ← bu dosya
+```
+
+### 2. Durumu doğrula (CNS-009 dersi — claim'i grep'le test et)
+
+```bash
+git log -1 --format="%h %s"        # 23b4302 Merge pull request #57 (veya #58 sonrası daha yeni)
+git status --short                  # temiz olmalı
+git log --oneline v2.1.1..HEAD      # v2.2.0 commit zinciri görünmeli
+python3 -m pytest --co -q | tail -1 # 758 tests collected
+mypy ao_kernel/ 2>&1 | tail -1      # Success: no issues
+ruff check ao_kernel/ tests/        # All checks passed
+gh api repos/Halildeu/ao-kernel/branches/main/protection --jq .required_status_checks.contexts
+# → ["lint","test (3.11)","test (3.12)","test (3.13)","coverage","typecheck"]
+```
+
+### 3. Sıradaki hedef — **Tranş B (v2.3.0) — Faz 4 Wiring**
+
+Plan dosyasının §6.3'ünde tam detay. Özet:
+
+| # | İş | Ön-şart | CNS |
+|---|---|---|---|
+| **B1** | Vector store → `semantic_retrieval.py` entegrasyonu | Backend seçim mekanizması kararı | CNS-007 (AÇILACAK) |
+| **B2** | Secrets factory → LLM transport | Dual-read pattern, geriye dönük uyum | CNS-005 D0.3 (tasarım ilkeleri var, kod yok) |
+| **B3** | Extension loader → startup path | Lazy vs eager + activation dispatch | CNS-008 (AÇILACAK) |
+| **B4** | Evidence writer robustness + MCP tool evidence | Yok, hafif | — |
+| **B5** | Agent coordination write path SDK expose | Public API mı internal mı | CNS-009 (AÇILACAK) |
+
+### 4. Tranş B başlangıç sırası
+
+1. **Yeni branch:** `git checkout -b claude/tranche-b origin/main` (veya yeni worktree)
+2. **CNS-20260414-007 aç:** B1 vector store tasarımı — opsiyonları Codex'e sor:
+   - (a) `VectorStoreBackend` client'a parametre olarak inject, default `InMemoryVectorStore`
+   - (b) Policy-driven seçim (`policy_context_memory_tiers.v1.json` içinde)
+   - (c) Env flag `AO_KERNEL_VECTOR_BACKEND=pgvector`
+   - (d) Provider registry entegrasyonu
+   - Hangisi D8 (fail-closed) ve D14 (auto-route normalize) ile uyumlu?
+3. **B1 implement** → ayrı commit
+4. **B2 (D0.3 safety):** `EnvSecretsProvider` dual-read — factory varsa factory, yoksa `os.getenv` fallback. Migration path'i kırma.
+5. **Sırayla B3, B4, B5** — her birinde gerekirse mini-CNS
+6. **PR aç:** claude/tranche-b → main, CI 7/7 yeşil
+7. **G3 gate:** M2 pattern (self-approve yasak, aynı Halildeu)
+8. **Tag v2.3.0** push → publish.yml → PyPI
+
+### 5. Planın dışında kalan uzun vadeli
+
+Tranş C (v3.0.0) coverage + uzun vadeli 5 iş plan dosyasında detaylı. Tranş B bittikten sonra değerlendirilir.
+
+---
+
+## Teknik Borçlar (farkındalık)
+
+Bu oturumda **bilinçli olarak ertelenen** borçlar:
+
+| Konu | Nerede? | Ne zaman? |
+|---|---|---|
+| `_internal/*` mypy coverage | pyproject.toml overrides (ignore_errors=true) | Tranş C (D13 phased) |
+| `mcp_server.py` bazı `# type: ignore[no-untyped-call,untyped-decorator]` | `ao_kernel/mcp_server.py` 4 satır | MCP SDK typing düzeldiğinde |
+| `_internal` session context_store %51 coverage | Tranş C | Tranş C |
+| `evidence/writer.py` %28 coverage | Tranş C | Tranş C |
+| `workspace.py` %46 coverage | Tranş C | Tranş C |
+
+Bunların **hiçbiri kullanıcıya yansımaz** — gate'ler gerçek, ama kapsam seçici.
+
+---
+
+## Kullanıcı Tercihleri (bu oturumdan teyit edilen)
+
+- **Dil:** Türkçe yanıt, kod/commit İngilizce (CLAUDE.md §16)
+- **Sıralı çalışma:** plan-first, adım adım, her aşamada commit
+- **Codex istişaresi:** mimari kararda zorunlu, itirazları kanıtla kabul/ret
+- **M2 merge pattern:** self-approve yasak → approval=0 pencere → merge → 1'e geri (onaylandı)
+- **Kalıcı ve etkin çözümler:** Pyproject relaxation yerine sistemik fix (A3'te cast, annotation ekleme seçildi; S1 option düşürüldü)
+- **Gate kurma:** cosmetic değil gerçek (typecheck continue-on-error kaldırıldı, required check olarak eklendi)
+
+---
+
+## Uncommitted / Open PR
+
+- Uncommitted: YOK
+- Open PR: #58 (plan v1.2 docs, CI'da, kapanıyor)
+- Worktree: `claude/wizardly-euclid` + `claude/tranche-a` + `claude/plan-v1.2` remote'ta duruyor (merge edilmiş / edilecek). Temizlik opsiyonel.
+
+---
+
+## Oturum Sağlığı — Son Kontrol
+
+- [x] v2.2.0 PyPI'da yayında
+- [x] GitHub release notes oluşturuldu
+- [x] Main branch `23b4302`, branch protection tam aktif
+- [x] Tag `v2.2.0` korumalı (ruleset 15043973)
+- [x] Memory güncel (project_origin + p3_candidates + feedback + MEMORY.md index)
+- [x] Plan dosyası v1.2 (G2 işaretli, Tranş A commit zinciri kayıtlı)
+- [x] 758/758 test yeşil, mypy strict 0, ruff 0 hata
+- [x] Bu handoff dosyası yazıldı
+
+**Sonraki oturum hazır. Tranş B ile başlanabilir.**


### PR DESCRIPTION
Pure documentation update. Updates the master plan file to reflect what
has actually landed so the next working session reads a current plan.

Changes:
- Plan version: v1.1 → v1.2
- G2 gate: marked merged @ 23b4302 with v2.2.0 tag + PyPI link
- Tranş A §6.2: full commit chain (A2-A8) recorded, release artifact URLs added
- Change Log: v1.2 entry

No code or config changes.