### PR TITLE
feat(secrets): dual-read API key resolver (B2, CNS-005 D0.3)

### DIFF
--- a/ao_kernel/_internal/secrets/api_key_resolver.py
+++ b/ao_kernel/_internal/secrets/api_key_resolver.py
@@ -1,0 +1,158 @@
+"""Provider API key resolver — dual-read pattern (factory > env fallback).
+
+Per CNS-20260414-005 D0.3: the secrets factory (``create_provider_from_env``)
+became available but call-sites still read directly from ``os.environ``. A
+hard switch would regress workflows where the configured provider
+intentionally masks or overrides env-only values; a silent switch would hide
+misconfigurations.
+
+The dual-read pattern keeps both paths alive during migration:
+
+    1. Ask the configured SecretsProvider (env, vault_stub, hashicorp_vault).
+       - Success -> return its value (source: "factory").
+       - Unknown secret id, or provider declines -> try next layer.
+    2. Fall back to ``os.environ`` directly (source: "environ").
+    3. Nothing found -> empty string (source: "missing").
+
+Call-sites read the VALUE; tests can pass ``audit=True`` to also inspect
+which path served it. Env fallback stays until every provider surface moves
+to the factory-only contract (tracked as D0.3 follow-up).
+
+Security notes:
+  - Never log the resolved value. The ``source`` channel is safe to log.
+  - Whitespace-only env values are treated as missing (matches
+    EnvSecretsProvider semantics) so accidentally-exported blank secrets
+    do not mask real ones.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any, Literal, TYPE_CHECKING, overload
+
+if TYPE_CHECKING:
+    from ao_kernel._internal.secrets.provider import SecretsProvider
+
+# Provider id (registry-canonical) -> preferred env-variable name, plus
+# accepted alternates for backward compatibility with older deployments.
+_PROVIDER_TO_ENVS: dict[str, tuple[str, ...]] = {
+    "openai": ("OPENAI_API_KEY",),
+    "anthropic": ("ANTHROPIC_API_KEY", "CLAUDE_API_KEY"),
+    "claude": ("ANTHROPIC_API_KEY", "CLAUDE_API_KEY"),
+    "google": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+    "gemini": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+    "deepseek": ("DEEPSEEK_API_KEY",),
+    "qwen": ("DASHSCOPE_API_KEY", "QWEN_API_KEY"),
+    "xai": ("XAI_API_KEY",),
+    "grok": ("XAI_API_KEY",),
+}
+
+
+def env_names_for(provider_id: str) -> tuple[str, ...]:
+    """Return accepted env-variable names for a provider id.
+
+    Unknown providers fall back to ``{PROVIDER_UPPER}_API_KEY`` — matches
+    the pre-D0.3 behaviour in mcp_server.py.
+    """
+    canonical = _PROVIDER_TO_ENVS.get(provider_id.lower())
+    if canonical:
+        return canonical
+    return (f"{provider_id.upper()}_API_KEY",)
+
+
+@overload
+def resolve_api_key(
+    provider_id: str,
+    *,
+    environ: Mapping[str, str] | None = ...,
+    secrets_provider: "SecretsProvider | None" = ...,
+    audit: Literal[False] = ...,
+) -> str: ...
+
+
+@overload
+def resolve_api_key(
+    provider_id: str,
+    *,
+    environ: Mapping[str, str] | None = ...,
+    secrets_provider: "SecretsProvider | None" = ...,
+    audit: Literal[True],
+) -> tuple[str, str]: ...
+
+
+def resolve_api_key(
+    provider_id: str,
+    *,
+    environ: Mapping[str, str] | None = None,
+    secrets_provider: "SecretsProvider | None" = None,
+    audit: bool = False,
+) -> str | tuple[str, str]:
+    """Resolve an API key for ``provider_id`` using dual-read precedence.
+
+    Args:
+        provider_id: Registry-canonical provider id (e.g. "openai", "claude").
+        environ: Mapping to read env variables from. Defaults to ``os.environ``.
+            Tests pass a dict to isolate state.
+        secrets_provider: Pre-built provider to consult before env. Defaults
+            to ``create_provider_from_env()`` when the caller leaves this None.
+            Pass an explicit provider (e.g. vault_stub) to pin the source.
+        audit: When True, returns ``(value, source)`` where source is one of
+            ``"factory"``, ``"environ"``, or ``"missing"``. When False (default)
+            returns only the value. Callers that just need the key pass no
+            argument; call-sites that log provenance pass ``audit=True``.
+
+    Returns:
+        Empty string when no key is found (D11-compatible; callers treat
+        empty as "skip the call"). See ``audit`` for provenance.
+    """
+    env = environ if environ is not None else os.environ
+
+    if secrets_provider is None:
+        secrets_provider = _default_provider()
+
+    candidates = env_names_for(provider_id)
+
+    # 1. Factory path — try each candidate env name as a canonical secret id.
+    if secrets_provider is not None:
+        for secret_id in candidates:
+            try:
+                value = secrets_provider.get(secret_id)
+            except Exception:  # noqa: BLE001 — provider faults must not block env fallback
+                value = None
+            if value:
+                stripped = value.strip()
+                if stripped:
+                    return (stripped, "factory") if audit else stripped
+
+    # 2. Env fallback — preserves pre-D0.3 behaviour for callers that have
+    #    not yet onboarded a SecretsProvider (vault_stub, hashicorp_vault).
+    for env_var in candidates:
+        raw = env.get(env_var, "")
+        if isinstance(raw, str):
+            stripped = raw.strip()
+            if stripped:
+                return (stripped, "environ") if audit else stripped
+
+    return ("", "missing") if audit else ""
+
+
+def _default_provider() -> "SecretsProvider | None":
+    """Build the factory-configured provider once. Returns None on load failure
+    so that resolve_api_key still works via the env fallback path.
+    """
+    try:
+        from ao_kernel._internal.secrets.factory import create_provider_from_env
+        return create_provider_from_env()
+    except Exception:  # noqa: BLE001 — factory load is best-effort
+        return None
+
+
+__all__ = ["resolve_api_key", "env_names_for"]
+
+
+# Ensure runtime attribute access still sees SecretsProvider even outside
+# TYPE_CHECKING — kept lazy to avoid import cycles at module load.
+def _runtime_check() -> Any:  # pragma: no cover — smoke helper
+    from ao_kernel._internal.secrets.provider import SecretsProvider  # noqa: F401
+    return SecretsProvider

--- a/ao_kernel/_internal/secrets/env_provider.py
+++ b/ao_kernel/_internal/secrets/env_provider.py
@@ -5,8 +5,20 @@ from collections.abc import Mapping
 
 from ao_kernel._internal.secrets.provider import SecretsProvider
 
+# Canonical secret IDs are the env variable names themselves. Callers pass
+# ``OPENAI_API_KEY`` and the provider returns ``os.environ["OPENAI_API_KEY"]``.
+# Keeping the map explicit (rather than identity) lets future providers route
+# through alternative env names without breaking existing callers.
 _SECRET_ID_TO_ENV: dict[str, str] = {
     "OPENAI_API_KEY": "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY": "ANTHROPIC_API_KEY",
+    "CLAUDE_API_KEY": "CLAUDE_API_KEY",
+    "GOOGLE_API_KEY": "GOOGLE_API_KEY",
+    "GEMINI_API_KEY": "GEMINI_API_KEY",
+    "DEEPSEEK_API_KEY": "DEEPSEEK_API_KEY",
+    "DASHSCOPE_API_KEY": "DASHSCOPE_API_KEY",
+    "QWEN_API_KEY": "QWEN_API_KEY",
+    "XAI_API_KEY": "XAI_API_KEY",
 }
 
 

--- a/ao_kernel/mcp_server.py
+++ b/ao_kernel/mcp_server.py
@@ -351,25 +351,22 @@ def handle_llm_call(params: dict[str, Any]) -> dict[str, Any]:
         provider_id = provider_id or route.get("provider_id", route.get("selected_provider", "openai"))
         model = model or route.get("model", route.get("selected_model", "gpt-4"))
 
-    # Resolve API key from environment (never from params)
-    import os
-    api_key_env_map = {
-        "openai": "OPENAI_API_KEY",
-        "claude": "ANTHROPIC_API_KEY",
-        "google": "GOOGLE_API_KEY",
-        "deepseek": "DEEPSEEK_API_KEY",
-        "qwen": "DASHSCOPE_API_KEY",
-        "xai": "XAI_API_KEY",
-    }
-    env_var = api_key_env_map.get(provider_id, f"{provider_id.upper()}_API_KEY")
-    api_key = os.environ.get(env_var, "")
+    # Resolve API key via dual-read (factory > env fallback, D11/D0.3).
+    # Never accept api_key as a tool parameter — it stays an env/secret concern.
+    from ao_kernel._internal.secrets.api_key_resolver import (
+        env_names_for,
+        resolve_api_key,
+    )
+    api_key = resolve_api_key(provider_id)
     if not api_key:
+        env_candidates = env_names_for(provider_id)
+        env_hint = " or ".join(env_candidates)
         return _decision_envelope(
             tool="ao_llm_call",
             allowed=False,
             decision="deny",
             reason_codes=["MISSING_API_KEY"],
-            error=f"API key not found in environment variable {env_var}",
+            error=f"API key not found (checked: {env_hint}).",
         )
 
     # Build + execute

--- a/tests/test_api_key_resolver.py
+++ b/tests/test_api_key_resolver.py
@@ -1,0 +1,205 @@
+"""Tests for ao_kernel._internal.secrets.api_key_resolver (B2, CNS-005 D0.3).
+
+The resolver's job is dual-read: consult the factory-configured
+SecretsProvider first, then fall back to os.environ. Every code path
+here is exercised with an isolated ``environ`` dict so tests never
+mutate the user's real environment.
+"""
+
+from __future__ import annotations
+
+from ao_kernel._internal.secrets.api_key_resolver import (
+    env_names_for,
+    resolve_api_key,
+)
+from ao_kernel._internal.secrets.provider import SecretsProvider
+
+
+class _DictProvider(SecretsProvider):
+    """Minimal stand-in for a secrets backend (vault, etc.)."""
+
+    def __init__(self, values: dict[str, str | None]) -> None:
+        self._values = values
+        self.calls: list[str] = []
+
+    def get(self, secret_id: str) -> str | None:
+        self.calls.append(secret_id)
+        return self._values.get(secret_id)
+
+
+class _BrokenProvider(SecretsProvider):
+    """Provider that raises on every lookup — env fallback must still work."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def get(self, secret_id: str) -> str | None:
+        self.calls.append(secret_id)
+        raise RuntimeError(f"backend down for {secret_id}")
+
+
+class TestEnvNamesMapping:
+    def test_openai_canonical(self):
+        assert env_names_for("openai") == ("OPENAI_API_KEY",)
+
+    def test_claude_alias_to_anthropic(self):
+        names = env_names_for("claude")
+        assert "ANTHROPIC_API_KEY" in names
+        assert "CLAUDE_API_KEY" in names
+
+    def test_google_alias_to_gemini(self):
+        names = env_names_for("google")
+        assert "GOOGLE_API_KEY" in names
+        assert "GEMINI_API_KEY" in names
+
+    def test_qwen_alias_to_dashscope(self):
+        assert "DASHSCOPE_API_KEY" in env_names_for("qwen")
+
+    def test_xai_alias_grok(self):
+        assert env_names_for("grok") == env_names_for("xai")
+
+    def test_unknown_provider_upper_case_fallback(self):
+        assert env_names_for("fictional") == ("FICTIONAL_API_KEY",)
+
+
+class TestFactoryPath:
+    def test_factory_returns_secret(self):
+        provider = _DictProvider({"OPENAI_API_KEY": "sk-from-vault"})
+        key = resolve_api_key(
+            "openai",
+            environ={},
+            secrets_provider=provider,
+        )
+        assert key == "sk-from-vault"
+
+    def test_factory_audit_flags_source(self):
+        provider = _DictProvider({"OPENAI_API_KEY": "sk-from-vault"})
+        value, source = resolve_api_key(
+            "openai",
+            environ={},
+            secrets_provider=provider,
+            audit=True,
+        )
+        assert value == "sk-from-vault"
+        assert source == "factory"
+
+    def test_factory_whitespace_is_ignored(self):
+        """Provider returning blanks must not mask env fallback."""
+        provider = _DictProvider({"OPENAI_API_KEY": "   "})
+        key = resolve_api_key(
+            "openai",
+            environ={"OPENAI_API_KEY": "sk-env"},
+            secrets_provider=provider,
+        )
+        assert key == "sk-env"
+
+    def test_factory_tries_alternate_secret_ids(self):
+        """claude -> ANTHROPIC_API_KEY primary, CLAUDE_API_KEY alternate."""
+        provider = _DictProvider({
+            "ANTHROPIC_API_KEY": None,
+            "CLAUDE_API_KEY": "sk-legacy",
+        })
+        key = resolve_api_key(
+            "claude",
+            environ={},
+            secrets_provider=provider,
+        )
+        assert key == "sk-legacy"
+        # Resolver stopped after finding the alternate; no wasted calls.
+        assert provider.calls == ["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"]
+
+
+class TestEnvFallback:
+    def test_env_used_when_provider_empty(self):
+        provider = _DictProvider({})
+        key = resolve_api_key(
+            "openai",
+            environ={"OPENAI_API_KEY": "sk-env"},
+            secrets_provider=provider,
+        )
+        assert key == "sk-env"
+
+    def test_env_audit_source(self):
+        provider = _DictProvider({})
+        value, source = resolve_api_key(
+            "openai",
+            environ={"OPENAI_API_KEY": "sk-env"},
+            secrets_provider=provider,
+            audit=True,
+        )
+        assert value == "sk-env"
+        assert source == "environ"
+
+    def test_env_alternate_name_accepted(self):
+        """claude: primary ANTHROPIC_API_KEY missing, CLAUDE_API_KEY present."""
+        key = resolve_api_key(
+            "claude",
+            environ={"CLAUDE_API_KEY": "sk-legacy-env"},
+            secrets_provider=_DictProvider({}),
+        )
+        assert key == "sk-legacy-env"
+
+    def test_whitespace_env_is_treated_as_missing(self):
+        key = resolve_api_key(
+            "openai",
+            environ={"OPENAI_API_KEY": "   "},
+            secrets_provider=_DictProvider({}),
+        )
+        assert key == ""
+
+    def test_nothing_found_returns_empty(self):
+        key = resolve_api_key(
+            "openai",
+            environ={},
+            secrets_provider=_DictProvider({}),
+        )
+        assert key == ""
+
+    def test_nothing_found_audit_source_missing(self):
+        value, source = resolve_api_key(
+            "openai",
+            environ={},
+            secrets_provider=_DictProvider({}),
+            audit=True,
+        )
+        assert value == ""
+        assert source == "missing"
+
+
+class TestProviderFaultTolerance:
+    def test_provider_exception_falls_through_to_env(self):
+        """A broken vault backend must NOT take down the whole call-path."""
+        provider = _BrokenProvider()
+        key = resolve_api_key(
+            "openai",
+            environ={"OPENAI_API_KEY": "sk-env"},
+            secrets_provider=provider,
+        )
+        assert key == "sk-env"
+        # Resolver still attempted the factory before falling back.
+        assert provider.calls == ["OPENAI_API_KEY"]
+
+    def test_provider_exception_missing_everywhere_returns_empty(self):
+        provider = _BrokenProvider()
+        key = resolve_api_key(
+            "openai",
+            environ={},
+            secrets_provider=provider,
+        )
+        assert key == ""
+
+
+class TestDefaultProviderInjection:
+    def test_no_provider_uses_factory_from_env(self, monkeypatch):
+        """With SECRETS_PROVIDER unset, create_provider_from_env builds EnvSecretsProvider."""
+        monkeypatch.delenv("SECRETS_PROVIDER", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-real-env")
+        # No explicit environ/provider kwargs — default path.
+        key = resolve_api_key("openai")
+        assert key == "sk-real-env"
+
+    def test_missing_env_returns_empty_with_default_provider(self, monkeypatch):
+        monkeypatch.delenv("SECRETS_PROVIDER", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        key = resolve_api_key("openai")
+        assert key == ""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -480,9 +480,43 @@ class TestHandleLLMCall:
             })
             assert result["allowed"] is False
             assert "MISSING_API_KEY" in result["reason_codes"]
+            # B2: error message must surface the env candidates that were checked
+            # so operators know which variable to set (dual-read visibility).
+            assert "OPENAI_API_KEY" in result["error"]
         finally:
             if old is not None:
                 os.environ["OPENAI_API_KEY"] = old
+
+    def test_missing_api_key_reports_all_candidates(self, monkeypatch):
+        """B2: claude provider should mention both ANTHROPIC_API_KEY and CLAUDE_API_KEY."""
+        for name in ("ANTHROPIC_API_KEY", "CLAUDE_API_KEY"):
+            monkeypatch.delenv(name, raising=False)
+        result = handle_llm_call({
+            "messages": [{"role": "user", "content": "test"}],
+            "provider_id": "claude",
+            "model": "claude-3-5-sonnet-latest",
+        })
+        assert result["allowed"] is False
+        assert "MISSING_API_KEY" in result["reason_codes"]
+        assert "ANTHROPIC_API_KEY" in result["error"]
+        assert "CLAUDE_API_KEY" in result["error"]
+
+    def test_legacy_claude_env_var_accepted(self, monkeypatch):
+        """B2: pre-D0.3 deployments using CLAUDE_API_KEY must keep working."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("CLAUDE_API_KEY", "sk-legacy-abc")
+        # The call will still fail at build/execute since we are not wired up
+        # to a live provider, but it must NOT fail with MISSING_API_KEY —
+        # the resolver found the alternate env name and passed it through.
+        result = handle_llm_call({
+            "messages": [{"role": "user", "content": "test"}],
+            "provider_id": "claude",
+            "model": "claude-3-5-sonnet-latest",
+        })
+        # Either the call succeeds, or it fails at a later stage (network,
+        # auth rejection, etc.). Anything EXCEPT MISSING_API_KEY proves the
+        # dual-read path served the legacy env name.
+        assert "MISSING_API_KEY" not in result.get("reason_codes", [])
 
     def test_tool_definitions_include_llm_call(self):
         names = [td["name"] for td in TOOL_DEFINITIONS]


### PR DESCRIPTION
## Summary

Wires the orphaned `SecretsProvider` factory into the MCP LLM call path
via a dual-read resolver. Vault-backed deployments no longer have to
re-export every secret to env; env-only deployments keep working as-is.

- **Factory > env fallback** — provider faults fall through safely
- **Alternate env names** — pre-D0.3 names (CLAUDE_API_KEY, GEMINI_API_KEY, etc.) still accepted
- **Visibility** — MISSING_API_KEY error lists every env candidate that was checked
- **Typed overloads** — `audit=True` returns `(value, source)` for provenance logging

## Why

Per **CNS-20260414-005 D0.3**: `create_provider_from_env()` shipped months
ago but **0 call-sites** ever consulted it. All production code paths
bypassed the factory and read `os.environ` directly. A silent switch would
mask misconfigurations; a hard cutover would regress deployments still on
env-only setups. Dual-read lets both coexist during migration.

## What changed

| File | Change |
|---|---|
| `ao_kernel/_internal/secrets/api_key_resolver.py` | new — dual-read resolver + provider alias table |
| `ao_kernel/_internal/secrets/env_provider.py` | `_SECRET_ID_TO_ENV`: 1 → 9 entries |
| `ao_kernel/mcp_server.py` | `ao_llm_call` uses resolver; error surfaces all candidates |
| `tests/test_api_key_resolver.py` | new — 20 tests |
| `tests/test_mcp_server.py` | +2 regression tests (multi-candidate error, legacy env) |

## Backward compat

Every previously-working env setup stays working. The resolver only
**adds** the factory-first path; env fallback is identical to the
pre-D0.3 behavior. Unknown providers still default to `{PROVIDER}_API_KEY`.

## Test plan

- [x] `pytest tests/ -q` → **780/780** green (758 baseline + 22 new)
- [x] `ruff check ao_kernel/ tests/` → clean
- [x] `mypy ao_kernel/ --ignore-missing-imports` → 0 issues
- [x] Manual smoke: `resolve_api_key('claude', environ={'CLAUDE_API_KEY': 'x'})` → `'x'`
- [ ] CI required 6 checks pass on PR

## What this does NOT do (deferred)

`llm.build_request_with_context` and `client.llm_call` trust the
caller-supplied `api_key` param today — they never read env, so there's
no dual-read target yet. Tightening those requires a separate migration
pass (tracked for Tranche B follow-up, not blocking v2.3.0).

## References

- `.ao/consultations/responses/CNS-20260414-005.codex.response.v1.json` (D0.3)
- `ao_kernel/_internal/secrets/factory.py` (create_provider_from_env)
- Depends on **#59** (Tranche B / B1) for shared release

🤖 Generated with [Claude Code](https://claude.com/claude-code)