### PR TITLE
feat(evidence): MCP tool-call evidence log + writer fsync (B4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,10 @@ __marimo__/
 # Example projects: never commit the workspace state or secrets they create.
 examples/*/.ao/
 examples/*/.cache/
+
+# Evidence trail artifacts (per-run / per-day JSONL emitted by MCP + workflow paths)
+.ao/evidence/
+.ao/sessions/
+.ao/cache/
+# Smoke-test / dev artefact — never commit a nested .ao
+.ao/.ao/

--- a/ao_kernel/_internal/evidence/mcp_event_log.py
+++ b/ao_kernel/_internal/evidence/mcp_event_log.py
@@ -1,0 +1,188 @@
+"""MCP tool-call evidence log — append-only JSONL, one event per handler invocation.
+
+Per CLAUDE.md §2 invariant #2: "Her side-effect JSONL append-only log."
+Pre-B4 the five MCP tools returned envelopes but wrote NO evidence trail;
+operators had no way to audit what ran, when, or with what decision.
+
+Contract:
+    - Library mode (no .ao/) => no-op. Evidence is a workspace feature.
+    - Event payload is a snapshot of the handler's decision envelope
+      with sensitive fields redacted (messages, params with api_key
+      substrings, etc.) so the log is safe to ship to operators.
+    - Append failures are swallowed (debug-logged). Evidence must never
+      block the primary tool call — fail-open for the writer is the
+      correct choice under this invariant because the MCP response
+      itself is already delivered by the time we log.
+    - fsync after every append so a process crash cannot produce a
+      truncated JSONL line (integrity manifest would otherwise flag it).
+    - Daily rotation keeps a single file per UTC day; concurrent writers
+      on the same process append through the same open-and-close pattern
+      to minimize overlap.
+
+Path layout:
+    .ao/evidence/mcp/YYYY-MM-DD.jsonl
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+# Keys that may embed secrets or user content; their values are replaced with
+# a redaction marker before the event is serialised. Matches by case-insensitive
+# key name suffix.
+_REDACT_SUFFIXES = (
+    "api_key",
+    "apikey",
+    "token",
+    "password",
+    "secret",
+    "messages",
+    "message",
+    "content",
+    "prompt",
+    "query",
+)
+
+_REDACTED = "***REDACTED***"
+
+# Keys whose VALUES should never be written at all (e.g. raw tool params).
+_DROP_KEYS = frozenset({"params", "raw_messages"})
+
+_SECRET_VALUE_PATTERN = re.compile(r"(sk-[A-Za-z0-9]{16,}|gh[a-z]_[A-Za-z0-9]{16,})")
+
+
+def _should_redact(key: str) -> bool:
+    lowered = key.lower()
+    return any(lowered.endswith(suffix) for suffix in _REDACT_SUFFIXES)
+
+
+def _scrub(value: Any) -> Any:
+    """Recursive, conservative redaction — preserves structure for auditors."""
+    if isinstance(value, Mapping):
+        scrubbed: dict[str, Any] = {}
+        for k, v in value.items():
+            if k in _DROP_KEYS:
+                scrubbed[k] = _REDACTED
+                continue
+            if _should_redact(str(k)):
+                scrubbed[k] = _REDACTED
+                continue
+            scrubbed[k] = _scrub(v)
+        return scrubbed
+    if isinstance(value, list):
+        return [_scrub(item) for item in value]
+    if isinstance(value, str):
+        # Redact obvious secret-shaped substrings inside free-form text.
+        if _SECRET_VALUE_PATTERN.search(value):
+            return _SECRET_VALUE_PATTERN.sub(_REDACTED, value)
+        return value
+    return value
+
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _resolve_log_path(workspace: Path | None) -> Path | None:
+    """Library mode => None; otherwise compute daily-rotated path."""
+    if workspace is None:
+        return None
+    if not workspace.is_dir():
+        return None
+    return workspace / ".ao" / "evidence" / "mcp" / f"{_today_utc()}.jsonl"
+
+
+def record_mcp_event(
+    workspace: Path | None,
+    tool: str,
+    envelope: Mapping[str, Any],
+    *,
+    params: Mapping[str, Any] | None = None,
+    duration_ms: int | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> bool:
+    """Append a single MCP tool-call event to the daily JSONL log.
+
+    Args:
+        workspace: Workspace root (None => library mode => no-op).
+        tool: Tool identifier (e.g. "ao_llm_call").
+        envelope: Decision envelope returned to the caller. Redacted before write.
+        params: Optional params dict the handler received. Written under
+            ``params_shape`` (keys + types only, never values) so auditors can
+            reconstruct the call surface without leaking content.
+        duration_ms: Optional handler wall-time in milliseconds.
+        extra: Free-form additional fields merged into the event payload
+            (after redaction). Caller-supplied — keep metadata only.
+
+    Returns:
+        True when the event was durably appended (and fsynced), False on
+        no-op (library mode) or any write failure.
+    """
+    path = _resolve_log_path(workspace)
+    if path is None:
+        return False
+
+    event: dict[str, Any] = {
+        "ts": _now_iso(),
+        "tool": tool,
+        "allowed": bool(envelope.get("allowed", False)),
+        "decision": envelope.get("decision", "unknown"),
+        "reason_codes": list(envelope.get("reason_codes") or []),
+        "policy_ref": envelope.get("policy_ref"),
+        "api_version": envelope.get("api_version"),
+        "data_shape": _shape(envelope.get("data")),
+        "error": envelope.get("error"),
+    }
+    if duration_ms is not None:
+        event["duration_ms"] = int(duration_ms)
+    if params is not None:
+        event["params_shape"] = _shape(params)
+    if extra:
+        event.update(_scrub(dict(extra)))
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n"
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(line)
+            handle.flush()
+            try:
+                os.fsync(handle.fileno())
+            except OSError:
+                # fsync may fail on some filesystems (network FS, docker
+                # bind mounts). The write itself already landed; treat
+                # fsync failure as non-fatal and continue.
+                pass
+    except Exception as exc:  # noqa: BLE001 — evidence write is best-effort
+        logger.debug("mcp_event_log: append failed (%s) for %s", exc, tool)
+        return False
+    return True
+
+
+def _shape(value: Any) -> Any:
+    """Type-only projection — keys with type names, never values.
+
+    Used to record call-surface shape in evidence without leaking content.
+    """
+    if isinstance(value, Mapping):
+        return {str(k): type(v).__name__ for k, v in value.items()}
+    if isinstance(value, list):
+        return [type(item).__name__ for item in value[:10]]
+    if value is None:
+        return None
+    return type(value).__name__
+
+
+__all__ = ["record_mcp_event"]

--- a/ao_kernel/_internal/evidence/writer.py
+++ b/ao_kernel/_internal/evidence/writer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from ao_kernel._internal.shared.utils import write_text_atomic
 
 import json
+import os
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -35,13 +36,29 @@ def _now_iso() -> str:
 
 def _append_text(path: Path, text: str) -> None:
     normalized = text if text.endswith("\n") else (text + "\n")
+    path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
         handle.write(normalized)
+        handle.flush()
+        try:
+            os.fsync(handle.fileno())
+        except OSError:
+            # fsync may be unsupported on the target filesystem (network FS,
+            # docker bind mounts). The write itself has already landed in the
+            # page cache; treat as non-fatal so integrity verification stays
+            # the authoritative check.
+            pass
 
 
 def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+        handle.flush()
+        try:
+            os.fsync(handle.fileno())
+        except OSError:
+            pass
 
 
 def _git_commit_and_dirty(workspace: Path) -> tuple[str, bool]:

--- a/ao_kernel/mcp_server.py
+++ b/ao_kernel/mcp_server.py
@@ -33,10 +33,20 @@ _API_VERSION = "0.1.0"
 
 
 def _find_workspace_root() -> Path | None:
-    """Find workspace root for context operations. Returns Path or None."""
+    """Return the project root (directory that CONTAINS ``.ao/``), not ``.ao`` itself.
+
+    ``config.workspace_root()`` returns the ``.ao`` directory by design, but
+    MCP context helpers (evidence, tool gateway, session save) all expect the
+    project root — the directory under which ``.ao/evidence/``, ``.ao/sessions/``,
+    and ``.ao/cache/`` live. Resolving to ``.parent`` once keeps the rest of
+    this module aligned with AoKernelClient.workspace_root semantics.
+    """
     from ao_kernel.config import workspace_root
     ws = workspace_root()
-    return Path(ws) if ws else None
+    if ws is None:
+        return None
+    ws_path = Path(ws)
+    return ws_path.parent if ws_path.name == ".ao" else ws_path
 
 
 # ── Decision Envelope ───────────────────────────────────────────────
@@ -525,12 +535,45 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
     },
 ]
 
+def _with_evidence(tool_name: str, handler: Any) -> Any:
+    """Wrap a raw handler so every dispatched call records a JSONL event.
+
+    Direct handler imports (tests, SDK smoke code) bypass the wrapper and
+    therefore stay silent — evidence is only emitted when a tool is invoked
+    through TOOL_DISPATCH or the ToolGateway, i.e. on the real MCP path.
+    Evidence write failures never propagate (fail-open, §2 invariant #2).
+    """
+    import functools
+    import time
+
+    @functools.wraps(handler)
+    def wrapped(params: dict[str, Any]) -> dict[str, Any]:
+        start = time.monotonic()
+        envelope: dict[str, Any] = handler(params)
+        duration_ms = int((time.monotonic() - start) * 1000)
+        try:
+            from ao_kernel._internal.evidence.mcp_event_log import record_mcp_event
+            ws = _find_workspace_root()
+            record_mcp_event(
+                ws,
+                tool_name,
+                envelope,
+                params=params if isinstance(params, dict) else None,
+                duration_ms=duration_ms,
+            )
+        except Exception:  # noqa: BLE001 — evidence is side-channel
+            pass
+        return envelope
+
+    return wrapped
+
+
 TOOL_DISPATCH = {
-    "ao_policy_check": handle_policy_check,
-    "ao_llm_route": handle_llm_route,
-    "ao_llm_call": handle_llm_call,
-    "ao_quality_gate": handle_quality_gate,
-    "ao_workspace_status": handle_workspace_status,
+    "ao_policy_check": _with_evidence("ao_policy_check", handle_policy_check),
+    "ao_llm_route": _with_evidence("ao_llm_route", handle_llm_route),
+    "ao_llm_call": _with_evidence("ao_llm_call", handle_llm_call),
+    "ao_quality_gate": _with_evidence("ao_quality_gate", handle_quality_gate),
+    "ao_workspace_status": _with_evidence("ao_workspace_status", handle_workspace_status),
 }
 
 

--- a/tests/test_mcp_dispatch_evidence.py
+++ b/tests/test_mcp_dispatch_evidence.py
@@ -1,0 +1,105 @@
+"""Integration tests for MCP evidence emission (B4).
+
+Verifies that dispatching a tool through TOOL_DISPATCH writes an event
+to the workspace evidence log, while direct handler imports stay silent
+(tests + SDK callers don't pollute evidence).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ao_kernel.mcp_server import (
+    TOOL_DISPATCH,
+    handle_workspace_status,
+    handle_policy_check,
+)
+
+
+def _init_workspace(path: Path) -> Path:
+    (path / ".ao").mkdir()
+    (path / ".ao" / "workspace.json").write_text(
+        json.dumps({"version": "v2", "kind": "ao-kernel"})
+    )
+    return path
+
+
+def _log_lines(workspace: Path) -> list[dict]:
+    mcp_dir = workspace / ".ao" / "evidence" / "mcp"
+    if not mcp_dir.is_dir():
+        return []
+    files = list(mcp_dir.glob("*.jsonl"))
+    if not files:
+        return []
+    return [json.loads(line) for line in files[0].read_text().splitlines()]
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    ws = _init_workspace(tmp_path)
+    monkeypatch.chdir(ws)
+    return ws
+
+
+class TestDispatchEmitsEvidence:
+    def test_workspace_status_logs_event(self, workspace):
+        dispatched = TOOL_DISPATCH["ao_workspace_status"]
+        envelope = dispatched({"workspace_root": str(workspace)})
+        assert envelope["api_version"] == "0.1.0"
+        events = _log_lines(workspace)
+        assert len(events) == 1
+        assert events[0]["tool"] == "ao_workspace_status"
+        assert events[0]["allowed"] is True
+        assert "duration_ms" in events[0]
+
+    def test_policy_check_logs_deny_envelope(self, workspace):
+        dispatched = TOOL_DISPATCH["ao_policy_check"]
+        envelope = dispatched({})  # missing policy_name -> deny
+        assert envelope["allowed"] is False
+        events = _log_lines(workspace)
+        assert len(events) == 1
+        assert events[0]["tool"] == "ao_policy_check"
+        assert events[0]["decision"] == "deny"
+        assert "MISSING_POLICY_NAME" in events[0]["reason_codes"]
+
+
+class TestDirectHandlerStaysSilent:
+    """Direct imports must NOT emit evidence — keeps unit tests clean."""
+
+    def test_direct_handle_policy_check_does_not_write(self, workspace):
+        handle_policy_check({})
+        assert _log_lines(workspace) == []
+
+    def test_direct_handle_workspace_status_does_not_write(self, workspace):
+        handle_workspace_status({"workspace_root": str(workspace)})
+        assert _log_lines(workspace) == []
+
+
+class TestParamsRedactedInEvent:
+    def test_params_shape_excludes_api_key_value(self, workspace):
+        dispatched = TOOL_DISPATCH["ao_policy_check"]
+        # Policy check will deny because the action is invalid; what we
+        # care about here is that the api_key VALUE never lands in the log.
+        # Construct fake token at runtime to keep the source file free of
+        # pre-commit secret patterns.
+        fake_key = "sk-" + ("e" * 20)
+        dispatched({
+            "policy_name": "policy_autonomy.v1.json",
+            "action": {"intent": "x", "mode": "autonomous"},
+            "workspace_root": str(workspace),
+            "api_key": fake_key,
+        })
+        log_dir = workspace / ".ao" / "evidence" / "mcp"
+        files = list(log_dir.glob("*.jsonl"))
+        # Even the file should not contain the raw key string.
+        assert files, "dispatch should have written a log line"
+        text = files[0].read_text()
+        assert fake_key not in text
+        events = [json.loads(line) for line in text.splitlines()]
+        # params_shape records types, not values.
+        shape = events[0]["params_shape"]
+        assert shape["api_key"] == "str"
+        assert shape["policy_name"] == "str"

--- a/tests/test_mcp_event_log.py
+++ b/tests/test_mcp_event_log.py
@@ -1,0 +1,164 @@
+"""Tests for ao_kernel._internal.evidence.mcp_event_log (B4).
+
+Covers:
+  - Library mode no-op
+  - Daily-rotated path layout
+  - Redaction of sensitive fields + secret-shaped substrings
+  - Params shape projection (types only, no values)
+  - Append semantics (new file, existing file, JSON parse)
+  - Fail-open on disk errors
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ao_kernel._internal.evidence.mcp_event_log import record_mcp_event
+
+
+class TestLibraryModeNoop:
+    def test_none_workspace_returns_false(self):
+        ok = record_mcp_event(None, "ao_policy_check", {"allowed": True})
+        assert ok is False
+
+    def test_missing_workspace_dir_returns_false(self, tmp_path):
+        ghost = tmp_path / "does-not-exist"
+        ok = record_mcp_event(ghost, "ao_policy_check", {"allowed": True})
+        assert ok is False
+
+
+class TestPathLayout:
+    def test_creates_daily_rotated_jsonl(self, tmp_path):
+        ok = record_mcp_event(
+            tmp_path,
+            "ao_workspace_status",
+            {"allowed": True, "decision": "allow", "api_version": "0.1.0"},
+        )
+        assert ok is True
+        mcp_dir = tmp_path / ".ao" / "evidence" / "mcp"
+        assert mcp_dir.is_dir()
+        files = list(mcp_dir.glob("*.jsonl"))
+        assert len(files) == 1
+        # Name format YYYY-MM-DD.jsonl
+        stem = files[0].stem
+        assert len(stem) == 10 and stem[4] == "-" and stem[7] == "-"
+
+
+class TestEventShape:
+    def test_event_is_valid_json(self, tmp_path):
+        envelope = {
+            "allowed": True,
+            "decision": "allow",
+            "reason_codes": ["OK"],
+            "policy_ref": "policy_x.v1.json",
+            "api_version": "0.1.0",
+            "data": {"nested": 1},
+            "error": None,
+        }
+        record_mcp_event(tmp_path, "ao_policy_check", envelope, duration_ms=42)
+        log_file = next((tmp_path / ".ao" / "evidence" / "mcp").glob("*.jsonl"))
+        lines = log_file.read_text().splitlines()
+        assert len(lines) == 1
+        event = json.loads(lines[0])
+        assert event["tool"] == "ao_policy_check"
+        assert event["allowed"] is True
+        assert event["decision"] == "allow"
+        assert event["reason_codes"] == ["OK"]
+        assert event["policy_ref"] == "policy_x.v1.json"
+        assert event["api_version"] == "0.1.0"
+        assert event["duration_ms"] == 42
+        assert "ts" in event and event["ts"].endswith("Z")
+
+    def test_data_shape_projection_is_type_only(self, tmp_path):
+        envelope = {
+            "allowed": True,
+            "decision": "allow",
+            "data": {"count": 3, "items": [1, 2, 3], "flag": True},
+        }
+        record_mcp_event(tmp_path, "t", envelope)
+        log_file = next((tmp_path / ".ao" / "evidence" / "mcp").glob("*.jsonl"))
+        event = json.loads(log_file.read_text())
+        # Projection: keys preserved, values replaced with type names.
+        assert event["data_shape"] == {"count": "int", "items": "list", "flag": "bool"}
+
+    def test_params_shape_is_type_only(self, tmp_path):
+        # Build fake at runtime (see test_extra_redacts_sensitive_keys).
+        fake_key = "sk-" + ("d" * 20)
+        params = {"provider_id": "openai", "api_key": fake_key}
+        record_mcp_event(tmp_path, "t", {"allowed": True}, params=params)
+        log_file = next((tmp_path / ".ao" / "evidence" / "mcp").glob("*.jsonl"))
+        event = json.loads(log_file.read_text())
+        assert event["params_shape"] == {"provider_id": "str", "api_key": "str"}
+        # Raw content must not appear anywhere in the serialised event.
+        assert fake_key not in log_file.read_text()
+
+
+class TestRedaction:
+    def test_extra_redacts_sensitive_keys(self, tmp_path):
+        # Construct fake secret at runtime so the source file itself does not
+        # contain a pattern the pre-commit guard would flag.
+        fake_key = "sk-" + ("a" * 20)
+        record_mcp_event(
+            tmp_path, "t", {"allowed": True},
+            extra={"api_key": fake_key, "normal_key": "visible"},
+        )
+        text = (next((tmp_path / ".ao" / "evidence" / "mcp").glob("*.jsonl"))).read_text()
+        assert fake_key not in text
+        assert "***REDACTED***" in text
+        assert "visible" in text  # non-sensitive keys preserved
+
+    def test_extra_redacts_secret_shaped_substrings(self, tmp_path):
+        fake_key = "sk-" + ("b" * 20)
+        record_mcp_event(
+            tmp_path, "t", {"allowed": True},
+            extra={"note": f"leaked {fake_key} during test"},
+        )
+        text = (next((tmp_path / ".ao" / "evidence" / "mcp").glob("*.jsonl"))).read_text()
+        assert fake_key not in text
+        assert "***REDACTED***" in text
+
+    def test_nested_mapping_redacted(self, tmp_path):
+        fake_token = "ghp_" + ("c" * 20)
+        record_mcp_event(
+            tmp_path, "t", {"allowed": True},
+            extra={"auth": {"token": fake_token, "scheme": "bearer"}},
+        )
+        event = json.loads((next((tmp_path / ".ao" / "evidence" / "mcp").glob("*.jsonl"))).read_text())
+        assert event["auth"]["token"] == "***REDACTED***"
+        assert event["auth"]["scheme"] == "bearer"
+
+    def test_messages_key_redacted(self, tmp_path):
+        record_mcp_event(
+            tmp_path, "t", {"allowed": True},
+            extra={"messages": [{"role": "user", "content": "private user text"}]},
+        )
+        text = (next((tmp_path / ".ao" / "evidence" / "mcp").glob("*.jsonl"))).read_text()
+        assert "private user text" not in text
+
+
+class TestAppendSemantics:
+    def test_multiple_events_append_to_same_file(self, tmp_path):
+        for i in range(3):
+            record_mcp_event(tmp_path, "t", {"allowed": True, "data": {"i": i}})
+        log_file = next((tmp_path / ".ao" / "evidence" / "mcp").glob("*.jsonl"))
+        lines = log_file.read_text().splitlines()
+        assert len(lines) == 3
+        # Every line is a complete JSON object (integrity check).
+        for line in lines:
+            json.loads(line)
+
+
+class TestFailOpen:
+    def test_write_failure_returns_false_and_does_not_raise(self, tmp_path, monkeypatch):
+        # Force the Path.open call to blow up — simulating a readonly FS.
+        original_open = Path.open
+
+        def boom(self, *a, **k):
+            if self.suffix == ".jsonl":
+                raise OSError("simulated readonly")
+            return original_open(self, *a, **k)
+
+        monkeypatch.setattr(Path, "open", boom)
+        ok = record_mcp_event(tmp_path, "t", {"allowed": True})
+        assert ok is False

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -491,7 +491,10 @@ class TestHandleLLMCall:
 
     def test_dispatch_includes_llm_call(self):
         assert "ao_llm_call" in TOOL_DISPATCH
-        assert TOOL_DISPATCH["ao_llm_call"] is handle_llm_call
+        # B4: dispatch entries are evidence-wrapped; verify the underlying
+        # handler via __wrapped__ (populated by functools.wraps).
+        dispatched = TOOL_DISPATCH["ao_llm_call"]
+        assert getattr(dispatched, "__wrapped__", dispatched) is handle_llm_call
 
 
 class TestQualityGatePreviousDecisions:


### PR DESCRIPTION
## Summary

Closes the Tranche B evidence-wiring gap. The five MCP tool handlers
returned decision envelopes but wrote **no** evidence — a direct
violation of CLAUDE.md §2 invariant #2.

- **New module** `ao_kernel/_internal/evidence/mcp_event_log.py` — daily JSONL, redacted, fsynced, fail-open
- **Wrapper** `TOOL_DISPATCH` entries pass through `_with_evidence()` — dispatched calls emit events, direct handler imports stay silent
- **Writer robustness** `_append_text` / `_append_jsonl` → `flush() + fsync()` + atomic parent mkdir
- **Path fix** `_find_workspace_root()` normalizes `.ao` → project root
- **.gitignore** `.ao/evidence/`, `.ao/sessions/`, `.ao/cache/`, `.ao/.ao/`

## Why this shape

- **Daily rotation** (`YYYY-MM-DD.jsonl`) keeps files bounded; operators can archive by date
- **Shape projection** (`params_shape`, `data_shape`: types only) lets auditors see the call surface without leaking content
- **Redaction** (`api_key`, `token`, `messages`, etc. + `sk-/ghp_` substring scrubber) mirrors production secret patterns
- **Fail-open** evidence failures NEVER block tool responses — CLAUDE.md §7 says fail-closed applies to governance paths, opt-in subsystems like evidence stay graceful

## Test plan

- [x] `pytest tests/ -q` → **775/775** green (758 baseline + 17 new)
- [x] `ruff check ao_kernel/ tests/` → clean
- [x] `mypy ao_kernel/ --ignore-missing-imports` → 0 issues
- [x] Smoke: dispatched `ao_workspace_status` → JSONL file created, event parseable, duration_ms recorded
- [x] Pre-commit hook secret guard: fake tokens constructed at runtime (not source literals)
- [ ] CI required 6 checks pass

## What this does NOT do

- No integration with `EvidenceWriter.run_dir` — that's workflow-run-scoped, different surface
- No retention / rotation pruning — operators archive old files out-of-band

## References

- `CLAUDE.md §2` invariant #2 (append-only JSONL evidence)
- Depends on **#59** (B1) and **#60** (B2) for shared release

🤖 Generated with [Claude Code](https://claude.com/claude-code)