### PR TITLE
docs(plan): handoff v2 for Tranche C onboarding

### DIFF
--- a/.claude/plans/SESSION-HANDOFF-2026-04-14-v2.md
+++ b/.claude/plans/SESSION-HANDOFF-2026-04-14-v2.md
@@ -1,0 +1,187 @@
+# Session Handoff — 2026-04-14 v2 (post v2.3.0)
+
+## TL;DR
+
+**ao-kernel v2.3.0 is live on PyPI.** Tranş B closed — every scaffold from
+v2.2.0 now has a wired production path. Three adversarial Codex consultations
+(CNS-007, CNS-008, CNS-009) surfaced 12 blocking + 7 warning objections;
+every one was grep-verified and absorbed. Next session picks up **Tranş C
+(v3.0.0) — coverage campaign + deferred scope items**.
+
+---
+
+## This Session's Ledger
+
+### Merged to main (6 PRs)
+
+| PR | Scope | CI | Rebase work |
+|---|---|---|---|
+| #59 | B1 — Vector store + embedding config + sidecar write (CNS-007) | 7/7 ✓ | BEHIND → rebase clean |
+| #60 | B2 — Secrets dual-read resolver (CNS-005 D0.3) | 7/7 ✓ | BEHIND → rebase clean |
+| #61 | B4 — MCP tool evidence trail + writer fsync | 7/7 ✓ | — |
+| #62 | B3 — Extension loader + dispatch + PRJ-HELLO (CNS-008) | 7/7 ✓ | `client.py` 3-way conflict → resolved |
+| #63 | B5 — Agent coord SDK + contract fixes (CNS-009) | 7/7 ✓ | `.gitignore` conflict → resolved |
+| #64 | Release v2.3.0 | 7/7 ✓ | — |
+
+All CI passes were **first attempt**. Every PR opened via the M2 merge
+pattern (protection approval=0 → merge → approval=1).
+
+### Measurable deltas
+
+| Metric | v2.2.0 | v2.3.0 |
+|---|---|---|
+| Tests | 758 | **896** (+138) |
+| New modules | — | `vector_store_resolver`, `embedding_config`, `semantic_indexer`, `api_key_resolver`, `mcp_event_log`, `extensions/dispatch`, `extensions/bootstrap`, `extensions/handlers/prj_hello` |
+| Coverage on new B1 modules | — | 91% |
+| CNS adversarial rounds | 6 to date | 9 to date (+3) |
+| Codex objections absorbed | 19 total | 38 total (+19 from CNS-007/008/009) |
+| Breaking changes (semver) | — | Minor (`agent_coordination` contract tightened) |
+
+### Bug hunt harvest
+
+Codex's grep-verified objections surfaced real contract bugs that had to
+land BEFORE the SDK surface froze:
+
+1. `record_decision(auto_promote=False)` silently wrote a short-TTL
+   canonical entry — flag/behavior mismatch. Fixed: below-threshold now
+   writes to session context or reports `destination="dropped"`.
+2. `finalize_session_sdk` double-promoted (session_lifecycle.end_session
+   already promoted at 0.7, then ran `promote_from_ephemeral` again with
+   caller-supplied threshold). Fixed: `end_session` takes the params,
+   single promotion pass, flag honored.
+3. `context_compiler` never reached the embedding pipeline
+   (`semantic_search(api_key="")` always returned empty). Fixed by
+   threading `embedding_config` + `vector_store` through
+   `compile_context` / `build_request_with_context`.
+4. `pgvector` table schema had no model namespace — model upgrades would
+   mingle incompatible embedding spaces silently. Fixed: `embedding_model`
+   column + BTREE index + store-side reject + search-side filter.
+5. Extension loader was lossy (owner/ui_surfaces/compat dropped, schema-
+   invalid manifests accepted). Fixed: lossless parse + jsonschema
+   validation.
+6. `get_revision()` truncated SHA-256 to 16 chars for no reason —
+   zero-cost, would-be public-contract lock-in. Fixed: full 64-char
+   opaque token.
+
+---
+
+## Next Session Boot Checklist
+
+### 1. Read first (in order)
+
+```
+~/.claude/projects/-Users-halilkocoglu-Documents-ao-kernel/memory/MEMORY.md
+~/.claude/projects/-Users-halilkocoglu-Documents-ao-kernel/memory/project_origin.md
+~/.claude/projects/-Users-halilkocoglu-Documents-ao-kernel/memory/feedback_codex_consultations.md
+.claude/plans/FAZ5-MASTER-PLAN.md
+.claude/plans/SESSION-HANDOFF-2026-04-14-v2.md    ← this doc
+```
+
+### 2. Verify state
+
+```bash
+git log -1 --format="%h %s"        # 794e5f5 Merge pull request #64 ...
+git status --short                  # empty
+python3 -m pytest --co -q | tail -1 # 896 tests collected
+mypy ao_kernel/ 2>&1 | tail -1      # Success: no issues
+ruff check ao_kernel/ tests/        # All checks passed
+gh api repos/Halildeu/ao-kernel/branches/main/protection --jq .required_status_checks.contexts
+# → ["lint","test (3.11)","test (3.12)","test (3.13)","coverage","typecheck"]
+python3 -c "import ao_kernel; print(ao_kernel.__version__)"  # 2.3.0
+```
+
+### 3. Next target — **Tranş C (v3.0.0) — Coverage + Deferred Scope**
+
+Tranş C rolls up every "deferred" item that fell outside the Tranş B
+scope fences. It is intentionally larger than B because the work is
+spread across many smaller modules.
+
+| # | Work item | CNS? | Notes |
+|---|---|---|---|
+| **C1** | `_internal/*` mypy coverage (D13 phased) | — | `pyproject.toml` overrides, remove `ignore_errors=true` per module |
+| **C2** | `evidence/writer.py` coverage 28% → 85% | — | run_dir flow tests + fail-open paths |
+| **C3** | `workspace.py` coverage 46% → 85% | — | find_root edge cases, init() idempotency |
+| **C4** | `context_store.py` coverage 51% → 85% | — | compaction edges, prune_expired race |
+| **C5** | Multi-tenant FS lock / CAS on canonical store | **CNS-010** | advisory-only today; lost-update risk real for multi-agent |
+| **C6** | MCP `ao_memory_*` tools (read/write) | **CNS-011** | scope-creep flagged in CNS-009; needs dedicated governance |
+| **C7** | Extension handler backfill (17 bundled manifests) | — | one reference handler (PRJ-HELLO) lives today; others wait for their code |
+| **C8** | CLI subprocess + concurrency tests | — | currently untested surface |
+
+### 4. Starting Tranş C — suggested order
+
+The fences in CNS-009 and CNS-008 both flagged these follow-ups; they
+are documentation gaps as much as implementation. Suggested sequence:
+
+1. `claude/tranche-c-mypy` from `origin/main` — C1 is a precondition for
+   every other Tranş C coverage gate (without `_internal/*` mypy clean
+   the coverage deltas are moot).
+2. C5 (FS lock) **before** C6 (MCP memory tools) — the MCP write surface
+   should never land without the underlying lock discipline first.
+3. C2/C3/C4 (coverage) can interleave with C5/C6 implementation.
+4. C7 (extension backfill) is opportunistic — each handler lands as its
+   extension's code comes online.
+5. C8 (CLI tests) closes last.
+
+### 5. Long-term items (outside Tranş C)
+
+These are still valid for post-v3.0.0 planning:
+
+- **Vision / audio implementation** — registry currently marks every
+  provider as `unsupported` for these capabilities. Dedicated CNS
+  needed before implementation.
+- **Async / await refactor** — would revise D9 (sync SDK surface).
+- **Automatic tool-use loop** — CNS-005 D0.2 captured the design brief;
+  no code yet.
+- **Prompt experiment framework (A/B, canary)** — product call pending.
+
+---
+
+## Technical Debts (acknowledged, not in Tranş C)
+
+| Debt | Where | Who/When |
+|---|---|---|
+| `mcp_server.py` a few `# type: ignore[no-untyped-call,untyped-decorator]` | 4 lines | Wait for upstream MCP SDK typing |
+| `AoKernelClient.compile_context_sdk` does not surface the same cache key semantics as `llm_call` | Follow-up polish | post-v3.0.0 |
+| Revision-based stale detection is advisory; no atomic CAS | `agent_coordination` | Tranş C / CNS-010 |
+| Vector store write-path has no retry on transient failures | `semantic_indexer` | only debug log today |
+
+None of these surface to users of the v2.3.0 SDK today.
+
+---
+
+## User Preferences (re-confirmed this session)
+
+- **Language:** Turkish replies, English code/commits/comments (CLAUDE.md §16)
+- **Plan-first:** CNS for architectural decisions, revise-then-implement
+- **Adversarial consensus:** Codex gets counter-party prompt, Claude
+  verifies every objection with grep before accepting/rejecting
+- **M2 merge pattern:** self-approve blocked → temporary approval=0
+  window → merge → approval=1 back (repeated for each PR in Tranş B)
+- **Structural fix > relaxation:** prefer fixing the underlying issue
+  over loosening gates (pyproject relaxation rejected during A3)
+- **Real gates:** typecheck is a blocking CI check, not cosmetic
+
+---
+
+## Uncommitted / Open PR
+
+- Uncommitted: none
+- Open PR: none
+- Branches on remote: `claude/tranche-b*`, `claude/release-v2.3.0`
+  (all merged, deletion optional cleanup)
+- v2.3.0 tag: live, PyPI published, GitHub release notes up
+
+---
+
+## Session Health — Final Check
+
+- [x] v2.3.0 on PyPI (2026-04-14 13:17 UTC)
+- [x] GitHub release notes published
+- [x] Main branch `794e5f5`, branch protection restored to approval=1
+- [x] Tag `v2.3.0` protected (ruleset 15043973)
+- [x] Memory up to date (project_origin + MEMORY.md index)
+- [x] All 6 CI checks required and enforced for admins
+- [x] 896/896 tests green, mypy strict 0, ruff 0
+- [x] This handoff doc written (CNS memory paths, Tranş C plan)
+
+**Next session can start Tranş C with zero ambiguity.**


### PR DESCRIPTION
Successor to the 2026-04-14 handoff. Documents v2.3.0 ship, Tranche B ledger, contract changes, and Tranche C plan (C1-C8 with suggested order). See file for full content.