### PR TITLE
feat(canonical): CAS mutators + FS lock + unique tmp + fail-closed load (C5a, CNS-010)

### DIFF
--- a/ao_kernel/_internal/shared/lock.py
+++ b/ao_kernel/_internal/shared/lock.py
@@ -1,0 +1,128 @@
+"""Platform-neutral filesystem lock — POSIX-only, Windows fail-closed.
+
+Per CNS-20260414-010 consensus:
+    - Core dependency line is preserved (only jsonschema is required).
+    - Platform-neutral claim is deliberately NOT over-promised: Windows
+      raises :class:`NotImplementedError` explicitly rather than failing
+      open with a no-op "lock." Windows support is tracked for Tranche D.
+    - POSIX path uses ``fcntl.flock(fd, LOCK_EX)`` on a sidecar lockfile
+      so the primary data file never holds an OS advisory lock tied to a
+      file descriptor we also use for reads.
+
+Public API is the :func:`file_lock` context manager:
+
+    from ao_kernel._internal.shared.lock import file_lock
+
+    with file_lock(workspace_root / ".ao" / "canonical_decisions.v1.lock"):
+        # Mutate canonical store — exclusive access guaranteed.
+        ...
+
+Callers that want to know whether locking is supported on this platform
+(e.g. to emit a clear error at startup instead of at write time) can call
+:func:`lock_supported`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+
+class LockTimeoutError(TimeoutError):
+    """Raised when :func:`file_lock` cannot acquire within its deadline."""
+
+
+class LockPlatformNotSupported(NotImplementedError):
+    """Raised when the host OS does not expose the lock primitives we use."""
+
+
+def lock_supported() -> bool:
+    """Return True on platforms where :func:`file_lock` is implemented.
+
+    Currently POSIX-only. Windows support is deferred to Tranche D
+    (v3.1.0); see :class:`LockPlatformNotSupported` for the error path
+    callers see if they try to use the lock on an unsupported platform.
+    """
+    return sys.platform != "win32"
+
+
+@contextlib.contextmanager
+def file_lock(
+    lockfile: Path,
+    *,
+    timeout: float = 5.0,
+    poll_interval: float = 0.05,
+) -> Iterator[None]:
+    """Acquire an exclusive advisory lock on *lockfile*.
+
+    The lockfile is created on demand (``O_CREAT``); it is a sidecar path
+    — typically ``<target>.lock`` — not the file you are mutating. Keeping
+    the lock separate means readers of the data file never need to open
+    the lockfile, and fs-scoped tools (grep, rsync) see a clean data file.
+
+    Args:
+        lockfile: Path to the advisory lock file. Created if missing.
+        timeout: Maximum seconds to wait for the lock before raising.
+        poll_interval: Sleep between acquisition attempts. Kept small
+            enough that typical short-held locks return promptly.
+
+    Raises:
+        LockPlatformNotSupported: When the host OS is not POSIX.
+        LockTimeoutError: When *timeout* elapses before the lock can be
+            acquired. Callers handle this as fail-closed — the underlying
+            mutation must not proceed.
+    """
+    if sys.platform == "win32":
+        raise LockPlatformNotSupported(
+            "Filesystem lock requires POSIX fcntl; Windows support is "
+            "planned for v3.1.0 (Tranche D)."
+        )
+
+    # Deferred import keeps the module importable on Windows for the
+    # lock_supported() / exception path above.
+    import fcntl
+
+    lockfile.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lockfile), os.O_CREAT | os.O_RDWR, 0o600)
+
+    deadline = time.monotonic() + max(0.0, timeout)
+    acquired = False
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise LockTimeoutError(
+                        f"Could not acquire lock on {lockfile} within {timeout}s"
+                    )
+                time.sleep(poll_interval)
+        yield
+    finally:
+        if acquired:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError as exc:
+                # Lock release failure cannot block the caller's exit path.
+                logger.warning("lock release failed for %s: %s", lockfile, exc)
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+__all__ = [
+    "file_lock",
+    "lock_supported",
+    "LockTimeoutError",
+    "LockPlatformNotSupported",
+]

--- a/ao_kernel/_internal/shared/utils.py
+++ b/ao_kernel/_internal/shared/utils.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -44,25 +45,64 @@ def write_json_atomic(path: Path, data: Any, *, indent: int = 2) -> None:
 
 
 def write_text_atomic(path: Path, content: str) -> None:
-    """Write *content* to *path* atomically via tmp-file + fsync + rename."""
+    """Write *content* to *path* atomically via unique tmp-file + fsync + rename.
+
+    Uses ``tempfile.mkstemp`` so each writer gets a process-unique tmp name
+    (``<stem>.<pid>.<random>.tmp``) inside the target directory. Prevents
+    the concurrent-writer collision that a fixed ``.tmp`` suffix would
+    allow — CNS-20260414-010 iter-1 blocking-1.
+
+    The fsync + rename semantics are unchanged: ``os.replace`` is atomic on
+    POSIX within the same filesystem, so readers never observe a partial
+    write.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    with tmp.open("w", encoding="utf-8") as f:
-        f.write(content)
-        f.flush()
-        os.fsync(f.fileno())
-    tmp.replace(path)
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        # Best-effort cleanup; rename failed so the tmp file is still ours.
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        raise
 
 
 def write_bytes_atomic(path: Path, data: bytes) -> None:
-    """Write *data* bytes to *path* atomically via tmp-file + fsync + rename."""
+    """Write *data* bytes to *path* atomically via unique tmp-file + fsync + rename.
+
+    See :func:`write_text_atomic` for the concurrency rationale; identical
+    mechanism, bytes mode.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    with tmp.open("wb") as f:
-        f.write(data)
-        f.flush()
-        os.fsync(f.fileno())
-    tmp.replace(path)
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(tmp_fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        raise
 
 
 # ── Time ──────────────────────────────────────────────────────────────

--- a/ao_kernel/context/canonical_store.py
+++ b/ao_kernel/context/canonical_store.py
@@ -22,14 +22,21 @@ temporary decisions. The promotion flow is:
 
 from __future__ import annotations
 
+import hashlib
 import json
+import warnings
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
+from ao_kernel._internal.shared.lock import file_lock, lock_supported
 from ao_kernel._internal.shared.utils import write_json_atomic
+from ao_kernel.errors import (
+    CanonicalRevisionConflict,
+    CanonicalStoreCorruptedError,
+)
 
 
 def _now_iso() -> str:
@@ -67,24 +74,201 @@ def _store_path(workspace_root: Path) -> Path:
     return workspace_root / "canonical_decisions.v1.json"
 
 
+def _lock_path(workspace_root: Path) -> Path:
+    """Sidecar lockfile path for CAS writes."""
+    return _store_path(workspace_root).with_suffix(".v1.json.lock")
+
+
+def _empty_store() -> dict[str, Any]:
+    return {"version": "v1", "decisions": {}, "facts": {}, "updated_at": _now_iso()}
+
+
+def store_revision(store: dict[str, Any]) -> str:
+    """Return the canonical revision token for a store snapshot.
+
+    Full SHA-256 hex digest of the sort-key JSON serialization. Callers
+    treat the value as opaque. Same contract as
+    :func:`ao_kernel.context.agent_coordination.get_revision`.
+    """
+    payload = json.dumps(store, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
 def load_store(workspace_root: Path) -> dict[str, Any]:
-    """Load canonical decision store. Returns empty store if not found."""
+    """Load canonical decision store.
+
+    Empty-store semantics:
+        - File absent -> return a fresh empty store (normal first-write path).
+        - File present but unreadable / unparseable / wrong shape -> raise
+          :class:`CanonicalStoreCorruptedError`.
+
+    CNS-20260414-010 iter-2 blocking: the previous silent-empty fallback
+    masked data loss. Callers that truly want empty-on-corruption must
+    catch the exception explicitly and decide whether to repair, archive,
+    or reset.
+    """
     path = _store_path(workspace_root)
     if not path.exists():
-        return {"version": "v1", "decisions": {}, "facts": {}, "updated_at": _now_iso()}
+        return _empty_store()
     try:
-        parsed = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return {"version": "v1", "decisions": {}, "facts": {}, "updated_at": _now_iso()}
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CanonicalStoreCorruptedError(
+            f"Cannot read canonical store at {path}: {exc}"
+        ) from exc
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CanonicalStoreCorruptedError(
+            f"Canonical store JSON at {path} is invalid: {exc}"
+        ) from exc
     if not isinstance(parsed, dict):
-        return {"version": "v1", "decisions": {}, "facts": {}, "updated_at": _now_iso()}
+        raise CanonicalStoreCorruptedError(
+            f"Canonical store at {path} must be a JSON object, got {type(parsed).__name__}"
+        )
     return parsed
 
 
 def save_store(workspace_root: Path, store: dict[str, Any]) -> None:
-    """Save canonical decision store atomically."""
+    """Legacy save — unconditional overwrite, no CAS, no lock.
+
+    Deprecated since v3.0.0. New code should use :func:`save_store_cas`
+    or rely on the mutator helpers (``promote_decision``, ``forget``, ...)
+    which route through the locked + CAS-aware path. Scheduled for
+    removal in v4.0.0.
+    """
+    warnings.warn(
+        "save_store() is deprecated since v3.0.0; use save_store_cas() "
+        "or the canonical_store mutator helpers instead. Scheduled for "
+        "removal in v4.0.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     store["updated_at"] = _now_iso()
     write_json_atomic(_store_path(workspace_root), store)
+
+
+def save_store_cas(
+    workspace_root: Path,
+    store: dict[str, Any],
+    *,
+    expected_revision: str | None,
+    allow_overwrite: bool = False,
+) -> str:
+    """Atomically save the store under an exclusive lock with CAS check.
+
+    The write pipeline is:
+        1. Acquire the sidecar filesystem lock (:mod:`lock`).
+        2. Re-read the on-disk store INSIDE the lock.
+        3. If ``expected_revision`` is not None, compare against the freshly
+           loaded revision. Mismatch raises :class:`CanonicalRevisionConflict`
+           unless ``allow_overwrite=True``.
+        4. Stamp ``updated_at`` and write atomically via ``write_json_atomic``.
+        5. Return the post-write revision token.
+
+    Args:
+        workspace_root: Project root containing ``.ao/``.
+        store: The full store dict to persist.
+        expected_revision: Revision the caller believes the store is at.
+            ``None`` skips the CAS check; the caller must still pass
+            ``allow_overwrite=True`` for a no-expectation write.
+        allow_overwrite: Bypass both the CAS and the None-revision check.
+            Used by the deprecated ``save_store`` shim and internal
+            bootstrap paths only.
+
+    Returns:
+        The SHA-256 revision token of the newly written store.
+
+    Raises:
+        CanonicalRevisionConflict: Fresh revision differs from
+            ``expected_revision`` and ``allow_overwrite`` is False.
+        LockPlatformNotSupported: On Windows (until Tranche D).
+        LockTimeoutError: Lock acquisition timed out.
+    """
+    path = _store_path(workspace_root)
+    lockfile = _lock_path(workspace_root)
+
+    # Windows still lands on the existing (non-locked) path until Tranche D;
+    # raising here instead of falling back avoids a silent downgrade.
+    if not lock_supported():
+        from ao_kernel._internal.shared.lock import LockPlatformNotSupported
+        raise LockPlatformNotSupported(
+            "save_store_cas requires POSIX fcntl locking; Windows support "
+            "is tracked in Tranche D (v3.1.0)."
+        )
+
+    with file_lock(lockfile):
+        current = _load_store_locked(workspace_root)
+        current_rev = store_revision(current)
+        if not allow_overwrite and expected_revision is not None:
+            if current_rev != expected_revision:
+                raise CanonicalRevisionConflict(
+                    f"Revision mismatch: expected {expected_revision}, "
+                    f"store is at {current_rev}"
+                )
+        store["updated_at"] = _now_iso()
+        write_json_atomic(path, store)
+        return store_revision(store)
+
+
+def _load_store_locked(workspace_root: Path) -> dict[str, Any]:
+    """Load the store while the caller already holds the lock.
+
+    Missing file -> empty store (first write), corruption propagates.
+    Split from ``load_store`` so the public helper does not re-enter the
+    lock on every read.
+    """
+    path = _store_path(workspace_root)
+    if not path.exists():
+        return _empty_store()
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CanonicalStoreCorruptedError(
+            f"Canonical store JSON at {path} is invalid: {exc}"
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise CanonicalStoreCorruptedError(
+            f"Canonical store at {path} must be a JSON object"
+        )
+    return parsed
+
+
+def _mutate_with_cas(
+    workspace_root: Path,
+    mutator: Callable[[dict[str, Any]], None],
+    *,
+    expected_revision: str | None,
+    allow_overwrite: bool,
+) -> str:
+    """Lock + read-modify-write helper used by every canonical mutator.
+
+    ``mutator`` receives the current store and mutates it in place. The
+    helper handles revision comparison, stamping, atomic write, and
+    returning the new revision.
+    """
+    lockfile = _lock_path(workspace_root)
+
+    if not lock_supported():
+        from ao_kernel._internal.shared.lock import LockPlatformNotSupported
+        raise LockPlatformNotSupported(
+            "canonical mutators require POSIX fcntl locking; "
+            "Windows support is tracked in Tranche D (v3.1.0)."
+        )
+
+    with file_lock(lockfile):
+        current = _load_store_locked(workspace_root)
+        current_rev = store_revision(current)
+        if not allow_overwrite and expected_revision is not None:
+            if current_rev != expected_revision:
+                raise CanonicalRevisionConflict(
+                    f"Revision mismatch: expected {expected_revision}, "
+                    f"store is at {current_rev}"
+                )
+        mutator(current)
+        current["updated_at"] = _now_iso()
+        write_json_atomic(_store_path(workspace_root), current)
+        return store_revision(current)
 
 
 def promote_decision(
@@ -103,6 +287,8 @@ def promote_decision(
     provenance: dict[str, Any] | None = None,
     vector_store: Any | None = None,
     embedding_config: Any | None = None,
+    expected_revision: str | None = None,
+    allow_overwrite: bool = True,
 ) -> CanonicalDecision:
     """Promote an ephemeral decision to canonical store.
 
@@ -111,10 +297,18 @@ def promote_decision(
     When ``vector_store`` is provided, the promoted decision is also
     embedded and indexed for semantic retrieval. Write-path failures
     are silently logged (never block promotion).
-    """
-    store = load_store(workspace_root)
-    now = _now_iso()
 
+    CAS parameters (CNS-20260414-010 iter-3 migration stage A):
+        expected_revision: Opt-in revision guard. When supplied together
+            with ``allow_overwrite=False``, a concurrent writer that
+            moved the store past this revision will cause the call to
+            raise :class:`CanonicalRevisionConflict`. ``None`` + the
+            default ``allow_overwrite=True`` preserves the v2.x behavior.
+        allow_overwrite: Default ``True`` for backward compatibility.
+            v4.0.0 will flip this to ``False`` and require callers to
+            opt in to overwriting stale revisions.
+    """
+    now = _now_iso()
     decision = CanonicalDecision(
         key=key,
         value=value,
@@ -129,12 +323,17 @@ def promote_decision(
         supersedes=supersedes,
         provenance=provenance or {},
     )
-
-    # Separate decisions from facts
     target = "facts" if category == "fact" else "decisions"
-    store.setdefault(target, {})[key] = asdict(decision)
 
-    save_store(workspace_root, store)
+    def _apply(store: dict[str, Any]) -> None:
+        store.setdefault(target, {})[key] = asdict(decision)
+
+    _mutate_with_cas(
+        workspace_root,
+        _apply,
+        expected_revision=expected_revision,
+        allow_overwrite=allow_overwrite,
+    )
 
     try:
         from ao_kernel.telemetry import record_canonical_promote
@@ -240,6 +439,8 @@ __all__ = [
     "CanonicalDecision",
     "load_store",
     "save_store",
+    "save_store_cas",
+    "store_revision",
     "promote_decision",
     "promote_from_ephemeral",
     "query",

--- a/ao_kernel/errors.py
+++ b/ao_kernel/errors.py
@@ -34,3 +34,25 @@ class VectorStoreConnectError(RuntimeError):
     Only raised under strict mode. Non-strict mode falls back to deterministic
     ordering with a warning.
     """
+
+
+class CanonicalStoreCorruptedError(RuntimeError):
+    """Canonical decision store file exists but its contents cannot be trusted.
+
+    Raised when the on-disk ``canonical_decisions.v1.json`` is unparseable
+    or structurally invalid. Previously ``load_store`` silently returned
+    an empty store — CNS-20260414-010 iter-2 flagged the silent-empty path
+    as a data-loss hazard. Callers that want to recover from corruption
+    should catch this exception explicitly and invoke a repair workflow
+    (``ao-kernel doctor``, manual restore from evidence, etc.).
+    """
+
+
+class CanonicalRevisionConflict(RuntimeError):
+    """A CAS write rejected because the store moved past ``expected_revision``.
+
+    Raised by :func:`ao_kernel.context.canonical_store.save_store_cas` when
+    the caller supplied an ``expected_revision`` that no longer matches
+    the current store revision. Callers typically handle this by reading
+    the current revision, re-applying their change on top, and retrying.
+    """

--- a/tests/test_canonical_store.py
+++ b/tests/test_canonical_store.py
@@ -31,10 +31,18 @@ class TestStoreLifecycle:
         assert loaded["decisions"]["test.key"]["value"] == "hello"
         assert "updated_at" in loaded
 
-    def test_corrupted_file_returns_empty(self, tmp_path: Path):
+    def test_corrupted_file_raises(self, tmp_path: Path):
+        """CNS-010 iter-2 blocking fix: silent-empty fallback removed.
+
+        A corrupted store is a data-loss hazard, not a normal path. Callers
+        that want to recover catch CanonicalStoreCorruptedError explicitly
+        and invoke a repair workflow.
+        """
+        import pytest
+        from ao_kernel.errors import CanonicalStoreCorruptedError
         (tmp_path / "canonical_decisions.v1.json").write_text("{{invalid")
-        store = load_store(tmp_path)
-        assert store["decisions"] == {}
+        with pytest.raises(CanonicalStoreCorruptedError):
+            load_store(tmp_path)
 
 
 class TestPromoteDecision:

--- a/tests/test_canonical_store_cas.py
+++ b/tests/test_canonical_store_cas.py
@@ -1,0 +1,187 @@
+"""Tests for canonical_store CAS + lock contract (C5a, CNS-010)."""
+
+from __future__ import annotations
+
+import threading
+import warnings
+
+import pytest
+
+from ao_kernel.context.canonical_store import (
+    load_store,
+    promote_decision,
+    save_store,
+    save_store_cas,
+    store_revision,
+)
+from ao_kernel.errors import (
+    CanonicalRevisionConflict,
+    CanonicalStoreCorruptedError,
+)
+
+
+@pytest.fixture
+def project_with_ao(tmp_path):
+    (tmp_path / ".ao").mkdir()
+    return tmp_path
+
+
+class TestStoreRevision:
+    def test_empty_store_has_stable_revision(self, project_with_ao):
+        rev1 = store_revision(load_store(project_with_ao))
+        rev2 = store_revision(load_store(project_with_ao))
+        assert rev1 == rev2
+        assert len(rev1) == 64
+
+    def test_revision_changes_after_mutation(self, project_with_ao):
+        rev_before = store_revision(load_store(project_with_ao))
+        promote_decision(
+            project_with_ao,
+            key="runtime.python",
+            value="3.11",
+            confidence=0.9,
+        )
+        rev_after = store_revision(load_store(project_with_ao))
+        assert rev_before != rev_after
+
+
+class TestSaveStoreCAS:
+    def test_first_write_with_none_revision_and_allow_overwrite(self, project_with_ao):
+        initial = {"version": "v1", "decisions": {"k": {"value": 1}}, "facts": {}}
+        new_rev = save_store_cas(
+            project_with_ao, initial,
+            expected_revision=None, allow_overwrite=True,
+        )
+        assert len(new_rev) == 64
+        reloaded = load_store(project_with_ao)
+        assert reloaded["decisions"]["k"]["value"] == 1
+
+    def test_cas_match_succeeds(self, project_with_ao):
+        store = load_store(project_with_ao)
+        store["decisions"]["k"] = {"value": 1}
+        new_rev = save_store_cas(
+            project_with_ao, store,
+            expected_revision=store_revision(load_store(project_with_ao)),
+            allow_overwrite=False,
+        )
+        assert new_rev != ""
+
+    def test_cas_mismatch_raises(self, project_with_ao):
+        store1 = load_store(project_with_ao)
+        stale_rev = store_revision(store1)
+        # Concurrent-ish writer moves the store forward.
+        promote_decision(
+            project_with_ao, key="other", value=1, confidence=0.9,
+        )
+        store1["decisions"]["k"] = {"value": 1}
+        with pytest.raises(CanonicalRevisionConflict):
+            save_store_cas(
+                project_with_ao, store1,
+                expected_revision=stale_rev,
+                allow_overwrite=False,
+            )
+
+    def test_allow_overwrite_bypasses_cas(self, project_with_ao):
+        store1 = load_store(project_with_ao)
+        stale_rev = store_revision(store1)
+        promote_decision(
+            project_with_ao, key="other", value=1, confidence=0.9,
+        )
+        store1["decisions"]["k"] = {"value": 1}
+        # Even with a stale expected_revision, allow_overwrite wins.
+        new_rev = save_store_cas(
+            project_with_ao, store1,
+            expected_revision=stale_rev,
+            allow_overwrite=True,
+        )
+        # New revision matches post-write snapshot; store now holds our write.
+        assert new_rev == store_revision(load_store(project_with_ao))
+        assert load_store(project_with_ao)["decisions"]["k"]["value"] == 1
+
+
+class TestPromoteDecisionCAS:
+    def test_promote_default_behavior_unchanged(self, project_with_ao):
+        cd = promote_decision(
+            project_with_ao,
+            key="x", value=1, confidence=0.9,
+        )
+        assert cd.key == "x"
+
+    def test_promote_with_matching_revision(self, project_with_ao):
+        rev = store_revision(load_store(project_with_ao))
+        cd = promote_decision(
+            project_with_ao,
+            key="x", value=1, confidence=0.9,
+            expected_revision=rev,
+            allow_overwrite=False,
+        )
+        assert cd.key == "x"
+
+    def test_promote_with_stale_revision_raises(self, project_with_ao):
+        rev = store_revision(load_store(project_with_ao))
+        promote_decision(
+            project_with_ao, key="other", value=1, confidence=0.9,
+        )
+        with pytest.raises(CanonicalRevisionConflict):
+            promote_decision(
+                project_with_ao,
+                key="x", value=1, confidence=0.9,
+                expected_revision=rev,
+                allow_overwrite=False,
+            )
+
+
+class TestCorruptionFailClosed:
+    def test_load_store_raises_on_invalid_json(self, project_with_ao):
+        (project_with_ao / ".ao" / "canonical_decisions.v1.json").write_text(
+            "{not json"
+        )
+        with pytest.raises(CanonicalStoreCorruptedError):
+            load_store(project_with_ao)
+
+    def test_load_store_raises_on_non_object_root(self, project_with_ao):
+        (project_with_ao / ".ao" / "canonical_decisions.v1.json").write_text("[]")
+        with pytest.raises(CanonicalStoreCorruptedError):
+            load_store(project_with_ao)
+
+
+class TestSaveStoreDeprecation:
+    def test_save_store_emits_deprecation_warning(self, project_with_ao):
+        store = {"version": "v1", "decisions": {}, "facts": {}}
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            save_store(project_with_ao, store)
+        deprecated = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecated, "expected save_store to emit DeprecationWarning"
+        assert "save_store_cas" in str(deprecated[0].message)
+
+
+class TestLockExclusivity:
+    """Verify concurrent writers serialize through the lock.
+
+    Two threads each do read-modify-write on different keys. With the lock
+    the final store must contain both keys; without the lock (race), the
+    later writer overwrites the earlier one.
+    """
+
+    def test_concurrent_promote_both_land(self, project_with_ao):
+        def writer(tag: str) -> None:
+            promote_decision(
+                project_with_ao,
+                key=f"concurrent.{tag}",
+                value=tag,
+                confidence=0.9,
+            )
+
+        threads = [
+            threading.Thread(target=writer, args=("a",)),
+            threading.Thread(target=writer, args=("b",)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        final = load_store(project_with_ao)
+        assert "concurrent.a" in final["decisions"]
+        assert "concurrent.b" in final["decisions"]

--- a/tests/test_chaos.py
+++ b/tests/test_chaos.py
@@ -64,15 +64,18 @@ class TestCorruption:
         with pytest.raises(WorkspaceCorruptedError):
             load_workspace_json(ws)
 
-    def test_corrupted_canonical_store_returns_empty(self, tmp_path: Path):
+    def test_corrupted_canonical_store_raises_fail_closed(self, tmp_path: Path):
+        """CNS-010 iter-2 blocking fix: canonical store corruption is now
+        fail-closed. Previous silent-empty fallback masked data loss."""
+        import pytest
         from ao_kernel.context.canonical_store import load_store
+        from ao_kernel.errors import CanonicalStoreCorruptedError
 
         (tmp_path / ".ao").mkdir()
         (tmp_path / ".ao" / "canonical_decisions.v1.json").write_text("not json!")
 
-        store = load_store(tmp_path)
-        assert store["decisions"] == {}
-        assert store["facts"] == {}
+        with pytest.raises(CanonicalStoreCorruptedError):
+            load_store(tmp_path)
 
     def test_corrupted_session_raises_fail_closed(self, tmp_path: Path):
         """Corrupted session must raise SessionCorruptedError (fail-closed)."""


### PR DESCRIPTION
## Summary

C5a — every canonical store write goes through a locked read-modify-write
path with optional revision CAS; corruption is no longer silently empty.
Addresses CNS-20260414-010 iter-1 blocking-1/2 and iter-2 blocking-5.

## New primitives

| Module | Addition |
|---|---|
| `_internal/shared/lock.py` | `file_lock()` POSIX fcntl + Windows fail-closed |
| `errors.py` | `CanonicalStoreCorruptedError`, `CanonicalRevisionConflict` |
| `canonical_store.py` | `store_revision()`, `save_store_cas()`, `_mutate_with_cas()` |
| `utils.py` | `write_text_atomic`/`write_bytes_atomic` unique tmp (`mkstemp`) |

## Breaking changes

- **`load_store()` corruption → raises** `CanonicalStoreCorruptedError`. Silent-empty fallback removed (data-loss hazard).
- **`save_store()` → DeprecationWarning**. Scheduled for removal v4.0.0.

## Backward-compat preserved

- `promote_decision` gains `(expected_revision=None, allow_overwrite=True)` keyword-only — default behavior unchanged.
- CAS is opt-in until call-sites migrate in C5b.

## Platform

POSIX only. Windows raises `LockPlatformNotSupported` (tracked in Tranche D / v3.1.0). Explicit opt-out: cannot silently downgrade to unlocked writes.

## Test plan

- [x] `pytest tests/` → **917/917** green (904 baseline + 13 new)
- [x] `ruff check ao_kernel/ tests/` → clean
- [x] `mypy ao_kernel/ --ignore-missing-imports` → 0 issues
- [x] Concurrent 2-thread `promote_decision` test: both writes land (lock serializes)
- [x] CAS mismatch raises; `allow_overwrite=True` bypasses
- [ ] CI required 6 checks pass

## Up next (C5b)

- `self_edit_memory.forget()` routes through `_mutate_with_cas` (currently bypasses via direct `load_store + save_store`)
- `agent_coordination.record_decision` / `finalize_session_sdk` thread `expected_revision` through client wrappers
- MCP `call_tool` implicit post-tool promote uses CAS path

## References

- `.ao/consultations/CNS-20260414-010.consensus.md` (Stage A of 2-stage migration)
- CNS-010 iter-1 blocking-1 (fixed tmp collision in utils.py)
- CNS-010 iter-1 blocking-2 (promote_decision stale read)
- CNS-010 iter-2 blocking-5 (silent-empty corruption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)