### PR TITLE
chore(mypy): _internal/providers strict (C1.1)

### DIFF
--- a/ao_kernel/_internal/providers/capability_model.py
+++ b/ao_kernel/_internal/providers/capability_model.py
@@ -79,7 +79,8 @@ def load_capability_registry(repo_root: Path | str | None = None) -> Dict[str, A
 
     for path in candidates:
         if path.exists():
-            return load_json(path)
+            loaded: Dict[str, Any] = load_json(path)
+            return loaded
 
     # Fallback to bundled defaults (importlib.resources)
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,12 +91,24 @@ ignore_missing_imports = true
 # Exclude files under .archive/ (historical patch backups)
 exclude = ["^\\.archive/"]
 
-# _internal: D13 — aşamalı tip kapsamı, test coverage gate'i de omit ediyor.
-# _internal tipleri Tranş C'de sistemik olarak eklenecek. Şimdilik yalnızca bu
-# katman override ile geçiliyor; public facade (ao_kernel/*.py + context/) tam
-# strict mypy altında.
+# _internal: D13 — aşamalı tip kapsamı. Tranş C içinde her submodule
+# strict'e opt-in ediyor; public facade (ao_kernel/*.py + context/) zaten
+# strict altında. Aşağıdaki override listesi, henüz strict'e geçmemiş
+# submodule'leri saklar. Strict'e alınan submodule'ler listeden silinir.
+# Opt-in sırası: providers (Tranş C / C1.1), shared, secrets, evidence,
+# session, orchestrator, prj_kernel_api (son).
 [[tool.mypy.overrides]]
-module = "ao_kernel._internal.*"
+module = [
+    "ao_kernel._internal.shared.*",
+    "ao_kernel._internal.utils.*",
+    "ao_kernel._internal.secrets.*",
+    "ao_kernel._internal.evidence.*",
+    "ao_kernel._internal.session.*",
+    "ao_kernel._internal.orchestrator.*",
+    "ao_kernel._internal.prj_kernel_api.*",
+    "ao_kernel._internal.roadmap.*",
+    "ao_kernel._internal.mcp.*",
+]
 ignore_errors = true
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

First batch of PR-C1 (`_internal/*` mypy strict rollout per CNS-20260414-010). Opts `_internal/providers` into strict mypy; fixes a single `no-any-return` on `capability_model.load_capability_registry`.

- `pyproject.toml` override split: submodules listed explicitly, providers excluded → strict
- `capability_model.py:82` annotated `loaded: Dict[str, Any]` before return

Rollout order (per handoff doc): **providers** → shared → secrets → evidence → session → orchestrator → prj_kernel_api.

## Test plan

- [x] `mypy ao_kernel/ --ignore-missing-imports` → Success (111 files)
- [x] `pytest tests/` → 949 passed
- [x] `ruff check` → clean
- [x] No runtime or test changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)