### PR TITLE
chore(mypy): _internal/shared strict (C1.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ exclude = ["^\\.archive/"]
 # session, orchestrator, prj_kernel_api (son).
 [[tool.mypy.overrides]]
 module = [
-    "ao_kernel._internal.shared.*",
     "ao_kernel._internal.utils.*",
     "ao_kernel._internal.secrets.*",
     "ao_kernel._internal.evidence.*",


### PR DESCRIPTION
Second batch of PR-C1 mypy rollout (CNS-20260414-010). `_internal/shared` already strict-clean; override list trimmed. 949 tests, typecheck, lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)