### PR TITLE
chore(mypy): _internal/secrets strict (C1.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ exclude = ["^\\.archive/"]
 [[tool.mypy.overrides]]
 module = [
     "ao_kernel._internal.utils.*",
-    "ao_kernel._internal.secrets.*",
     "ao_kernel._internal.evidence.*",
     "ao_kernel._internal.session.*",
     "ao_kernel._internal.orchestrator.*",


### PR DESCRIPTION
Third batch of PR-C1 mypy rollout (CNS-20260414-010). `_internal/secrets` already strict-clean (per handoff note "already mostly typed"). Override list trimmed. 949 tests, typecheck, lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)