### PR TITLE
chore(mypy): _internal/session strict (C1.5)

### DIFF
--- a/ao_kernel/_internal/session/agent_context_version.py
+++ b/ao_kernel/_internal/session/agent_context_version.py
@@ -142,6 +142,7 @@ def load_agent_context_version(*, workspace_root: Path) -> dict[str, Any] | None
     if not path.exists():
         return None
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        payload: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+        return payload
     except Exception:
         return None

--- a/ao_kernel/_internal/session/context_store.py
+++ b/ao_kernel/_internal/session/context_store.py
@@ -41,11 +41,13 @@ def _load_schema() -> dict[str, Any]:
     """Load session context schema — tries repo root, falls back to bundled defaults."""
     repo_path = _repo_root() / "schemas" / "session-context.schema.json"
     if repo_path.exists():
-        return json.loads(repo_path.read_text(encoding="utf-8"))
+        schema: dict[str, Any] = json.loads(repo_path.read_text(encoding="utf-8"))
+        return schema
     # Fallback: bundled defaults
     try:
         from ao_kernel._internal.shared.resource_loader import load_resource
-        return load_resource("schemas", "session-context.schema.json")
+        bundled: dict[str, Any] = load_resource("schemas", "session-context.schema.json")
+        return bundled
     except (ImportError, FileNotFoundError):
         pass
     raise SessionContextError("SCHEMA_NOT_FOUND", "Missing session-context.schema.json")

--- a/ao_kernel/_internal/session/cross_session_context.py
+++ b/ao_kernel/_internal/session/cross_session_context.py
@@ -16,6 +16,16 @@ from ao_kernel._internal.session.context_store import (
 from ao_kernel._internal.shared.utils import write_json_atomic
 
 
+def _asdict(value: Any) -> dict[str, Any]:
+    """Narrow an ``Any`` to ``dict[str, Any]``; returns ``{}`` otherwise."""
+    return value if isinstance(value, dict) else {}
+
+
+def _aslist(value: Any) -> list[Any]:
+    """Narrow an ``Any`` to ``list[Any]``; returns ``[]`` otherwise."""
+    return value if isinstance(value, list) else []
+
+
 def _now_iso8601() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
@@ -111,8 +121,8 @@ def build_cross_session_context(*, workspace_root: Path, session_name_filter: st
                     import logging
                     logging.getLogger("ao_kernel").warning("cross-session pruned context save failed: %s", exc)
 
-            decisions = ctx.get("ephemeral_decisions") if isinstance(ctx.get("ephemeral_decisions"), list) else []
-            provider_state = ctx.get("provider_state") if isinstance(ctx.get("provider_state"), dict) else {}
+            decisions = _aslist(ctx.get("ephemeral_decisions"))
+            provider_state = _asdict(ctx.get("provider_state"))
             if isinstance(provider_state.get("provider"), str) and str(provider_state.get("provider")).strip():
                 provider_rows.append(
                     {
@@ -125,7 +135,7 @@ def build_cross_session_context(*, workspace_root: Path, session_name_filter: st
                         "summary_ref": str(provider_state.get("summary_ref") or ""),
                     }
                 )
-            compaction = ctx.get("compaction") if isinstance(ctx.get("compaction"), dict) else {}
+            compaction = _asdict(ctx.get("compaction"))
             if isinstance(compaction.get("status"), str) and str(compaction.get("status")).strip() not in {"", "idle"}:
                 try:
                     approx_input_tokens = int(compaction.get("approx_input_tokens") or 0)

--- a/ao_kernel/_internal/session/provider_memory.py
+++ b/ao_kernel/_internal/session/provider_memory.py
@@ -18,6 +18,11 @@ from ao_kernel._internal.session.context_store import (
 from ao_kernel._internal.utils.budget import estimate_tokens
 
 
+def _asdict(value: Any) -> dict[str, Any]:
+    """Narrow an ``Any`` to ``dict[str, Any]``; returns ``{}`` otherwise."""
+    return value if isinstance(value, dict) else {}
+
+
 def _safe_slug(value: str) -> str:
     normalized = re.sub(r"[^A-Za-z0-9._-]+", "-", str(value or "").strip())
     normalized = normalized.strip("-._")
@@ -69,7 +74,7 @@ def read_provider_session_state(
     memory_strategy = str(ctx.get("memory_strategy") or "local_only")
     payload["memory_strategy"] = memory_strategy
 
-    provider_state = ctx.get("provider_state") if isinstance(ctx.get("provider_state"), dict) else {}
+    provider_state = _asdict(ctx.get("provider_state"))
     payload["provider_state"] = provider_state
 
     continuation: dict[str, Any] = {}
@@ -93,7 +98,7 @@ def read_provider_session_state(
     payload["continuation"] = continuation
 
     # Include compaction summary ref if available (for context reuse)
-    compaction = ctx.get("compaction") if isinstance(ctx.get("compaction"), dict) else {}
+    compaction = _asdict(ctx.get("compaction"))
     if compaction.get("status") == "completed" and compaction.get("summary_ref"):
         payload["compaction_summary_ref"] = str(compaction["summary_ref"])
 
@@ -213,7 +218,7 @@ def maybe_auto_compact_markdown(
     if sp.context_path.exists():
         try:
             ctx = load_context(sp.context_path)
-            existing_state = ctx.get("provider_state") if isinstance(ctx.get("provider_state"), dict) else {}
+            existing_state = _asdict(ctx.get("provider_state"))
             mark_compaction(
                 ctx,
                 summary_ref=summary_ref,
@@ -261,7 +266,7 @@ def persist_provider_result(
 
     try:
         ctx = load_context(sp.context_path)
-        existing_state = ctx.get("provider_state") if isinstance(ctx.get("provider_state"), dict) else {}
+        existing_state = _asdict(ctx.get("provider_state"))
         upsert_provider_state(
             ctx,
             provider=provider,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ exclude = ["^\\.archive/"]
 [[tool.mypy.overrides]]
 module = [
     "ao_kernel._internal.utils.*",
-    "ao_kernel._internal.session.*",
     "ao_kernel._internal.orchestrator.*",
     "ao_kernel._internal.prj_kernel_api.*",
     "ao_kernel._internal.roadmap.*",


### PR DESCRIPTION
Fifth batch of PR-C1 mypy rollout (CNS-20260414-010). 30 strict errors fixed: type-annotated JSON loads in context_store + agent_context_version, and private `_asdict`/`_aslist` helpers in cross_session_context + provider_memory that narrow `Any` values. No runtime change. 949 tests, typecheck, lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)