### PR TITLE
chore(mypy): _internal/orchestrator strict (C1.6)

### DIFF
--- a/ao_kernel/_internal/orchestrator/quality_gate.py
+++ b/ao_kernel/_internal/orchestrator/quality_gate.py
@@ -46,8 +46,10 @@ def _load_quality_gate_policy(workspace_root: Path | None = None) -> dict[str, A
             schema_path = load_resource_path("schemas", "policy-quality-gates.schema.v1.json")
             try:
                 if schema_path:
-                    return load_policy_validated(ws_policy, schema_path)
-                return json.loads(ws_policy.read_text(encoding="utf-8"))
+                    validated: dict[str, Any] = load_policy_validated(ws_policy, schema_path)
+                    return validated
+                parsed: dict[str, Any] = json.loads(ws_policy.read_text(encoding="utf-8"))
+                return parsed
             except (ValueError, Exception) as exc:
                 import logging
                 logging.getLogger("ao_kernel").warning(
@@ -55,7 +57,8 @@ def _load_quality_gate_policy(workspace_root: Path | None = None) -> dict[str, A
                 )
 
     try:
-        return load_resource("policies", "policy_quality_gates.v1.json")
+        bundled: dict[str, Any] = load_resource("policies", "policy_quality_gates.v1.json")
+        return bundled
     except (FileNotFoundError, Exception) as exc:
         # Fail-closed: if policy can't load, enable restrictive defaults
         import logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ exclude = ["^\\.archive/"]
 [[tool.mypy.overrides]]
 module = [
     "ao_kernel._internal.utils.*",
-    "ao_kernel._internal.orchestrator.*",
     "ao_kernel._internal.prj_kernel_api.*",
     "ao_kernel._internal.roadmap.*",
     "ao_kernel._internal.mcp.*",


### PR DESCRIPTION
Sixth batch of PR-C1 mypy rollout (CNS-20260414-010). Three no-any-return errors fixed on `quality_gate.load_quality_gate_policy` load paths. 949 tests, typecheck, lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)