### PR TITLE
chore(mypy): _internal/prj_kernel_api strict (C1.7 — last major)

### DIFF
--- a/ao_kernel/_internal/prj_kernel_api/dotenv_loader.py
+++ b/ao_kernel/_internal/prj_kernel_api/dotenv_loader.py
@@ -59,13 +59,13 @@ def load_env_presence(
     env_mode: str = "dotenv",
 ) -> Dict[str, object]:
     if env_mode == "process":
-        keys = sorted(expected_keys) if expected_keys else []
-        present_keys = {k for k in keys if os.environ.get(k)}
-        missing_expected = [k for k in keys if k not in present_keys]
+        proc_keys = sorted(expected_keys) if expected_keys else []
+        proc_present: set[str] = {k for k in proc_keys if os.environ.get(k)}
+        proc_missing = [k for k in proc_keys if k not in proc_present]
         return {
-            "present_keys": present_keys,
-            "missing_expected_keys": missing_expected,
-            "source_used": "process_env" if present_keys else "none",
+            "present_keys": proc_present,
+            "missing_expected_keys": proc_missing,
+            "source_used": "process_env" if proc_present else "none",
             "parse_errors": [],
         }
 

--- a/ao_kernel/_internal/prj_kernel_api/llm_response_normalizer.py
+++ b/ao_kernel/_internal/prj_kernel_api/llm_response_normalizer.py
@@ -61,8 +61,9 @@ def extract_llm_output_text(resp_bytes: bytes) -> str:
                             parts.append(text)
                     if parts:
                         return "\n".join(parts).strip()
-            if isinstance(first.get("text"), str):
-                return first.get("text", "").strip()
+            first_text = first.get("text")
+            if isinstance(first_text, str):
+                return first_text.strip()
 
     # OpenAI Responses API: {"output":[{"content":[{"text":"..."}]}]}
     output = obj.get("output")

--- a/ao_kernel/_internal/prj_kernel_api/llm_router.py
+++ b/ao_kernel/_internal/prj_kernel_api/llm_router.py
@@ -9,7 +9,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 
 def _load_json(path: Path) -> Dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    loaded: Dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    return loaded
 
 
 def _parse_ts(ts: Optional[str]) -> Optional[datetime]:
@@ -43,10 +44,11 @@ def _resolve_workspace_root(repo_root: Path, workspace_root: str | Path | None) 
 def _load_operations_json(filename: str, repo_root: Path) -> Dict[str, Any]:
     """Load operations JSON — tries repo-root first, falls back to bundled defaults."""
     from ao_kernel._internal.shared.resource_loader import load_resource
-    return load_resource("operations", filename)
+    payload: Dict[str, Any] = load_resource("operations", filename)
+    return payload
 
 
-def _policy_paths(repo_root: Path, workspace_root: str | Path | None = None) -> Tuple[Path, Path, Path, Path]:
+def _policy_paths(repo_root: Path, workspace_root: str | Path | None = None) -> Tuple[Path | None, Path | None, Path | None, Path]:
     """Return probe_state path only. Operations loaded via _load_operations_json()."""
     ws_root = _resolve_workspace_root(repo_root, workspace_root)
     probe_state = ws_root / ".cache" / "state" / "llm_probe_state.v1.json"
@@ -56,7 +58,7 @@ def _policy_paths(repo_root: Path, workspace_root: str | Path | None = None) -> 
 
 def _merge_state(provider_map: Dict[str, Any], probe_state: Dict[str, Any]) -> Dict[str, Any]:
     """Merge runtime probe state into provider_map (without mutating input)."""
-    merged = json.loads(json.dumps(provider_map))
+    merged: Dict[str, Any] = json.loads(json.dumps(provider_map))
     state_classes = probe_state.get("classes", {})
     for cls, cls_data in state_classes.items():
         mp_cls = merged.get("classes", {}).get(cls)

--- a/ao_kernel/_internal/prj_kernel_api/llm_stream.py
+++ b/ao_kernel/_internal/prj_kernel_api/llm_stream.py
@@ -45,7 +45,7 @@ class StreamEvent:
 # ── SSE Line Parser ─────────────────────────────────────────────────
 
 
-def _parse_sse_lines(response) -> Iterator[dict[str, str]]:
+def _parse_sse_lines(response: Any) -> Iterator[dict[str, str]]:
     """Parse raw SSE lines from a file-like HTTP response.
 
     Yields dicts with keys: 'event' (optional), 'data'.
@@ -116,7 +116,8 @@ def _extract_anthropic_delta(data: dict[str, Any]) -> str:
     if evt_type == "content_block_delta":
         delta = data.get("delta")
         if isinstance(delta, dict) and delta.get("type") == "text_delta":
-            return delta.get("text", "")
+            text_val = delta.get("text", "")
+            return text_val if isinstance(text_val, str) else ""
     return ""
 
 
@@ -152,7 +153,8 @@ def _extract_google_delta(data: dict[str, Any]) -> str:
     first_part = parts[0]
     if not isinstance(first_part, dict):
         return ""
-    return first_part.get("text", "")
+    text_val = first_part.get("text", "")
+    return text_val if isinstance(text_val, str) else ""
 
 
 # ── Usage Extraction ────────────────────────────────────────────────
@@ -221,7 +223,8 @@ def _classify_event(
             "message_delta": "usage",
             "message_stop": "done",
         }
-        return mapping.get(evt, evt)
+        mapped = mapping.get(evt, evt)
+        return mapped if isinstance(mapped, str) else str(mapped)
 
     # OpenAI-compatible
     choices = event_data.get("choices", [])
@@ -249,11 +252,13 @@ def _classify_event(
 def _extract_index(event_data: dict[str, Any], provider_id: str) -> int:
     """Extract content block index from event."""
     if provider_id == "claude":
-        return event_data.get("index", 0)
+        idx = event_data.get("index", 0)
+        return idx if isinstance(idx, int) else 0
     choices = event_data.get("choices", [])
     if isinstance(choices, list) and choices:
         first = choices[0] if isinstance(choices[0], dict) else {}
-        return first.get("index", 0)
+        idx = first.get("index", 0)
+        return idx if isinstance(idx, int) else 0
     return 0
 
 
@@ -261,7 +266,7 @@ def _extract_index(event_data: dict[str, Any], provider_id: str) -> int:
 
 
 def iter_stream_events(
-    response,
+    response: Any,
     provider_id: str,
     *,
     capture_raw: bool = True,

--- a/ao_kernel/_internal/prj_kernel_api/llm_stream_transport.py
+++ b/ao_kernel/_internal/prj_kernel_api/llm_stream_transport.py
@@ -91,7 +91,7 @@ def execute_stream_request(
     total_chars = 0
     chunk_count = 0
     usage: dict[str, int] | None = None
-    captured: list[dict[str, Any]] = [] if capture_events else None
+    captured: list[dict[str, Any]] | None = [] if capture_events else None
     error_code: str | None = None
     error_detail: str | None = None
     finish_reason = "unknown"
@@ -247,7 +247,7 @@ def _elapsed_ms_from(start: float, end: float) -> int:
     return int(round((end - start) * 1000.0))
 
 
-def _get_raw_socket(resp) -> socket.socket | None:
+def _get_raw_socket(resp: Any) -> socket.socket | None:
     """Extract underlying socket for idle timeout setting."""
     try:
         fp = getattr(resp, "fp", None)

--- a/ao_kernel/_internal/prj_kernel_api/llm_transport.py
+++ b/ao_kernel/_internal/prj_kernel_api/llm_transport.py
@@ -187,7 +187,7 @@ def execute_http_request_with_resilience(
             "tls_cafile": None,
         }
 
-    retry_evidence: list[dict] = []
+    retry_evidence: list[dict[str, Any]] = []
 
     def _on_retry(attempt: int, wait: float, exc: Exception) -> None:
         retry_evidence.append({

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ exclude = ["^\\.archive/"]
 [[tool.mypy.overrides]]
 module = [
     "ao_kernel._internal.utils.*",
-    "ao_kernel._internal.prj_kernel_api.*",
     "ao_kernel._internal.roadmap.*",
     "ao_kernel._internal.mcp.*",
 ]


### PR DESCRIPTION
Final major batch of PR-C1 mypy rollout (CNS-20260414-010). 16 strict errors fixed across 6 files (dotenv_loader, llm_router, llm_stream, llm_response_normalizer, llm_transport, llm_stream_transport). prj_kernel_api — the largest `_internal` submodule — is now fully typed. 949 tests, typecheck, lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)