### PR TITLE
feat(evidence): PR-A5 evidence timeline CLI + SHA-256 manifest + replay

### DIFF
--- a/.claude/plans/PR-A5-IMPLEMENTATION-PLAN.md
+++ b/.claude/plans/PR-A5-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,206 @@
+# PR-A5 Implementation Plan v2 — Evidence Timeline CLI + SHA-256 Manifest + Replay
+
+**Tranche A PR 6/8** — post CNS-025 iter-1 PARTIAL (5B + 5W absorbed). Target iter-2 AGREE via MCP reply (thread `019d93d3-054f-7743-b166-e892d712ff88`).
+
+## Revision History
+
+| Version | Date | Scope |
+|---|---|---|
+| v1 | 2026-04-16 | Initial draft; CNS-025 iter-1 submission. |
+| **v2** | **2026-04-16** | **5 blocker absorbed: B1 manifest canonical shape (`manifest.json` + `{version,run_id,generated_at,files:[{path,sha256,bytes}]}`), B2 replay_safe=False fix (5 event call site), B3 replay → "inferred state trace" (not exact recorded state), B4 manifest scope += `patches/*.revdiff`, B5 `_internal/evidence/` layout (no public evidence_cli.py). 5 warning noted (W1-W5).** |
+
+---
+
+## 1. Amaç
+
+FAZ-A'nın evidence tarafını kapatır. PR-A3 `EvidenceEmitter` JSONL append-only yazıyor (18-kind taxonomy, per-run lock + monotonic seq). PR-A5 **okuma + doğrulama + replay** katmanını ekler:
+
+- `ao-kernel evidence timeline --run <run_id>` — JSONL → kronolojik tablo (human-readable veya `--format json`)
+- `ao-kernel evidence replay --run <run_id> --mode inspect|dry-run` — deterministic replay via `replay_safe` flag
+- `ao-kernel evidence verify-manifest --run <run_id>` — SHA-256 manifest on-demand generation + verification
+- `ao-kernel evidence generate-manifest --run <run_id>` — manifest.json üretir (on-demand, PR-A3 invariant: emit sırasında manifest güncellenmez)
+
+FAZ-A release gate: "`ao-kernel evidence timeline` CLI works" (§10).
+
+### Kapsam özeti
+
+| Katman | Modül / Dosya | Yaklaşık LOC |
+|---|---|---|
+| CLI dispatcher | `ao_kernel/cli.py` delta (evidence subcommand) | ~40 |
+| Timeline handler | `ao_kernel/_internal/evidence/timeline.py` (yeni, B5 absorb) | ~200 |
+| Replay handler | `ao_kernel/_internal/evidence/replay.py` (yeni, B3 absorb) | ~200 |
+| Manifest generator | `ao_kernel/_internal/evidence/manifest.py` (yeni, B1+B4 absorb) | ~150 |
+| CLI handlers | `ao_kernel/_internal/evidence/cli_handlers.py` (yeni) | ~80 |
+| Tests | `tests/test_evidence_cli.py` (yeni) | ~400 |
+| Docs update | `docs/EVIDENCE-TIMELINE.md` §7/§8 CLI reference | ~30 delta |
+| CHANGELOG | `[Unreleased]` → FAZ-A PR-A5 entry | ~40 |
+| **Toplam** | 4 yeni _internal modül + 2 delta (cli.py + evidence_emitter.py) + 1 test | **~1130** |
+
+- Yeni schema: **0** (manifest.json layout defined in docs, not a versioned schema).
+- Yeni policy: **0**.
+- Yeni core dep: **0** (stdlib: `hashlib`, `json`, `argparse`, `pathlib`).
+- Evidence kind delta: **0** (18-kind whitelist intact).
+- Tahmini yeni test: **≥ 25** (target 1510+).
+
+---
+
+## 2. Scope Fences
+
+### Scope İçi
+
+- **`ao-kernel evidence timeline --run <run_id>`**
+  - Reads `{workspace}/.ao/evidence/workflows/{run_id}/events.jsonl`
+  - Default output: kronolojik tablo (`seq | ts | kind | actor | step_id | payload_summary`)
+  - `--format json` → newline-delimited JSON (passthrough with validation)
+  - `--filter-kind step_started,step_completed` → whitelist filter
+  - `--filter-actor adapter` → actor filter
+  - `--limit N` → son N event
+  - Default output tablo: `seq | ts | kind | actor | step_id | payload_summary` (payload_summary = canonical compact JSON, 96 char üstünde `93...` truncate; Q1 resolved)
+  - `--format json` → full event NDJSON (filtrelenmiş tam event objeleri, envelope-only değil; Q1 resolved)
+  - Graceful handling: missing run_id → error (exit 1); empty JSONL → "no events" (exit 0); malformed JSONL → error (exit 1)
+
+- **`ao-kernel evidence replay --run <run_id> --mode inspect|dry-run`**
+  - `inspect`: print each event with `replay_safe` annotation + **inferred** state trace (B3 absorb: "inferred/synthetic state trace validates observable event order", not "exact recorded state")
+  - `dry-run`: walk the 9-state machine from `created` → terminal using **inferred transitions**; report:
+    - `state_source: event` (explicit event like `workflow_started → running`)
+    - `state_source: inferred` (e.g., `diff_applied → applying`)
+    - `state_source: synthetic` (driver's CAS chain like `running → applying → verifying → completed` without matching events)
+    - Illegal/unexpected transition → warning, not hard failure (evidence stream is a projection of state, not the state itself)
+  - Evidence taxonomy: 18 kind'dan `replay_safe=True` olanlar deterministic; `replay_safe=False` olanlar non-deterministic (adapter invocations, approval responses, external API calls) (B2 absorb: 5 call site fix'i PR-A5'te yapılır)
+  - No actual re-execution — read-only analysis
+
+- **`ao-kernel evidence generate-manifest --run <run_id>`**
+  - Scans `{run_dir}/events.jsonl` + `{run_dir}/adapter-*.jsonl` + `{run_dir}/artifacts/**/*.json` + `{run_dir}/patches/*.revdiff` (B4 absorb)
+  - Computes SHA-256 for each file
+  - Writes `{run_dir}/manifest.json` atomically (tempfile + fsync + rename)
+  - Manifest shape (B1 absorb — canonical, docs §5 güncellenir): `{"version": "1", "run_id": str, "generated_at": ISO-8601, "files": [{"path": relative, "sha256": hex, "bytes": int}]}`
+  - Overwrites existing manifest (idempotent)
+
+- **`ao-kernel evidence verify-manifest --run <run_id>`**
+  - Reads `{run_dir}/manifest.json`
+  - Recomputes SHA-256 for each listed file
+  - Reports match/mismatch per file
+  - Exit codes (W3 + W5 absorb): `0` = all match; `1` = hash mismatch or missing listed file; `2` = manifest outdated (new in-scope file not in manifest); `3` = manifest.json itself missing (use `--generate-if-missing`)
+  - Outdated detection: scans run_dir for in-scope files not listed in manifest → `manifest_outdated=true` → exit 2
+  - `--generate-if-missing` flag: if manifest absent, generate first then verify (convenience)
+
+- **`ao_kernel/_internal/evidence/timeline.py`** — JSONL reader + formatter + filter (B5 absorb: _internal, not public facade)
+- **`ao_kernel/_internal/evidence/replay.py`** — inferred state trace walker (B3 absorb: "inferred/synthetic", not "exact recorded state"); annotates `replay_safe` per event; reports `state_source: inferred|synthetic|event`
+- **`ao_kernel/_internal/evidence/manifest.py`** — manifest generator + verifier; canonical shape `manifest.json`: `{version: "1", run_id, generated_at, files: [{path, sha256, bytes}]}` (B1 absorb); scope: `events.jsonl` + `adapter-*.jsonl` + `artifacts/**/*.json` + `patches/*.revdiff` (B4 absorb); excludes `manifest.json`, `*.lock`, `*.tmp`
+- **`ao_kernel/_internal/evidence/cli_handlers.py`** — argparse handler delegates to timeline/replay/manifest
+
+- **`ao_kernel/executor/evidence_emitter.py` delta (B2 absorb):** 5 call site'ta `replay_safe=False` fix:
+  - `Executor._run_adapter_step` → `adapter_invoked(replay_safe=False)`, `adapter_returned(replay_safe=False)`
+  - `MultiStepDriver._emit` → `approval_granted(replay_safe=False)`, `approval_denied(replay_safe=False)`
+  - `pr_opened` → `replay_safe=False` (PR-A6'da wiring; PR-A5 emitter default korunur ama docs + replay tool "effective replay_safe" taxonomy'si hazırlanır)
+
+- **Tests:** ≥25 across `test_evidence_cli.py`:
+  - timeline happy path (seeded events.jsonl → table output)
+  - timeline with filters (kind, actor, limit)
+  - timeline empty run → "no events"
+  - timeline missing run → error
+  - timeline --format json
+  - replay inspect annotates replay_safe
+  - replay dry-run walks state machine, reports illegal transition
+  - generate-manifest creates manifest.json
+  - verify-manifest all-match → exit 0
+  - verify-manifest mismatch → exit non-zero
+  - verify-manifest missing file → exit non-zero
+  - generate-if-missing convenience
+  - manifest idempotent overwrite
+
+### Scope Dışı
+
+| Alan | Nereye | Neden |
+|---|---|---|
+| Demo `.demo/` runnable script | PR-A6 | Release gate sonlayıcı |
+| Production adapter fixtures | PR-A6 | Adapter manifests |
+| Tutorial docs | PR-A6 | Adoption gate |
+| `[coding]` meta-extra | PR-A6 | pyproject.toml extras |
+| `[llm]` fallback intent classifier | PR-A6 | IntentRouter stub |
+| Replay `full` mode (re-execution) | FAZ-B+ | Requires sandbox + budget + adapter re-invocation |
+| Evidence streaming / watch mode | FAZ-B+ | Ops hardening scope |
+| Evidence retention / cleanup | FAZ-B+ | Ops policy |
+| Evidence export (Prometheus / OTEL) | FAZ-B | Metrics export scope |
+
+### Bozulmaz İlkeler (korunur)
+
+1. **Evidence append-only** — PR-A5 CLI **yalnızca okur**; JSONL'a yazmaz (manifest.json ayrı dosya, events.jsonl dokunulmaz).
+2. **Per-run lock** — manifest generation sırasında `events.jsonl.lock` acquire edilir (concurrent emit ile çakışma önlenir); verify sırasında lock gereksiz (read-only).
+3. **Manifest on-demand** — PR-A3 invariant korunur: emit sırasında manifest güncellenmez; CLI `generate-manifest` explicit çağrılır.
+4. **18-kind taxonomy** — CLI yeni kind eklemez; timeline filter sadece mevcut kind'ları kabul eder.
+5. **Opaque event_id** — CLI `seq` ile sıralar, event_id'yi opaque gösterir (sort by seq, not event_id).
+6. **Redacted payloads** — CLI, evidence_emitter tarafından zaten redact edilmiş payload'ları okur; ek redaction yapmaz (double-redaction riski yok).
+7. **POSIX-only** — manifest lock + atomic write POSIX (A3 invariant).
+8. **Canonical JSON** — manifest.json `sort_keys=True, ensure_ascii=False, separators=(",",":")` (replay determinism).
+
+---
+
+## 3. Write Order
+
+```
+Layer 0 — Manifest generator (_internal)
+  1. ao_kernel/_internal/evidence/manifest.py
+     - generate_manifest(workspace_root, run_id) -> ManifestResult
+     - verify_manifest(workspace_root, run_id) -> VerifyResult
+     - ManifestResult dataclass (files, generated_at)
+     - VerifyResult dataclass (files, all_match, mismatches)
+
+Layer 1 — Evidence handlers (_internal, B5 absorb)
+  2. ao_kernel/_internal/evidence/timeline.py
+     - timeline(workspace_root, run_id, *, format, filter_kinds, filter_actor, limit) -> str
+  3. ao_kernel/_internal/evidence/replay.py
+     - replay(workspace_root, run_id, *, mode) -> ReplayReport
+  4. ao_kernel/_internal/evidence/cli_handlers.py
+     - cmd_timeline(args) / cmd_replay(args) / cmd_generate_manifest(args) / cmd_verify_manifest(args)
+
+Layer 2 — CLI dispatcher delta
+  5. ao_kernel/cli.py
+     - `evidence` subcommand group: timeline, replay, generate-manifest, verify-manifest
+     - argparse subparser registration
+
+Layer 3 — Tests
+  4. tests/test_evidence_cli.py (~25 tests)
+  5. tests/fixtures/evidence/ (seeded events.jsonl + adapter log + artifact)
+
+Layer 4 — Docs + CHANGELOG
+  6. docs/EVIDENCE-TIMELINE.md §7/§8 CLI reference
+  7. CHANGELOG.md [Unreleased] → FAZ-A PR-A5
+```
+
+---
+
+## 4. CNS-025 Question Candidates
+
+6 spec-level soru:
+
+**Q1 — Timeline output format.** Default tablo `seq | ts | kind | actor | step_id | payload_summary` mi? payload_summary max kaç karakter (truncation)? `--format json` full event mi yoksa envelope-only mi?
+
+**Q2 — Replay dry-run state machine walk.** 9-state machine transition'larını event stream'den nasıl reconstruct ediyoruz? `workflow_started` → state=running; `step_started/completed/failed` → step-level; `approval_requested/granted/denied` → waiting_approval/running/cancelled; `workflow_completed/failed` → terminal. Evidence'de explicit state transition event yok — state INFERRED mi?
+
+**Q3 — Manifest scope.** `events.jsonl` + `adapter-*.jsonl` + `artifacts/*.json` — başka dosya var mı? `patches/*.revdiff` manifest kapsamında mı? (reverse-diff dosyaları evidence integrity scope'u mu yoksa workspace artifact scope'u mu?)
+
+**Q4 — Verify-manifest concurrent write tolerance.** verify sırasında yeni event emit olursa (running workflow), manifest stale olur. Verify sadece manifest snapshot'taki dosyaları kontrol edip, post-manifest event'leri ignore mu? Yoksa "manifest outdated" uyarısı mı?
+
+**Q5 — `evidence_cli.py` public module vs _internal.** Planın evidence_cli'yi public yapması doğru mu? Caller (non-CLI) programmatic kullanım: `from ao_kernel.evidence_cli import timeline, replay`. Yoksa `ao_kernel._internal/evidence/cli_handlers.py` + public yüzey sadece `ao_kernel.cli` mi?
+
+**Q6 — PR-A5 test fixture strategy.** Integration test'ler seeded `events.jsonl` ile mi çalışır (deterministic fixture) yoksa real `EvidenceEmitter.emit_event` + real `MultiStepDriver.run_workflow` ile mi? Seeded fixture → hızlı + stable; real flow → gerçek end-to-end ama yavaş. Hangisi?
+
+---
+
+## 5. Audit Trail
+
+| Field | Value |
+|---|---|
+| Plan version | **v2 (post CNS-025 iter-1 absorption)** |
+| Head SHA | `0dfd742` |
+| Base branch | `main` |
+| Target branch | `claude/tranche-a-pr-a5` |
+| CNS-025 thread | NEW (fresh MCP thread) |
+| Total test target | 1510+ (1485 + ≥25) |
+| Coverage gate | 85% |
+| Core dep | `jsonschema>=4.23.0` unchanged |
+
+| CNS-025 thread | `019d93d3-054f-7743-b166-e892d712ff88` |
+
+**Status:** Plan v2 complete. Submit iter-2 via `mcp__codex__codex-reply`.

--- a/ao_kernel/_internal/evidence/cli_handlers.py
+++ b/ao_kernel/_internal/evidence/cli_handlers.py
@@ -1,0 +1,124 @@
+"""CLI handlers for ``ao-kernel evidence`` subcommands (PR-A5).
+
+Called from ``ao_kernel.cli`` argparse dispatcher. Returns int exit code.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def cmd_timeline(args: Any) -> int:
+    """Handle ``ao-kernel evidence timeline``."""
+    from ao_kernel._internal.evidence.timeline import timeline
+
+    workspace = _resolve_workspace(args)
+    try:
+        output = timeline(
+            workspace, args.run_id,
+            format=getattr(args, "format", "table"),
+            filter_kinds=(
+                args.filter_kind.split(",") if getattr(args, "filter_kind", None) else None
+            ),
+            filter_actor=getattr(args, "filter_actor", None),
+            limit=getattr(args, "limit", None),
+        )
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(output)
+    return 0
+
+
+def cmd_replay(args: Any) -> int:
+    """Handle ``ao-kernel evidence replay``."""
+    from ao_kernel._internal.evidence.replay import format_replay_report, replay
+
+    workspace = _resolve_workspace(args)
+    try:
+        report = replay(
+            workspace, args.run_id,
+            mode=getattr(args, "mode", "inspect"),
+        )
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(format_replay_report(report))
+    return 1 if report.warnings else 0
+
+
+def cmd_generate_manifest(args: Any) -> int:
+    """Handle ``ao-kernel evidence generate-manifest``."""
+    from ao_kernel._internal.evidence.manifest import generate_manifest
+
+    workspace = _resolve_workspace(args)
+    try:
+        result = generate_manifest(workspace, args.run_id)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"manifest generated: {result.manifest_path}")
+    print(f"  files: {len(result.files)}")
+    print(f"  generated_at: {result.generated_at}")
+    return 0
+
+
+def cmd_verify_manifest(args: Any) -> int:
+    """Handle ``ao-kernel evidence verify-manifest``.
+
+    Exit codes: 0=OK, 1=mismatch/missing, 2=outdated, 3=manifest missing.
+    """
+    from ao_kernel._internal.evidence.manifest import verify_manifest
+
+    workspace = _resolve_workspace(args)
+    try:
+        result = verify_manifest(
+            workspace, args.run_id,
+            generate_if_missing=getattr(args, "generate_if_missing", False),
+        )
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 3
+
+    # I4-B1 fix: missing manifest.json itself → exit 3 (before generic missing)
+    if result.missing == ("manifest.json",):
+        print(f"MISSING: manifest.json for run {result.run_id} (use --generate-if-missing)")
+        return 3
+
+    if result.all_match and not result.manifest_outdated:
+        print(f"OK: all files match for run {result.run_id}")
+        return 0
+
+    if result.mismatches or result.missing:
+        for m in result.mismatches:
+            print(f"MISMATCH: {m}")
+        for m in result.missing:
+            print(f"MISSING: {m}")
+        return 1
+
+    if result.manifest_outdated:
+        for e in result.extra_in_scope:
+            print(f"OUTDATED (new file not in manifest): {e}")
+        return 2
+
+    return 0
+
+
+def _resolve_workspace(args: Any) -> Path:
+    ws = getattr(args, "workspace_root", None)
+    if ws:
+        return Path(ws)
+    from ao_kernel.config import workspace_root
+    resolved = workspace_root()
+    if resolved is None:
+        print("error: no .ao/ workspace found", file=sys.stderr)
+        sys.exit(1)
+    return resolved

--- a/ao_kernel/_internal/evidence/manifest.py
+++ b/ao_kernel/_internal/evidence/manifest.py
@@ -1,0 +1,206 @@
+"""On-demand SHA-256 manifest generator + verifier (PR-A5).
+
+Scope (CNS-025 B1+B4 absorb):
+  events.jsonl, adapter-*.jsonl, artifacts/**/*.json, patches/*.revdiff
+  Excludes: manifest.json, *.lock, *.tmp
+
+Canonical manifest shape:
+  {"version":"1","run_id":"...","generated_at":"...","files":[{"path":"...","sha256":"...","bytes":N}]}
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+_INCLUDE_GLOBS = [
+    "events.jsonl",
+    "adapter-*.jsonl",
+    "artifacts/**/*.json",
+    "patches/*.revdiff",
+]
+
+_EXCLUDE_NAMES = {"manifest.json"}
+_EXCLUDE_SUFFIXES = {".lock", ".tmp"}
+
+
+@dataclass(frozen=True)
+class FileEntry:
+    path: str  # run-relative
+    sha256: str
+    bytes: int
+
+
+@dataclass(frozen=True)
+class ManifestResult:
+    run_id: str
+    generated_at: str
+    files: tuple[FileEntry, ...]
+    manifest_path: Path
+
+
+@dataclass(frozen=True)
+class VerifyResult:
+    run_id: str
+    all_match: bool
+    manifest_outdated: bool
+    mismatches: tuple[str, ...]
+    missing: tuple[str, ...]
+    extra_in_scope: tuple[str, ...]
+
+
+def generate_manifest(workspace_root: Path, run_id: str) -> ManifestResult:
+    """Scan the run evidence directory and write manifest.json.
+
+    I4-B2 fix: acquires ``events.jsonl.lock`` during scan + write to
+    prevent hash race with concurrent ``EvidenceEmitter.emit_event``.
+    """
+    from ao_kernel._internal.shared.lock import file_lock
+
+    run_dir = workspace_root / ".ao" / "evidence" / "workflows" / run_id
+    if not run_dir.is_dir():
+        raise FileNotFoundError(f"run dir not found: {run_dir}")
+
+    lock_path = run_dir / "events.jsonl.lock"
+    with file_lock(lock_path):
+        entries = _scan_files(run_dir)
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    manifest = {
+        "version": "1",
+        "run_id": run_id,
+        "generated_at": now,
+        "files": [
+            {"path": e.path, "sha256": e.sha256, "bytes": e.bytes}
+            for e in entries
+        ],
+    }
+    manifest_path = run_dir / "manifest.json"
+    _atomic_write_json(manifest_path, manifest)
+
+    return ManifestResult(
+        run_id=run_id,
+        generated_at=now,
+        files=entries,
+        manifest_path=manifest_path,
+    )
+
+
+def verify_manifest(
+    workspace_root: Path,
+    run_id: str,
+    *,
+    generate_if_missing: bool = False,
+) -> VerifyResult:
+    """Recompute hashes and compare against existing manifest.
+
+    Exit code semantics (caller maps):
+      0 = all_match=True, manifest_outdated=False
+      1 = mismatch or missing listed file
+      2 = manifest_outdated (new in-scope file not in manifest)
+      3 = manifest.json itself missing (unless generate_if_missing)
+    """
+    run_dir = workspace_root / ".ao" / "evidence" / "workflows" / run_id
+    manifest_path = run_dir / "manifest.json"
+
+    if not manifest_path.exists():
+        if generate_if_missing:
+            generate_manifest(workspace_root, run_id)
+        else:
+            return VerifyResult(
+                run_id=run_id,
+                all_match=False,
+                manifest_outdated=False,
+                mismatches=(),
+                missing=("manifest.json",),
+                extra_in_scope=(),
+            )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    listed: dict[str, dict[str, object]] = {
+        f["path"]: f for f in manifest.get("files", [])
+    }
+
+    mismatches: list[str] = []
+    missing: list[str] = []
+
+    for rel_path, expected in listed.items():
+        full = run_dir / rel_path
+        if not full.exists():
+            missing.append(rel_path)
+            continue
+        actual_hash = _sha256(full)
+        if actual_hash != expected.get("sha256"):
+            mismatches.append(rel_path)
+
+    # Outdated detection: scan for in-scope files not in manifest
+    current = _scan_files(run_dir)
+    current_paths = {e.path for e in current}
+    listed_paths = set(listed.keys())
+    extra = sorted(current_paths - listed_paths)
+
+    return VerifyResult(
+        run_id=run_id,
+        all_match=len(mismatches) == 0 and len(missing) == 0 and len(extra) == 0,
+        manifest_outdated=len(extra) > 0,
+        mismatches=tuple(mismatches),
+        missing=tuple(missing),
+        extra_in_scope=tuple(extra),
+    )
+
+
+def _scan_files(run_dir: Path) -> tuple[FileEntry, ...]:
+    """Collect in-scope files under run_dir, hashing each."""
+    entries: list[FileEntry] = []
+    for pattern in _INCLUDE_GLOBS:
+        for match in sorted(run_dir.glob(pattern)):
+            if not match.is_file():
+                continue
+            if match.name in _EXCLUDE_NAMES:
+                continue
+            if match.suffix in _EXCLUDE_SUFFIXES:
+                continue
+            rel = str(match.relative_to(run_dir))
+            h = _sha256(match)
+            entries.append(FileEntry(path=rel, sha256=h, bytes=match.stat().st_size))
+    # Deduplicate (glob patterns may overlap)
+    seen: dict[str, FileEntry] = {}
+    for e in entries:
+        seen.setdefault(e.path, e)
+    return tuple(sorted(seen.values(), key=lambda e: e.path))
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _atomic_write_json(path: Path, data: Mapping[str, object]) -> None:
+    body = json.dumps(
+        data, sort_keys=True, ensure_ascii=False, separators=(",", ":"),
+    ).encode("utf-8")
+    fd, tmp = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=path.parent,
+    )
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(body)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise

--- a/ao_kernel/_internal/evidence/replay.py
+++ b/ao_kernel/_internal/evidence/replay.py
@@ -1,0 +1,204 @@
+"""Evidence replay engine (PR-A5).
+
+Walks the event stream and infers run-level state transitions.
+Does NOT re-execute — read-only analysis. Reports
+``state_source: event|inferred|synthetic`` per transition (B3 absorb).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+
+_EVENT_STATE_MAP: dict[str, str] = {
+    "workflow_started": "running",
+    "workflow_completed": "completed",
+    "workflow_failed": "failed",
+    "approval_requested": "waiting_approval",
+    "approval_granted": "running",
+    "approval_denied": "cancelled",
+}
+
+_INFERRED_STATE_MAP: dict[str, str] = {
+    "diff_applied": "applying",
+    "test_executed": "verifying",
+    "diff_previewed": "running",  # pre-apply; state stays running
+}
+
+
+@dataclass
+class StateTransition:
+    seq: int
+    event_kind: str
+    from_state: str
+    to_state: str
+    state_source: Literal["event", "inferred", "synthetic"]
+    replay_safe: bool
+    stored_replay_safe: bool
+    note: str = ""
+
+
+@dataclass
+class ReplayReport:
+    run_id: str
+    mode: str
+    transitions: list[StateTransition] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    final_inferred_state: str = "unknown"
+
+
+# Effective replay_safe taxonomy (B2 absorb — authoritative, not stored value)
+_NON_REPLAY_SAFE_KINDS = frozenset({
+    "adapter_invoked", "adapter_returned",
+    "approval_granted", "approval_denied",
+    "pr_opened",
+})
+
+
+def replay(
+    workspace_root: Path,
+    run_id: str,
+    *,
+    mode: str = "inspect",
+) -> ReplayReport:
+    """Walk the event stream and produce a replay report.
+
+    ``mode="inspect"``: annotate each event with replay_safe + state trace.
+    ``mode="dry-run"``: full state machine walk with warnings for
+    illegal/unexpected transitions.
+    """
+    events_path = (
+        workspace_root / ".ao" / "evidence" / "workflows" / run_id / "events.jsonl"
+    )
+    if not events_path.exists():
+        raise FileNotFoundError(f"events not found: {events_path}")
+
+    events = _parse_sorted(events_path)
+    report = ReplayReport(run_id=run_id, mode=mode)
+    current_state = "created"
+
+    for evt in events:
+        kind = evt.get("kind", "")
+        seq = evt.get("seq", 0)
+        stored_safe = evt.get("replay_safe", True)
+        effective_safe = kind not in _NON_REPLAY_SAFE_KINDS
+
+        # Determine target state
+        target = _EVENT_STATE_MAP.get(kind)
+        source: Literal["event", "inferred", "synthetic"] = "event"
+        if target is None:
+            target = _INFERRED_STATE_MAP.get(kind)
+            source = "inferred" if target else "synthetic"
+
+        if target is None:
+            # No state implication — step_started, step_completed etc.
+            # Record for inspect but don't transition.
+            if mode == "inspect":
+                report.transitions.append(StateTransition(
+                    seq=seq, event_kind=kind,
+                    from_state=current_state, to_state=current_state,
+                    state_source="synthetic",
+                    replay_safe=effective_safe,
+                    stored_replay_safe=stored_safe,
+                    note="no state transition",
+                ))
+            continue
+
+        # Check legality; insert synthetic chain if needed (I4-B3)
+        from ao_kernel.workflow.state_machine import allowed_next
+        try:
+            legal = target in allowed_next(current_state)
+        except ValueError:
+            legal = False
+
+        if not legal and current_state != target:
+            # Attempt synthetic chain (e.g., running → applying → verifying → completed)
+            chain = _synthetic_chain(current_state, target)
+            if chain:
+                for intermediate in chain:
+                    report.transitions.append(StateTransition(
+                        seq=seq, event_kind=kind,
+                        from_state=current_state, to_state=intermediate,
+                        state_source="synthetic",
+                        replay_safe=effective_safe,
+                        stored_replay_safe=stored_safe,
+                        note="synthetic intermediate",
+                    ))
+                    current_state = intermediate
+                legal = True  # chain resolved the gap
+            else:
+                report.warnings.append(
+                    f"seq={seq}: illegal transition {current_state!r} → {target!r} "
+                    f"(event={kind}, source={source})"
+                )
+
+        report.transitions.append(StateTransition(
+            seq=seq, event_kind=kind,
+            from_state=current_state, to_state=target,
+            state_source=source,
+            replay_safe=effective_safe,
+            stored_replay_safe=stored_safe,
+            note="illegal" if not legal and current_state != target else "",
+        ))
+        current_state = target
+
+    report.final_inferred_state = current_state
+    return report
+
+
+def format_replay_report(report: ReplayReport) -> str:
+    """Human-readable replay report."""
+    lines = [
+        f"Replay report for run {report.run_id} (mode={report.mode})",
+        f"Final inferred state: {report.final_inferred_state}",
+        f"Transitions: {len(report.transitions)}",
+        f"Warnings: {len(report.warnings)}",
+        "",
+    ]
+    for t in report.transitions:
+        safe_marker = "R" if t.replay_safe else "N"
+        stored_marker = "R" if t.stored_replay_safe else "N"
+        mismatch = " MISMATCH" if t.replay_safe != t.stored_replay_safe else ""
+        lines.append(
+            f"  seq={t.seq:>3} {t.event_kind:24} "
+            f"{t.from_state:20} → {t.to_state:20} "
+            f"[{t.state_source:9}] safe={safe_marker}/stored={stored_marker}{mismatch}"
+            f"{' ⚠ ' + t.note if t.note else ''}"
+        )
+    if report.warnings:
+        lines.append("")
+        lines.append("Warnings:")
+        for w in report.warnings:
+            lines.append(f"  ⚠ {w}")
+    return "\n".join(lines)
+
+
+_SYNTHETIC_CHAINS: dict[tuple[str, str], list[str]] = {
+    ("running", "completed"): ["applying", "verifying"],
+    ("running", "verifying"): ["applying"],
+    ("applying", "completed"): ["verifying"],
+}
+
+
+def _synthetic_chain(current: str, target: str) -> list[str]:
+    """Return intermediate states for a synthetic transition chain.
+
+    Returns empty list if no known chain exists. Used to bridge the
+    gap between the driver's CAS chain (which may skip evidence events
+    for intermediate states) and the state machine's transition table.
+    """
+    return list(_SYNTHETIC_CHAINS.get((current, target), []))
+
+
+def _parse_sorted(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        events.append(json.loads(line))
+    events.sort(key=lambda e: e.get("seq", 0))
+    return events

--- a/ao_kernel/_internal/evidence/timeline.py
+++ b/ao_kernel/_internal/evidence/timeline.py
@@ -1,0 +1,101 @@
+"""Evidence timeline reader + formatter (PR-A5).
+
+Reads per-run ``events.jsonl``, sorts by ``seq``, filters by kind/actor,
+formats as human-readable table or NDJSON.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+
+def timeline(
+    workspace_root: Path,
+    run_id: str,
+    *,
+    format: str = "table",
+    filter_kinds: Sequence[str] | None = None,
+    filter_actor: str | None = None,
+    limit: int | None = None,
+) -> str:
+    """Return formatted timeline string.
+
+    Raises ``FileNotFoundError`` when run dir or events.jsonl absent.
+    Returns ``"no events"`` for empty JSONL.
+    """
+    events_path = (
+        workspace_root / ".ao" / "evidence" / "workflows" / run_id / "events.jsonl"
+    )
+    if not events_path.exists():
+        raise FileNotFoundError(f"events not found: {events_path}")
+
+    events = _parse_events(events_path)
+    if not events:
+        return "no events"
+
+    # Sort by seq (monotonic ordering key)
+    events.sort(key=lambda e: e.get("seq", 0))
+
+    # Filters
+    if filter_kinds:
+        allowed = set(filter_kinds)
+        events = [e for e in events if e.get("kind") in allowed]
+    if filter_actor:
+        events = [e for e in events if e.get("actor") == filter_actor]
+
+    # Limit (last N)
+    if limit is not None and limit > 0:
+        events = events[-limit:]
+
+    if not events:
+        return "no events (after filters)"
+
+    if format == "json":
+        return "\n".join(
+            json.dumps(e, sort_keys=True, ensure_ascii=False) for e in events
+        )
+
+    return _format_table(events)
+
+
+def _parse_events(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"malformed JSONL at {path}:{lineno}: {exc}"
+            ) from exc
+    return events
+
+
+def _format_table(events: list[dict[str, Any]]) -> str:
+    header = f"{'seq':>5} | {'ts':24} | {'kind':24} | {'actor':12} | {'step_id':30} | payload_summary"
+    sep = "-" * len(header)
+    rows = [header, sep]
+    for e in events:
+        seq = e.get("seq", "?")
+        ts = e.get("ts", "")[:24]
+        kind = e.get("kind", "")[:24]
+        actor = e.get("actor", "")[:12]
+        step_id = (e.get("step_id") or "")[:30]
+        summary = _payload_summary(e.get("payload", {}))
+        rows.append(
+            f"{seq:>5} | {ts:24} | {kind:24} | {actor:12} | {step_id:30} | {summary}"
+        )
+    return "\n".join(rows)
+
+
+def _payload_summary(payload: dict[str, Any], max_len: int = 96) -> str:
+    compact = json.dumps(
+        payload, sort_keys=True, ensure_ascii=False, separators=(",", ":"),
+    )
+    if len(compact) <= max_len:
+        return compact
+    return compact[: max_len - 3] + "..."

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -83,6 +83,29 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("doctor", help="Workspace health check")
 
+    # Evidence subcommands (PR-A5)
+    ev_p = sub.add_parser("evidence", help="Evidence timeline + replay + manifest")
+    ev_sub = ev_p.add_subparsers(dest="evidence_command")
+
+    tl_p = ev_sub.add_parser("timeline", help="Show evidence event timeline")
+    tl_p.add_argument("--run", dest="run_id", required=True, help="Run ID (UUID)")
+    tl_p.add_argument("--format", choices=["table", "json"], default="table")
+    tl_p.add_argument("--filter-kind", default=None, help="Comma-separated kind filter")
+    tl_p.add_argument("--filter-actor", default=None, help="Actor filter")
+    tl_p.add_argument("--limit", type=int, default=None, help="Last N events")
+
+    rp_p = ev_sub.add_parser("replay", help="Replay event stream (inspect/dry-run)")
+    rp_p.add_argument("--run", dest="run_id", required=True, help="Run ID (UUID)")
+    rp_p.add_argument("--mode", choices=["inspect", "dry-run"], default="inspect")
+
+    gm_p = ev_sub.add_parser("generate-manifest", help="Generate SHA-256 manifest")
+    gm_p.add_argument("--run", dest="run_id", required=True, help="Run ID (UUID)")
+
+    vm_p = ev_sub.add_parser("verify-manifest", help="Verify SHA-256 manifest")
+    vm_p.add_argument("--run", dest="run_id", required=True, help="Run ID (UUID)")
+    vm_p.add_argument("--generate-if-missing", action="store_true",
+                       help="Generate manifest first if absent")
+
     mcp_p = sub.add_parser("mcp", help="MCP server commands")
     mcp_sub = mcp_p.add_subparsers(dest="mcp_command")
     serve_p = mcp_sub.add_parser("serve", help="Start MCP server")
@@ -108,6 +131,27 @@ def main(argv: list[str] | None = None) -> int:
     if cmd is None:
         parser.print_help()
         return 0
+
+    # Evidence subcommand (PR-A5)
+    if cmd == "evidence":
+        from ao_kernel._internal.evidence.cli_handlers import (
+            cmd_generate_manifest,
+            cmd_replay,
+            cmd_timeline,
+            cmd_verify_manifest,
+        )
+        ev_dispatch = {
+            "timeline": cmd_timeline,
+            "replay": cmd_replay,
+            "generate-manifest": cmd_generate_manifest,
+            "verify-manifest": cmd_verify_manifest,
+        }
+        ev_cmd = getattr(args, "evidence_command", None)
+        handler = ev_dispatch.get(ev_cmd) if ev_cmd else None
+        if handler is None:
+            print("Usage: ao-kernel evidence {timeline|replay|generate-manifest|verify-manifest}")
+            return 1
+        return handler(args)
 
     # MCP subcommand
     if cmd == "mcp":

--- a/ao_kernel/executor/executor.py
+++ b/ao_kernel/executor/executor.py
@@ -313,7 +313,7 @@ class Executor:
                 policy=self._policy,
             )
 
-            # adapter_invoked
+            # adapter_invoked (B2 absorb: replay_safe=False — adapter invocation is non-deterministic)
             invoked = emit_event(
                 self._workspace_root,
                 run_id=run_id,
@@ -325,6 +325,7 @@ class Executor:
                     "transport": manifest.invocation.get("transport"),
                 },
                 step_id=step_def.step_name,
+                replay_safe=False,
             )
             evidence_event_ids.append(invoked.event_id)
 
@@ -374,7 +375,7 @@ class Executor:
                 payload=artifact_payload,
             )
 
-            # adapter_returned (v2 note: actor is adapter-sourced, reported by orchestrator)
+            # adapter_returned (B2 absorb: replay_safe=False — adapter response is non-deterministic)
             returned = emit_event(
                 self._workspace_root,
                 run_id=run_id,
@@ -390,6 +391,7 @@ class Executor:
                     "attempt": attempt,
                 },
                 step_id=step_id_for_events,
+                replay_safe=False,
             )
             evidence_event_ids.append(returned.event_id)
         finally:

--- a/ao_kernel/executor/multi_step_driver.py
+++ b/ao_kernel/executor/multi_step_driver.py
@@ -1528,12 +1528,17 @@ class MultiStepDriver:
         *,
         step_id: str | None = None,
         actor: str = "ao-kernel",
+        replay_safe: bool = True,
     ) -> None:
+        # B2 absorb: approval_granted/denied are non-deterministic
+        if kind in ("approval_granted", "approval_denied"):
+            replay_safe = False
         try:
             emit_event(
                 self._workspace_root,
                 run_id=run_id, kind=kind, actor=actor,
                 payload=dict(payload), step_id=step_id,
+                replay_safe=replay_safe,
             )
         except Exception:  # noqa: BLE001 - evidence write is best-effort side-channel
             # Evidence emission failure must not block the main flow

--- a/docs/EVIDENCE-TIMELINE.md
+++ b/docs/EVIDENCE-TIMELINE.md
@@ -182,9 +182,10 @@ Workflow run artefacts (events.jsonl + adapter logs) carry a SHA-256 integrity m
 
 ```json
 {
-  "version": "v1",
+  "version": "1",
   "run_id": "a1b2c3d4-e5f6-4789-9012-3456789abcde",
-  "artefacts": [
+  "generated_at": "2026-04-16T12:45:00+00:00",
+  "files": [
     {
       "path": "events.jsonl",
       "sha256": "7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069",
@@ -194,13 +195,24 @@ Workflow run artefacts (events.jsonl + adapter logs) carry a SHA-256 integrity m
       "path": "adapter-claude-code-cli.jsonl",
       "sha256": "a3f5c9e0...",
       "bytes": 12408
+    },
+    {
+      "path": "artifacts/invoke_coding_agent-attempt1.json",
+      "sha256": "b4d2e1f0...",
+      "bytes": 1024
+    },
+    {
+      "path": "patches/patch-abc.revdiff",
+      "sha256": "c5e3f2a1...",
+      "bytes": 512
     }
-  ],
-  "last_updated": "2026-04-15T12:45:00+03:00"
+  ]
 }
 ```
 
-The manifest is **generated on demand** by the PR-A5 `ao-kernel evidence timeline --verify-manifest` CLI (see §7), not updated per-event. PR-A3 emits events append-only (lock + fsync) without maintaining a manifest file; the CLI re-hashes the stream at query time so the hot write path stays free of cross-file coordination. Replay tooling verifies the manifest SHA-256s before trusting the stream.
+**Manifest scope (PR-A5):** `events.jsonl` + `adapter-*.jsonl` + `artifacts/**/*.json` + `patches/*.revdiff`. Excludes: `manifest.json`, `*.lock`, `*.tmp`.
+
+The manifest is **generated on demand** by `ao-kernel evidence generate-manifest --run <run_id>`. PR-A3 emits events append-only (lock + fsync) without maintaining a manifest file; the CLI re-hashes the artefacts at command time so the hot write path stays free of cross-file coordination. `ao-kernel evidence verify-manifest --run <run_id>` recomputes SHA-256s and exits non-zero on mismatch (exit 1), outdated manifest (exit 2), or missing manifest (exit 3). Replay tooling verifies the manifest SHA-256s before trusting the stream.
 
 **MCP events do NOT carry a manifest** (per CLAUDE.md §2, Tranche D scope). The dual-form evidence contract is: workspace artefacts have manifests, MCP events are fsync'd JSONL only.
 
@@ -249,22 +261,35 @@ Redaction is a defense-in-depth layer. The primary defense is `policy_worktree_p
 
 ---
 
-## 8. CLI Plan — `ao-kernel evidence timeline` (Tranche A PR-A5)
+## 8. CLI Reference — `ao-kernel evidence` (PR-A5 shipped)
 
-The evidence CLI is part of FAZ-A's release gate. Command surface (to be implemented in PR-A5, not PR-A0):
+Four subcommands:
 
 ```bash
+# Timeline — chronological event table or NDJSON
 ao-kernel evidence timeline --run <run_id>
 ao-kernel evidence timeline --run <run_id> --format json
-ao-kernel evidence timeline --run <run_id> --replay inspect
-ao-kernel evidence timeline --run <run_id> --replay dry-run
-ao-kernel evidence timeline --run <run_id> --filter-kind adapter_invoked,adapter_returned
-ao-kernel evidence timeline --run <run_id> --verify-manifest
+ao-kernel evidence timeline --run <run_id> --filter-kind step_started,step_completed
+ao-kernel evidence timeline --run <run_id> --filter-actor adapter
+ao-kernel evidence timeline --run <run_id> --limit 20
+
+# Replay — inferred state trace + replay_safe annotation
+ao-kernel evidence replay --run <run_id> --mode inspect
+ao-kernel evidence replay --run <run_id> --mode dry-run
+
+# Manifest — on-demand SHA-256 generation
+ao-kernel evidence generate-manifest --run <run_id>
+
+# Verify — recompute + compare
+ao-kernel evidence verify-manifest --run <run_id>
+ao-kernel evidence verify-manifest --run <run_id> --generate-if-missing
 ```
 
-Default output is a chronological, human-readable summary: each event on one line with `ts`, `kind`, `actor`, and a one-line payload summary. Secrets are already redacted in the source JSONL; the CLI does not re-redact.
+**Timeline default output:** `seq | ts | kind | actor | step_id | payload_summary` (96-char payload truncation). `--format json` emits full event NDJSON. Secrets are already redacted in the source JSONL; the CLI does not re-redact.
 
-`--verify-manifest` recomputes SHA-256s for every artefact in the manifest and exits non-zero on mismatch.
+**Replay:** produces an **inferred state trace** — not an exact recorded state. `state_source` per transition is `event` (explicit like `workflow_started → running`), `inferred` (e.g., `diff_applied → applying`), or `synthetic` (driver CAS chain with no matching evidence event). Illegal transitions produce warnings, not hard failures.
+
+**Verify exit codes:** `0` = all match; `1` = hash mismatch or missing listed file; `2` = manifest outdated (new in-scope file); `3` = `manifest.json` missing.
 
 ---
 

--- a/tests/test_evidence_cli.py
+++ b/tests/test_evidence_cli.py
@@ -1,0 +1,389 @@
+"""Tests for PR-A5 evidence CLI: timeline, replay, manifest, verify."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ao_kernel._internal.evidence.manifest import (
+    generate_manifest,
+    verify_manifest,
+)
+from ao_kernel._internal.evidence.replay import replay, format_replay_report
+from ao_kernel._internal.evidence.timeline import timeline
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_run(tmp_path: Path, run_id: str = "test-run-001") -> Path:
+    """Seed a minimal run evidence dir with 5 events."""
+    run_dir = tmp_path / ".ao" / "evidence" / "workflows" / run_id
+    run_dir.mkdir(parents=True)
+    events = [
+        {"seq": 1, "ts": "2026-04-16T00:00:01Z", "kind": "workflow_started",
+         "actor": "ao-kernel", "step_id": None, "run_id": run_id,
+         "event_id": "e1", "payload": {"workflow_id": "test_flow"},
+         "payload_hash": "aaa", "replay_safe": True},
+        {"seq": 2, "ts": "2026-04-16T00:00:02Z", "kind": "step_started",
+         "actor": "ao-kernel", "step_id": "step1", "run_id": run_id,
+         "event_id": "e2", "payload": {"step_name": "step1", "attempt": 1},
+         "payload_hash": "bbb", "replay_safe": True},
+        {"seq": 3, "ts": "2026-04-16T00:00:03Z", "kind": "adapter_invoked",
+         "actor": "ao-kernel", "step_id": "step1", "run_id": run_id,
+         "event_id": "e3", "payload": {"adapter_id": "codex-stub"},
+         "payload_hash": "ccc", "replay_safe": False},
+        {"seq": 4, "ts": "2026-04-16T00:00:04Z", "kind": "step_completed",
+         "actor": "ao-kernel", "step_id": "step1", "run_id": run_id,
+         "event_id": "e4", "payload": {"step_name": "step1", "final_state": "completed"},
+         "payload_hash": "ddd", "replay_safe": True},
+        {"seq": 5, "ts": "2026-04-16T00:00:05Z", "kind": "workflow_completed",
+         "actor": "ao-kernel", "step_id": None, "run_id": run_id,
+         "event_id": "e5", "payload": {"steps_executed": ["step1"]},
+         "payload_hash": "eee", "replay_safe": True},
+    ]
+    lines = [json.dumps(e, sort_keys=True) for e in events]
+    (run_dir / "events.jsonl").write_text("\n".join(lines) + "\n")
+    return run_dir
+
+
+def _seed_artifacts(run_dir: Path) -> None:
+    """Add adapter log + artifact + revdiff for manifest tests."""
+    (run_dir / "adapter-codex-stub.jsonl").write_text(
+        json.dumps({"line": 1, "log": "hello"}) + "\n"
+    )
+    artifacts_dir = run_dir / "artifacts"
+    artifacts_dir.mkdir(exist_ok=True)
+    (artifacts_dir / "step1-attempt1.json").write_text(
+        json.dumps({"status": "ok"}, sort_keys=True)
+    )
+    patches_dir = run_dir / "patches"
+    patches_dir.mkdir(exist_ok=True)
+    (patches_dir / "patch-abc.revdiff").write_text("--- a/x\n+++ b/x\n")
+
+
+# ---------------------------------------------------------------------------
+# Timeline tests
+# ---------------------------------------------------------------------------
+
+
+class TestTimeline:
+    def test_happy_path_table_output(self, tmp_path: Path) -> None:
+        _seed_run(tmp_path)
+        out = timeline(tmp_path, "test-run-001")
+        assert "workflow_started" in out
+        assert "workflow_completed" in out
+        assert "seq" in out  # header
+
+    def test_json_format(self, tmp_path: Path) -> None:
+        _seed_run(tmp_path)
+        out = timeline(tmp_path, "test-run-001", format="json")
+        lines = out.strip().split("\n")
+        assert len(lines) == 5
+        first = json.loads(lines[0])
+        assert first["kind"] == "workflow_started"
+
+    def test_filter_by_kind(self, tmp_path: Path) -> None:
+        _seed_run(tmp_path)
+        out = timeline(tmp_path, "test-run-001",
+                       filter_kinds=["workflow_started", "workflow_completed"])
+        assert "adapter_invoked" not in out
+        assert "workflow_started" in out
+
+    def test_filter_by_actor(self, tmp_path: Path) -> None:
+        _seed_run(tmp_path)
+        out = timeline(tmp_path, "test-run-001", filter_actor="human")
+        assert out == "no events (after filters)"
+
+    def test_limit(self, tmp_path: Path) -> None:
+        _seed_run(tmp_path)
+        out = timeline(tmp_path, "test-run-001", format="json", limit=2)
+        lines = out.strip().split("\n")
+        assert len(lines) == 2
+        assert json.loads(lines[-1])["kind"] == "workflow_completed"
+
+    def test_missing_run_raises(self, tmp_path: Path) -> None:
+        (tmp_path / ".ao").mkdir(parents=True)
+        with pytest.raises(FileNotFoundError):
+            timeline(tmp_path, "nonexistent-run")
+
+    def test_empty_events(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / ".ao" / "evidence" / "workflows" / "empty-run"
+        run_dir.mkdir(parents=True)
+        (run_dir / "events.jsonl").write_text("")
+        out = timeline(tmp_path, "empty-run")
+        assert out == "no events"
+
+    def test_malformed_jsonl_raises(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / ".ao" / "evidence" / "workflows" / "bad-run"
+        run_dir.mkdir(parents=True)
+        (run_dir / "events.jsonl").write_text("not json\n")
+        with pytest.raises(ValueError, match="malformed"):
+            timeline(tmp_path, "bad-run")
+
+    def test_payload_summary_truncation(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / ".ao" / "evidence" / "workflows" / "long-payload"
+        run_dir.mkdir(parents=True)
+        big_payload = {"key": "x" * 200}
+        event = {
+            "seq": 1, "ts": "2026-04-16T00:00:01Z", "kind": "workflow_started",
+            "actor": "ao-kernel", "run_id": "long-payload", "event_id": "e1",
+            "payload": big_payload, "payload_hash": "fff", "replay_safe": True,
+        }
+        (run_dir / "events.jsonl").write_text(json.dumps(event) + "\n")
+        out = timeline(tmp_path, "long-payload")
+        assert "..." in out  # truncated
+
+
+# ---------------------------------------------------------------------------
+# Replay tests
+# ---------------------------------------------------------------------------
+
+
+class TestReplay:
+    def test_inspect_annotates_replay_safe(self, tmp_path: Path) -> None:
+        _seed_run(tmp_path)
+        report = replay(tmp_path, "test-run-001", mode="inspect")
+        assert report.run_id == "test-run-001"
+        assert report.final_inferred_state == "completed"
+        # adapter_invoked should be marked non-replay-safe
+        adapter_transitions = [
+            t for t in report.transitions if t.event_kind == "adapter_invoked"
+        ]
+        assert len(adapter_transitions) == 1
+        assert adapter_transitions[0].replay_safe is False
+
+    def test_dry_run_reports_state_source(self, tmp_path: Path) -> None:
+        _seed_run(tmp_path)
+        report = replay(tmp_path, "test-run-001", mode="dry-run")
+        sources = {t.state_source for t in report.transitions}
+        assert "event" in sources  # workflow_started → running
+
+    def test_format_replay_report_runs(self, tmp_path: Path) -> None:
+        _seed_run(tmp_path)
+        report = replay(tmp_path, "test-run-001")
+        output = format_replay_report(report)
+        assert "Replay report" in output
+        assert "completed" in output
+
+    def test_stored_vs_effective_replay_safe_mismatch(self, tmp_path: Path) -> None:
+        """adapter_invoked has stored replay_safe=False (B2 fixed in emitter)
+        and effective replay_safe=False — no mismatch expected for PR-A5."""
+        _seed_run(tmp_path)
+        report = replay(tmp_path, "test-run-001")
+        adapter_t = [t for t in report.transitions if t.event_kind == "adapter_invoked"]
+        if adapter_t:
+            # Both stored and effective should be False after B2 fix
+            assert adapter_t[0].stored_replay_safe is False
+            assert adapter_t[0].replay_safe is False
+
+
+# ---------------------------------------------------------------------------
+# Manifest tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateManifest:
+    def test_generates_manifest_json(self, tmp_path: Path) -> None:
+        run_dir = _seed_run(tmp_path)
+        _seed_artifacts(run_dir)
+        result = generate_manifest(tmp_path, "test-run-001")
+        assert result.manifest_path.exists()
+        manifest = json.loads(result.manifest_path.read_text())
+        assert manifest["version"] == "1"
+        assert manifest["run_id"] == "test-run-001"
+        paths = {f["path"] for f in manifest["files"]}
+        assert "events.jsonl" in paths
+        assert "adapter-codex-stub.jsonl" in paths
+        assert "artifacts/step1-attempt1.json" in paths
+        assert "patches/patch-abc.revdiff" in paths
+
+    def test_idempotent_overwrite(self, tmp_path: Path) -> None:
+        run_dir = _seed_run(tmp_path)
+        _seed_artifacts(run_dir)
+        r1 = generate_manifest(tmp_path, "test-run-001")
+        r2 = generate_manifest(tmp_path, "test-run-001")
+        assert r1.manifest_path == r2.manifest_path
+        assert {f.sha256 for f in r1.files} == {f.sha256 for f in r2.files}
+
+    def test_missing_run_raises(self, tmp_path: Path) -> None:
+        (tmp_path / ".ao" / "evidence" / "workflows").mkdir(parents=True)
+        with pytest.raises(FileNotFoundError):
+            generate_manifest(tmp_path, "nonexistent")
+
+    def test_excludes_manifest_and_lock(self, tmp_path: Path) -> None:
+        run_dir = _seed_run(tmp_path)
+        (run_dir / "events.jsonl.lock").write_text("")
+        (run_dir / "temp.tmp").write_text("")
+        result = generate_manifest(tmp_path, "test-run-001")
+        paths = {f.path for f in result.files}
+        assert "events.jsonl.lock" not in paths
+        assert "temp.tmp" not in paths
+
+
+class TestVerifyManifest:
+    def test_all_match_returns_ok(self, tmp_path: Path) -> None:
+        run_dir = _seed_run(tmp_path)
+        _seed_artifacts(run_dir)
+        generate_manifest(tmp_path, "test-run-001")
+        result = verify_manifest(tmp_path, "test-run-001")
+        assert result.all_match is True
+        assert result.manifest_outdated is False
+        assert result.mismatches == ()
+        assert result.missing == ()
+
+    def test_mismatch_detected(self, tmp_path: Path) -> None:
+        run_dir = _seed_run(tmp_path)
+        _seed_artifacts(run_dir)
+        generate_manifest(tmp_path, "test-run-001")
+        # Tamper with events.jsonl
+        (run_dir / "events.jsonl").write_text("tampered\n")
+        result = verify_manifest(tmp_path, "test-run-001")
+        assert result.all_match is False
+        assert "events.jsonl" in result.mismatches
+
+    def test_missing_file_detected(self, tmp_path: Path) -> None:
+        run_dir = _seed_run(tmp_path)
+        _seed_artifacts(run_dir)
+        generate_manifest(tmp_path, "test-run-001")
+        (run_dir / "adapter-codex-stub.jsonl").unlink()
+        result = verify_manifest(tmp_path, "test-run-001")
+        assert result.all_match is False
+        assert "adapter-codex-stub.jsonl" in result.missing
+
+    def test_outdated_new_file_detected(self, tmp_path: Path) -> None:
+        run_dir = _seed_run(tmp_path)
+        _seed_artifacts(run_dir)
+        generate_manifest(tmp_path, "test-run-001")
+        # Add a new in-scope file after manifest was generated
+        (run_dir / "adapter-new-agent.jsonl").write_text("{}\n")
+        result = verify_manifest(tmp_path, "test-run-001")
+        assert result.manifest_outdated is True
+        assert "adapter-new-agent.jsonl" in result.extra_in_scope
+
+    def test_missing_manifest_returns_missing(self, tmp_path: Path) -> None:
+        _seed_run(tmp_path)
+        result = verify_manifest(tmp_path, "test-run-001")
+        assert result.all_match is False
+        assert "manifest.json" in result.missing
+
+    def test_generate_if_missing_creates_then_verifies(self, tmp_path: Path) -> None:
+        run_dir = _seed_run(tmp_path)
+        _seed_artifacts(run_dir)
+        result = verify_manifest(
+            tmp_path, "test-run-001", generate_if_missing=True,
+        )
+        assert result.all_match is True
+        assert (run_dir / "manifest.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# CLI integration (main entrypoint)
+# ---------------------------------------------------------------------------
+
+
+class TestReplayEdgeCases:
+    def test_replay_malformed_jsonl_handled(self, tmp_path: Path) -> None:
+        """RW3: replay should not crash on malformed JSONL."""
+        run_dir = tmp_path / ".ao" / "evidence" / "workflows" / "bad-replay"
+        run_dir.mkdir(parents=True)
+        (run_dir / "events.jsonl").write_text("not json\n")
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            replay(tmp_path, "bad-replay")
+
+    def test_replay_empty_events(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / ".ao" / "evidence" / "workflows" / "empty-replay"
+        run_dir.mkdir(parents=True)
+        (run_dir / "events.jsonl").write_text("")
+        report = replay(tmp_path, "empty-replay")
+        assert report.final_inferred_state == "created"
+        assert report.transitions == []
+
+    def test_replay_missing_run(self, tmp_path: Path) -> None:
+        (tmp_path / ".ao" / "evidence" / "workflows").mkdir(parents=True)
+        with pytest.raises(FileNotFoundError):
+            replay(tmp_path, "nonexistent")
+
+
+class TestManifestLock:
+    def test_generate_creates_lock_file_temporarily(self, tmp_path: Path) -> None:
+        """I4-B2: generate_manifest acquires events.jsonl.lock."""
+        run_dir = _seed_run(tmp_path)
+        _seed_artifacts(run_dir)
+        result = generate_manifest(tmp_path, "test-run-001")
+        # Lock is released after context manager exits; manifest written
+        assert result.manifest_path.exists()
+
+
+class TestCLIEntrypoint:
+    def test_timeline_subcommand(self, tmp_path: Path) -> None:
+        _seed_run(tmp_path)
+        from ao_kernel.cli import main
+        exit_code = main([
+            "--workspace-root", str(tmp_path),
+            "evidence", "timeline", "--run", "test-run-001",
+        ])
+        assert exit_code == 0
+
+    def test_replay_subcommand(self, tmp_path: Path) -> None:
+        _seed_run(tmp_path)
+        from ao_kernel.cli import main
+        exit_code = main([
+            "--workspace-root", str(tmp_path),
+            "evidence", "replay", "--run", "test-run-001", "--mode", "inspect",
+        ])
+        assert exit_code == 0
+
+    def test_generate_manifest_subcommand(self, tmp_path: Path) -> None:
+        run_dir = _seed_run(tmp_path)
+        _seed_artifacts(run_dir)
+        from ao_kernel.cli import main
+        exit_code = main([
+            "--workspace-root", str(tmp_path),
+            "evidence", "generate-manifest", "--run", "test-run-001",
+        ])
+        assert exit_code == 0
+        assert (run_dir / "manifest.json").exists()
+
+    def test_verify_manifest_subcommand_after_generate(self, tmp_path: Path) -> None:
+        run_dir = _seed_run(tmp_path)
+        _seed_artifacts(run_dir)
+        from ao_kernel.cli import main
+        main(["--workspace-root", str(tmp_path),
+              "evidence", "generate-manifest", "--run", "test-run-001"])
+        exit_code = main([
+            "--workspace-root", str(tmp_path),
+            "evidence", "verify-manifest", "--run", "test-run-001",
+        ])
+        assert exit_code == 0
+
+    def test_evidence_no_subcommand_prints_usage(self, tmp_path: Path) -> None:
+        from ao_kernel.cli import main
+        exit_code = main([
+            "--workspace-root", str(tmp_path), "evidence",
+        ])
+        assert exit_code == 1
+
+    def test_verify_missing_manifest_exit_3(self, tmp_path: Path) -> None:
+        _seed_run(tmp_path)
+        from ao_kernel._internal.evidence.cli_handlers import cmd_verify_manifest
+        import argparse
+        args = argparse.Namespace(
+            workspace_root=str(tmp_path),
+            run_id="test-run-001",
+            generate_if_missing=False,
+        )
+        exit_code = cmd_verify_manifest(args)
+        assert exit_code == 3  # I4-B1 fix: missing manifest.json → exactly exit 3
+
+    def test_replay_happy_path_no_warnings(self, tmp_path: Path) -> None:
+        """I4-B3 fix: valid happy-path replay should produce 0 warnings
+        thanks to synthetic chain bridging."""
+        _seed_run(tmp_path)
+        report = replay(tmp_path, "test-run-001")
+        assert report.final_inferred_state == "completed"
+        assert report.warnings == []  # no illegal transitions


### PR DESCRIPTION
## Summary

FAZ-A Tranche A PR 7/8. Evidence read + verify + replay layer. Closes the **"ao-kernel evidence timeline CLI works"** release gate.

- **`ao-kernel evidence timeline`** — chronological event table or NDJSON, with kind/actor/limit filters
- **`ao-kernel evidence replay`** — inferred state trace walker (inspect / dry-run modes); `state_source: event|inferred|synthetic`
- **`ao-kernel evidence generate-manifest`** — on-demand SHA-256 manifest under per-run lock
- **`ao-kernel evidence verify-manifest`** — recompute + compare; exit codes 0/1/2/3

## Test plan

- [x] 34 new tests in `test_evidence_cli.py`
- [x] `python3 -m pytest -q` → **1516 passed**, 3 skipped
- [x] Coverage **85.20%** (gate 85)
- [x] `ruff check` → All checks passed
- [x] `mypy --ignore-missing-imports` → 149 files, no issues
- [x] B2 fix: `replay_safe=False` for adapter_invoked/returned + approval_granted/denied
- [x] Docs §5/§8 updated to canonical manifest shape + 4-subcommand CLI reference

## Adversarial consensus (CNS-20260416-025, thread `019d93d3-054f-7743-b166-e892d712ff88`)

| Iter | Verdict | Key |
|---|---|---|
| 1 | PARTIAL (5B+5W) | manifest drift, replay_safe wrong, replay overclaim, revdiff scope, public API |
| 2 | PARTIAL (2 stale-text) | §3 write order + scope summary still referenced public evidence_cli |
| 3 | **AGREE** | All 5+2 blockers absorbed |
| 4 | PARTIAL (4 post-impl) | exit code 3, manifest lock, synthetic chain, docs |
| Fix | All 4 fixed | exit code, file_lock, _synthetic_chain helper, docs §5/§8 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)