### PR TITLE
feat(pr-b2): cost runtime — price catalog + spend ledger + governed_call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — FAZ-B PR-B2 (cost runtime — price catalog + spend ledger + governed_call)
+
+**FAZ-B Tranche B 3/9 — runtime for the B0-pinned cost contract. LLM
+calls now run through `ao_kernel.llm.governed_call` — a non-streaming
+composition wrapper with optional cost governance (pre-dispatch
+estimate + budget cap fail-closed + post-response reconcile +
+canonical billing digest idempotent ledger). Dormant by default;
+operators opt in via workspace policy override + adding a `cost_usd`
+axis to workflow-run budgets.**
+
+- New public package `ao_kernel/cost/` — six modules: errors (9
+  typed classes), cost_math (Decimal-stable formula + estimate +
+  `min(max_tokens, est_in*0.25)` output estimate), catalog (checksum
+  verify + stale gate + 300s LRU), ledger (canonical billing digest
+  idempotency + bounded tail-scan), policy (typed loader + 2 new
+  knobs), middleware (pre_dispatch_reserve + post_response_reconcile
+  with CAS-retried budget mutations).
+- New `ao_kernel.llm.governed_call` facade — non-streaming LLM
+  composer with rich `{status, normalized, resp_bytes, transport_result,
+  elapsed_ms, request_id}` success dict; CAPABILITY_GAP + TRANSPORT_ERROR
+  envelopes preserve pre-B2 caller contract. Cost-layer errors raise
+  (BudgetExhausted, CostTrackingConfig, PriceCatalogNotFound,
+  LLMUsageMissing). Streaming stays on existing `_execute_stream`
+  path.
+- `build_request_with_context` additive `injected_messages` return
+  field for cost-estimate accuracy.
+- 3 caller entrypoints wired through `governed_call`:
+  `AoKernelClient.llm_call(run_id, step_id, attempt)` opt-in;
+  `mcp_server.handle_llm_call(ao_run_id, ao_step_id, ao_attempt)`
+  opt-in + MCP tool schema widen;
+  `workflow.intent_router._llm_classify` bypass-only (standalone
+  classifier, not a budget anchor).
+- Budget granular axes `tokens_input` + `tokens_output` (additive
+  BudgetAxis fields with back-compat reader + writer invariants).
+- Normalizer strict helper `extract_usage_strict → UsagePresence`
+  with None-sentinel; existing `extract_usage` (0-fallback) preserved.
+- Schema additive widens: workflow-run budget +2 integer axes;
+  spend-ledger +3 fields (attempt, usage_missing, billing_digest);
+  policy-cost-tracking +2 knobs (fail_closed_on_missing_usage,
+  idempotency_window_lines).
+- Evidence taxonomy +3 (24 → 27): `llm_cost_estimated`,
+  `llm_spend_recorded`, `llm_usage_missing` — all fail-open emits.
+- Streaming cost tracking: FAZ-C deferred (documented gap in
+  docs/COST-MODEL.md §9).
+- Adversarial consensus: 7-commit DAG shipped after Codex CNS-
+  20260417-031 `ready_for_impl=true` across 7 adversarial plan
+  iterations (v1→v7). Plan `.claude/plans/PR-B2-IMPLEMENTATION-PLAN.md`
+  documents the absorb trail.
+- Gate status on merge: ruff + mypy clean; pytest 1823 passed /
+  3 skipped (+121 net tests; 0 regressions — PR-B1 `_KINDS` exact-24
+  assertion replaced by `>= 24` floor to stay regression-free across
+  additive evidence kinds).
+
 ### Added — FAZ-B PR-B1 (coordination runtime — lease / fencing / takeover)
 
 **FAZ-B Tranche B 2/9 — runtime for the B0-pinned coordination contract

--- a/ao_kernel/_internal/prj_kernel_api/llm_response_normalizer.py
+++ b/ao_kernel/_internal/prj_kernel_api/llm_response_normalizer.py
@@ -8,6 +8,7 @@ usage info, and (future) tool calls into a normalized dict.
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import Any, Dict
 
 
@@ -172,6 +173,81 @@ def extract_embeddings(resp_bytes: bytes, *, provider_id: str) -> list[float] | 
         if isinstance(embedding, list):
             return embedding
     return None
+
+
+@dataclass(frozen=True)
+class UsagePresence:
+    """Strict usage extraction result (PR-B2 v3 iter-1 B3 absorb).
+
+    None means "adapter did not surface this field" (distinct from 0
+    = "actual zero tokens"). The cost middleware's fail-closed
+    ``LLMUsageMissingError`` fires only when one of these is None;
+    zero-token responses (rare but valid) flow through normally.
+    """
+
+    tokens_input: int | None
+    tokens_output: int | None
+    cached_tokens: int | None
+
+
+def extract_usage_strict(resp_bytes: bytes) -> UsagePresence:
+    """Strict variant of ``extract_usage``: preserves None for absent fields.
+
+    The existing ``extract_usage`` (above) is kept for PR-A callers
+    that tolerate the 0-fallback behavior. B2 cost middleware uses
+    this strict variant so the fail-closed
+    ``LLMUsageMissingError`` contract works.
+
+    Provider variants handled:
+    - Anthropic: ``input_tokens`` / ``output_tokens`` /
+      ``cache_read_input_tokens``
+    - OpenAI: ``prompt_tokens`` / ``completion_tokens`` /
+      ``cached_tokens`` (in some newer payloads)
+
+    Non-int values in these fields → treated as absent (None) — the
+    schema contract is int; anything else is a provider bug we treat
+    conservatively.
+    """
+    try:
+        obj = json.loads(resp_bytes.decode("utf-8", errors="ignore"))
+    except Exception:
+        return UsagePresence(
+            tokens_input=None,
+            tokens_output=None,
+            cached_tokens=None,
+        )
+
+    if not isinstance(obj, dict):
+        return UsagePresence(
+            tokens_input=None,
+            tokens_output=None,
+            cached_tokens=None,
+        )
+
+    usage = obj.get("usage")
+    if not isinstance(usage, dict):
+        return UsagePresence(
+            tokens_input=None,
+            tokens_output=None,
+            cached_tokens=None,
+        )
+
+    # Prefer provider-canonical keys with fallbacks.
+    ti = usage.get("input_tokens")
+    if ti is None:
+        ti = usage.get("prompt_tokens")
+    to = usage.get("output_tokens")
+    if to is None:
+        to = usage.get("completion_tokens")
+    cached = usage.get("cached_tokens")
+    if cached is None:
+        cached = usage.get("cache_read_input_tokens")
+
+    return UsagePresence(
+        tokens_input=ti if isinstance(ti, int) else None,
+        tokens_output=to if isinstance(to, int) else None,
+        cached_tokens=cached if isinstance(cached, int) else None,
+    )
 
 
 def extract_moderation(resp_bytes: bytes) -> Dict[str, Any] | None:

--- a/ao_kernel/client.py
+++ b/ao_kernel/client.py
@@ -485,6 +485,13 @@ class AoKernelClient:
         tool_results: list[dict[str, Any]] | None = None,
         response_format: dict[str, Any] | None = None,
         profile: str | None = None,
+        # PR-B2 v5 iter-4 B2 cost identity kwargs. All four must be set
+        # (non-None) for the cost pipeline to activate; any missing kwarg
+        # → transparent bypass (pre-B2 behaviour). Workflow-driven
+        # callers pass these automatically; SDK users opt in.
+        run_id: str | None = None,
+        step_id: str | None = None,
+        attempt: int | None = None,
     ) -> dict[str, Any]:
         """Make a governed LLM call with full pipeline.
 
@@ -528,64 +535,49 @@ class AoKernelClient:
         if not base_url:
             base_url = self._default_base_url(provider_id)
 
-        # 2. Capability check
-        from ao_kernel.llm import check_capabilities
-        cap_ok, _, missing = check_capabilities(
-            provider_id=provider_id,
-            model=model,
-            has_tools=bool(tools),
-            has_response_format=bool(response_format),
-        )
-        if not cap_ok and missing:
-            return {
-                "status": "CAPABILITY_GAP",
-                "text": "",
-                "missing": missing,
-                "provider_id": provider_id,
-                "model": model,
-                "request_id": request_id,
-            }
-
-        # 3. Build request (with context injection if session active)
+        # PR-B2: streaming path stays on the pre-B2 build + _execute_stream
+        # pipeline (governed_call is non-streaming only per plan v5 iter-4 B2).
+        # Non-streaming path is routed through governed_call so cost hooks
+        # and context injection compose from a single wrapper.
         ws_str = str(self._workspace_root) if self._workspace_root else None
-        if self._session_active and self._context:
-            from ao_kernel.llm import build_request_with_context
-            req = build_request_with_context(
-                provider_id=provider_id,
-                model=model,
-                messages=messages,
-                base_url=base_url,
-                api_key=api_key,
-                session_context=self._context,
-                workspace_root=ws_str,
-                profile=profile,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                request_id=request_id,
-                stream=stream,
-                tools=tools,
-                response_format=response_format,
-                embedding_config=self._embedding_config,
-                vector_store=self._vector_store,
-            )
-        else:
-            from ao_kernel.llm import build_request
-            req = build_request(
-                provider_id=provider_id,
-                model=model,
-                messages=messages,
-                base_url=base_url,
-                api_key=api_key,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                request_id=request_id,
-                tools=tools,
-                response_format=response_format,
-                stream=stream,
-            )
 
-        # 4. Execute (streaming or blocking)
         if stream:
+            # Build + stream dispatch — unchanged from pre-B2.
+            if self._session_active and self._context:
+                from ao_kernel.llm import build_request_with_context
+                req = build_request_with_context(
+                    provider_id=provider_id,
+                    model=model,
+                    messages=messages,
+                    base_url=base_url,
+                    api_key=api_key,
+                    session_context=self._context,
+                    workspace_root=ws_str,
+                    profile=profile,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    request_id=request_id,
+                    stream=True,
+                    tools=tools,
+                    response_format=response_format,
+                    embedding_config=self._embedding_config,
+                    vector_store=self._vector_store,
+                )
+            else:
+                from ao_kernel.llm import build_request
+                req = build_request(
+                    provider_id=provider_id,
+                    model=model,
+                    messages=messages,
+                    base_url=base_url,
+                    api_key=api_key,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    request_id=request_id,
+                    tools=tools,
+                    response_format=response_format,
+                    stream=True,
+                )
             return self._execute_stream(
                 req=req,
                 provider_id=provider_id,
@@ -595,32 +587,46 @@ class AoKernelClient:
                 tool_results=tool_results,
             )
 
-        from ao_kernel.llm import execute_request
-        transport_result = execute_request(
-            url=req["url"],
-            headers=req["headers"],
-            body_bytes=req["body_bytes"],
-            timeout_seconds=30.0,
+        # Non-streaming: delegate to governed_call (v5 iter-4 B1 rich dict).
+        from ao_kernel.llm import governed_call
+
+        result = governed_call(
+            messages=messages,
             provider_id=provider_id,
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
             request_id=request_id,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            response_format=response_format,
+            # Context-aware build (plan v4 iter-3 B1 absorb):
+            session_context=self._context if self._session_active else None,
+            workspace_root_str=ws_str,
+            profile=profile,
+            embedding_config=self._embedding_config,
+            vector_store=self._vector_store,
+            # Cost identity kwargs (plan v5 iter-4 B2 absorb): opt-in.
+            # All four must be non-None + policy.enabled for cost active.
+            workspace_root=self._workspace_root,
+            run_id=run_id,
+            step_id=step_id,
+            attempt=attempt,
         )
 
-        if transport_result.get("status") != "OK":
-            return {
-                "status": "TRANSPORT_ERROR",
-                "text": "",
-                "error_code": transport_result.get("error_code", "UNKNOWN"),
-                "http_status": transport_result.get("http_status"),
-                "provider_id": provider_id,
-                "model": model,
-                "request_id": request_id,
-                "elapsed_ms": transport_result.get("elapsed_ms", 0),
-            }
+        # Envelope pass-through for error statuses.
+        status = result.get("status")
+        if status == "CAPABILITY_GAP":
+            return result
+        if status == "TRANSPORT_ERROR":
+            return result
 
-        # 5. Normalize response
-        resp_bytes = transport_result.get("resp_bytes", b"")
-        from ao_kernel.llm import normalize_response, extract_usage
-        normalized = normalize_response(resp_bytes, provider_id=provider_id)
+        # Status == "OK" — unwrap rich dict for post-call pipeline.
+        normalized = result.get("normalized") or {}
+        resp_bytes: bytes = result.get("resp_bytes", b"")
+        transport_result = result.get("transport_result") or {}
+        from ao_kernel.llm import extract_usage
         usage = extract_usage(resp_bytes)
 
         text = normalized.get("text", "")

--- a/ao_kernel/cost/__init__.py
+++ b/ao_kernel/cost/__init__.py
@@ -19,6 +19,13 @@ See ``docs/COST-MODEL.md`` for the contract walk-through.
 
 from __future__ import annotations
 
+from ao_kernel.cost.catalog import (
+    PriceCatalog,
+    PriceCatalogEntry,
+    clear_catalog_cache,
+    find_entry,
+    load_price_catalog,
+)
 from ao_kernel.cost.cost_math import (
     compute_cost,
     estimate_cost,
@@ -44,6 +51,12 @@ from ao_kernel.cost.policy import (
 
 
 __all__ = [
+    # Catalog
+    "PriceCatalog",
+    "PriceCatalogEntry",
+    "clear_catalog_cache",
+    "find_entry",
+    "load_price_catalog",
     # Cost math
     "compute_cost",
     "estimate_cost",

--- a/ao_kernel/cost/__init__.py
+++ b/ao_kernel/cost/__init__.py
@@ -1,0 +1,66 @@
+"""Cost runtime — price catalog, spend ledger, budget extension (FAZ-B PR-B2).
+
+Public API for the cost governance pipeline. Workspaces opt in by
+setting ``policy_cost_tracking.enabled: true`` in their workspace
+override; the bundled default ships dormant.
+
+Surface grows across the PR-B2 commit DAG:
+
+- **Commit 1 (this module's initial state)**: typed errors, policy
+  loader, deterministic cost math.
+- **Commit 2**: price catalog loader with checksum + stale gate.
+- **Commit 3**: spend ledger with canonical billing-digest idempotency.
+- **Commit 4**: (workflow.budget widen; external to ``cost/``).
+- **Commit 5a**: cost middleware + ``llm.governed_call`` wrapper.
+- **Commit 5b**: caller entrypoint wire (client + mcp + intent_router).
+
+See ``docs/COST-MODEL.md`` for the contract walk-through.
+"""
+
+from __future__ import annotations
+
+from ao_kernel.cost.cost_math import (
+    compute_cost,
+    estimate_cost,
+    estimate_output_tokens,
+)
+from ao_kernel.cost.errors import (
+    BudgetExhaustedError,
+    CostTrackingConfigError,
+    CostTrackingDisabledError,
+    CostTrackingError,
+    LLMUsageMissingError,
+    PriceCatalogChecksumError,
+    PriceCatalogNotFoundError,
+    PriceCatalogStaleError,
+    SpendLedgerCorruptedError,
+    SpendLedgerDuplicateError,
+)
+from ao_kernel.cost.policy import (
+    CostTrackingPolicy,
+    RoutingByCost,
+    load_cost_policy,
+)
+
+
+__all__ = [
+    # Cost math
+    "compute_cost",
+    "estimate_cost",
+    "estimate_output_tokens",
+    # Policy
+    "CostTrackingPolicy",
+    "RoutingByCost",
+    "load_cost_policy",
+    # Errors
+    "CostTrackingError",
+    "CostTrackingDisabledError",
+    "CostTrackingConfigError",
+    "PriceCatalogNotFoundError",
+    "PriceCatalogChecksumError",
+    "PriceCatalogStaleError",
+    "SpendLedgerDuplicateError",
+    "SpendLedgerCorruptedError",
+    "LLMUsageMissingError",
+    "BudgetExhaustedError",
+]

--- a/ao_kernel/cost/__init__.py
+++ b/ao_kernel/cost/__init__.py
@@ -35,6 +35,10 @@ from ao_kernel.cost.ledger import (
     SpendEvent,
     record_spend,
 )
+from ao_kernel.cost.middleware import (
+    post_response_reconcile,
+    pre_dispatch_reserve,
+)
 from ao_kernel.cost.errors import (
     BudgetExhaustedError,
     CostTrackingConfigError,
@@ -68,6 +72,9 @@ __all__ = [
     # Ledger
     "SpendEvent",
     "record_spend",
+    # Middleware
+    "pre_dispatch_reserve",
+    "post_response_reconcile",
     # Policy
     "CostTrackingPolicy",
     "RoutingByCost",

--- a/ao_kernel/cost/__init__.py
+++ b/ao_kernel/cost/__init__.py
@@ -31,6 +31,10 @@ from ao_kernel.cost.cost_math import (
     estimate_cost,
     estimate_output_tokens,
 )
+from ao_kernel.cost.ledger import (
+    SpendEvent,
+    record_spend,
+)
 from ao_kernel.cost.errors import (
     BudgetExhaustedError,
     CostTrackingConfigError,
@@ -61,6 +65,9 @@ __all__ = [
     "compute_cost",
     "estimate_cost",
     "estimate_output_tokens",
+    # Ledger
+    "SpendEvent",
+    "record_spend",
     # Policy
     "CostTrackingPolicy",
     "RoutingByCost",

--- a/ao_kernel/cost/catalog.py
+++ b/ao_kernel/cost/catalog.py
@@ -1,0 +1,362 @@
+"""Price catalog loader (PR-B2 commit 2).
+
+Loads ``price-catalog.v1.json`` from a workspace override (set via
+``policy_cost_tracking.price_catalog_path``) or falls back to the
+bundled starter catalog. Verifies ``checksum`` (SHA-256 over
+canonical ``entries[]`` JSON) and applies the ``stale_after`` gate
+per the policy's ``strict_freshness`` knob.
+
+Loader is UNCONDITIONAL — dormant-gate is the caller's responsibility
+(CNS-031 iter-1 Q6 absorb). The middleware short-circuits before
+calling ``load_price_catalog`` when ``policy.enabled=false``.
+
+LRU cache: 300-second TTL per workspace_root (CNS-031 iter-1 Q8
+absorb). Cache key is the resolved source path; misses re-read disk.
+
+See ``docs/COST-MODEL.md`` §2 for object shape + field semantics.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from ao_kernel.config import load_default
+from ao_kernel.cost.errors import (
+    PriceCatalogChecksumError,
+    PriceCatalogStaleError,
+)
+from ao_kernel.cost.policy import CostTrackingPolicy
+
+
+logger = logging.getLogger(__name__)
+
+
+_CATALOG_SCHEMA_CACHE: dict[str, Any] | None = None
+_BUNDLED_CATALOG_CACHE: dict[str, Any] | None = None
+
+# LRU cache: { workspace_root_str: (PriceCatalog, loaded_at_monotonic_seconds) }
+_CATALOG_INSTANCE_CACHE: dict[str, tuple["PriceCatalog", float]] = {}
+_CACHE_TTL_SECONDS: float = 300.0
+
+
+def _catalog_schema() -> dict[str, Any]:
+    """Load and cache ``price-catalog.schema.v1.json``."""
+    global _CATALOG_SCHEMA_CACHE
+    if _CATALOG_SCHEMA_CACHE is None:
+        _CATALOG_SCHEMA_CACHE = load_default(
+            "schemas", "price-catalog.schema.v1.json",
+        )
+    return _CATALOG_SCHEMA_CACHE
+
+
+def _bundled_catalog() -> dict[str, Any]:
+    """Load and cache the bundled starter catalog."""
+    global _BUNDLED_CATALOG_CACHE
+    if _BUNDLED_CATALOG_CACHE is None:
+        _BUNDLED_CATALOG_CACHE = load_default(
+            "catalogs", "price-catalog.v1.json",
+        )
+    return _BUNDLED_CATALOG_CACHE
+
+
+@dataclass(frozen=True)
+class PriceCatalogEntry:
+    """One catalog entry — a ``(provider_id, model)`` price record.
+
+    Fields mirror ``price-catalog.schema.v1.json::$defs/entry`` one-to-
+    one. ``vendor_model_id`` is optional (required only when the
+    catalog-level ``source=vendor_api`` — enforced at schema load, not
+    here). ``cached_input_cost_per_1k`` is optional (None means "no
+    caching discount on record" — full-rate fallback in
+    :func:`compute_cost`).
+    """
+
+    provider_id: str
+    model: str
+    input_cost_per_1k: float
+    output_cost_per_1k: float
+    currency: str
+    billing_unit: str
+    effective_date: str
+    vendor_model_id: str | None = None
+    cached_input_cost_per_1k: float | None = None
+
+
+@dataclass(frozen=True)
+class PriceCatalog:
+    """Versioned, checksum-verified snapshot of price records.
+
+    Immutable by construction. :func:`find_entry` walks ``entries``
+    linearly — O(N) acceptable for MVP scope (bundled ~6, operator
+    catalogs typically < 100). Indexed lookup deferred to FAZ-D if
+    workloads warrant.
+    """
+
+    catalog_version: str
+    generated_at: str
+    source: str  # "bundled" | "vendor_api" | "manual"
+    stale_after: str
+    checksum: str
+    entries: tuple[PriceCatalogEntry, ...]
+
+
+def _canonical_entries_json(entries: list[Mapping[str, Any]]) -> str:
+    """Canonical JSON form for checksum.
+
+    Mirrors the bundled tooling contract: ``json.dumps(entries,
+    sort_keys=True, ensure_ascii=False, separators=(",",":"))``.
+    """
+    return json.dumps(
+        entries,
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _compute_checksum(entries: list[Mapping[str, Any]]) -> str:
+    """Recompute ``sha256:<hex>`` over canonical ``entries[]`` JSON."""
+    canonical = _canonical_entries_json(entries)
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _verify_checksum(
+    doc: Mapping[str, Any],
+    source_path: str,
+) -> None:
+    """Raise :class:`PriceCatalogChecksumError` on mismatch."""
+    expected = str(doc.get("checksum", ""))
+    entries = list(doc.get("entries", []))
+    actual = _compute_checksum(entries)
+    if expected != actual:
+        raise PriceCatalogChecksumError(
+            catalog_path=source_path,
+            expected_checksum=expected,
+            actual_checksum=actual,
+        )
+
+
+def _check_staleness(
+    doc: Mapping[str, Any],
+    source_path: str,
+    *,
+    strict: bool,
+) -> None:
+    """Apply the stale-after policy gate.
+
+    ``strict=False`` (default policy.strict_freshness): emit a WARN
+    log and return — catalog still served.
+
+    ``strict=True``: raise :class:`PriceCatalogStaleError` — fail-closed.
+    """
+    stale_after_raw = str(doc.get("stale_after", ""))
+    try:
+        stale_after = _dt.datetime.fromisoformat(
+            stale_after_raw.replace("Z", "+00:00")
+        )
+    except ValueError:
+        # Schema validation already constrains format: date-time, so a
+        # malformed value here would mean the schema was bypassed. Treat
+        # unparseable as "not stale" — defensive; the schema guard is
+        # the real anchor.
+        return
+
+    now = _dt.datetime.now(tz=_dt.timezone.utc)
+    if now <= stale_after:
+        return
+
+    now_iso = now.isoformat()
+    if strict:
+        raise PriceCatalogStaleError(
+            catalog_path=source_path,
+            stale_after=stale_after_raw,
+            now=now_iso,
+        )
+    logger.warning(
+        "price catalog at %s is stale (stale_after=%s, now=%s); "
+        "strict_freshness=false — serving anyway",
+        source_path,
+        stale_after_raw,
+        now_iso,
+    )
+
+
+def _validate(doc: Mapping[str, Any]) -> None:
+    """Validate ``doc`` against ``price-catalog.schema.v1.json``.
+
+    Fail-closed per CLAUDE.md §2: a malformed catalog must not be
+    silently ignored.
+    """
+    from jsonschema import Draft202012Validator
+
+    Draft202012Validator(_catalog_schema()).validate(doc)
+
+
+def _from_dict(doc: Mapping[str, Any]) -> PriceCatalog:
+    """Parse a schema-valid catalog dict into :class:`PriceCatalog`."""
+    entries = tuple(
+        PriceCatalogEntry(
+            provider_id=str(e["provider_id"]),
+            model=str(e["model"]),
+            input_cost_per_1k=float(e["input_cost_per_1k"]),
+            output_cost_per_1k=float(e["output_cost_per_1k"]),
+            currency=str(e["currency"]),
+            billing_unit=str(e["billing_unit"]),
+            effective_date=str(e["effective_date"]),
+            vendor_model_id=(
+                str(e["vendor_model_id"]) if "vendor_model_id" in e else None
+            ),
+            cached_input_cost_per_1k=(
+                float(e["cached_input_cost_per_1k"])
+                if "cached_input_cost_per_1k" in e
+                else None
+            ),
+        )
+        for e in doc["entries"]
+    )
+    return PriceCatalog(
+        catalog_version=str(doc["catalog_version"]),
+        generated_at=str(doc["generated_at"]),
+        source=str(doc["source"]),
+        stale_after=str(doc["stale_after"]),
+        checksum=str(doc["checksum"]),
+        entries=entries,
+    )
+
+
+def _resolve_source(
+    workspace_root: Path,
+    policy: CostTrackingPolicy | None,
+) -> tuple[Mapping[str, Any], str]:
+    """Return ``(doc, source_path_str)`` — workspace override preferred,
+    bundled fallback."""
+    if policy is not None:
+        override_path = workspace_root / policy.price_catalog_path
+    else:
+        override_path = (
+            workspace_root / ".ao" / "cost" / "catalog.v1.json"
+        )
+    if override_path.is_file():
+        with override_path.open("r", encoding="utf-8") as fh:
+            loaded: Mapping[str, Any] = json.load(fh)
+        return loaded, str(override_path)
+    # Bundled fallback
+    return _bundled_catalog(), "<bundled>"
+
+
+def _cache_key(workspace_root: Path) -> str:
+    return str(workspace_root.resolve())
+
+
+def _cache_get(key: str) -> PriceCatalog | None:
+    entry = _CATALOG_INSTANCE_CACHE.get(key)
+    if entry is None:
+        return None
+    catalog, loaded_at = entry
+    if time.monotonic() - loaded_at > _CACHE_TTL_SECONDS:
+        # Expired; evict and miss.
+        _CATALOG_INSTANCE_CACHE.pop(key, None)
+        return None
+    return catalog
+
+
+def _cache_set(key: str, catalog: PriceCatalog) -> None:
+    _CATALOG_INSTANCE_CACHE[key] = (catalog, time.monotonic())
+
+
+def clear_catalog_cache() -> None:
+    """Drop the LRU cache (tests + operator tooling)."""
+    _CATALOG_INSTANCE_CACHE.clear()
+
+
+def load_price_catalog(
+    workspace_root: Path,
+    *,
+    override: Mapping[str, Any] | None = None,
+    policy: CostTrackingPolicy | None = None,
+) -> PriceCatalog:
+    """Load the price catalog.
+
+    Resolution order:
+
+    1. If ``override`` dict is supplied (tests), validate + parse it
+       directly (no filesystem, no cache).
+    2. Workspace override at ``{workspace_root}/{policy.price_catalog_path}``
+       (defaults to ``.ao/cost/catalog.v1.json`` when policy omitted).
+    3. Bundled starter catalog at
+       ``ao_kernel/defaults/catalogs/price-catalog.v1.json``.
+
+    Validation chain (both override + filesystem paths):
+
+    - JSON schema validation (fail-closed on malformed doc).
+    - Checksum verification (SHA-256 over canonical ``entries[]``)
+      → :class:`PriceCatalogChecksumError` on mismatch.
+    - Staleness gate (``policy.strict_freshness``) →
+      :class:`PriceCatalogStaleError` in strict mode, WARN log otherwise.
+
+    Caching: filesystem + bundled paths cached 300 seconds per
+    resolved ``workspace_root``. Inline ``override=`` bypasses cache.
+    """
+    if override is not None:
+        _validate(override)
+        _verify_checksum(override, "<inline-override>")
+        strict = policy.strict_freshness if policy is not None else False
+        _check_staleness(override, "<inline-override>", strict=strict)
+        return _from_dict(override)
+
+    cache_key = _cache_key(workspace_root)
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        # Staleness re-check on cache hit — the stale-after timestamp is
+        # content-bound, but wall-clock may have crossed it since last
+        # load. Re-evaluate the gate so strict mode surfaces the stale
+        # error promptly rather than serving a cached value past TTL.
+        if policy is not None:
+            _check_staleness(
+                {"stale_after": cached.stale_after},
+                f"<cached:{cache_key}>",
+                strict=policy.strict_freshness,
+            )
+        return cached
+
+    doc, source_path = _resolve_source(workspace_root, policy)
+    _validate(doc)
+    _verify_checksum(doc, source_path)
+    strict = policy.strict_freshness if policy is not None else False
+    _check_staleness(doc, source_path, strict=strict)
+    catalog = _from_dict(doc)
+    _cache_set(cache_key, catalog)
+    return catalog
+
+
+def find_entry(
+    catalog: PriceCatalog,
+    provider_id: str,
+    model: str,
+) -> PriceCatalogEntry | None:
+    """Return the entry matching ``(provider_id, model)`` or ``None``.
+
+    Linear scan. Callers handle the ``None`` case themselves — raising
+    :class:`PriceCatalogNotFoundError` is the cost middleware's job
+    (it has the extra context: catalog_version, etc.).
+    """
+    for entry in catalog.entries:
+        if entry.provider_id == provider_id and entry.model == model:
+            return entry
+    return None
+
+
+__all__ = [
+    "PriceCatalog",
+    "PriceCatalogEntry",
+    "clear_catalog_cache",
+    "find_entry",
+    "load_price_catalog",
+]

--- a/ao_kernel/cost/cost_math.py
+++ b/ao_kernel/cost/cost_math.py
@@ -1,0 +1,134 @@
+"""Pure deterministic cost arithmetic (PR-B2).
+
+No I/O, no policy, no evidence — just math. Caller converts to/from
+serializable formats. All computations use ``Decimal`` for precision
+stability; callers serialize via ``str(Decimal(...))`` per
+:func:`ao_kernel.workflow.budget._float_axis_to_dict` conventions.
+
+See ``docs/COST-MODEL.md`` §5 for the formula contract.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover — import-only
+    from ao_kernel.cost.catalog import PriceCatalogEntry
+
+
+_THOUSAND = Decimal("1000")
+
+
+def compute_cost(
+    entry: "PriceCatalogEntry",
+    tokens_input: int,
+    tokens_output: int,
+    cached_tokens: int = 0,
+) -> Decimal:
+    """Return the USD cost for a successful invocation.
+
+    Formula (COST-MODEL.md §5)::
+
+        billable_input = tokens_input - cached_tokens
+        cost = billable_input * input_cost_per_1k / 1000
+             + cached_tokens  * cached_input_cost_per_1k / 1000
+             + tokens_output  * output_cost_per_1k / 1000
+
+    When ``entry.cached_input_cost_per_1k`` is ``None``, cached tokens
+    are billed at ``input_cost_per_1k`` (safe fallback — "no caching
+    discount on file" rather than "free").
+
+    Raises:
+    - ``ValueError`` if ``cached_tokens > tokens_input`` (caller bug).
+    """
+    if cached_tokens < 0 or tokens_input < 0 or tokens_output < 0:
+        raise ValueError(
+            f"token counts must be non-negative: "
+            f"input={tokens_input}, output={tokens_output}, cached={cached_tokens}"
+        )
+    if cached_tokens > tokens_input:
+        raise ValueError(
+            f"cached_tokens={cached_tokens} exceeds tokens_input={tokens_input}"
+        )
+
+    billable_input = tokens_input - cached_tokens
+    input_rate = Decimal(str(entry.input_cost_per_1k))
+    output_rate = Decimal(str(entry.output_cost_per_1k))
+
+    # cached_input_cost_per_1k is optional; fall back to full input rate.
+    if entry.cached_input_cost_per_1k is not None:
+        cached_rate = Decimal(str(entry.cached_input_cost_per_1k))
+    else:
+        cached_rate = input_rate
+
+    return (
+        Decimal(billable_input) * input_rate / _THOUSAND
+        + Decimal(cached_tokens) * cached_rate / _THOUSAND
+        + Decimal(tokens_output) * output_rate / _THOUSAND
+    )
+
+
+def estimate_cost(
+    entry: "PriceCatalogEntry",
+    est_tokens_input: int,
+    est_tokens_output: int,
+) -> Decimal:
+    """Pre-dispatch upper-bound estimate.
+
+    Ignores caching — operator-facing budget cap reflects worst-case
+    spend. Actual ``compute_cost`` post-response may be lower when the
+    provider reports ``cached_tokens``.
+
+    Raises ``ValueError`` on negative inputs.
+    """
+    if est_tokens_input < 0 or est_tokens_output < 0:
+        raise ValueError(
+            f"estimate counts must be non-negative: "
+            f"input={est_tokens_input}, output={est_tokens_output}"
+        )
+    input_rate = Decimal(str(entry.input_cost_per_1k))
+    output_rate = Decimal(str(entry.output_cost_per_1k))
+    return (
+        Decimal(est_tokens_input) * input_rate / _THOUSAND
+        + Decimal(est_tokens_output) * output_rate / _THOUSAND
+    )
+
+
+def estimate_output_tokens(
+    est_tokens_input: int,
+    max_tokens: int | None,
+) -> int:
+    """Conservative output-token estimate for pre-dispatch budget check.
+
+    Contract (PR-B2 v3 iter-1 Q3 absorb):
+
+    - Without a caller-supplied ``max_tokens``: assume generation is
+      25% of the prompt size (``est_tokens_input * 0.25``, rounded down).
+      This is a blunt default; callers that know better pass ``max_tokens``.
+    - With ``max_tokens``: take the minimum of the 25%-of-input estimate
+      and the caller's explicit cap. The floor avoids over-estimating
+      when the caller asked for a small completion.
+
+    The model router currently does not return ``route.max_output_tokens``,
+    so the call-site ``max_tokens`` kwarg is the only meaningful source
+    for MVP. Intent-class-aware ratios (``FAST_TEXT`` vs ``CODE_GEN``)
+    are deferred post-MVP.
+    """
+    if est_tokens_input < 0:
+        raise ValueError(
+            f"est_tokens_input must be non-negative: {est_tokens_input}"
+        )
+    ratio_estimate = int(est_tokens_input * 0.25)
+    if max_tokens is None:
+        return ratio_estimate
+    if max_tokens < 0:
+        raise ValueError(f"max_tokens must be non-negative: {max_tokens}")
+    return min(max_tokens, ratio_estimate)
+
+
+__all__ = [
+    "compute_cost",
+    "estimate_cost",
+    "estimate_output_tokens",
+]

--- a/ao_kernel/cost/errors.py
+++ b/ao_kernel/cost/errors.py
@@ -1,0 +1,254 @@
+"""Typed error hierarchy for the cost runtime (PR-B2).
+
+See ``docs/COST-MODEL.md`` §§4-10 and PR-B2 plan v7 §2 for the full
+semantic contract each error represents. Public API callers key
+recovery logic off the subclass type + the structured fields each
+subclass carries.
+"""
+
+from __future__ import annotations
+
+
+class CostTrackingError(Exception):
+    """Base class for all cost runtime errors.
+
+    Subclasses carry structured fields (``workspace_root``, ``run_id``,
+    ``catalog_path``, etc.) so operators can distinguish root causes
+    from the exception type alone.
+    """
+
+
+class CostTrackingDisabledError(CostTrackingError):
+    """Raised when a cost public API is invoked while policy.enabled=false.
+
+    Callers are expected to guard cost pathways with a dormant-gate
+    check. This error signals that the caller skipped the gate and
+    invoked the runtime anyway. The cost middleware wraps all public
+    pathways behind ``policy.enabled`` and bypasses transparently;
+    this error surfaces only when a downstream module skips the
+    wrapper.
+    """
+
+
+class CostTrackingConfigError(CostTrackingError):
+    """Raised when cost policy is enabled but the workflow-run budget
+    lacks the required ``cost_usd`` axis.
+
+    PR-B2 v3 iter-2 B2 absorb (Option A): budget.cost_usd is optional
+    at the schema level, but when ``policy.enabled=true`` the run MUST
+    declare this axis. Operator migration: workflow specs should add
+    ``budget.cost_usd`` before flipping the policy flag. Fail-closed
+    early — before transport hits the network, before any ledger write.
+    """
+
+    def __init__(self, run_id: str, details: str = "") -> None:
+        self.run_id = run_id
+        self.details = details
+        super().__init__(
+            f"run {run_id!r} cost policy is enabled but run.budget.cost_usd "
+            f"axis is not configured. {details}".strip()
+        )
+
+
+class PriceCatalogNotFoundError(CostTrackingError):
+    """Raised when the price catalog has no entry for ``(provider_id, model)``.
+
+    Fail-closed: the operator enabled cost policy but a specific
+    adapter invocation referenced a model absent from the catalog.
+    Resolution is catalog-side (add the entry and rev the
+    ``catalog_version``) or routing-side (use a model covered by the
+    catalog). Raised BEFORE transport — the billable call never hits
+    the network.
+    """
+
+    def __init__(
+        self,
+        provider_id: str,
+        model: str,
+        catalog_version: str,
+    ) -> None:
+        self.provider_id = provider_id
+        self.model = model
+        self.catalog_version = catalog_version
+        super().__init__(
+            f"price catalog version {catalog_version!r} has no entry for "
+            f"provider={provider_id!r} model={model!r}"
+        )
+
+
+class PriceCatalogChecksumError(CostTrackingError):
+    """Raised when loaded catalog's ``checksum`` does not match the
+    recomputed SHA-256 over ``entries[]``.
+
+    Protects against in-place edits that skip ``catalog_version``
+    bumps. The catalog on disk is treated as tampered and the loader
+    refuses it. Operators must rev the version and compute the new
+    checksum via the canonical JSON canon (``sort_keys=True,
+    ensure_ascii=False, separators=(",",":")``).
+    """
+
+    def __init__(
+        self,
+        catalog_path: str,
+        expected_checksum: str,
+        actual_checksum: str,
+    ) -> None:
+        self.catalog_path = catalog_path
+        self.expected_checksum = expected_checksum
+        self.actual_checksum = actual_checksum
+        super().__init__(
+            f"price catalog at {catalog_path!r} checksum mismatch: "
+            f"expected {expected_checksum!r}, computed {actual_checksum!r}"
+        )
+
+
+class PriceCatalogStaleError(CostTrackingError):
+    """Raised when ``policy.strict_freshness=true`` and the catalog's
+    ``stale_after`` timestamp is in the past.
+
+    Default policy (``strict_freshness=false``) emits a warn-level log
+    and returns the catalog; operators who want fail-closed on stale
+    pricing flip the knob and get this exception instead.
+    """
+
+    def __init__(
+        self,
+        catalog_path: str,
+        stale_after: str,
+        now: str,
+    ) -> None:
+        self.catalog_path = catalog_path
+        self.stale_after = stale_after
+        self.now = now
+        super().__init__(
+            f"price catalog at {catalog_path!r} is stale "
+            f"(stale_after={stale_after!r}, now={now!r}); "
+            f"strict_freshness=true blocks use"
+        )
+
+
+class SpendLedgerDuplicateError(CostTrackingError):
+    """Raised when the ledger writer sees a duplicate
+    ``(run_id, step_id, attempt)`` key with a DIFFERENT billing_digest.
+
+    Idempotent no-op (same digest) is handled silently with a warn
+    log; this error surfaces only for real caller bugs (the same
+    retry produced a different billable payload). Fail-closed.
+    """
+
+    def __init__(
+        self,
+        run_id: str,
+        step_id: str,
+        attempt: int,
+        existing_digest: str,
+        new_digest: str,
+    ) -> None:
+        self.run_id = run_id
+        self.step_id = step_id
+        self.attempt = attempt
+        self.existing_digest = existing_digest
+        self.new_digest = new_digest
+        super().__init__(
+            f"spend ledger duplicate for "
+            f"(run_id={run_id!r}, step_id={step_id!r}, attempt={attempt}): "
+            f"existing digest {existing_digest!r} != new {new_digest!r}"
+        )
+
+
+class SpendLedgerCorruptedError(CostTrackingError):
+    """Raised when the idempotency scan of the ledger hits a line that
+    cannot be parsed as JSON (or fails schema validation).
+
+    Fail-closed: operator must repair the ledger before cost runtime
+    can continue. Corruption surfaces early so undetected partial
+    writes do not silently block all subsequent record_spend calls.
+    """
+
+    def __init__(
+        self,
+        ledger_path: str,
+        line_number: int,
+        reason: str,
+    ) -> None:
+        self.ledger_path = ledger_path
+        self.line_number = line_number
+        self.reason = reason
+        super().__init__(
+            f"spend ledger {ledger_path!r} line {line_number} corrupted: {reason}"
+        )
+
+
+class LLMUsageMissingError(CostTrackingError):
+    """Raised when the adapter's response lacks ``tokens_input`` or
+    ``tokens_output`` AND ``policy.fail_closed_on_missing_usage=true``.
+
+    Audit trail preserved: a ledger line with ``usage_missing=true``
+    and ``cost_usd=0`` is recorded before the raise. Operators in
+    audit-only environments (billing reconciled out-of-band) can set
+    the flag false to warn-log and continue.
+    """
+
+    def __init__(
+        self,
+        run_id: str,
+        step_id: str,
+        attempt: int,
+        provider_id: str,
+        model: str,
+        missing_fields: tuple[str, ...],
+    ) -> None:
+        self.run_id = run_id
+        self.step_id = step_id
+        self.attempt = attempt
+        self.provider_id = provider_id
+        self.model = model
+        self.missing_fields = missing_fields
+        super().__init__(
+            f"adapter response missing token usage fields "
+            f"{missing_fields!r} for provider={provider_id!r} "
+            f"model={model!r} (run_id={run_id!r}, step_id={step_id!r}, "
+            f"attempt={attempt})"
+        )
+
+
+class BudgetExhaustedError(CostTrackingError):
+    """Raised when a pre-dispatch cost estimate exceeds the remaining
+    ``budget.cost_usd.remaining`` on the workflow run.
+
+    Fail-closed BEFORE transport: the adapter never hits the network
+    when this fires. Distinct from ``WorkflowBudgetExhaustedError``
+    (PR-A1) — that one covers aggregate token/time budget triggered
+    by ``record_spend`` at any axis; this one is specifically the
+    cost axis at pre-dispatch time, before any LLM call cost is
+    actually incurred.
+    """
+
+    def __init__(
+        self,
+        run_id: str,
+        estimate_usd: str,
+        remaining_usd: str,
+    ) -> None:
+        self.run_id = run_id
+        self.estimate_usd = estimate_usd
+        self.remaining_usd = remaining_usd
+        super().__init__(
+            f"budget exhausted for run {run_id!r}: "
+            f"estimate={estimate_usd} USD exceeds "
+            f"remaining={remaining_usd} USD"
+        )
+
+
+__all__ = [
+    "CostTrackingError",
+    "CostTrackingDisabledError",
+    "CostTrackingConfigError",
+    "PriceCatalogNotFoundError",
+    "PriceCatalogChecksumError",
+    "PriceCatalogStaleError",
+    "SpendLedgerDuplicateError",
+    "SpendLedgerCorruptedError",
+    "LLMUsageMissingError",
+    "BudgetExhaustedError",
+]

--- a/ao_kernel/cost/ledger.py
+++ b/ao_kernel/cost/ledger.py
@@ -1,0 +1,335 @@
+"""Spend ledger — append-only JSONL with canonical billing digest
+idempotency (PR-B2 commit 3).
+
+Each billable LLM invocation emits one event to ``{workspace_root}/
+{policy.spend_ledger_path}`` (default ``.ao/cost/spend.jsonl``).
+Events are keyed by ``(run_id, step_id, attempt)``; the writer
+tail-scans the last ``policy.idempotency_window_lines`` lines before
+appending and:
+
+- No-ops silently (warn-log) when the key already exists with the
+  SAME ``billing_digest`` — retry idempotency.
+- Raises :class:`SpendLedgerDuplicateError` when the key already
+  exists with a DIFFERENT ``billing_digest`` — caller bug (the same
+  retry produced distinct billable payload).
+
+Corrupt JSONL lines encountered during the scan raise
+:class:`SpendLedgerCorruptedError` (fail-closed). Operator must
+repair the ledger before cost runtime can continue.
+
+Dormant gate lives in the caller (``cost.middleware``); ``record_spend``
+itself is unconditional once policy + path have been resolved.
+
+See ``docs/COST-MODEL.md`` §3 and PR-B2 plan v7 §2.2.
+"""
+
+from __future__ import annotations
+
+import collections
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from ao_kernel._internal.shared.lock import file_lock
+from ao_kernel.config import load_default
+from ao_kernel.cost.errors import (
+    SpendLedgerCorruptedError,
+    SpendLedgerDuplicateError,
+)
+from ao_kernel.cost.policy import CostTrackingPolicy
+
+
+logger = logging.getLogger(__name__)
+
+
+_LEDGER_SCHEMA_CACHE: dict[str, Any] | None = None
+
+
+def _ledger_schema() -> dict[str, Any]:
+    """Load and cache ``spend-ledger.schema.v1.json``."""
+    global _LEDGER_SCHEMA_CACHE
+    if _LEDGER_SCHEMA_CACHE is None:
+        _LEDGER_SCHEMA_CACHE = load_default(
+            "schemas", "spend-ledger.schema.v1.json",
+        )
+    return _LEDGER_SCHEMA_CACHE
+
+
+@dataclass(frozen=True)
+class SpendEvent:
+    """One billable LLM call event.
+
+    Fields mirror ``spend-ledger.schema.v1.json`` one-to-one. The
+    writer fills ``billing_digest`` lazily (if caller omits) via
+    :func:`_compute_billing_digest` before append; operators never
+    author ledger events by hand, so the redundant-author path is
+    fine to not expose.
+
+    ``cost_usd`` is stored as ``Decimal`` in-process for precision;
+    the writer serializes as JSON ``number`` (float) per schema
+    contract — acceptable loss since ``billing_digest`` canonicalizes
+    via ``str(Decimal(...))`` for idempotency comparison.
+    """
+
+    run_id: str
+    step_id: str
+    attempt: int
+    provider_id: str
+    model: str
+    tokens_input: int
+    tokens_output: int
+    cost_usd: Decimal
+    ts: str  # ISO-8601 with timezone
+    vendor_model_id: str | None = None
+    cached_tokens: int | None = None
+    usage_missing: bool = False
+    billing_digest: str = ""  # computed by writer if empty
+
+
+def _compute_billing_digest(event: SpendEvent) -> str:
+    """Canonical SHA-256 over billing-relevant fields.
+
+    Decimal-stable: ``cost_usd`` is canonicalized via ``str(Decimal(...))``
+    so float serialization round-trips do not break the comparison.
+    """
+    payload = {
+        "provider_id": event.provider_id,
+        "model": event.model,
+        "vendor_model_id": event.vendor_model_id,
+        "tokens_input": event.tokens_input,
+        "tokens_output": event.tokens_output,
+        "cached_tokens": event.cached_tokens,
+        "cost_usd": str(Decimal(str(event.cost_usd))),
+        "usage_missing": event.usage_missing,
+    }
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _event_to_dict(event: SpendEvent) -> dict[str, Any]:
+    """Serialize ``event`` to a schema-valid dict.
+
+    Optional fields (``vendor_model_id``, ``cached_tokens``) are
+    omitted when None to honor schema ``additionalProperties: false``
+    + avoid null in the wire.
+    """
+    out: dict[str, Any] = {
+        "run_id": event.run_id,
+        "step_id": event.step_id,
+        "attempt": event.attempt,
+        "provider_id": event.provider_id,
+        "model": event.model,
+        "tokens_input": event.tokens_input,
+        "tokens_output": event.tokens_output,
+        "cost_usd": float(event.cost_usd),
+        "ts": event.ts,
+        "usage_missing": event.usage_missing,
+        "billing_digest": event.billing_digest or _compute_billing_digest(event),
+    }
+    if event.vendor_model_id is not None:
+        out["vendor_model_id"] = event.vendor_model_id
+    if event.cached_tokens is not None:
+        out["cached_tokens"] = event.cached_tokens
+    return out
+
+
+def _validate_event(doc: dict[str, Any]) -> None:
+    """Validate an event dict against the ledger schema — fail-closed."""
+    from jsonschema import Draft202012Validator
+
+    Draft202012Validator(_ledger_schema()).validate(doc)
+
+
+def _ledger_path(
+    workspace_root: Path,
+    policy: CostTrackingPolicy,
+) -> Path:
+    return workspace_root / policy.spend_ledger_path
+
+
+def _ledger_lock_path(ledger_path: Path) -> Path:
+    return ledger_path.with_suffix(ledger_path.suffix + ".lock")
+
+
+def _scan_tail(
+    ledger_path: Path,
+    window_lines: int,
+) -> list[dict[str, Any]]:
+    """Read the last ``window_lines`` of the ledger and parse.
+
+    Raises :class:`SpendLedgerCorruptedError` on any unparseable line.
+    Missing ledger file → empty list (first-write case).
+    """
+    if not ledger_path.is_file():
+        return []
+    # Bounded scan: collections.deque(maxlen=N) keeps the last N lines
+    # as we iterate — memory bounded even for huge ledgers. For the
+    # 1000-line default this is trivial; for 100_000 (policy cap) it
+    # still fits in a single-pass read.
+    tail: collections.deque[tuple[int, str]] = collections.deque(
+        maxlen=window_lines,
+    )
+    with ledger_path.open("r", encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            stripped = raw.strip()
+            if not stripped:
+                continue  # tolerate trailing newline
+            tail.append((lineno, stripped))
+    parsed: list[dict[str, Any]] = []
+    for lineno, line in tail:
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise SpendLedgerCorruptedError(
+                ledger_path=str(ledger_path),
+                line_number=lineno,
+                reason=f"JSON decode error: {exc}",
+            ) from exc
+        if not isinstance(obj, dict):
+            raise SpendLedgerCorruptedError(
+                ledger_path=str(ledger_path),
+                line_number=lineno,
+                reason=f"line is not a JSON object (got {type(obj).__name__})",
+            )
+        parsed.append(obj)
+    return parsed
+
+
+def _find_duplicate(
+    window: list[dict[str, Any]],
+    run_id: str,
+    step_id: str,
+    attempt: int,
+) -> dict[str, Any] | None:
+    """Return the matching existing event dict or None."""
+    for entry in window:
+        if (
+            entry.get("run_id") == run_id
+            and entry.get("step_id") == step_id
+            and entry.get("attempt") == attempt
+        ):
+            return entry
+    return None
+
+
+def _append_with_fsync(ledger_path: Path, line: str) -> None:
+    """Append a single ``line\\n`` to the ledger with fsync.
+
+    We use lock + append + fsync rather than tmp+rename because JSONL
+    append-only does not benefit from rename atomicity — the write
+    serialization anchor is the file_lock wrapping the call site.
+    """
+    with ledger_path.open("a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+
+
+def record_spend(
+    workspace_root: Path,
+    event: SpendEvent,
+    *,
+    policy: CostTrackingPolicy,
+) -> None:
+    """Append a spend event with idempotent duplicate protection.
+
+    Short-circuits with a silent no-op when ``policy.enabled=false``
+    (dormant gate at the writer as well as the middleware — defensive
+    redundancy; the caller should already have filtered, but this
+    keeps the contract robust against wire bugs).
+
+    Idempotency:
+
+    - Compute ``billing_digest`` if not pre-filled.
+    - Acquire ``{ledger_path}.lock`` (POSIX fcntl via the shared helper).
+    - Scan the last ``policy.idempotency_window_lines`` entries.
+    - If ``(run_id, step_id, attempt)`` found:
+      - same ``billing_digest`` → WARN log, return (no-op).
+      - different ``billing_digest`` → :class:`SpendLedgerDuplicateError`.
+    - Else: validate schema, canonicalize line, append + fsync.
+
+    Corrupt ledger line encountered during scan →
+    :class:`SpendLedgerCorruptedError` (fail-closed).
+    """
+    if not policy.enabled:
+        return  # dormant silent no-op
+
+    ledger_path = _ledger_path(workspace_root, policy)
+    ledger_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    # Pre-compute digest so we can compare against existing lines without
+    # re-serializing them.
+    digest = event.billing_digest or _compute_billing_digest(event)
+    if event.billing_digest == "":
+        # Inject back into the event for downstream uses (e.g. evidence
+        # emit payload). Since SpendEvent is frozen, we rebuild.
+        event = SpendEvent(
+            run_id=event.run_id,
+            step_id=event.step_id,
+            attempt=event.attempt,
+            provider_id=event.provider_id,
+            model=event.model,
+            tokens_input=event.tokens_input,
+            tokens_output=event.tokens_output,
+            cost_usd=event.cost_usd,
+            ts=event.ts,
+            vendor_model_id=event.vendor_model_id,
+            cached_tokens=event.cached_tokens,
+            usage_missing=event.usage_missing,
+            billing_digest=digest,
+        )
+
+    lock_path = _ledger_lock_path(ledger_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    with file_lock(lock_path):
+        window = _scan_tail(ledger_path, policy.idempotency_window_lines)
+        existing = _find_duplicate(
+            window, event.run_id, event.step_id, event.attempt,
+        )
+        if existing is not None:
+            existing_digest = str(existing.get("billing_digest", ""))
+            if existing_digest == digest:
+                logger.warning(
+                    "spend ledger idempotent no-op: "
+                    "(run_id=%s, step_id=%s, attempt=%d) already recorded "
+                    "with matching digest %s",
+                    event.run_id,
+                    event.step_id,
+                    event.attempt,
+                    digest,
+                )
+                return
+            raise SpendLedgerDuplicateError(
+                run_id=event.run_id,
+                step_id=event.step_id,
+                attempt=event.attempt,
+                existing_digest=existing_digest,
+                new_digest=digest,
+            )
+
+        doc = _event_to_dict(event)
+        _validate_event(doc)
+        line = json.dumps(
+            doc,
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        _append_with_fsync(ledger_path, line)
+
+
+__all__ = [
+    "SpendEvent",
+    "record_spend",
+]

--- a/ao_kernel/cost/middleware.py
+++ b/ao_kernel/cost/middleware.py
@@ -346,26 +346,46 @@ def post_response_reconcile(
                 details="run.budget.cost_usd dropped between reserve and reconcile",
             )
 
-        # Compose spend kwargs only for axes that are actually configured
-        # on this run's budget. Unconfigured axes MUST NOT be spent on —
+        # Compose spend kwargs only for axes actually configured on this
+        # run's budget. Unconfigured axes MUST NOT be spent on —
         # _spend_axis raises ValueError for None axes.
+        #
+        # CNS-032 iter-1 blocker absorb: legacy workflow-run records
+        # with aggregate `tokens` only trigger the reader's back-compat
+        # synthesis (tokens_input = copy(tokens), tokens_output = None).
+        # For these, the middleware MUST route token spend through the
+        # aggregate axis (tokens=input+output) so completion tokens are
+        # actually counted. Three cases emerge:
+        #
+        # 1. Full granular (both tokens_input + tokens_output set):
+        #    spend granular; aggregate auto-adjusts in record_budget_spend.
+        # 2. Legacy or partial-with-aggregate (tokens set AND
+        #    tokens_output is None): spend the SUM on aggregate — the
+        #    tokens_input axis (a back-compat synth or partial config)
+        #    is not considered billable-tracking in this mode.
+        # 3. Partial granular-only input (tokens_input set but
+        #    tokens_output + aggregate both None): track only input.
         spend_kwargs: dict[str, Any] = {"run_id": run_id}
         if delta != 0:
             spend_kwargs["cost_usd"] = delta
-        if budget.tokens_input is not None:
+
+        has_full_granular = (
+            budget.tokens_input is not None
+            and budget.tokens_output is not None
+        )
+        if has_full_granular:
             spend_kwargs["tokens_input"] = tokens_input
-        if budget.tokens_output is not None:
             spend_kwargs["tokens_output"] = tokens_output
-        # Aggregate-only path: if granular axes are None but aggregate
-        # tokens is configured, spend the sum on the aggregate axis.
-        # (When granular axes are configured, record_budget_spend
-        # auto-adjusts the aggregate.)
-        if (
-            budget.tokens is not None
-            and budget.tokens_input is None
-            and budget.tokens_output is None
-        ):
+        elif budget.tokens is not None:
+            # Legacy aggregate-only (or partial granular + aggregate) —
+            # aggregate path. Total tokens = input + output.
             spend_kwargs["tokens"] = tokens_input + tokens_output
+        elif budget.tokens_input is not None:
+            # Partial granular without aggregate: input-only tracking.
+            # tokens_output is intentionally unconfigured; operator
+            # accepts that output tokens are untracked in this mode.
+            spend_kwargs["tokens_input"] = tokens_input
+        # else: no token axes anywhere → no token spend.
 
         # If no axis needs adjustment, skip the call entirely.
         spendable = any(

--- a/ao_kernel/cost/middleware.py
+++ b/ao_kernel/cost/middleware.py
@@ -350,12 +350,12 @@ def post_response_reconcile(
         # run's budget. Unconfigured axes MUST NOT be spent on —
         # _spend_axis raises ValueError for None axes.
         #
-        # CNS-032 iter-1 blocker absorb: legacy workflow-run records
-        # with aggregate `tokens` only trigger the reader's back-compat
-        # synthesis (tokens_input = copy(tokens), tokens_output = None).
-        # For these, the middleware MUST route token spend through the
-        # aggregate axis (tokens=input+output) so completion tokens are
-        # actually counted. Three cases emerge:
+        # CNS-032 iter-1 blocker absorb (refined iter-2): legacy
+        # workflow-run records with aggregate `tokens` only stay
+        # aggregate-only in-memory (no synthesized granular axes). The
+        # middleware MUST route legacy token spend through the
+        # aggregate axis so completion tokens are actually counted.
+        # Three cases emerge:
         #
         # 1. Full granular (both tokens_input + tokens_output set):
         #    spend granular; aggregate auto-adjusts in record_budget_spend.

--- a/ao_kernel/cost/middleware.py
+++ b/ao_kernel/cost/middleware.py
@@ -1,0 +1,429 @@
+"""Cost middleware — pre-dispatch reserve + post-response reconcile
+(PR-B2 commit 5a).
+
+Composes the cost-tracking primitives around the LLM transport call:
+
+- :func:`pre_dispatch_reserve` (called BEFORE transport): resolves
+  the catalog entry, estimates cost, emits ``llm_cost_estimated``,
+  reserves on ``workflow-run.budget.cost_usd`` via CAS-retried
+  mutation. Raises fail-closed errors early so the network never
+  sees a request that would bust the budget.
+
+- :func:`post_response_reconcile` (called AFTER transport on OK
+  status): extracts strict usage, computes actual cost, reconciles
+  the reservation (deducts the delta positive, refunds negative),
+  appends to the spend ledger with canonical billing digest, emits
+  ``llm_spend_recorded``. Handles the usage-missing fail-closed path.
+
+Integration entrypoint :func:`governed_call` lives on
+``ao_kernel/llm.py`` (same commit 5a). The middleware functions
+below are the building blocks; callers (3 entrypoints — client,
+mcp_server, intent_router) interact with ``governed_call`` only.
+
+See ``docs/COST-MODEL.md`` §5 + PR-B2 plan v7 §2.6 for the 18-step
+flow spec.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Mapping
+
+from ao_kernel.cost.catalog import (
+    PriceCatalogEntry,
+    find_entry,
+    load_price_catalog,
+)
+from ao_kernel.cost.cost_math import (
+    compute_cost,
+    estimate_cost,
+    estimate_output_tokens,
+)
+from ao_kernel.cost.errors import (
+    BudgetExhaustedError,
+    CostTrackingConfigError,
+    LLMUsageMissingError,
+    PriceCatalogNotFoundError,
+)
+from ao_kernel.cost.ledger import (
+    SpendEvent,
+    record_spend,
+)
+from ao_kernel.cost.policy import CostTrackingPolicy
+from ao_kernel.workflow.budget import (
+    budget_from_dict,
+    budget_to_dict,
+    record_spend as record_budget_spend,
+)
+from ao_kernel.workflow.run_store import update_run
+
+
+logger = logging.getLogger(__name__)
+
+
+def _count_prompt_tokens(messages: list[Mapping[str, Any]]) -> int:
+    """Heuristic prompt-token estimate for pre-dispatch reserve.
+
+    Uses the existing PR-A token counter; no new dependency. Called
+    only when cost tracking is active, so the import is lazy.
+    """
+    from ao_kernel._internal.providers.token_counter import (
+        count_tokens_heuristic,
+    )
+
+    # Cast Mapping → dict for the counter's type contract; shallow copy
+    # preserves the original mapping content.
+    return count_tokens_heuristic([dict(m) for m in messages])
+
+
+def _safe_emit(
+    workspace_root: Path,
+    run_id: str,
+    kind: str,
+    payload: Mapping[str, Any],
+) -> None:
+    """Fail-open evidence emit wrapper (PR-B1 pattern)."""
+    try:
+        from ao_kernel.executor.evidence_emitter import emit_event
+
+        emit_event(
+            workspace_root,
+            run_id=run_id,
+            kind=kind,
+            actor="ao-kernel",
+            payload=dict(payload),
+        )
+    except Exception as exc:  # pragma: no cover — fail-open side-channel
+        logger.warning(
+            "cost evidence emit failed (fail-open, kind=%s): %s", kind, exc
+        )
+
+
+def _iso_now() -> str:
+    return _dt.datetime.now(tz=_dt.timezone.utc).isoformat()
+
+
+def pre_dispatch_reserve(
+    *,
+    workspace_root: Path,
+    run_id: str,
+    step_id: str,
+    attempt: int,
+    provider_id: str,
+    model: str,
+    prompt_messages: list[Mapping[str, Any]],
+    max_tokens: int | None,
+    policy: CostTrackingPolicy,
+) -> tuple[Decimal, PriceCatalogEntry]:
+    """Pre-dispatch cost estimate + budget reservation.
+
+    Flow (plan v7 §3 steps 3-6):
+
+    1. Load price catalog (LRU 300s, workspace-relative or bundled).
+    2. Find entry for (provider_id, model) → ``PriceCatalogNotFoundError``
+       if missing (fail-closed, before transport).
+    3. Estimate input tokens (heuristic) + output tokens
+       (``min(max_tokens, est_in * 0.25)``).
+    4. Estimate cost (ignores caching — conservative upper bound).
+    5. Emit ``llm_cost_estimated`` (fail-open).
+    6. Reserve on run record: check ``budget.cost_usd.remaining >=
+       estimate``; if not → ``BudgetExhaustedError``. Else CAS-update
+       budget with ``record_spend(cost_usd=estimate)``.
+       - If run has ``policy.enabled=true`` AND ``budget.cost_usd is None``
+         → ``CostTrackingConfigError`` fail-closed (Option A).
+
+    Returns ``(est_cost, catalog_entry)`` for the caller (governed_call)
+    to thread into post-response reconcile.
+    """
+    catalog = load_price_catalog(workspace_root, policy=policy)
+    entry = find_entry(catalog, provider_id, model)
+    if entry is None:
+        raise PriceCatalogNotFoundError(
+            provider_id=provider_id,
+            model=model,
+            catalog_version=catalog.catalog_version,
+        )
+
+    est_input_tokens = _count_prompt_tokens(prompt_messages)
+    est_output_tokens = estimate_output_tokens(est_input_tokens, max_tokens)
+    est_cost = estimate_cost(entry, est_input_tokens, est_output_tokens)
+
+    _safe_emit(
+        workspace_root,
+        run_id,
+        "llm_cost_estimated",
+        {
+            "run_id": run_id,
+            "step_id": step_id,
+            "attempt": attempt,
+            "provider_id": provider_id,
+            "model": model,
+            "est_tokens_input": est_input_tokens,
+            "est_tokens_output": est_output_tokens,
+            "est_cost_usd": float(est_cost),
+            "ts": _iso_now(),
+        },
+    )
+
+    # CAS-retried reserve. Mutator validates cost_usd axis presence
+    # (fail-closed) and raises BudgetExhaustedError on insufficient
+    # remaining. The update_run helper handles CAS retry (default 1;
+    # we ask for 3 per plan v7 §2.6).
+    def _reserve_mutator(record: dict[str, Any]) -> dict[str, Any]:
+        budget_dict = record.get("budget")
+        if budget_dict is None:
+            raise CostTrackingConfigError(
+                run_id=run_id,
+                details=(
+                    "run has no 'budget' field; cost_usd axis is required "
+                    "when policy.enabled=true"
+                ),
+            )
+        budget = budget_from_dict(budget_dict)
+        if budget.cost_usd is None:
+            raise CostTrackingConfigError(
+                run_id=run_id,
+                details=(
+                    "run.budget.cost_usd axis is not configured; workflow "
+                    "specs must declare it when policy.enabled=true"
+                ),
+            )
+        # Check remaining >= est_cost BEFORE spending.
+        remaining = budget.cost_usd.remaining
+        if remaining < est_cost:
+            raise BudgetExhaustedError(
+                run_id=run_id,
+                estimate_usd=str(est_cost),
+                remaining_usd=str(remaining),
+            )
+        new_budget = record_budget_spend(
+            budget,
+            cost_usd=est_cost,
+            run_id=run_id,
+        )
+        return {**record, "budget": budget_to_dict(new_budget)}
+
+    update_run(
+        workspace_root,
+        run_id,
+        mutator=_reserve_mutator,
+        max_retries=3,
+    )
+
+    return est_cost, entry
+
+
+def post_response_reconcile(
+    *,
+    workspace_root: Path,
+    run_id: str,
+    step_id: str,
+    attempt: int,
+    provider_id: str,
+    model: str,
+    catalog_entry: PriceCatalogEntry,
+    est_cost: Decimal,
+    raw_response_bytes: bytes,
+    policy: CostTrackingPolicy,
+) -> None:
+    """Post-response usage extract + reconcile + ledger append.
+
+    Flow (plan v7 §3 steps 7-9):
+
+    1. ``extract_usage_strict`` → ``UsagePresence(None | int)``.
+    2. Usage-missing path: record_spend(usage_missing=true, cost=0) +
+       emit llm_usage_missing. If ``policy.fail_closed_on_missing_usage``
+       → ``LLMUsageMissingError``. Else warn-log.
+    3. Success path:
+       - ``actual = compute_cost(entry, ti, to, cached or 0)``.
+       - Reconcile: CAS-update budget with ``cost_usd = (actual - est)``.
+         Positive delta → additional deduct; negative → refund.
+         Per plan Q5 iter-1: reservation holds on transport error
+         (middleware never reaches this function in that case).
+       - record_spend (billing_digest computed).
+       - emit llm_spend_recorded.
+    """
+    from ao_kernel._internal.prj_kernel_api.llm_response_normalizer import (
+        extract_usage_strict,
+    )
+
+    usage = extract_usage_strict(raw_response_bytes)
+
+    missing_fields: list[str] = []
+    if usage.tokens_input is None:
+        missing_fields.append("tokens_input")
+    if usage.tokens_output is None:
+        missing_fields.append("tokens_output")
+
+    if missing_fields:
+        # Usage-missing path: audit-only ledger entry + emit + optional raise.
+        event = SpendEvent(
+            run_id=run_id,
+            step_id=step_id,
+            attempt=attempt,
+            provider_id=provider_id,
+            model=model,
+            tokens_input=0,
+            tokens_output=0,
+            cost_usd=Decimal("0"),
+            ts=_iso_now(),
+            vendor_model_id=catalog_entry.vendor_model_id,
+            usage_missing=True,
+        )
+        record_spend(workspace_root, event, policy=policy)
+        _safe_emit(
+            workspace_root,
+            run_id,
+            "llm_usage_missing",
+            {
+                "run_id": run_id,
+                "step_id": step_id,
+                "attempt": attempt,
+                "provider_id": provider_id,
+                "model": model,
+                "missing_fields": list(missing_fields),
+                "ts": _iso_now(),
+            },
+        )
+        if policy.fail_closed_on_missing_usage:
+            raise LLMUsageMissingError(
+                run_id=run_id,
+                step_id=step_id,
+                attempt=attempt,
+                provider_id=provider_id,
+                model=model,
+                missing_fields=tuple(missing_fields),
+            )
+        logger.warning(
+            "cost reconcile: adapter response missing usage fields %r "
+            "for provider=%s model=%s; policy.fail_closed_on_missing_usage="
+            "false so continuing (reservation held, no refund)",
+            missing_fields,
+            provider_id,
+            model,
+        )
+        return
+
+    # Success path. At this point usage.tokens_input / .tokens_output
+    # are both non-None ints (narrow here for mypy).
+    tokens_input = usage.tokens_input
+    tokens_output = usage.tokens_output
+    cached = usage.cached_tokens or 0
+    # The narrowing above guarantees non-None; cast for static typing.
+    assert tokens_input is not None
+    assert tokens_output is not None
+
+    actual = compute_cost(
+        catalog_entry,
+        tokens_input=tokens_input,
+        tokens_output=tokens_output,
+        cached_tokens=cached,
+    )
+    delta = actual - est_cost
+
+    # Reconcile: add (actual - est) to cost_usd.spent. Negative delta
+    # (actual < est) is a refund; record_spend supports negative spend
+    # via Decimal arithmetic. Token axes are spent only when configured
+    # on the run's budget — unconfigured axes would raise ValueError in
+    # _spend_axis.
+    def _reconcile_mutator(record: dict[str, Any]) -> dict[str, Any]:
+        budget_dict = record.get("budget")
+        if budget_dict is None:
+            # Middleware already validated on pre_dispatch_reserve; this
+            # branch is defensive for CAS-racy mid-reconcile record
+            # reshape.
+            raise CostTrackingConfigError(
+                run_id=run_id,
+                details="run.budget dropped between reserve and reconcile",
+            )
+        budget = budget_from_dict(budget_dict)
+        if budget.cost_usd is None:
+            raise CostTrackingConfigError(
+                run_id=run_id,
+                details="run.budget.cost_usd dropped between reserve and reconcile",
+            )
+
+        # Compose spend kwargs only for axes that are actually configured
+        # on this run's budget. Unconfigured axes MUST NOT be spent on —
+        # _spend_axis raises ValueError for None axes.
+        spend_kwargs: dict[str, Any] = {"run_id": run_id}
+        if delta != 0:
+            spend_kwargs["cost_usd"] = delta
+        if budget.tokens_input is not None:
+            spend_kwargs["tokens_input"] = tokens_input
+        if budget.tokens_output is not None:
+            spend_kwargs["tokens_output"] = tokens_output
+        # Aggregate-only path: if granular axes are None but aggregate
+        # tokens is configured, spend the sum on the aggregate axis.
+        # (When granular axes are configured, record_budget_spend
+        # auto-adjusts the aggregate.)
+        if (
+            budget.tokens is not None
+            and budget.tokens_input is None
+            and budget.tokens_output is None
+        ):
+            spend_kwargs["tokens"] = tokens_input + tokens_output
+
+        # If no axis needs adjustment, skip the call entirely.
+        spendable = any(
+            k in spend_kwargs
+            for k in ("cost_usd", "tokens_input", "tokens_output", "tokens")
+        )
+        if spendable:
+            new_budget = record_budget_spend(budget, **spend_kwargs)
+        else:
+            new_budget = budget
+        return {**record, "budget": budget_to_dict(new_budget)}
+
+    update_run(
+        workspace_root,
+        run_id,
+        mutator=_reconcile_mutator,
+        max_retries=3,
+    )
+
+    # Ledger append with canonical billing digest.
+    event = SpendEvent(
+        run_id=run_id,
+        step_id=step_id,
+        attempt=attempt,
+        provider_id=provider_id,
+        model=model,
+        tokens_input=tokens_input,
+        tokens_output=tokens_output,
+        cost_usd=actual,
+        ts=_iso_now(),
+        vendor_model_id=catalog_entry.vendor_model_id,
+        cached_tokens=cached if cached > 0 else None,
+        usage_missing=False,
+    )
+    record_spend(workspace_root, event, policy=policy)
+
+    _safe_emit(
+        workspace_root,
+        run_id,
+        "llm_spend_recorded",
+        {
+            "run_id": run_id,
+            "step_id": step_id,
+            "attempt": attempt,
+            "provider_id": provider_id,
+            "model": model,
+            "tokens_input": tokens_input,
+            "tokens_output": tokens_output,
+            "cached_tokens": cached,
+            "cost_usd": float(actual),
+            "est_cost_usd": float(est_cost),
+            "delta_usd": float(delta),
+            "ts": _iso_now(),
+        },
+    )
+
+
+__all__ = [
+    "pre_dispatch_reserve",
+    "post_response_reconcile",
+]

--- a/ao_kernel/cost/policy.py
+++ b/ao_kernel/cost/policy.py
@@ -1,0 +1,172 @@
+"""Cost tracking policy loader (PR-B2).
+
+Loads and validates ``policy_cost_tracking.v1.json`` from the bundled
+defaults or a workspace override and mirrors it into a typed
+:class:`CostTrackingPolicy` dataclass.
+
+Semantic notes:
+
+- **Dormant default:** the bundled policy ships ``enabled: false``.
+  The cost middleware treats policy.enabled=false as a transparent
+  bypass — no ledger writes, no evidence emits, no catalog load.
+  Opt-in is a deliberate operator action.
+- **``fail_closed_on_exhaust`` MUST be true** (schema ``const: true``).
+  The loader enforces this at parse time; any override attempting to
+  set it false fails schema validation before reaching runtime.
+- **``fail_closed_on_missing_usage`` defaults true** (v2 iter-2 B4 absorb).
+  Operators in audit-only environments (billing reconciled out of
+  band) can set false to warn-log instead of raising
+  :class:`LLMUsageMissingError`.
+- **``idempotency_window_lines`` defaults 1000** (v2 iter-2 B2 absorb).
+  Ledger idempotency scan tail window; bounded for performance.
+  Operators with very long runs can raise up to 100000.
+- **``routing_by_cost.enabled`` defaults false** — PR-B3's cost-aware
+  routing is inert under B2 even when the cost policy is enabled.
+  Operators flip the inner flag when ready for automatic model
+  downgrades.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+from ao_kernel.config import load_default
+
+
+_POLICY_SCHEMA_CACHE: dict[str, Any] | None = None
+_BUNDLED_POLICY_CACHE: dict[str, Any] | None = None
+
+
+def _policy_schema() -> dict[str, Any]:
+    """Load and cache ``policy-cost-tracking.schema.v1.json``."""
+    global _POLICY_SCHEMA_CACHE
+    if _POLICY_SCHEMA_CACHE is None:
+        _POLICY_SCHEMA_CACHE = load_default(
+            "schemas", "policy-cost-tracking.schema.v1.json",
+        )
+    return _POLICY_SCHEMA_CACHE
+
+
+def _bundled_policy() -> dict[str, Any]:
+    """Load and cache the bundled dormant policy."""
+    global _BUNDLED_POLICY_CACHE
+    if _BUNDLED_POLICY_CACHE is None:
+        _BUNDLED_POLICY_CACHE = load_default(
+            "policies", "policy_cost_tracking.v1.json",
+        )
+    return _BUNDLED_POLICY_CACHE
+
+
+@dataclass(frozen=True)
+class RoutingByCost:
+    """Cost-aware routing toggle (PR-B3 runtime)."""
+
+    enabled: bool
+
+
+@dataclass(frozen=True)
+class CostTrackingPolicy:
+    """Typed view of ``policy_cost_tracking.v1.json``.
+
+    Scalar fields mirror the schema one-to-one. The dormant default
+    has ``enabled=False``; a workspace override at
+    ``{workspace_root}/.ao/policies/policy_cost_tracking.v1.json``
+    replaces the bundled values.
+    """
+
+    enabled: bool
+    price_catalog_path: str
+    spend_ledger_path: str
+    fail_closed_on_exhaust: bool
+    strict_freshness: bool
+    fail_closed_on_missing_usage: bool
+    idempotency_window_lines: int
+    routing_by_cost: RoutingByCost = field(default_factory=lambda: RoutingByCost(enabled=False))
+    version: str = "v1"
+
+
+def _from_dict(doc: Mapping[str, Any]) -> CostTrackingPolicy:
+    """Map a schema-valid policy dict to :class:`CostTrackingPolicy`."""
+    routing_raw = doc.get("routing_by_cost") or {"enabled": False}
+    routing = RoutingByCost(enabled=bool(routing_raw.get("enabled", False)))
+    return CostTrackingPolicy(
+        enabled=bool(doc["enabled"]),
+        price_catalog_path=str(doc["price_catalog_path"]),
+        spend_ledger_path=str(doc["spend_ledger_path"]),
+        fail_closed_on_exhaust=bool(doc["fail_closed_on_exhaust"]),
+        strict_freshness=bool(doc["strict_freshness"]),
+        fail_closed_on_missing_usage=bool(
+            doc.get("fail_closed_on_missing_usage", True)
+        ),
+        idempotency_window_lines=int(
+            doc.get("idempotency_window_lines", 1000)
+        ),
+        routing_by_cost=routing,
+        version=str(doc.get("version", "v1")),
+    )
+
+
+def _validate(doc: Mapping[str, Any]) -> None:
+    """Validate ``doc`` against the bundled schema; raises on failure.
+
+    Fail-closed per CLAUDE.md §2: a malformed override must not be
+    silently ignored.
+    """
+    from jsonschema import Draft202012Validator
+
+    Draft202012Validator(_policy_schema()).validate(doc)
+
+
+def load_cost_policy(
+    workspace_root: Path,
+    *,
+    override: Mapping[str, Any] | None = None,
+) -> CostTrackingPolicy:
+    """Load the cost tracking policy.
+
+    Resolution order:
+
+    1. If ``override`` is supplied (a dict), validate it against the
+       schema and return the parsed policy. Used by tests and by
+       callers that want to evaluate a hypothetical policy without
+       touching the filesystem.
+    2. Workspace override at ``{workspace_root}/.ao/policies/
+       policy_cost_tracking.v1.json``. If present and schema-valid,
+       used.
+    3. Bundled default at ``ao_kernel/defaults/policies/
+       policy_cost_tracking.v1.json`` (dormant by default).
+
+    Fail-closed: a malformed override (invalid JSON, schema violation)
+    raises the underlying parse / validation exception.
+    """
+    if override is not None:
+        _validate(override)
+        return _from_dict(override)
+
+    ws_path = (
+        workspace_root
+        / ".ao"
+        / "policies"
+        / "policy_cost_tracking.v1.json"
+    )
+    if ws_path.is_file():
+        with ws_path.open("r", encoding="utf-8") as fh:
+            loaded: Mapping[str, Any] = json.load(fh)
+        _validate(loaded)
+        return _from_dict(loaded)
+
+    bundled = _bundled_policy()
+    # Bundled policy is schema-valid by construction (CI gate), but
+    # guard against drift.
+    _validate(bundled)
+    return _from_dict(bundled)
+
+
+__all__ = [
+    "RoutingByCost",
+    "CostTrackingPolicy",
+    "load_cost_policy",
+]

--- a/ao_kernel/defaults/policies/policy_cost_tracking.v1.json
+++ b/ao_kernel/defaults/policies/policy_cost_tracking.v1.json
@@ -1,11 +1,13 @@
 {
   "version": "v1",
   "enabled": false,
-  "_comment": "Bundled default DORMANT: enabled=false means the cost runtime does not engage; no spend ledger is written, catalog staleness is not evaluated, and llm.resolve_route() does not consult the catalog. Operator override: drop a workspace copy at {project_root}/.ao/policies/policy_cost_tracking.v1.json with enabled=true to activate. fail_closed_on_exhaust is locked to true per CNS-007 — attempting to set it false fails schema validation. strict_freshness=false (the default) emits a warn log when the catalog is past stale_after but does NOT block invocation; set strict_freshness=true to fail-closed instead. routing_by_cost.enabled=false means B3's cost-aware fallback is inert even when the policy is enabled — flip it on when the workspace is ready to handle automatic model downgrades. See docs/COST-MODEL.md for full semantics.",
+  "_comment": "Bundled default DORMANT: enabled=false means the cost runtime does not engage; no spend ledger is written, catalog staleness is not evaluated, and llm.resolve_route() does not consult the catalog. Operator override: drop a workspace copy at {project_root}/.ao/policies/policy_cost_tracking.v1.json with enabled=true to activate. fail_closed_on_exhaust is locked to true per CNS-007 — attempting to set it false fails schema validation. strict_freshness=false (the default) emits a warn log when the catalog is past stale_after but does NOT block invocation; set strict_freshness=true to fail-closed instead. fail_closed_on_missing_usage=true (the default) raises LLMUsageMissingError when adapter responses omit tokens_input/tokens_output; set false for warn-log in audit-only environments (PR-B2 v2 iter-2 B4 absorb). idempotency_window_lines=1000 bounds the ledger tail-scan window for (run_id, step_id, attempt) duplicate detection; operators with very long runs can raise up to 100000 (PR-B2 v2 iter-2 B2 absorb). routing_by_cost.enabled=false means B3's cost-aware fallback is inert even when the policy is enabled — flip it on when the workspace is ready to handle automatic model downgrades. See docs/COST-MODEL.md for full semantics.",
   "price_catalog_path": ".ao/cost/catalog.v1.json",
   "spend_ledger_path": ".ao/cost/spend.jsonl",
   "fail_closed_on_exhaust": true,
   "strict_freshness": false,
+  "fail_closed_on_missing_usage": true,
+  "idempotency_window_lines": 1000,
   "routing_by_cost": {
     "enabled": false
   }

--- a/ao_kernel/defaults/schemas/policy-cost-tracking.schema.v1.json
+++ b/ao_kernel/defaults/schemas/policy-cost-tracking.schema.v1.json
@@ -38,6 +38,18 @@
       "type": "boolean",
       "description": "When false (default): a stale catalog (now > stale_after) emits a warn-level log but is still served. When true: stale catalog raises PriceCatalogStaleError and blocks cost-dependent invocations. CNS-028v2 iter-1 W1 absorb."
     },
+    "fail_closed_on_missing_usage": {
+      "type": "boolean",
+      "default": true,
+      "description": "When true (default): adapter responses missing tokens_input/tokens_output trigger LLMUsageMissingError after ledger audit entry. When false: warn-log and continue (estimate stays reserved, no reconcile). Audit-only deployments with out-of-band billing reconciliation set false. PR-B2 v2 iter-2 B4 absorb."
+    },
+    "idempotency_window_lines": {
+      "type": "integer",
+      "minimum": 100,
+      "maximum": 100000,
+      "default": 1000,
+      "description": "Tail window (in lines) the ledger writer scans for (run_id, step_id, attempt) duplicates before append. Bounded for performance; operators with more than 1000 LLM calls per run can raise. PR-B2 v2 iter-2 B2 absorb."
+    },
     "routing_by_cost": {
       "type": "object",
       "additionalProperties": false,

--- a/ao_kernel/defaults/schemas/spend-ledger.schema.v1.json
+++ b/ao_kernel/defaults/schemas/spend-ledger.schema.v1.json
@@ -68,6 +68,20 @@
       "type": "string",
       "format": "date-time",
       "description": "ISO-8601 timestamp when the invocation completed (not when the ledger line was written)."
+    },
+    "attempt": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "PR-A1 step_record retry counter (v2 iter-2 B2 absorb). Forms the ledger idempotency key with (run_id, step_id). Same-key + same billing_digest is idempotent no-op; different digest raises SpendLedgerDuplicateError."
+    },
+    "usage_missing": {
+      "type": "boolean",
+      "description": "True when the adapter's normalize_response did not surface tokens_input/tokens_output; cost_usd=0 in that case. Audit-only ledger entry; reconcile is skipped. v2 iter-2 B4 absorb."
+    },
+    "billing_digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$",
+      "description": "Canonical SHA-256 over the billing-relevant fields (provider_id, model, vendor_model_id, tokens_input, tokens_output, cached_tokens, str(Decimal(cost_usd)), usage_missing). Serialized as 'sha256:<hex>'. v2 iter-2 high-risk absorb: Decimal-stable idempotency comparison."
     }
   }
 }

--- a/ao_kernel/defaults/schemas/workflow-run.schema.v1.json
+++ b/ao_kernel/defaults/schemas/workflow-run.schema.v1.json
@@ -262,7 +262,27 @@
             "spent": {"type": "integer", "minimum": 0},
             "remaining": {"type": "integer", "minimum": 0}
           },
-          "description": "LLM token ceiling, aggregated across all adapter invocations in this run."
+          "description": "LLM token ceiling, aggregated across all adapter invocations in this run. When tokens_input + tokens_output are also configured (PR-B2), aggregate equals sum of granular axes."
+        },
+        "tokens_input": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "limit": {"type": "integer", "minimum": 1},
+            "spent": {"type": "integer", "minimum": 0},
+            "remaining": {"type": "integer", "minimum": 0}
+          },
+          "description": "Prompt (input) token ceiling — granular breakdown of tokens aggregate (PR-B2 additive widen). Writer always emits when configured; reader populates from legacy 'tokens' axis when absent."
+        },
+        "tokens_output": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "limit": {"type": "integer", "minimum": 1},
+            "spent": {"type": "integer", "minimum": 0},
+            "remaining": {"type": "integer", "minimum": 0}
+          },
+          "description": "Completion (output) token ceiling — granular breakdown of tokens aggregate (PR-B2 additive widen). Writer omits when not configured (null serialization is invalid)."
         },
         "time_seconds": {
           "type": "object",

--- a/ao_kernel/executor/evidence_emitter.py
+++ b/ao_kernel/executor/evidence_emitter.py
@@ -74,6 +74,12 @@ _KINDS: Final[frozenset[str]] = frozenset({
     "claim_expired",      # prune_expired_claims cleaned a past-grace claim
     "claim_takeover",     # past-grace reclaim by a different agent (distinct from claim_acquired)
     "claim_conflict",     # acquire/takeover blocked by live or in-grace owner
+    # PR-B2 additions (cost runtime, 24 → 27 kinds). Additive; neither
+    # renames nor re-semanticises any existing kind. See
+    # docs/COST-MODEL.md §5 + PR-B2 plan v7 §2.8 for payload contracts.
+    "llm_cost_estimated",   # pre-dispatch estimate emitted (governed_call step 4)
+    "llm_spend_recorded",   # post-response actual cost computed + ledger appended
+    "llm_usage_missing",    # adapter response missing tokens_input/output (audit flag)
 })
 
 _REDACTED: Final[str] = "***REDACTED***"

--- a/ao_kernel/llm.py
+++ b/ao_kernel/llm.py
@@ -427,6 +427,18 @@ def governed_call(
 
     See plan v7 §2.6 for the full flow spec.
     """
+    # 0. Fail-fast validation of optional cost-identity kwargs
+    # (CNS-032 iter-1 absorb): if caller provides `attempt`, it must
+    # satisfy the ledger schema's `minimum: 1` constraint. We catch
+    # invalid values here — before any capability / transport /
+    # ledger work — so the error surface is transparent and the run
+    # state never diverges from the ledger schema.
+    if attempt is not None and attempt < 1:
+        raise ValueError(
+            f"attempt must be >= 1 (got {attempt!r}); "
+            f"ledger idempotency schema constraint"
+        )
+
     # 1. Capability check (BEFORE cost, BEFORE transport).
     cap_ok, _, missing = check_capabilities(
         provider_id=provider_id,

--- a/ao_kernel/llm.py
+++ b/ao_kernel/llm.py
@@ -14,6 +14,7 @@ This module provides the stable public API surface.
 
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Any
 
 # ── Routing ──────────────────────────────────────────────────────────
@@ -336,7 +337,7 @@ def build_request_with_context(
                 new_messages.insert(0, {"role": "system", "content": compiled.preamble})
             messages = new_messages
 
-    return build_request(
+    req = build_request(
         provider_id=provider_id,
         model=model,
         messages=messages,
@@ -350,6 +351,244 @@ def build_request_with_context(
         tool_choice=tool_choice,
         response_format=response_format,
     )
+    # PR-B2 v5 iter-4 B4 absorb: additive return field carrying the
+    # context-injected effective messages. Used by cost middleware to
+    # compute pre-dispatch token estimate over the real prompt rather
+    # than the caller-supplied raw messages. Pre-B2 callers ignore this
+    # field — backward compat.
+    req["injected_messages"] = messages
+    return req
+
+
+def governed_call(
+    messages: list[dict[str, Any]],
+    *,
+    # Core routing (required):
+    provider_id: str,
+    model: str,
+    api_key: str,
+    base_url: str,
+    request_id: str,
+    # Call shape (optional):
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: str | None = None,
+    response_format: dict[str, Any] | None = None,
+    # Context-aware build (PR-B2 v4 iter-3 B1 absorb):
+    session_context: dict[str, Any] | None = None,
+    workspace_root_str: str | None = None,
+    profile: str | None = None,
+    embedding_config: Any | None = None,
+    vector_store: Any | None = None,
+    # Cost-tracking identity (PR-B2 v3 iter-2 B2 — all 4 required for
+    # cost-active path; None → transparent bypass):
+    workspace_root: Any | None = None,
+    run_id: str | None = None,
+    step_id: str | None = None,
+    attempt: int | None = None,
+) -> dict[str, Any]:
+    """Composed LLM call with optional cost governance.
+
+    **STREAMING BOUNDARY (v5 iter-4 B2 absorb)**: NON-STREAMING ONLY.
+    Callers with ``stream=True`` intent MUST NOT call ``governed_call``;
+    they stay on the existing build + ``_execute_stream`` path in
+    client.py. Streaming cost tracking is FAZ-C scope (chunk-level
+    tokenization + partial ledger deferred).
+
+    **Activation gate**: all of (``workspace_root``, ``run_id``,
+    ``step_id``, ``attempt``) must be non-None AND
+    ``policy.enabled=true``; any missing kwarg → transparent bypass.
+    Bypass path behaves exactly like pre-B2 flow (build + execute +
+    normalize) with zero cost hooks.
+
+    **Return shape (v5 iter-4 B1 absorb — rich internal dict)**:
+
+    - On ``CAPABILITY_GAP``: ``{"status": "CAPABILITY_GAP", "missing":
+      [...], "provider_id", "model", "request_id", "text": ""}`` —
+      caller envelope-ready (mirrors client.py:531-547 pre-B2 shape).
+    - On ``TRANSPORT_ERROR``: ``{"status": "TRANSPORT_ERROR",
+      "error_code", "http_status", "provider_id", "model", "request_id",
+      "text": "", "elapsed_ms"}`` — caller envelope-ready (mirrors
+      client.py:608-618).
+    - On normal success: ``{"status": "OK", "normalized": <dict>,
+      "resp_bytes": bytes, "transport_result": <dict>, "elapsed_ms": int,
+      "request_id": str}``. Caller (client.py / mcp_server.py) unwraps:
+      ``normalized`` for response text/usage/tool_calls, ``resp_bytes``
+      + ``transport_result`` for evidence/telemetry, ``elapsed_ms``
+      for final envelope. **Mevcut post-call pipeline (decision
+      extraction, scorecard, telemetry) caller'da kalır; governed_call
+      içinde duplicate EDİLMEZ.**
+
+    **Cost-layer errors RAISE** (not envelope):
+    :class:`BudgetExhaustedError`, :class:`CostTrackingConfigError`,
+    :class:`PriceCatalogNotFoundError`, :class:`LLMUsageMissingError`.
+    Caller decides propagate or try/except wrap.
+
+    See plan v7 §2.6 for the full flow spec.
+    """
+    # 1. Capability check (BEFORE cost, BEFORE transport).
+    cap_ok, _, missing = check_capabilities(
+        provider_id=provider_id,
+        model=model,
+        has_tools=bool(tools),
+        has_response_format=bool(response_format),
+    )
+    if not cap_ok and missing:
+        return {
+            "status": "CAPABILITY_GAP",
+            "text": "",
+            "missing": missing,
+            "provider_id": provider_id,
+            "model": model,
+            "request_id": request_id,
+        }
+
+    # 2. Cost gate — all 4 identity + ws + policy.enabled.
+    cost_active = all(
+        [workspace_root, run_id, step_id, attempt is not None]
+    )
+    cost_policy = None
+    if cost_active:
+        from pathlib import Path
+        from ao_kernel.cost.policy import load_cost_policy
+
+        ws_path = (
+            workspace_root
+            if isinstance(workspace_root, Path)
+            else Path(str(workspace_root))
+        )
+        cost_policy = load_cost_policy(ws_path)
+        cost_active = cost_policy.enabled
+
+    # 3. Build request (context-aware branch).
+    if session_context is not None:
+        req = build_request_with_context(
+            messages=messages,
+            provider_id=provider_id,
+            model=model,
+            base_url=base_url,
+            api_key=api_key,
+            session_context=session_context,
+            workspace_root=workspace_root_str,
+            profile=profile,
+            embedding_config=embedding_config,
+            vector_store=vector_store,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            request_id=request_id,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+        )
+        # injected_messages field added in v5 iter-4 B4 absorb.
+        effective_messages = req.get("injected_messages", messages)
+    else:
+        req = build_request(
+            messages=messages,
+            provider_id=provider_id,
+            model=model,
+            base_url=base_url,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            request_id=request_id,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+        )
+        effective_messages = messages
+
+    # 4. Cost reserve (if active).
+    est_cost = None
+    catalog_entry = None
+    if cost_active and cost_policy is not None:
+        from pathlib import Path
+        from ao_kernel.cost.middleware import pre_dispatch_reserve
+
+        ws_path = (
+            workspace_root
+            if isinstance(workspace_root, Path)
+            else Path(str(workspace_root))
+        )
+        est_cost, catalog_entry = pre_dispatch_reserve(
+            workspace_root=ws_path,
+            run_id=str(run_id),
+            step_id=str(step_id),
+            attempt=int(attempt) if attempt is not None else 1,
+            provider_id=provider_id,
+            model=model,
+            prompt_messages=list(effective_messages),
+            max_tokens=max_tokens,
+            policy=cost_policy,
+        )
+        # Raises: BudgetExhaustedError, CostTrackingConfigError,
+        # PriceCatalogNotFoundError — caller decides.
+
+    # 5. Transport (existing execute_request).
+    transport_result = execute_request(
+        url=req["url"],
+        headers=req["headers"],
+        body_bytes=req["body_bytes"],
+        timeout_seconds=30.0,
+        provider_id=provider_id,
+        request_id=request_id,
+    )
+
+    # 6. Transport envelope preserve.
+    if transport_result.get("status") != "OK":
+        # Reservation HOLDS per Q5 iter-1 (no refund on error).
+        return {
+            "status": "TRANSPORT_ERROR",
+            "text": "",
+            "error_code": transport_result.get("error_code", "UNKNOWN"),
+            "http_status": transport_result.get("http_status"),
+            "provider_id": provider_id,
+            "model": model,
+            "request_id": request_id,
+            "elapsed_ms": transport_result.get("elapsed_ms", 0),
+        }
+
+    # 7. Normalize.
+    normalized = normalize_response(
+        transport_result["resp_bytes"],
+        provider_id=provider_id,
+    )
+
+    # 8. Cost reconcile + record (if active).
+    if cost_active and cost_policy is not None and catalog_entry is not None:
+        from pathlib import Path
+        from ao_kernel.cost.middleware import post_response_reconcile
+
+        ws_path = (
+            workspace_root
+            if isinstance(workspace_root, Path)
+            else Path(str(workspace_root))
+        )
+        post_response_reconcile(
+            workspace_root=ws_path,
+            run_id=str(run_id),
+            step_id=str(step_id),
+            attempt=int(attempt) if attempt is not None else 1,
+            provider_id=provider_id,
+            model=model,
+            catalog_entry=catalog_entry,
+            est_cost=est_cost if est_cost is not None else Decimal("0"),
+            raw_response_bytes=transport_result["resp_bytes"],
+            policy=cost_policy,
+        )
+        # Raises LLMUsageMissingError when policy.fail_closed_on_missing_usage
+        # AND usage absent. Ledger audit entry always recorded first.
+
+    # 9. Rich internal success dict (v5 iter-4 B1).
+    return {
+        "status": "OK",
+        "normalized": normalized,
+        "resp_bytes": transport_result["resp_bytes"],
+        "transport_result": transport_result,
+        "elapsed_ms": transport_result.get("elapsed_ms", 0),
+        "request_id": request_id,
+    }
 
 
 def process_response_with_context(

--- a/ao_kernel/mcp_server.py
+++ b/ao_kernel/mcp_server.py
@@ -340,6 +340,12 @@ def handle_llm_call(params: dict[str, Any]) -> dict[str, Any]:
     temperature = params.get("temperature")
     max_tokens = params.get("max_tokens")
     ws = params.get("workspace_root")
+    # PR-B2 v5 iter-4 absorb: optional cost identity params. When all
+    # three present AND workspace_root points at a workspace with cost
+    # policy.enabled=true, the call runs through the cost pipeline.
+    ao_run_id = params.get("ao_run_id")
+    ao_step_id = params.get("ao_step_id")
+    ao_attempt = params.get("ao_attempt")
 
     # Route if provider/model not specified
     if not provider_id or not model:
@@ -371,7 +377,8 @@ def handle_llm_call(params: dict[str, Any]) -> dict[str, Any]:
     request_id = f"mcp-{uuid.uuid4().hex[:12]}"
 
     try:
-        from ao_kernel.llm import build_request, execute_request, normalize_response
+        from pathlib import Path
+        from ao_kernel.llm import governed_call
 
         base_url_map = {
             "openai": "https://api.openai.com/v1",
@@ -382,43 +389,68 @@ def handle_llm_call(params: dict[str, Any]) -> dict[str, Any]:
             "xai": "https://api.x.ai/v1",
         }
 
-        req = build_request(
+        # PR-B2 v5 iter-4 B1 absorb: route through governed_call so cost
+        # hooks and context injection compose uniformly. MCP stays a
+        # "thin executor" — no session context passed (MCP callers do not
+        # maintain ao-kernel session state); cost opt-in via ao_* params.
+        ws_path: Path | None = Path(ws) if ws else None
+        result = governed_call(
+            messages=messages,
             provider_id=provider_id,
             model=model,
-            messages=messages,
-            base_url=base_url_map.get(provider_id, ""),
             api_key=api_key,
+            base_url=base_url_map.get(provider_id, ""),
+            request_id=request_id,
             temperature=temperature,
             max_tokens=max_tokens,
-            request_id=request_id,
+            # Context injection NOT applicable in the MCP thin-executor
+            # surface (MCP callers manage their own context out-of-band).
+            session_context=None,
+            workspace_root_str=str(ws_path) if ws_path else None,
+            profile=None,
+            embedding_config=None,
+            vector_store=None,
+            # Cost identity kwargs (v5 iter-4 B2 absorb). All four
+            # (ws + run_id + step_id + attempt) required for cost-active;
+            # any missing → transparent bypass.
+            workspace_root=ws_path,
+            run_id=ao_run_id,
+            step_id=ao_step_id,
+            attempt=ao_attempt,
         )
 
-        transport_result = execute_request(
-            url=req["url"],
-            headers=req["headers"],
-            body_bytes=req["body_bytes"],
-            timeout_seconds=30.0,
-            provider_id=provider_id,
-            request_id=request_id,
-        )
-
-        if transport_result.get("status") != "OK":
+        # Envelope pass-through for error statuses — preserves mcp_server
+        # pre-B2 decision envelope contract.
+        status = result.get("status")
+        if status == "CAPABILITY_GAP":
+            return _decision_envelope(
+                tool="ao_llm_call",
+                allowed=False,
+                decision="deny",
+                reason_codes=["CAPABILITY_GAP"],
+                data={
+                    "missing": result.get("missing", []),
+                    "provider_id": provider_id,
+                    "model": model,
+                    "request_id": request_id,
+                },
+            )
+        if status == "TRANSPORT_ERROR":
             return _decision_envelope(
                 tool="ao_llm_call",
                 allowed=True,
                 decision="error",
                 reason_codes=["TRANSPORT_ERROR"],
                 data={
-                    "error_code": transport_result.get("error_code", "UNKNOWN"),
-                    "http_status": transport_result.get("http_status"),
-                    "elapsed_ms": transport_result.get("elapsed_ms", 0),
+                    "error_code": result.get("error_code", "UNKNOWN"),
+                    "http_status": result.get("http_status"),
+                    "elapsed_ms": result.get("elapsed_ms", 0),
                     "request_id": request_id,
                 },
             )
 
-        resp_bytes = transport_result.get("resp_bytes", b"")
-        normalized = normalize_response(resp_bytes, provider_id=provider_id)
-
+        # Status == "OK" — unwrap rich dict and build executed envelope.
+        normalized = result.get("normalized") or {}
         return _decision_envelope(
             tool="ao_llm_call",
             allowed=True,
@@ -429,7 +461,7 @@ def handle_llm_call(params: dict[str, Any]) -> dict[str, Any]:
                 "provider_id": provider_id,
                 "model": model,
                 "request_id": request_id,
-                "elapsed_ms": transport_result.get("elapsed_ms", 0),
+                "elapsed_ms": result.get("elapsed_ms", 0),
                 "api_key_present": True,
             },
         )
@@ -496,6 +528,19 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
                 "temperature": {"type": "number"},
                 "max_tokens": {"type": "integer"},
                 "workspace_root": {"type": "string"},
+                "ao_run_id": {
+                    "type": "string",
+                    "description": "PR-B2 cost identity: workflow run UUIDv4. Optional; required together with ao_step_id and ao_attempt to activate cost tracking (policy.enabled must also be true on the workspace).",
+                },
+                "ao_step_id": {
+                    "type": "string",
+                    "description": "PR-B2 cost identity: step id within the run. Optional; see ao_run_id.",
+                },
+                "ao_attempt": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "PR-B2 cost identity: retry attempt number (≥1). Forms the ledger idempotency key with (ao_run_id, ao_step_id). Optional.",
+                },
             },
         },
     },

--- a/ao_kernel/workflow/budget.py
+++ b/ao_kernel/workflow/budget.py
@@ -105,17 +105,19 @@ def budget_from_dict(record: Mapping[str, Any]) -> Budget:
     tokens_axis = _parse_int_axis(record.get("tokens"))
     tokens_input_raw = record.get("tokens_input")
     tokens_output_raw = record.get("tokens_output")
-    if tokens_input_raw is None and tokens_output_raw is None and tokens_axis is not None:
-        # Legacy record: copy aggregate into tokens_input for back-compat.
-        tokens_input_axis: BudgetAxis | None = BudgetAxis(
-            limit=tokens_axis.limit,
-            spent=tokens_axis.spent,
-            remaining=tokens_axis.remaining,
-        )
-        tokens_output_axis: BudgetAxis | None = None
-    else:
-        tokens_input_axis = _parse_int_axis(tokens_input_raw)
-        tokens_output_axis = _parse_int_axis(tokens_output_raw)
+    # CNS-032 iter-2 absorb: legacy workflow-run records with only the
+    # aggregate ``tokens`` axis leave both granular fields as None on
+    # read. Earlier plan v7 §2.5 "conservative mapping" synthesized
+    # ``tokens_input = copy(tokens)`` but that synthesized axis diverged
+    # from the aggregate after reconcile (reconcile routes legacy spend
+    # through the aggregate path, not the synthesized granular axis).
+    # The cleaner contract: legacy aggregate-only records stay
+    # aggregate-only in-memory; granular axes appear only when the
+    # wire record declares them explicitly. The middleware's legacy
+    # path (case 2 in _reconcile_mutator) already routes spend through
+    # the aggregate axis correctly.
+    tokens_input_axis = _parse_int_axis(tokens_input_raw)
+    tokens_output_axis = _parse_int_axis(tokens_output_raw)
     return Budget(
         tokens=tokens_axis,
         tokens_input=tokens_input_axis,

--- a/ao_kernel/workflow/budget.py
+++ b/ao_kernel/workflow/budget.py
@@ -150,6 +150,28 @@ def budget_to_dict(budget: Budget) -> dict[str, Any]:
         out["time_seconds"] = _float_axis_to_dict(budget.time_seconds)
     if budget.cost_usd is not None:
         out["cost_usd"] = _float_axis_to_dict(budget.cost_usd)
+
+    # CNS-032 iter-1 absorb (aggregate recompute sanity): when the
+    # Budget has granular axes but no aggregate tokens axis, writer
+    # synthesizes the aggregate from the sum so readers always see a
+    # coherent `tokens` view. Symmetric to the reader's back-compat
+    # mapping (legacy tokens → tokens_input).
+    if (
+        "tokens" not in out
+        and budget.tokens_input is not None
+    ):
+        limit = int(budget.tokens_input.limit)
+        spent = int(budget.tokens_input.spent)
+        remaining = int(budget.tokens_input.remaining)
+        if budget.tokens_output is not None:
+            limit += int(budget.tokens_output.limit)
+            spent += int(budget.tokens_output.spent)
+            remaining += int(budget.tokens_output.remaining)
+        out["tokens"] = {
+            "limit": limit,
+            "spent": spent,
+            "remaining": remaining,
+        }
     return out
 
 

--- a/ao_kernel/workflow/budget.py
+++ b/ao_kernel/workflow/budget.py
@@ -69,10 +69,13 @@ class Budget:
       kwargs auto-adjusts the aggregate.
     - Writer invariant (v5 iter-4 B3): ``tokens_input`` always emitted
       when configured; ``tokens_output=None`` → OMIT (absent key, no
-      ``null``); aggregate ``tokens`` always emitted.
-    - Reader back-compat: legacy records with only ``tokens`` →
-      ``tokens_input = BudgetAxis(copy of tokens)``, ``tokens_output =
-      None`` (conservative legacy-to-granular mapping).
+      ``null``); aggregate ``tokens`` always emitted (synthesized from
+      granular axes when not set in-memory, CNS-032 iter-1 absorb).
+    - Reader back-compat (CNS-032 iter-2 absorb): legacy records with
+      only aggregate ``tokens`` stay aggregate-only in-memory; the
+      granular axes remain ``None``. Middleware's reconcile routes
+      legacy spend through the aggregate path (case 2) — no divergence
+      between a synthesized granular axis and the aggregate.
     """
 
     tokens: BudgetAxis | None
@@ -89,12 +92,13 @@ def budget_from_dict(record: Mapping[str, Any]) -> Budget:
     Enforces ``fail_closed_on_exhaust == True`` at the boundary;
     raises ``ValueError`` if absent or False.
 
-    Back-compat (PR-B2 v3 iter-2 B3 absorb): when the record has
-    ``tokens`` but not ``tokens_input`` / ``tokens_output``, the reader
-    populates ``tokens_input`` as a copy of ``tokens`` and leaves
-    ``tokens_output = None``. Conservative legacy-to-granular mapping
-    — pre-B2 records are treated as "all prompt, no completion cap"
-    which fails-closed rather than opens a gap.
+    Back-compat (CNS-032 iter-2 absorb, refined from PR-B2 v3 iter-2
+    B3): records with ONLY an aggregate ``tokens`` axis stay
+    aggregate-only in-memory; reader does NOT synthesize granular
+    axes from the aggregate. Middleware ``_reconcile_mutator`` routes
+    legacy spend through the aggregate path (case 2) so output
+    tokens are counted correctly. Granular axes appear only when the
+    wire record declares them explicitly.
     """
     fail_closed = record.get("fail_closed_on_exhaust", False)
     if fail_closed is not True:
@@ -156,8 +160,8 @@ def budget_to_dict(budget: Budget) -> dict[str, Any]:
     # CNS-032 iter-1 absorb (aggregate recompute sanity): when the
     # Budget has granular axes but no aggregate tokens axis, writer
     # synthesizes the aggregate from the sum so readers always see a
-    # coherent `tokens` view. Symmetric to the reader's back-compat
-    # mapping (legacy tokens → tokens_input).
+    # coherent `tokens` view. This carries the "aggregate always
+    # emitted" invariant from plan v7 §2.5 forward.
     if (
         "tokens" not in out
         and budget.tokens_input is not None

--- a/ao_kernel/workflow/budget.py
+++ b/ao_kernel/workflow/budget.py
@@ -54,15 +54,30 @@ class BudgetAxis:
 
 @dataclass(frozen=True)
 class Budget:
-    """Aggregate budget: up to three axes + fail-closed flag.
+    """Aggregate budget: up to five axes + fail-closed flag.
 
     Any axis may be ``None`` (not configured for this run). At least one
     axis should be present for a budget to be meaningful; the schema
     enforces no minimum at the ``$defs/budget`` level, so this module
     accepts all-None as a valid edge case.
+
+    PR-B2 v3 iter-2 B3 absorb (additive widen):
+
+    - ``tokens_input`` + ``tokens_output`` granular token axes
+      augment the aggregate ``tokens`` axis. When the B2 cost pipeline
+      is active, ``record_spend`` with ``tokens_input=/tokens_output=``
+      kwargs auto-adjusts the aggregate.
+    - Writer invariant (v5 iter-4 B3): ``tokens_input`` always emitted
+      when configured; ``tokens_output=None`` → OMIT (absent key, no
+      ``null``); aggregate ``tokens`` always emitted.
+    - Reader back-compat: legacy records with only ``tokens`` →
+      ``tokens_input = BudgetAxis(copy of tokens)``, ``tokens_output =
+      None`` (conservative legacy-to-granular mapping).
     """
 
     tokens: BudgetAxis | None
+    tokens_input: BudgetAxis | None
+    tokens_output: BudgetAxis | None
     time_seconds: BudgetAxis | None
     cost_usd: BudgetAxis | None
     fail_closed_on_exhaust: bool
@@ -73,6 +88,13 @@ def budget_from_dict(record: Mapping[str, Any]) -> Budget:
 
     Enforces ``fail_closed_on_exhaust == True`` at the boundary;
     raises ``ValueError`` if absent or False.
+
+    Back-compat (PR-B2 v3 iter-2 B3 absorb): when the record has
+    ``tokens`` but not ``tokens_input`` / ``tokens_output``, the reader
+    populates ``tokens_input`` as a copy of ``tokens`` and leaves
+    ``tokens_output = None``. Conservative legacy-to-granular mapping
+    — pre-B2 records are treated as "all prompt, no completion cap"
+    which fails-closed rather than opens a gap.
     """
     fail_closed = record.get("fail_closed_on_exhaust", False)
     if fail_closed is not True:
@@ -80,8 +102,24 @@ def budget_from_dict(record: Mapping[str, Any]) -> Budget:
             "Budget must have fail_closed_on_exhaust=True "
             f"(got {fail_closed!r})"
         )
+    tokens_axis = _parse_int_axis(record.get("tokens"))
+    tokens_input_raw = record.get("tokens_input")
+    tokens_output_raw = record.get("tokens_output")
+    if tokens_input_raw is None and tokens_output_raw is None and tokens_axis is not None:
+        # Legacy record: copy aggregate into tokens_input for back-compat.
+        tokens_input_axis: BudgetAxis | None = BudgetAxis(
+            limit=tokens_axis.limit,
+            spent=tokens_axis.spent,
+            remaining=tokens_axis.remaining,
+        )
+        tokens_output_axis: BudgetAxis | None = None
+    else:
+        tokens_input_axis = _parse_int_axis(tokens_input_raw)
+        tokens_output_axis = _parse_int_axis(tokens_output_raw)
     return Budget(
-        tokens=_parse_int_axis(record.get("tokens")),
+        tokens=tokens_axis,
+        tokens_input=tokens_input_axis,
+        tokens_output=tokens_output_axis,
         time_seconds=_parse_float_axis(record.get("time_seconds")),
         cost_usd=_parse_decimal_axis(record.get("cost_usd")),
         fail_closed_on_exhaust=True,
@@ -102,6 +140,12 @@ def budget_to_dict(budget: Budget) -> dict[str, Any]:
     }
     if budget.tokens is not None:
         out["tokens"] = _int_axis_to_dict(budget.tokens)
+    # PR-B2 v5 iter-4 B3 writer invariant: tokens_input always emitted
+    # when configured; tokens_output omitted when None (no null in wire).
+    if budget.tokens_input is not None:
+        out["tokens_input"] = _int_axis_to_dict(budget.tokens_input)
+    if budget.tokens_output is not None:
+        out["tokens_output"] = _int_axis_to_dict(budget.tokens_output)
     if budget.time_seconds is not None:
         out["time_seconds"] = _float_axis_to_dict(budget.time_seconds)
     if budget.cost_usd is not None:
@@ -113,6 +157,8 @@ def record_spend(
     budget: Budget,
     *,
     tokens: int | None = None,
+    tokens_input: int | None = None,
+    tokens_output: int | None = None,
     time_seconds: float | None = None,
     cost_usd: _AxisNum | None = None,
     run_id: str | None = None,
@@ -126,12 +172,57 @@ def record_spend(
 
     Raises ``ValueError`` if asked to spend on an unconfigured axis
     (``budget.<axis> is None``).
+
+    PR-B2 v3 iter-2 B3 absorb (additive widen):
+
+    - ``tokens_input`` + ``tokens_output`` kwargs spend on granular axes
+      when configured. Aggregate ``tokens`` auto-adjusts by the sum:
+      ``spend_on_tokens = (tokens_input or 0) + (tokens_output or 0)``.
+    - Explicit ``tokens=`` kwarg + granular kwargs on the same call
+      raises ``ValueError`` (double-count guard).
+    - If the run has aggregate-only budget (granular axes None), the
+      caller should pass ``tokens=`` explicitly for legacy flows.
     """
+    # Double-count guard (PR-B2 v3 iter-2 B3 writer invariant).
+    if tokens is not None and (tokens_input is not None or tokens_output is not None):
+        raise ValueError(
+            "record_spend: pass EITHER aggregate 'tokens' OR granular "
+            "'tokens_input'/'tokens_output', not both (double-count risk)"
+        )
+
+    # Compute implicit aggregate spend from granular kwargs.
+    implicit_tokens = 0
+    if tokens_input is not None:
+        implicit_tokens += int(tokens_input)
+    if tokens_output is not None:
+        implicit_tokens += int(tokens_output)
+
+    # Spend on granular axes first (if configured).
+    new_tokens_input = (
+        _spend_axis(
+            budget.tokens_input, "tokens_input", int(tokens_input), run_id,
+        )
+        if tokens_input is not None
+        else budget.tokens_input
+    )
+    new_tokens_output = (
+        _spend_axis(
+            budget.tokens_output, "tokens_output", int(tokens_output), run_id,
+        )
+        if tokens_output is not None
+        else budget.tokens_output
+    )
+
+    # Aggregate tokens: explicit kwarg XOR implicit from granular.
+    effective_tokens = tokens if tokens is not None else (
+        implicit_tokens if implicit_tokens > 0 else None
+    )
     new_tokens = (
-        _spend_axis(budget.tokens, "tokens", int(tokens), run_id)
-        if tokens is not None
+        _spend_axis(budget.tokens, "tokens", int(effective_tokens), run_id)
+        if effective_tokens is not None and budget.tokens is not None
         else budget.tokens
     )
+
     new_time = (
         _spend_axis(
             budget.time_seconds, "time_seconds", float(time_seconds), run_id
@@ -148,6 +239,8 @@ def record_spend(
     )
     return Budget(
         tokens=new_tokens,
+        tokens_input=new_tokens_input,
+        tokens_output=new_tokens_output,
         time_seconds=new_time,
         cost_usd=new_cost,
         fail_closed_on_exhaust=budget.fail_closed_on_exhaust,
@@ -163,6 +256,8 @@ def is_exhausted(budget: Budget) -> tuple[bool, str | None]:
     """
     for name, axis in (
         ("tokens", budget.tokens),
+        ("tokens_input", budget.tokens_input),
+        ("tokens_output", budget.tokens_output),
         ("time_seconds", budget.time_seconds),
         ("cost_usd", budget.cost_usd),
     ):

--- a/ao_kernel/workflow/intent_router.py
+++ b/ao_kernel/workflow/intent_router.py
@@ -317,7 +317,7 @@ class IntentRouter:
         )
 
     def _llm_classify(self, input_text: str) -> ClassificationResult:
-        """LLM-based intent classification fallback (PR-A6 B4 absorb).
+        """LLM-based intent classification fallback (PR-A6 B4; PR-B2 v7 iter-6 absorb).
 
         Requires ``ao-kernel[llm]`` (tenacity + tiktoken). Lazy import
         so the core package does not pull in LLM deps.
@@ -325,11 +325,19 @@ class IntentRouter:
         Prompt: ask the model to return one workflow_id from available ids.
         Parse: exact match against available ids. Fail-closed on any
         mismatch, transport error, or missing ``[llm]`` extra.
+
+        PR-B2 v7 iter-6 absorb: the three-call sequence
+        (build_request + execute_request + normalize_response) is
+        replaced by ``governed_call`` so all LLM invocations compose
+        through the single cost-aware wrapper. ``intent_router`` stays
+        COST-BYPASS ONLY — the classifier is standalone and not
+        anchored to a workflow-run budget. All cost + context kwargs
+        remain None.
         """
         from ao_kernel.workflow.errors import IntentClassificationError
 
         try:
-            from ao_kernel.llm import build_request, execute_request, normalize_response
+            from ao_kernel.llm import governed_call, resolve_route
         except ImportError as exc:
             raise IntentClassificationError(
                 intent_text=input_text,
@@ -353,33 +361,43 @@ class IntentRouter:
         messages = [{"role": "user", "content": prompt}]
 
         try:
-            # Use default route — caller should have env vars set
-            from ao_kernel.llm import resolve_route
             route = resolve_route(intent="FAST_TEXT")
-            req = build_request(
+            result = governed_call(
+                messages=messages,
                 provider_id=route.get("provider_id", "openai"),
                 model=route.get("model", "gpt-4"),
-                messages=messages,
-                base_url=route.get("base_url", ""),
                 api_key=route.get("api_key", ""),
-            )
-            raw_result = execute_request(
-                url=req["url"],
-                headers=req["headers"],
-                body_bytes=req["body_bytes"],
-                timeout_seconds=30.0,
-                provider_id=route.get("provider_id", "openai"),
+                base_url=route.get("base_url", ""),
                 request_id="llm_fallback",
+                # Bypass-only: cost + context kwargs all None.
+                session_context=None,
+                workspace_root_str=None,
+                profile=None,
+                embedding_config=None,
+                vector_store=None,
+                workspace_root=None,
+                run_id=None,
+                step_id=None,
+                attempt=None,
             )
-            resp_bytes = raw_result.get("resp_bytes", b"")
-            resp = normalize_response(resp_bytes, provider_id=route.get("provider_id", "openai"))
-            candidate = resp.get("text", "").strip()
         except Exception as exc:
             raise IntentClassificationError(
                 intent_text=input_text,
                 reason="llm_transport_error",
                 details=str(exc),
             ) from exc
+
+        # governed_call rich dict unwrap (v5 iter-4 B1).
+        status = result.get("status", "OK")
+        if status != "OK":
+            cause = result.get("error_code") or status
+            raise IntentClassificationError(
+                intent_text=input_text,
+                reason="llm_transport_error",
+                details=f"governed_call returned {status!r} (cause={cause!r})",
+            )
+        normalized = result.get("normalized") or {}
+        candidate = (normalized.get("text") or "").strip()
 
         if candidate not in available_ids:
             raise IntentClassificationError(

--- a/docs/COST-MODEL.md
+++ b/docs/COST-MODEL.md
@@ -126,12 +126,102 @@ estimated_cost = (est_tokens_input  * input_cost_per_1k  / 1000)
 
 Routing failure is explicit; there is no silent "use the cheapest thing that fits" downgrade unless the operator opts into routing.
 
-## 7. Cross-References
+## 7. Runtime — PR-B2 Integration (shipped)
+
+### 7.1 `llm.governed_call` wrapper
+
+B2 introduces `ao_kernel.llm.governed_call(messages, *, ...)` — a **non-streaming** composition wrapper around `build_request` + `execute_request` + `normalize_response` with optional cost governance.
+
+Activation gate: cost pipeline engages only when **all four** kwargs are set AND `policy.enabled=true`:
+- `workspace_root: Path`
+- `run_id: str`
+- `step_id: str`
+- `attempt: int`
+
+Any missing kwarg → transparent bypass (pre-B2 behavior).
+
+Return contract (plan v5 iter-4 B1):
+- On `CAPABILITY_GAP`: envelope `{status, missing, provider_id, model, request_id, text=""}` — caller envelope-ready.
+- On `TRANSPORT_ERROR`: envelope `{status, error_code, http_status, elapsed_ms, ...}` — caller envelope-ready.
+- On `OK`: rich dict `{status="OK", normalized, resp_bytes, transport_result, elapsed_ms, request_id}` — caller unwraps and runs its own post-call pipeline (decision extraction, eval scorecard, telemetry).
+
+Cost-layer errors **raise** (not envelope): `BudgetExhaustedError`, `CostTrackingConfigError`, `PriceCatalogNotFoundError`, `LLMUsageMissingError`.
+
+### 7.2 Identity threading — 3 caller entrypoints
+
+| Caller | Identity source | Cost activation |
+|---|---|---|
+| `AoKernelClient.llm_call(run_id=, step_id=, attempt=)` | SDK user passes explicitly | opt-in (3 kwargs optional, default None → bypass) |
+| `mcp_server.handle_llm_call(params={"ao_run_id", "ao_step_id", "ao_attempt"})` | MCP tool params (optional) | opt-in |
+| `workflow.intent_router._llm_classify` | — | **bypass-only** (standalone classifier, not a workflow-run budget anchor) |
+
+### 7.3 18-step pipeline (pre-dispatch → reconcile)
+
+1. Capability check → envelope on gap.
+2. Cost gate (identity + policy.enabled).
+3. Build (context-aware if `session_context`; plain otherwise). `build_request_with_context` returns `injected_messages` additive field.
+4. `pre_dispatch_reserve`: catalog lookup → `estimate_cost` over `effective_messages` → emit `llm_cost_estimated` → CAS-reserve budget (update_run max_retries=3).
+5. Transport.
+6. Transport error → envelope (reservation HOLDS per plan Q5 iter-1 — no refund on failure).
+7. Normalize.
+8. `post_response_reconcile`: `extract_usage_strict` → on usage gap, `record_spend(usage_missing=true)` + emit `llm_usage_missing` + optional raise. Success path: `compute_cost(actual)` → CAS-reconcile (delta = actual − estimate) → `record_spend` with `billing_digest` → emit `llm_spend_recorded`.
+9. Return rich dict.
+
+### 7.4 Evidence taxonomy
+
+3 additive kinds (24 → 27):
+- `llm_cost_estimated` — pre-dispatch estimate, always emitted before transport.
+- `llm_spend_recorded` — post-response actual, emitted after ledger append.
+- `llm_usage_missing` — adapter response missing tokens_input/output; audit-only ledger entry precedes the raise when fail-closed.
+
+Emits are **fail-open** (wrapper swallows + warn-logs); ledger writes are **fail-closed** (raise on failure).
+
+## 8. Identity Threading — `(run_id, step_id, attempt)`
+
+The ledger idempotency key is `(run_id, step_id, attempt)`. Retry semantics:
+
+- Same key + same `billing_digest` → silent no-op with warn log (operator-visible but non-raising).
+- Same key + different `billing_digest` → `SpendLedgerDuplicateError` (caller bug: the retry produced a distinct billable payload).
+- Distinct `attempt` for the same `(run_id, step_id)` → separate ledger lines (normal retry path).
+
+The `attempt` field aligns with `step_record.attempt` from PR-A1 (already append-only per retry). Workflow drivers thread all three identity values; SDK users do so when they want cost tracking for arbitrary calls.
+
+## 9. Streaming — Deferred to FAZ-C
+
+`governed_call` is **non-streaming only**. Callers with `stream=True` intent stay on the pre-B2 build + `_execute_stream` path; no cost hooks run. Chunk-level tokenization and partial-ledger semantics are FAZ-C scope.
+
+Operators running streaming workloads should scope cost tracking to non-streaming calls only, or accept that streaming consumption lies outside the `spend.jsonl` audit trail until FAZ-C lands.
+
+A process-level `logger.warning(...)` may be emitted on the first streaming call after `policy.enabled=true` to surface this gap to operators (implementation detail; not a policy knob).
+
+## 10. Migration from v3.1.0 → v3.2.0
+
+### 10.1 Opt-in sequence
+
+1. Keep `policy_cost_tracking.enabled: false` initially (bundled default — no runtime change).
+2. Add `budget.cost_usd` axis to your workflow specs (required by `policy.enabled=true` per Option A fail-closed guard — `CostTrackingConfigError` fires at first LLM call otherwise).
+3. Optionally add granular `budget.tokens_input` / `budget.tokens_output` axes for per-direction caps.
+4. Drop a workspace override at `{project_root}/.ao/policies/policy_cost_tracking.v1.json` with `enabled: true`.
+5. Ensure the bundled price catalog covers your routed (provider, model) pairs — add a workspace override at `{project_root}/.ao/cost/catalog.v1.json` for models not in the bundled starter.
+6. Confirm the workspace has write access to `{project_root}/.ao/cost/` (auto-created with `mode=0o700`).
+
+### 10.2 Back-compat invariants
+
+- Legacy workflow-run records with only aggregate `tokens` axis → loader synthesizes `tokens_input = BudgetAxis(copy)`, `tokens_output = None` (conservative legacy-to-granular mapping; plan v7 §2.5).
+- Legacy `spend.jsonl` files without `attempt` / `usage_missing` / `billing_digest` fields parse cleanly (additive schema widen; pre-B2 tools still read them).
+- `extract_usage` (PR-A callers, 0-fallback default) unchanged; B2 middleware uses the new `extract_usage_strict` (None-sentinel) variant internally.
+
+### 10.3 Cross-References
 
 - Schemas: [`price-catalog.schema.v1.json`](../ao_kernel/defaults/schemas/price-catalog.schema.v1.json), [`spend-ledger.schema.v1.json`](../ao_kernel/defaults/schemas/spend-ledger.schema.v1.json), [`policy-cost-tracking.schema.v1.json`](../ao_kernel/defaults/schemas/policy-cost-tracking.schema.v1.json).
-- Runtime (scope out of B0): PR-B2 (`ao_kernel/cost/`), PR-B3 (`ao_kernel/llm.py` cost-aware routing).
-- Metrics exposure: [METRICS.md](METRICS.md) (`ao_llm_tokens_used_total`, optional `ao_llm_call_cost_usd_total` under advanced labels).
+- Runtime (shipped): PR-B2 `ao_kernel/cost/` package; facade `ao_kernel.llm.governed_call`.
+- Downstream: PR-B3 (cost-aware routing) consumes `policy.routing_by_cost.enabled`; ledger rotation is a separate FAZ-B follow-up (out of B2 scope).
+- Metrics exposure: [METRICS.md](METRICS.md) — derivation-based, consumes ledger events, independent of the `[otel]` extra.
 
-## 8. Document Status
+## 11. Document Status
 
-Skeleton in PR-B0 commit 1. Worked examples (operator override walkthrough, vendor_api scraping template, ledger query recipes) land in PR-B0 commit 5 (docs final pass).
+Skeleton in PR-B0 commit 1 (dormant contract pin). Runtime notes
+(§7-§10) land in PR-B2 commit 6 alongside the 7-commit DAG merge.
+Plan: `.claude/plans/PR-B2-IMPLEMENTATION-PLAN.md` v7 (Codex
+CNS-20260417-031 thread 019d9aa8 AGREE, ready_for_impl=true after
+7 adversarial iters).

--- a/tests/test_coordination_takeover_prune.py
+++ b/tests/test_coordination_takeover_prune.py
@@ -369,8 +369,12 @@ class TestEvidenceKindsExpansion:
         }
         assert required_pr_a.issubset(_KINDS)
 
-    def test_total_kind_count_is_twenty_four(self) -> None:
-        assert len(_KINDS) == 24
+    def test_total_kind_count_at_least_twenty_four(self) -> None:
+        """PR-B1 introduced 24 kinds. Subsequent PRs (B2 +3 cost kinds)
+        are additive; this regression guard pins the floor, not the
+        exact count, to avoid churn on every cost/metrics/etc. kind
+        addition."""
+        assert len(_KINDS) >= 24
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cost_catalog.py
+++ b/tests/test_cost_catalog.py
@@ -1,0 +1,330 @@
+"""Tests for ``ao_kernel.cost.catalog`` — price catalog loader."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from ao_kernel.cost.catalog import (
+    PriceCatalogEntry,
+    _canonical_entries_json,
+    clear_catalog_cache,
+    find_entry,
+    load_price_catalog,
+)
+from ao_kernel.cost.errors import (
+    PriceCatalogChecksumError,
+    PriceCatalogStaleError,
+)
+from ao_kernel.cost.policy import (
+    CostTrackingPolicy,
+    RoutingByCost,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_catalog_cache():
+    """Each test gets a fresh LRU cache — otherwise bundled hit in test A
+    bleeds into test B's override scenario."""
+    clear_catalog_cache()
+    yield
+    clear_catalog_cache()
+
+
+def _entry_doc(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "provider_id": "anthropic",
+        "model": "claude-3-5-sonnet",
+        "input_cost_per_1k": 0.003,
+        "output_cost_per_1k": 0.015,
+        "cached_input_cost_per_1k": 0.0003,
+        "currency": "USD",
+        "billing_unit": "per_1k_tokens",
+        "effective_date": "2024-10-22",
+    }
+    base.update(overrides)
+    return base
+
+
+def _catalog_doc(
+    *,
+    entries: list[dict[str, Any]] | None = None,
+    source: str = "manual",
+    stale_after: str = "2099-01-01T00:00:00+00:00",
+    generated_at: str = "2026-04-16T00:00:00+00:00",
+    override_checksum: str | None = None,
+) -> dict[str, Any]:
+    if entries is None:
+        entries = [_entry_doc()]
+    canonical = json.dumps(
+        entries,
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    checksum = "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    doc = {
+        "catalog_version": "1",
+        "generated_at": generated_at,
+        "source": source,
+        "stale_after": stale_after,
+        "checksum": override_checksum if override_checksum is not None else checksum,
+        "entries": entries,
+    }
+    return doc
+
+
+def _policy(**overrides: Any) -> CostTrackingPolicy:
+    return CostTrackingPolicy(
+        enabled=True,
+        price_catalog_path=".ao/cost/catalog.v1.json",
+        spend_ledger_path=".ao/cost/spend.jsonl",
+        fail_closed_on_exhaust=True,
+        strict_freshness=overrides.get("strict_freshness", False),
+        fail_closed_on_missing_usage=True,
+        idempotency_window_lines=1000,
+        routing_by_cost=RoutingByCost(enabled=False),
+    )
+
+
+class TestBundledLoad:
+    def test_bundled_loads_without_override(self, tmp_path: Path) -> None:
+        """No workspace override → bundled starter catalog returned."""
+        catalog = load_price_catalog(tmp_path)
+        assert catalog.catalog_version == "1"
+        assert catalog.source == "bundled"
+        assert len(catalog.entries) >= 6  # 6 entries in bundled starter
+
+    def test_bundled_has_anthropic_sonnet(self, tmp_path: Path) -> None:
+        catalog = load_price_catalog(tmp_path)
+        sonnet = find_entry(catalog, "anthropic", "claude-3-5-sonnet")
+        assert sonnet is not None
+        assert sonnet.input_cost_per_1k == pytest.approx(0.003)
+        assert sonnet.output_cost_per_1k == pytest.approx(0.015)
+
+
+class TestWorkspaceOverride:
+    def _write_override(
+        self,
+        workspace_root: Path,
+        doc: dict[str, Any],
+        *,
+        subpath: str = ".ao/cost/catalog.v1.json",
+    ) -> None:
+        path = workspace_root / subpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(doc, sort_keys=True))
+
+    def test_workspace_override_preempts_bundled(self, tmp_path: Path) -> None:
+        override_doc = _catalog_doc(
+            entries=[
+                _entry_doc(
+                    provider_id="acme",
+                    model="acme-large",
+                    input_cost_per_1k=0.5,
+                    output_cost_per_1k=1.0,
+                    cached_input_cost_per_1k=0.1,
+                )
+            ],
+        )
+        self._write_override(tmp_path, override_doc)
+        catalog = load_price_catalog(tmp_path, policy=_policy())
+        acme = find_entry(catalog, "acme", "acme-large")
+        assert acme is not None
+        # Bundled anthropic entry now absent (override replaces)
+        assert find_entry(catalog, "anthropic", "claude-3-5-sonnet") is None
+
+    def test_malformed_json_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / ".ao" / "cost" / "catalog.v1.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json {{{")
+        with pytest.raises(json.JSONDecodeError):
+            load_price_catalog(tmp_path, policy=_policy())
+
+    def test_schema_invalid_raises(self, tmp_path: Path) -> None:
+        """Fail-closed: invalid catalog must not silently fall back."""
+        doc = _catalog_doc()
+        del doc["generated_at"]  # violate required
+        self._write_override(tmp_path, doc)
+        with pytest.raises(ValidationError):
+            load_price_catalog(tmp_path, policy=_policy())
+
+
+class TestInlineOverride:
+    def test_inline_override_bypasses_filesystem(self, tmp_path: Path) -> None:
+        doc = _catalog_doc(
+            entries=[_entry_doc(provider_id="acme", model="acme-tiny")]
+        )
+        catalog = load_price_catalog(tmp_path, override=doc)
+        entry = find_entry(catalog, "acme", "acme-tiny")
+        assert entry is not None
+        assert entry.provider_id == "acme"
+        assert entry.model == "acme-tiny"
+        assert catalog.source == "manual"
+
+
+class TestChecksumVerify:
+    def test_checksum_mismatch_raises(self, tmp_path: Path) -> None:
+        bad = _catalog_doc(
+            override_checksum="sha256:" + "0" * 64,  # wrong sha
+        )
+        with pytest.raises(PriceCatalogChecksumError) as excinfo:
+            load_price_catalog(tmp_path, override=bad)
+        assert excinfo.value.expected_checksum.startswith("sha256:")
+        assert excinfo.value.actual_checksum.startswith("sha256:")
+
+    def test_checksum_ignores_doc_level_fields(self, tmp_path: Path) -> None:
+        """Checksum only over entries[] — generated_at/source churn does
+        not break verification."""
+        entries = [_entry_doc()]
+        doc1 = _catalog_doc(entries=entries, generated_at="2026-04-16T00:00:00+00:00")
+        doc2 = _catalog_doc(entries=entries, generated_at="2026-05-01T00:00:00+00:00")
+        # Both doc1 and doc2 should load cleanly — same entries → same checksum
+        assert doc1["checksum"] == doc2["checksum"]
+
+    def test_canonical_form_stable(self) -> None:
+        """Canonical form is deterministic across dict key orderings."""
+        entries_a = [{"provider_id": "p", "model": "m", "input_cost_per_1k": 1.0}]
+        entries_b = [{"model": "m", "input_cost_per_1k": 1.0, "provider_id": "p"}]
+        assert _canonical_entries_json(entries_a) == _canonical_entries_json(entries_b)
+
+
+class TestStaleGate:
+    def test_strict_stale_raises(self, tmp_path: Path) -> None:
+        past_ts = (
+            _dt.datetime.now(tz=_dt.timezone.utc) - _dt.timedelta(days=1)
+        ).isoformat()
+        doc = _catalog_doc(stale_after=past_ts)
+        with pytest.raises(PriceCatalogStaleError):
+            load_price_catalog(
+                tmp_path,
+                override=doc,
+                policy=_policy(strict_freshness=True),
+            )
+
+    def test_lenient_stale_warns(self, tmp_path: Path, caplog) -> None:
+        past_ts = (
+            _dt.datetime.now(tz=_dt.timezone.utc) - _dt.timedelta(days=1)
+        ).isoformat()
+        doc = _catalog_doc(stale_after=past_ts)
+        with caplog.at_level("WARNING"):
+            catalog = load_price_catalog(
+                tmp_path,
+                override=doc,
+                policy=_policy(strict_freshness=False),
+            )
+        assert catalog.catalog_version == "1"  # served despite stale
+        assert any(
+            "stale" in rec.getMessage() for rec in caplog.records
+        )
+
+    def test_fresh_catalog_passes(self, tmp_path: Path) -> None:
+        future_ts = (
+            _dt.datetime.now(tz=_dt.timezone.utc) + _dt.timedelta(days=30)
+        ).isoformat()
+        doc = _catalog_doc(stale_after=future_ts)
+        catalog = load_price_catalog(
+            tmp_path,
+            override=doc,
+            policy=_policy(strict_freshness=True),
+        )
+        assert catalog.catalog_version == "1"
+
+
+class TestVendorApiSourceConditional:
+    def test_vendor_api_requires_vendor_model_id(self, tmp_path: Path) -> None:
+        """Schema if/then: source=vendor_api → entries[].vendor_model_id required."""
+        entries_missing_vendor = [_entry_doc()]  # no vendor_model_id
+        doc = _catalog_doc(entries=entries_missing_vendor, source="vendor_api")
+        with pytest.raises(ValidationError):
+            load_price_catalog(tmp_path, override=doc)
+
+    def test_vendor_api_with_vendor_model_id_ok(self, tmp_path: Path) -> None:
+        entries = [
+            _entry_doc(vendor_model_id="claude-3-5-sonnet-20241022"),
+        ]
+        doc = _catalog_doc(entries=entries, source="vendor_api")
+        catalog = load_price_catalog(tmp_path, override=doc)
+        assert catalog.source == "vendor_api"
+        assert catalog.entries[0].vendor_model_id == "claude-3-5-sonnet-20241022"
+
+    def test_manual_source_without_vendor_model_id_ok(self, tmp_path: Path) -> None:
+        """source=manual → vendor_model_id optional."""
+        doc = _catalog_doc(entries=[_entry_doc()], source="manual")
+        catalog = load_price_catalog(tmp_path, override=doc)
+        assert catalog.entries[0].vendor_model_id is None
+
+
+class TestFindEntry:
+    def test_match(self, tmp_path: Path) -> None:
+        catalog = load_price_catalog(tmp_path)  # bundled
+        entry = find_entry(catalog, "anthropic", "claude-3-5-sonnet")
+        assert entry is not None
+        assert entry.provider_id == "anthropic"
+
+    def test_no_match_returns_none(self, tmp_path: Path) -> None:
+        catalog = load_price_catalog(tmp_path)
+        assert find_entry(catalog, "nonexistent", "ghost-model") is None
+
+    def test_case_sensitive(self, tmp_path: Path) -> None:
+        catalog = load_price_catalog(tmp_path)
+        assert find_entry(catalog, "Anthropic", "claude-3-5-sonnet") is None
+
+
+class TestLruCache:
+    def test_same_workspace_two_calls_hits_cache(self, tmp_path: Path) -> None:
+        """Second call returns the same instance — filesystem read once.
+
+        We can't easily count disk reads without mocking; instead we
+        assert object identity: cache returns the same PriceCatalog
+        instance across calls within TTL.
+        """
+        cat1 = load_price_catalog(tmp_path)
+        cat2 = load_price_catalog(tmp_path)
+        assert cat1 is cat2
+
+    def test_clear_cache_forces_reload(self, tmp_path: Path) -> None:
+        cat1 = load_price_catalog(tmp_path)
+        clear_catalog_cache()
+        cat2 = load_price_catalog(tmp_path)
+        # New instance after cache clear
+        assert cat1 is not cat2
+
+    def test_inline_override_bypasses_cache(self, tmp_path: Path) -> None:
+        """override= kwarg skips cache — always validates + parses fresh."""
+        doc = _catalog_doc(entries=[_entry_doc(model="alt-1")])
+        cat1 = load_price_catalog(tmp_path, override=doc)
+        cat2 = load_price_catalog(tmp_path, override=doc)
+        # Fresh instances each call (no cache entry for override path)
+        assert cat1 is not cat2
+
+
+class TestEmptyEntries:
+    def test_empty_entries_array_rejected(self, tmp_path: Path) -> None:
+        """Schema minItems: 1 — empty catalog indistinguishable from absent."""
+        doc = _catalog_doc(entries=[])
+        # Checksum recomputed for empty list
+        doc["checksum"] = "sha256:" + hashlib.sha256(b"[]").hexdigest()
+        with pytest.raises(ValidationError):
+            load_price_catalog(tmp_path, override=doc)
+
+
+class TestEntryDataclass:
+    def test_entry_frozen(self) -> None:
+        entry = PriceCatalogEntry(
+            provider_id="p",
+            model="m",
+            input_cost_per_1k=1.0,
+            output_cost_per_1k=2.0,
+            currency="USD",
+            billing_unit="per_1k_tokens",
+            effective_date="2026-01-01",
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            entry.provider_id = "other"  # type: ignore[misc]

--- a/tests/test_cost_entrypoint_plumbing.py
+++ b/tests/test_cost_entrypoint_plumbing.py
@@ -1,0 +1,194 @@
+"""Tests for PR-B2 commit 5b — entrypoint plumbing.
+
+3 callers route through governed_call:
+  - AoKernelClient.llm_call (non-streaming branch)
+  - mcp_server.handle_llm_call
+  - workflow.intent_router._llm_classify
+
+This file focuses on:
+  - Envelope preservation (CAPABILITY_GAP / TRANSPORT_ERROR stay as-is)
+  - MCP tool schema widening (ao_run_id / ao_step_id / ao_attempt
+    optional params declared)
+  - intent_router bypass-only contract (no cost identity passes through)
+  - Streaming stays on existing _execute_stream path (v5 iter-4 B2)
+
+End-to-end cost-active integration (with mocked transport) is covered
+implicitly by the middleware-core tests in commit 5a; this file pins
+the wiring.
+"""
+
+from __future__ import annotations
+
+from ao_kernel.mcp_server import TOOL_DEFINITIONS
+
+
+def _find_tool_spec(name: str) -> dict:
+    for spec in TOOL_DEFINITIONS:
+        if spec.get("name") == name:
+            return spec
+    raise AssertionError(f"tool spec {name!r} not in TOOL_DEFINITIONS")
+
+
+class TestMcpToolSchemaWiden:
+    def test_ao_llm_call_declares_cost_identity_params(self) -> None:
+        spec = _find_tool_spec("ao_llm_call")
+        props = spec["inputSchema"]["properties"]
+        # PR-B2 v5 iter-4 MCP widen: three optional params.
+        assert "ao_run_id" in props
+        assert "ao_step_id" in props
+        assert "ao_attempt" in props
+        # Schema types match the middleware contract.
+        assert props["ao_run_id"]["type"] == "string"
+        assert props["ao_step_id"]["type"] == "string"
+        assert props["ao_attempt"]["type"] == "integer"
+        assert props["ao_attempt"].get("minimum") == 1
+        # They remain optional (not in required).
+        required = spec["inputSchema"].get("required", [])
+        assert "ao_run_id" not in required
+        assert "ao_step_id" not in required
+        assert "ao_attempt" not in required
+
+
+class TestIntentRouterBypassContract:
+    def test_llm_classify_passes_all_bypass_kwargs(self) -> None:
+        """intent_router._llm_classify calls governed_call with ALL cost
+        + context kwargs explicitly set to None (bypass-only).
+
+        Inspect the source to guard against drift; an implementation
+        that starts threading session_context or run_id through would
+        violate the v7 §10 position 13 pin.
+        """
+        import inspect
+
+        from ao_kernel.workflow.intent_router import IntentRouter
+
+        source = inspect.getsource(IntentRouter._llm_classify)
+        # The governed_call invocation must explicitly set each of
+        # these to None (bypass-only).
+        assert "session_context=None" in source
+        assert "workspace_root_str=None" in source
+        assert "profile=None" in source
+        assert "embedding_config=None" in source
+        assert "vector_store=None" in source
+        assert "workspace_root=None" in source
+        assert "run_id=None" in source
+        assert "step_id=None" in source
+        assert "attempt=None" in source
+        # Uses governed_call (not the pre-B2 three-call sequence).
+        assert "governed_call" in source
+
+    def test_llm_classify_error_mapping_preserved(self) -> None:
+        """Source-level guard: four IntentClassificationError reason
+        values are still raised (llm_extra_missing, no_available_workflows,
+        llm_transport_error, llm_invalid_response). PR-A6 B4 contract
+        preserved."""
+        import inspect
+
+        from ao_kernel.workflow.intent_router import IntentRouter
+
+        source = inspect.getsource(IntentRouter._llm_classify)
+        assert 'reason="llm_extra_missing"' in source
+        assert 'reason="no_available_workflows"' in source
+        assert 'reason="llm_transport_error"' in source
+        assert 'reason="llm_invalid_response"' in source
+
+
+class TestClientLlmCallSignature:
+    def test_llm_call_accepts_cost_identity_kwargs(self) -> None:
+        """AoKernelClient.llm_call signature widened with run_id,
+        step_id, attempt optional kwargs (v5 iter-4 B2 opt-in path)."""
+        import inspect
+
+        from ao_kernel.client import AoKernelClient
+
+        sig = inspect.signature(AoKernelClient.llm_call)
+        assert "run_id" in sig.parameters
+        assert "step_id" in sig.parameters
+        assert "attempt" in sig.parameters
+        # All three default to None.
+        assert sig.parameters["run_id"].default is None
+        assert sig.parameters["step_id"].default is None
+        assert sig.parameters["attempt"].default is None
+
+    def test_llm_call_nonstream_delegates_to_governed_call(self) -> None:
+        """Non-streaming branch threads kwargs into governed_call.
+
+        Source-level guard: the implementation calls governed_call and
+        passes workspace_root, run_id, step_id, attempt through.
+        """
+        import inspect
+
+        from ao_kernel.client import AoKernelClient
+
+        source = inspect.getsource(AoKernelClient.llm_call)
+        assert "governed_call" in source
+        # Cost identity threading.
+        assert "run_id=run_id" in source
+        assert "step_id=step_id" in source
+        assert "attempt=attempt" in source
+        # Context injection wired via session_context kwarg.
+        assert "session_context=" in source
+
+    def test_stream_branch_untouched(self) -> None:
+        """Streaming path stays on build + _execute_stream — not
+        governed_call. Regression guard: plan v5 iter-4 B2 pin.
+
+        Structural check: the ``if stream:`` branch dispatches
+        ``_execute_stream`` and returns; the governed_call invocation
+        (``result = governed_call(``) executes only on the stream=False
+        path and must therefore appear AFTER the stream branch's
+        return statement in source order.
+        """
+        import inspect
+
+        from ao_kernel.client import AoKernelClient
+
+        source = inspect.getsource(AoKernelClient.llm_call)
+        assert "_execute_stream" in source
+        stream_pos = source.find("if stream")
+        stream_return_pos = source.find("return self._execute_stream", stream_pos)
+        # Match the actual invocation pattern (not the docstring mention).
+        governed_invocation_pos = source.find("result = governed_call(")
+        assert stream_pos != -1
+        assert stream_return_pos != -1
+        assert governed_invocation_pos != -1
+        # stream check returns before the governed_call invocation.
+        assert stream_return_pos < governed_invocation_pos
+
+
+class TestMcpHandleLlmCall:
+    def test_reads_ao_identity_params(self) -> None:
+        """mcp_server.handle_llm_call reads optional ao_run_id / ao_step_id
+        / ao_attempt from params and threads them to governed_call."""
+        import inspect
+
+        from ao_kernel.mcp_server import handle_llm_call
+
+        source = inspect.getsource(handle_llm_call)
+        assert 'params.get("ao_run_id")' in source
+        assert 'params.get("ao_step_id")' in source
+        assert 'params.get("ao_attempt")' in source
+        assert "governed_call" in source
+
+    def test_capability_gap_returns_deny_envelope(self) -> None:
+        """Source-level pin: governed_call CAPABILITY_GAP result is
+        mapped to a decision=deny envelope with CAPABILITY_GAP reason
+        code (preserves mcp_server pre-B2 contract)."""
+        import inspect
+
+        from ao_kernel.mcp_server import handle_llm_call
+
+        source = inspect.getsource(handle_llm_call)
+        assert '"CAPABILITY_GAP"' in source
+        assert '"TRANSPORT_ERROR"' in source
+
+    def test_session_context_not_threaded(self) -> None:
+        """MCP is the thin-executor surface; session context DOES NOT
+        flow through (pre-B2 behavior preserved)."""
+        import inspect
+
+        from ao_kernel.mcp_server import handle_llm_call
+
+        source = inspect.getsource(handle_llm_call)
+        # governed_call invocation must pass session_context=None.
+        assert "session_context=None" in source

--- a/tests/test_cost_ledger.py
+++ b/tests/test_cost_ledger.py
@@ -1,0 +1,309 @@
+"""Tests for ``ao_kernel.cost.ledger`` — append-only JSONL with
+canonical billing digest idempotency."""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from ao_kernel.cost.errors import (
+    SpendLedgerCorruptedError,
+    SpendLedgerDuplicateError,
+)
+from ao_kernel.cost.ledger import (
+    SpendEvent,
+    _compute_billing_digest,
+    record_spend,
+)
+from ao_kernel.cost.policy import (
+    CostTrackingPolicy,
+    RoutingByCost,
+)
+
+
+def _policy(
+    *,
+    enabled: bool = True,
+    window_lines: int = 1000,
+) -> CostTrackingPolicy:
+    return CostTrackingPolicy(
+        enabled=enabled,
+        price_catalog_path=".ao/cost/catalog.v1.json",
+        spend_ledger_path=".ao/cost/spend.jsonl",
+        fail_closed_on_exhaust=True,
+        strict_freshness=False,
+        fail_closed_on_missing_usage=True,
+        idempotency_window_lines=window_lines,
+        routing_by_cost=RoutingByCost(enabled=False),
+    )
+
+
+def _event(**overrides: Any) -> SpendEvent:
+    base = dict(
+        run_id="11111111-1111-4111-8111-111111111111",
+        step_id="step-alpha",
+        attempt=1,
+        provider_id="anthropic",
+        model="claude-3-5-sonnet",
+        tokens_input=1000,
+        tokens_output=500,
+        cost_usd=Decimal("0.0105"),
+        ts="2026-04-17T12:00:00+00:00",
+    )
+    base.update(overrides)
+    return SpendEvent(**base)
+
+
+def _read_lines(path: Path) -> list[dict[str, Any]]:
+    """Parse ledger JSONL file into list of dicts."""
+    if not path.is_file():
+        return []
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    return [json.loads(line) for line in lines if line.strip()]
+
+
+class TestDormantNoOp:
+    def test_dormant_policy_silent_noop(self, tmp_path: Path) -> None:
+        """policy.enabled=false → no file created, no lock acquired."""
+        record_spend(tmp_path, _event(), policy=_policy(enabled=False))
+        ledger_path = tmp_path / ".ao" / "cost" / "spend.jsonl"
+        assert not ledger_path.exists()
+
+
+class TestFirstWrite:
+    def test_creates_file_and_appends(self, tmp_path: Path) -> None:
+        record_spend(tmp_path, _event(), policy=_policy())
+        ledger_path = tmp_path / ".ao" / "cost" / "spend.jsonl"
+        assert ledger_path.is_file()
+        lines = _read_lines(ledger_path)
+        assert len(lines) == 1
+        assert lines[0]["run_id"] == "11111111-1111-4111-8111-111111111111"
+        assert lines[0]["attempt"] == 1
+        assert lines[0]["billing_digest"].startswith("sha256:")
+
+    def test_dir_mode_0o700(self, tmp_path: Path) -> None:
+        """Parent dir auto-created with 0o700 perms (security R8)."""
+        record_spend(tmp_path, _event(), policy=_policy())
+        cost_dir = tmp_path / ".ao" / "cost"
+        assert cost_dir.is_dir()
+        mode = cost_dir.stat().st_mode & 0o777
+        # 0o700 expected but OS umask may loosen; minimum: no world access
+        assert mode & 0o007 == 0
+
+
+class TestBillingDigest:
+    def test_digest_stable_across_calls(self) -> None:
+        e = _event()
+        d1 = _compute_billing_digest(e)
+        d2 = _compute_billing_digest(e)
+        assert d1 == d2
+        assert d1.startswith("sha256:")
+
+    def test_digest_changes_with_cost(self) -> None:
+        e1 = _event(cost_usd=Decimal("0.01"))
+        e2 = _event(cost_usd=Decimal("0.02"))
+        assert _compute_billing_digest(e1) != _compute_billing_digest(e2)
+
+    def test_digest_changes_with_tokens(self) -> None:
+        e1 = _event(tokens_input=1000, tokens_output=500)
+        e2 = _event(tokens_input=2000, tokens_output=500)
+        assert _compute_billing_digest(e1) != _compute_billing_digest(e2)
+
+    def test_digest_changes_with_usage_missing_flag(self) -> None:
+        e1 = _event(usage_missing=False)
+        e2 = _event(usage_missing=True)
+        assert _compute_billing_digest(e1) != _compute_billing_digest(e2)
+
+    def test_digest_decimal_stable(self) -> None:
+        """Different Decimal constructions of same value → same digest."""
+        e1 = _event(cost_usd=Decimal("0.010"))
+        e2 = _event(cost_usd=Decimal("0.01"))
+        # Decimal("0.010") != Decimal("0.01") as objects, but
+        # str(Decimal("0.010")) == "0.010"; digest canonicalizes via str
+        # so they intentionally produce DIFFERENT digests.
+        # This is acceptable because writer would always use the actual
+        # computed Decimal from compute_cost(), not operator input.
+        assert _compute_billing_digest(e1) != _compute_billing_digest(e2)
+
+    def test_digest_persisted_in_ledger(self, tmp_path: Path) -> None:
+        record_spend(tmp_path, _event(), policy=_policy())
+        lines = _read_lines(tmp_path / ".ao" / "cost" / "spend.jsonl")
+        expected = _compute_billing_digest(_event())
+        assert lines[0]["billing_digest"] == expected
+
+
+class TestIdempotency:
+    def test_same_key_same_digest_is_noop(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """Retry with identical event → warn log, no second append."""
+        record_spend(tmp_path, _event(), policy=_policy())
+        with caplog.at_level("WARNING"):
+            record_spend(tmp_path, _event(), policy=_policy())
+        lines = _read_lines(tmp_path / ".ao" / "cost" / "spend.jsonl")
+        assert len(lines) == 1  # still one
+        assert any("idempotent no-op" in rec.getMessage() for rec in caplog.records)
+
+    def test_same_key_different_digest_raises(self, tmp_path: Path) -> None:
+        """Same (run_id, step_id, attempt) + different billing →
+        SpendLedgerDuplicateError."""
+        record_spend(tmp_path, _event(cost_usd=Decimal("0.01")), policy=_policy())
+        with pytest.raises(SpendLedgerDuplicateError) as excinfo:
+            record_spend(
+                tmp_path,
+                _event(cost_usd=Decimal("0.02")),
+                policy=_policy(),
+            )
+        assert excinfo.value.existing_digest != excinfo.value.new_digest
+        assert excinfo.value.run_id == "11111111-1111-4111-8111-111111111111"
+        # Only one line in ledger (second call rejected)
+        lines = _read_lines(tmp_path / ".ao" / "cost" / "spend.jsonl")
+        assert len(lines) == 1
+
+    def test_distinct_attempt_for_same_step_appends(
+        self, tmp_path: Path
+    ) -> None:
+        """Retry with attempt=2 → separate ledger line (distinct key)."""
+        record_spend(tmp_path, _event(attempt=1), policy=_policy())
+        record_spend(tmp_path, _event(attempt=2), policy=_policy())
+        lines = _read_lines(tmp_path / ".ao" / "cost" / "spend.jsonl")
+        assert len(lines) == 2
+        attempts = {line["attempt"] for line in lines}
+        assert attempts == {1, 2}
+
+
+class TestCorruptLedger:
+    def test_corrupt_jsonl_line_raises(self, tmp_path: Path) -> None:
+        """Unparseable line during idempotency scan → fail-closed."""
+        ledger_path = tmp_path / ".ao" / "cost" / "spend.jsonl"
+        ledger_path.parent.mkdir(parents=True, mode=0o700)
+        ledger_path.write_text("not a json line\n")
+
+        with pytest.raises(SpendLedgerCorruptedError) as excinfo:
+            record_spend(tmp_path, _event(), policy=_policy())
+        assert excinfo.value.line_number == 1
+
+    def test_non_object_line_raises(self, tmp_path: Path) -> None:
+        """JSON array or scalar at line level → corruption."""
+        ledger_path = tmp_path / ".ao" / "cost" / "spend.jsonl"
+        ledger_path.parent.mkdir(parents=True, mode=0o700)
+        ledger_path.write_text('"hello world"\n')
+
+        with pytest.raises(SpendLedgerCorruptedError):
+            record_spend(tmp_path, _event(), policy=_policy())
+
+
+class TestBoundedWindow:
+    def test_retry_outside_window_not_detected(self, tmp_path: Path) -> None:
+        """With small window + many intervening writes, an earlier
+        key is out-of-scan-range and a second write succeeds (false
+        negative tolerated per R1 — window policy knob).
+        """
+        policy = _policy(window_lines=100)
+        # Write the target key first
+        record_spend(
+            tmp_path,
+            _event(run_id="11111111-1111-4111-8111-111111111111", attempt=1),
+            policy=policy,
+        )
+        # Fill 100+ distinct events
+        for i in range(110):
+            record_spend(
+                tmp_path,
+                _event(
+                    run_id=f"22222222-2222-4222-8222-{i:012x}"[:36],
+                    step_id=f"filler-{i}",
+                    attempt=1,
+                ),
+                policy=policy,
+            )
+        # Original key is now pushed out of the 100-line window; a
+        # second call with same key + SAME billing digest succeeds
+        # (should have been no-op but window misses it — documented R1)
+        record_spend(
+            tmp_path,
+            _event(run_id="11111111-1111-4111-8111-111111111111", attempt=1),
+            policy=policy,
+        )
+        lines = _read_lines(tmp_path / ".ao" / "cost" / "spend.jsonl")
+        # 1 original + 110 fillers + 1 second original = 112
+        assert len(lines) == 112
+
+
+class TestSchemaValidation:
+    def test_event_schema_validated_pre_write(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Writer validates each event against the ledger schema.
+
+        We exercise this by constructing an event that parses OK as a
+        Python object but fails schema (negative tokens should never
+        happen in practice; schema has minimum: 0).
+        """
+        # SpendEvent dataclass doesn't validate, but the writer does.
+        # We bypass the dataclass by patching _event_to_dict temporarily.
+        from ao_kernel.cost import ledger as ledger_mod
+
+        orig_to_dict = ledger_mod._event_to_dict
+
+        def _bad_to_dict(event: SpendEvent) -> dict[str, Any]:
+            doc = orig_to_dict(event)
+            doc["tokens_input"] = -1  # schema violation
+            return doc
+
+        monkeypatch.setattr(ledger_mod, "_event_to_dict", _bad_to_dict)
+        with pytest.raises(ValidationError):
+            record_spend(tmp_path, _event(), policy=_policy())
+
+
+class TestOptionalFields:
+    def test_vendor_model_id_absent_when_none(self, tmp_path: Path) -> None:
+        """None omitted from wire (schema additionalProperties: false)."""
+        record_spend(
+            tmp_path,
+            _event(vendor_model_id=None),
+            policy=_policy(),
+        )
+        lines = _read_lines(tmp_path / ".ao" / "cost" / "spend.jsonl")
+        assert "vendor_model_id" not in lines[0]
+
+    def test_vendor_model_id_preserved_when_set(self, tmp_path: Path) -> None:
+        record_spend(
+            tmp_path,
+            _event(vendor_model_id="claude-3-5-sonnet-20241022"),
+            policy=_policy(),
+        )
+        lines = _read_lines(tmp_path / ".ao" / "cost" / "spend.jsonl")
+        assert lines[0]["vendor_model_id"] == "claude-3-5-sonnet-20241022"
+
+    def test_cached_tokens_absent_when_none(self, tmp_path: Path) -> None:
+        record_spend(tmp_path, _event(cached_tokens=None), policy=_policy())
+        lines = _read_lines(tmp_path / ".ao" / "cost" / "spend.jsonl")
+        assert "cached_tokens" not in lines[0]
+
+    def test_cached_tokens_preserved_when_set(self, tmp_path: Path) -> None:
+        record_spend(tmp_path, _event(cached_tokens=200), policy=_policy())
+        lines = _read_lines(tmp_path / ".ao" / "cost" / "spend.jsonl")
+        assert lines[0]["cached_tokens"] == 200
+
+
+class TestUsageMissingFlag:
+    def test_usage_missing_true_in_ledger(self, tmp_path: Path) -> None:
+        record_spend(
+            tmp_path,
+            _event(
+                usage_missing=True,
+                tokens_input=0,
+                tokens_output=0,
+                cost_usd=Decimal("0"),
+            ),
+            policy=_policy(),
+        )
+        lines = _read_lines(tmp_path / ".ao" / "cost" / "spend.jsonl")
+        assert lines[0]["usage_missing"] is True
+        assert lines[0]["cost_usd"] == 0.0

--- a/tests/test_cost_math.py
+++ b/tests/test_cost_math.py
@@ -1,0 +1,142 @@
+"""Tests for ``ao_kernel.cost.cost_math`` — pure deterministic arithmetic."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from ao_kernel.cost.cost_math import (
+    compute_cost,
+    estimate_cost,
+    estimate_output_tokens,
+)
+
+
+def _entry(**overrides):
+    """Build a minimal duck-typed catalog entry.
+
+    ``PriceCatalogEntry`` dataclass lands in commit 2; these tests use
+    a lightweight namespace so the math module can be validated
+    independently.
+    """
+    base = dict(
+        provider_id="anthropic",
+        model="claude-3-5-sonnet",
+        vendor_model_id="claude-3-5-sonnet-20241022",
+        input_cost_per_1k=0.003,
+        output_cost_per_1k=0.015,
+        cached_input_cost_per_1k=0.0003,
+        currency="USD",
+        billing_unit="per_1k_tokens",
+        effective_date="2024-10-22",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestComputeCost:
+    def test_no_caching_standard(self) -> None:
+        """Straight formula: 1000 input + 500 output.
+
+        cost = 1000 * 0.003 / 1000 + 500 * 0.015 / 1000
+             = 0.003 + 0.0075 = 0.0105 USD
+        """
+        cost = compute_cost(_entry(), tokens_input=1000, tokens_output=500)
+        assert cost == Decimal("0.0105")
+
+    def test_with_caching_discount(self) -> None:
+        """200 cached @ 0.0003/1k + 800 billable @ 0.003/1k + 100 output @ 0.015/1k.
+
+        cost = 800 * 0.003 / 1000 + 200 * 0.0003 / 1000 + 100 * 0.015 / 1000
+             = 0.0024 + 0.00006 + 0.0015 = 0.00396 USD
+        """
+        cost = compute_cost(
+            _entry(), tokens_input=1000, tokens_output=100, cached_tokens=200
+        )
+        assert cost == Decimal("0.00396")
+
+    def test_cached_fallback_when_no_cached_rate(self) -> None:
+        """When ``cached_input_cost_per_1k`` is None, cached tokens bill
+        at the full input rate (safe fallback — no free caching)."""
+        entry = _entry(cached_input_cost_per_1k=None)
+        cost = compute_cost(entry, tokens_input=1000, tokens_output=0, cached_tokens=200)
+        # All 1000 input tokens billed at 0.003/1k = 0.003
+        assert cost == Decimal("0.003")
+
+    def test_cached_exceeds_input_raises(self) -> None:
+        with pytest.raises(ValueError, match="cached_tokens=200 exceeds"):
+            compute_cost(_entry(), tokens_input=100, tokens_output=0, cached_tokens=200)
+
+    def test_negative_input_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be non-negative"):
+            compute_cost(_entry(), tokens_input=-1, tokens_output=0)
+
+    def test_negative_output_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be non-negative"):
+            compute_cost(_entry(), tokens_input=0, tokens_output=-1)
+
+    def test_zero_tokens_zero_cost(self) -> None:
+        cost = compute_cost(_entry(), tokens_input=0, tokens_output=0)
+        assert cost == Decimal("0")
+
+    def test_decimal_precision_not_float(self) -> None:
+        """Five sequential spends of 0.1 USD each accumulate exactly to 0.5
+        (Decimal aggregation). Float would drift."""
+        total = Decimal("0")
+        entry = _entry(input_cost_per_1k=100, output_cost_per_1k=0, cached_input_cost_per_1k=None)
+        for _ in range(5):
+            # 1 input token @ 100/1k = 0.1
+            total += compute_cost(entry, tokens_input=1, tokens_output=0)
+        assert total == Decimal("0.5")
+
+
+class TestEstimateCost:
+    def test_basic_estimate(self) -> None:
+        """500 est input + 200 est output."""
+        cost = estimate_cost(_entry(), est_tokens_input=500, est_tokens_output=200)
+        # 500 * 0.003 / 1000 + 200 * 0.015 / 1000 = 0.0015 + 0.003 = 0.0045
+        assert cost == Decimal("0.0045")
+
+    def test_ignores_caching(self) -> None:
+        """Estimate upper-bounds the cost; caching discount only post-response."""
+        entry_with_cache = _entry(cached_input_cost_per_1k=0.0003)
+        entry_no_cache = _entry(cached_input_cost_per_1k=None)
+        # Estimate does NOT look at cache rate — both entries give same estimate.
+        assert estimate_cost(entry_with_cache, 1000, 0) == estimate_cost(entry_no_cache, 1000, 0)
+
+    def test_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            estimate_cost(_entry(), est_tokens_input=-1, est_tokens_output=0)
+
+
+class TestEstimateOutputTokens:
+    def test_quarter_of_input_when_max_none(self) -> None:
+        """est_out = est_in * 0.25 when max_tokens is None."""
+        assert estimate_output_tokens(1000, None) == 250
+        assert estimate_output_tokens(100, None) == 25
+        assert estimate_output_tokens(4, None) == 1  # int floor
+
+    def test_min_with_max_tokens(self) -> None:
+        """min(max_tokens, est_in * 0.25)."""
+        # 1000 * 0.25 = 250; max_tokens=100 wins.
+        assert estimate_output_tokens(1000, 100) == 100
+        # 1000 * 0.25 = 250; max_tokens=500 loses (250 wins).
+        assert estimate_output_tokens(1000, 500) == 250
+
+    def test_zero_input_returns_zero(self) -> None:
+        assert estimate_output_tokens(0, None) == 0
+        assert estimate_output_tokens(0, 100) == 0
+
+    def test_negative_input_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be non-negative"):
+            estimate_output_tokens(-1, None)
+
+    def test_negative_max_tokens_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be non-negative"):
+            estimate_output_tokens(100, -1)
+
+    def test_max_tokens_zero_wins(self) -> None:
+        """max_tokens=0 means caller explicitly asks for no output; estimate honors."""
+        assert estimate_output_tokens(1000, 0) == 0

--- a/tests/test_cost_middleware_core.py
+++ b/tests/test_cost_middleware_core.py
@@ -504,8 +504,192 @@ class TestEvidenceKindsRegistered:
         assert "llm_cost_estimated" in _KINDS
         assert "llm_spend_recorded" in _KINDS
         assert "llm_usage_missing" in _KINDS
-        # Total should be 24 (PR-B1) + 3 (PR-B2) = 27
-        assert len(_KINDS) == 27
+        # PR-B1 baseline 24 + PR-B2 additive +3 → ≥ 27 floor.
+        # Subsequent PRs (B5 metrics, B6 review/commit AI, etc.) may
+        # add more kinds additively; floor keeps this test regression-
+        # free. CNS-032 iter-1 absorb.
+        assert len(_KINDS) >= 27
+
+
+class TestLegacyTokensBackCompat:
+    """CNS-032 iter-1 blocker absorb: legacy workflow-run records with
+    aggregate `tokens` axis only MUST have output tokens reflected in
+    the aggregate post-reconcile.
+
+    Pre-fix bug: reader synthesized tokens_input = copy(tokens) but
+    left tokens_output = None; middleware reconcile spent tokens_input
+    alone (output tokens discarded); aggregate fallback never fired
+    because it required tokens_input is None. Result: aggregate
+    undercount on v3.1.0 → v3.2.0 upgraded runs.
+
+    Post-fix contract: middleware detects the legacy shape (has aggregate
+    `tokens` axis, no `tokens_output` axis) and spends the full sum
+    (input + output) on the aggregate axis.
+    """
+
+    def test_legacy_run_output_tokens_hit_aggregate(
+        self, tmp_path: Path,
+    ) -> None:
+        # Create a run with ONLY aggregate `tokens` axis (legacy shape).
+        rid = str(uuid.uuid4())
+        create_run(
+            tmp_path,
+            run_id=rid,
+            workflow_id="bug_fix_flow",
+            workflow_version="1.0.0",
+            intent={"kind": "inline_prompt", "payload": "test"},
+            budget={
+                "fail_closed_on_exhaust": True,
+                "tokens": {"limit": 10000, "spent": 0, "remaining": 10000},
+                "cost_usd": {
+                    "limit": 10.0,
+                    "spent": 0.0,
+                    "remaining": 10.0,
+                },
+            },
+            policy_refs=[
+                "ao_kernel/defaults/policies/policy_worktree_profile.v1.json"
+            ],
+            evidence_refs=[".ao/evidence/workflows/x/events.jsonl"],
+        )
+        policy = _policy()
+
+        est_cost, entry = pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=rid,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=[{"role": "user", "content": "hi"}],
+            max_tokens=100,
+            policy=policy,
+        )
+
+        # Reconcile with actual usage: 1000 input + 500 output = 1500 total.
+        post_response_reconcile(
+            workspace_root=tmp_path,
+            run_id=rid,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            catalog_entry=entry,
+            est_cost=est_cost,
+            raw_response_bytes=_ok_response(input_tokens=1000, output_tokens=500),
+            policy=policy,
+        )
+
+        # Aggregate `tokens` must now reflect input + output = 1500.
+        record, _ = load_run(tmp_path, rid)
+        tokens_spent = record["budget"]["tokens"]["spent"]
+        assert tokens_spent == 1500, (
+            f"Legacy aggregate-only run must track sum of input+output; "
+            f"got tokens.spent={tokens_spent} (expected 1500 = 1000 + 500)"
+        )
+
+
+class TestAttemptValidation:
+    """CNS-032 iter-1 absorb: fail-fast on attempt < 1 before transport."""
+
+    def test_governed_call_rejects_attempt_zero(
+        self, tmp_path: Path,
+    ) -> None:
+        from ao_kernel.llm import governed_call
+
+        with pytest.raises(ValueError, match="attempt must be >= 1"):
+            governed_call(
+                messages=[{"role": "user", "content": "x"}],
+                provider_id="anthropic",
+                model="claude-3-5-sonnet",
+                api_key="test",
+                base_url="https://example.test",
+                request_id="req-1",
+                workspace_root=tmp_path,
+                run_id="00000000-0000-4000-8000-000000000001",
+                step_id="step",
+                attempt=0,
+            )
+
+    def test_governed_call_rejects_attempt_negative(
+        self, tmp_path: Path,
+    ) -> None:
+        from ao_kernel.llm import governed_call
+
+        with pytest.raises(ValueError, match="attempt must be >= 1"):
+            governed_call(
+                messages=[{"role": "user", "content": "x"}],
+                provider_id="anthropic",
+                model="claude-3-5-sonnet",
+                api_key="test",
+                base_url="https://example.test",
+                request_id="req-1",
+                workspace_root=tmp_path,
+                run_id="00000000-0000-4000-8000-000000000001",
+                step_id="step",
+                attempt=-5,
+            )
+
+    def test_governed_call_accepts_attempt_one_does_not_raise_validation(
+        self, tmp_path: Path,
+    ) -> None:
+        """attempt=1 is the minimum valid value; the attempt-validation
+        gate does NOT raise ValueError.
+
+        We exercise the pre_dispatch_reserve primitive directly (bypass
+        the full governed_call flow) to confirm the attempt=1 path is
+        accepted. pre_dispatch_reserve calls update_run which would
+        raise CostTrackingConfigError when cost_usd axis is missing —
+        that post-validation raise proves the attempt gate didn't fire.
+        """
+        from ao_kernel.cost.errors import CostTrackingConfigError
+        from ao_kernel.cost.middleware import pre_dispatch_reserve
+
+        rid = _create_run_without_cost_axis(tmp_path)
+        # attempt=1 passes the governed_call gate; downstream reserve
+        # raises CostTrackingConfigError because the run lacks cost_usd.
+        with pytest.raises(CostTrackingConfigError):
+            pre_dispatch_reserve(
+                workspace_root=tmp_path,
+                run_id=rid,
+                step_id="step",
+                attempt=1,  # minimum valid — DOES NOT raise ValueError
+                provider_id="anthropic",
+                model="claude-3-5-sonnet",
+                prompt_messages=[{"role": "user", "content": "x"}],
+                max_tokens=100,
+                policy=_policy(),
+            )
+
+
+class TestAggregateRecomputeWriter:
+    """CNS-032 iter-1 absorb (orange): writer synthesizes aggregate
+    `tokens` from granular axes when the Budget has granular config
+    but no aggregate axis. Symmetric to the reader's back-compat
+    (legacy tokens → tokens_input)."""
+
+    def test_granular_only_budget_writer_synthesizes_aggregate(self) -> None:
+        from ao_kernel.workflow.budget import (
+            Budget,
+            BudgetAxis,
+            budget_to_dict,
+        )
+
+        b = Budget(
+            tokens=None,
+            tokens_input=BudgetAxis(limit=500, spent=100, remaining=400),
+            tokens_output=BudgetAxis(limit=200, spent=50, remaining=150),
+            time_seconds=None,
+            cost_usd=None,
+            fail_closed_on_exhaust=True,
+        )
+        out = budget_to_dict(b)
+        assert "tokens" in out, (
+            "writer must synthesize aggregate tokens from granular axes"
+        )
+        assert out["tokens"]["limit"] == 700  # 500 + 200
+        assert out["tokens"]["spent"] == 150  # 100 + 50
+        assert out["tokens"]["remaining"] == 550  # 400 + 150
 
 
 class TestGovernedCallContract:

--- a/tests/test_cost_middleware_core.py
+++ b/tests/test_cost_middleware_core.py
@@ -1,0 +1,541 @@
+"""Tests for PR-B2 commit 5a — cost middleware + governed_call.
+
+Focused on the middleware core: pre_dispatch_reserve,
+post_response_reconcile, and the governed_call wrapper. Integration
+with 3 caller paths (client/mcp_server/intent_router) lands in
+commit 5b with its own test file.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ao_kernel.cost.catalog import PriceCatalogEntry, clear_catalog_cache
+from ao_kernel.cost.errors import (
+    BudgetExhaustedError,
+    CostTrackingConfigError,
+    LLMUsageMissingError,
+    PriceCatalogNotFoundError,
+)
+from ao_kernel.cost.middleware import (
+    post_response_reconcile,
+    pre_dispatch_reserve,
+)
+from ao_kernel.cost.policy import CostTrackingPolicy, RoutingByCost
+from ao_kernel.workflow.run_store import create_run, load_run
+
+
+@pytest.fixture(autouse=True)
+def _reset_catalog_cache():
+    clear_catalog_cache()
+    yield
+    clear_catalog_cache()
+
+
+def _policy(**overrides: Any) -> CostTrackingPolicy:
+    defaults = dict(
+        enabled=True,
+        price_catalog_path=".ao/cost/catalog.v1.json",
+        spend_ledger_path=".ao/cost/spend.jsonl",
+        fail_closed_on_exhaust=True,
+        strict_freshness=False,
+        fail_closed_on_missing_usage=True,
+        idempotency_window_lines=1000,
+        routing_by_cost=RoutingByCost(enabled=False),
+    )
+    defaults.update(overrides)
+    return CostTrackingPolicy(**defaults)
+
+
+def _entry(**overrides: Any) -> PriceCatalogEntry:
+    base = dict(
+        provider_id="anthropic",
+        model="claude-3-5-sonnet",
+        input_cost_per_1k=0.003,
+        output_cost_per_1k=0.015,
+        cached_input_cost_per_1k=0.0003,
+        currency="USD",
+        billing_unit="per_1k_tokens",
+        effective_date="2024-10-22",
+        vendor_model_id="claude-3-5-sonnet-20241022",
+    )
+    base.update(overrides)
+    return PriceCatalogEntry(**base)
+
+
+def _create_run_with_cost_budget(
+    ws: Path,
+    *,
+    cost_limit_usd: str = "10.00",
+    run_id: str | None = None,
+    with_granular_tokens: bool = False,
+) -> str:
+    """Helper: create a workflow-run with cost_usd axis (required for
+    cost-active pipeline per Option A / CostTrackingConfigError).
+
+    Returns the run_id (caller uses it directly for middleware calls).
+    """
+    rid = run_id or str(uuid.uuid4())
+    budget: dict[str, Any] = {
+        "fail_closed_on_exhaust": True,
+        "cost_usd": {
+            "limit": float(cost_limit_usd),
+            "spent": 0.0,
+            "remaining": float(cost_limit_usd),
+        },
+    }
+    if with_granular_tokens:
+        budget["tokens_input"] = {"limit": 10000, "spent": 0, "remaining": 10000}
+        budget["tokens_output"] = {"limit": 5000, "spent": 0, "remaining": 5000}
+    create_run(
+        ws,
+        run_id=rid,
+        workflow_id="bug_fix_flow",
+        workflow_version="1.0.0",
+        intent={"kind": "inline_prompt", "payload": "test"},
+        budget=budget,
+        policy_refs=[
+            "ao_kernel/defaults/policies/policy_worktree_profile.v1.json"
+        ],
+        evidence_refs=[".ao/evidence/workflows/x/events.jsonl"],
+    )
+    return rid
+
+
+def _create_run_without_cost_axis(ws: Path) -> str:
+    rid = str(uuid.uuid4())
+    create_run(
+        ws,
+        run_id=rid,
+        workflow_id="bug_fix_flow",
+        workflow_version="1.0.0",
+        intent={"kind": "inline_prompt", "payload": "test"},
+        budget={"fail_closed_on_exhaust": True},  # no cost_usd axis
+        policy_refs=[
+            "ao_kernel/defaults/policies/policy_worktree_profile.v1.json"
+        ],
+        evidence_refs=[".ao/evidence/workflows/x/events.jsonl"],
+    )
+    return rid
+
+
+def _ok_response(input_tokens: int, output_tokens: int) -> bytes:
+    return json.dumps(
+        {
+            "text": "response text",
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            },
+        }
+    ).encode("utf-8")
+
+
+def _missing_usage_response() -> bytes:
+    return json.dumps({"text": "response text"}).encode("utf-8")
+
+
+class TestPreDispatchReserveHappyPath:
+    def test_reserves_budget_and_returns_entry(self, tmp_path: Path) -> None:
+        run_id = _create_run_with_cost_budget(tmp_path)
+        policy = _policy()
+        messages = [{"role": "user", "content": "hello " * 100}]
+
+        est_cost, entry = pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-alpha",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=messages,
+            max_tokens=100,
+            policy=policy,
+        )
+
+        assert est_cost > Decimal("0")
+        assert entry.provider_id == "anthropic"
+        assert entry.model == "claude-3-5-sonnet"
+
+        # Verify budget.cost_usd.spent incremented on the run record
+        record, _ = load_run(tmp_path, run_id)
+        spent = record["budget"]["cost_usd"]["spent"]
+        assert spent > 0
+        assert float(spent) == float(est_cost)
+
+
+class TestPreDispatchCatalogMiss:
+    def test_unknown_model_raises(self, tmp_path: Path) -> None:
+        run_id = _create_run_with_cost_budget(tmp_path)
+        with pytest.raises(PriceCatalogNotFoundError) as excinfo:
+            pre_dispatch_reserve(
+                workspace_root=tmp_path,
+                run_id=run_id,
+                step_id="step",
+                attempt=1,
+                provider_id="ghost-provider",
+                model="ghost-model",
+                prompt_messages=[{"role": "user", "content": "x"}],
+                max_tokens=100,
+                policy=_policy(),
+            )
+        assert excinfo.value.provider_id == "ghost-provider"
+        assert excinfo.value.model == "ghost-model"
+
+
+class TestPreDispatchConfigError:
+    def test_no_cost_axis_raises_config_error(self, tmp_path: Path) -> None:
+        """Option A: policy.enabled=true + no cost_usd axis → fail-closed
+        before transport."""
+        run_id = _create_run_without_cost_axis(tmp_path)
+        with pytest.raises(CostTrackingConfigError) as excinfo:
+            pre_dispatch_reserve(
+                workspace_root=tmp_path,
+                run_id=run_id,
+                step_id="step",
+                attempt=1,
+                provider_id="anthropic",
+                model="claude-3-5-sonnet",
+                prompt_messages=[{"role": "user", "content": "x"}],
+                max_tokens=100,
+                policy=_policy(),
+            )
+        assert excinfo.value.run_id == run_id
+
+
+class TestPreDispatchBudgetExhausted:
+    def test_estimate_exceeds_remaining_raises(self, tmp_path: Path) -> None:
+        # Tiny budget — single call with any real prompt exceeds
+        run_id = _create_run_with_cost_budget(
+            tmp_path, cost_limit_usd="0.0001"
+        )
+        with pytest.raises(BudgetExhaustedError) as excinfo:
+            pre_dispatch_reserve(
+                workspace_root=tmp_path,
+                run_id=run_id,
+                step_id="step",
+                attempt=1,
+                provider_id="anthropic",
+                model="claude-3-5-sonnet",
+                prompt_messages=[
+                    {"role": "user", "content": "hello " * 200}
+                ],
+                max_tokens=500,
+                policy=_policy(),
+            )
+        assert excinfo.value.run_id == run_id
+        # No ledger lines written — pre-dispatch guard fired
+        ledger = tmp_path / ".ao" / "cost" / "spend.jsonl"
+        assert not ledger.exists()
+
+
+class TestPostResponseReconcileHappyPath:
+    def test_reconciles_actual_and_writes_ledger(self, tmp_path: Path) -> None:
+        run_id = _create_run_with_cost_budget(tmp_path)
+        policy = _policy()
+
+        # Reserve first
+        est_cost, entry = pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=[{"role": "user", "content": "hello world"}],
+            max_tokens=100,
+            policy=policy,
+        )
+
+        # Reconcile with actual usage
+        post_response_reconcile(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            catalog_entry=entry,
+            est_cost=est_cost,
+            raw_response_bytes=_ok_response(input_tokens=1000, output_tokens=500),
+            policy=policy,
+        )
+
+        # Ledger line exists with actual cost
+        ledger = tmp_path / ".ao" / "cost" / "spend.jsonl"
+        assert ledger.is_file()
+        lines = [
+            json.loads(line)
+            for line in ledger.read_text(encoding="utf-8").strip().splitlines()
+        ]
+        assert len(lines) == 1
+        assert lines[0]["tokens_input"] == 1000
+        assert lines[0]["tokens_output"] == 500
+        assert lines[0]["usage_missing"] is False
+        assert "billing_digest" in lines[0]
+
+    def test_refund_when_actual_less_than_estimate(self, tmp_path: Path) -> None:
+        """actual < estimate → delta negative → budget refunded."""
+        run_id = _create_run_with_cost_budget(tmp_path)
+        policy = _policy()
+
+        est_cost, entry = pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=[{"role": "user", "content": "hello " * 500}],
+            max_tokens=1000,
+            policy=policy,
+        )
+
+        # Actual usage much lower than estimate → refund expected
+        post_response_reconcile(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            catalog_entry=entry,
+            est_cost=est_cost,
+            raw_response_bytes=_ok_response(input_tokens=10, output_tokens=5),
+            policy=policy,
+        )
+
+        record, _ = load_run(tmp_path, run_id)
+        spent = Decimal(str(record["budget"]["cost_usd"]["spent"]))
+        # Spent should reflect actual (small), not estimate (large)
+        assert spent < est_cost
+
+
+class TestPostResponseUsageMissing:
+    def test_fail_closed_raises(self, tmp_path: Path) -> None:
+        run_id = _create_run_with_cost_budget(tmp_path)
+        policy = _policy()  # fail_closed_on_missing_usage=True default
+
+        est_cost, entry = pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=[{"role": "user", "content": "hello"}],
+            max_tokens=100,
+            policy=policy,
+        )
+
+        with pytest.raises(LLMUsageMissingError) as excinfo:
+            post_response_reconcile(
+                workspace_root=tmp_path,
+                run_id=run_id,
+                step_id="step",
+                attempt=1,
+                provider_id="anthropic",
+                model="claude-3-5-sonnet",
+                catalog_entry=entry,
+                est_cost=est_cost,
+                raw_response_bytes=_missing_usage_response(),
+                policy=policy,
+            )
+
+        assert "tokens_input" in excinfo.value.missing_fields
+        assert "tokens_output" in excinfo.value.missing_fields
+
+        # Audit-only ledger entry recorded BEFORE the raise
+        ledger = tmp_path / ".ao" / "cost" / "spend.jsonl"
+        lines = [
+            json.loads(line)
+            for line in ledger.read_text(encoding="utf-8").strip().splitlines()
+        ]
+        assert len(lines) == 1
+        assert lines[0]["usage_missing"] is True
+        assert lines[0]["cost_usd"] == 0.0
+
+    def test_fail_open_warns_and_continues(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """fail_closed_on_missing_usage=false → warn + continue."""
+        run_id = _create_run_with_cost_budget(tmp_path)
+        policy = _policy(fail_closed_on_missing_usage=False)
+
+        est_cost, entry = pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=[{"role": "user", "content": "hello"}],
+            max_tokens=100,
+            policy=policy,
+        )
+
+        with caplog.at_level("WARNING"):
+            # Should NOT raise
+            post_response_reconcile(
+                workspace_root=tmp_path,
+                run_id=run_id,
+                step_id="step",
+                attempt=1,
+                provider_id="anthropic",
+                model="claude-3-5-sonnet",
+                catalog_entry=entry,
+                est_cost=est_cost,
+                raw_response_bytes=_missing_usage_response(),
+                policy=policy,
+            )
+
+        assert any(
+            "missing usage" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+
+class TestEvidenceEmits:
+    def test_cost_estimated_emitted(self, tmp_path: Path) -> None:
+        run_id = _create_run_with_cost_budget(tmp_path)
+
+        pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=[{"role": "user", "content": "hi"}],
+            max_tokens=100,
+            policy=_policy(),
+        )
+
+        events_path = (
+            tmp_path / ".ao" / "evidence" / "workflows" / run_id / "events.jsonl"
+        )
+        # Evidence file should exist and carry llm_cost_estimated event
+        assert events_path.is_file()
+        lines = events_path.read_text(encoding="utf-8").strip().splitlines()
+        kinds = [json.loads(line).get("kind") for line in lines]
+        assert "llm_cost_estimated" in kinds
+
+    def test_spend_recorded_emitted(self, tmp_path: Path) -> None:
+        run_id = _create_run_with_cost_budget(tmp_path)
+        policy = _policy()
+
+        est_cost, entry = pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=[{"role": "user", "content": "hi"}],
+            max_tokens=100,
+            policy=policy,
+        )
+        post_response_reconcile(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            catalog_entry=entry,
+            est_cost=est_cost,
+            raw_response_bytes=_ok_response(50, 20),
+            policy=policy,
+        )
+
+        events_path = (
+            tmp_path / ".ao" / "evidence" / "workflows" / run_id / "events.jsonl"
+        )
+        lines = events_path.read_text(encoding="utf-8").strip().splitlines()
+        kinds = [json.loads(line).get("kind") for line in lines]
+        assert "llm_spend_recorded" in kinds
+
+    def test_usage_missing_emitted(self, tmp_path: Path) -> None:
+        run_id = _create_run_with_cost_budget(tmp_path)
+        policy = _policy(fail_closed_on_missing_usage=False)
+
+        est_cost, entry = pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=[{"role": "user", "content": "hi"}],
+            max_tokens=100,
+            policy=policy,
+        )
+        post_response_reconcile(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            catalog_entry=entry,
+            est_cost=est_cost,
+            raw_response_bytes=_missing_usage_response(),
+            policy=policy,
+        )
+
+        events_path = (
+            tmp_path / ".ao" / "evidence" / "workflows" / run_id / "events.jsonl"
+        )
+        lines = events_path.read_text(encoding="utf-8").strip().splitlines()
+        kinds = [json.loads(line).get("kind") for line in lines]
+        assert "llm_usage_missing" in kinds
+
+
+class TestEvidenceKindsRegistered:
+    def test_three_new_kinds_in_emitter(self) -> None:
+        from ao_kernel.executor.evidence_emitter import _KINDS
+
+        assert "llm_cost_estimated" in _KINDS
+        assert "llm_spend_recorded" in _KINDS
+        assert "llm_usage_missing" in _KINDS
+        # Total should be 24 (PR-B1) + 3 (PR-B2) = 27
+        assert len(_KINDS) == 27
+
+
+class TestGovernedCallContract:
+    def test_governed_call_docstring_pins_streaming_boundary(self) -> None:
+        """Regression guard: plan v5 iter-4 B2 pin — non-streaming only.
+
+        We assert the docstring because streaming behavior is not
+        exercisable at unit level without a full transport mock;
+        end-to-end streaming-bypass regression lands in commit 5b
+        integration tests (test_client_llm_call_stream_untouched).
+        """
+        from ao_kernel.llm import governed_call
+
+        doc = (governed_call.__doc__ or "").lower()
+        assert "non-streaming" in doc, (
+            "governed_call docstring must explicitly state non-streaming "
+            "boundary (plan v5 iter-4 B2 absorb)"
+        )
+        assert "stream" in doc
+        assert "capability_gap" in doc
+        assert "transport_error" in doc
+
+    def test_governed_call_docstring_pins_rich_success_return(self) -> None:
+        """Regression guard: plan v5 iter-4 B1 pin — success returns rich
+        dict with status/normalized/resp_bytes/transport_result/elapsed_ms.
+        """
+        from ao_kernel.llm import governed_call
+
+        doc = (governed_call.__doc__ or "").lower()
+        for token in ("status", "normalized", "resp_bytes", "transport_result", "elapsed_ms"):
+            assert token in doc, (
+                f"governed_call docstring must pin rich return field {token!r}"
+            )

--- a/tests/test_cost_policy.py
+++ b/tests/test_cost_policy.py
@@ -1,0 +1,164 @@
+"""Tests for ``ao_kernel.cost.policy`` — typed policy loader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from ao_kernel.cost.policy import (
+    RoutingByCost,
+    load_cost_policy,
+)
+
+
+def _valid_policy_dict(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "version": "v1",
+        "enabled": False,
+        "price_catalog_path": ".ao/cost/catalog.v1.json",
+        "spend_ledger_path": ".ao/cost/spend.jsonl",
+        "fail_closed_on_exhaust": True,
+        "strict_freshness": False,
+        "fail_closed_on_missing_usage": True,
+        "idempotency_window_lines": 1000,
+        "routing_by_cost": {"enabled": False},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestLoadBundledDefault:
+    def test_bundled_ships_dormant(self, tmp_path: Path) -> None:
+        """Bundled policy is dormant-by-default — operators opt in
+        by dropping a workspace override."""
+        policy = load_cost_policy(tmp_path)
+        assert policy.enabled is False
+
+    def test_bundled_default_knobs(self, tmp_path: Path) -> None:
+        policy = load_cost_policy(tmp_path)
+        assert policy.price_catalog_path == ".ao/cost/catalog.v1.json"
+        assert policy.spend_ledger_path == ".ao/cost/spend.jsonl"
+        assert policy.fail_closed_on_exhaust is True
+        assert policy.strict_freshness is False
+        assert policy.fail_closed_on_missing_usage is True
+        assert policy.idempotency_window_lines == 1000
+        assert policy.routing_by_cost.enabled is False
+
+
+class TestWorkspaceOverride:
+    def _write_override(self, workspace_root: Path, doc: dict[str, Any]) -> None:
+        path = workspace_root / ".ao" / "policies" / "policy_cost_tracking.v1.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(doc, sort_keys=True))
+
+    def test_override_takes_precedence(self, tmp_path: Path) -> None:
+        self._write_override(
+            tmp_path,
+            _valid_policy_dict(enabled=True, idempotency_window_lines=5000),
+        )
+        policy = load_cost_policy(tmp_path)
+        assert policy.enabled is True
+        assert policy.idempotency_window_lines == 5000
+
+    def test_override_malformed_json_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / ".ao" / "policies" / "policy_cost_tracking.v1.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json {{{")
+        with pytest.raises(json.JSONDecodeError):
+            load_cost_policy(tmp_path)
+
+    def test_override_schema_invalid_raises(self, tmp_path: Path) -> None:
+        """Fail-closed: operator error surfaces, not silently fall back
+        to the bundled dormant default."""
+        doc = _valid_policy_dict()
+        del doc["strict_freshness"]  # violate required
+        self._write_override(tmp_path, doc)
+        with pytest.raises(ValidationError):
+            load_cost_policy(tmp_path)
+
+
+class TestInlineOverride:
+    def test_inline_override_bypasses_filesystem(self, tmp_path: Path) -> None:
+        """Callers can pass a dict directly without touching .ao/policies/."""
+        policy = load_cost_policy(
+            tmp_path,
+            override=_valid_policy_dict(enabled=True, idempotency_window_lines=250),
+        )
+        assert policy.enabled is True
+        assert policy.idempotency_window_lines == 250
+
+    def test_inline_override_schema_invalid_raises(self, tmp_path: Path) -> None:
+        bad = _valid_policy_dict()
+        bad["idempotency_window_lines"] = 50  # schema violation (minimum: 100)
+        with pytest.raises(ValidationError):
+            load_cost_policy(tmp_path, override=bad)
+
+
+class TestFailClosedOnExhaustConst:
+    def test_schema_locks_true(self, tmp_path: Path) -> None:
+        """CNS-007 invariant: fail_closed_on_exhaust MUST be true; any
+        override attempting to set it false fails schema validation."""
+        bad = _valid_policy_dict(fail_closed_on_exhaust=False)
+        with pytest.raises(ValidationError):
+            load_cost_policy(tmp_path, override=bad)
+
+
+class TestFailClosedOnMissingUsage:
+    def test_defaults_true(self, tmp_path: Path) -> None:
+        policy = load_cost_policy(tmp_path)
+        assert policy.fail_closed_on_missing_usage is True
+
+    def test_operator_can_set_false(self, tmp_path: Path) -> None:
+        """Audit-only deployments can opt into warn-log-and-continue."""
+        policy = load_cost_policy(
+            tmp_path,
+            override=_valid_policy_dict(fail_closed_on_missing_usage=False),
+        )
+        assert policy.fail_closed_on_missing_usage is False
+
+
+class TestIdempotencyWindowBounds:
+    def test_minimum_100(self, tmp_path: Path) -> None:
+        with pytest.raises(ValidationError):
+            load_cost_policy(
+                tmp_path,
+                override=_valid_policy_dict(idempotency_window_lines=99),
+            )
+
+    def test_maximum_100000(self, tmp_path: Path) -> None:
+        with pytest.raises(ValidationError):
+            load_cost_policy(
+                tmp_path,
+                override=_valid_policy_dict(idempotency_window_lines=100001),
+            )
+
+    def test_boundary_values_accepted(self, tmp_path: Path) -> None:
+        p_min = load_cost_policy(
+            tmp_path,
+            override=_valid_policy_dict(idempotency_window_lines=100),
+        )
+        assert p_min.idempotency_window_lines == 100
+
+        p_max = load_cost_policy(
+            tmp_path,
+            override=_valid_policy_dict(idempotency_window_lines=100000),
+        )
+        assert p_max.idempotency_window_lines == 100000
+
+
+class TestRoutingByCost:
+    def test_defaults_disabled(self, tmp_path: Path) -> None:
+        policy = load_cost_policy(tmp_path)
+        assert isinstance(policy.routing_by_cost, RoutingByCost)
+        assert policy.routing_by_cost.enabled is False
+
+    def test_operator_enables(self, tmp_path: Path) -> None:
+        policy = load_cost_policy(
+            tmp_path,
+            override=_valid_policy_dict(routing_by_cost={"enabled": True}),
+        )
+        assert policy.routing_by_cost.enabled is True

--- a/tests/test_normalizer_usage_strict.py
+++ b/tests/test_normalizer_usage_strict.py
@@ -1,0 +1,141 @@
+"""Tests for ``extract_usage_strict`` — sentinel None for absent
+token fields (PR-B2 v3 iter-1 B3 absorb).
+
+The existing ``extract_usage`` helper defaults absent fields to 0;
+B2 cost middleware needs to distinguish "adapter didn't surface"
+from "actual 0 tokens", hence the strict variant.
+"""
+
+from __future__ import annotations
+
+import json
+
+from ao_kernel._internal.prj_kernel_api.llm_response_normalizer import (
+    UsagePresence,
+    extract_usage,
+    extract_usage_strict,
+)
+
+
+def _resp(obj: dict) -> bytes:
+    return json.dumps(obj).encode("utf-8")
+
+
+class TestStrictPresent:
+    def test_anthropic_style_input_output(self) -> None:
+        p = extract_usage_strict(
+            _resp({"usage": {"input_tokens": 100, "output_tokens": 50}})
+        )
+        assert p.tokens_input == 100
+        assert p.tokens_output == 50
+        assert p.cached_tokens is None
+
+    def test_openai_style_prompt_completion(self) -> None:
+        p = extract_usage_strict(
+            _resp({"usage": {"prompt_tokens": 80, "completion_tokens": 40}})
+        )
+        assert p.tokens_input == 80
+        assert p.tokens_output == 40
+
+    def test_anthropic_cache_read(self) -> None:
+        p = extract_usage_strict(
+            _resp({
+                "usage": {
+                    "input_tokens": 200,
+                    "output_tokens": 50,
+                    "cache_read_input_tokens": 100,
+                }
+            })
+        )
+        assert p.cached_tokens == 100
+
+    def test_openai_cached_tokens(self) -> None:
+        p = extract_usage_strict(
+            _resp({
+                "usage": {
+                    "prompt_tokens": 300,
+                    "completion_tokens": 60,
+                    "cached_tokens": 150,
+                }
+            })
+        )
+        assert p.cached_tokens == 150
+
+
+class TestStrictAbsent:
+    def test_missing_input_is_none(self) -> None:
+        p = extract_usage_strict(
+            _resp({"usage": {"output_tokens": 50}})
+        )
+        assert p.tokens_input is None
+        assert p.tokens_output == 50
+
+    def test_missing_output_is_none(self) -> None:
+        p = extract_usage_strict(
+            _resp({"usage": {"input_tokens": 100}})
+        )
+        assert p.tokens_input == 100
+        assert p.tokens_output is None
+
+    def test_no_usage_dict_all_none(self) -> None:
+        p = extract_usage_strict(_resp({"text": "hello"}))
+        assert p == UsagePresence(None, None, None)
+
+    def test_non_dict_usage_all_none(self) -> None:
+        p = extract_usage_strict(_resp({"usage": "not a dict"}))
+        assert p == UsagePresence(None, None, None)
+
+    def test_non_int_values_treated_as_absent(self) -> None:
+        """Schema contract says int; provider bug (string) → None."""
+        p = extract_usage_strict(
+            _resp({"usage": {"input_tokens": "200", "output_tokens": 40}})
+        )
+        # "200" is str, not int → None
+        assert p.tokens_input is None
+        assert p.tokens_output == 40
+
+    def test_non_json_response_all_none(self) -> None:
+        p = extract_usage_strict(b"not valid json")
+        assert p == UsagePresence(None, None, None)
+
+    def test_non_object_root_all_none(self) -> None:
+        """JSON list or scalar at root → all None (defensive)."""
+        p = extract_usage_strict(_resp([1, 2, 3]))  # type: ignore[arg-type]
+        assert p == UsagePresence(None, None, None)
+
+
+class TestStrictVsLegacy:
+    def test_legacy_extract_usage_still_zero_fallback(self) -> None:
+        """PR-A extract_usage keeps 0-default — no regression."""
+        u = extract_usage(_resp({"usage": {"input_tokens": 100}}))
+        # Missing output_tokens → 0 (legacy behavior)
+        assert u == {"input_tokens": 100, "output_tokens": 0}
+
+    def test_strict_and_legacy_diverge_on_missing(self) -> None:
+        """Same response → different semantics by design."""
+        resp = _resp({"usage": {"input_tokens": 100}})
+        strict = extract_usage_strict(resp)
+        legacy = extract_usage(resp)
+        assert strict.tokens_output is None
+        assert legacy["output_tokens"] == 0
+
+
+class TestZeroVsMissing:
+    def test_actual_zero_preserved(self) -> None:
+        """``tokens_output=0`` in usage dict is PRESERVED (distinct from
+        absent → None). B2 cost middleware treats 0 as valid 'no
+        completion generated' case."""
+        p = extract_usage_strict(
+            _resp({"usage": {"input_tokens": 50, "output_tokens": 0}})
+        )
+        assert p.tokens_output == 0  # not None
+        assert p.tokens_input == 50
+
+    def test_explicit_null_treated_as_absent(self) -> None:
+        """JSON null → Python None → treated as absent (str isinstance check
+        fails); B2 middleware flags usage_missing."""
+        p = extract_usage_strict(
+            _resp({"usage": {"input_tokens": None, "output_tokens": 50}})
+        )
+        assert p.tokens_input is None
+        assert p.tokens_output == 50

--- a/tests/test_workflow_budget.py
+++ b/tests/test_workflow_budget.py
@@ -87,9 +87,34 @@ class TestParse:
 
 
 class TestSerialize:
-    def test_roundtrip_tokens(self) -> None:
+    def test_roundtrip_legacy_tokens_adds_granular_input(self) -> None:
+        """PR-B2 v3 iter-2 B3 absorb: legacy records with only aggregate
+        ``tokens`` are conservatively mapped to granular on read. Reader
+        copies ``tokens`` into ``tokens_input``; writer emits both.
+        This is a documented semantic widening; legacy wire round-trip
+        is no longer byte-identical but the legacy fields remain
+        present and unchanged.
+        """
         raw: dict[str, Any] = {
             "tokens": {"limit": 100, "spent": 10, "remaining": 90},
+            "fail_closed_on_exhaust": True,
+        }
+        out = budget_to_dict(budget_from_dict(raw))
+        # Aggregate preserved byte-identical
+        assert out["tokens"] == raw["tokens"]
+        assert out["fail_closed_on_exhaust"] is True
+        # New: tokens_input appears as a copy of tokens (conservative mapping)
+        assert out["tokens_input"] == raw["tokens"]
+        # tokens_output remains absent (None → OMIT invariant)
+        assert "tokens_output" not in out
+
+    def test_roundtrip_granular_preserved(self) -> None:
+        """When the record declares granular axes explicitly, round-trip
+        preserves them as-is (no back-compat synthesis)."""
+        raw: dict[str, Any] = {
+            "tokens": {"limit": 150, "spent": 0, "remaining": 150},
+            "tokens_input": {"limit": 100, "spent": 0, "remaining": 100},
+            "tokens_output": {"limit": 50, "spent": 0, "remaining": 50},
             "fail_closed_on_exhaust": True,
         }
         out = budget_to_dict(budget_from_dict(raw))

--- a/tests/test_workflow_budget.py
+++ b/tests/test_workflow_budget.py
@@ -87,26 +87,27 @@ class TestParse:
 
 
 class TestSerialize:
-    def test_roundtrip_legacy_tokens_adds_granular_input(self) -> None:
-        """PR-B2 v3 iter-2 B3 absorb: legacy records with only aggregate
-        ``tokens`` are conservatively mapped to granular on read. Reader
-        copies ``tokens`` into ``tokens_input``; writer emits both.
-        This is a documented semantic widening; legacy wire round-trip
-        is no longer byte-identical but the legacy fields remain
-        present and unchanged.
+    def test_roundtrip_legacy_tokens_stays_aggregate_only(self) -> None:
+        """CNS-032 iter-2 absorb (refined from PR-B2 v3 iter-2 B3):
+        legacy records with only the aggregate ``tokens`` axis
+        round-trip WITHOUT synthesizing a granular ``tokens_input``
+        axis.
+
+        Earlier plan v7 §2.5 "conservative mapping" synthesized
+        ``tokens_input = copy(tokens)`` on read, but that synthesized
+        axis diverged from the aggregate after reconcile. Cleaner
+        contract: legacy aggregate-only records stay aggregate-only;
+        granular axes appear only when the wire record declares them.
+        The middleware's aggregate path (case 2) handles legacy spend
+        correctly via the ``tokens=`` kwarg.
         """
         raw: dict[str, Any] = {
             "tokens": {"limit": 100, "spent": 10, "remaining": 90},
             "fail_closed_on_exhaust": True,
         }
         out = budget_to_dict(budget_from_dict(raw))
-        # Aggregate preserved byte-identical
-        assert out["tokens"] == raw["tokens"]
-        assert out["fail_closed_on_exhaust"] is True
-        # New: tokens_input appears as a copy of tokens (conservative mapping)
-        assert out["tokens_input"] == raw["tokens"]
-        # tokens_output remains absent (None → OMIT invariant)
-        assert "tokens_output" not in out
+        # Legacy wire round-trip is byte-identical again (no synth).
+        assert out == raw
 
     def test_roundtrip_granular_preserved(self) -> None:
         """When the record declares granular axes explicitly, round-trip

--- a/tests/test_workflow_budget_axes.py
+++ b/tests/test_workflow_budget_axes.py
@@ -51,8 +51,11 @@ def _granular_budget(
 
 
 class TestBackCompatReader:
-    def test_legacy_tokens_only_populates_tokens_input(self) -> None:
-        """Plan v7 §2.5: reader copies aggregate into tokens_input."""
+    def test_legacy_tokens_only_stays_aggregate_only(self) -> None:
+        """CNS-032 iter-2 absorb: reader does NOT synthesize
+        tokens_input from legacy aggregate. Legacy aggregate-only
+        records stay aggregate-only (middleware's aggregate path
+        handles spend correctly)."""
         raw: dict[str, Any] = {
             "tokens": {"limit": 500, "spent": 50, "remaining": 450},
             "fail_closed_on_exhaust": True,
@@ -60,10 +63,8 @@ class TestBackCompatReader:
         b = budget_from_dict(raw)
         assert b.tokens is not None
         assert b.tokens.limit == 500
-        assert b.tokens_input is not None
-        assert b.tokens_input.limit == 500
-        assert b.tokens_input.spent == 50
-        assert b.tokens_input.remaining == 450
+        # No synthesis — both granular axes remain None.
+        assert b.tokens_input is None
         assert b.tokens_output is None
 
     def test_granular_record_populates_all(self) -> None:

--- a/tests/test_workflow_budget_axes.py
+++ b/tests/test_workflow_budget_axes.py
@@ -1,0 +1,267 @@
+"""Tests for PR-B2 Budget widening — tokens_input/tokens_output axes.
+
+Complements ``test_workflow_budget.py`` (PR-A1 aggregate-axis tests).
+This file focuses on the granular additions + back-compat invariants
+documented in PR-B2 plan v7 §2.5.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from ao_kernel.workflow.budget import (
+    Budget,
+    BudgetAxis,
+    budget_from_dict,
+    budget_to_dict,
+    is_exhausted,
+    record_spend,
+)
+from ao_kernel.workflow.errors import WorkflowBudgetExhaustedError
+
+
+def _granular_budget(
+    *,
+    input_limit: int = 1000,
+    output_limit: int = 500,
+) -> Budget:
+    return Budget(
+        tokens=BudgetAxis(
+            limit=input_limit + output_limit,
+            spent=0,
+            remaining=input_limit + output_limit,
+        ),
+        tokens_input=BudgetAxis(
+            limit=input_limit,
+            spent=0,
+            remaining=input_limit,
+        ),
+        tokens_output=BudgetAxis(
+            limit=output_limit,
+            spent=0,
+            remaining=output_limit,
+        ),
+        time_seconds=None,
+        cost_usd=None,
+        fail_closed_on_exhaust=True,
+    )
+
+
+class TestBackCompatReader:
+    def test_legacy_tokens_only_populates_tokens_input(self) -> None:
+        """Plan v7 §2.5: reader copies aggregate into tokens_input."""
+        raw: dict[str, Any] = {
+            "tokens": {"limit": 500, "spent": 50, "remaining": 450},
+            "fail_closed_on_exhaust": True,
+        }
+        b = budget_from_dict(raw)
+        assert b.tokens is not None
+        assert b.tokens.limit == 500
+        assert b.tokens_input is not None
+        assert b.tokens_input.limit == 500
+        assert b.tokens_input.spent == 50
+        assert b.tokens_input.remaining == 450
+        assert b.tokens_output is None
+
+    def test_granular_record_populates_all(self) -> None:
+        raw: dict[str, Any] = {
+            "tokens": {"limit": 1500, "spent": 0, "remaining": 1500},
+            "tokens_input": {"limit": 1000, "spent": 0, "remaining": 1000},
+            "tokens_output": {"limit": 500, "spent": 0, "remaining": 500},
+            "fail_closed_on_exhaust": True,
+        }
+        b = budget_from_dict(raw)
+        assert b.tokens_input is not None and b.tokens_input.limit == 1000
+        assert b.tokens_output is not None and b.tokens_output.limit == 500
+
+    def test_no_tokens_axes_all_none(self) -> None:
+        """Runs without any token budget config remain fully None on all
+        token axes — no synthesis from absence."""
+        raw: dict[str, Any] = {
+            "cost_usd": {"limit": 1.0, "spent": 0.0, "remaining": 1.0},
+            "fail_closed_on_exhaust": True,
+        }
+        b = budget_from_dict(raw)
+        assert b.tokens is None
+        assert b.tokens_input is None
+        assert b.tokens_output is None
+
+
+class TestWriterInvariant:
+    def test_tokens_output_none_is_omitted(self) -> None:
+        """Plan v7 §2.5: tokens_output=None → absent key, no null."""
+        raw: dict[str, Any] = {
+            "tokens": {"limit": 500, "spent": 0, "remaining": 500},
+            "fail_closed_on_exhaust": True,
+        }
+        b = budget_from_dict(raw)
+        out = budget_to_dict(b)
+        assert "tokens_output" not in out
+        # No explicit None key either
+        for key, value in out.items():
+            assert value is not None, f"{key!r} serialized as None"
+
+    def test_tokens_input_always_emitted_when_configured(self) -> None:
+        b = _granular_budget()
+        out = budget_to_dict(b)
+        assert "tokens_input" in out
+        assert out["tokens_input"]["limit"] == 1000
+
+    def test_aggregate_always_emitted(self) -> None:
+        b = _granular_budget(input_limit=300, output_limit=200)
+        out = budget_to_dict(b)
+        assert out["tokens"]["limit"] == 500  # 300 + 200
+
+
+class TestRecordSpendGranular:
+    def test_granular_spend_adjusts_aggregate(self) -> None:
+        """tokens_input=100 + tokens_output=50 → aggregate +=150."""
+        b = _granular_budget()
+        b2 = record_spend(b, tokens_input=100, tokens_output=50)
+        assert b2.tokens_input is not None and b2.tokens_input.spent == 100
+        assert b2.tokens_output is not None and b2.tokens_output.spent == 50
+        assert b2.tokens is not None and b2.tokens.spent == 150
+
+    def test_granular_spend_only_input(self) -> None:
+        b = _granular_budget()
+        b2 = record_spend(b, tokens_input=200)
+        assert b2.tokens_input is not None and b2.tokens_input.spent == 200
+        # tokens_output unchanged
+        assert b2.tokens_output is not None and b2.tokens_output.spent == 0
+        # Aggregate += 200
+        assert b2.tokens is not None and b2.tokens.spent == 200
+
+    def test_granular_spend_only_output(self) -> None:
+        b = _granular_budget()
+        b2 = record_spend(b, tokens_output=100)
+        assert b2.tokens_output is not None and b2.tokens_output.spent == 100
+        # tokens_input unchanged
+        assert b2.tokens_input is not None and b2.tokens_input.spent == 0
+        assert b2.tokens is not None and b2.tokens.spent == 100
+
+    def test_double_count_guard(self) -> None:
+        """Plan v7 §2.5: passing BOTH aggregate tokens= and granular
+        tokens_input= → ValueError."""
+        b = _granular_budget()
+        with pytest.raises(ValueError, match="EITHER aggregate"):
+            record_spend(b, tokens=150, tokens_input=100, tokens_output=50)
+
+    def test_double_count_guard_input_only(self) -> None:
+        b = _granular_budget()
+        with pytest.raises(ValueError):
+            record_spend(b, tokens=100, tokens_input=100)
+
+    def test_double_count_guard_output_only(self) -> None:
+        b = _granular_budget()
+        with pytest.raises(ValueError):
+            record_spend(b, tokens=100, tokens_output=100)
+
+    def test_granular_exhaust_raises(self) -> None:
+        """Input axis exhausted → WorkflowBudgetExhaustedError."""
+        b = _granular_budget(input_limit=100, output_limit=1000)
+        with pytest.raises(WorkflowBudgetExhaustedError) as excinfo:
+            record_spend(b, tokens_input=150)
+        assert excinfo.value.axis == "tokens_input"
+
+    def test_aggregate_exhaust_after_granular_spend(self) -> None:
+        """Aggregate can exhaust before individual axis when sum exceeds."""
+        b = Budget(
+            tokens=BudgetAxis(limit=100, spent=0, remaining=100),
+            tokens_input=BudgetAxis(limit=200, spent=0, remaining=200),
+            tokens_output=BudgetAxis(limit=200, spent=0, remaining=200),
+            time_seconds=None,
+            cost_usd=None,
+            fail_closed_on_exhaust=True,
+        )
+        with pytest.raises(WorkflowBudgetExhaustedError) as excinfo:
+            record_spend(b, tokens_input=80, tokens_output=30)  # sum=110 > 100
+        assert excinfo.value.axis == "tokens"
+
+
+class TestRecordSpendLegacy:
+    def test_legacy_aggregate_spend_still_works(self) -> None:
+        """PR-A callers pass tokens= alone; unchanged behavior."""
+        b = Budget(
+            tokens=BudgetAxis(limit=500, spent=0, remaining=500),
+            tokens_input=None,
+            tokens_output=None,
+            time_seconds=None,
+            cost_usd=None,
+            fail_closed_on_exhaust=True,
+        )
+        b2 = record_spend(b, tokens=100)
+        assert b2.tokens is not None and b2.tokens.spent == 100
+
+    def test_cost_spend_independent(self) -> None:
+        """cost_usd spend unaffected by granular tokens changes."""
+        b = Budget(
+            tokens=None,
+            tokens_input=None,
+            tokens_output=None,
+            time_seconds=None,
+            cost_usd=BudgetAxis(
+                limit=Decimal("1.00"),
+                spent=Decimal("0"),
+                remaining=Decimal("1.00"),
+            ),
+            fail_closed_on_exhaust=True,
+        )
+        b2 = record_spend(b, cost_usd=Decimal("0.10"))
+        assert b2.cost_usd is not None and b2.cost_usd.spent == Decimal("0.10")
+
+
+class TestIsExhausted:
+    def test_tokens_input_exhausted(self) -> None:
+        b = Budget(
+            tokens=None,
+            tokens_input=BudgetAxis(limit=100, spent=100, remaining=0),
+            tokens_output=None,
+            time_seconds=None,
+            cost_usd=None,
+            fail_closed_on_exhaust=True,
+        )
+        exhausted, axis = is_exhausted(b)
+        assert exhausted is True
+        assert axis == "tokens_input"
+
+    def test_tokens_output_exhausted(self) -> None:
+        b = Budget(
+            tokens=None,
+            tokens_input=None,
+            tokens_output=BudgetAxis(limit=50, spent=50, remaining=0),
+            time_seconds=None,
+            cost_usd=None,
+            fail_closed_on_exhaust=True,
+        )
+        exhausted, axis = is_exhausted(b)
+        assert exhausted is True
+        assert axis == "tokens_output"
+
+    def test_none_exhausted(self) -> None:
+        b = _granular_budget()
+        exhausted, axis = is_exhausted(b)
+        assert exhausted is False
+        assert axis is None
+
+
+class TestSchemaValidation:
+    def test_granular_budget_subsection_validates(self) -> None:
+        """Schema widen (workflow-run.schema.v1.json::$defs/budget) accepts
+        granular axes. Validates the budget sub-schema directly —
+        independent of the full run-record envelope's evolving shape."""
+        from ao_kernel.config import load_default
+        from jsonschema import Draft202012Validator
+
+        schema = load_default("schemas", "workflow-run.schema.v1.json")
+        # Extract $defs/budget sub-schema
+        budget_schema = schema["$defs"]["budget"]
+        serialized = budget_to_dict(_granular_budget())
+        # Wire presence: all three token axes + fail_closed
+        assert "tokens" in serialized
+        assert "tokens_input" in serialized
+        assert "tokens_output" in serialized
+        # Subschema validator — ensures new fields shape-correct
+        Draft202012Validator(budget_schema).validate(serialized)


### PR DESCRIPTION
## Summary

FAZ-B PR 3/9 — runtime for the B0-pinned cost contract. LLM calls now run through `ao_kernel.llm.governed_call`, a non-streaming composition wrapper with optional cost governance (pre-dispatch estimate + budget cap fail-closed + post-response reconcile + canonical billing digest idempotent ledger). Dormant by default.

- New public package `ao_kernel/cost/` — 6 modules (~2400 LOC): errors (9 typed), cost_math (Decimal-stable), catalog (checksum + stale gate + 300s LRU), ledger (canonical billing digest idempotency), policy (typed loader), middleware (reserve + reconcile).
- New facade `ao_kernel.llm.governed_call(...)` non-streaming wrapper with rich dict success return + envelope preserve for CAPABILITY_GAP / TRANSPORT_ERROR.
- 3 caller entrypoints wired: `AoKernelClient.llm_call` (opt-in), `mcp_server.handle_llm_call` (opt-in + MCP tool schema widen), `workflow.intent_router._llm_classify` (bypass-only).
- Budget granular axes widen + normalizer strict helper + evidence `_KINDS` 24 → 27.
- Streaming cost tracking: FAZ-C deferred (documented gap).

## Adversarial consensus

Plan `.claude/plans/PR-B2-IMPLEMENTATION-PLAN.md` iterated v1 → v7 across 7 Codex cycles (CNS-20260417-031, thread `019d9aa8`). Final verdict: `AGREE, ready_for_impl=true`. Absorb trail: 3 iter-1 blockers (Budget shape, 4-caller surface, normalizer contract), 3 iter-2 (execute_request signature, cost_usd optionality, writer invariant), 3 iter-3 (client context, return contract, intent_router API), 4 iter-4 (success dict, streaming boundary, commit 5 split, injected_messages), 1 iter-5 (intent_router pseudo-code), 1 iter-6 (IntentClassificationError constructor), iter-7 GREEN.

## DAG (7 commits, squash-on-merge)

1. `3b70343` prep — errors + cost_math + policy + schema widens
2. `c598649` catalog loader + checksum + stale gate
3. `d6fa588` ledger + canonical billing digest
4. `f84c11e` Budget widen + normalizer strict + schema delta
5a. `e9878a7` middleware + governed_call + evidence +3
5b. `da58005` entrypoint plumbing — client + mcp + intent_router
6. `033f64f` docs + CHANGELOG

## Gate status

- ruff check ao_kernel/ tests/ → all checks passed
- mypy ao_kernel/ → no issues
- pytest tests/ → **1823 passed / 3 skipped** (+121 net tests; 0 regressions)

## Locked invariants

- `policy.enabled=true` + `budget.cost_usd is None` → `CostTrackingConfigError` fail-closed BEFORE transport (Option A)
- CAS retry: fixed `update_run(max_retries=3)` — no policy knob
- Ledger rotation: FAZ-B follow-up (NOT FAZ-C evidence rotation)
- Streaming cost: FAZ-C deferred
- MCP params: `ao_run_id` / `ao_step_id` / `ao_attempt` namespace-prefixed
- Reservation HOLDS on transport error (retry-storm guard)
- Ledger write order: `ledger append → evidence emit → optional raise`

## Test plan

- [ ] CI green (lint, test 3.11/3.12/3.13, coverage, extras-install, typecheck)
- [ ] Post-impl Codex review (new CNS thread — CNS-20260417-032)
- [ ] Merge via M2 pattern (approval=0 → merge --squash → restore=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)