### PR TITLE
test(pr-b2): CNS-032 post-merge scope — E2E + injected_messages + concurrent ledger

### DIFF
--- a/tests/test_build_request_with_context_injected.py
+++ b/tests/test_build_request_with_context_injected.py
@@ -1,0 +1,175 @@
+"""Behavioral tests for ``build_request_with_context`` — ``injected_messages``
+return field.
+
+CNS-032 post-merge scope absorb: v5 iter-4 B4 added ``injected_messages``
+to the return dict of ``build_request_with_context`` so cost middleware can
+estimate prompt tokens over the effective (context-injected) prompt rather
+than the caller-supplied raw messages. The field is currently pinned via a
+docstring-guard regression test; this file upgrades to an observable
+behavioral contract — the dict shape and content are asserted directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ao_kernel.llm import build_request_with_context
+
+
+def _base_kwargs() -> dict[str, Any]:
+    return dict(
+        provider_id="anthropic",
+        model="claude-3-5-sonnet",
+        base_url="https://api.anthropic.test/v1",
+        api_key="test-key",
+        request_id="req-injected-1",
+    )
+
+
+class TestInjectedMessagesFieldPresence:
+    def test_field_present_with_session_context(self) -> None:
+        """When session_context is non-empty, the return dict carries
+        an ``injected_messages`` field."""
+        messages = [{"role": "user", "content": "hello"}]
+        session_context = {
+            "ephemeral_decisions": [
+                {
+                    "key": "api.endpoint",
+                    "value": "/v1/users",
+                    "confidence": 0.9,
+                    "created_at": "2026-04-17T10:00:00+00:00",
+                },
+            ],
+        }
+
+        result = build_request_with_context(
+            messages=messages,
+            session_context=session_context,
+            **_base_kwargs(),
+        )
+
+        assert "injected_messages" in result
+        assert isinstance(result["injected_messages"], list)
+
+    def test_field_present_without_session_context(self) -> None:
+        """When session_context is None, ``injected_messages`` is still
+        populated (reflecting the unmodified input messages) so callers
+        never have to branch on presence."""
+        messages = [{"role": "user", "content": "hi"}]
+        result = build_request_with_context(
+            messages=messages,
+            **_base_kwargs(),
+        )
+
+        assert "injected_messages" in result
+        assert result["injected_messages"] == messages
+
+
+class TestInjectedMessagesRoundtrip:
+    def test_decisions_inject_system_preamble(self) -> None:
+        """session_context with ephemeral_decisions → compile_context
+        produces a non-empty preamble → injected_messages prepends a
+        system message that differs from the raw input."""
+        raw_messages = [
+            {"role": "user", "content": "list users"},
+        ]
+        session_context = {
+            "ephemeral_decisions": [
+                {
+                    "key": "api.endpoint",
+                    "value": "/v1/users",
+                    "confidence": 0.9,
+                    "created_at": "2026-04-17T10:00:00+00:00",
+                },
+                {
+                    "key": "api.method",
+                    "value": "GET",
+                    "confidence": 0.85,
+                    "created_at": "2026-04-17T10:01:00+00:00",
+                },
+            ],
+        }
+
+        result = build_request_with_context(
+            messages=raw_messages,
+            session_context=session_context,
+            **_base_kwargs(),
+        )
+
+        injected = result["injected_messages"]
+        assert injected != raw_messages, (
+            "session decisions must change the effective prompt"
+        )
+        # System preamble is the first element.
+        assert injected[0].get("role") == "system"
+        preamble = injected[0].get("content", "")
+        assert "api.endpoint" in preamble
+        assert "/v1/users" in preamble
+        assert "api.method" in preamble
+        # Original user turn is preserved (tail intact).
+        assert injected[-1] == raw_messages[-1]
+
+    def test_existing_system_message_merged_not_replaced(self) -> None:
+        """If the caller already has a system message, the preamble is
+        prefixed to it rather than replacing it (both pieces survive)."""
+        raw_messages = [
+            {"role": "system", "content": "You are a concise assistant."},
+            {"role": "user", "content": "hello"},
+        ]
+        session_context = {
+            "ephemeral_decisions": [
+                {
+                    "key": "tone.preference",
+                    "value": "terse",
+                    "confidence": 0.8,
+                    "created_at": "2026-04-17T10:00:00+00:00",
+                },
+            ],
+        }
+
+        result = build_request_with_context(
+            messages=raw_messages,
+            session_context=session_context,
+            **_base_kwargs(),
+        )
+
+        injected = result["injected_messages"]
+        assert injected[0]["role"] == "system"
+        merged = injected[0]["content"]
+        # Original system content retained.
+        assert "concise assistant" in merged
+        # Preamble prepended with the decision.
+        assert "tone.preference" in merged or "terse" in merged
+
+    def test_empty_session_context_is_identity(self) -> None:
+        """session_context with no decisions → compile_context yields an
+        empty preamble → injected_messages == raw input (no mutation)."""
+        raw_messages = [{"role": "user", "content": "hi"}]
+        session_context: dict[str, Any] = {"ephemeral_decisions": []}
+
+        result = build_request_with_context(
+            messages=raw_messages,
+            session_context=session_context,
+            **_base_kwargs(),
+        )
+
+        assert result["injected_messages"] == raw_messages
+
+
+class TestInjectedMessagesBackwardCompat:
+    def test_caller_can_ignore_extra_field(self) -> None:
+        """Pre-B2 callers extract ``body_bytes``/``url``/``headers`` and
+        never read ``injected_messages``; the additive field does not
+        break the existing dict contract."""
+        messages = [{"role": "user", "content": "hello"}]
+        result = build_request_with_context(
+            messages=messages,
+            session_context={"ephemeral_decisions": []},
+            **_base_kwargs(),
+        )
+
+        for required_key in ("url", "headers", "body_bytes"):
+            assert required_key in result, (
+                f"build_request_with_context must preserve {required_key!r} "
+                f"even with injected_messages field added"
+            )

--- a/tests/test_cost_governed_call_e2e.py
+++ b/tests/test_cost_governed_call_e2e.py
@@ -1,0 +1,632 @@
+"""End-to-end tests for ``governed_call`` with a mocked transport.
+
+CNS-032 post-merge scope absorb: the middleware-core tests in
+``test_cost_middleware_core.py`` exercise ``pre_dispatch_reserve`` and
+``post_response_reconcile`` as primitives. This file closes the gap by
+driving the full cost-active ``governed_call`` pipeline — build → transport
+→ normalize → reconcile → ledger → evidence — with ``execute_request``
+monkeypatched to return canned bytes.
+
+Scope:
+
+- OK flow (cost-active) — rich success dict, budget decremented, ledger
+  appended, two evidence events (``llm_cost_estimated`` +
+  ``llm_spend_recorded``) emitted.
+- CAPABILITY_GAP envelope — no transport call, no ledger, no evidence.
+- TRANSPORT_ERROR envelope — reservation HELD per Q5 iter-1,
+  ``llm_cost_estimated`` emitted but no ``llm_spend_recorded``.
+- Bypass path — any of the four identity kwargs missing → transparent
+  pre-B2 flow (build + transport + normalize), no cost hooks.
+- Refund semantics — actual < estimate → negative delta ledger entry.
+- Usage-missing — fail-closed raise AND fail-open warn branches.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ao_kernel.cost.catalog import clear_catalog_cache
+from ao_kernel.cost.errors import LLMUsageMissingError
+from ao_kernel.llm import governed_call
+from ao_kernel.workflow.run_store import create_run, load_run
+
+
+# ─── Fixtures + helpers ──────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_catalog_cache():
+    clear_catalog_cache()
+    yield
+    clear_catalog_cache()
+
+
+def _write_enabled_policy(
+    workspace_root: Path,
+    *,
+    fail_closed_on_missing_usage: bool = True,
+) -> None:
+    """Drop a workspace override that flips the cost policy to enabled.
+
+    The bundled default ``policy_cost_tracking.v1.json`` ships dormant
+    (``enabled=false``). ``governed_call`` short-circuits to bypass mode
+    when policy is dormant, so cost-active tests need this override.
+    """
+    policy_dir = workspace_root / ".ao" / "policies"
+    policy_dir.mkdir(parents=True, exist_ok=True)
+    (policy_dir / "policy_cost_tracking.v1.json").write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "enabled": True,
+                "price_catalog_path": ".ao/cost/catalog.v1.json",
+                "spend_ledger_path": ".ao/cost/spend.jsonl",
+                "fail_closed_on_exhaust": True,
+                "strict_freshness": False,
+                "fail_closed_on_missing_usage": fail_closed_on_missing_usage,
+                "idempotency_window_lines": 1000,
+                "routing_by_cost": {"enabled": False},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _create_run_with_cost_budget(
+    workspace_root: Path,
+    *,
+    cost_limit_usd: float = 10.0,
+) -> str:
+    """Create a workflow-run with a cost_usd axis (required for
+    cost-active governed_call per Option A)."""
+    run_id = str(uuid.uuid4())
+    create_run(
+        workspace_root,
+        run_id=run_id,
+        workflow_id="bug_fix_flow",
+        workflow_version="1.0.0",
+        intent={"kind": "inline_prompt", "payload": "test"},
+        budget={
+            "fail_closed_on_exhaust": True,
+            "cost_usd": {
+                "limit": cost_limit_usd,
+                "spent": 0.0,
+                "remaining": cost_limit_usd,
+            },
+        },
+        policy_refs=[
+            "ao_kernel/defaults/policies/policy_worktree_profile.v1.json"
+        ],
+        evidence_refs=[".ao/evidence/workflows/x/events.jsonl"],
+    )
+    return run_id
+
+
+def _ok_transport_result(
+    input_tokens: int = 50,
+    output_tokens: int = 20,
+    *,
+    http_status: int = 200,
+    elapsed_ms: int = 120,
+) -> dict[str, Any]:
+    """Canned transport response with Anthropic-style usage payload."""
+    body = {
+        "text": "mock response",
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        },
+    }
+    return {
+        "status": "OK",
+        "http_status": http_status,
+        "resp_bytes": json.dumps(body).encode("utf-8"),
+        "elapsed_ms": elapsed_ms,
+    }
+
+
+def _missing_usage_transport_result() -> dict[str, Any]:
+    return {
+        "status": "OK",
+        "http_status": 200,
+        "resp_bytes": json.dumps({"text": "mock response"}).encode("utf-8"),
+        "elapsed_ms": 100,
+    }
+
+
+def _error_transport_result() -> dict[str, Any]:
+    return {
+        "status": "ERROR",
+        "http_status": 504,
+        "error_code": "TIMEOUT",
+        "elapsed_ms": 30000,
+    }
+
+
+def _read_ledger_lines(workspace_root: Path) -> list[dict[str, Any]]:
+    ledger = workspace_root / ".ao" / "cost" / "spend.jsonl"
+    if not ledger.is_file():
+        return []
+    return [
+        json.loads(line)
+        for line in ledger.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _read_evidence_kinds(workspace_root: Path, run_id: str) -> list[str]:
+    events_path = (
+        workspace_root
+        / ".ao"
+        / "evidence"
+        / "workflows"
+        / run_id
+        / "events.jsonl"
+    )
+    if not events_path.is_file():
+        return []
+    return [
+        json.loads(line).get("kind", "")
+        for line in events_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _base_call_kwargs() -> dict[str, Any]:
+    return dict(
+        messages=[{"role": "user", "content": "hello world"}],
+        provider_id="anthropic",
+        model="claude-3-5-sonnet",
+        api_key="test-key",
+        base_url="https://api.anthropic.test/v1",
+        request_id="req-e2e-1",
+    )
+
+
+# ─── CAPABILITY_GAP envelope ─────────────────────────────────────────
+
+
+class TestCapabilityGapEnvelope:
+    def test_missing_capability_returns_envelope_no_transport(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """check_capabilities → (False, _, ['streaming']) → envelope with
+        status=CAPABILITY_GAP. Transport MUST NOT be called."""
+        call_count = {"transport": 0}
+
+        def _fail_if_called(**_kwargs: Any) -> dict[str, Any]:
+            call_count["transport"] += 1
+            raise AssertionError(
+                "execute_request must not be called after CAPABILITY_GAP"
+            )
+
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (False, "anthropic", ["streaming"]),
+        )
+        monkeypatch.setattr("ao_kernel.llm.execute_request", _fail_if_called)
+
+        result = governed_call(**_base_call_kwargs())
+
+        assert result["status"] == "CAPABILITY_GAP"
+        assert result["missing"] == ["streaming"]
+        assert result["text"] == ""
+        assert result["provider_id"] == "anthropic"
+        assert result["model"] == "claude-3-5-sonnet"
+        assert result["request_id"] == "req-e2e-1"
+        assert call_count["transport"] == 0
+
+    def test_capability_gap_cost_active_no_ledger_no_evidence(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cost-active wiring + capability gap → bail before reserve.
+        No ledger lines, no evidence emits, budget untouched."""
+        _write_enabled_policy(tmp_path)
+        run_id = _create_run_with_cost_budget(tmp_path)
+
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (False, "anthropic", ["vision"]),
+        )
+
+        result = governed_call(
+            **_base_call_kwargs(),
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-A",
+            attempt=1,
+        )
+
+        assert result["status"] == "CAPABILITY_GAP"
+        assert _read_ledger_lines(tmp_path) == []
+        assert _read_evidence_kinds(tmp_path, run_id) == []
+        record, _ = load_run(tmp_path, run_id)
+        assert record["budget"]["cost_usd"]["spent"] == 0.0
+
+
+# ─── TRANSPORT_ERROR envelope ────────────────────────────────────────
+
+
+class TestTransportErrorEnvelope:
+    def test_transport_error_returns_envelope(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (True, "anthropic", []),
+        )
+        monkeypatch.setattr(
+            "ao_kernel.llm.execute_request",
+            lambda **_: _error_transport_result(),
+        )
+
+        result = governed_call(**_base_call_kwargs())
+
+        assert result["status"] == "TRANSPORT_ERROR"
+        assert result["error_code"] == "TIMEOUT"
+        assert result["http_status"] == 504
+        assert result["text"] == ""
+        assert result["provider_id"] == "anthropic"
+        assert result["model"] == "claude-3-5-sonnet"
+        assert result["request_id"] == "req-e2e-1"
+        assert result["elapsed_ms"] == 30000
+
+    def test_transport_error_cost_active_reservation_held(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Transport error post-reserve: reservation HELD (Q5 iter-1),
+        ledger EMPTY (no llm_spend_recorded), ``llm_cost_estimated``
+        DID emit during pre_dispatch_reserve."""
+        _write_enabled_policy(tmp_path)
+        run_id = _create_run_with_cost_budget(tmp_path)
+
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (True, "anthropic", []),
+        )
+        monkeypatch.setattr(
+            "ao_kernel.llm.execute_request",
+            lambda **_: _error_transport_result(),
+        )
+
+        result = governed_call(
+            **_base_call_kwargs(),
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-A",
+            attempt=1,
+        )
+
+        assert result["status"] == "TRANSPORT_ERROR"
+        assert _read_ledger_lines(tmp_path) == []
+        record, _ = load_run(tmp_path, run_id)
+        assert record["budget"]["cost_usd"]["spent"] > 0.0
+
+        kinds = _read_evidence_kinds(tmp_path, run_id)
+        assert "llm_cost_estimated" in kinds
+        assert "llm_spend_recorded" not in kinds
+
+
+# ─── OK flow (cost-active) ───────────────────────────────────────────
+
+
+class TestOkCostActive:
+    def test_full_cost_active_flow_rich_success_dict(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_enabled_policy(tmp_path)
+        run_id = _create_run_with_cost_budget(tmp_path)
+
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (True, "anthropic", []),
+        )
+        monkeypatch.setattr(
+            "ao_kernel.llm.execute_request",
+            lambda **_: _ok_transport_result(
+                input_tokens=1000, output_tokens=500, elapsed_ms=420
+            ),
+        )
+
+        result = governed_call(
+            **_base_call_kwargs(),
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-A",
+            attempt=1,
+        )
+
+        assert result["status"] == "OK"
+        assert "normalized" in result
+        assert "resp_bytes" in result
+        assert "transport_result" in result
+        assert result["elapsed_ms"] == 420
+        assert result["request_id"] == "req-e2e-1"
+        assert isinstance(result["resp_bytes"], bytes)
+        assert isinstance(result["normalized"], dict)
+        assert result["normalized"].get("usage") is not None
+
+    def test_full_cost_active_flow_ledger_appended(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_enabled_policy(tmp_path)
+        run_id = _create_run_with_cost_budget(tmp_path)
+
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (True, "anthropic", []),
+        )
+        monkeypatch.setattr(
+            "ao_kernel.llm.execute_request",
+            lambda **_: _ok_transport_result(
+                input_tokens=1000, output_tokens=500
+            ),
+        )
+
+        governed_call(
+            **_base_call_kwargs(),
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-A",
+            attempt=1,
+        )
+
+        lines = _read_ledger_lines(tmp_path)
+        assert len(lines) == 1
+        entry = lines[0]
+        assert entry["run_id"] == run_id
+        assert entry["step_id"] == "step-A"
+        assert entry["attempt"] == 1
+        assert entry["tokens_input"] == 1000
+        assert entry["tokens_output"] == 500
+        assert entry["usage_missing"] is False
+        assert entry["billing_digest"].startswith("sha256:")
+        assert entry["cost_usd"] > 0
+
+    def test_full_cost_active_flow_budget_decremented(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_enabled_policy(tmp_path)
+        run_id = _create_run_with_cost_budget(tmp_path, cost_limit_usd=10.0)
+
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (True, "anthropic", []),
+        )
+        monkeypatch.setattr(
+            "ao_kernel.llm.execute_request",
+            lambda **_: _ok_transport_result(
+                input_tokens=1000, output_tokens=500
+            ),
+        )
+
+        governed_call(
+            **_base_call_kwargs(),
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-A",
+            attempt=1,
+        )
+
+        record, _ = load_run(tmp_path, run_id)
+        spent = Decimal(str(record["budget"]["cost_usd"]["spent"]))
+        # 1000 input tokens * $0.003/1k + 500 output tokens * $0.015/1k
+        # = $0.003 + $0.0075 = $0.0105
+        assert spent == Decimal("0.0105")
+        remaining = Decimal(str(record["budget"]["cost_usd"]["remaining"]))
+        assert remaining == Decimal("10.0") - spent
+
+    def test_full_cost_active_flow_two_evidence_events(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PR-B2 additive kinds — pre-dispatch + post-response both fire."""
+        _write_enabled_policy(tmp_path)
+        run_id = _create_run_with_cost_budget(tmp_path)
+
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (True, "anthropic", []),
+        )
+        monkeypatch.setattr(
+            "ao_kernel.llm.execute_request",
+            lambda **_: _ok_transport_result(),
+        )
+
+        governed_call(
+            **_base_call_kwargs(),
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-A",
+            attempt=1,
+        )
+
+        kinds = _read_evidence_kinds(tmp_path, run_id)
+        assert "llm_cost_estimated" in kinds
+        assert "llm_spend_recorded" in kinds
+        # usage_missing must NOT emit on the happy path.
+        assert "llm_usage_missing" not in kinds
+
+
+# ─── Refund semantics ────────────────────────────────────────────────
+
+
+class TestRefundSemantics:
+    def test_actual_less_than_estimate_refunds_budget(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reserve reservation is later adjusted down when actual usage
+        lands below estimate. Ledger records ACTUAL (not estimate)."""
+        _write_enabled_policy(tmp_path)
+        run_id = _create_run_with_cost_budget(tmp_path, cost_limit_usd=100.0)
+
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (True, "anthropic", []),
+        )
+        # Huge max_tokens → large estimate, but actual usage is tiny.
+        monkeypatch.setattr(
+            "ao_kernel.llm.execute_request",
+            lambda **_: _ok_transport_result(input_tokens=10, output_tokens=5),
+        )
+
+        kwargs = dict(_base_call_kwargs(), max_tokens=2000)
+        kwargs["messages"] = [{"role": "user", "content": "hello " * 500}]
+
+        governed_call(
+            **kwargs,
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-A",
+            attempt=1,
+        )
+
+        record, _ = load_run(tmp_path, run_id)
+        spent = Decimal(str(record["budget"]["cost_usd"]["spent"]))
+        # actual = 10 * 0.003/1k + 5 * 0.015/1k = 0.00003 + 0.000075 = 0.000105
+        expected_actual = Decimal("0.000105")
+        assert spent == expected_actual, (
+            f"spent={spent} should reconcile to ACTUAL cost, not estimate"
+        )
+
+        lines = _read_ledger_lines(tmp_path)
+        assert len(lines) == 1
+        # Cost in ledger tracks actual (float rounding tolerated)
+        assert abs(lines[0]["cost_usd"] - float(expected_actual)) < 1e-9
+
+
+# ─── Usage-missing ───────────────────────────────────────────────────
+
+
+class TestUsageMissing:
+    def test_fail_closed_raises_llm_usage_missing_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cost-active + usage missing + fail_closed=true → raise.
+        Audit-only ledger entry is still recorded BEFORE the raise."""
+        _write_enabled_policy(tmp_path, fail_closed_on_missing_usage=True)
+        run_id = _create_run_with_cost_budget(tmp_path)
+
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (True, "anthropic", []),
+        )
+        monkeypatch.setattr(
+            "ao_kernel.llm.execute_request",
+            lambda **_: _missing_usage_transport_result(),
+        )
+
+        with pytest.raises(LLMUsageMissingError) as excinfo:
+            governed_call(
+                **_base_call_kwargs(),
+                workspace_root=tmp_path,
+                run_id=run_id,
+                step_id="step-A",
+                attempt=1,
+            )
+
+        assert "tokens_input" in excinfo.value.missing_fields
+        assert "tokens_output" in excinfo.value.missing_fields
+
+        lines = _read_ledger_lines(tmp_path)
+        assert len(lines) == 1
+        assert lines[0]["usage_missing"] is True
+        assert lines[0]["cost_usd"] == 0.0
+
+        kinds = _read_evidence_kinds(tmp_path, run_id)
+        assert "llm_usage_missing" in kinds
+        assert "llm_cost_estimated" in kinds
+        assert "llm_spend_recorded" not in kinds
+
+    def test_fail_open_warns_and_returns_ok(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_enabled_policy(tmp_path, fail_closed_on_missing_usage=False)
+        run_id = _create_run_with_cost_budget(tmp_path)
+
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (True, "anthropic", []),
+        )
+        monkeypatch.setattr(
+            "ao_kernel.llm.execute_request",
+            lambda **_: _missing_usage_transport_result(),
+        )
+
+        # Does NOT raise — warn-log path.
+        result = governed_call(
+            **_base_call_kwargs(),
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-A",
+            attempt=1,
+        )
+
+        assert result["status"] == "OK"
+        lines = _read_ledger_lines(tmp_path)
+        assert len(lines) == 1
+        assert lines[0]["usage_missing"] is True
+
+
+# ─── Bypass path ─────────────────────────────────────────────────────
+
+
+class TestBypassPath:
+    def test_no_identity_kwargs_bypasses_cost_runtime(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All cost-identity kwargs None → transparent pre-B2 flow:
+        no ledger write, no evidence emit, no policy load. Success
+        return is still the rich dict shape."""
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (True, "anthropic", []),
+        )
+        monkeypatch.setattr(
+            "ao_kernel.llm.execute_request",
+            lambda **_: _ok_transport_result(),
+        )
+
+        result = governed_call(**_base_call_kwargs())
+
+        assert result["status"] == "OK"
+        assert "normalized" in result
+        assert _read_ledger_lines(tmp_path) == []
+
+    def test_dormant_policy_bypasses_cost_runtime(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All identity kwargs present but bundled policy is dormant →
+        bypass. No override written → bundled default (enabled=false)
+        is loaded."""
+        run_id = _create_run_with_cost_budget(tmp_path)
+
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (True, "anthropic", []),
+        )
+        monkeypatch.setattr(
+            "ao_kernel.llm.execute_request",
+            lambda **_: _ok_transport_result(),
+        )
+
+        result = governed_call(
+            **_base_call_kwargs(),
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-A",
+            attempt=1,
+        )
+
+        assert result["status"] == "OK"
+        # Dormant policy → no ledger, no evidence, budget untouched.
+        assert _read_ledger_lines(tmp_path) == []
+        assert _read_evidence_kinds(tmp_path, run_id) == []
+        record, _ = load_run(tmp_path, run_id)
+        assert record["budget"]["cost_usd"]["spent"] == 0.0

--- a/tests/test_cost_ledger_concurrent.py
+++ b/tests/test_cost_ledger_concurrent.py
@@ -1,0 +1,360 @@
+"""Concurrent-writer + CAS retry exhaustion tests for cost runtime.
+
+CNS-032 post-merge scope absorb: the single-writer ``record_spend`` paths
+are covered in ``test_cost_ledger.py``. This file exercises:
+
+- Parallel ``record_spend`` invocations across multiple threads — the
+  sidecar ``file_lock`` must serialise writes so the final JSONL has
+  no interleaved bytes and every distinct ``(run_id, step_id, attempt)``
+  key produces exactly one line.
+- Concurrent writes with IDENTICAL idempotency keys — first writer wins,
+  subsequent writers no-op silently under the lock (warn-log path).
+- CAS retry exhaustion — when ``update_run`` exhausts ``max_retries=3``
+  inside ``pre_dispatch_reserve``, the ``WorkflowCASConflictError``
+  propagates through the middleware to the caller.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import uuid
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ao_kernel.cost.catalog import clear_catalog_cache
+from ao_kernel.cost.ledger import SpendEvent, record_spend
+from ao_kernel.cost.policy import CostTrackingPolicy, RoutingByCost
+from ao_kernel.workflow.errors import WorkflowCASConflictError
+from ao_kernel.workflow.run_store import create_run
+
+
+@pytest.fixture(autouse=True)
+def _reset_catalog_cache():
+    clear_catalog_cache()
+    yield
+    clear_catalog_cache()
+
+
+def _policy(**overrides: Any) -> CostTrackingPolicy:
+    defaults = dict(
+        enabled=True,
+        price_catalog_path=".ao/cost/catalog.v1.json",
+        spend_ledger_path=".ao/cost/spend.jsonl",
+        fail_closed_on_exhaust=True,
+        strict_freshness=False,
+        fail_closed_on_missing_usage=True,
+        idempotency_window_lines=1000,
+        routing_by_cost=RoutingByCost(enabled=False),
+    )
+    defaults.update(overrides)
+    return CostTrackingPolicy(**defaults)
+
+
+def _event(
+    *,
+    run_id: str = "11111111-1111-4111-8111-111111111111",
+    step_id: str = "step-alpha",
+    attempt: int = 1,
+    cost_usd: Decimal = Decimal("0.0105"),
+) -> SpendEvent:
+    return SpendEvent(
+        run_id=run_id,
+        step_id=step_id,
+        attempt=attempt,
+        provider_id="anthropic",
+        model="claude-3-5-sonnet",
+        tokens_input=1000,
+        tokens_output=500,
+        cost_usd=cost_usd,
+        ts="2026-04-17T12:00:00+00:00",
+    )
+
+
+def _read_ledger(workspace_root: Path) -> list[dict[str, Any]]:
+    ledger = workspace_root / ".ao" / "cost" / "spend.jsonl"
+    if not ledger.is_file():
+        return []
+    return [
+        json.loads(line)
+        for line in ledger.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _run_threads(
+    target: Any,
+    args_per_thread: list[tuple[Any, ...]],
+) -> list[BaseException]:
+    """Spawn one thread per args tuple, join all, return any captured
+    exceptions in thread-start order."""
+    captured: list[BaseException | None] = [None] * len(args_per_thread)
+
+    def _wrap(idx: int, args: tuple[Any, ...]) -> None:
+        try:
+            target(*args)
+        except BaseException as exc:
+            captured[idx] = exc
+
+    threads = [
+        threading.Thread(target=_wrap, args=(i, args))
+        for i, args in enumerate(args_per_thread)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10.0)
+        assert not t.is_alive(), f"thread {t} did not finish within 10s"
+    return [e for e in captured if e is not None]
+
+
+# ─── Parallel distinct keys — file_lock serialization ────────────────
+
+
+class TestConcurrentDistinctKeys:
+    def test_all_distinct_keys_appended(self, tmp_path: Path) -> None:
+        """Five threads record distinct events in parallel. The sidecar
+        lock serialises writes → the ledger contains exactly 5 lines,
+        one per thread, all schema-valid JSON."""
+        policy = _policy()
+        events = [
+            _event(step_id=f"step-{i}", attempt=1, cost_usd=Decimal("0.01"))
+            for i in range(5)
+        ]
+        errors = _run_threads(
+            lambda e: record_spend(tmp_path, e, policy=policy),
+            [(e,) for e in events],
+        )
+        assert errors == []
+
+        lines = _read_ledger(tmp_path)
+        assert len(lines) == 5
+        step_ids = {line["step_id"] for line in lines}
+        assert step_ids == {f"step-{i}" for i in range(5)}
+
+    def test_concurrent_writes_not_interleaved(self, tmp_path: Path) -> None:
+        """Ten threads with distinct events. Every line must parse as a
+        complete JSON object — proof that fsync + lock prevent torn
+        writes."""
+        policy = _policy()
+        events = [
+            _event(
+                run_id=str(uuid.uuid4()),
+                step_id=f"step-{i}",
+                attempt=1,
+                cost_usd=Decimal("0.005"),
+            )
+            for i in range(10)
+        ]
+        errors = _run_threads(
+            lambda e: record_spend(tmp_path, e, policy=policy),
+            [(e,) for e in events],
+        )
+        assert errors == []
+
+        # Reading succeeds: every line is a full JSON object.
+        lines = _read_ledger(tmp_path)
+        assert len(lines) == 10
+        for line in lines:
+            assert "billing_digest" in line
+            assert "run_id" in line
+            assert "attempt" in line
+
+    def test_higher_concurrency_preserves_line_count(
+        self, tmp_path: Path
+    ) -> None:
+        """Twenty distinct events in parallel — harsher stress test for
+        the lock. Line count remains exact."""
+        policy = _policy()
+        events = [
+            _event(
+                run_id=str(uuid.uuid4()),
+                step_id=f"stress-{i}",
+                attempt=1,
+            )
+            for i in range(20)
+        ]
+        errors = _run_threads(
+            lambda e: record_spend(tmp_path, e, policy=policy),
+            [(e,) for e in events],
+        )
+        assert errors == []
+        assert len(_read_ledger(tmp_path)) == 20
+
+
+# ─── Parallel identical keys — idempotency under lock ────────────────
+
+
+class TestConcurrentIdenticalKeys:
+    def test_same_digest_concurrent_only_one_line(
+        self, tmp_path: Path
+    ) -> None:
+        """Five threads submit an identical event. The first writer wins
+        the lock and appends; the rest scan the tail, find their key with
+        the same digest, and no-op. Final count: 1."""
+        policy = _policy()
+        shared_event = _event()
+        errors = _run_threads(
+            lambda: record_spend(tmp_path, shared_event, policy=policy),
+            [() for _ in range(5)],
+        )
+        assert errors == []
+
+        lines = _read_ledger(tmp_path)
+        assert len(lines) == 1
+        assert lines[0]["run_id"] == shared_event.run_id
+        assert lines[0]["step_id"] == shared_event.step_id
+
+
+# ─── CAS retry exhaustion ───────────────────────────────────────────
+
+
+class TestCASRetryExhaustion:
+    def test_update_run_conflict_propagates_from_pre_dispatch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Simulate a persistent CAS conflict inside update_run. The
+        middleware asks for ``max_retries=3``; when the retry loop
+        exhausts, ``WorkflowCASConflictError`` propagates unchanged."""
+        from ao_kernel.cost import middleware
+
+        run_id = str(uuid.uuid4())
+        create_run(
+            tmp_path,
+            run_id=run_id,
+            workflow_id="bug_fix_flow",
+            workflow_version="1.0.0",
+            intent={"kind": "inline_prompt", "payload": "x"},
+            budget={
+                "fail_closed_on_exhaust": True,
+                "cost_usd": {
+                    "limit": 10.0,
+                    "spent": 0.0,
+                    "remaining": 10.0,
+                },
+            },
+            policy_refs=[
+                "ao_kernel/defaults/policies/policy_worktree_profile.v1.json"
+            ],
+            evidence_refs=[".ao/evidence/workflows/x/events.jsonl"],
+        )
+
+        call_count = {"n": 0}
+
+        def _always_conflict(*_args: Any, **_kwargs: Any) -> None:
+            call_count["n"] += 1
+            raise WorkflowCASConflictError(
+                run_id=run_id,
+                expected_revision="expected",
+                actual_revision="actual",
+            )
+
+        monkeypatch.setattr(middleware, "update_run", _always_conflict)
+
+        with pytest.raises(WorkflowCASConflictError) as excinfo:
+            middleware.pre_dispatch_reserve(
+                workspace_root=tmp_path,
+                run_id=run_id,
+                step_id="step",
+                attempt=1,
+                provider_id="anthropic",
+                model="claude-3-5-sonnet",
+                prompt_messages=[{"role": "user", "content": "hi"}],
+                max_tokens=100,
+                policy=_policy(),
+            )
+
+        assert excinfo.value.run_id == run_id
+        # Middleware calls update_run exactly once per reserve; the
+        # internal retry loop lives inside run_store.update_run. Our
+        # monkeypatch simulates the post-exhaustion raise.
+        assert call_count["n"] == 1
+
+    def test_update_run_conflict_propagates_from_post_reconcile(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same contract on the reconcile side — CAS exhaustion
+        during budget reconcile raises through the middleware."""
+        from ao_kernel.cost import middleware
+        from ao_kernel.cost.catalog import PriceCatalogEntry
+
+        run_id = str(uuid.uuid4())
+        create_run(
+            tmp_path,
+            run_id=run_id,
+            workflow_id="bug_fix_flow",
+            workflow_version="1.0.0",
+            intent={"kind": "inline_prompt", "payload": "x"},
+            budget={
+                "fail_closed_on_exhaust": True,
+                "cost_usd": {
+                    "limit": 10.0,
+                    "spent": 0.0,
+                    "remaining": 10.0,
+                },
+            },
+            policy_refs=[
+                "ao_kernel/defaults/policies/policy_worktree_profile.v1.json"
+            ],
+            evidence_refs=[".ao/evidence/workflows/x/events.jsonl"],
+        )
+
+        def _always_conflict(*_args: Any, **_kwargs: Any) -> None:
+            raise WorkflowCASConflictError(
+                run_id=run_id,
+                expected_revision="expected",
+                actual_revision="actual",
+            )
+
+        monkeypatch.setattr(middleware, "update_run", _always_conflict)
+
+        entry = PriceCatalogEntry(
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            input_cost_per_1k=0.003,
+            output_cost_per_1k=0.015,
+            cached_input_cost_per_1k=0.0003,
+            currency="USD",
+            billing_unit="per_1k_tokens",
+            effective_date="2024-10-22",
+            vendor_model_id="claude-3-5-sonnet-20241022",
+        )
+        raw = json.dumps(
+            {"usage": {"input_tokens": 100, "output_tokens": 50}}
+        ).encode("utf-8")
+
+        with pytest.raises(WorkflowCASConflictError):
+            middleware.post_response_reconcile(
+                workspace_root=tmp_path,
+                run_id=run_id,
+                step_id="step",
+                attempt=1,
+                provider_id="anthropic",
+                model="claude-3-5-sonnet",
+                catalog_entry=entry,
+                est_cost=Decimal("0.01"),
+                raw_response_bytes=raw,
+                policy=_policy(),
+            )
+
+
+# ─── Dormant bypass under concurrency ────────────────────────────────
+
+
+class TestDormantConcurrent:
+    def test_dormant_policy_no_file_under_concurrency(
+        self, tmp_path: Path
+    ) -> None:
+        """Even with many concurrent callers, dormant policy must NOT
+        create the ledger file or acquire the lock."""
+        policy = _policy(enabled=False)
+        errors = _run_threads(
+            lambda: record_spend(tmp_path, _event(), policy=policy),
+            [() for _ in range(5)],
+        )
+        assert errors == []
+        ledger = tmp_path / ".ao" / "cost" / "spend.jsonl"
+        assert not ledger.exists()


### PR DESCRIPTION
## Summary

- **tests/test_cost_governed_call_e2e.py** (13 tests): drives the full cost-active `governed_call` pipeline with a monkeypatched `execute_request` — covers OK rich success dict, CAPABILITY_GAP / TRANSPORT_ERROR envelopes, ledger append + budget decrement, dual `llm_cost_estimated` / `llm_spend_recorded` emits, refund semantics, usage-missing fail-closed + fail-open branches, and bypass path.
- **tests/test_build_request_with_context_injected.py** (6 tests): upgrades the v5 iter-4 B4 `injected_messages` return field from a docstring regression guard to an observable behavioral contract (presence, decision-driven preamble injection, system-message merge, empty-context identity, backward compat).
- **tests/test_cost_ledger_concurrent.py** (7 tests): exercises the sidecar `file_lock` under `threading.Thread ×N` — distinct keys serialize to N lines, identical keys idempotent-no-op to 1 line, no torn JSONL bytes under 20-thread stress. CAS retry exhaustion asserts `WorkflowCASConflictError` propagates through `pre_dispatch_reserve` + `post_response_reconcile`.

## Context

Post-merge scope items flagged by Codex post-impl review (CNS-032) on PR-B2 ([#99](https://github.com/Halildeu/ao-kernel/pull/99)). The middleware-core tests in `test_cost_middleware_core.py` exercise `pre_dispatch_reserve` / `post_response_reconcile` as primitives; these 3 files close the E2E pipeline + concurrency + behavioral-contract gaps.

Baseline: 1828 passed after B2 merge → **1854 passed + 3 skipped** (1857 total, +26 tests additive). No production code touched.

## Test plan

- [x] `ruff check ao_kernel/ tests/` → All checks passed
- [x] `mypy ao_kernel/ --ignore-missing-imports` → Success: no issues found in 165 source files
- [x] `pytest tests/ -q` → 1854 passed, 3 skipped in 36.70s
- [x] Individual files: 13 E2E + 6 injected + 7 concurrent = 26/26 green
- [ ] CI green on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)