### PR TITLE
feat(pr-b5): metrics export — Prometheus textfile + [metrics] extra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install -e ".[dev,llm]"
+        run: pip install -e ".[dev,llm,metrics]"
       - name: Run tests
         run: pytest tests/ -v --cov=ao_kernel --cov-branch --cov-report=term-missing
 
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install dependencies
-        run: pip install -e ".[dev,llm]"
+        run: pip install -e ".[dev,llm,metrics]"
       - name: Run tests with coverage gate
         run: |
           pytest tests/ --cov=ao_kernel --cov-branch --cov-report=xml --cov-report=term-missing
@@ -73,7 +73,7 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install dependencies
-        run: pip install -e ".[dev,llm,mcp]"
+        run: pip install -e ".[dev,llm,mcp,metrics]"
       - name: Mypy
         run: mypy ao_kernel/
 
@@ -92,3 +92,4 @@ jobs:
           pip install -e ".[otel]"     && python -c "import opentelemetry; print('otel OK')"
           pip install -e ".[mcp]"      && python -c "import mcp; print('mcp OK')"
           pip install -e ".[mcp-http]" && python -c "import starlette, uvicorn; print('mcp-http OK')"
+          pip install -e ".[metrics]"  && python -c "import prometheus_client; print('metrics OK')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,113 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — FAZ-B PR-B5 (metrics export — Prometheus textfile + `[metrics]` extra)
+
+**FAZ-B Tranche B 5/9 — evidence-derived metrics export. Stateless
+CLI scans `events.jsonl` + run_store + coordination registry →
+eight Prometheus metric families. Dormant-by-default; opt-in via
+`policy_metrics.v1.json`. `[metrics]` optional extra keeps
+prometheus-client out of the core dependency tree.**
+
+- New `ao_kernel.metrics/` public package:
+  * `policy.py` — `MetricsPolicy` frozen dataclass + `load_metrics_policy`
+    with bundled-default + workspace-override resolution +
+    `InvalidLabelAllowlistError` runtime defence against
+    programmatic schema bypass.
+  * `registry.py` — lazy `prometheus_client` adapter (mirrors
+    `telemetry._check_otel` pattern). `build_registry(policy,
+    include_llm_metrics=True)` returns a `BuiltRegistry` container
+    with the eight metric families or `None` when the extra is
+    missing.
+  * `derivation.py` — `derive_metrics_from_evidence(ws, built, policy)`
+    scans `.ao/evidence/workflows/*/events.jsonl`, dispatches events
+    to metric populators, reads `state.v1.json.completed_at` for
+    cancelled runs (plan v4 Q3 A), and queries
+    `coordination.registry.live_claims_count()` for the active gauge
+    (plan v4 Q1 A). Fail-closed on corrupt JSONL
+    (`EvidenceSourceCorruptedError`).
+  * `export.py` — `generate_textfile(built, metrics_dormant,
+    cost_dormant)` serializes with banner comments for dormant /
+    cost-dormant / extra-missing paths.
+  * `errors.py` — five typed errors inheriting from `MetricsError`
+    base.
+
+- **Eight metric families** (`ao_llm_call_duration_seconds` histogram,
+  `ao_llm_tokens_used_total` counter, `ao_llm_cost_usd_total`
+  counter, `ao_llm_usage_missing_total` counter, `ao_policy_check_total`
+  counter, `ao_workflow_duration_seconds` histogram,
+  `ao_claim_active_total` gauge, `ao_claim_takeover_total` counter).
+  LLM duration source canonicalized to
+  `llm_spend_recorded.duration_ms` — the cost middleware emits the
+  transport-layer `elapsed_ms` value (plan v4 iter-2 fix; reserve /
+  normalize / reconcile overhead excluded).
+
+- **`llm_spend_recorded.duration_ms` B2 event extension** (additive,
+  backward-compatible). `ao_kernel/llm.py::governed_call` threads
+  `transport_result["elapsed_ms"]` into `post_response_reconcile`,
+  which emits the field only when present. Pre-B5 callers that omit
+  the kwarg retain the legacy payload shape (plan v4 R13).
+
+- **`coordination.registry.live_claims_count(workspace_root)` helper**
+  — module-level read-only snapshot. Dormant policy → empty dict;
+  otherwise loads the `_index` + each per-resource SSOT under
+  `claims.lock` and applies the liveness predicate. The gauge
+  source that prevents evidence-derived net-count races (plan v4
+  Q1 A).
+
+- **`workflow.run_store.list_terminal_runs(workspace_root)` helper**
+  — internal read-only scan of `.ao/runs/*/state.v1.json` for
+  terminal records (completed / failed / cancelled). No CAS lock or
+  schema validation; malformed files are skipped silently (tolerates
+  concurrent writer drift).
+
+- **CLI surface** (`ao-kernel metrics …`):
+  * `metrics export` — cumulative Prometheus textfile; atomic
+    `--output` write via `write_text_atomic`. Exit codes: 0 success
+    / dormant-graceful, 1 user error, 2 internal (corrupt JSONL),
+    3 `[metrics]` extra missing informational.
+  * `metrics debug-query` — non-Prometheus JSON query for operator
+    debugging. `--since` is timezone-strict (`parse_iso8601_strict`
+    rejects naive input); `--run` filters to a single run directory.
+    Never emits Prometheus textfile.
+
+- **Cost-disjunction invariant**: when
+  `policy_cost_tracking.v1.json.enabled=false`, the metrics export
+  builds the registry with `include_llm_metrics=False` and the
+  `ao_llm_*` family is **absent** from the textfile (no metadata,
+  no zero-synthetic samples). Operator banner:
+  `# ao-kernel metrics: cost tracking dormant …`.
+
+- **Cardinality hard-warning** in `docs/METRICS.md` §6.6: `agent_id`
+  and `model` advanced labels must be bounded enumerations, not
+  ephemeral / per-request strings. Schema closed-enum constrains
+  names, not values — documented so operators avoid storage bombs.
+
+- **Bundled Grafana dashboard** (`docs/grafana/ao_kernel_default.v1.json`):
+  Grafana 10+ schema, 8 panels, `DS_PROMETHEUS` template variable,
+  panel→metric matrix test guards the drift between dashboard and
+  runtime. `docs/grafana/README.md` provides four import recipes
+  (UI / file provisioning / K8s ConfigMap / HTTP API).
+
+- **`[metrics]` optional extra** — `prometheus-client>=0.20.0` via
+  `pip install ao-kernel[metrics]`. `enterprise` meta-extra widened
+  to include it.
+
+- **Tests** (~65 new across 6 files):
+  * `test_metrics_policy.py` (13)
+  * `test_metrics_registry.py` (13)
+  * `test_cost_duration_ms.py` (4)
+  * `test_metrics_derivation.py` (13)
+  * `test_metrics_export.py` (6)
+  * `test_metrics_cli.py` (4)
+  * `test_metrics_helpers.py` (5)
+  * `test_metrics_debug_query.py` (12)
+  * `test_grafana_dashboard_shape.py` (8)
+
+- Plan trace: CNS-20260417-035 (thread `019d9cec`), 3-iter plan-time
+  absorb (REVISE → PARTIAL → AGREE). Full plan at
+  [`.claude/plans/PR-B5-IMPLEMENTATION-PLAN.md`](../.claude/plans/PR-B5-IMPLEMENTATION-PLAN.md).
+
 ### Added — FAZ-B PR-B6 (review AI + commit AI workflow runtime — thin, driver-owned)
 
 **FAZ-B Tranche B 6/9 — runtime for the B0-pinned review/commit AI

--- a/ao_kernel/_internal/metrics/__init__.py
+++ b/ao_kernel/_internal/metrics/__init__.py
@@ -1,0 +1,7 @@
+"""Internal metrics helpers (CLI handlers, debug-query).
+
+PR-B5 split: public facade lives at :mod:`ao_kernel.metrics`; the
+argparse glue + non-Prometheus debug query surface live here so the
+public package stays narrow (policy + errors + registry + derivation
++ export only).
+"""

--- a/ao_kernel/_internal/metrics/cli_handlers.py
+++ b/ao_kernel/_internal/metrics/cli_handlers.py
@@ -55,6 +55,26 @@ def cmd_metrics_export(args: Any) -> int:
     # operator without failing the export.
     cost_dormant = _is_cost_dormant(workspace)
 
+    # Post-impl review CNS-036 iter-1 A2 absorb: dormant policy →
+    # banner-only textfile, no body. Skip registry construction
+    # entirely so `prometheus_client` cannot synthesize zero samples
+    # for label-less families (Gauge / scalar Counter emit `0.0`
+    # even without observations, which the docs and tests promised
+    # would be absent).
+    if not metrics_policy.enabled:
+        payload = _banner_only_textfile(
+            metrics_dormant=True,
+            cost_dormant=cost_dormant,
+        )
+        try:
+            _emit_output(payload, args)
+        except (OSError, PermissionError) as exc:
+            print(
+                f"error: output write failed — {exc}", file=sys.stderr,
+            )
+            return 1
+        return 0
+
     # Build registry. LLM families skipped when cost-dormant so they
     # cannot appear in the textfile even as metadata (plan v4 §2
     # invariant).
@@ -68,7 +88,7 @@ def cmd_metrics_export(args: Any) -> int:
         if not is_metrics_available():
             payload = generate_textfile(
                 built=None,
-                metrics_dormant=not metrics_policy.enabled,
+                metrics_dormant=False,
                 cost_dormant=cost_dormant,
             )
             _emit_output(payload, args)
@@ -88,12 +108,13 @@ def cmd_metrics_export(args: Any) -> int:
         print(f"error: corrupt evidence JSONL — {exc}", file=sys.stderr)
         return 2
 
-    # Serialize. Dormant / cost-dormant banners prepend naturally via
-    # the export helper; callers rely on the resulting text being
-    # Prometheus-parseable even with comments attached.
+    # Serialize. Cost-dormant banner prepends naturally via the export
+    # helper; the body carries Prometheus-parseable samples for the
+    # non-LLM families (always present) + LLM families (present only
+    # when cost tracking is active).
     payload = generate_textfile(
         built,
-        metrics_dormant=not metrics_policy.enabled,
+        metrics_dormant=False,
         cost_dormant=cost_dormant,
     )
 
@@ -104,6 +125,29 @@ def cmd_metrics_export(args: Any) -> int:
         return 1
 
     return 0
+
+
+def _banner_only_textfile(
+    *, metrics_dormant: bool, cost_dormant: bool
+) -> str:
+    """Emit just the banner comments, no metric body.
+
+    Used by the dormant branch (post-impl review CNS-036 iter-1 A2
+    absorb). Keeps the textfile a valid Prometheus exposition — the
+    `# `-prefixed lines parse as comments — while ensuring zero
+    synthetic samples leak out when the policy is off.
+    """
+    from ao_kernel.metrics.export import (
+        _COST_DORMANT_BANNER,
+        _DORMANT_BANNER,
+    )
+
+    header = ""
+    if metrics_dormant:
+        header += _DORMANT_BANNER
+    if cost_dormant:
+        header += _COST_DORMANT_BANNER
+    return header
 
 
 def _emit_output(payload: str, args: Any) -> None:
@@ -122,7 +166,13 @@ def _emit_output(payload: str, args: Any) -> None:
 def _resolve_workspace(args: Any) -> Path:
     """Resolve workspace root from ``--workspace-root`` or CWD lookup.
 
-    Mirrors :func:`ao_kernel._internal.evidence.cli_handlers._resolve_workspace`.
+    :func:`ao_kernel.config.workspace_root` returns the ``.ao/``
+    directory itself; downstream consumers (``metrics/policy.py``,
+    ``cost/policy.py``, ``metrics/derivation.py``) prepend ``.ao``
+    themselves. We therefore normalize to the parent of ``.ao`` so
+    ``workspace_root / ".ao" / ...`` builds a real path instead of
+    the doubled ``.ao/.ao/...`` (post-impl review CNS-20260417-036
+    iter-1 A1 absorb).
     """
     ws = getattr(args, "workspace_root", None)
     if ws:
@@ -133,6 +183,8 @@ def _resolve_workspace(args: Any) -> Path:
     if resolved is None:
         print("error: no .ao/ workspace found", file=sys.stderr)
         sys.exit(1)
+    if resolved.name == ".ao":
+        return resolved.parent
     return resolved
 
 

--- a/ao_kernel/_internal/metrics/cli_handlers.py
+++ b/ao_kernel/_internal/metrics/cli_handlers.py
@@ -1,0 +1,159 @@
+"""CLI handlers for ``ao-kernel metrics`` subcommands (PR-B5 C3).
+
+Dispatched from :mod:`ao_kernel.cli`. Returns int exit code.
+
+Exit code mapping (plan v4 §2.6):
+
+- 0: success (textfile emitted to stdout/--output) or dormant-graceful
+     (banner-only textfile; Grafana shows "No data" with explicit
+     comment rationale).
+- 1: user error (workspace resolve fail, --output path not writable,
+     incompatible flags).
+- 2: internal (corrupt evidence JSONL → :class:`EvidenceSourceCorruptedError`).
+- 3: extra-missing informational (``pip install 'ao-kernel[metrics]'``
+     prompt; textfile banner-only).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def cmd_metrics_export(args: Any) -> int:
+    """Handle ``ao-kernel metrics export`` (cumulative Prometheus textfile).
+
+    Full workspace scan → Prometheus exposition format. Plan v4 §2.6
+    explicit invariants:
+
+    - No ``--since`` or ``--run`` filtering (these break Prometheus
+      counter semantics; debug-query is the debug surface for
+      windowed queries).
+    - Output is atomic when ``--output`` is supplied (tmp + fsync +
+      rename via :func:`write_text_atomic`).
+    - Dormant policy → exit 0 with banner comment (Grafana "No data").
+    - Cost-dormant (cost tracking dormant) → LLM metric family absent;
+      banner explains the cause.
+    """
+    from ao_kernel.metrics.derivation import derive_metrics_from_evidence
+    from ao_kernel.metrics.errors import EvidenceSourceCorruptedError
+    from ao_kernel.metrics.export import generate_textfile
+    from ao_kernel.metrics.policy import load_metrics_policy
+    from ao_kernel.metrics.registry import build_registry, is_metrics_available
+
+    workspace = _resolve_workspace(args)
+
+    # Load metrics policy (fail-closed on corrupt override).
+    metrics_policy = load_metrics_policy(workspace)
+
+    # Load cost policy to decide cost-disjunction gate. The policy
+    # loader is imported lazily so the metrics export CLI does not
+    # pull in the cost runtime when it is not needed (e.g., dormant
+    # workspace). Cost policy absence or load failure is treated as
+    # cost-dormant — the banner surfaces the condition to the
+    # operator without failing the export.
+    cost_dormant = _is_cost_dormant(workspace)
+
+    # Build registry. LLM families skipped when cost-dormant so they
+    # cannot appear in the textfile even as metadata (plan v4 §2
+    # invariant).
+    built = build_registry(
+        metrics_policy,
+        include_llm_metrics=not cost_dormant,
+    )
+
+    # Extra-missing branch: prometheus-client not installed.
+    if built is None:
+        if not is_metrics_available():
+            payload = generate_textfile(
+                built=None,
+                metrics_dormant=not metrics_policy.enabled,
+                cost_dormant=cost_dormant,
+            )
+            _emit_output(payload, args)
+            return 3
+        # Unexpected: is_metrics_available() returned False earlier
+        # but build_registry returned None anyway — treat as internal.
+        print(
+            "error: metrics registry could not be constructed",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Populate metrics families from evidence + run_store + coordination.
+    try:
+        derive_metrics_from_evidence(workspace, built, metrics_policy)
+    except EvidenceSourceCorruptedError as exc:
+        print(f"error: corrupt evidence JSONL — {exc}", file=sys.stderr)
+        return 2
+
+    # Serialize. Dormant / cost-dormant banners prepend naturally via
+    # the export helper; callers rely on the resulting text being
+    # Prometheus-parseable even with comments attached.
+    payload = generate_textfile(
+        built,
+        metrics_dormant=not metrics_policy.enabled,
+        cost_dormant=cost_dormant,
+    )
+
+    try:
+        _emit_output(payload, args)
+    except (OSError, PermissionError) as exc:
+        print(f"error: output write failed — {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+def _emit_output(payload: str, args: Any) -> None:
+    """Write ``payload`` to ``--output`` (atomic) or stdout."""
+    output_path = getattr(args, "output", None)
+    if output_path:
+        from ao_kernel._internal.shared.utils import write_text_atomic
+
+        write_text_atomic(Path(output_path), payload)
+        return
+    sys.stdout.write(payload)
+    if not payload.endswith("\n"):
+        sys.stdout.write("\n")
+
+
+def _resolve_workspace(args: Any) -> Path:
+    """Resolve workspace root from ``--workspace-root`` or CWD lookup.
+
+    Mirrors :func:`ao_kernel._internal.evidence.cli_handlers._resolve_workspace`.
+    """
+    ws = getattr(args, "workspace_root", None)
+    if ws:
+        return Path(ws)
+    from ao_kernel.config import workspace_root
+
+    resolved = workspace_root()
+    if resolved is None:
+        print("error: no .ao/ workspace found", file=sys.stderr)
+        sys.exit(1)
+    return resolved
+
+
+def _is_cost_dormant(workspace: Path) -> bool:
+    """Return ``True`` when cost tracking is effectively off.
+
+    A missing cost policy file or a load failure counts as dormant —
+    the metrics CLI surfaces this via the cost-dormant banner rather
+    than aborting the export.
+    """
+    try:
+        from ao_kernel.cost.policy import load_cost_policy
+    except ImportError:
+        return True
+    try:
+        policy = load_cost_policy(workspace)
+    except Exception:
+        return True
+    return not policy.enabled
+
+
+__all__ = [
+    "cmd_metrics_export",
+]

--- a/ao_kernel/_internal/metrics/debug_query.py
+++ b/ao_kernel/_internal/metrics/debug_query.py
@@ -1,0 +1,214 @@
+"""Debug-query subcommand (PR-B5 C3b) — non-Prometheus JSON query surface.
+
+``ao-kernel metrics debug-query --since <ISO8601> [--run <id>]`` emits
+a JSON document with filtered evidence events and summary aggregates.
+Never emits Prometheus textfile — the design explicitly separates the
+cumulative-only textfile export (``metrics export``) from the
+windowed / run-scoped ad-hoc query surface so operators can debug
+live workspaces without breaking scrape counter semantics.
+
+Plan v4 iter-2 absorb: ``--since`` is strict timezone-aware. The
+underlying :func:`ao_kernel._internal.shared.utils.parse_iso8601`
+helper accepts naive ISO strings but evidence timestamps are
+always aware — mixing the two produces silent semantic drift, so
+this module adds :func:`parse_iso8601_strict` that enforces the
+contract at the CLI boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ao_kernel._internal.shared.utils import parse_iso8601
+from ao_kernel.metrics.errors import (
+    EvidenceSourceCorruptedError,
+    EvidenceSourceMissingError,
+)
+
+
+def parse_iso8601_strict(value: str) -> datetime:
+    """Parse an ISO-8601 timestamp with mandatory timezone information.
+
+    Wraps :func:`ao_kernel._internal.shared.utils.parse_iso8601` and
+    tightens the contract:
+
+    - Naive input (``tzinfo is None``) is rejected. Operators must
+      supply ``Z`` or an explicit ``+HH:MM`` offset.
+    - Non-string input is rejected (``argparse type=parse_iso8601_strict``
+      converts anyway, but the guard keeps the error message tight).
+    - Epoch integers are rejected implicitly because ``parse_iso8601``
+      only accepts strings.
+
+    Raises:
+        ValueError: Either the string cannot be parsed or the parsed
+            datetime is naive. The argparse dispatcher surfaces the
+            raised message as a CLI error.
+    """
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            "--since: ISO-8601 string required (got empty / non-string)"
+        )
+    parsed = parse_iso8601(value)
+    if parsed is None:
+        raise ValueError(
+            f"--since: ISO-8601 parse failed for {value!r}; "
+            f"expected e.g. '2026-04-17T18:00:00Z' or "
+            f"'2026-04-17T18:00:00+00:00'"
+        )
+    if parsed.tzinfo is None:
+        raise ValueError(
+            f"--since: timezone required, use 'Z' or '+HH:MM' offset "
+            f"(got {value!r})"
+        )
+    return parsed
+
+
+def cmd_metrics_debug_query(args: Any) -> int:
+    """Handle ``ao-kernel metrics debug-query``.
+
+    Returns JSON to stdout (default) or ``--output``. The output is a
+    single JSON object with three top-level keys:
+
+    - ``filter``: the applied filters (since, run_id, applied_at).
+    - ``summary``: event counts by kind.
+    - ``events``: list of matching events sorted by (ts, seq).
+
+    Exit codes:
+
+    - 0 success (events list may be empty).
+    - 1 user error (invalid --since, --run not found).
+    - 2 internal (corrupt JSONL).
+    """
+    workspace = _resolve_workspace(args)
+    since = getattr(args, "since", None)
+    run_filter = getattr(args, "run", None)
+
+    # --since is argparse-validated by the type=parse_iso8601_strict
+    # callback, so we receive either None or a tz-aware datetime.
+    try:
+        events = _collect_events(
+            workspace, since=since, run_filter=run_filter,
+        )
+    except EvidenceSourceCorruptedError as exc:
+        print(f"error: corrupt evidence JSONL — {exc}", file=sys.stderr)
+        return 2
+    except EvidenceSourceMissingError as exc:
+        print(f"error: evidence source missing — {exc}", file=sys.stderr)
+        return 1
+
+    summary = _summarize(events)
+    payload: dict[str, Any] = {
+        "filter": {
+            "since": since.isoformat() if since else None,
+            "run_id": run_filter,
+            "applied_at": datetime.now(timezone.utc).isoformat(),
+        },
+        "summary": summary,
+        "events": events,
+    }
+
+    serialized = json.dumps(
+        payload, sort_keys=True, ensure_ascii=False, indent=2,
+    )
+    output_path = getattr(args, "output", None)
+    if output_path:
+        from ao_kernel._internal.shared.utils import write_text_atomic
+
+        write_text_atomic(Path(output_path), serialized + "\n")
+    else:
+        sys.stdout.write(serialized + "\n")
+    return 0
+
+
+def _collect_events(
+    workspace: Path,
+    *,
+    since: datetime | None,
+    run_filter: str | None,
+) -> list[dict[str, Any]]:
+    root = workspace / ".ao" / "evidence" / "workflows"
+    if not root.is_dir():
+        if run_filter:
+            raise EvidenceSourceMissingError(
+                f"no evidence directory at {root}"
+            )
+        return []
+
+    if run_filter:
+        targets = [root / run_filter]
+        if not targets[0].is_dir():
+            raise EvidenceSourceMissingError(
+                f"run {run_filter!r} has no evidence at {targets[0]}"
+            )
+    else:
+        targets = [d for d in sorted(root.iterdir()) if d.is_dir()]
+
+    results: list[dict[str, Any]] = []
+    for run_dir in targets:
+        events_path = run_dir / "events.jsonl"
+        if not events_path.is_file():
+            continue
+        text = events_path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                event = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise EvidenceSourceCorruptedError(
+                    f"malformed JSONL at {events_path}:{lineno}: {exc}"
+                ) from exc
+            if since is not None and not _event_at_or_after(event, since):
+                continue
+            results.append(event)
+    results.sort(
+        key=lambda e: (str(e.get("ts") or ""), e.get("seq") or 0),
+    )
+    return results
+
+
+def _event_at_or_after(event: dict[str, Any], since: datetime) -> bool:
+    ts_value = event.get("ts")
+    if not isinstance(ts_value, str):
+        return False
+    parsed = parse_iso8601(ts_value)
+    if parsed is None:
+        return False
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed >= since
+
+
+def _summarize(events: list[dict[str, Any]]) -> dict[str, Any]:
+    counts: dict[str, int] = {}
+    for event in events:
+        kind = str(event.get("kind") or "unknown")
+        counts[kind] = counts.get(kind, 0) + 1
+    return {
+        "total": len(events),
+        "by_kind": dict(sorted(counts.items())),
+    }
+
+
+def _resolve_workspace(args: Any) -> Path:
+    ws = getattr(args, "workspace_root", None)
+    if ws:
+        return Path(ws)
+    from ao_kernel.config import workspace_root
+
+    resolved = workspace_root()
+    if resolved is None:
+        print("error: no .ao/ workspace found", file=sys.stderr)
+        sys.exit(1)
+    return resolved
+
+
+__all__ = [
+    "cmd_metrics_debug_query",
+    "parse_iso8601_strict",
+]

--- a/ao_kernel/_internal/metrics/debug_query.py
+++ b/ao_kernel/_internal/metrics/debug_query.py
@@ -196,6 +196,12 @@ def _summarize(events: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def _resolve_workspace(args: Any) -> Path:
+    """Mirror of :func:`ao_kernel._internal.metrics.cli_handlers._resolve_workspace`.
+
+    Normalizes the ``.ao/`` directory returned by
+    :func:`ao_kernel.config.workspace_root` to its parent so downstream
+    evidence-path composers build the correct nested directory.
+    """
     ws = getattr(args, "workspace_root", None)
     if ws:
         return Path(ws)
@@ -205,6 +211,8 @@ def _resolve_workspace(args: Any) -> Path:
     if resolved is None:
         print("error: no .ao/ workspace found", file=sys.stderr)
         sys.exit(1)
+    if resolved.name == ".ao":
+        return resolved.parent
     return resolved
 
 

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -113,6 +113,29 @@ def _build_parser() -> argparse.ArgumentParser:
     serve_p.add_argument("--host", default="127.0.0.1", help="HTTP bind host (default: 127.0.0.1)")
     serve_p.add_argument("--port", type=int, default=8080, help="HTTP port (default: 8080)")
 
+    # Metrics subcommands (PR-B5)
+    metrics_p = sub.add_parser(
+        "metrics",
+        help="Prometheus textfile export + debug query",
+    )
+    metrics_sub = metrics_p.add_subparsers(dest="metrics_command")
+
+    export_p = metrics_sub.add_parser(
+        "export",
+        help="Emit cumulative Prometheus textfile",
+    )
+    export_p.add_argument(
+        "--format",
+        choices=["prometheus"],
+        default="prometheus",
+        help="Output format (only 'prometheus' for textfile mode)",
+    )
+    export_p.add_argument(
+        "--output",
+        default=None,
+        help="File path for atomic write; omit for stdout",
+    )
+
     return parser
 
 
@@ -161,6 +184,20 @@ def main(argv: list[str] | None = None) -> int:
         from ao_kernel.i18n import msg
         print(msg("usage_mcp_serve"))
         return 1
+
+    # Metrics subcommand (PR-B5)
+    if cmd == "metrics":
+        from ao_kernel._internal.metrics.cli_handlers import cmd_metrics_export
+
+        metrics_cmd = getattr(args, "metrics_command", None)
+        metrics_dispatch = {
+            "export": cmd_metrics_export,
+        }
+        handler = metrics_dispatch.get(metrics_cmd) if metrics_cmd else None
+        if handler is None:
+            print("Usage: ao-kernel metrics {export}")
+            return 1
+        return handler(args)
 
     handler = dispatch.get(cmd)
     if handler is None:

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -136,6 +136,43 @@ def _build_parser() -> argparse.ArgumentParser:
         help="File path for atomic write; omit for stdout",
     )
 
+    # PR-B5 C3b: debug-query — non-Prometheus JSON query surface.
+    from ao_kernel._internal.metrics.debug_query import parse_iso8601_strict
+
+    debug_p = metrics_sub.add_parser(
+        "debug-query",
+        help=(
+            "Ad-hoc JSON query over evidence events "
+            "(never Prometheus textfile; for operator debugging)"
+        ),
+    )
+    debug_p.add_argument(
+        "--since",
+        type=parse_iso8601_strict,
+        default=None,
+        help=(
+            "Filter events at or after this ISO-8601 timestamp; "
+            "timezone required (use 'Z' or '+HH:MM')"
+        ),
+    )
+    debug_p.add_argument(
+        "--run",
+        dest="run",
+        default=None,
+        help="Limit to a single run_id",
+    )
+    debug_p.add_argument(
+        "--format",
+        choices=["json"],
+        default="json",
+        help="Output format (only 'json' for debug-query)",
+    )
+    debug_p.add_argument(
+        "--output",
+        default=None,
+        help="File path for atomic write; omit for stdout",
+    )
+
     return parser
 
 
@@ -187,15 +224,21 @@ def main(argv: list[str] | None = None) -> int:
 
     # Metrics subcommand (PR-B5)
     if cmd == "metrics":
-        from ao_kernel._internal.metrics.cli_handlers import cmd_metrics_export
+        from ao_kernel._internal.metrics.cli_handlers import (
+            cmd_metrics_export,
+        )
+        from ao_kernel._internal.metrics.debug_query import (
+            cmd_metrics_debug_query,
+        )
 
         metrics_cmd = getattr(args, "metrics_command", None)
         metrics_dispatch = {
             "export": cmd_metrics_export,
+            "debug-query": cmd_metrics_debug_query,
         }
         handler = metrics_dispatch.get(metrics_cmd) if metrics_cmd else None
         if handler is None:
-            print("Usage: ao-kernel metrics {export}")
+            print("Usage: ao-kernel metrics {export|debug-query}")
             return 1
         return handler(args)
 

--- a/ao_kernel/coordination/registry.py
+++ b/ao_kernel/coordination/registry.py
@@ -1228,6 +1228,17 @@ def live_claims_count(workspace_root: Path) -> dict[str, int]:
     claim file is a real problem the operator must address via
     ``ao-kernel doctor`` before metrics can be trusted.
 
+    .. note::
+       This helper acquires ``claims.lock`` — the same lockfile the
+       writing path uses — so it will **create** the lock file on
+       first read if the workspace has never acquired a claim. The
+       coordination module treats this as intentional: the "read-
+       only" label applies to the claim SSOT (no claim file is
+       mutated), not to the lockfile. Metrics scrape cadence is slow
+       (minutes) so lock contention with writers is negligible in
+       practice, but operators should know reads and writes share
+       a single lock.
+
     Mirrors :meth:`ClaimRegistry.list_agent_claims` structurally but
     iterates the full index rather than a single agent.
     """

--- a/ao_kernel/coordination/registry.py
+++ b/ao_kernel/coordination/registry.py
@@ -1203,3 +1203,52 @@ class ClaimRegistry:
                 "now": now.isoformat(),
             },
         )
+
+
+# ---------------------------------------------------------------------------
+# PR-B5 C3 — live claim count helper (module-level read-only snapshot)
+# ---------------------------------------------------------------------------
+
+
+def live_claims_count(workspace_root: Path) -> dict[str, int]:
+    """Return ``{agent_id: count}`` of currently-held live claims.
+
+    Plan v4 Q1 A: the canonical source of truth for the
+    ``ao_claim_active_total`` Prometheus gauge. An evidence-derived
+    net-count (``acquired - released - expired``) would race with the
+    takeover / grace path and can report negative values; querying
+    the registry's on-disk SSOT under the ``claims.lock`` produces a
+    consistent snapshot.
+
+    Dormant policy → empty dict (no raise). The metrics subsystem
+    treats this as "gauge stays at 0" which matches operator
+    expectations when coordination is disabled.
+
+    Corrupt SSOT (``ClaimCorruptedError``) propagates: a corrupted
+    claim file is a real problem the operator must address via
+    ``ao-kernel doctor`` before metrics can be trusted.
+
+    Mirrors :meth:`ClaimRegistry.list_agent_claims` structurally but
+    iterates the full index rather than a single agent.
+    """
+    policy = load_coordination_policy(workspace_root)
+    if not policy.enabled:
+        return {}
+    _claims_dir(workspace_root).mkdir(parents=True, exist_ok=True)
+    reg = ClaimRegistry(workspace_root)
+    with file_lock(_claims_lock_path(workspace_root)):
+        reg._ensure_index_consistent()
+        index = reg._load_index()
+        now = datetime.now(timezone.utc)
+        counts: dict[str, int] = {}
+        for agent_id, resource_ids in index.agents.items():
+            live = 0
+            for resource_id in resource_ids:
+                claim = reg._load_claim_if_exists(resource_id)
+                if claim is None:
+                    continue
+                if reg._claim_is_live(claim, policy, now):
+                    live += 1
+            if live > 0:
+                counts[agent_id] = live
+        return counts

--- a/ao_kernel/cost/middleware.py
+++ b/ao_kernel/cost/middleware.py
@@ -228,6 +228,7 @@ def post_response_reconcile(
     est_cost: Decimal,
     raw_response_bytes: bytes,
     policy: CostTrackingPolicy,
+    elapsed_ms: float | None = None,
 ) -> None:
     """Post-response usage extract + reconcile + ledger append.
 
@@ -244,7 +245,20 @@ def post_response_reconcile(
          Per plan Q5 iter-1: reservation holds on transport error
          (middleware never reaches this function in that case).
        - record_spend (billing_digest computed).
-       - emit llm_spend_recorded.
+       - emit llm_spend_recorded (+``duration_ms`` when
+         ``elapsed_ms`` passthrough present — PR-B5 C2b absorb).
+
+    Parameters:
+        elapsed_ms: Transport wall-clock duration in milliseconds,
+            captured by :func:`execute_request` and threaded through
+            :func:`ao_kernel.llm.governed_call`. Emitted as
+            ``llm_spend_recorded.duration_ms`` so PR-B5 metrics
+            derivation can populate ``ao_llm_call_duration_seconds``
+            from the canonical LLM-facade timing rather than the
+            generic adapter lifecycle events (plan v4 iter-2 fix).
+            ``None`` (default) preserves pre-B5 backward compat: the
+            emitted event omits ``duration_ms`` entirely and the
+            metric histogram skips this call.
     """
     from ao_kernel._internal.prj_kernel_api.llm_response_normalizer import (
         extract_usage_strict,
@@ -422,24 +436,30 @@ def post_response_reconcile(
     )
     record_spend(workspace_root, event, policy=policy)
 
+    # PR-B5 C2b: emit ``duration_ms`` when transport elapsed is known.
+    # Canonical source for ``ao_llm_call_duration_seconds`` histogram;
+    # omitted on legacy callers (backward-compat per plan v4 R13).
+    payload: dict[str, Any] = {
+        "run_id": run_id,
+        "step_id": step_id,
+        "attempt": attempt,
+        "provider_id": provider_id,
+        "model": model,
+        "tokens_input": tokens_input,
+        "tokens_output": tokens_output,
+        "cached_tokens": cached,
+        "cost_usd": float(actual),
+        "est_cost_usd": float(est_cost),
+        "delta_usd": float(delta),
+        "ts": _iso_now(),
+    }
+    if elapsed_ms is not None:
+        payload["duration_ms"] = round(float(elapsed_ms), 3)
     _safe_emit(
         workspace_root,
         run_id,
         "llm_spend_recorded",
-        {
-            "run_id": run_id,
-            "step_id": step_id,
-            "attempt": attempt,
-            "provider_id": provider_id,
-            "model": model,
-            "tokens_input": tokens_input,
-            "tokens_output": tokens_output,
-            "cached_tokens": cached,
-            "cost_usd": float(actual),
-            "est_cost_usd": float(est_cost),
-            "delta_usd": float(delta),
-            "ts": _iso_now(),
-        },
+        payload,
     )
 
 

--- a/ao_kernel/llm.py
+++ b/ao_kernel/llm.py
@@ -577,6 +577,11 @@ def governed_call(
             if isinstance(workspace_root, Path)
             else Path(str(workspace_root))
         )
+        # PR-B5 C2b: thread transport ``elapsed_ms`` into the
+        # reconcile → emit path so ``llm_spend_recorded`` carries
+        # ``duration_ms`` for the PR-B5 metrics derivation. Pure
+        # transport time; reserve/normalize/reconcile overhead is
+        # explicitly excluded (plan v4 iter-2 correction).
         post_response_reconcile(
             workspace_root=ws_path,
             run_id=str(run_id),
@@ -588,6 +593,7 @@ def governed_call(
             est_cost=est_cost if est_cost is not None else Decimal("0"),
             raw_response_bytes=transport_result["resp_bytes"],
             policy=cost_policy,
+            elapsed_ms=transport_result.get("elapsed_ms"),
         )
         # Raises LLMUsageMissingError when policy.fail_closed_on_missing_usage
         # AND usage absent. Ledger audit entry always recorded first.

--- a/ao_kernel/metrics/__init__.py
+++ b/ao_kernel/metrics/__init__.py
@@ -1,0 +1,53 @@
+"""ao-kernel metrics export (PR-B5).
+
+Public package providing Prometheus textfile metrics export for
+ao-kernel workspaces. See ``docs/METRICS.md`` for the operator guide.
+
+Surface overview (populated across C1..C3b):
+
+- :mod:`ao_kernel.metrics.policy` — ``policy_metrics.v1.json`` loader
+  (``MetricsPolicy`` dataclass + ``load_metrics_policy``).
+- :mod:`ao_kernel.metrics.errors` — five typed exceptions
+  (``MetricsError`` base; ``MetricsDisabledError``,
+  ``MetricsExtraNotInstalledError``, ``EvidenceSourceMissingError``,
+  ``EvidenceSourceCorruptedError``, ``InvalidLabelAllowlistError``).
+- :mod:`ao_kernel.metrics.registry` (C2) — lazy ``prometheus_client``
+  wrapper with no-op fallback; builds the eight default metric
+  families based on the policy's advanced-label allowlist.
+- :mod:`ao_kernel.metrics.derivation` (C3) — evidence events scan →
+  metric family population. Fail-closed on malformed JSONL.
+- :mod:`ao_kernel.metrics.export` (C3) — Prometheus textfile
+  serializer with dormant / cost-dormant banner comments.
+
+The public re-exports below deliberately stay narrow: operators drive
+metrics through the ``ao-kernel metrics`` CLI, and the library-mode
+surface is the policy loader + typed errors.
+"""
+
+from __future__ import annotations
+
+from ao_kernel.metrics.errors import (
+    EvidenceSourceCorruptedError,
+    EvidenceSourceMissingError,
+    InvalidLabelAllowlistError,
+    MetricsDisabledError,
+    MetricsError,
+    MetricsExtraNotInstalledError,
+)
+from ao_kernel.metrics.policy import (
+    LabelsAdvanced,
+    MetricsPolicy,
+    load_metrics_policy,
+)
+
+__all__ = [
+    "EvidenceSourceCorruptedError",
+    "EvidenceSourceMissingError",
+    "InvalidLabelAllowlistError",
+    "LabelsAdvanced",
+    "MetricsDisabledError",
+    "MetricsError",
+    "MetricsExtraNotInstalledError",
+    "MetricsPolicy",
+    "load_metrics_policy",
+]

--- a/ao_kernel/metrics/derivation.py
+++ b/ao_kernel/metrics/derivation.py
@@ -1,0 +1,368 @@
+"""Evidence events → Prometheus metric population (PR-B5 C3).
+
+Stateless, read-only scan of ``.ao/evidence/workflows/*/events.jsonl``
+files plus two small facade reads (coordination live-count + run_store
+terminal scan). Fail-closed on malformed JSONL per
+:class:`EvidenceSourceCorruptedError` (mirrors the ``timeline.py``
+internal pattern). No filtering / windowing — plan v4 §2.3 dropped
+``run_id_filter`` / ``since_ts`` from the default textfile mode
+because Prometheus counter semantics require cumulative full scans.
+
+The one-way flow is:
+
+    events.jsonl lines → event dicts → per-kind handler → metric family
+
+Cancelled workflow runs take a separate branch: the coordination
+runtime never emits a ``workflow_cancelled`` event (denial path emits
+``approval_denied`` and transitions run state). So the workflow
+duration histogram reads ``state.v1.json.completed_at`` for cancelled
+runs via :func:`ao_kernel.workflow.run_store.list_terminal_runs`
+(plan v4 Q3 A).
+
+The claim active gauge is populated from
+:func:`ao_kernel.coordination.registry.live_claims_count` rather than
+an evidence-derived net count — expired/takeover races make the net
+count negative (plan v4 Q1 A).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ao_kernel.coordination.registry import live_claims_count
+from ao_kernel.metrics.errors import EvidenceSourceCorruptedError
+from ao_kernel.metrics.policy import MetricsPolicy
+from ao_kernel.metrics.registry import BuiltRegistry
+from ao_kernel.workflow.run_store import list_terminal_runs
+
+
+_WORKFLOW_STARTED = "workflow_started"
+_WORKFLOW_COMPLETED = "workflow_completed"
+_WORKFLOW_FAILED = "workflow_failed"
+_LLM_SPEND = "llm_spend_recorded"
+_LLM_USAGE_MISSING = "llm_usage_missing"
+_POLICY_CHECKED = "policy_checked"
+_CLAIM_TAKEOVER = "claim_takeover"
+
+_TERMINAL_STATES = frozenset({"completed", "failed", "cancelled"})
+
+
+@dataclass
+class DerivationStats:
+    """Summary of a derivation pass, exposed for CLI verbose output and
+    regression tests.
+
+    ``duration_ms_missing`` tracks the plan v4 R13 backward-compat
+    branch: pre-B5 ``llm_spend_recorded`` events without the
+    ``duration_ms`` field are counted here and skipped for histogram
+    population (no synthetic default).
+    """
+
+    events_scanned: int = 0
+    runs_scanned: int = 0
+    llm_spend_counted: int = 0
+    llm_usage_missing_counted: int = 0
+    policy_checks_counted: int = 0
+    claim_takeovers_counted: int = 0
+    workflow_terminals_counted: int = 0
+    cancelled_from_state: int = 0
+    duration_ms_missing: int = 0
+    corrupt_files: tuple[Path, ...] = field(default_factory=tuple)
+
+
+def _parse_iso(ts: str) -> datetime:
+    """Parse ISO-8601 timestamp into aware UTC datetime.
+
+    Mirrors ``coordination.registry._parse_iso`` so derivation and
+    coordination agree on the same ``Z`` shorthand handling.
+    """
+    normalised = ts.replace("Z", "+00:00") if ts.endswith("Z") else ts
+    dt = datetime.fromisoformat(normalised)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _events_for_run(run_dir: Path) -> list[dict[str, Any]]:
+    """Read + parse ``events.jsonl`` under ``run_dir``.
+
+    Raises :class:`EvidenceSourceCorruptedError` on any malformed line
+    (fail-closed per CLAUDE.md §2). Returns ``[]`` when the file is
+    absent or empty — a run directory without evidence is not an
+    error (e.g., a created-state run that never reached execution).
+    """
+    events_path = run_dir / "events.jsonl"
+    if not events_path.is_file():
+        return []
+    events: list[dict[str, Any]] = []
+    text = events_path.read_text(encoding="utf-8")
+    for lineno, line in enumerate(text.splitlines(), 1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            events.append(json.loads(stripped))
+        except json.JSONDecodeError as exc:
+            raise EvidenceSourceCorruptedError(
+                f"malformed JSONL at {events_path}:{lineno}: {exc}"
+            ) from exc
+    return events
+
+
+def _iter_run_directories(workspace_root: Path) -> list[Path]:
+    """Return all run directories under ``.ao/evidence/workflows/``.
+
+    Each child is a ``run_id`` directory containing ``events.jsonl``
+    and optional adapter logs. Returns ``[]`` for an empty workspace
+    (dormant parity — no raise).
+    """
+    root = workspace_root / ".ao" / "evidence" / "workflows"
+    if not root.is_dir():
+        return []
+    return [d for d in sorted(root.iterdir()) if d.is_dir()]
+
+
+def _apply_llm_spend(
+    built: BuiltRegistry,
+    payload: dict[str, Any],
+    advanced_model: bool,
+) -> tuple[bool, bool]:
+    """Populate LLM counters + (maybe) duration histogram from a
+    single ``llm_spend_recorded`` payload.
+
+    Returns ``(spend_counted, duration_missing)``: the caller uses
+    these for DerivationStats bookkeeping. ``duration_missing=True``
+    signals the plan v4 R13 backward-compat branch (pre-B5 event
+    without ``duration_ms``).
+    """
+    cost_family = built.llm_cost_usd
+    tokens_family = built.llm_tokens_used
+    if cost_family is None or tokens_family is None:
+        # Cost-disjunction branch: registry was built without LLM
+        # families (see :func:`build_registry(..., include_llm_metrics=False)`).
+        return False, False
+
+    provider = str(payload.get("provider_id") or "unknown")
+    model = str(payload.get("model") or "unknown")
+    base_labels = {"provider": provider}
+    if advanced_model:
+        base_labels["model"] = model
+
+    # tokens counter (3 directions: input / output / cached)
+    for direction, field_name in (
+        ("input", "tokens_input"),
+        ("output", "tokens_output"),
+        ("cached", "cached_tokens"),
+    ):
+        raw = payload.get(field_name)
+        if raw is None:
+            continue
+        try:
+            count = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if count <= 0:
+            continue
+        labels = {**base_labels, "direction": direction}
+        tokens_family.labels(**labels).inc(count)
+
+    # cost counter (≥0)
+    cost_raw = payload.get("cost_usd")
+    if cost_raw is not None:
+        try:
+            cost = float(cost_raw)
+        except (TypeError, ValueError):
+            cost = 0.0
+        if cost > 0:
+            cost_family.labels(**base_labels).inc(cost)
+
+    # duration histogram (plan v4 R13 backward-compat)
+    duration_missing = False
+    duration_raw = payload.get("duration_ms")
+    if duration_raw is None:
+        duration_missing = True
+    else:
+        try:
+            duration_ms = float(duration_raw)
+        except (TypeError, ValueError):
+            duration_missing = True
+        else:
+            duration_family = built.llm_call_duration
+            if duration_ms >= 0 and duration_family is not None:
+                duration_family.labels(**base_labels).observe(
+                    duration_ms / 1000.0,
+                )
+
+    return True, duration_missing
+
+
+def _apply_usage_missing(
+    built: BuiltRegistry,
+    payload: dict[str, Any],
+    advanced_model: bool,
+) -> bool:
+    family = built.llm_usage_missing
+    if family is None:
+        return False
+    provider = str(payload.get("provider_id") or "unknown")
+    labels = {"provider": provider}
+    if advanced_model:
+        labels["model"] = str(payload.get("model") or "unknown")
+    family.labels(**labels).inc()
+    return True
+
+
+def _apply_policy_checked(
+    built: BuiltRegistry, payload: dict[str, Any]
+) -> bool:
+    violations_raw = payload.get("violations_count")
+    try:
+        violations = int(violations_raw or 0)
+    except (TypeError, ValueError):
+        violations = 0
+    outcome = "deny" if violations > 0 else "allow"
+    built.policy_check.labels(outcome=outcome).inc()
+    return True
+
+
+def _apply_claim_takeover(built: BuiltRegistry) -> bool:
+    built.claim_takeover.inc()
+    return True
+
+
+def _apply_workflow_duration(
+    built: BuiltRegistry,
+    started_ts: str,
+    completed_ts: str,
+    final_state: str,
+) -> bool:
+    try:
+        delta = (
+            _parse_iso(completed_ts) - _parse_iso(started_ts)
+        ).total_seconds()
+    except (TypeError, ValueError):
+        return False
+    if delta < 0:
+        return False
+    built.workflow_duration.labels(final_state=final_state).observe(delta)
+    return True
+
+
+def _apply_claim_active(
+    built: BuiltRegistry,
+    workspace_root: Path,
+    advanced_agent_id: bool,
+) -> None:
+    try:
+        counts = live_claims_count(workspace_root)
+    except Exception:
+        # Coordination subsystem errors (dormant policy, corrupted
+        # claim file) are fail-open for the gauge: an observability
+        # surface should not crash because a different subsystem is
+        # unhealthy. The operator is expected to run
+        # ``ao-kernel doctor`` if the gauge reports 0.
+        counts = {}
+    if advanced_agent_id:
+        for agent_id, count in counts.items():
+            built.claim_active.labels(agent_id=agent_id).set(count)
+    else:
+        total = sum(counts.values())
+        built.claim_active.set(total)
+
+
+def derive_metrics_from_evidence(
+    workspace_root: Path,
+    built: BuiltRegistry,
+    policy: MetricsPolicy,
+) -> DerivationStats:
+    """Populate ``built`` with metrics derived from the workspace's
+    evidence trail + coordination registry + run_store.
+
+    Fail-closed behaviour:
+
+    - Malformed JSONL → :class:`EvidenceSourceCorruptedError` (no
+      partial metrics — a corrupt audit trail cannot be trusted).
+    - Missing workspace (``.ao/evidence/workflows/`` absent) → stats
+      reflect zero scans; the caller / CLI surfaces a dormant banner.
+    """
+    stats = DerivationStats()
+    allowlist = policy.advanced_allowlist()
+    advanced_model = "model" in allowlist
+    advanced_agent_id = "agent_id" in allowlist
+
+    # Track workflow_started payloads so we can compute duration on
+    # the paired terminal event emitted later in the file.
+    started_ts_by_run: dict[str, str] = {}
+
+    run_dirs = _iter_run_directories(workspace_root)
+    for run_dir in run_dirs:
+        stats.runs_scanned += 1
+        events = _events_for_run(run_dir)
+        for event in events:
+            stats.events_scanned += 1
+            kind = event.get("kind")
+            payload = event.get("payload") or {}
+            if kind == _LLM_SPEND:
+                spend_counted, duration_missing = _apply_llm_spend(
+                    built, payload, advanced_model,
+                )
+                if spend_counted:
+                    stats.llm_spend_counted += 1
+                if duration_missing:
+                    stats.duration_ms_missing += 1
+            elif kind == _LLM_USAGE_MISSING:
+                if _apply_usage_missing(built, payload, advanced_model):
+                    stats.llm_usage_missing_counted += 1
+            elif kind == _POLICY_CHECKED:
+                if _apply_policy_checked(built, payload):
+                    stats.policy_checks_counted += 1
+            elif kind == _CLAIM_TAKEOVER:
+                if _apply_claim_takeover(built):
+                    stats.claim_takeovers_counted += 1
+            elif kind == _WORKFLOW_STARTED:
+                ts = event.get("ts") or payload.get("ts")
+                run_id = payload.get("run_id") or run_dir.name
+                if ts:
+                    started_ts_by_run[run_id] = str(ts)
+            elif kind in (_WORKFLOW_COMPLETED, _WORKFLOW_FAILED):
+                ts = event.get("ts") or payload.get("ts")
+                run_id = payload.get("run_id") or run_dir.name
+                started = started_ts_by_run.pop(run_id, None)
+                if started and ts:
+                    final_state = (
+                        "completed"
+                        if kind == _WORKFLOW_COMPLETED
+                        else "failed"
+                    )
+                    if _apply_workflow_duration(
+                        built, started, str(ts), final_state,
+                    ):
+                        stats.workflow_terminals_counted += 1
+
+    # Plan v4 Q3 A: cancelled runs have no terminal event — derive
+    # duration from ``state.v1.json.{created_at, completed_at}``.
+    for record in list_terminal_runs(workspace_root):
+        if record.get("state") != "cancelled":
+            continue
+        started = record.get("created_at")
+        completed = record.get("completed_at")
+        if not (started and completed):
+            continue
+        if _apply_workflow_duration(
+            built, str(started), str(completed), "cancelled",
+        ):
+            stats.cancelled_from_state += 1
+
+    _apply_claim_active(built, workspace_root, advanced_agent_id)
+
+    return stats
+
+
+__all__ = [
+    "DerivationStats",
+    "derive_metrics_from_evidence",
+]

--- a/ao_kernel/metrics/derivation.py
+++ b/ao_kernel/metrics/derivation.py
@@ -1,12 +1,17 @@
 """Evidence events → Prometheus metric population (PR-B5 C3).
 
-Stateless, read-only scan of ``.ao/evidence/workflows/*/events.jsonl``
-files plus two small facade reads (coordination live-count + run_store
-terminal scan). Fail-closed on malformed JSONL per
-:class:`EvidenceSourceCorruptedError` (mirrors the ``timeline.py``
-internal pattern). No filtering / windowing — plan v4 §2.3 dropped
-``run_id_filter`` / ``since_ts`` from the default textfile mode
-because Prometheus counter semantics require cumulative full scans.
+Evidence / run_store / coordination-SSOT read pipeline. Fail-closed
+on malformed JSONL per :class:`EvidenceSourceCorruptedError` (mirrors
+the ``timeline.py`` internal pattern). No filtering / windowing —
+plan v4 §2.3 dropped ``run_id_filter`` / ``since_ts`` from the
+default textfile mode because Prometheus counter semantics require
+cumulative full scans.
+
+.. note::
+   The :func:`ao_kernel.coordination.registry.live_claims_count` hook
+   acquires ``claims.lock`` to read the claim SSOT; on a workspace
+   with coordination enabled, the lockfile is created on first
+   metrics scrape. No claim files are mutated.
 
 The one-way flow is:
 

--- a/ao_kernel/metrics/errors.py
+++ b/ao_kernel/metrics/errors.py
@@ -1,0 +1,101 @@
+"""Typed exceptions for ao-kernel metrics export (PR-B5).
+
+Five error types cover the dormant-policy + fail-closed-derivation +
+cardinality-guard surface of the metrics package:
+
+- :class:`MetricsError` — common base (catch-all for metrics subsystem).
+- :class:`MetricsDisabledError` — operator called an API that requires
+  ``policy_metrics.enabled=true`` while the policy was dormant.
+- :class:`MetricsExtraNotInstalledError` — ``[metrics]`` optional extra
+  (``prometheus-client``) is not installed; lazy-import failed.
+- :class:`EvidenceSourceMissingError` — the evidence events source file
+  referenced by a scoped export is absent (not raised for dormant-mode
+  empty workspace; only for explicit run-scoped queries in debug-query).
+- :class:`EvidenceSourceCorruptedError` — evidence JSONL contains
+  malformed lines. Mirrors the coordination package's fail-closed
+  posture (``timeline.py`` ``json.JSONDecodeError → ValueError``): a
+  corrupt audit trail MUST NOT silently yield half-correct metrics.
+- :class:`InvalidLabelAllowlistError` — runtime defence-in-depth when
+  a programmatically-constructed policy (bypassing schema validation)
+  carries an ``allowlist`` value outside the closed enum
+  ``{"model", "agent_id"}``.
+"""
+
+from __future__ import annotations
+
+
+class MetricsError(Exception):
+    """Base class for all metrics-subsystem errors.
+
+    Callers that want a single catch-all (``except MetricsError``) can
+    rely on every error in this package inheriting from this class.
+    """
+
+
+class MetricsDisabledError(MetricsError):
+    """Raised when a metrics API is called while policy is dormant.
+
+    ``policy_metrics.enabled=false`` is the bundled-default posture;
+    APIs that require metrics (e.g. ``build_registry`` called without
+    the dormant-graceful path) surface this error rather than silently
+    returning a no-op registry.
+    """
+
+
+class MetricsExtraNotInstalledError(MetricsError):
+    """Raised when ``[metrics]`` optional extra is not installed.
+
+    Lazy-imports of :mod:`prometheus_client` fail with ``ImportError``;
+    the metrics subsystem translates this into a typed error so CLI
+    exit-code mapping (exit 3 informational) is deterministic.
+    """
+
+
+class EvidenceSourceMissingError(MetricsError, FileNotFoundError):
+    """Raised when a scoped evidence source is missing.
+
+    Specifically raised by debug-query when ``--run <run_id>`` targets
+    a non-existent run directory, or ``--since`` filters result in an
+    explicit empty source that should be surfaced to the operator.
+
+    Not raised by default textfile export: a missing workspace returns
+    an empty registry (dormant parity) rather than erroring.
+    """
+
+
+class EvidenceSourceCorruptedError(MetricsError, ValueError):
+    """Raised when evidence JSONL contains malformed lines.
+
+    Fail-closed derivation: the metrics subsystem never produces
+    half-correct output from a partially-unreadable audit trail.
+    Operators are expected to run ``ao-kernel doctor`` or inspect the
+    evidence run directory manually before re-running export.
+
+    Mirrors the ``ao_kernel._internal.evidence.timeline`` pattern
+    (``json.JSONDecodeError → ValueError``) so the two subsystems
+    share identical fail-closed semantics.
+    """
+
+
+class InvalidLabelAllowlistError(MetricsError, ValueError):
+    """Raised when ``labels_advanced.allowlist`` contains an unknown value.
+
+    Schema validation normally catches this at load time (the closed
+    enum rejects typos). This runtime guard defends against
+    programmatic construction that bypasses
+    :func:`ao_kernel.metrics.policy.load_metrics_policy` — e.g., a
+    caller builds a :class:`MetricsPolicy` directly from a raw dict
+    without running ``_validate``. Defence in depth: the subsystem
+    refuses to proceed with a non-closed-enum allowlist regardless of
+    how the policy object was constructed.
+    """
+
+
+__all__ = [
+    "MetricsError",
+    "MetricsDisabledError",
+    "MetricsExtraNotInstalledError",
+    "EvidenceSourceMissingError",
+    "EvidenceSourceCorruptedError",
+    "InvalidLabelAllowlistError",
+]

--- a/ao_kernel/metrics/export.py
+++ b/ao_kernel/metrics/export.py
@@ -1,0 +1,135 @@
+"""Prometheus textfile exporter (PR-B5 C3).
+
+Thin wrapper over :func:`prometheus_client.generate_latest` that
+prepends operator-readable banner comments for two dormant-mode
+paths (plan v4 §2.6):
+
+- ``metrics policy dormant`` — ``policy_metrics.enabled=false``.
+- ``cost tracking dormant`` — ``policy_cost_tracking.enabled=false``
+  (no ``ao_llm_*`` metric family in the output; derivation skipped
+  building them via :func:`build_registry(..., include_llm_metrics=False)`).
+
+Both banners are valid Prometheus textfile comments (``# `` prefix)
+so they pass the exposition-format parser without emitting synthetic
+samples. Grafana renders the resulting dashboards as "No data" while
+the operator understands the root cause from the comment.
+
+Cumulative-only contract (plan v4 §2.6): the exporter always produces
+the full registry snapshot. Windowed / run-scoped queries live on the
+separate ``ao-kernel metrics debug-query`` subcommand (C3b) which
+emits JSON, never Prometheus textfile.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ao_kernel.metrics.errors import MetricsExtraNotInstalledError
+from ao_kernel.metrics.registry import BuiltRegistry, is_metrics_available
+
+
+_DORMANT_BANNER = (
+    "# ao-kernel metrics: dormant (policy_metrics.enabled=false). "
+    "Operator action: copy "
+    "ao_kernel/defaults/policies/policy_metrics.v1.json to "
+    ".ao/policies/ and set enabled=true.\n"
+)
+
+_COST_DORMANT_BANNER = (
+    "# ao-kernel metrics: cost tracking dormant "
+    "(policy_cost_tracking.enabled=false); LLM metric family absent. "
+    "See docs/METRICS.md §6 for the cost-tracking prerequisite.\n"
+)
+
+_EXTRA_MISSING_BANNER = (
+    "# ao-kernel metrics: [metrics] optional extra not installed; "
+    "no textfile content. pip install 'ao-kernel[metrics]' to enable.\n"
+)
+
+
+def generate_textfile(
+    built: BuiltRegistry | None,
+    *,
+    metrics_dormant: bool,
+    cost_dormant: bool,
+) -> str:
+    """Return the Prometheus textfile payload as a UTF-8 string.
+
+    Parameters:
+        built: The constructed registry (from
+            :func:`ao_kernel.metrics.registry.build_registry`) or
+            ``None`` when the optional extra is absent. The export
+            CLI translates ``None`` into an exit-3 informational
+            banner via the ``# extra missing`` comment below.
+        metrics_dormant: ``True`` when the metrics policy is dormant
+            (``policy_metrics.enabled=false``). The caller still
+            builds a registry (for shape tests and cardinality
+            assertions) but the exporter prepends the dormant banner
+            so Grafana displays "No data" with explicit rationale.
+        cost_dormant: ``True`` when the cost-tracking policy is
+            dormant. The ``ao_llm_*`` families are absent from the
+            registry (cost-disjunction), and this banner makes the
+            absence visible.
+
+    Raises:
+        MetricsExtraNotInstalledError: Callers that demand strict
+            behaviour (rather than the informational banner) use
+            :func:`generate_textfile_strict`; this helper tolerates
+            ``built=None`` by default per plan v4 exit-3 semantics.
+    """
+    if built is None:
+        return _EXTRA_MISSING_BANNER
+    header = ""
+    if metrics_dormant:
+        header += _DORMANT_BANNER
+    if cost_dormant:
+        header += _COST_DORMANT_BANNER
+    body = _serialize(built.registry)
+    return header + body
+
+
+def generate_textfile_strict(
+    built: BuiltRegistry | None,
+    *,
+    metrics_dormant: bool,
+    cost_dormant: bool,
+) -> str:
+    """Strict variant that raises when the extra is missing.
+
+    Useful for tests that want to assert the happy-path body size
+    without stepping through the banner-only branch.
+    """
+    if built is None:
+        if not is_metrics_available():
+            raise MetricsExtraNotInstalledError(
+                "prometheus-client not installed; "
+                "cannot serialize metrics without the [metrics] extra"
+            )
+        # is_metrics_available() true + built None is a caller bug.
+        raise MetricsExtraNotInstalledError(
+            "built registry is None despite prometheus-client present; "
+            "caller must pass a valid BuiltRegistry"
+        )
+    return generate_textfile(
+        built,
+        metrics_dormant=metrics_dormant,
+        cost_dormant=cost_dormant,
+    )
+
+
+def _serialize(registry: Any) -> str:
+    """Delegate to prometheus_client.generate_latest.
+
+    Imported inside the function so importing this module does not
+    pull in ``prometheus_client`` unconditionally (respects the
+    lazy-import contract mirrored from :mod:`ao_kernel.telemetry`).
+    """
+    from prometheus_client import generate_latest
+
+    return generate_latest(registry).decode("utf-8")
+
+
+__all__ = [
+    "generate_textfile",
+    "generate_textfile_strict",
+]

--- a/ao_kernel/metrics/export.py
+++ b/ao_kernel/metrics/export.py
@@ -123,10 +123,14 @@ def _serialize(registry: Any) -> str:
     Imported inside the function so importing this module does not
     pull in ``prometheus_client`` unconditionally (respects the
     lazy-import contract mirrored from :mod:`ao_kernel.telemetry`).
+    ``generate_latest`` is typed as ``bytes`` in the shipped stubs;
+    the explicit ``str`` annotation here pins our decoded contract
+    for downstream callers.
     """
     from prometheus_client import generate_latest
 
-    return generate_latest(registry).decode("utf-8")
+    decoded: str = generate_latest(registry).decode("utf-8")
+    return decoded
 
 
 __all__ = [

--- a/ao_kernel/metrics/policy.py
+++ b/ao_kernel/metrics/policy.py
@@ -1,0 +1,207 @@
+"""Metrics export policy loader (PR-B5).
+
+Loads and validates ``policy_metrics.v1.json`` from the bundled
+defaults or a workspace override, mirrors it into a typed
+:class:`MetricsPolicy` dataclass, and exposes the advanced-label
+allowlist accessor used by the registry adapter.
+
+Semantic notes:
+
+- **Dormant default:** the bundled policy ships ``enabled: false``.
+  The export CLI produces a banner-only textfile when the policy is
+  dormant; opt-in is a deliberate operator action.
+- **Low-cardinality baseline:** when ``labels_advanced.enabled=false``
+  (bundled default), only the low-cardinality label set is emitted
+  (``provider``, ``direction``, ``outcome``, ``final_state``).
+- **Advanced labels are closed-enum:** ``labels_advanced.allowlist``
+  entries must be members of ``{"model", "agent_id"}``. Schema
+  validation rejects typos at load time; :class:`InvalidLabelAllowlistError`
+  is a runtime defence-in-depth guard for programmatically-constructed
+  policies that bypass ``_validate``.
+- **Defence in depth:** both ``labels_advanced.enabled=true`` AND a
+  non-empty ``allowlist`` must hold for any advanced label to appear.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from ao_kernel.config import load_default
+from ao_kernel.errors import DefaultsNotFoundError
+from ao_kernel.metrics.errors import InvalidLabelAllowlistError
+
+
+_POLICY_SCHEMA_CACHE: dict[str, Any] | None = None
+
+# Closed enum mirror of the schema's
+# ``labels_advanced.allowlist.items.enum``. The schema is authoritative
+# but the runtime also guards programmatic construction that bypasses
+# :func:`load_metrics_policy` (e.g., :class:`MetricsPolicy` built from a
+# raw dict in a test helper). Drift between this set and the schema
+# enum would be a real bug; the parity is covered by a dedicated test.
+_LEGAL_ADVANCED_LABELS: frozenset[str] = frozenset({"model", "agent_id"})
+
+
+def _policy_schema() -> dict[str, Any]:
+    """Load and cache ``policy-metrics.schema.v1.json``."""
+    global _POLICY_SCHEMA_CACHE
+    if _POLICY_SCHEMA_CACHE is None:
+        _POLICY_SCHEMA_CACHE = load_default(
+            "schemas", "policy-metrics.schema.v1.json",
+        )
+    return _POLICY_SCHEMA_CACHE
+
+
+@dataclass(frozen=True)
+class LabelsAdvanced:
+    """Typed view of ``policy_metrics.labels_advanced``.
+
+    The outer ``enabled`` flag gates the allowlist: if ``enabled=false``
+    the ``allowlist`` tuple is treated as empty regardless of contents
+    (consistent with the schema's "both switches must align" semantic).
+    """
+
+    enabled: bool
+    allowlist: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MetricsPolicy:
+    """Typed view of ``policy_metrics.v1.json``.
+
+    Scalar fields mirror the schema one-to-one. The dataclass is frozen
+    so policy objects are hashable and safe to share across the
+    registry / derivation / export subsystems.
+    """
+
+    enabled: bool
+    labels_advanced: LabelsAdvanced
+    version: str = "v1"
+
+    def advanced_allowlist(self) -> tuple[str, ...]:
+        """Return the effective advanced-label allowlist.
+
+        Honors the defence-in-depth invariant: if
+        ``labels_advanced.enabled=false``, returns an empty tuple even
+        when the underlying list is non-empty. Callers use this as the
+        single source of truth for "which advanced labels should we
+        expose on metric families?".
+        """
+        if not self.labels_advanced.enabled:
+            return ()
+        return self.labels_advanced.allowlist
+
+
+def _check_allowlist(allowlist: tuple[str, ...]) -> None:
+    """Runtime defence: allowlist subset of the closed enum.
+
+    Schema validation should catch typos at load time; this guard
+    protects against callers who construct :class:`MetricsPolicy`
+    programmatically (e.g., from raw dicts in tests) while bypassing
+    :func:`_validate`.
+    """
+    illegal = set(allowlist) - _LEGAL_ADVANCED_LABELS
+    if illegal:
+        raise InvalidLabelAllowlistError(
+            "labels_advanced.allowlist contains non-closed-enum "
+            f"values: {sorted(illegal)!r}; expected subset of "
+            f"{sorted(_LEGAL_ADVANCED_LABELS)!r}"
+        )
+
+
+def _from_dict(doc: Mapping[str, Any]) -> MetricsPolicy:
+    """Map a schema-valid policy dict to :class:`MetricsPolicy`.
+
+    Applies the runtime allowlist guard before returning so callers
+    that construct the dataclass via this helper are protected.
+    """
+    la_raw = doc.get("labels_advanced") or {}
+    allowlist = tuple(la_raw.get("allowlist") or ())
+    _check_allowlist(allowlist)
+    labels_advanced = LabelsAdvanced(
+        enabled=bool(la_raw.get("enabled", False)),
+        allowlist=allowlist,
+    )
+    return MetricsPolicy(
+        enabled=bool(doc["enabled"]),
+        labels_advanced=labels_advanced,
+        version=str(doc.get("version", "v1")),
+    )
+
+
+def _validate(doc: Mapping[str, Any]) -> None:
+    """Validate ``doc`` against the bundled schema; raises on failure.
+
+    Uses :mod:`jsonschema` Draft 2020-12. Malformed overrides must not
+    be silently ignored (CLAUDE.md §2 fail-closed posture); callers
+    surface the raised ``ValidationError`` to the operator.
+    """
+    from jsonschema import Draft202012Validator
+
+    Draft202012Validator(_policy_schema()).validate(doc)
+
+
+def load_metrics_policy(
+    workspace_root: Path,
+    *,
+    override: Mapping[str, Any] | None = None,
+) -> MetricsPolicy:
+    """Load the metrics export policy.
+
+    Resolution order:
+
+    1. If ``override`` is supplied (a dict), validate it against the
+       schema and return the parsed policy. Used by tests and by
+       callers that want to evaluate a hypothetical policy without
+       touching the filesystem.
+    2. Workspace override at
+       ``{workspace_root}/.ao/policies/policy_metrics.v1.json``.
+       If present and schema-valid, used.
+    3. Bundled default at
+       ``ao_kernel/defaults/policies/policy_metrics.v1.json``
+       (dormant by default).
+
+    Fail-closed: a malformed override (invalid JSON, schema violation)
+    raises the underlying parse / validation exception. The export CLI
+    never silently falls back to the bundled default when the operator
+    has explicitly placed an override file.
+
+    Raises:
+        json.JSONDecodeError: Workspace override JSON is malformed.
+        jsonschema.ValidationError: Workspace override violates schema.
+        InvalidLabelAllowlistError: ``allowlist`` contains values
+            outside the closed enum (mainly a programmatic-construction
+            guard; schema validation normally catches this first).
+        DefaultsNotFoundError: Bundled default is missing (should never
+            happen in a shipped wheel).
+    """
+    if override is not None:
+        _validate(override)
+        return _from_dict(override)
+
+    workspace_override = (
+        workspace_root / ".ao" / "policies" / "policy_metrics.v1.json"
+    )
+    if workspace_override.is_file():
+        doc = json.loads(workspace_override.read_text(encoding="utf-8"))
+        _validate(doc)
+        return _from_dict(doc)
+
+    # Bundled default (dormant enabled=false)
+    try:
+        bundled = load_default("policies", "policy_metrics.v1.json")
+    except DefaultsNotFoundError:
+        # Shouldn't happen — the bundled policy ships with the wheel.
+        raise
+    _validate(bundled)
+    return _from_dict(bundled)
+
+
+__all__ = [
+    "LabelsAdvanced",
+    "MetricsPolicy",
+    "load_metrics_policy",
+]

--- a/ao_kernel/metrics/registry.py
+++ b/ao_kernel/metrics/registry.py
@@ -1,0 +1,269 @@
+"""Prometheus registry adapter (PR-B5 C2).
+
+Lazy-imports ``prometheus_client`` — when the ``[metrics]`` optional
+extra is not installed, every public helper returns a no-op sentinel
+(``None`` for the registry, ``False`` for availability). Mirrors the
+OTEL adapter pattern in :mod:`ao_kernel.telemetry`.
+
+Eight metric families (plan v4 §2.2):
+
+- ``ao_llm_call_duration_seconds`` — histogram, label ``provider``
+  (+``model`` when advanced allowlist opts in).
+- ``ao_llm_tokens_used_total`` — counter, labels ``provider`` /
+  ``direction`` (+``model``).
+- ``ao_llm_cost_usd_total`` — counter, label ``provider`` (+``model``).
+- ``ao_llm_usage_missing_total`` — counter, label ``provider``
+  (+``model``).
+- ``ao_policy_check_total`` — counter, label ``outcome``.
+- ``ao_workflow_duration_seconds`` — histogram, label ``final_state``.
+- ``ao_claim_active_total`` — gauge (+``agent_id`` when advanced).
+- ``ao_claim_takeover_total`` — counter, no labels.
+
+Plan v4 §2 cost-disjunction: when cost tracking is dormant at the
+derivation layer, the ``ao_llm_*`` families are still registered here
+(metadata only); they simply have no samples. The textfile export
+omits empty families when the metric family has never been observed,
+which delivers the "metric family absent" guarantee demanded by the
+cost-dormant acceptance checklist. See
+:func:`ao_kernel.metrics.registry.build_registry` for the lazy
+"register only if cost-active" branch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ao_kernel.metrics.policy import MetricsPolicy
+
+
+# ── prometheus_client Availability Check ────────────────────────────
+
+_PROMETHEUS_AVAILABLE: bool | None = None
+
+
+def _check_prometheus() -> bool:
+    """Cache the availability check for the ``[metrics]`` extra.
+
+    Mirrors :func:`ao_kernel.telemetry._check_otel`: first call imports
+    ``prometheus_client`` (or catches ImportError), subsequent calls
+    return the cached bool.
+    """
+    global _PROMETHEUS_AVAILABLE
+    if _PROMETHEUS_AVAILABLE is not None:
+        return _PROMETHEUS_AVAILABLE
+    try:
+        import prometheus_client  # noqa: F401
+        _PROMETHEUS_AVAILABLE = True
+    except ImportError:
+        _PROMETHEUS_AVAILABLE = False
+    return _PROMETHEUS_AVAILABLE
+
+
+def is_metrics_available() -> bool:
+    """Return True if ``prometheus-client`` is importable.
+
+    Drives the CLI exit-code branching for the "extra missing"
+    informational banner (plan v4 §2.6 exit 3).
+    """
+    return _check_prometheus()
+
+
+# ── Histogram Buckets ───────────────────────────────────────────────
+
+# Plan v4 §2.2: LLM upper raised to 600 (GPT-4-turbo outlier tolerance).
+_LLM_DURATION_BUCKETS: tuple[float, ...] = (
+    0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 300.0, 600.0,
+)
+
+# Workflow buckets extend to 7200s (2h) because human-approval steps
+# can dwell overnight.
+_WORKFLOW_DURATION_BUCKETS: tuple[float, ...] = (
+    1.0, 5.0, 15.0, 60.0, 300.0, 900.0, 3600.0, 7200.0,
+)
+
+
+# ── Built Registry ──────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class BuiltRegistry:
+    """Container for the eight metric families built from a policy.
+
+    Fields are ``Any`` typed because ``prometheus_client`` types are
+    only available when the extra is installed; the dataclass is the
+    single surface the rest of the subsystem imports, keeping
+    :mod:`prometheus_client` imports contained to this module.
+
+    ``include_llm_metrics`` reflects the plan v4 cost-disjunction:
+    when cost tracking is dormant the caller constructs the registry
+    with ``include_llm_metrics=False`` and the four ``ao_llm_*``
+    fields are ``None``.
+    """
+
+    registry: Any  # prometheus_client.CollectorRegistry
+    llm_call_duration: Any | None
+    llm_tokens_used: Any | None
+    llm_cost_usd: Any | None
+    llm_usage_missing: Any | None
+    policy_check: Any
+    workflow_duration: Any
+    claim_active: Any
+    claim_takeover: Any
+
+
+def _label_names(
+    base: tuple[str, ...],
+    advanced_candidates: tuple[str, ...],
+    allowlist: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Expand ``base`` with the subset of ``advanced_candidates`` the
+    policy allows.
+
+    Example: ``_label_names(("provider",), ("model",), ("model",))``
+    returns ``("provider", "model")``. When the allowlist is empty the
+    function returns the ``base`` labels unchanged so the default
+    low-cardinality surface is preserved.
+    """
+    advanced = tuple(
+        name for name in advanced_candidates if name in allowlist
+    )
+    return base + advanced
+
+
+def build_registry(
+    policy: MetricsPolicy,
+    *,
+    include_llm_metrics: bool = True,
+) -> BuiltRegistry | None:
+    """Construct the metric families driven by ``policy``.
+
+    Returns ``None`` when ``prometheus-client`` is not installed (the
+    caller is expected to surface an "extra missing" banner rather
+    than crash on import errors).
+
+    Parameters:
+        policy: ``MetricsPolicy`` controlling the advanced-label
+            allowlist. The policy's ``enabled`` flag is NOT consulted
+            here — the export CLI owns the dormant/enabled branching.
+            This function just builds the families.
+        include_llm_metrics: Plan v4 cost-disjunction hook. When
+            ``False`` (cost tracking dormant), the four ``ao_llm_*``
+            families are skipped entirely so they do not appear in
+            the textfile output even as metadata. The derivation
+            layer is responsible for deciding the value: if
+            ``policy_cost_tracking.v1.json.enabled=false`` at the
+            same workspace, the LLM families are absent.
+    """
+    if not _check_prometheus():
+        return None
+
+    from prometheus_client import (
+        CollectorRegistry,
+        Counter,
+        Gauge,
+        Histogram,
+    )
+
+    registry = CollectorRegistry()
+    allowlist = policy.advanced_allowlist()
+
+    # LLM families — plan v4 §2.2 + cost-disjunction gate.
+    llm_call_duration: Any | None = None
+    llm_tokens_used: Any | None = None
+    llm_cost_usd: Any | None = None
+    llm_usage_missing: Any | None = None
+    if include_llm_metrics:
+        llm_duration_labels = _label_names(
+            ("provider",), ("model",), allowlist,
+        )
+        llm_call_duration = Histogram(
+            "ao_llm_call_duration_seconds",
+            "Wall-clock seconds spent in a single LLM transport call, "
+            "derived from llm_spend_recorded.duration_ms (PR-B5 C2b).",
+            labelnames=llm_duration_labels,
+            buckets=_LLM_DURATION_BUCKETS,
+            registry=registry,
+        )
+        llm_tokens_labels = _label_names(
+            ("provider", "direction"), ("model",), allowlist,
+        )
+        llm_tokens_used = Counter(
+            "ao_llm_tokens_used_total",
+            "Token counts from llm_spend_recorded.tokens_input / "
+            "tokens_output / cached_tokens (direction label).",
+            labelnames=llm_tokens_labels,
+            registry=registry,
+        )
+        llm_cost_labels = _label_names(
+            ("provider",), ("model",), allowlist,
+        )
+        llm_cost_usd = Counter(
+            "ao_llm_cost_usd_total",
+            "Actual billed cost from llm_spend_recorded.cost_usd.",
+            labelnames=llm_cost_labels,
+            registry=registry,
+        )
+        llm_usage_missing = Counter(
+            "ao_llm_usage_missing_total",
+            "Count of llm_usage_missing events (adapter responses "
+            "without usage fields; cost reservation held).",
+            labelnames=llm_cost_labels,
+            registry=registry,
+        )
+
+    # Non-LLM families — always registered.
+    policy_check = Counter(
+        "ao_policy_check_total",
+        "Policy evaluations derived from policy_checked.violations_count "
+        "(outcome=allow when violations_count==0, deny when >0).",
+        labelnames=("outcome",),
+        registry=registry,
+    )
+
+    workflow_duration = Histogram(
+        "ao_workflow_duration_seconds",
+        "Wall-clock seconds per workflow run; cancelled runs derive "
+        "duration from state.v1.json.completed_at (plan v4 Q3).",
+        labelnames=("final_state",),
+        buckets=_WORKFLOW_DURATION_BUCKETS,
+        registry=registry,
+    )
+
+    claim_active_labels = _label_names(
+        (), ("agent_id",), allowlist,
+    )
+    claim_active = Gauge(
+        "ao_claim_active_total",
+        "Live coordination claims, computed via "
+        "coordination.registry.live_claims_count() (plan v4 Q1).",
+        labelnames=claim_active_labels,
+        registry=registry,
+    )
+
+    claim_takeover = Counter(
+        "ao_claim_takeover_total",
+        "Count of claim_takeover events (coordination forced "
+        "takeover path).",
+        labelnames=(),
+        registry=registry,
+    )
+
+    return BuiltRegistry(
+        registry=registry,
+        llm_call_duration=llm_call_duration,
+        llm_tokens_used=llm_tokens_used,
+        llm_cost_usd=llm_cost_usd,
+        llm_usage_missing=llm_usage_missing,
+        policy_check=policy_check,
+        workflow_duration=workflow_duration,
+        claim_active=claim_active,
+        claim_takeover=claim_takeover,
+    )
+
+
+__all__ = [
+    "BuiltRegistry",
+    "build_registry",
+    "is_metrics_available",
+]

--- a/ao_kernel/workflow/run_store.py
+++ b/ao_kernel/workflow/run_store.py
@@ -364,3 +364,49 @@ def _now_iso() -> str:
     ``Z`` and explicit offset).
     """
     return datetime.now(timezone.utc).isoformat()
+
+
+_TERMINAL_STATES: frozenset[str] = frozenset({"completed", "failed", "cancelled"})
+
+
+def list_terminal_runs(workspace_root: Path) -> list[dict[str, Any]]:
+    """Return the records of every workflow run in a terminal state.
+
+    Plan v4 Q3 A: the ``ao_workflow_duration_seconds`` histogram needs
+    cancelled run durations, but the runtime never emits a
+    ``workflow_cancelled`` event (denial path emits ``approval_denied``
+    + transitions run state). The PR-B5 derivation layer uses this
+    helper to read ``state.v1.json.{created_at, completed_at}`` for
+    cancelled runs without introducing a new event kind.
+
+    The helper is read-only: no CAS lock, no schema validation. Corrupt
+    or partially-written state files are skipped silently — the
+    caller (metrics derivation) treats a missing / malformed state file
+    as "run absent from histogram" rather than raising, because
+    the export CLI must not abort on transient run-store drift while
+    a workflow is concurrently writing.
+
+    Internal scope: the helper is returned from the module but is not
+    part of the facade re-export surface in
+    :mod:`ao_kernel.workflow.__init__`. Callers outside the metrics
+    derivation layer should use :func:`load_run` instead.
+    """
+    runs_dir = workspace_root / ".ao" / "runs"
+    if not runs_dir.is_dir():
+        return []
+    results: list[dict[str, Any]] = []
+    for run_dir in sorted(runs_dir.iterdir()):
+        if not run_dir.is_dir():
+            continue
+        state_path = run_dir / "state.v1.json"
+        if not state_path.is_file():
+            continue
+        try:
+            record = json.loads(state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(record, dict):
+            continue
+        if record.get("state") in _TERMINAL_STATES:
+            results.append(record)
+    return results

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -1,30 +1,49 @@
 # Metrics — Prometheus / OTEL Export Surface
 
-**Status:** FAZ-B PR-B0 contract pin (docs skeleton). Runtime implementation: PR-B5 (`ao_kernel/metrics/` + `[metrics]` extra).
+**Status:** FAZ-B PR-B5 shipped — `ao_kernel/metrics/` runtime + `[metrics]` extra + `ao-kernel metrics {export,debug-query}` CLI + bundled Grafana dashboard. PR-B0 shipped the schema + dormant policy skeleton; PR-B5 added the runtime populator + CLI.
 
 ## 1. Overview
 
 ao-kernel exposes governance and runtime metrics in two orthogonal channels:
 
-1. **Prometheus textfile export** (PR-B5) — low-cardinality default label set; operators scrape via `ao-kernel metrics export --format prometheus`. Ships under `[metrics]` optional extra.
+1. **Prometheus textfile export** (PR-B5) — low-cardinality default label set; operators scrape via `ao-kernel metrics export --format prometheus`. Ships under the `[metrics]` optional extra.
 2. **OTEL span bridge** (existing, [PR-A telemetry](../ao_kernel/telemetry.py)) — unchanged; `[metrics]` and `[otel]` extras are independent, installable separately.
 
 The `[metrics]` extra has no hard dependency on `[otel]`. The library never runs an HTTP server; operators who want push-to-Prometheus run the CLI in their own cron or sidecar.
 
-## 2. Default Metric Set
+**Runtime architecture (evidence-derived):**
+
+```
+events.jsonl  ──►  ao_kernel.metrics.derivation  ──►  prometheus_client registry
+                                                  │
+state.v1.json ──►  run_store.list_terminal_runs   ├──►  ao_kernel.metrics.export
+                                                  │     (Prometheus textfile)
+claim SSOT    ──►  coordination.live_claims_count ┘
+```
+
+The derivation layer is **stateless + read-only** — no coupling into hot LLM / executor / cost paths. Scrape cadence is driven by the operator's cron or systemd timer calling the CLI.
+
+## 2. Default Metric Set (eight families)
 
 Low-cardinality labels only. See §3 for opt-in expansion.
 
-| Metric | Type | Labels | Fired by |
+| Metric | Type | Labels | Source |
 |---|---|---|---|
-| `ao_llm_call_duration_seconds` | histogram | `provider` | PR-A `llm` facade |
-| `ao_llm_tokens_used_total` | counter | `provider`, `direction` ∈ `{input, output, cached}` | PR-A `llm` facade |
-| `ao_policy_check_total` | counter | `outcome` ∈ `{allow, deny}` | PR-A `governance.check_policy` |
-| `ao_workflow_duration_seconds` | histogram | `final_state` ∈ `{completed, failed, cancelled}` | PR-A4b `MultiStepDriver` |
-| `ao_claim_active_total` | gauge | (none — scalar) | PR-B1 coordination |
-| `ao_claim_takeover_total` | counter | (none — scalar) | PR-B1 coordination |
+| `ao_llm_call_duration_seconds` | histogram | `provider` | `llm_spend_recorded.duration_ms` (PR-B5 C2b) |
+| `ao_llm_tokens_used_total` | counter | `provider`, `direction` ∈ `{input, output, cached}` | `llm_spend_recorded.{tokens_input,tokens_output,cached_tokens}` |
+| `ao_llm_cost_usd_total` | counter | `provider` | `llm_spend_recorded.cost_usd` |
+| `ao_llm_usage_missing_total` | counter | `provider` | `llm_usage_missing` event count |
+| `ao_policy_check_total` | counter | `outcome` ∈ `{allow, deny}` | `policy_checked.violations_count` (`==0` → allow, `>0` → deny) |
+| `ao_workflow_duration_seconds` | histogram | `final_state` ∈ `{completed, failed, cancelled}` | `workflow_started` + terminal event (or `state.v1.json.completed_at` for cancelled) |
+| `ao_claim_active_total` | gauge | (none — scalar) | `coordination.registry.live_claims_count()` snapshot |
+| `ao_claim_takeover_total` | counter | (none — scalar) | `claim_takeover` event count |
 
-**Deliberately excluded by default:** `model`, `agent_id`, `run_id`, `workflow_id`, `step_id`. Each would produce O(100) – O(10k) distinct values in a reasonable deployment, and Prometheus cardinality costs scale multiplicatively. Exposing them without an opt-in would create a silent storage bomb.
+**Histogram buckets** (plan v4 §2.2):
+
+- LLM: `0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 300, 600` seconds (upper 600s tolerates GPT-4-turbo outliers).
+- Workflow: `1, 5, 15, 60, 300, 900, 3600, 7200` seconds (human-approval steps can dwell overnight).
+
+**Deliberately excluded by default:** `model`, `agent_id`, `run_id`, `workflow_id`, `step_id`. Each would produce O(100) – O(10k) distinct values in a reasonable deployment, and Prometheus cardinality costs scale multiplicatively. Exposing them without an opt-in would create a silent storage bomb. See §6 for the cardinality guard.
 
 ## 3. Advanced Labels (Schema-Backed Opt-In)
 
@@ -46,9 +65,9 @@ The `enabled` flag on the top-level policy gates metrics emission altogether. Th
 
 ## 4. Grafana Integration
 
-Reference dashboard JSON ships under `docs/grafana/` (PR-B5). Operators import into their own Grafana instance; the library does not host Grafana.
+Reference dashboard JSON ships at [`docs/grafana/ao_kernel_default.v1.json`](grafana/ao_kernel_default.v1.json). Operators import into their own Grafana instance via one of four recipes documented in [`docs/grafana/README.md`](grafana/README.md) (UI upload, local file provisioning, Kubernetes ConfigMap, or Grafana HTTP API).
 
-Dashboard panels target the default metric set; advanced-label panels ship commented-out so importing the dashboard does not break when `labels_advanced.enabled: false`.
+The dashboard ships with eight panels — one per metric family — all targeting the default low-cardinality label set. A shape test (`tests/test_grafana_dashboard_shape.py`) pins the panel → metric mapping so the dashboard and runtime cannot drift apart.
 
 ## 5. OTEL Bridge
 
@@ -56,19 +75,106 @@ Dashboard panels target the default metric set; advanced-label panels ship comme
 
 Operators who want both can install both extras (`pip install ao-kernel[otel,metrics]`); the two surfaces do not interfere.
 
-## 6. CLI
+## 6. CLI + Operator Runbook
 
-`ao-kernel metrics export --format prometheus` (PR-B5) emits the current metric set in Prometheus textfile format on stdout. Typical integration: cron → file → Prometheus `textfile` collector.
+### 6.1 `ao-kernel metrics export`
+
+Cumulative Prometheus textfile emitter. Typical integration:
+
+```bash
+# Cron every minute:
+* * * * * /usr/bin/ao-kernel metrics export \
+  --output /var/lib/node_exporter/textfile/ao-kernel.prom
+```
+
+The output is always a full workspace scan (no `--since` / `--run` — those flags would break Prometheus counter semantics; see §6.4).
+
+**Exit codes:**
+
+| Code | Meaning |
+|---|---|
+| 0 | Success (textfile emitted; may be banner-only when dormant). |
+| 1 | User error (`--output` path not writable). |
+| 2 | Internal (corrupt evidence JSONL → `EvidenceSourceCorruptedError`). |
+| 3 | `[metrics]` extra not installed — informational banner, not a crash. |
+
+### 6.2 Dormant policy ↔ banner-only textfile
+
+When `policy_metrics.v1.json.enabled=false` (bundled default), the textfile contains only banner comments:
+
+```
+# ao-kernel metrics: dormant (policy_metrics.enabled=false). Operator action: ...
+```
+
+Grafana renders every panel as "No data" with the banner rationale visible to operators via Prometheus text format.
+
+### 6.3 Cost-tracking prerequisite (disjunction)
+
+**LLM metrics require cost tracking enabled.** When `policy_cost_tracking.v1.json.enabled=false`, the `ao_llm_*` metric family is **absent** from the textfile (plan v4 §2 cost-disjunction invariant). No zero-synthetic samples, no HELP/TYPE metadata stubs — the family simply does not exist in the output:
+
+```
+# ao-kernel metrics: cost tracking dormant (policy_cost_tracking.enabled=false); LLM metric family absent.
+```
+
+This disjunction matches the runtime reality: `llm_spend_recorded` and `llm_usage_missing` events are only emitted by `governed_call` on the cost-active path. Collecting zero-filled samples when no data exists would lie to the dashboard.
+
+To get LLM metrics, enable both policies:
+
+```json
+// .ao/policies/policy_metrics.v1.json
+{"version": "v1", "enabled": true, "labels_advanced": {"enabled": false, "allowlist": []}}
+// .ao/policies/policy_cost_tracking.v1.json
+{"version": "v1", "enabled": true, /* … cost knobs … */}
+```
+
+### 6.4 Why no `--since` / `--run` flags
+
+Prometheus textfile collectors are **cumulative** — samples grow monotonically, and the collector computes deltas between scrapes. A windowed (`--since`) or run-scoped (`--run`) export would reset counters between scrapes, which Prometheus interprets as a counter restart and treats the drop as a huge negative rate.
+
+For operator debugging (ad-hoc "what happened in the last hour" queries), use `ao-kernel metrics debug-query` (§6.5) which emits JSON specifically designed for filtering.
+
+### 6.5 `ao-kernel metrics debug-query`
+
+Non-Prometheus JSON query surface for operator debugging. Never emits textfile.
+
+```bash
+# All events in run X since a specific moment:
+ao-kernel metrics debug-query \
+  --run 00000000-0000-4000-8000-000000000001 \
+  --since 2026-04-17T18:00:00+00:00 \
+  --output debug.json
+```
+
+**`--since` contract:** ISO-8601 with **mandatory timezone** (`Z` or `+HH:MM`). Naive input is rejected at argparse:
+
+```
+error: argument --since: timezone required, use 'Z' or '+HH:MM' offset
+```
+
+Epoch integers are also rejected — the contract insists on ISO-8601 string form so there is no ambiguity about the reference frame.
+
+### 6.6 Cardinality hard-warning
+
+**Do not opt into advanced labels with ephemeral values.** The schema's closed enum constrains *names* (`model`, `agent_id`) but not *values*. If an operator sets `labels_advanced.allowlist = ["agent_id"]` and the runtime sees a fresh `agent_id` per request (e.g., containing a UUID), Prometheus will accumulate unbounded time series — one per request — and storage will collapse.
+
+Treat `agent_id` and `model` as **bounded enumerations** in the workspace. `agent_id` should be a small set of deployment names ("crawler", "reviewer", "planner", …), and `model` the short list of actually-used LLM models. Do not set `agent_id` to a per-request token. This is a non-retrieval-specific invariant: the textfile collector accepts whatever is emitted and Prometheus replicates the mistake forever.
 
 Future formats (OpenMetrics, StatsD, InfluxDB) are not in scope for B5; they are deferred to post-FAZ-E if demanded.
 
 ## 7. Cross-References
 
 - Schema: [`policy-metrics.schema.v1.json`](../ao_kernel/defaults/schemas/policy-metrics.schema.v1.json)
-- Policy: [`policy_metrics.v1.json`](../ao_kernel/defaults/policies/policy_metrics.v1.json) (PR-B0 commit 4 — dormant default)
+- Policy: [`policy_metrics.v1.json`](../ao_kernel/defaults/policies/policy_metrics.v1.json) (PR-B0 — dormant default)
+- Runtime:
+  - [`ao_kernel/metrics/policy.py`](../ao_kernel/metrics/policy.py) — loader + dataclass
+  - [`ao_kernel/metrics/registry.py`](../ao_kernel/metrics/registry.py) — 8 families, lazy `prometheus_client`
+  - [`ao_kernel/metrics/derivation.py`](../ao_kernel/metrics/derivation.py) — evidence → metric populator
+  - [`ao_kernel/metrics/export.py`](../ao_kernel/metrics/export.py) — textfile serializer + banners
+- CLI handlers: [`ao_kernel/_internal/metrics/cli_handlers.py`](../ao_kernel/_internal/metrics/cli_handlers.py), [`ao_kernel/_internal/metrics/debug_query.py`](../ao_kernel/_internal/metrics/debug_query.py)
+- Grafana dashboard: [`docs/grafana/ao_kernel_default.v1.json`](grafana/ao_kernel_default.v1.json), [`docs/grafana/README.md`](grafana/README.md)
 - OTEL spans: [`ao_kernel/telemetry.py`](../ao_kernel/telemetry.py), docstrings therein
-- Runtime (scope out of B0): PR-B5 `ao_kernel/metrics/` package + `[metrics]` extra
+- Cost events consumed: `llm_spend_recorded` + `llm_usage_missing` (emitted by [`ao_kernel/cost/middleware.py`](../ao_kernel/cost/middleware.py); `duration_ms` additive field from PR-B5 C2b)
 
 ## 8. Document Status
 
-Skeleton in PR-B0 commit 1. Panel-by-panel Grafana walkthrough, cardinality-tuning case study, and PR-A evidence → metric extraction recipe land in PR-B0 commit 5 (docs final pass).
+Operator runbook + cost-disjunction + cardinality warning landed in PR-B5 C5. Future revisions may add: histogram bucket knob walk-through (FAZ-D), streaming token metrics (FAZ-C), evidence → metric extraction recipe beyond the current eight families.

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -1,0 +1,88 @@
+# ao-kernel Grafana dashboards
+
+`ao_kernel_default.v1.json` is a **default observability dashboard** for the eight metric families emitted by `ao-kernel metrics export` (PR-B5). It ships with the repository so operators can import a known-good surface without hand-rolling queries.
+
+## Panel → metric matrix
+
+| # | Panel | Metric family | PromQL |
+|---|---|---|---|
+| 1 | LLM call duration p95 | `ao_llm_call_duration_seconds` | `histogram_quantile(0.95, sum(rate(ao_llm_call_duration_seconds_bucket[5m])) by (provider, le))` |
+| 2 | LLM tokens/s | `ao_llm_tokens_used_total` | `sum(rate(ao_llm_tokens_used_total[5m])) by (provider, direction)` |
+| 3 | LLM cost USD/hour | `ao_llm_cost_usd_total` | `sum(rate(ao_llm_cost_usd_total[1h])) by (provider) * 3600` |
+| 4 | LLM usage-missing rate | `ao_llm_usage_missing_total` | `sum(rate(ao_llm_usage_missing_total[5m])) by (provider)` |
+| 5 | Policy deny rate | `ao_policy_check_total` | `sum(rate(ao_policy_check_total{outcome="deny"}[5m]))` |
+| 6 | Workflow duration p95 | `ao_workflow_duration_seconds` | `histogram_quantile(0.95, sum(rate(ao_workflow_duration_seconds_bucket[5m])) by (final_state, le))` |
+| 7 | Active coordination claims | `ao_claim_active_total` | `ao_claim_active_total` |
+| 8 | Claim takeovers (1h) | `ao_claim_takeover_total` | `increase(ao_claim_takeover_total[1h])` |
+
+The dashboard shape test (`tests/test_grafana_dashboard_shape.py`) pins the fact that every panel's first target references the metric family in the table above.
+
+## Import recipes
+
+### 1. Grafana UI (manual)
+
+1. Open **Dashboards → New → Import**.
+2. Click **Upload JSON file** and select `docs/grafana/ao_kernel_default.v1.json`.
+3. Pick your Prometheus datasource for `DS_PROMETHEUS`.
+4. Click **Import**.
+
+### 2. Local file provisioning (self-hosted Grafana)
+
+```yaml
+# /etc/grafana/provisioning/dashboards/ao-kernel.yaml
+apiVersion: 1
+providers:
+  - name: ao-kernel
+    orgId: 1
+    folder: ao-kernel
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 60
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards/ao-kernel
+```
+
+Copy `ao_kernel_default.v1.json` to `/var/lib/grafana/dashboards/ao-kernel/`.
+
+### 3. Kubernetes ConfigMap (grafana-operator)
+
+```bash
+kubectl create configmap ao-kernel-default-dashboard \
+  --from-file=ao_kernel_default.v1.json=docs/grafana/ao_kernel_default.v1.json \
+  -n monitoring
+```
+
+Reference the ConfigMap from your `GrafanaDashboard` CR or sidecar loader.
+
+### 4. Grafana HTTP API
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $GRAFANA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @docs/grafana/ao_kernel_default.v1.json \
+  "https://grafana.example.com/api/dashboards/db"
+```
+
+## Prerequisite: Prometheus textfile scrape
+
+Every panel assumes a Prometheus instance scrapes the textfile ao-kernel writes:
+
+```bash
+ao-kernel metrics export --output /var/lib/node_exporter/textfile/ao-kernel.prom
+```
+
+Wire this into a cron job (every minute) or a systemd timer. The **textfile collector** on your node_exporter or pushgateway-free equivalent ingests the file on the next scrape.
+
+## Dormant workspaces
+
+When `policy_metrics.v1.json.enabled=false` (bundled default) the textfile contains only banner comments — Grafana renders every panel as "No data". That is the intended behaviour; the banner spells out the rationale so operators can opt in explicitly.
+
+## Cost-tracking prerequisite
+
+LLM panels (1–4) depend on `policy_cost_tracking.v1.json.enabled=true`. When cost tracking is dormant the textfile omits the `ao_llm_*` family entirely and the four LLM panels display "No data" — see `docs/METRICS.md` §6 for the disjunction contract.
+
+## Advanced labels (opt-in, high cardinality)
+
+Set `labels_advanced.enabled=true` and list values in `allowlist` (closed enum: `model`, `agent_id`) to expand the panels with an extra dimension. Cardinality warning: do not set `agent_id` to an ephemeral / per-request string — the time-series explosion will crush your Prometheus storage.

--- a/docs/grafana/ao_kernel_default.v1.json
+++ b/docs/grafana/ao_kernel_default.v1.json
@@ -1,0 +1,175 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "ao-kernel default Prometheus dashboard (PR-B5). Eight panels cover LLM observability (duration p95, tokens/s, cost/h, usage-miss rate), policy enforcement (deny rate), workflow duration (p95 by final_state), and coordination (active claims + takeover count). Default label cardinality is low — import the advanced overlay panels (commented out) only after enabling labels_advanced.{enabled,allowlist} in policy_metrics.v1.json.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 1,
+      "title": "LLM call duration p95 (by provider)",
+      "type": "timeseries",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(ao_llm_call_duration_seconds_bucket[5m])) by (provider, le))",
+          "legendFormat": "{{provider}} p95",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green"}, {"color": "red", "value": 60}]}
+        },
+        "overrides": []
+      },
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "id": 2,
+      "title": "LLM tokens/s (by provider + direction)",
+      "type": "timeseries",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "targets": [
+        {
+          "expr": "sum(rate(ao_llm_tokens_used_total[5m])) by (provider, direction)",
+          "legendFormat": "{{provider}} / {{direction}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "tps"}, "overrides": []},
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "id": 3,
+      "title": "LLM cost (USD/hour, by provider)",
+      "type": "stat",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 8},
+      "targets": [
+        {
+          "expr": "sum(rate(ao_llm_cost_usd_total[1h])) by (provider) * 3600",
+          "legendFormat": "{{provider}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "currencyUSD", "decimals": 2}, "overrides": []},
+      "options": {"textMode": "auto", "graphMode": "area"}
+    },
+    {
+      "id": 4,
+      "title": "LLM usage-missing rate (by provider)",
+      "type": "timeseries",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 8},
+      "targets": [
+        {
+          "expr": "sum(rate(ao_llm_usage_missing_total[5m])) by (provider)",
+          "legendFormat": "{{provider}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "id": 5,
+      "title": "Policy deny rate",
+      "type": "timeseries",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 8},
+      "targets": [
+        {
+          "expr": "sum(rate(ao_policy_check_total{outcome=\"deny\"}[5m]))",
+          "legendFormat": "deny/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "options": {"tooltip": {"mode": "single"}}
+    },
+    {
+      "id": 6,
+      "title": "Workflow duration p95 (by final_state)",
+      "type": "timeseries",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 8},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(ao_workflow_duration_seconds_bucket[5m])) by (final_state, le))",
+          "legendFormat": "{{final_state}} p95",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "options": {"tooltip": {"mode": "multi"}}
+    },
+    {
+      "id": 7,
+      "title": "Active coordination claims",
+      "type": "stat",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 14},
+      "targets": [
+        {
+          "expr": "ao_claim_active_total",
+          "legendFormat": "claims",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "options": {"textMode": "auto", "graphMode": "area"}
+    },
+    {
+      "id": 8,
+      "title": "Claim takeovers (last 1h)",
+      "type": "stat",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 14},
+      "targets": [
+        {
+          "expr": "increase(ao_claim_takeover_total[1h])",
+          "legendFormat": "takeovers/1h",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "options": {"textMode": "auto", "graphMode": "area"}
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["ao-kernel", "observability"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "Prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "ao-kernel — default",
+  "uid": "ao-kernel-default-v1",
+  "version": 1,
+  "weekStart": ""
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,12 +61,15 @@ pgvector = [
     "pgvector",
     "psycopg2-binary",
 ]
-# Meta-extras (PR-A6)
+metrics = [
+    "prometheus-client>=0.20.0",
+]
+# Meta-extras (PR-A6, widened in PR-B5 for metrics)
 coding = [
     "ao-kernel[llm]",
 ]
 enterprise = [
-    "ao-kernel[otel,mcp,pgvector]",
+    "ao-kernel[otel,mcp,pgvector,metrics]",
 ]
 
 [project.scripts]

--- a/tests/test_cost_duration_ms.py
+++ b/tests/test_cost_duration_ms.py
@@ -1,0 +1,289 @@
+"""Tests for PR-B5 C2b — ``llm_spend_recorded.duration_ms`` additive field.
+
+Pinpoints the B2 middleware extension without touching the broader
+B2 flow (regression coverage already lives in
+``test_cost_middleware_core.py``). Focus:
+
+1. ``elapsed_ms`` kwarg forwards into the emitted
+   ``llm_spend_recorded`` payload as ``duration_ms``.
+2. Backward-compat: ``elapsed_ms=None`` (default) keeps the legacy
+   payload shape (no ``duration_ms`` key).
+3. Floats are rounded to 3 decimals (Prometheus histograms convert
+   ms→s, so excess precision is lost — rounding here keeps the
+   evidence event compact and deterministic).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ao_kernel.cost.catalog import PriceCatalogEntry, clear_catalog_cache
+from ao_kernel.cost.middleware import (
+    post_response_reconcile,
+    pre_dispatch_reserve,
+)
+from ao_kernel.cost.policy import CostTrackingPolicy, RoutingByCost
+from ao_kernel.workflow.run_store import create_run
+
+
+@pytest.fixture(autouse=True)
+def _reset_catalog_cache():
+    clear_catalog_cache()
+    yield
+    clear_catalog_cache()
+
+
+def _policy() -> CostTrackingPolicy:
+    return CostTrackingPolicy(
+        enabled=True,
+        price_catalog_path=".ao/cost/catalog.v1.json",
+        spend_ledger_path=".ao/cost/spend.jsonl",
+        fail_closed_on_exhaust=True,
+        strict_freshness=False,
+        fail_closed_on_missing_usage=True,
+        idempotency_window_lines=1000,
+        routing_by_cost=RoutingByCost(enabled=False),
+    )
+
+
+def _entry() -> PriceCatalogEntry:
+    return PriceCatalogEntry(
+        provider_id="anthropic",
+        model="claude-3-5-sonnet",
+        input_cost_per_1k=0.003,
+        output_cost_per_1k=0.015,
+        cached_input_cost_per_1k=0.0003,
+        currency="USD",
+        billing_unit="per_1k_tokens",
+        effective_date="2024-10-22",
+        vendor_model_id="claude-3-5-sonnet-20241022",
+    )
+
+
+def _create_run_with_budget(ws: Path) -> str:
+    rid = str(uuid.uuid4())
+    budget: dict[str, Any] = {
+        "fail_closed_on_exhaust": True,
+        "cost_usd": {"limit": 10.0, "spent": 0.0, "remaining": 10.0},
+    }
+    create_run(
+        ws,
+        run_id=rid,
+        workflow_id="bug_fix_flow",
+        workflow_version="1.0.0",
+        intent={"kind": "inline_prompt", "payload": "test"},
+        budget=budget,
+        policy_refs=[
+            "ao_kernel/defaults/policies/policy_worktree_profile.v1.json"
+        ],
+        evidence_refs=[".ao/evidence/workflows/x/events.jsonl"],
+    )
+    return rid
+
+
+def _ok_response(input_tokens: int = 100, output_tokens: int = 50) -> bytes:
+    return json.dumps(
+        {
+            "text": "response text",
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            },
+        }
+    ).encode("utf-8")
+
+
+def _spend_events(ws: Path, run_id: str) -> list[dict[str, Any]]:
+    events_path = (
+        ws / ".ao" / "evidence" / "workflows" / run_id / "events.jsonl"
+    )
+    lines = events_path.read_text(encoding="utf-8").strip().splitlines()
+    return [
+        json.loads(line)
+        for line in lines
+        if json.loads(line).get("kind") == "llm_spend_recorded"
+    ]
+
+
+class TestDurationMsPassthrough:
+    def test_elapsed_ms_appears_as_duration_ms(
+        self, tmp_path: Path
+    ) -> None:
+        """C2b canonical case: ``elapsed_ms=250.5`` threads through
+        the reconcile into the emitted ``llm_spend_recorded`` payload
+        as ``duration_ms=250.5``. This is the single source of truth
+        PR-B5 derivation reads for ``ao_llm_call_duration_seconds``."""
+        run_id = _create_run_with_budget(tmp_path)
+        policy = _policy()
+        pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-alpha",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=[{"role": "user", "content": "hello"}],
+            max_tokens=100,
+            policy=policy,
+        )
+        post_response_reconcile(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-alpha",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            catalog_entry=_entry(),
+            est_cost=Decimal("0.0010"),
+            raw_response_bytes=_ok_response(),
+            policy=policy,
+            elapsed_ms=250.5,
+        )
+
+        spends = _spend_events(tmp_path, run_id)
+        assert len(spends) == 1
+        payload = spends[0].get("payload", spends[0])
+        assert payload["duration_ms"] == 250.5
+
+
+class TestDurationMsBackwardCompat:
+    def test_duration_ms_omitted_when_elapsed_ms_none(
+        self, tmp_path: Path
+    ) -> None:
+        """Backward compat (plan v4 R13): legacy callers that don't
+        pass ``elapsed_ms`` see the pre-B5 payload shape — no
+        ``duration_ms`` key at all, not ``None``. The derivation
+        layer uses key-presence to decide "skip this call"."""
+        run_id = _create_run_with_budget(tmp_path)
+        policy = _policy()
+        pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-alpha",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=[{"role": "user", "content": "hello"}],
+            max_tokens=100,
+            policy=policy,
+        )
+        # Omit elapsed_ms entirely (legacy caller shape).
+        post_response_reconcile(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-alpha",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            catalog_entry=_entry(),
+            est_cost=Decimal("0.0010"),
+            raw_response_bytes=_ok_response(),
+            policy=policy,
+        )
+
+        spends = _spend_events(tmp_path, run_id)
+        assert len(spends) == 1
+        payload = spends[0].get("payload", spends[0])
+        assert "duration_ms" not in payload
+
+
+class TestDurationMsPrecision:
+    def test_float_rounded_to_three_decimals(
+        self, tmp_path: Path
+    ) -> None:
+        """Excess precision is rounded to 3 decimals so the emitted
+        event stays compact and deterministic across runs. Prometheus
+        converts ms→s anyway, so sub-microsecond detail is noise."""
+        run_id = _create_run_with_budget(tmp_path)
+        policy = _policy()
+        pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-alpha",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=[{"role": "user", "content": "hello"}],
+            max_tokens=100,
+            policy=policy,
+        )
+        post_response_reconcile(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-alpha",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            catalog_entry=_entry(),
+            est_cost=Decimal("0.0010"),
+            raw_response_bytes=_ok_response(),
+            policy=policy,
+            elapsed_ms=123.4567891234,  # well past 3 decimals
+        )
+
+        spends = _spend_events(tmp_path, run_id)
+        payload = spends[0].get("payload", spends[0])
+        assert payload["duration_ms"] == 123.457
+
+
+class TestDurationMsAbsentInUsageMissingPath:
+    def test_usage_missing_event_has_no_duration_ms(
+        self, tmp_path: Path
+    ) -> None:
+        """Plan v4 R14: the usage-missing path emits
+        ``llm_usage_missing`` (not ``llm_spend_recorded``), so
+        ``duration_ms`` is not relevant there. This test pins the
+        absence so derivation correctly excludes usage-miss calls
+        from the duration histogram."""
+        from ao_kernel.cost.errors import LLMUsageMissingError
+
+        run_id = _create_run_with_budget(tmp_path)
+        policy = _policy()
+        pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-alpha",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=[{"role": "user", "content": "hello"}],
+            max_tokens=100,
+            policy=policy,
+        )
+        # Missing-usage response → raises LLMUsageMissingError after
+        # emitting ``llm_usage_missing`` (audit + no duration field).
+        with pytest.raises(LLMUsageMissingError):
+            post_response_reconcile(
+                workspace_root=tmp_path,
+                run_id=run_id,
+                step_id="step-alpha",
+                attempt=1,
+                provider_id="anthropic",
+                model="claude-3-5-sonnet",
+                catalog_entry=_entry(),
+                est_cost=Decimal("0.0010"),
+                raw_response_bytes=b'{"text": "missing usage"}',
+                policy=policy,
+                elapsed_ms=250.5,  # passed but irrelevant
+            )
+
+        events_path = (
+            tmp_path
+            / ".ao"
+            / "evidence"
+            / "workflows"
+            / run_id
+            / "events.jsonl"
+        )
+        lines = events_path.read_text(encoding="utf-8").strip().splitlines()
+        kinds = [json.loads(line).get("kind") for line in lines]
+        assert "llm_usage_missing" in kinds
+        # ``llm_spend_recorded`` must NOT be emitted in the missing
+        # path; duration_ms has no carrier.
+        assert "llm_spend_recorded" not in kinds

--- a/tests/test_cost_duration_ms.py
+++ b/tests/test_cost_duration_ms.py
@@ -232,6 +232,90 @@ class TestDurationMsPrecision:
         assert payload["duration_ms"] == 123.457
 
 
+class TestDurationMsGovernedCallPassthrough:
+    """Post-impl review CNS-036 iter-1 A4 absorb: the canonical e2e
+    chain is `governed_call` → `execute_request()` → `elapsed_ms`
+    capture → `post_response_reconcile(..., elapsed_ms=...)` →
+    emitted `llm_spend_recorded.duration_ms`. The direct middleware
+    tests cover the emit contract; this test pins the wrapper flow
+    end-to-end with a monkey-patched transport so real HTTP is not
+    required."""
+
+    def test_governed_call_threads_elapsed_ms_to_event(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import ao_kernel.llm as llm_mod
+
+        run_id = _create_run_with_budget(tmp_path)
+
+        # Workspace-scoped cost policy override: enabled=true. Using
+        # the same shape as PR #100's test_cost_governed_call_e2e.py
+        # (which relies on the bundled price catalog at
+        # ao_kernel/defaults/catalogs/price-catalog.v1.json).
+        (tmp_path / ".ao" / "policies").mkdir(parents=True, exist_ok=True)
+        (
+            tmp_path / ".ao" / "policies" / "policy_cost_tracking.v1.json"
+        ).write_text(
+            json.dumps({
+                "version": "v1",
+                "enabled": True,
+                "price_catalog_path": ".ao/cost/catalog.v1.json",
+                "spend_ledger_path": ".ao/cost/spend.jsonl",
+                "fail_closed_on_exhaust": True,
+                "strict_freshness": False,
+                "fail_closed_on_missing_usage": True,
+                "idempotency_window_lines": 1000,
+                "routing_by_cost": {"enabled": False},
+            }),
+            encoding="utf-8",
+        )
+
+        # Stub transport: return a success envelope with a specific
+        # `elapsed_ms` so we can pin it in the emitted event.
+        def _fake_execute_request(**kwargs):
+            return {
+                "status": "OK",
+                "http_status": 200,
+                "resp_bytes": json.dumps({
+                    "text": "mock response",
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                    },
+                }).encode("utf-8"),
+                "elapsed_ms": 987.654,
+            }
+
+        monkeypatch.setattr(
+            llm_mod, "execute_request", _fake_execute_request,
+        )
+        monkeypatch.setattr(
+            "ao_kernel.llm.check_capabilities",
+            lambda **_: (True, "anthropic", []),
+        )
+
+        result = llm_mod.governed_call(
+            [{"role": "user", "content": "hello"}],
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            api_key="test-key",
+            base_url="https://api.anthropic.test/v1",
+            request_id="req-e2e-1",
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step-alpha",
+            attempt=1,
+        )
+        assert result["status"] == "OK"
+
+        spends = _spend_events(tmp_path, run_id)
+        assert len(spends) == 1
+        payload = spends[0].get("payload", spends[0])
+        # `elapsed_ms` from the stubbed transport must round-trip
+        # into the event as `duration_ms` (3-decimal precision).
+        assert payload["duration_ms"] == 987.654
+
+
 class TestDurationMsAbsentInUsageMissingPath:
     def test_usage_missing_event_has_no_duration_ms(
         self, tmp_path: Path

--- a/tests/test_grafana_dashboard_shape.py
+++ b/tests/test_grafana_dashboard_shape.py
@@ -1,0 +1,119 @@
+"""Shape test for the bundled Grafana dashboard (PR-B5 C4).
+
+Pins the panel → metric matrix declared in `docs/grafana/README.md`
+so that an operator-facing dashboard edit cannot silently drop a
+metric from the matrix without breaking the test. Also covers:
+
+- Valid JSON + schema version compatibility.
+- Eight panels (seven visible panels in the default + one that was
+  merged but we count based on plan v4 §2.8).
+- Each panel's first target expression references the expected
+  metric name from the plan.
+- Datasource template variable present for portable import.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+_DASHBOARD_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "grafana"
+    / "ao_kernel_default.v1.json"
+)
+
+
+# Panel title → metric family substring that must appear in the
+# first target's ``expr``. Derived from plan v4 §2.8 panel-matrix.
+_EXPECTED_PANELS: dict[str, str] = {
+    "LLM call duration p95 (by provider)": "ao_llm_call_duration_seconds",
+    "LLM tokens/s (by provider + direction)": "ao_llm_tokens_used_total",
+    "LLM cost (USD/hour, by provider)": "ao_llm_cost_usd_total",
+    "LLM usage-missing rate (by provider)": "ao_llm_usage_missing_total",
+    "Policy deny rate": "ao_policy_check_total",
+    "Workflow duration p95 (by final_state)": "ao_workflow_duration_seconds",
+    "Active coordination claims": "ao_claim_active_total",
+    "Claim takeovers (last 1h)": "ao_claim_takeover_total",
+}
+
+
+def _load_dashboard() -> dict:
+    return json.loads(_DASHBOARD_PATH.read_text(encoding="utf-8"))
+
+
+class TestStructure:
+    def test_dashboard_file_exists(self) -> None:
+        assert _DASHBOARD_PATH.is_file(), (
+            f"bundled dashboard missing at {_DASHBOARD_PATH}"
+        )
+
+    def test_dashboard_is_valid_json(self) -> None:
+        # Raises JSONDecodeError on failure.
+        doc = _load_dashboard()
+        assert isinstance(doc, dict)
+
+    def test_schema_version_recent(self) -> None:
+        """Grafana 10+ ships schemaVersion 38; older versions still
+        import but with warnings."""
+        doc = _load_dashboard()
+        assert doc["schemaVersion"] >= 30
+
+
+class TestPanels:
+    def test_eight_panels_present(self) -> None:
+        doc = _load_dashboard()
+        assert len(doc["panels"]) == 8
+
+    def test_panel_title_to_metric_matrix(self) -> None:
+        """Every panel's first target must reference the metric family
+        declared in plan v4 §2.8. Drift between dashboard and
+        runtime (e.g., a renamed metric) fails this test."""
+        doc = _load_dashboard()
+        seen: dict[str, str] = {}
+        for panel in doc["panels"]:
+            title = panel["title"]
+            expr = panel["targets"][0]["expr"]
+            seen[title] = expr
+
+        missing_titles = set(_EXPECTED_PANELS.keys()) - set(seen.keys())
+        assert not missing_titles, (
+            f"dashboard missing expected panels: {sorted(missing_titles)}"
+        )
+        for title, metric_fragment in _EXPECTED_PANELS.items():
+            assert metric_fragment in seen[title], (
+                f"panel {title!r} expr does not reference {metric_fragment!r}; "
+                f"got: {seen[title]!r}"
+            )
+
+    def test_every_panel_has_gridpos(self) -> None:
+        """Layout drift — missing gridPos breaks auto-arrangement."""
+        doc = _load_dashboard()
+        for panel in doc["panels"]:
+            assert "gridPos" in panel, (
+                f"panel {panel.get('title')!r} missing gridPos"
+            )
+
+
+class TestTemplating:
+    def test_datasource_variable_present(self) -> None:
+        """Importable dashboards must expose a datasource template so
+        operators can bind Prometheus without editing the JSON."""
+        doc = _load_dashboard()
+        names = {v["name"] for v in doc["templating"]["list"]}
+        assert "DS_PROMETHEUS" in names
+
+
+class TestDocsParity:
+    def test_readme_mentions_each_expected_panel(self) -> None:
+        """The Grafana README panel-matrix table must list every
+        expected title so operators can trace panels back to metric
+        families."""
+        readme_path = _DASHBOARD_PATH.parent / "README.md"
+        text = readme_path.read_text(encoding="utf-8")
+        for metric in _EXPECTED_PANELS.values():
+            assert metric in text, (
+                f"README.md does not document metric {metric!r}"
+            )

--- a/tests/test_metrics_cli.py
+++ b/tests/test_metrics_cli.py
@@ -1,0 +1,85 @@
+"""Tests for ``ao-kernel metrics export`` CLI (PR-B5 C3 handler)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from ao_kernel._internal.metrics.cli_handlers import cmd_metrics_export
+
+
+prometheus_client = pytest.importorskip("prometheus_client")
+
+
+def _args(workspace: Path, **kwargs) -> SimpleNamespace:
+    ns = SimpleNamespace(
+        workspace_root=str(workspace),
+        output=kwargs.get("output"),
+        format=kwargs.get("format", "prometheus"),
+    )
+    return ns
+
+
+class TestStdoutHappyPath:
+    def test_dormant_workspace_exit_zero_with_banner(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Plan v4 §2.6 Q2: dormant policy → exit 0 + banner."""
+        rc = cmd_metrics_export(_args(tmp_path))
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "policy_metrics.enabled=false" in captured.out
+
+
+class TestOutputFlag:
+    def test_atomic_output_writes_file(self, tmp_path: Path) -> None:
+        output_path = tmp_path / "metrics.prom"
+        rc = cmd_metrics_export(
+            _args(tmp_path, output=str(output_path))
+        )
+        assert rc == 0
+        assert output_path.is_file()
+        content = output_path.read_text(encoding="utf-8")
+        assert "# ao-kernel metrics" in content
+
+
+class TestCorruptJSONL:
+    def test_corrupt_events_returns_exit_two(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Plan v4 §2.6 exit 2: corrupt evidence JSONL fail-closed."""
+        evidence_dir = (
+            tmp_path / ".ao" / "evidence" / "workflows" / "run-x"
+        )
+        evidence_dir.mkdir(parents=True, exist_ok=True)
+        (evidence_dir / "events.jsonl").write_text(
+            '{"kind": "policy_checked"}\n{ not valid\n',
+            encoding="utf-8",
+        )
+
+        rc = cmd_metrics_export(_args(tmp_path))
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "corrupt evidence" in captured.err.lower()
+
+
+class TestExtraMissingInformational:
+    def test_missing_prometheus_client_returns_exit_three(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Plan v4 §2.6 exit 3: `[metrics]` extra missing →
+        informational banner, no crash."""
+        from ao_kernel.metrics import registry as registry_mod
+
+        monkeypatch.setattr(
+            registry_mod, "_PROMETHEUS_AVAILABLE", False, raising=False,
+        )
+        rc = cmd_metrics_export(_args(tmp_path))
+        assert rc == 3
+        captured = capsys.readouterr()
+        assert "[metrics] optional extra not installed" in captured.out

--- a/tests/test_metrics_cli.py
+++ b/tests/test_metrics_cli.py
@@ -49,7 +49,26 @@ class TestCorruptJSONL:
     def test_corrupt_events_returns_exit_two(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """Plan v4 §2.6 exit 2: corrupt evidence JSONL fail-closed."""
+        """Plan v4 §2.6 exit 2: corrupt evidence JSONL fail-closed.
+
+        Post-impl review absorb: evidence validation runs only when
+        policy is enabled (dormant branch is banner-only to avoid
+        zero-synthetic samples), so the test enables the policy to
+        reach the corrupt-JSONL path.
+        """
+        import json
+
+        (tmp_path / ".ao" / "policies").mkdir(parents=True)
+        (
+            tmp_path / ".ao" / "policies" / "policy_metrics.v1.json"
+        ).write_text(
+            json.dumps({
+                "version": "v1",
+                "enabled": True,
+                "labels_advanced": {"enabled": False, "allowlist": []},
+            }),
+            encoding="utf-8",
+        )
         evidence_dir = (
             tmp_path / ".ao" / "evidence" / "workflows" / "run-x"
         )
@@ -73,8 +92,29 @@ class TestExtraMissingInformational:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Plan v4 §2.6 exit 3: `[metrics]` extra missing →
-        informational banner, no crash."""
+        informational banner, no crash.
+
+        Post-impl review absorb: the extra-missing branch runs only
+        when the policy is enabled (dormant branch short-circuits
+        before registry construction to prevent zero-synthetic
+        samples). Enable the policy so the extra-missing code path
+        becomes reachable.
+        """
+        import json
+
         from ao_kernel.metrics import registry as registry_mod
+
+        (tmp_path / ".ao" / "policies").mkdir(parents=True)
+        (
+            tmp_path / ".ao" / "policies" / "policy_metrics.v1.json"
+        ).write_text(
+            json.dumps({
+                "version": "v1",
+                "enabled": True,
+                "labels_advanced": {"enabled": False, "allowlist": []},
+            }),
+            encoding="utf-8",
+        )
 
         monkeypatch.setattr(
             registry_mod, "_PROMETHEUS_AVAILABLE", False, raising=False,
@@ -83,3 +123,104 @@ class TestExtraMissingInformational:
         assert rc == 3
         captured = capsys.readouterr()
         assert "[metrics] optional extra not installed" in captured.out
+
+
+class TestDormantBannerOnly:
+    """Post-impl review CNS-036 iter-1 A2: dormant policy → banner
+    comments ONLY, no synthetic zero samples from label-less
+    Gauge/Counter families."""
+
+    def test_dormant_output_has_no_metric_samples(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """`ao_claim_active_total 0.0` (Gauge) + `ao_claim_takeover_total
+        0.0` (Counter) must NOT appear when policy dormant."""
+        rc = cmd_metrics_export(_args(tmp_path))
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Banners still present:
+        assert "policy_metrics.enabled=false" in out
+        # But NO metric sample lines — only `# `-prefixed comments.
+        for line in out.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            assert stripped.startswith("#"), (
+                f"dormant output contains non-comment line: {stripped!r}"
+            )
+
+    def test_dormant_is_valid_prometheus_exposition(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Banner-only text still parses as Prometheus exposition
+        (zero families, but no syntax error)."""
+        from prometheus_client.parser import text_string_to_metric_families
+
+        rc = cmd_metrics_export(_args(tmp_path))
+        assert rc == 0
+        out = capsys.readouterr().out
+        families = list(text_string_to_metric_families(out))
+        assert families == []
+
+
+class TestWorkspaceAutoResolution:
+    """Post-impl review CNS-036 iter-1 A1: `workspace_root()`
+    returns the `.ao/` directory itself; `_resolve_workspace`
+    must normalize to the parent so downstream path composers
+    do not produce `.ao/.ao/...` doubled paths."""
+
+    def test_auto_resolution_normalizes_dot_ao_to_parent(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Simulate a workspace discovered via cwd lookup: policy at
+        # `{tmp}/.ao/policies/policy_metrics.v1.json` with enabled=true,
+        # an evidence event to populate `ao_policy_check_total`.
+        import json
+
+        (tmp_path / ".ao" / "policies").mkdir(parents=True)
+        (
+            tmp_path
+            / ".ao"
+            / "policies"
+            / "policy_metrics.v1.json"
+        ).write_text(
+            json.dumps({
+                "version": "v1",
+                "enabled": True,
+                "labels_advanced": {"enabled": False, "allowlist": []},
+            }),
+            encoding="utf-8",
+        )
+        evidence_dir = (
+            tmp_path / ".ao" / "evidence" / "workflows" / "run-auto"
+        )
+        evidence_dir.mkdir(parents=True)
+        (evidence_dir / "events.jsonl").write_text(
+            json.dumps({
+                "kind": "policy_checked",
+                "ts": "2026-04-17T10:00:00+00:00",
+                "payload": {"violations_count": 0},
+            }) + "\n",
+            encoding="utf-8",
+        )
+
+        # Force workspace_root() to return the .ao/ directory itself
+        # (production semantic from ao_kernel.config).
+        monkeypatch.chdir(tmp_path)
+
+        # No --workspace-root arg → exercise the auto-resolution branch.
+        from types import SimpleNamespace
+
+        rc = cmd_metrics_export(
+            SimpleNamespace(workspace_root=None, output=None, format="prometheus")
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Policy should be NON-dormant — the metric family appears
+        # and the dormant banner must be absent.
+        assert "policy_metrics.enabled=false" not in out
+        assert "ao_policy_check_total" in out
+        assert 'outcome="allow"' in out

--- a/tests/test_metrics_debug_query.py
+++ b/tests/test_metrics_debug_query.py
@@ -1,0 +1,214 @@
+"""Tests for ``ao-kernel metrics debug-query`` — PR-B5 C3b.
+
+Covers the timezone-strict ``--since`` contract (plan v4 iter-2 fix),
+the --run filter, corrupt-JSONL fail-closed, and the JSON output
+shape (summary + events).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from ao_kernel._internal.metrics.debug_query import (
+    cmd_metrics_debug_query,
+    parse_iso8601_strict,
+)
+
+
+def _args(workspace: Path, **kwargs) -> SimpleNamespace:
+    return SimpleNamespace(
+        workspace_root=str(workspace),
+        since=kwargs.get("since"),
+        run=kwargs.get("run"),
+        output=kwargs.get("output"),
+        format=kwargs.get("format", "json"),
+    )
+
+
+def _write_events(
+    ws: Path, run_id: str, events: list[dict]
+) -> None:
+    path = ws / ".ao" / "evidence" / "workflows" / run_id / "events.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(e, sort_keys=True) for e in events) + "\n",
+        encoding="utf-8",
+    )
+
+
+class TestParseIso8601Strict:
+    def test_accepts_z_shorthand(self) -> None:
+        parsed = parse_iso8601_strict("2026-04-17T18:00:00Z")
+        # ``Z`` must become UTC (offset zero) — the strict wrapper
+        # preserves whatever parse_iso8601 produces.
+        assert parsed.tzinfo is not None
+        assert parsed.utcoffset().total_seconds() == 0
+
+    def test_accepts_explicit_offset(self) -> None:
+        parsed = parse_iso8601_strict("2026-04-17T21:00:00+03:00")
+        assert parsed.tzinfo is not None
+        assert parsed.isoformat() == "2026-04-17T21:00:00+03:00"
+
+    def test_rejects_naive_iso(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            parse_iso8601_strict("2026-04-17T18:00:00")
+        assert "timezone required" in str(excinfo.value)
+
+    def test_rejects_epoch_int(self) -> None:
+        # Epoch ints aren't ISO-8601 strings — parse fails at the
+        # underlying helper, strict wrapper surfaces the message.
+        with pytest.raises(ValueError) as excinfo:
+            parse_iso8601_strict("1713376200")
+        assert "ISO-8601" in str(excinfo.value) or "timezone" in str(
+            excinfo.value
+        )
+
+    def test_rejects_empty_string(self) -> None:
+        with pytest.raises(ValueError):
+            parse_iso8601_strict("")
+
+
+class TestHappyPath:
+    def test_empty_workspace_returns_empty_events(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = cmd_metrics_debug_query(_args(tmp_path))
+        assert rc == 0
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["summary"] == {"total": 0, "by_kind": {}}
+        assert payload["events"] == []
+
+    def test_summary_counts_by_kind(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_events(
+            tmp_path,
+            "run-alpha",
+            [
+                {
+                    "kind": "policy_checked",
+                    "ts": "2026-04-17T10:00:00+00:00",
+                    "payload": {"violations_count": 0},
+                },
+                {
+                    "kind": "policy_checked",
+                    "ts": "2026-04-17T10:01:00+00:00",
+                    "payload": {"violations_count": 2},
+                },
+                {
+                    "kind": "claim_takeover",
+                    "ts": "2026-04-17T10:02:00+00:00",
+                    "payload": {},
+                },
+            ],
+        )
+        rc = cmd_metrics_debug_query(_args(tmp_path))
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["summary"]["total"] == 3
+        assert payload["summary"]["by_kind"] == {
+            "claim_takeover": 1,
+            "policy_checked": 2,
+        }
+
+
+class TestSinceFilter:
+    def test_since_filters_out_earlier_events(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_events(
+            tmp_path,
+            "run-beta",
+            [
+                {
+                    "kind": "policy_checked",
+                    "ts": "2026-04-17T09:00:00+00:00",
+                    "payload": {"violations_count": 0},
+                },
+                {
+                    "kind": "policy_checked",
+                    "ts": "2026-04-17T11:00:00+00:00",
+                    "payload": {"violations_count": 0},
+                },
+            ],
+        )
+        since = datetime(2026, 4, 17, 10, 0, 0, tzinfo=timezone.utc)
+        rc = cmd_metrics_debug_query(_args(tmp_path, since=since))
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["summary"]["total"] == 1
+
+
+class TestRunFilter:
+    def test_run_filter_scopes_events(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_events(
+            tmp_path,
+            "run-c1",
+            [
+                {
+                    "kind": "policy_checked",
+                    "ts": "2026-04-17T10:00:00+00:00",
+                    "payload": {},
+                }
+            ],
+        )
+        _write_events(
+            tmp_path,
+            "run-c2",
+            [
+                {
+                    "kind": "policy_checked",
+                    "ts": "2026-04-17T10:00:00+00:00",
+                    "payload": {},
+                }
+            ],
+        )
+        rc = cmd_metrics_debug_query(_args(tmp_path, run="run-c1"))
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["summary"]["total"] == 1
+        assert payload["filter"]["run_id"] == "run-c1"
+
+    def test_run_filter_unknown_returns_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # No evidence dir at all → run filter cannot resolve → exit 1.
+        rc = cmd_metrics_debug_query(_args(tmp_path, run="run-missing"))
+        assert rc == 1
+
+
+class TestCorruptJSONL:
+    def test_corrupt_events_returns_exit_two(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        evidence_dir = (
+            tmp_path / ".ao" / "evidence" / "workflows" / "run-x"
+        )
+        evidence_dir.mkdir(parents=True, exist_ok=True)
+        (evidence_dir / "events.jsonl").write_text(
+            '{"kind": "policy_checked"}\n{ not valid\n',
+            encoding="utf-8",
+        )
+        rc = cmd_metrics_debug_query(_args(tmp_path))
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "corrupt evidence" in err.lower()
+
+
+class TestOutputFlag:
+    def test_atomic_output_writes_json(self, tmp_path: Path) -> None:
+        output_path = tmp_path / "debug.json"
+        rc = cmd_metrics_debug_query(
+            _args(tmp_path, output=str(output_path))
+        )
+        assert rc == 0
+        content = json.loads(output_path.read_text(encoding="utf-8"))
+        assert set(content.keys()) == {"filter", "summary", "events"}

--- a/tests/test_metrics_derivation.py
+++ b/tests/test_metrics_derivation.py
@@ -1,0 +1,494 @@
+"""Tests for ``ao_kernel.metrics.derivation`` — PR-B5 C3.
+
+Covers the events.jsonl → metric population pipeline: LLM spend with
+``duration_ms`` (canonical source), usage-missing counter, policy
+check outcome derivation, workflow started/terminal pairing,
+cancelled-from-state branch (plan v4 Q3 A), claim takeover counter,
+and fail-closed behaviour on corrupt JSONL.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ao_kernel.metrics.derivation import (
+    DerivationStats,
+    derive_metrics_from_evidence,
+)
+from ao_kernel.metrics.errors import EvidenceSourceCorruptedError
+from ao_kernel.metrics.policy import (
+    LabelsAdvanced,
+    MetricsPolicy,
+    load_metrics_policy,
+)
+from ao_kernel.metrics.registry import build_registry
+
+
+prometheus_client = pytest.importorskip("prometheus_client")
+
+
+def _write_events(ws: Path, run_id: str, events: list[dict[str, Any]]) -> None:
+    path = ws / ".ao" / "evidence" / "workflows" / run_id / "events.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(e, sort_keys=True) for e in events) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _bundled_policy(ws: Path) -> MetricsPolicy:
+    return load_metrics_policy(ws)
+
+
+def _build(policy: MetricsPolicy, *, include_llm: bool = True):
+    built = build_registry(policy, include_llm_metrics=include_llm)
+    assert built is not None
+    return built
+
+
+def _sample_values(family: Any) -> list[tuple[dict[str, str], float]]:
+    """Extract (labels, value) pairs from a prometheus metric family.
+
+    Skips the ``_created`` timestamp samples prometheus_client adds
+    alongside every counter/histogram (those carry the registry start
+    epoch which drowns out the actual counts in tests).
+    """
+    samples: list[tuple[dict[str, str], float]] = []
+    for metric in family.collect():
+        for sample in metric.samples:
+            if sample.name.endswith("_created"):
+                continue
+            samples.append((dict(sample.labels), sample.value))
+    return samples
+
+
+class TestLLMSpendDerivation:
+    def test_duration_ms_populates_histogram(
+        self, tmp_path: Path
+    ) -> None:
+        """`llm_spend_recorded.duration_ms` is the canonical source
+        for `ao_llm_call_duration_seconds` (plan v4 iter-2 fix)."""
+        _write_events(
+            tmp_path,
+            "run-alpha",
+            [
+                {
+                    "kind": "llm_spend_recorded",
+                    "seq": 1,
+                    "ts": "2026-04-17T10:00:00+00:00",
+                    "payload": {
+                        "provider_id": "anthropic",
+                        "model": "claude-3-5",
+                        "tokens_input": 100,
+                        "tokens_output": 50,
+                        "cached_tokens": 0,
+                        "cost_usd": 0.003,
+                        "duration_ms": 250.5,
+                    },
+                },
+            ],
+        )
+        policy = _bundled_policy(tmp_path)
+        built = _build(policy)
+        stats = derive_metrics_from_evidence(tmp_path, built, policy)
+
+        assert stats.llm_spend_counted == 1
+        assert stats.duration_ms_missing == 0
+        # Histogram sum sample records the observation (250.5 ms →
+        # 0.2505 s). We find the `_sum` sample specifically rather
+        # than scanning values because histogram samples include
+        # bucket counters at every boundary.
+        sum_samples = [
+            (labels, value)
+            for labels, value in _sample_values(built.llm_call_duration)
+            if labels == {"provider": "anthropic"}
+        ]
+        # One of the samples with those labels should match the
+        # observed duration (histogram `_sum`).
+        assert any(
+            v == pytest.approx(0.2505) for _, v in sum_samples
+        )
+
+    def test_tokens_counter_three_directions(
+        self, tmp_path: Path
+    ) -> None:
+        """`tokens_input/tokens_output/cached_tokens` → direction
+        label with three series."""
+        _write_events(
+            tmp_path,
+            "run-alpha",
+            [
+                {
+                    "kind": "llm_spend_recorded",
+                    "ts": "2026-04-17T10:00:00+00:00",
+                    "payload": {
+                        "provider_id": "openai",
+                        "model": "gpt-4o",
+                        "tokens_input": 100,
+                        "tokens_output": 40,
+                        "cached_tokens": 20,
+                        "cost_usd": 0.02,
+                        "duration_ms": 800.0,
+                    },
+                },
+            ],
+        )
+        policy = _bundled_policy(tmp_path)
+        built = _build(policy)
+        derive_metrics_from_evidence(tmp_path, built, policy)
+
+        values = {
+            labels["direction"]: value
+            for labels, value in _sample_values(built.llm_tokens_used)
+            if labels.get("provider") == "openai"
+            and "direction" in labels
+            and labels.get("direction") in {"input", "output", "cached"}
+        }
+        assert values == {"input": 100.0, "output": 40.0, "cached": 20.0}
+
+    def test_cost_counter_accumulates(self, tmp_path: Path) -> None:
+        _write_events(
+            tmp_path,
+            "run-alpha",
+            [
+                {
+                    "kind": "llm_spend_recorded",
+                    "ts": "2026-04-17T10:00:00+00:00",
+                    "payload": {
+                        "provider_id": "anthropic",
+                        "tokens_input": 10,
+                        "tokens_output": 5,
+                        "cost_usd": 0.001,
+                        "duration_ms": 100.0,
+                    },
+                },
+                {
+                    "kind": "llm_spend_recorded",
+                    "ts": "2026-04-17T10:01:00+00:00",
+                    "payload": {
+                        "provider_id": "anthropic",
+                        "tokens_input": 10,
+                        "tokens_output": 5,
+                        "cost_usd": 0.002,
+                        "duration_ms": 100.0,
+                    },
+                },
+            ],
+        )
+        policy = _bundled_policy(tmp_path)
+        built = _build(policy)
+        derive_metrics_from_evidence(tmp_path, built, policy)
+
+        samples = _sample_values(built.llm_cost_usd)
+        anthropic_total = next(
+            v for labels, v in samples
+            if labels == {"provider": "anthropic"}
+        )
+        assert anthropic_total == pytest.approx(0.003)
+
+    def test_missing_duration_ms_skips_histogram(
+        self, tmp_path: Path
+    ) -> None:
+        """Plan v4 R13: pre-B5 events without ``duration_ms`` are
+        counted for tokens/cost but skipped for the duration
+        histogram. Stats.duration_ms_missing surfaces the count."""
+        _write_events(
+            tmp_path,
+            "run-beta",
+            [
+                {
+                    "kind": "llm_spend_recorded",
+                    "ts": "2026-04-17T10:00:00+00:00",
+                    "payload": {
+                        "provider_id": "anthropic",
+                        "tokens_input": 1,
+                        "tokens_output": 1,
+                        "cost_usd": 0.0001,
+                        # duration_ms absent
+                    },
+                },
+            ],
+        )
+        policy = _bundled_policy(tmp_path)
+        built = _build(policy)
+        stats = derive_metrics_from_evidence(tmp_path, built, policy)
+
+        assert stats.duration_ms_missing == 1
+        # No observations recorded → all histogram buckets remain 0.
+        samples = _sample_values(built.llm_call_duration)
+        observed = [v for labels, v in samples if labels == {"provider": "anthropic"}]
+        assert all(v == 0 for v in observed) or observed == []
+
+
+class TestUsageMissingCounter:
+    def test_llm_usage_missing_event_increments(
+        self, tmp_path: Path
+    ) -> None:
+        _write_events(
+            tmp_path,
+            "run-gamma",
+            [
+                {
+                    "kind": "llm_usage_missing",
+                    "ts": "2026-04-17T10:00:00+00:00",
+                    "payload": {
+                        "provider_id": "anthropic",
+                        "model": "claude-3-5",
+                        "missing_fields": ["tokens_input"],
+                    },
+                },
+            ],
+        )
+        policy = _bundled_policy(tmp_path)
+        built = _build(policy)
+        stats = derive_metrics_from_evidence(tmp_path, built, policy)
+
+        assert stats.llm_usage_missing_counted == 1
+        samples = _sample_values(built.llm_usage_missing)
+        assert any(
+            labels == {"provider": "anthropic"} and v == 1.0
+            for labels, v in samples
+        )
+
+
+class TestPolicyCheckOutcome:
+    def test_zero_violations_is_allow(self, tmp_path: Path) -> None:
+        _write_events(
+            tmp_path,
+            "run-delta",
+            [
+                {
+                    "kind": "policy_checked",
+                    "ts": "2026-04-17T10:00:00+00:00",
+                    "payload": {"violations_count": 0},
+                },
+                {
+                    "kind": "policy_checked",
+                    "ts": "2026-04-17T10:01:00+00:00",
+                    "payload": {"violations_count": 2},
+                },
+            ],
+        )
+        policy = _bundled_policy(tmp_path)
+        built = _build(policy)
+        derive_metrics_from_evidence(tmp_path, built, policy)
+
+        samples = dict(
+            (labels["outcome"], value)
+            for labels, value in _sample_values(built.policy_check)
+            if "outcome" in labels
+        )
+        assert samples == {"allow": 1.0, "deny": 1.0}
+
+
+class TestClaimTakeoverCounter:
+    def test_takeover_event_increments(self, tmp_path: Path) -> None:
+        _write_events(
+            tmp_path,
+            "run-epsilon",
+            [
+                {
+                    "kind": "claim_takeover",
+                    "ts": "2026-04-17T10:00:00+00:00",
+                    "payload": {"resource_id": "res-1"},
+                },
+            ],
+        )
+        policy = _bundled_policy(tmp_path)
+        built = _build(policy)
+        stats = derive_metrics_from_evidence(tmp_path, built, policy)
+
+        assert stats.claim_takeovers_counted == 1
+        samples = _sample_values(built.claim_takeover)
+        assert any(v == 1.0 for _, v in samples)
+
+
+class TestWorkflowDuration:
+    def test_started_completed_pair_records_duration(
+        self, tmp_path: Path
+    ) -> None:
+        run_id = "00000000-0000-4000-8000-000000000001"
+        _write_events(
+            tmp_path,
+            run_id,
+            [
+                {
+                    "kind": "workflow_started",
+                    "ts": "2026-04-17T10:00:00+00:00",
+                    "payload": {"run_id": run_id},
+                },
+                {
+                    "kind": "workflow_completed",
+                    "ts": "2026-04-17T10:00:30+00:00",
+                    "payload": {"run_id": run_id},
+                },
+            ],
+        )
+        policy = _bundled_policy(tmp_path)
+        built = _build(policy)
+        stats = derive_metrics_from_evidence(tmp_path, built, policy)
+
+        assert stats.workflow_terminals_counted == 1
+        samples = _sample_values(built.workflow_duration)
+        # Histogram sum for completed ≈ 30 seconds.
+        assert any(
+            labels.get("final_state") == "completed"
+            and v == pytest.approx(30.0)
+            for labels, v in samples
+        )
+
+    def test_cancelled_from_state_completed_at(
+        self, tmp_path: Path
+    ) -> None:
+        """Plan v4 Q3 A: cancelled runs are read from
+        state.v1.json.completed_at because no terminal event exists."""
+        from ao_kernel.workflow.run_store import create_run
+
+        run_id = "00000000-0000-4000-8000-000000000002"
+        create_run(
+            tmp_path,
+            run_id=run_id,
+            workflow_id="bug_fix_flow",
+            workflow_version="1.0.0",
+            intent={"kind": "inline_prompt", "payload": "t"},
+            budget={"fail_closed_on_exhaust": True},
+            policy_refs=[
+                "ao_kernel/defaults/policies/policy_worktree_profile.v1.json"
+            ],
+            evidence_refs=[
+                f".ao/evidence/workflows/{run_id}/events.jsonl"
+            ],
+        )
+        # Directly mutate state to cancelled with completed_at for
+        # this derivation test (production code transitions via
+        # runtime; here we pin the derivation branch).
+        state_path = tmp_path / ".ao" / "runs" / run_id / "state.v1.json"
+        record = json.loads(state_path.read_text(encoding="utf-8"))
+        record["state"] = "cancelled"
+        record["completed_at"] = "2026-04-17T10:00:00+00:00"
+        record["created_at"] = "2026-04-17T09:58:00+00:00"
+        # Recompute revision not needed for derivation (list_terminal_runs
+        # does raw JSON read without schema validation).
+        state_path.write_text(
+            json.dumps(record, sort_keys=True), encoding="utf-8"
+        )
+
+        policy = _bundled_policy(tmp_path)
+        built = _build(policy)
+        stats = derive_metrics_from_evidence(tmp_path, built, policy)
+
+        assert stats.cancelled_from_state == 1
+        samples = _sample_values(built.workflow_duration)
+        assert any(
+            labels.get("final_state") == "cancelled"
+            and v == pytest.approx(120.0)  # 2 minutes
+            for labels, v in samples
+        )
+
+
+class TestFailClosedOnCorruptJSONL:
+    def test_corrupt_events_jsonl_raises(self, tmp_path: Path) -> None:
+        events_path = (
+            tmp_path / ".ao" / "evidence" / "workflows" / "run-x" / "events.jsonl"
+        )
+        events_path.parent.mkdir(parents=True, exist_ok=True)
+        events_path.write_text(
+            '{"kind": "policy_checked"}\n{ not valid json\n',
+            encoding="utf-8",
+        )
+
+        policy = _bundled_policy(tmp_path)
+        built = _build(policy)
+        with pytest.raises(EvidenceSourceCorruptedError):
+            derive_metrics_from_evidence(tmp_path, built, policy)
+
+
+class TestEmptyWorkspace:
+    def test_no_evidence_dir_returns_empty_stats(
+        self, tmp_path: Path
+    ) -> None:
+        """Missing `.ao/evidence/workflows/` → zero scans, no raise.
+        Dormant-parity behaviour per plan v4 §2.3."""
+        policy = _bundled_policy(tmp_path)
+        built = _build(policy)
+        stats = derive_metrics_from_evidence(tmp_path, built, policy)
+        assert stats == DerivationStats()
+
+
+class TestAdvancedLabels:
+    def test_model_label_appears_when_allowlisted(
+        self, tmp_path: Path
+    ) -> None:
+        _write_events(
+            tmp_path,
+            "run-zeta",
+            [
+                {
+                    "kind": "llm_spend_recorded",
+                    "ts": "2026-04-17T10:00:00+00:00",
+                    "payload": {
+                        "provider_id": "anthropic",
+                        "model": "claude-3-5-sonnet",
+                        "tokens_input": 10,
+                        "tokens_output": 5,
+                        "cost_usd": 0.001,
+                        "duration_ms": 100.0,
+                    },
+                },
+            ],
+        )
+        policy = MetricsPolicy(
+            enabled=True,
+            labels_advanced=LabelsAdvanced(
+                enabled=True,
+                allowlist=("model",),
+            ),
+        )
+        built = _build(policy)
+        derive_metrics_from_evidence(tmp_path, built, policy)
+
+        samples = _sample_values(built.llm_cost_usd)
+        assert any(
+            labels.get("model") == "claude-3-5-sonnet"
+            and labels.get("provider") == "anthropic"
+            for labels, _ in samples
+        )
+
+
+class TestCostDisjunction:
+    def test_llm_spend_events_ignored_when_llm_families_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """With `include_llm_metrics=False` (cost dormant), the
+        registry has `llm_cost_usd=None`; spend events are parsed
+        but produce no samples."""
+        _write_events(
+            tmp_path,
+            "run-eta",
+            [
+                {
+                    "kind": "llm_spend_recorded",
+                    "ts": "2026-04-17T10:00:00+00:00",
+                    "payload": {
+                        "provider_id": "anthropic",
+                        "tokens_input": 10,
+                        "tokens_output": 5,
+                        "cost_usd": 0.001,
+                        "duration_ms": 100.0,
+                    },
+                },
+            ],
+        )
+        policy = _bundled_policy(tmp_path)
+        built = build_registry(policy, include_llm_metrics=False)
+        assert built is not None
+        stats = derive_metrics_from_evidence(tmp_path, built, policy)
+
+        # Stats counter still increments only when spend counted
+        # (returns False in cost-disjunction branch → stats = 0).
+        assert stats.llm_spend_counted == 0
+        # Textfile output confirms absence (other tests cover this).

--- a/tests/test_metrics_export.py
+++ b/tests/test_metrics_export.py
@@ -1,0 +1,103 @@
+"""Tests for ``ao_kernel.metrics.export`` — PR-B5 C3 textfile serializer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ao_kernel.metrics.export import (
+    generate_textfile,
+    generate_textfile_strict,
+)
+from ao_kernel.metrics.errors import MetricsExtraNotInstalledError
+from ao_kernel.metrics.policy import load_metrics_policy
+from ao_kernel.metrics.registry import build_registry
+
+
+prometheus_client = pytest.importorskip("prometheus_client")
+
+
+class TestBasicSerialization:
+    def test_produces_valid_prometheus_exposition(
+        self, tmp_path: Path
+    ) -> None:
+        policy = load_metrics_policy(tmp_path)
+        built = build_registry(policy)
+        assert built is not None
+
+        output = generate_textfile(
+            built, metrics_dormant=False, cost_dormant=False,
+        )
+        # Exposition format always has HELP / TYPE blocks for each
+        # family.
+        assert "# HELP ao_policy_check_total" in output
+        assert "# TYPE ao_policy_check_total counter" in output
+
+    def test_parser_roundtrip_accepts_output(
+        self, tmp_path: Path
+    ) -> None:
+        """The emitted textfile must be parseable by prometheus_client
+        itself — any syntax error breaks Grafana scrape ingestion."""
+        from prometheus_client.parser import text_string_to_metric_families
+
+        policy = load_metrics_policy(tmp_path)
+        built = build_registry(policy)
+        assert built is not None
+        output = generate_textfile(
+            built, metrics_dormant=False, cost_dormant=False,
+        )
+        families = list(text_string_to_metric_families(output))
+        # All 8 default families + their helper series parse.
+        names = {f.name for f in families}
+        assert "ao_policy_check" in names
+        assert "ao_workflow_duration_seconds" in names
+
+
+class TestDormantBanners:
+    def test_metrics_dormant_banner_prepended(
+        self, tmp_path: Path
+    ) -> None:
+        policy = load_metrics_policy(tmp_path)
+        built = build_registry(policy)
+        output = generate_textfile(
+            built, metrics_dormant=True, cost_dormant=False,
+        )
+        assert output.startswith(
+            "# ao-kernel metrics: dormant "
+            "(policy_metrics.enabled=false)."
+        )
+
+    def test_cost_dormant_banner_and_no_llm_prefix(
+        self, tmp_path: Path
+    ) -> None:
+        policy = load_metrics_policy(tmp_path)
+        built = build_registry(policy, include_llm_metrics=False)
+        output = generate_textfile(
+            built, metrics_dormant=False, cost_dormant=True,
+        )
+        assert "cost tracking dormant" in output
+        # Cost-disjunction invariant: no ao_llm_* in output when
+        # cost-dormant. The cumulative textfile acceptance test.
+        assert "ao_llm_" not in output
+
+
+class TestExtraMissingBanner:
+    def test_built_none_produces_extra_missing_banner(self) -> None:
+        output = generate_textfile(
+            built=None, metrics_dormant=False, cost_dormant=False,
+        )
+        assert "optional extra not installed" in output
+
+    def test_strict_raises_when_extra_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ao_kernel.metrics import registry as registry_mod
+
+        monkeypatch.setattr(
+            registry_mod, "_PROMETHEUS_AVAILABLE", False, raising=False,
+        )
+        with pytest.raises(MetricsExtraNotInstalledError):
+            generate_textfile_strict(
+                None, metrics_dormant=False, cost_dormant=False,
+            )

--- a/tests/test_metrics_helpers.py
+++ b/tests/test_metrics_helpers.py
@@ -1,0 +1,122 @@
+"""Tests for PR-B5 C3 helpers — coordination ``live_claims_count`` and
+``run_store.list_terminal_runs``.
+
+These helpers are consumed by
+:func:`ao_kernel.metrics.derivation.derive_metrics_from_evidence`
+(claim_active gauge + cancelled workflow duration). Covered here in
+isolation for faster feedback and to pin the contract the derivation
+test relies on.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ao_kernel.coordination.registry import (
+    ClaimRegistry,
+    live_claims_count,
+)
+from ao_kernel.workflow.run_store import create_run, list_terminal_runs
+
+
+class TestLiveClaimsCount:
+    def test_dormant_policy_returns_empty_dict(
+        self, tmp_path: Path
+    ) -> None:
+        """Bundled default ships enabled=false; helper returns {}
+        without raising. The metrics derivation treats this as "gauge
+        at 0" which matches operator expectations."""
+        assert live_claims_count(tmp_path) == {}
+
+    def test_live_claims_counted_per_agent(
+        self, tmp_path: Path
+    ) -> None:
+        """With an enabled policy override, acquire two claims for
+        two agents and confirm the snapshot reports the correct
+        live counts."""
+        policy_path = (
+            tmp_path / ".ao" / "policies" / "policy_coordination_claims.v1.json"
+        )
+        policy_path.parent.mkdir(parents=True, exist_ok=True)
+        policy_path.write_text(
+            json.dumps({
+                "version": "v1",
+                "enabled": True,
+                "heartbeat_interval_seconds": 30,
+                "expiry_seconds": 90,
+                "takeover_grace_period_seconds": 15,
+                "max_claims_per_agent": 5,
+                "claim_resource_patterns": ["*"],
+                "evidence_redaction": {"patterns": []},
+            }, sort_keys=True),
+            encoding="utf-8",
+        )
+        reg = ClaimRegistry(tmp_path)
+        reg.acquire_claim("res-a", "agent-1")
+        reg.acquire_claim("res-b", "agent-1")
+        reg.acquire_claim("res-c", "agent-2")
+
+        counts = live_claims_count(tmp_path)
+        assert counts == {"agent-1": 2, "agent-2": 1}
+
+
+class TestListTerminalRuns:
+    @staticmethod
+    def _make_run(ws: Path, run_id: str, state: str) -> None:
+        create_run(
+            ws,
+            run_id=run_id,
+            workflow_id="bug_fix_flow",
+            workflow_version="1.0.0",
+            intent={"kind": "inline_prompt", "payload": "t"},
+            budget={"fail_closed_on_exhaust": True},
+            policy_refs=[
+                "ao_kernel/defaults/policies/policy_worktree_profile.v1.json"
+            ],
+            evidence_refs=[
+                f".ao/evidence/workflows/{run_id}/events.jsonl"
+            ],
+        )
+        state_path = ws / ".ao" / "runs" / run_id / "state.v1.json"
+        record = json.loads(state_path.read_text(encoding="utf-8"))
+        record["state"] = state
+        if state in {"completed", "failed", "cancelled"}:
+            record["completed_at"] = "2026-04-17T10:00:00+00:00"
+        state_path.write_text(
+            json.dumps(record, sort_keys=True), encoding="utf-8"
+        )
+
+    def test_empty_runs_dir_returns_empty_list(
+        self, tmp_path: Path
+    ) -> None:
+        assert list_terminal_runs(tmp_path) == []
+
+    def test_filters_to_terminal_states(self, tmp_path: Path) -> None:
+        run_ids = [
+            "00000000-0000-4000-8000-000000000001",
+            "00000000-0000-4000-8000-000000000002",
+            "00000000-0000-4000-8000-000000000003",
+            "00000000-0000-4000-8000-000000000004",
+        ]
+        self._make_run(tmp_path, run_ids[0], "running")
+        self._make_run(tmp_path, run_ids[1], "completed")
+        self._make_run(tmp_path, run_ids[2], "failed")
+        self._make_run(tmp_path, run_ids[3], "cancelled")
+
+        terminals = list_terminal_runs(tmp_path)
+        states = sorted(r["state"] for r in terminals)
+        assert states == ["cancelled", "completed", "failed"]
+
+    def test_malformed_state_file_skipped(
+        self, tmp_path: Path
+    ) -> None:
+        """Corrupt / partially-written state files are skipped (read-
+        only helper, no schema validation). This prevents the metrics
+        export from aborting while a workflow is concurrently writing."""
+        run_dir = tmp_path / ".ao" / "runs" / "junk"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "state.v1.json").write_text(
+            "{ not valid json", encoding="utf-8"
+        )
+        assert list_terminal_runs(tmp_path) == []

--- a/tests/test_metrics_policy.py
+++ b/tests/test_metrics_policy.py
@@ -1,0 +1,211 @@
+"""Tests for ``ao_kernel.metrics.policy`` — PR-B5 C1 policy loader.
+
+Mirrors the shape of ``test_coordination_policy.py``: dormant default,
+workspace override precedence, schema validation, runtime defence.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from ao_kernel.metrics.errors import InvalidLabelAllowlistError
+from ao_kernel.metrics.policy import (
+    LabelsAdvanced,
+    MetricsPolicy,
+    load_metrics_policy,
+)
+
+
+def _valid_policy_dict(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "version": "v1",
+        "enabled": False,
+        "labels_advanced": {
+            "enabled": False,
+            "allowlist": [],
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+class TestLoadBundledDefault:
+    def test_bundled_ships_dormant(self, tmp_path: Path) -> None:
+        """PR-B5 invariant: bundled policy_metrics.v1.json ships with
+        enabled=false. The export CLI relies on this for dormant-mode
+        banner semantics."""
+        policy = load_metrics_policy(tmp_path)
+        assert policy.enabled is False
+
+    def test_bundled_labels_advanced_disabled(self, tmp_path: Path) -> None:
+        """Bundled ships labels_advanced.enabled=false + empty allowlist
+        so the low-cardinality default label set is emitted even after
+        an operator flips policy.enabled=true without further tuning."""
+        policy = load_metrics_policy(tmp_path)
+        assert policy.labels_advanced.enabled is False
+        assert policy.labels_advanced.allowlist == ()
+
+
+class TestWorkspaceOverride:
+    @staticmethod
+    def _write_override(
+        workspace_root: Path, doc: dict[str, Any]
+    ) -> None:
+        path = (
+            workspace_root
+            / ".ao"
+            / "policies"
+            / "policy_metrics.v1.json"
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(doc, sort_keys=True))
+
+    def test_override_takes_precedence(self, tmp_path: Path) -> None:
+        self._write_override(
+            tmp_path,
+            _valid_policy_dict(enabled=True),
+        )
+        policy = load_metrics_policy(tmp_path)
+        assert policy.enabled is True
+
+    def test_override_enables_advanced_labels(
+        self, tmp_path: Path
+    ) -> None:
+        self._write_override(
+            tmp_path,
+            _valid_policy_dict(
+                enabled=True,
+                labels_advanced={
+                    "enabled": True,
+                    "allowlist": ["model"],
+                },
+            ),
+        )
+        policy = load_metrics_policy(tmp_path)
+        assert policy.labels_advanced.enabled is True
+        assert policy.labels_advanced.allowlist == ("model",)
+
+    def test_override_missing_falls_back_to_bundled(
+        self, tmp_path: Path
+    ) -> None:
+        """No override file → bundled default. No raise, dormant."""
+        assert not (tmp_path / ".ao").exists()
+        policy = load_metrics_policy(tmp_path)
+        assert policy.enabled is False
+
+    def test_override_corrupt_json_raises(self, tmp_path: Path) -> None:
+        """Fail-closed: malformed JSON in override file → JSONDecodeError.
+        Operators must fix the override; silent fallback to bundled is
+        forbidden by CLAUDE.md §2."""
+        path = (
+            tmp_path
+            / ".ao"
+            / "policies"
+            / "policy_metrics.v1.json"
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{ not valid json")
+        with pytest.raises(json.JSONDecodeError):
+            load_metrics_policy(tmp_path)
+
+
+class TestSchemaValidation:
+    def test_override_invalid_allowlist_enum(
+        self, tmp_path: Path
+    ) -> None:
+        """Schema's closed enum ``{"model", "agent_id"}`` rejects typos
+        at load time. Covers the canonical B0 contract the runtime
+        relies on."""
+        with pytest.raises(ValidationError):
+            load_metrics_policy(
+                tmp_path,
+                override=_valid_policy_dict(
+                    labels_advanced={
+                        "enabled": True,
+                        "allowlist": ["run_id"],  # not in enum
+                    },
+                ),
+            )
+
+    def test_override_missing_required_fields(
+        self, tmp_path: Path
+    ) -> None:
+        """Missing ``enabled`` field → ValidationError (schema requires
+        version + enabled + labels_advanced)."""
+        bad = {"version": "v1", "labels_advanced": {"enabled": False, "allowlist": []}}
+        with pytest.raises(ValidationError):
+            load_metrics_policy(tmp_path, override=bad)
+
+    def test_override_extra_top_level_key_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        """additionalProperties=false → extra key rejected."""
+        with pytest.raises(ValidationError):
+            load_metrics_policy(
+                tmp_path,
+                override=_valid_policy_dict(unknown_knob=True),
+            )
+
+
+class TestRuntimeDefenceInDepth:
+    def test_programmatic_bypass_caught_in_from_dict(self) -> None:
+        """Runtime guard: if a caller constructs a policy dict with an
+        allowlist value outside the closed enum and passes it directly
+        to ``_from_dict`` (bypassing schema), the loader raises
+        :class:`InvalidLabelAllowlistError`. Defence in depth for
+        programmatic construction paths."""
+        from ao_kernel.metrics.policy import _from_dict
+
+        bad = {
+            "version": "v1",
+            "enabled": True,
+            "labels_advanced": {
+                "enabled": True,
+                "allowlist": ["provider"],  # plausible typo; not legal
+            },
+        }
+        with pytest.raises(InvalidLabelAllowlistError):
+            _from_dict(bad)
+
+    def test_advanced_allowlist_respects_enabled_flag(self) -> None:
+        """Defence-in-depth accessor: even when allowlist is non-empty,
+        ``advanced_allowlist()`` returns () if labels_advanced.enabled
+        is false. Callers rely on this for the "both switches must
+        align" invariant."""
+        policy = MetricsPolicy(
+            enabled=True,
+            labels_advanced=LabelsAdvanced(
+                enabled=False,
+                allowlist=("model",),
+            ),
+        )
+        assert policy.advanced_allowlist() == ()
+
+    def test_advanced_allowlist_returns_values_when_enabled(self) -> None:
+        policy = MetricsPolicy(
+            enabled=True,
+            labels_advanced=LabelsAdvanced(
+                enabled=True,
+                allowlist=("model", "agent_id"),
+            ),
+        )
+        assert policy.advanced_allowlist() == ("model", "agent_id")
+
+
+class TestLoadedPolicyIsHashable:
+    def test_policy_is_hashable_for_caching(
+        self, tmp_path: Path
+    ) -> None:
+        """Registry adapter (C2) caches built metric families keyed by
+        policy; the dataclass being frozen+hashable is load-bearing."""
+        policy = load_metrics_policy(tmp_path)
+        # Hashable objects can serve as dict keys:
+        cache = {policy: "cached"}
+        assert cache[policy] == "cached"
+        # And hash() is stable for frozen dataclasses:
+        assert hash(policy) == hash(load_metrics_policy(tmp_path))

--- a/tests/test_metrics_registry.py
+++ b/tests/test_metrics_registry.py
@@ -1,0 +1,202 @@
+"""Tests for ``ao_kernel.metrics.registry`` — PR-B5 C2 adapter.
+
+Covers: prometheus_client availability cache, 8 metric family
+registration, advanced-label expansion driven by
+``MetricsPolicy.advanced_allowlist``, cost-disjunction gate
+(``include_llm_metrics=False`` → LLM families absent), histogram
+bucket configuration, and the no-op path when the extra is missing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ao_kernel.metrics import registry as metrics_registry
+from ao_kernel.metrics.policy import (
+    LabelsAdvanced,
+    MetricsPolicy,
+    load_metrics_policy,
+)
+
+
+# prometheus-client ships in ao_kernel[metrics]; skip this whole
+# module if the dev environment hasn't installed it.
+prometheus_client = pytest.importorskip("prometheus_client")
+
+
+def _bundled_policy(tmp_path: Path) -> MetricsPolicy:
+    return load_metrics_policy(tmp_path)
+
+
+def _advanced_policy(*allowed: str) -> MetricsPolicy:
+    return MetricsPolicy(
+        enabled=True,
+        labels_advanced=LabelsAdvanced(
+            enabled=True,
+            allowlist=tuple(allowed),
+        ),
+    )
+
+
+class TestAvailability:
+    def test_is_metrics_available_true(self) -> None:
+        """prometheus-client installed in dev env → True."""
+        assert metrics_registry.is_metrics_available() is True
+
+    def test_availability_is_cached(self) -> None:
+        """Module-level cache: two calls return the same bool without
+        re-running the import. Covers the performance invariant the
+        CLI relies on (export hot path must not re-import on every
+        call)."""
+        first = metrics_registry._check_prometheus()
+        second = metrics_registry._check_prometheus()
+        assert first is second is True
+
+
+class TestBuildRegistryDefaultLabels:
+    def test_build_returns_registry_when_extra_present(
+        self, tmp_path: Path
+    ) -> None:
+        built = metrics_registry.build_registry(_bundled_policy(tmp_path))
+        assert built is not None
+        assert isinstance(built.registry, prometheus_client.CollectorRegistry)
+
+    def test_eight_families_present(self, tmp_path: Path) -> None:
+        """Plan v4 §2.2: 8 metric families under default policy."""
+        built = metrics_registry.build_registry(_bundled_policy(tmp_path))
+        assert built is not None
+        assert built.llm_call_duration is not None
+        assert built.llm_tokens_used is not None
+        assert built.llm_cost_usd is not None
+        assert built.llm_usage_missing is not None
+        assert built.policy_check is not None
+        assert built.workflow_duration is not None
+        assert built.claim_active is not None
+        assert built.claim_takeover is not None
+
+    def test_default_low_cardinality_labels(
+        self, tmp_path: Path
+    ) -> None:
+        """Bundled policy (labels_advanced disabled) → default low-
+        cardinality label set. No ``model`` / ``agent_id`` labels."""
+        built = metrics_registry.build_registry(_bundled_policy(tmp_path))
+        assert built is not None
+        assert built.llm_call_duration._labelnames == ("provider",)
+        assert built.llm_tokens_used._labelnames == ("provider", "direction")
+        assert built.llm_cost_usd._labelnames == ("provider",)
+        assert built.llm_usage_missing._labelnames == ("provider",)
+        assert built.policy_check._labelnames == ("outcome",)
+        assert built.workflow_duration._labelnames == ("final_state",)
+        assert built.claim_active._labelnames == ()
+        assert built.claim_takeover._labelnames == ()
+
+
+class TestBuildRegistryAdvancedLabels:
+    def test_model_advanced_expands_llm_labels(self) -> None:
+        """Allowlist=['model'] → llm families add ``model`` label."""
+        built = metrics_registry.build_registry(_advanced_policy("model"))
+        assert built is not None
+        assert built.llm_call_duration._labelnames == ("provider", "model")
+        assert built.llm_tokens_used._labelnames == (
+            "provider", "direction", "model",
+        )
+        assert built.llm_cost_usd._labelnames == ("provider", "model")
+        assert built.llm_usage_missing._labelnames == ("provider", "model")
+        # claim_active should NOT gain model — only agent_id is in its
+        # advanced candidate set.
+        assert built.claim_active._labelnames == ()
+
+    def test_agent_id_advanced_expands_claim_active(self) -> None:
+        """Allowlist=['agent_id'] → claim_active gauge gains agent_id."""
+        built = metrics_registry.build_registry(_advanced_policy("agent_id"))
+        assert built is not None
+        assert built.claim_active._labelnames == ("agent_id",)
+        # LLM families stay on the default provider-only surface.
+        assert built.llm_cost_usd._labelnames == ("provider",)
+
+    def test_both_advanced_labels_expand_independently(self) -> None:
+        built = metrics_registry.build_registry(
+            _advanced_policy("model", "agent_id")
+        )
+        assert built is not None
+        assert built.llm_call_duration._labelnames == ("provider", "model")
+        assert built.claim_active._labelnames == ("agent_id",)
+
+
+class TestCostDisjunction:
+    def test_include_llm_metrics_false_omits_llm_families(
+        self, tmp_path: Path
+    ) -> None:
+        """Plan v4 §2 cost-disjunction: cost tracking dormant →
+        ``ao_llm_*`` families absent from the registry. Prevents
+        zero-synthetic series in the textfile output."""
+        built = metrics_registry.build_registry(
+            _bundled_policy(tmp_path),
+            include_llm_metrics=False,
+        )
+        assert built is not None
+        assert built.llm_call_duration is None
+        assert built.llm_tokens_used is None
+        assert built.llm_cost_usd is None
+        assert built.llm_usage_missing is None
+        # Non-LLM families stay populated.
+        assert built.policy_check is not None
+        assert built.workflow_duration is not None
+        assert built.claim_active is not None
+        assert built.claim_takeover is not None
+
+    def test_cost_dormant_textfile_lacks_llm_prefix(
+        self, tmp_path: Path
+    ) -> None:
+        """With LLM families omitted the Prometheus exposition must
+        not mention ``ao_llm_`` — the strongest acceptance criterion
+        for "LLM metric family absent" (plan v4 iter-2 A3)."""
+        built = metrics_registry.build_registry(
+            _bundled_policy(tmp_path),
+            include_llm_metrics=False,
+        )
+        assert built is not None
+        output = prometheus_client.generate_latest(built.registry).decode(
+            "utf-8"
+        )
+        assert "ao_llm_" not in output
+
+
+class TestHistogramBuckets:
+    def test_llm_duration_upper_is_600_seconds(
+        self, tmp_path: Path
+    ) -> None:
+        """Plan v4 §2.2: LLM upper bucket = 600s (GPT-4-turbo outlier
+        tolerance; raised from 300s in v3)."""
+        built = metrics_registry.build_registry(_bundled_policy(tmp_path))
+        assert built is not None
+        # prometheus_client appends +Inf so we check the explicit
+        # bucket tuple we configured.
+        assert built.llm_call_duration._upper_bounds[-2] == 600.0
+
+    def test_workflow_duration_upper_is_7200_seconds(
+        self, tmp_path: Path
+    ) -> None:
+        built = metrics_registry.build_registry(_bundled_policy(tmp_path))
+        assert built is not None
+        assert built.workflow_duration._upper_bounds[-2] == 7200.0
+
+
+class TestExtraMissingFallback:
+    def test_build_returns_none_when_prometheus_client_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Dev environment has prometheus-client, but the runtime
+        check is monkey-patched to emulate a vanilla wheel install.
+        Callers translate ``None`` into the exit-3 informational
+        banner (plan v4 §2.6)."""
+        monkeypatch.setattr(
+            metrics_registry,
+            "_PROMETHEUS_AVAILABLE",
+            False,
+            raising=False,
+        )
+        policy = _bundled_policy(tmp_path)
+        assert metrics_registry.build_registry(policy) is None


### PR DESCRIPTION
## Summary

**FAZ-B Tranche 5/9** — evidence-derived Prometheus textfile metrics export. Stateless CLI scans `events.jsonl` + run_store + coordination registry → eight metric families. Dormant-by-default; opt-in via `policy_metrics.v1.json`. `[metrics]` optional extra keeps `prometheus-client` out of the core dependency tree.

- **8-commit DAG** (7 feature + 1 post-impl absorb); ~2100 runtime + docs + dashboard LOC; ~85 new tests.
- **Plan trace**: CNS-20260417-035 thread `019d9cec` 3-iter plan-time (REVISE → PARTIAL → AGREE) + CNS-20260417-036 thread `019d9d23` post-impl 2-iter (PARTIAL → AGREE).
- **Regression**: 1998/1998 full suite; B0/B1/B2/B6 delta zero; lint + mypy clean.

### Commits (bottom-up)

| SHA | Scope |
|---|---|
| `d987e84` | C1 — policy + 5 error types + `[metrics]` extra + 13 tests |
| `e3de35c` | C2 — prometheus registry adapter (8 families, lazy import) + 13 tests |
| `a1cb380` | C2b — `llm_spend_recorded.duration_ms` additive (B2 event) + 4 tests |
| `a659d79` | C3 — derivation + export + CLI + helpers (live_claims_count, list_terminal_runs) + 28 tests |
| `2ce0f96` | C3b — debug-query subcommand + `parse_iso8601_strict` + 12 tests |
| `76a2e6b` | C4 — Grafana default dashboard + README + 8 shape tests |
| `8ed27ff` | C5 — METRICS.md operator runbook + CHANGELOG |
| `95d939e` | **Post-impl absorb** — CLI workspace `.ao/.ao` bug + dormant banner-only + e2e gap |

### Locked invariants (Codex post-impl AGREE)

- **LLM duration canonical source**: `llm_spend_recorded.duration_ms` (B2 event additive); value from `transport_result["elapsed_ms"]` — pure transport time, excludes reserve/normalize/reconcile overhead.
- **Cumulative-only textfile**: `metrics export` has no `--since`/`--run` flags (Prometheus counter semantics).
- **Cost-disjunction**: `cost_dormant=true` → `ao_llm_*` family absent from textfile (not zero-synthetic).
- **Dormant policy → banner-only**: no registry construction; no zero-synthetic label-less samples.
- **`--since` timezone-strict**: naive ISO + epoch rejected at argparse; `_internal/shared/utils.py:parse_iso8601` wrapper.
- **Runtime label-allowlist defence**: `InvalidLabelAllowlistError` on programmatic schema bypass.
- **Fail-closed corrupt JSONL**: `EvidenceSourceCorruptedError` (mirrors `timeline.py`).
- **Workspace resolution normalization**: `_resolve_workspace` returns `.parent` when `workspace_root()` yields `.ao/` (downstream composers prepend `.ao` themselves).

### Metric families (8)

| Metric | Type | Default labels | Source |
|---|---|---|---|
| `ao_llm_call_duration_seconds` | histogram | `provider` | `llm_spend_recorded.duration_ms` |
| `ao_llm_tokens_used_total` | counter | `provider`, `direction` | `llm_spend_recorded.tokens_*` |
| `ao_llm_cost_usd_total` | counter | `provider` | `llm_spend_recorded.cost_usd` |
| `ao_llm_usage_missing_total` | counter | `provider` | `llm_usage_missing` event |
| `ao_policy_check_total` | counter | `outcome` | `policy_checked.violations_count` |
| `ao_workflow_duration_seconds` | histogram | `final_state` | `workflow_started`+terminal OR `state.v1.json.completed_at` |
| `ao_claim_active_total` | gauge | (none) | `coordination.registry.live_claims_count()` |
| `ao_claim_takeover_total` | counter | (none) | `claim_takeover` event |

Buckets: LLM `(0.1..600)`, workflow `(1..7200)` seconds.

### Runtime architecture

```
events.jsonl  ──►  derivation  ──►  prometheus_client registry
state.v1.json ──►  list_terminal_runs   ├──►  generate_textfile
claim SSOT    ──►  live_claims_count    ┘     (textfile + banners)
```

Stateless + read-only; no LLM/executor hot-path coupling.

### CLI surface

- `ao-kernel metrics export` — cumulative Prometheus textfile; exit 0 success, 1 user error, 2 corrupt JSONL, 3 `[metrics]` extra missing.
- `ao-kernel metrics debug-query` — non-Prometheus JSON query; `--since` timezone-strict; `--run` scoped.

### Grafana integration

- Bundled dashboard: [`docs/grafana/ao_kernel_default.v1.json`](docs/grafana/ao_kernel_default.v1.json) — 8 panels, `DS_PROMETHEUS` template variable.
- Import recipes: UI / file provisioning / K8s ConfigMap / Grafana HTTP API ([`docs/grafana/README.md`](docs/grafana/README.md)).
- Drift guard: `tests/test_grafana_dashboard_shape.py` pins panel→metric matrix.

## Test plan

- [x] `ao-kernel metrics export` from empty workspace → banner-only exit 0
- [x] `ao-kernel metrics export` with enabled policy + events → eight-family textfile
- [x] `metrics export` with corrupt JSONL → exit 2
- [x] `metrics export` with `[metrics]` extra missing (enabled policy) → exit 3 informational banner
- [x] `metrics debug-query --since <naive ISO>` → argparse error
- [x] `metrics debug-query --run <run_id>` → scoped events JSON
- [x] `governed_call` + stub transport → `duration_ms` in emitted `llm_spend_recorded`
- [x] Cost-dormant workspace → `ao_llm_*` absent from textfile
- [x] Dormant policy → banner-only; zero-synthetic samples forbidden
- [x] Auto-resolved CLI from workspace root (no `--workspace-root`) — no `.ao/.ao` doubling
- [x] Full suite regression 1998/1998; lint + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)