### PR TITLE
feat(pr-b4): policy simulation harness — dry-run evaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **FAZ-B Tranche B 4/9 — dry-run evaluation of proposed policy
 changes. The simulator reuses `governance.check_policy` + the
-executor's policy primitives under a 23-sentinel purity guard
+executor's policy primitives under a 24-sentinel purity guard
 that fail-closes on any side effect. Operators point it at a
 scenario set + a `proposed_policies` dict and receive a
 `DiffReport` with per-scenario transitions, per-policy
@@ -22,7 +22,7 @@ breakdown, and canonical policy hashes.**
     (purity violations, reentrancy, scenario validation,
     adapter discovery, target policy lookup, proposed policy
     shape, aggregate abort, report serialisation).
-  * `_purity.py` — 23-sentinel monkey-patch context manager:
+  * `_purity.py` — 24-sentinel monkey-patch context manager:
     4 `emit_event` paths (incl. public facade re-export),
     `worktree_builder.create_worktree`, 4 subprocess entry
     points, 4 pathlib Path writes, 4 os mutations, 4 tempfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,85 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — FAZ-B PR-B4 (policy simulation harness)
+
+**FAZ-B Tranche B 4/9 — dry-run evaluation of proposed policy
+changes. The simulator reuses `governance.check_policy` + the
+executor's policy primitives under a 23-sentinel purity guard
+that fail-closes on any side effect. Operators point it at a
+scenario set + a `proposed_policies` dict and receive a
+`DiffReport` with per-scenario transitions, per-policy
+breakdown, and canonical policy hashes.**
+
+- New `ao_kernel.policy_sim/` public package:
+  * `errors.py` — 9 typed errors rooted at `PolicySimError`
+    (purity violations, reentrancy, scenario validation,
+    adapter discovery, target policy lookup, proposed policy
+    shape, aggregate abort, report serialisation).
+  * `_purity.py` — 23-sentinel monkey-patch context manager:
+    4 `emit_event` paths (incl. public facade re-export),
+    `worktree_builder.create_worktree`, 4 subprocess entry
+    points, 4 pathlib Path writes, 4 os mutations, 4 tempfile
+    allocators, 2 socket operations,
+    `importlib.resources.as_file`. Not re-entrant — nested
+    entry raises `PolicySimReentrantError`.
+  * `_policy_shape_registry.py` — centralised primitive
+    key-read introspection; validators aggregate
+    `required_top_keys` and `type_contracts` across every
+    registered consumer.
+  * `scenario.py` — frozen dataclasses + loader +
+    bundled-fixture helper. Per-scenario `target_policy_name`
+    supports multi-policy ScenarioSets in a single run.
+  * `diff.py` — `SimulationResult`, `ScenarioDelta`,
+    `DiffReport` frozen dataclasses + canonical policy hash
+    (aligned with `executor/artifacts.py`).
+    `DiffReport.to_dict()` normalises `Path`, `frozenset`,
+    `re.Pattern`, and manifest `source_path` for stable JSON
+    output.
+  * `loader.py` — `BaselineSource` enum (`BUNDLED` |
+    `WORKSPACE_OVERRIDE` | `EXPLICIT`) +
+    `validate_proposed_policy` +
+    `policy_override_context` monkey-patch of
+    `ao_kernel.config.load_with_override`.
+  * `simulator.py` — public entrypoint
+    `simulate_policy_change(*, project_root, scenarios,
+    proposed_policies, baseline_source, baseline_overrides,
+    include_host_fs_probes)`. Adapter snapshot taken BEFORE
+    entering the purity context.
+  * `report.py` — JSON + text formatters, atomic file writer,
+    policies-from-dir loader.
+- `ao-kernel policy-sim run` CLI — new subcommand with full
+  `--scenarios`, `--proposed-policies`,
+  `--baseline-source`, `--baseline-overrides`, `--format`,
+  `--output`, `--enable-host-fs-probes`, `--project-root`
+  flags. Exit codes: 0 (success), 1 (user error), 2 (internal),
+  3 (tightening detected).
+- Bundled JSON scenarios under
+  `ao_kernel/defaults/policies/policy_sim_scenarios/`:
+  `adapter_http_with_secret.v1.json`,
+  `autonomy_unknown_intent.v1.json`,
+  `path_poisoned_python.v1.json`, plus a manifest pointing at
+  them.
+- New JSON schema `policy-sim-scenario.schema.v1.json` with
+  draft-2020-12 `allOf` branches enforcing the
+  `target_policy_name` XOR `target_policy_names` invariant.
+- `docs/POLICY-SIM.md` new — operator-facing contract,
+  scenario model, public API walkthrough, CLI reference, report
+  shape.
+
+**Locked invariants**:
+- Purity guard NOT re-entrant; originals always restored in
+  `finally` (exception-safe).
+- Model + adapter snapshot pre-captured outside the purity
+  context so bundled fixtures do not trip
+  `importlib.resources.as_file`.
+- `_KINDS == 27` preserved (`executor/evidence_emitter.py:46`)
+  — the simulator emits no new evidence kinds.
+- Canonical policy hash bytes match `executor/artifacts.py`;
+  cross-module drift surfaces as a contract-test failure.
+- JSON-only scenarios in v1 (YAML deferred to an optional
+  extra).
+
 ### Added — FAZ-B PR-B3 (cost-aware model routing)
 
 **FAZ-B Tranche B 3/9 — opt-in cost-aware selection. When operators

--- a/ao_kernel/_internal/policy_sim/__init__.py
+++ b/ao_kernel/_internal/policy_sim/__init__.py
@@ -1,0 +1,1 @@
+"""Private CLI helpers for ``ao-kernel policy-sim`` (PR-B4 C4)."""

--- a/ao_kernel/_internal/policy_sim/cli_handlers.py
+++ b/ao_kernel/_internal/policy_sim/cli_handlers.py
@@ -1,0 +1,153 @@
+"""CLI handler for ``ao-kernel policy-sim run`` (PR-B4 C4).
+
+Plan v3 §2.8 exit codes:
+
+- ``0`` — success, no tightening transitions
+- ``1`` — user error (bad scenario file, missing adapter,
+  structurally invalid proposed policy, target policy absent)
+- ``2`` — internal error (purity violation, reentrancy, other
+  simulator abort)
+- ``3`` — success with warning (≥1 allow→deny transition)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from ao_kernel.policy_sim.errors import (
+    PolicySimReentrantError,
+    PolicySimSideEffectError,
+    ProposedPolicyInvalidError,
+    ScenarioAdapterMissingError,
+    ScenarioValidationError,
+    SimulationAbortedError,
+    TargetPolicyNotFoundError,
+)
+from ao_kernel.policy_sim.loader import BaselineSource
+from ao_kernel.policy_sim.report import (
+    has_tightening,
+    load_policies_from_dir,
+    render,
+    write_atomic,
+)
+from ao_kernel.policy_sim.scenario import (
+    Scenario,
+    load_bundled_scenarios,
+    load_scenario_file,
+    load_scenarios_from_dir,
+)
+from ao_kernel.policy_sim.simulator import simulate_policy_change
+
+
+_EXIT_OK = 0
+_EXIT_USER_ERROR = 1
+_EXIT_INTERNAL = 2
+_EXIT_TIGHTENING = 3
+
+
+def cmd_policy_sim_run(args: argparse.Namespace) -> int:
+    try:
+        scenarios = _resolve_scenarios(args.scenarios)
+    except (ScenarioValidationError, FileNotFoundError) as exc:
+        print(f"scenario load failed: {exc}", file=sys.stderr)
+        return _EXIT_USER_ERROR
+
+    try:
+        proposed = load_policies_from_dir(Path(args.proposed_policies))
+    except json.JSONDecodeError as exc:
+        print(f"invalid JSON in --proposed-policies: {exc}", file=sys.stderr)
+        return _EXIT_USER_ERROR
+
+    baseline_source_value = getattr(args, "baseline_source", "bundled")
+    try:
+        baseline_source = BaselineSource(baseline_source_value)
+    except ValueError:
+        print(
+            f"unknown --baseline-source {baseline_source_value!r}; "
+            f"expected one of: bundled, workspace_override, explicit",
+            file=sys.stderr,
+        )
+        return _EXIT_USER_ERROR
+
+    baseline_overrides = None
+    if (
+        baseline_source is BaselineSource.EXPLICIT
+        and getattr(args, "baseline_overrides", None)
+    ):
+        try:
+            baseline_overrides = load_policies_from_dir(
+                Path(args.baseline_overrides)
+            )
+        except json.JSONDecodeError as exc:
+            print(
+                f"invalid JSON in --baseline-overrides: {exc}",
+                file=sys.stderr,
+            )
+            return _EXIT_USER_ERROR
+
+    project_root = Path(args.project_root or Path.cwd()).resolve()
+
+    try:
+        report = simulate_policy_change(
+            project_root=project_root,
+            scenarios=scenarios,
+            proposed_policies=proposed,
+            baseline_source=baseline_source,
+            baseline_overrides=baseline_overrides,
+            include_host_fs_probes=bool(
+                getattr(args, "enable_host_fs_probes", False)
+            ),
+        )
+    except (
+        ProposedPolicyInvalidError,
+        ScenarioAdapterMissingError,
+        TargetPolicyNotFoundError,
+    ) as exc:
+        print(f"simulation input error: {exc}", file=sys.stderr)
+        return _EXIT_USER_ERROR
+    except (
+        PolicySimSideEffectError,
+        PolicySimReentrantError,
+        SimulationAbortedError,
+    ) as exc:
+        print(f"simulation aborted: {exc}", file=sys.stderr)
+        return _EXIT_INTERNAL
+
+    fmt = getattr(args, "format", "json")
+    rendered = render(report, fmt)
+
+    output_path = getattr(args, "output", None)
+    if output_path:
+        write_atomic(Path(output_path), rendered)
+    else:
+        sys.stdout.write(rendered)
+        if not rendered.endswith("\n"):
+            sys.stdout.write("\n")
+
+    if has_tightening(report):
+        return _EXIT_TIGHTENING
+    return _EXIT_OK
+
+
+def _resolve_scenarios(spec: str | None) -> Sequence[Scenario]:
+    """Turn the ``--scenarios`` argument into a scenario list.
+
+    - ``None`` → bundled fixtures (``load_bundled_scenarios``).
+    - Directory path → load every ``*.json`` file inside.
+    - File path → load that single file.
+    """
+    if not spec:
+        return load_bundled_scenarios()
+    path = Path(spec)
+    if path.is_dir():
+        return load_scenarios_from_dir(path)
+    if path.is_file():
+        return (load_scenario_file(path),)
+    raise FileNotFoundError(f"scenarios path not found: {spec!r}")
+
+
+__all__ = ["cmd_policy_sim_run"]

--- a/ao_kernel/_internal/policy_sim/cli_handlers.py
+++ b/ao_kernel/_internal/policy_sim/cli_handlers.py
@@ -16,7 +16,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Sequence
+from typing import Literal, Sequence, cast
 
 from ao_kernel.policy_sim.errors import (
     PolicySimReentrantError,
@@ -117,7 +117,8 @@ def cmd_policy_sim_run(args: argparse.Namespace) -> int:
         print(f"simulation aborted: {exc}", file=sys.stderr)
         return _EXIT_INTERNAL
 
-    fmt = getattr(args, "format", "json")
+    fmt_raw = getattr(args, "format", "json")
+    fmt = cast(Literal["json", "text"], fmt_raw)
     rendered = render(report, fmt)
 
     output_path = getattr(args, "output", None)

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -173,6 +173,60 @@ def _build_parser() -> argparse.ArgumentParser:
         help="File path for atomic write; omit for stdout",
     )
 
+    # Policy-sim subcommand (PR-B4)
+    policy_sim_p = sub.add_parser(
+        "policy-sim",
+        help="Dry-run simulation of proposed policy changes",
+    )
+    policy_sim_sub = policy_sim_p.add_subparsers(dest="policy_sim_command")
+
+    run_p = policy_sim_sub.add_parser(
+        "run",
+        help="Evaluate scenarios against baseline + proposed policy sets",
+    )
+    run_p.add_argument(
+        "--scenarios",
+        default=None,
+        help="Scenario file or directory; omit for bundled fixtures",
+    )
+    run_p.add_argument(
+        "--proposed-policies",
+        required=True,
+        help="Directory containing proposed policy JSON files",
+    )
+    run_p.add_argument(
+        "--baseline-source",
+        choices=["bundled", "workspace_override", "explicit"],
+        default="bundled",
+        help="Baseline assembly source (default: bundled)",
+    )
+    run_p.add_argument(
+        "--baseline-overrides",
+        default=None,
+        help="Directory for baseline overrides (used with --baseline-source=explicit)",
+    )
+    run_p.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="json",
+        help="Report format (default: json)",
+    )
+    run_p.add_argument(
+        "--output",
+        default=None,
+        help="File path for atomic write; omit for stdout",
+    )
+    run_p.add_argument(
+        "--enable-host-fs-probes",
+        action="store_true",
+        help="Opt-in host-FS-dependent probes (default off; deferred in v1)",
+    )
+    run_p.add_argument(
+        "--project-root",
+        default=None,
+        help="Project root for adapter discovery (default: cwd)",
+    )
+
     return parser
 
 
@@ -220,6 +274,18 @@ def main(argv: list[str] | None = None) -> int:
             return _cmd_mcp_serve(args)
         from ao_kernel.i18n import msg
         print(msg("usage_mcp_serve"))
+        return 1
+
+    # Policy-sim subcommand (PR-B4)
+    if cmd == "policy-sim":
+        from ao_kernel._internal.policy_sim.cli_handlers import (
+            cmd_policy_sim_run,
+        )
+
+        ps_cmd = getattr(args, "policy_sim_command", None)
+        if ps_cmd == "run":
+            return cmd_policy_sim_run(args)
+        print("Usage: ao-kernel policy-sim run [options]", file=sys.stderr)
         return 1
 
     # Metrics subcommand (PR-B5)

--- a/ao_kernel/defaults/policies/policy_sim_scenarios/__manifest__.v1.json
+++ b/ao_kernel/defaults/policies/policy_sim_scenarios/__manifest__.v1.json
@@ -1,0 +1,9 @@
+{
+  "version": "v1",
+  "description": "Bundled scenario manifest for policy_sim. Operator workspace overrides are discovered via glob; this file lists the three reference fixtures shipped inside the wheel.",
+  "scenarios": [
+    "adapter_http_with_secret.v1.json",
+    "autonomy_unknown_intent.v1.json",
+    "path_poisoned_python.v1.json"
+  ]
+}

--- a/ao_kernel/defaults/policies/policy_sim_scenarios/adapter_http_with_secret.v1.json
+++ b/ao_kernel/defaults/policies/policy_sim_scenarios/adapter_http_with_secret.v1.json
@@ -1,0 +1,19 @@
+{
+  "scenario_id": "adapter_http_with_secret",
+  "description": "HTTP adapter binds auth_secret_id_ref; baseline policy_worktree_profile permits http_header exposure mode so the scenario resolves to allow.",
+  "kind": "executor_primitive",
+  "target_policy_name": "policy_worktree_profile.v1.json",
+  "inputs": {
+    "adapter_manifest_ref": "codex-stub",
+    "parent_env": {
+      "PATH": "/usr/bin:/usr/local/bin",
+      "ANTHROPIC_API_KEY": "sk-test-redacted"
+    },
+    "requested_command": null,
+    "requested_cwd": null
+  },
+  "expected_baseline": {
+    "violations_expected": [],
+    "decision_expected": "allow"
+  }
+}

--- a/ao_kernel/defaults/policies/policy_sim_scenarios/autonomy_unknown_intent.v1.json
+++ b/ao_kernel/defaults/policies/policy_sim_scenarios/autonomy_unknown_intent.v1.json
@@ -1,0 +1,17 @@
+{
+  "scenario_id": "autonomy_unknown_intent",
+  "description": "governance_policy scenario — action string is not in policy_autonomy's intent allowlist so check_policy surfaces AUTONOMY_UNKNOWN_INTENT. Baseline resolves to deny.",
+  "kind": "governance_policy",
+  "target_policy_name": "policy_autonomy.v1.json",
+  "inputs": {
+    "adapter_manifest_ref": null,
+    "parent_env": {},
+    "requested_command": null,
+    "requested_cwd": null,
+    "action": "AUTONOMY_UNKNOWN_INTENT"
+  },
+  "expected_baseline": {
+    "violations_expected": ["AUTONOMY_UNKNOWN_INTENT"],
+    "decision_expected": "deny"
+  }
+}

--- a/ao_kernel/defaults/policies/policy_sim_scenarios/path_poisoned_python.v1.json
+++ b/ao_kernel/defaults/policies/policy_sim_scenarios/path_poisoned_python.v1.json
@@ -1,0 +1,18 @@
+{
+  "scenario_id": "path_poisoned_python",
+  "description": "parent PATH contains an attacker-controlled prefix; baseline policy_worktree_profile's command_allowlist should surface command_path_outside_policy so the scenario resolves to deny. Exercised only when --enable-host-fs-probes flips validate_command on.",
+  "kind": "executor_primitive",
+  "target_policy_name": "policy_worktree_profile.v1.json",
+  "inputs": {
+    "adapter_manifest_ref": "codex-stub",
+    "parent_env": {
+      "PATH": "/tmp/poison:/usr/bin"
+    },
+    "requested_command": "/tmp/poison/python",
+    "requested_cwd": null
+  },
+  "expected_baseline": {
+    "violations_expected": ["command_path_outside_policy"],
+    "decision_expected": "deny"
+  }
+}

--- a/ao_kernel/defaults/schemas/policy-sim-scenario.schema.v1.json
+++ b/ao_kernel/defaults/schemas/policy-sim-scenario.schema.v1.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:policy-sim-scenario:v1",
+  "title": "Policy Simulation Scenario",
+  "description": "Validates a single scenario document for ao_kernel.policy_sim. Scenarios live under policy_sim_scenarios/*.v1.json (bundled) or under a workspace override. See docs/POLICY-SIM.md and PR-B4 plan v3 §2.2/§2.9 for semantics.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["scenario_id", "kind", "inputs", "expected_baseline"],
+  "properties": {
+    "scenario_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120,
+      "pattern": "^[a-z][a-z0-9_]{0,119}$",
+      "description": "Stable id used in reports. Lowercase + digits + underscore only."
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable summary; not load-bearing."
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["executor_primitive", "governance_policy", "combined"],
+      "description": "executor_primitive: invokes build_sandbox + resolve_allowed_secrets + check_http_header_exposure against policy_worktree_profile. governance_policy: invokes check_policy against target_policy_name. combined: both."
+    },
+    "target_policy_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Policy file the scenario evaluates. Required for executor_primitive and governance_policy kinds. Must be a key in proposed_policies OR baseline_overrides OR bundled defaults."
+    },
+    "target_policy_names": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1},
+      "description": "Required for kind=combined. One entry per primitive invoked by the scenario."
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "adapter_manifest_ref": {
+          "type": ["string", "null"],
+          "description": "Adapter id resolved against the pre-simulation AdapterRegistry snapshot (load_bundled() + load_workspace(project_root))."
+        },
+        "parent_env": {
+          "type": "object",
+          "additionalProperties": {"type": "string"},
+          "description": "Environment variables presented to build_sandbox / resolve_allowed_secrets."
+        },
+        "requested_command": {
+          "type": ["string", "null"],
+          "description": "Optional command for validate_command probes (gated by --enable-host-fs-probes)."
+        },
+        "requested_cwd": {
+          "type": ["string", "null"],
+          "description": "Ephemeral sentinel path; validate_cwd is excluded from v1 simulator per §2.3."
+        },
+        "action": {
+          "type": ["string", "null"],
+          "description": "Action string passed to check_policy for governance_policy scenarios."
+        }
+      }
+    },
+    "expected_baseline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision_expected"],
+      "properties": {
+        "violations_expected": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Ordered list of violation kind codes expected under the baseline policy."
+        },
+        "decision_expected": {
+          "type": "string",
+          "enum": ["allow", "deny"]
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"kind": {"const": "combined"}}},
+      "then": {
+        "required": ["target_policy_names"],
+        "not": {"required": ["target_policy_name"]}
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {"enum": ["executor_primitive", "governance_policy"]}
+        }
+      },
+      "then": {
+        "required": ["target_policy_name"],
+        "not": {"required": ["target_policy_names"]}
+      }
+    }
+  ]
+}

--- a/ao_kernel/policy_sim/__init__.py
+++ b/ao_kernel/policy_sim/__init__.py
@@ -1,0 +1,48 @@
+"""Policy simulation harness (PR-B4).
+
+Public package for dry-run evaluation of proposed policy changes
+against scenario fixtures. Mid-depth simulator reusing
+``governance.check_policy`` + executor policy primitives under a
+side-effect-free contract (no workspace writes, no evidence emits,
+no subprocess spawns, no network).
+
+See ``docs/POLICY-SIM.md`` for the operator-facing contract and
+``.claude/plans/PR-B4-DRAFT-PLAN.md`` v3 for the adversarially-
+reviewed design.
+
+Public surface is built up across the commit DAG:
+
+- **Commit 1** (this file's initial state): typed errors,
+  purity contract, policy shape registry, scenario schema.
+- **Commit 2**: scenario model + bundled JSON samples.
+- **Commit 3**: simulator core + diff engine + loader.
+- **Commit 4**: reporter + CLI handler.
+- **Commit 5**: public surface + docs + integration tests.
+"""
+
+from __future__ import annotations
+
+from ao_kernel.policy_sim.errors import (
+    PolicySimError,
+    PolicySimReentrantError,
+    PolicySimSideEffectError,
+    ProposedPolicyInvalidError,
+    ReportSerializationError,
+    ScenarioAdapterMissingError,
+    ScenarioValidationError,
+    SimulationAbortedError,
+    TargetPolicyNotFoundError,
+)
+
+
+__all__ = [
+    "PolicySimError",
+    "PolicySimReentrantError",
+    "PolicySimSideEffectError",
+    "ProposedPolicyInvalidError",
+    "ReportSerializationError",
+    "ScenarioAdapterMissingError",
+    "ScenarioValidationError",
+    "SimulationAbortedError",
+    "TargetPolicyNotFoundError",
+]

--- a/ao_kernel/policy_sim/__init__.py
+++ b/ao_kernel/policy_sim/__init__.py
@@ -33,9 +33,20 @@ from ao_kernel.policy_sim.errors import (
     SimulationAbortedError,
     TargetPolicyNotFoundError,
 )
+from ao_kernel.policy_sim.scenario import (
+    ExpectedBaseline,
+    Scenario,
+    ScenarioInputs,
+    ScenarioKind,
+    ScenarioSet,
+    load_bundled_scenarios,
+    load_scenario_file,
+    load_scenarios_from_dir,
+)
 
 
 __all__ = [
+    # Errors
     "PolicySimError",
     "PolicySimReentrantError",
     "PolicySimSideEffectError",
@@ -45,4 +56,13 @@ __all__ = [
     "ScenarioValidationError",
     "SimulationAbortedError",
     "TargetPolicyNotFoundError",
+    # Scenario model
+    "ExpectedBaseline",
+    "Scenario",
+    "ScenarioInputs",
+    "ScenarioKind",
+    "ScenarioSet",
+    "load_bundled_scenarios",
+    "load_scenario_file",
+    "load_scenarios_from_dir",
 ]

--- a/ao_kernel/policy_sim/__init__.py
+++ b/ao_kernel/policy_sim/__init__.py
@@ -33,6 +33,20 @@ from ao_kernel.policy_sim.errors import (
     SimulationAbortedError,
     TargetPolicyNotFoundError,
 )
+from ao_kernel.policy_sim.diff import (
+    DiffReport,
+    ScenarioDelta,
+    SimulationResult,
+    TransitionKind,
+    ViolationDiff,
+    canonical_policy_hash,
+    dump_json,
+)
+from ao_kernel.policy_sim.loader import (
+    BaselineSource,
+    policy_override_context,
+    validate_proposed_policy,
+)
 from ao_kernel.policy_sim.scenario import (
     ExpectedBaseline,
     Scenario,
@@ -43,6 +57,7 @@ from ao_kernel.policy_sim.scenario import (
     load_scenario_file,
     load_scenarios_from_dir,
 )
+from ao_kernel.policy_sim.simulator import simulate_policy_change
 
 
 __all__ = [
@@ -65,4 +80,16 @@ __all__ = [
     "load_bundled_scenarios",
     "load_scenario_file",
     "load_scenarios_from_dir",
+    # Simulator + diff + loader (C3)
+    "BaselineSource",
+    "DiffReport",
+    "ScenarioDelta",
+    "SimulationResult",
+    "TransitionKind",
+    "ViolationDiff",
+    "canonical_policy_hash",
+    "dump_json",
+    "policy_override_context",
+    "simulate_policy_change",
+    "validate_proposed_policy",
 ]

--- a/ao_kernel/policy_sim/_policy_shape_registry.py
+++ b/ao_kernel/policy_sim/_policy_shape_registry.py
@@ -92,8 +92,12 @@ POLICY_SHAPE_REGISTRY: Mapping[str, tuple[PolicyShapeEntry, ...]] = {
                 ("intents",),
                 ("defaults", "mode"),
             ),
+            # governance.check_policy consumes `intents` as a dict
+            # (bundled default `policy_autonomy.v1.json` is a dict);
+            # iter-3 post-impl absorb switches this contract from
+            # list → dict so valid autonomy policies pass validation.
             type_contracts={
-                ("intents",): list,
+                ("intents",): dict,
                 ("defaults", "mode"): str,
             },
         ),

--- a/ao_kernel/policy_sim/_policy_shape_registry.py
+++ b/ao_kernel/policy_sim/_policy_shape_registry.py
@@ -1,0 +1,174 @@
+"""Centralised policy shape registry for the simulation harness
+(PR-B4 plan v3 N1 absorb).
+
+Each entry declares the keys a consuming primitive reads from a
+policy document. Validators use the registry to reject proposed
+policies whose shape does not match a consumer's expectations
+without duplicating primitive internals.
+
+Commit-1 ships a minimal surface: the fields consumed by
+``executor.policy_enforcer.build_sandbox``,
+``resolve_allowed_secrets``, and ``check_http_header_exposure``
+for ``policy_worktree_profile.v1.json``, plus the
+``check_policy``-backed ``intents`` / ``defaults.mode`` axis for
+``policy_autonomy.v1.json``. C3 extends the registry with the
+full tool-calling policy surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class PolicyShapeEntry:
+    """One primitive's view into a policy document.
+
+    - ``primitive_name``: human-readable label ("build_sandbox",
+      "check_policy::autonomy", ...).
+    - ``policy_name_target``: the policy file the primitive
+      reads, e.g. ``policy_worktree_profile.v1.json``.
+    - ``required_top_keys``: top-level keys that must be present.
+    - ``consumed_sub_paths``: tuple of key paths (each a tuple)
+      the primitive dereferences. Used to build structural
+      violation records without duplicating primitive logic.
+    - ``type_contracts``: ``{sub_path: expected_type}`` for the
+      handful of type checks the primitive relies on (e.g.
+      ``env_allowlist.allowed_keys`` must be ``list``).
+    """
+
+    primitive_name: str
+    policy_name_target: str
+    required_top_keys: frozenset[str]
+    consumed_sub_paths: tuple[tuple[str, ...], ...]
+    type_contracts: Mapping[tuple[str, ...], type]
+
+
+# Registry keyed by policy_name. A single policy may be consumed
+# by multiple primitives; the loader aggregates required_top_keys
+# and type_contracts across entries so a proposed policy must
+# satisfy every consumer in one pass.
+POLICY_SHAPE_REGISTRY: Mapping[str, tuple[PolicyShapeEntry, ...]] = {
+    "policy_worktree_profile.v1.json": (
+        PolicyShapeEntry(
+            primitive_name="build_sandbox",
+            policy_name_target="policy_worktree_profile.v1.json",
+            required_top_keys=frozenset(
+                {
+                    "version",
+                    "enabled",
+                    "worktree",
+                    "env_allowlist",
+                    "secrets",
+                    "command_allowlist",
+                    "cwd_confinement",
+                    "evidence_redaction",
+                    "rollout",
+                }
+            ),
+            consumed_sub_paths=(
+                ("env_allowlist", "allowed_keys"),
+                ("secrets", "exposure_modes"),
+                ("command_allowlist", "prefixes"),
+                ("cwd_confinement", "allowed_prefixes"),
+                ("evidence_redaction", "patterns"),
+            ),
+            type_contracts={
+                ("env_allowlist", "allowed_keys"): list,
+                ("secrets", "exposure_modes"): list,
+                ("command_allowlist", "prefixes"): list,
+                ("cwd_confinement", "allowed_prefixes"): list,
+                ("evidence_redaction", "patterns"): list,
+            },
+        ),
+    ),
+    "policy_autonomy.v1.json": (
+        PolicyShapeEntry(
+            primitive_name="check_policy::autonomy",
+            policy_name_target="policy_autonomy.v1.json",
+            required_top_keys=frozenset({"version", "intents", "defaults"}),
+            consumed_sub_paths=(
+                ("intents",),
+                ("defaults", "mode"),
+            ),
+            type_contracts={
+                ("intents",): list,
+                ("defaults", "mode"): str,
+            },
+        ),
+    ),
+}
+
+
+def get_registry_entries(policy_name: str) -> tuple[PolicyShapeEntry, ...]:
+    """Return the registry entries for ``policy_name`` or an empty
+    tuple when no primitive reads the policy yet (validator still
+    enforces JSON-schema-level structural checks elsewhere)."""
+    return POLICY_SHAPE_REGISTRY.get(policy_name, ())
+
+
+def aggregated_required_keys(policy_name: str) -> frozenset[str]:
+    """Union of ``required_top_keys`` across every registered
+    primitive for ``policy_name``."""
+    entries = get_registry_entries(policy_name)
+    if not entries:
+        return frozenset()
+    merged: set[str] = set()
+    for entry in entries:
+        merged.update(entry.required_top_keys)
+    return frozenset(merged)
+
+
+def aggregated_type_contracts(
+    policy_name: str,
+) -> Mapping[tuple[str, ...], type]:
+    """Union of ``type_contracts`` across every registered
+    primitive for ``policy_name``. When two primitives disagree
+    on a sub-path (should not happen in v1 — contracts are
+    disjoint), the first registered wins and a caller-level test
+    surfaces the drift."""
+    entries = get_registry_entries(policy_name)
+    merged: dict[tuple[str, ...], type] = {}
+    for entry in entries:
+        for path, expected in entry.type_contracts.items():
+            merged.setdefault(path, expected)
+    return merged
+
+
+def walk_policy(
+    policy: Mapping[str, Any],
+    path: tuple[str, ...],
+) -> Any:
+    """Safely navigate ``policy`` down ``path``. Returns a
+    sentinel ``_MISSING`` when any segment is absent so callers
+    can report a structured violation without ``KeyError``
+    surprises.
+    """
+    current: Any = policy
+    for segment in path:
+        if not isinstance(current, Mapping):
+            return _MISSING
+        if segment not in current:
+            return _MISSING
+        current = current[segment]
+    return current
+
+
+class _MissingSentinel:
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return "<_MISSING>"
+
+
+_MISSING = _MissingSentinel()
+
+
+__all__ = [
+    "PolicyShapeEntry",
+    "POLICY_SHAPE_REGISTRY",
+    "_MISSING",
+    "aggregated_required_keys",
+    "aggregated_type_contracts",
+    "get_registry_entries",
+    "walk_policy",
+]

--- a/ao_kernel/policy_sim/_purity.py
+++ b/ao_kernel/policy_sim/_purity.py
@@ -1,0 +1,188 @@
+"""No-side-effects guard for the policy simulation harness (PR-B4).
+
+The simulator evaluates scenarios against proposed policy changes
+without touching the workspace, spawning subprocesses, hitting
+the network, or writing any files. ``pure_execution_context``
+monkey-patches a fixed set of sentinel APIs so that any
+accidental side effect — from the simulator itself or from
+re-used code paths in ``executor`` / ``governance`` — fail-closes
+rather than silently mutating state.
+
+Sentinel coverage (plan v3 §2.1):
+
+- 4 evidence-emit entry points (3 pre-imported aliases + public
+  facade re-export).
+- ``worktree_builder.create_worktree``.
+- 4 ``subprocess`` entry points.
+- 4 ``pathlib.Path`` write methods.
+- 4 ``os`` mutation entry points.
+- 4 ``tempfile`` allocators.
+- 2 ``socket`` operations (connect + bind).
+- ``importlib.resources.as_file`` (temp extraction).
+
+Total: 23 sentinels + re-entrancy guard.
+
+The context manager is **not** re-entrant: a nested entry raises
+``PolicySimReentrantError`` rather than partially restoring
+state on exit. Tests must always use a fresh context per
+invocation.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import socket
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from importlib import resources as _importlib_resources
+from typing import Any, Callable, Iterator
+
+from ao_kernel.policy_sim.errors import (
+    PolicySimReentrantError,
+    PolicySimSideEffectError,
+)
+
+
+# Sentinel name → (owning module object, attribute name).
+# Order matters for deterministic save/restore bookkeeping.
+_SENTINELS: tuple[tuple[str, Any, str], ...] = (
+    # Evidence emit — patch all four import paths so pre-imported
+    # aliases in executor.py / multi_step_driver.py and the
+    # public facade re-export all fail-close together.
+    (
+        "ao_kernel.executor.evidence_emitter.emit_event",
+        None,
+        "emit_event",
+    ),
+    (
+        "ao_kernel.executor.executor.emit_event",
+        None,
+        "emit_event",
+    ),
+    (
+        "ao_kernel.executor.multi_step_driver.emit_event",
+        None,
+        "emit_event",
+    ),
+    (
+        "ao_kernel.executor.emit_event",
+        None,
+        "emit_event",
+    ),
+    # Worktree creation.
+    (
+        "ao_kernel.executor.worktree_builder.create_worktree",
+        None,
+        "create_worktree",
+    ),
+    # Subprocess (re-entrant safe — we patch __init__ not Popen
+    # itself so the class identity is preserved for isinstance
+    # checks downstream).
+    ("subprocess.Popen.__init__", subprocess.Popen, "__init__"),
+    ("subprocess.run", subprocess, "run"),
+    ("subprocess.call", subprocess, "call"),
+    ("subprocess.check_output", subprocess, "check_output"),
+    # Filesystem writes (pathlib).
+    ("pathlib.Path.write_text", pathlib.Path, "write_text"),
+    ("pathlib.Path.write_bytes", pathlib.Path, "write_bytes"),
+    ("pathlib.Path.mkdir", pathlib.Path, "mkdir"),
+    ("pathlib.Path.touch", pathlib.Path, "touch"),
+    # Filesystem mutations (os).
+    ("os.replace", os, "replace"),
+    ("os.rename", os, "rename"),
+    ("os.remove", os, "remove"),
+    ("os.unlink", os, "unlink"),
+    # Tempfile allocators (importlib.resources.as_file uses
+    # mkstemp internally for extractable resources; patching
+    # tempfile.mkstemp + as_file covers both the low-level call
+    # and the common high-level helper).
+    ("tempfile.NamedTemporaryFile", tempfile, "NamedTemporaryFile"),
+    ("tempfile.mkstemp", tempfile, "mkstemp"),
+    ("tempfile.TemporaryFile", tempfile, "TemporaryFile"),
+    ("tempfile.mkdtemp", tempfile, "mkdtemp"),
+    # Network.
+    ("socket.socket.connect", socket.socket, "connect"),
+    ("socket.socket.bind", socket.socket, "bind"),
+    # Importlib resource extraction.
+    (
+        "importlib.resources.as_file",
+        _importlib_resources,
+        "as_file",
+    ),
+)
+
+
+PATCHED_SENTINEL_NAMES: frozenset[str] = frozenset(
+    entry[0] for entry in _SENTINELS
+)
+"""Public read-only view of the sentinel names for test assertions."""
+
+
+def _resolve_target(path: str, owner: Any, attr: str) -> tuple[Any, str]:
+    """Resolve ``path`` to ``(module_or_class, attribute_name)``.
+
+    Owners for the emit_event / worktree_builder sentinels are
+    supplied as ``None`` because the ao_kernel submodules are not
+    necessarily imported at module load time (purity guard must
+    stay importable in minimal environments). Lazily resolve the
+    module via ``__import__`` on first sentinel setup.
+    """
+    if owner is not None:
+        return owner, attr
+
+    module_path, _, attr_name = path.rpartition(".")
+    module = __import__(module_path, fromlist=[attr_name])
+    return module, attr_name
+
+
+def _make_raiser(sentinel_name: str) -> Callable[..., None]:
+    def _raise(*_args: Any, **_kwargs: Any) -> None:
+        raise PolicySimSideEffectError(sentinel_name)
+
+    _raise.__name__ = f"_policy_sim_guard_{sentinel_name.replace('.', '_')}"
+    _raise.__qualname__ = _raise.__name__
+    return _raise
+
+
+_ACTIVE: dict[str, bool] = {"in_context": False}
+
+
+@contextmanager
+def pure_execution_context() -> Iterator[None]:
+    """Monkeypatch the sentinel surface so any forbidden side
+    effect raises :class:`PolicySimSideEffectError`.
+
+    The context manager is strictly not re-entrant: a nested
+    entry raises :class:`PolicySimReentrantError` before any
+    patching occurs so the outer state remains intact. On exit,
+    originals are always restored via ``finally`` — even if an
+    exception propagates — so pytest parametrisation and failure
+    paths do not leak guards.
+    """
+    if _ACTIVE["in_context"]:
+        raise PolicySimReentrantError()
+
+    originals: list[tuple[Any, str, Any]] = []
+    try:
+        for path, owner_hint, attr in _SENTINELS:
+            owner, attr_name = _resolve_target(path, owner_hint, attr)
+            original = getattr(owner, attr_name)
+            originals.append((owner, attr_name, original))
+            setattr(owner, attr_name, _make_raiser(path))
+        _ACTIVE["in_context"] = True
+        yield
+    finally:
+        # Restore in reverse patch order so multi-target attrs
+        # (e.g. subprocess.Popen.__init__ after subprocess.run
+        # patched) roll back cleanly.
+        for owner, attr_name, original in reversed(originals):
+            setattr(owner, attr_name, original)
+        _ACTIVE["in_context"] = False
+
+
+__all__ = [
+    "PATCHED_SENTINEL_NAMES",
+    "pure_execution_context",
+]

--- a/ao_kernel/policy_sim/diff.py
+++ b/ao_kernel/policy_sim/diff.py
@@ -1,0 +1,301 @@
+"""Diff engine for the policy simulation harness (PR-B4 C3).
+
+Pairs baseline + proposed ``SimulationResult`` per scenario into
+a ``ScenarioDelta`` carrying the transition kind and violation
+diff. Aggregates scenario deltas into a ``DiffReport`` with
+per-policy breakdown and stable, canonicalised JSON output
+(plan v3 N3 / N4 absorb).
+
+All dataclasses are frozen; ``DiffReport.to_dict`` is the one
+normalisation boundary between internal Python types (``Path``,
+``frozenset``, compiled regex, manifest ``source_path``) and
+the JSON-serialisable surface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Literal, Mapping
+
+
+TransitionKind = Literal[
+    "allow_to_allow",
+    "allow_to_deny",
+    "deny_to_allow",
+    "deny_to_deny",
+    "error",
+]
+
+
+_TRANSITION_LABELS: Mapping[TransitionKind, str] = {
+    "allow_to_allow": "allow→allow",
+    "allow_to_deny": "allow→deny",
+    "deny_to_allow": "deny→allow",
+    "deny_to_deny": "deny→deny",
+    "error": "error",
+}
+
+
+@dataclass(frozen=True)
+class SimulationResult:
+    """One primitive pass's decision + violations.
+
+    ``violation_kinds`` is the ordered list of violation codes
+    surfaced; ``decision`` is ``"allow"`` when ``violation_kinds``
+    is empty, ``"deny"`` otherwise, or ``"error"`` when the
+    primitive itself raised.
+    """
+
+    scenario_id: str
+    decision: Literal["allow", "deny", "error"]
+    violation_kinds: tuple[str, ...] = ()
+    error_detail: str = ""
+
+
+@dataclass(frozen=True)
+class ViolationDiff:
+    """Added / removed violation codes between two ``SimulationResult``s.
+
+    Frozensets keep the diff set-like while staying hashable for
+    :class:`ScenarioDelta`; :meth:`DiffReport.to_dict` serialises
+    them as sorted lists for operator-readable JSON.
+    """
+
+    added: frozenset[str]
+    removed: frozenset[str]
+
+
+@dataclass(frozen=True)
+class ScenarioDelta:
+    scenario_id: str
+    target_policy_name: str
+    baseline: SimulationResult
+    proposed: SimulationResult
+    transition: TransitionKind
+    violation_diff: ViolationDiff
+    notable: bool
+
+
+@dataclass(frozen=True)
+class DiffReport:
+    baseline_policy_hashes: Mapping[str, str]
+    proposed_policy_hashes: Mapping[str, str]
+    scenarios_evaluated: int
+    transitions: Mapping[TransitionKind, int]
+    transitions_by_policy: Mapping[str, Mapping[TransitionKind, int]]
+    deltas: tuple[ScenarioDelta, ...]
+    emitted_at: str
+    host_fs_dependent: bool = False
+    host_fs_fingerprint: str | None = None
+
+    @property
+    def notable_deltas(self) -> tuple[ScenarioDelta, ...]:
+        return tuple(d for d in self.deltas if d.notable)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable representation.
+
+        Normalisation pass (plan v3 N4 absorb):
+        - ``Path`` → ``str``
+        - ``frozenset`` → sorted ``list``
+        - compiled regex → ``.pattern``
+        - manifest ``source_path`` → relative ``str``
+
+        Output order is stable for cross-run diffs: scenario
+        deltas are sorted by scenario_id; mappings expose keys in
+        sorted order on serialisation (caller passes
+        ``sort_keys=True``).
+        """
+        return {
+            "schema_version": "v1",
+            "emitted_at": self.emitted_at,
+            "scenarios_evaluated": self.scenarios_evaluated,
+            "baseline_policy_hashes": dict(self.baseline_policy_hashes),
+            "proposed_policy_hashes": dict(self.proposed_policy_hashes),
+            "transitions": {
+                _TRANSITION_LABELS[k]: v
+                for k, v in self.transitions.items()
+            },
+            "transitions_by_policy": {
+                policy: {
+                    _TRANSITION_LABELS[k]: v for k, v in counts.items()
+                }
+                for policy, counts in self.transitions_by_policy.items()
+            },
+            "host_fs_dependent": self.host_fs_dependent,
+            "host_fs_fingerprint": self.host_fs_fingerprint,
+            "deltas": [
+                _serialise_delta(d)
+                for d in sorted(self.deltas, key=lambda x: x.scenario_id)
+            ],
+            "notable_deltas_count": len(self.notable_deltas),
+        }
+
+
+def _serialise_delta(delta: ScenarioDelta) -> dict[str, Any]:
+    return {
+        "scenario_id": delta.scenario_id,
+        "target_policy_name": delta.target_policy_name,
+        "transition": _TRANSITION_LABELS[delta.transition],
+        "notable": delta.notable,
+        "baseline": _serialise_result(delta.baseline),
+        "proposed": _serialise_result(delta.proposed),
+        "violation_diff": {
+            "added": sorted(delta.violation_diff.added),
+            "removed": sorted(delta.violation_diff.removed),
+        },
+    }
+
+
+def _serialise_result(result: SimulationResult) -> dict[str, Any]:
+    return {
+        "decision": result.decision,
+        "violation_kinds": list(result.violation_kinds),
+        "error_detail": result.error_detail,
+    }
+
+
+def compute_transition(
+    baseline: SimulationResult, proposed: SimulationResult
+) -> TransitionKind:
+    """Classify a (baseline, proposed) pair into a ``TransitionKind``."""
+    if baseline.decision == "error" or proposed.decision == "error":
+        return "error"
+    mapping: Mapping[tuple[str, str], TransitionKind] = {
+        ("allow", "allow"): "allow_to_allow",
+        ("allow", "deny"): "allow_to_deny",
+        ("deny", "allow"): "deny_to_allow",
+        ("deny", "deny"): "deny_to_deny",
+    }
+    return mapping[(baseline.decision, proposed.decision)]
+
+
+def compute_violation_diff(
+    baseline: SimulationResult, proposed: SimulationResult
+) -> ViolationDiff:
+    base = frozenset(baseline.violation_kinds)
+    prop = frozenset(proposed.violation_kinds)
+    return ViolationDiff(added=prop - base, removed=base - prop)
+
+
+def make_scenario_delta(
+    *,
+    scenario_id: str,
+    target_policy_name: str,
+    baseline: SimulationResult,
+    proposed: SimulationResult,
+) -> ScenarioDelta:
+    transition = compute_transition(baseline, proposed)
+    diff = compute_violation_diff(baseline, proposed)
+    notable = transition not in ("allow_to_allow", "deny_to_deny") or bool(
+        diff.added or diff.removed
+    )
+    return ScenarioDelta(
+        scenario_id=scenario_id,
+        target_policy_name=target_policy_name,
+        baseline=baseline,
+        proposed=proposed,
+        transition=transition,
+        violation_diff=diff,
+        notable=notable,
+    )
+
+
+def canonical_policy_hash(policy: Mapping[str, Any]) -> str:
+    """Return ``"sha256:<hex>"`` over the canonical JSON form of
+    ``policy``.
+
+    Canonicalisation matches :mod:`ao_kernel.executor.artifacts`
+    (plan v3 N3 absorb): ``sort_keys=True``,
+    ``ensure_ascii=False``, ``separators=(",", ":")``, UTF-8
+    bytes.
+    """
+    canonical = json.dumps(
+        policy,
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def aggregate_transition_counts(
+    deltas: Iterable[ScenarioDelta],
+) -> tuple[
+    Mapping[TransitionKind, int], Mapping[str, Mapping[TransitionKind, int]]
+]:
+    """Fold per-delta transitions into aggregate + per-policy
+    counters. Keys are present for every ``TransitionKind`` so
+    downstream reporters don't have to guard for missing axes."""
+    all_kinds: tuple[TransitionKind, ...] = (
+        "allow_to_allow",
+        "allow_to_deny",
+        "deny_to_allow",
+        "deny_to_deny",
+        "error",
+    )
+    overall: dict[TransitionKind, int] = {k: 0 for k in all_kinds}
+    by_policy: dict[str, dict[TransitionKind, int]] = {}
+    for delta in deltas:
+        overall[delta.transition] += 1
+        bucket = by_policy.setdefault(
+            delta.target_policy_name, {k: 0 for k in all_kinds}
+        )
+        bucket[delta.transition] += 1
+    return overall, by_policy
+
+
+def dump_json(report: DiffReport) -> str:
+    """Canonical JSON serialisation of ``report.to_dict()``.
+
+    Uses the same canonicalisation as :func:`canonical_policy_hash`
+    so ``dump_json(report)`` is stable cross-run.
+    """
+    payload = report.to_dict()
+    return json.dumps(
+        _stringify_unknowns(payload),
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _stringify_unknowns(value: Any) -> Any:
+    """Last-resort normaliser for ``Path`` / ``re.Pattern`` /
+    anything else the primary normalisation missed. Raises
+    :class:`ReportSerializationError`-materialised strings rather
+    than hiding drift."""
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, re.Pattern):
+        return value.pattern
+    if isinstance(value, frozenset):
+        return sorted(value)
+    if isinstance(value, Mapping):
+        return {k: _stringify_unknowns(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_stringify_unknowns(v) for v in value]
+    return value
+
+
+__all__ = [
+    "DiffReport",
+    "ScenarioDelta",
+    "SimulationResult",
+    "TransitionKind",
+    "ViolationDiff",
+    "aggregate_transition_counts",
+    "canonical_policy_hash",
+    "compute_transition",
+    "compute_violation_diff",
+    "dump_json",
+    "make_scenario_delta",
+]
+
+
+# Silence unused-import lint — ``field`` kept for future extension.
+_ = field

--- a/ao_kernel/policy_sim/errors.py
+++ b/ao_kernel/policy_sim/errors.py
@@ -1,0 +1,186 @@
+"""Typed error hierarchy for the policy simulation harness (PR-B4).
+
+Each subclass carries the structured fields operators need to
+distinguish root causes from the exception type alone. See
+``docs/POLICY-SIM.md`` and PR-B4 plan v3 §2.7 for the full
+semantic contract.
+"""
+
+from __future__ import annotations
+
+
+class PolicySimError(Exception):
+    """Base class for all policy-simulation runtime errors."""
+
+
+class PolicySimSideEffectError(PolicySimError):
+    """Raised when a simulation step triggers a forbidden side
+    effect (evidence emit, worktree creation, subprocess spawn,
+    filesystem write, network I/O, tempfile creation, or
+    importlib resource extraction).
+
+    The ``sentinel_name`` field identifies which guarded attribute
+    was touched; ``context`` carries a short description of the
+    call site (helpful for operator diagnosis).
+    """
+
+    def __init__(self, sentinel_name: str, context: str = "") -> None:
+        self.sentinel_name = sentinel_name
+        self.context = context
+        suffix = f" ({context})" if context else ""
+        super().__init__(
+            f"policy-sim side-effect sentinel tripped: "
+            f"{sentinel_name!r}{suffix}"
+        )
+
+
+class PolicySimReentrantError(PolicySimError):
+    """Raised when ``pure_execution_context`` is entered while
+    another instance is already active on the same thread.
+
+    Nested entries cannot restore the outer context's patched
+    sentinels on exit without leaking state, so the guard
+    fail-closes rather than silently partial-restoring.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "pure_execution_context is not re-entrant; nested "
+            "entry would leak sentinel state on exit"
+        )
+
+
+class ScenarioValidationError(PolicySimError):
+    """Raised when a scenario document fails schema validation.
+
+    The ``scenario_id`` field echoes the offending scenario's id
+    (or a synthetic fallback when the id itself is absent);
+    ``reason`` carries the underlying validator message.
+    """
+
+    def __init__(self, scenario_id: str, reason: str) -> None:
+        self.scenario_id = scenario_id
+        self.reason = reason
+        super().__init__(
+            f"scenario {scenario_id!r} failed validation: {reason}"
+        )
+
+
+class ScenarioAdapterMissingError(PolicySimError):
+    """Raised when a scenario references an ``adapter_manifest_ref``
+    that is absent from the pre-simulation adapter registry
+    snapshot (neither bundled nor workspace override)."""
+
+    def __init__(self, scenario_id: str, adapter_ref: str) -> None:
+        self.scenario_id = scenario_id
+        self.adapter_ref = adapter_ref
+        super().__init__(
+            f"scenario {scenario_id!r} references unknown adapter "
+            f"{adapter_ref!r}; load_bundled() + load_workspace() "
+            f"produced no matching manifest"
+        )
+
+
+class TargetPolicyNotFoundError(PolicySimError):
+    """Raised when a scenario's ``target_policy_name`` is not
+    present in ``proposed_policies`` nor ``baseline_overrides``
+    nor in the bundled defaults.
+
+    The per-scenario routing model (plan v3 bulgu 1 absorb) means
+    each scenario names the policy it evaluates; this error
+    surfaces configuration drift early rather than deep inside
+    the loader.
+    """
+
+    def __init__(self, scenario_id: str, policy_name: str) -> None:
+        self.scenario_id = scenario_id
+        self.policy_name = policy_name
+        super().__init__(
+            f"scenario {scenario_id!r} targets policy "
+            f"{policy_name!r} which is not available in "
+            f"proposed_policies, baseline_overrides, or bundled "
+            f"defaults"
+        )
+
+
+class ProposedPolicyInvalidError(PolicySimError):
+    """Raised when a proposed policy dict fails the structural
+    shape checks mirrored from the consuming primitive (per the
+    ``_policy_shape_registry``).
+
+    The ``violations`` field is a sequence of structured records
+    (``(path, expected, observed)`` tuples rendered as strings)
+    so operators see every violation in one pass.
+    """
+
+    def __init__(
+        self,
+        policy_name: str,
+        violations: tuple[str, ...],
+    ) -> None:
+        self.policy_name = policy_name
+        self.violations = violations
+        joined = "; ".join(violations) if violations else "(no detail)"
+        super().__init__(
+            f"proposed policy {policy_name!r} failed structural "
+            f"shape checks: {joined}"
+        )
+
+
+class SimulationAbortedError(PolicySimError):
+    """Aggregate wrapper raised when per-scenario evaluation
+    produced one or more unrecoverable errors the harness chose
+    to surface in one exception rather than bubbling them
+    individually.
+
+    ``causes`` is the ordered list of underlying exceptions; the
+    first is set as ``__cause__`` so ``raise ... from ...``
+    semantics still work for drill-down.
+    """
+
+    def __init__(
+        self,
+        scenario_ids: tuple[str, ...],
+        causes: tuple[BaseException, ...],
+    ) -> None:
+        self.scenario_ids = scenario_ids
+        self.causes = causes
+        super().__init__(
+            f"simulation aborted on scenarios {list(scenario_ids)!r}: "
+            f"{len(causes)} underlying error(s)"
+        )
+        if causes:
+            self.__cause__ = causes[0]
+
+
+class ReportSerializationError(PolicySimError):
+    """Raised when the reporter cannot JSON-encode a value
+    produced by the simulator (typically a ``Path``, ``Decimal``,
+    regex pattern, or frozenset that escaped
+    ``DiffReport.to_dict`` normalisation).
+
+    Surfaces with the offending type name + an operator-readable
+    hint pointing at the normalisation contract.
+    """
+
+    def __init__(self, field_path: str, value_type: str) -> None:
+        self.field_path = field_path
+        self.value_type = value_type
+        super().__init__(
+            f"report field {field_path!r} holds non-JSON "
+            f"serialisable type {value_type!r}; extend "
+            f"DiffReport.to_dict normalisation"
+        )
+
+
+__all__ = [
+    "PolicySimError",
+    "PolicySimSideEffectError",
+    "PolicySimReentrantError",
+    "ScenarioValidationError",
+    "ScenarioAdapterMissingError",
+    "TargetPolicyNotFoundError",
+    "ProposedPolicyInvalidError",
+    "SimulationAbortedError",
+    "ReportSerializationError",
+]

--- a/ao_kernel/policy_sim/loader.py
+++ b/ao_kernel/policy_sim/loader.py
@@ -88,6 +88,7 @@ def resolve_target_policy(
     *,
     policy_name: str,
     scenario_id: str,
+    project_root: Any = None,
     proposed_policies: Mapping[str, Mapping[str, Any]],
     baseline_source: BaselineSource,
     baseline_overrides: Mapping[str, Mapping[str, Any]] | None,
@@ -96,16 +97,25 @@ def resolve_target_policy(
 
     Precedence follows ``baseline_source``:
 
-    - ``EXPLICIT``: ``baseline_overrides[policy_name]`` wins; falls
-      back to bundled if absent only when the scenario can't find
-      one anywhere.
-    - ``WORKSPACE_OVERRIDE``: use
-      :func:`ao_kernel.config.load_with_override` (disk read).
-    - ``BUNDLED``: :func:`ao_kernel.config.load_default` directly.
+    - ``EXPLICIT``: ``baseline_overrides[policy_name]`` wins;
+      falls back to bundled if absent only when the scenario
+      can't find one anywhere.
+    - ``WORKSPACE_OVERRIDE``: call
+      :func:`ao_kernel.config.load_with_override` with
+      ``workspace=project_root`` so the loader reads
+      ``<project_root>/.ao/policies/<name>``. Missing override
+      file (``FileNotFoundError``) falls through to bundled;
+      malformed JSON + schema validation errors propagate
+      (fail-closed per the loader contract).
+    - ``BUNDLED``: :func:`ao_kernel.config.load_default`
+      directly.
 
-    Raises :class:`TargetPolicyNotFoundError` when no source
-    has a policy with the requested name.
+    Raises :class:`TargetPolicyNotFoundError` when no source has
+    a policy with the requested name AND the policy is not
+    supplied via ``proposed_policies``.
     """
+    from ao_kernel.config import DefaultsNotFoundError
+
     if baseline_source is BaselineSource.EXPLICIT and baseline_overrides:
         explicit = baseline_overrides.get(policy_name)
         if explicit is not None:
@@ -118,23 +128,27 @@ def resolve_target_policy(
         from ao_kernel import config as _cfg
 
         try:
-            return _cfg.load_with_override("policies", policy_name)
-        except Exception:
-            pass  # fall back to bundled
+            return _cfg.load_with_override(
+                "policies", policy_name, workspace=project_root
+            )
+        except FileNotFoundError:
+            # Missing workspace override → fall through to bundled.
+            pass
+        # Other exceptions (JSONDecodeError, ValidationError, etc.)
+        # propagate as-is — fail-closed per plan v3 invariant 5.
 
     # Bundled fallback for any path that didn't short-circuit.
     try:
         return load_default("policies", policy_name)
-    except Exception as exc:
-        # If even bundled defaults miss the name AND proposed_policies
-        # doesn't have it either, the scenario is mis-targeted.
+    except DefaultsNotFoundError as exc:
+        # Bundled defaults miss the name. Fall back to the
+        # proposed dict itself when the operator is introducing a
+        # brand-new policy file.
         if policy_name not in proposed_policies:
             raise TargetPolicyNotFoundError(
                 scenario_id=scenario_id,
                 policy_name=policy_name,
             ) from exc
-        # Proposed-only policy: baseline is the proposed dict itself
-        # (operator is introducing a brand-new policy file).
         return dict(proposed_policies[policy_name])
 
 

--- a/ao_kernel/policy_sim/loader.py
+++ b/ao_kernel/policy_sim/loader.py
@@ -1,0 +1,187 @@
+"""Proposed-policy loader + baseline source resolver + in-memory
+override context for the policy simulation harness (PR-B4 C3).
+
+Three surfaces:
+
+1. :class:`BaselineSource` enum (plan v3 N2 absorb) — controls
+   whether the simulator's baseline comes from bundled defaults,
+   on-disk workspace overrides, or an explicit dict.
+2. :func:`validate_proposed_policy` — structural shape check
+   against :mod:`_policy_shape_registry` (plan v3 N1 absorb).
+3. :func:`policy_override_context` — monkey-patches
+   ``ao_kernel.config.load_with_override`` so that
+   ``governance.check_policy`` reads proposed policy dicts from
+   memory instead of disk. Non-overridden policy names fall
+   through to the original loader unchanged.
+"""
+
+from __future__ import annotations
+
+import enum
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping
+
+from ao_kernel import config as _config
+from ao_kernel.config import load_default
+from ao_kernel.policy_sim._policy_shape_registry import (
+    _MISSING,
+    aggregated_required_keys,
+    aggregated_type_contracts,
+    walk_policy,
+)
+from ao_kernel.policy_sim.errors import (
+    ProposedPolicyInvalidError,
+    TargetPolicyNotFoundError,
+)
+
+
+class BaselineSource(enum.Enum):
+    """How to assemble the baseline policy set."""
+
+    BUNDLED = "bundled"
+    WORKSPACE_OVERRIDE = "workspace_override"
+    EXPLICIT = "explicit"
+
+
+def validate_proposed_policy(
+    policy_name: str, policy: Mapping[str, Any]
+) -> None:
+    """Run structural shape checks for ``policy``.
+
+    Uses the shape registry aggregators so a single policy that
+    is read by multiple primitives still satisfies every
+    consumer in one pass. Unknown policy names pass through
+    without checks — the JSON schema (loaded separately) is the
+    authoritative contract for those cases.
+    """
+    required = aggregated_required_keys(policy_name)
+    type_contracts = aggregated_type_contracts(policy_name)
+    if not required and not type_contracts:
+        return
+
+    violations: list[str] = []
+    for key in sorted(required):
+        if key not in policy:
+            violations.append(f"missing required top-level key {key!r}")
+
+    for path, expected in type_contracts.items():
+        observed = walk_policy(policy, path)
+        if observed is _MISSING:
+            violations.append(
+                f"missing required path {'.'.join(path)!r}"
+            )
+            continue
+        if not isinstance(observed, expected):
+            violations.append(
+                f"path {'.'.join(path)!r} expected {expected.__name__}, "
+                f"got {type(observed).__name__}"
+            )
+
+    if violations:
+        raise ProposedPolicyInvalidError(
+            policy_name=policy_name,
+            violations=tuple(violations),
+        )
+
+
+def resolve_target_policy(
+    *,
+    policy_name: str,
+    scenario_id: str,
+    proposed_policies: Mapping[str, Mapping[str, Any]],
+    baseline_source: BaselineSource,
+    baseline_overrides: Mapping[str, Mapping[str, Any]] | None,
+) -> Mapping[str, Any]:
+    """Resolve the *baseline* policy for ``policy_name``.
+
+    Precedence follows ``baseline_source``:
+
+    - ``EXPLICIT``: ``baseline_overrides[policy_name]`` wins; falls
+      back to bundled if absent only when the scenario can't find
+      one anywhere.
+    - ``WORKSPACE_OVERRIDE``: use
+      :func:`ao_kernel.config.load_with_override` (disk read).
+    - ``BUNDLED``: :func:`ao_kernel.config.load_default` directly.
+
+    Raises :class:`TargetPolicyNotFoundError` when no source
+    has a policy with the requested name.
+    """
+    if baseline_source is BaselineSource.EXPLICIT and baseline_overrides:
+        explicit = baseline_overrides.get(policy_name)
+        if explicit is not None:
+            return dict(explicit)
+
+    if baseline_source is BaselineSource.WORKSPACE_OVERRIDE:
+        # load_with_override consults disk; the simulator wraps
+        # this call in policy_override_context so proposed
+        # policies do not leak through during baseline assembly.
+        from ao_kernel import config as _cfg
+
+        try:
+            return _cfg.load_with_override("policies", policy_name)
+        except Exception:
+            pass  # fall back to bundled
+
+    # Bundled fallback for any path that didn't short-circuit.
+    try:
+        return load_default("policies", policy_name)
+    except Exception as exc:
+        # If even bundled defaults miss the name AND proposed_policies
+        # doesn't have it either, the scenario is mis-targeted.
+        if policy_name not in proposed_policies:
+            raise TargetPolicyNotFoundError(
+                scenario_id=scenario_id,
+                policy_name=policy_name,
+            ) from exc
+        # Proposed-only policy: baseline is the proposed dict itself
+        # (operator is introducing a brand-new policy file).
+        return dict(proposed_policies[policy_name])
+
+
+@contextmanager
+def policy_override_context(
+    policy_overrides: Mapping[str, Mapping[str, Any]],
+) -> Iterator[None]:
+    """Monkey-patch :func:`ao_kernel.config.load_with_override`
+    so it returns the in-memory dict for any ``filename`` in
+    ``policy_overrides``. Other names fall through to the
+    original implementation unchanged.
+
+    ``governance.check_policy`` performs
+    ``from ao_kernel.config import load_with_override`` inside
+    its function body (see ``ao_kernel/governance.py:40``), so
+    the patch applies on every call — even in threads that
+    imported the module before the context started.
+
+    Thread-safety note: the monkey-patch mutates module-level
+    state. Simulations run single-threaded; the patch is
+    restored in ``finally`` for exception safety.
+    """
+    original = _config.load_with_override
+
+    def _patched(
+        resource_type: str,
+        filename: str,
+        workspace: Any = None,
+    ) -> dict[str, Any]:
+        override = policy_overrides.get(filename)
+        if override is not None:
+            # Defensive copy so callers cannot mutate the
+            # simulator's proposed dict through the returned
+            # value.
+            return dict(override)
+        return original(resource_type, filename, workspace=workspace)
+
+    _config.load_with_override = _patched  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _config.load_with_override = original  # type: ignore[assignment]
+
+
+__all__ = [
+    "BaselineSource",
+    "policy_override_context",
+    "resolve_target_policy",
+    "validate_proposed_policy",
+]

--- a/ao_kernel/policy_sim/loader.py
+++ b/ao_kernel/policy_sim/loader.py
@@ -114,7 +114,11 @@ def resolve_target_policy(
     a policy with the requested name AND the policy is not
     supplied via ``proposed_policies``.
     """
-    from ao_kernel.config import DefaultsNotFoundError
+    # DefaultsNotFoundError is exported from the module but not
+    # listed in __all__; keep the import explicit + typed-ignored.
+    from ao_kernel.config import (  # type: ignore[attr-defined]
+        DefaultsNotFoundError,
+    )
 
     if baseline_source is BaselineSource.EXPLICIT and baseline_overrides:
         explicit = baseline_overrides.get(policy_name)
@@ -186,11 +190,11 @@ def policy_override_context(
             return dict(override)
         return original(resource_type, filename, workspace=workspace)
 
-    _config.load_with_override = _patched  # type: ignore[assignment]
+    _config.load_with_override = _patched
     try:
         yield
     finally:
-        _config.load_with_override = original  # type: ignore[assignment]
+        _config.load_with_override = original
 
 
 __all__ = [

--- a/ao_kernel/policy_sim/report.py
+++ b/ao_kernel/policy_sim/report.py
@@ -17,11 +17,14 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Iterable, Literal, Mapping
+from typing import Any, Iterable, Literal, Mapping
 
+# `TransitionKind` annotated in the typed tuples below so mypy
+# narrows `.get()` without per-call casts.
 from ao_kernel.policy_sim.diff import (
     DiffReport,
     ScenarioDelta,
+    TransitionKind as _TransitionKind,
     dump_json,
 )
 
@@ -29,7 +32,23 @@ from ao_kernel.policy_sim.diff import (
 ReportFormat = Literal["json", "text"]
 
 
-_TIGHTENING_KINDS = ("allow_to_deny",)
+_KIND_LABELS_OVERALL: tuple[tuple[_TransitionKind, str], ...] = (
+    ("allow_to_allow", "allow→allow"),
+    ("deny_to_deny", "deny→deny"),
+    ("allow_to_deny", "allow→deny  ⚠ tightening"),
+    ("deny_to_allow", "deny→allow  ⚠ loosening"),
+    ("error", "error"),
+)
+
+_KIND_LABELS_PER_POLICY: tuple[tuple[_TransitionKind, str], ...] = (
+    ("allow_to_allow", "allow→allow"),
+    ("allow_to_deny", "allow→deny"),
+    ("deny_to_allow", "deny→allow"),
+    ("deny_to_deny", "deny→deny"),
+    ("error", "error"),
+)
+
+_TIGHTENING_KINDS: tuple[_TransitionKind, ...] = ("allow_to_deny",)
 
 
 def render(report: DiffReport, fmt: ReportFormat) -> str:
@@ -80,14 +99,8 @@ def _render_policies_section(report: DiffReport) -> Iterable[str]:
 
 def _render_transitions_overall(report: DiffReport) -> Iterable[str]:
     yield "Transitions (all):"
-    for kind, label in (
-        ("allow_to_allow", "allow→allow"),
-        ("deny_to_deny", "deny→deny"),
-        ("allow_to_deny", "allow→deny  ⚠ tightening"),
-        ("deny_to_allow", "deny→allow  ⚠ loosening"),
-        ("error", "error"),
-    ):
-        count = report.transitions.get(kind, 0)  # type: ignore[arg-type]
+    for kind, label in _KIND_LABELS_OVERALL:
+        count = report.transitions.get(kind, 0)
         yield f"  {label}: {count}"
 
 
@@ -98,13 +111,7 @@ def _render_transitions_per_policy(report: DiffReport) -> Iterable[str]:
         total = sum(counts.values())
         parts = [
             f"{label}={counts.get(kind, 0)}"
-            for kind, label in (
-                ("allow_to_allow", "allow→allow"),
-                ("allow_to_deny", "allow→deny"),
-                ("deny_to_allow", "deny→allow"),
-                ("deny_to_deny", "deny→deny"),
-                ("error", "error"),
-            )
+            for kind, label in _KIND_LABELS_PER_POLICY
             if counts.get(kind, 0)
         ]
         summary = ", ".join(parts) if parts else "no transitions"
@@ -133,7 +140,7 @@ def has_tightening(report: DiffReport) -> bool:
     """Return True iff the report carries at least one
     ``allow_to_deny`` transition — triggers CLI exit code 3."""
     return any(
-        report.transitions.get(kind, 0) > 0  # type: ignore[arg-type]
+        report.transitions.get(kind, 0) > 0
         for kind in _TIGHTENING_KINDS
     )
 
@@ -154,7 +161,9 @@ def write_atomic(output_path: Path, content: str) -> None:
     os.replace(tmp_path, output_path)
 
 
-def load_policies_from_dir(directory: Path) -> Mapping[str, Mapping]:
+def load_policies_from_dir(
+    directory: Path,
+) -> Mapping[str, Mapping[str, Any]]:
     """Load every ``*.json`` file in ``directory`` as
     ``{filename: parsed_dict}``.
 
@@ -162,7 +171,7 @@ def load_policies_from_dir(directory: Path) -> Mapping[str, Mapping]:
     ``--baseline-overrides`` arguments into the Mapping shapes
     ``simulate_policy_change`` expects.
     """
-    mapping: dict[str, Mapping] = {}
+    mapping: dict[str, Mapping[str, Any]] = {}
     if not directory.exists():
         return mapping
     for path in sorted(directory.glob("*.json")):
@@ -173,13 +182,9 @@ def load_policies_from_dir(directory: Path) -> Mapping[str, Mapping]:
 
 __all__ = [
     "ReportFormat",
+    "ScenarioDelta",
     "has_tightening",
     "load_policies_from_dir",
     "render",
     "write_atomic",
 ]
-
-
-# Reference silence for helper that would otherwise be reported
-# as unused by some lint passes; kept inline for discoverability.
-_ = sorted([ScenarioDelta])

--- a/ao_kernel/policy_sim/report.py
+++ b/ao_kernel/policy_sim/report.py
@@ -1,0 +1,185 @@
+"""Reporter for the policy simulation harness (PR-B4 C4).
+
+Two output formats:
+
+- ``json`` — canonical JSON via :func:`diff.dump_json` (stable
+  cross-run, sorted keys, ensure_ascii=False, tight separators).
+- ``text`` — operator-readable table + per-policy breakdown +
+  notable delta bullets.
+
+File writing uses a tmp-then-rename atomic pattern; we stay
+outside the purity context (the CLI handler is the caller)
+because writes are the whole point of ``--output``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Iterable, Literal, Mapping
+
+from ao_kernel.policy_sim.diff import (
+    DiffReport,
+    ScenarioDelta,
+    dump_json,
+)
+
+
+ReportFormat = Literal["json", "text"]
+
+
+_TIGHTENING_KINDS = ("allow_to_deny",)
+
+
+def render(report: DiffReport, fmt: ReportFormat) -> str:
+    """Render ``report`` in the requested format."""
+    if fmt == "json":
+        return dump_json(report)
+    if fmt == "text":
+        return _render_text(report)
+    raise ValueError(f"unsupported report format: {fmt!r}")
+
+
+def _render_text(report: DiffReport) -> str:
+    lines: list[str] = []
+    lines.append("Policy Simulation Report")
+    lines.append("=" * len(lines[0]))
+    lines.append("")
+    lines.extend(_render_policies_section(report))
+    lines.append("")
+    lines.append(f"Scenarios evaluated: {report.scenarios_evaluated}")
+    lines.append(
+        f"host_fs_dependent: {str(report.host_fs_dependent).lower()}"
+    )
+    if report.host_fs_fingerprint:
+        lines.append(f"host_fs_fingerprint: {report.host_fs_fingerprint}")
+    lines.append("")
+    lines.extend(_render_transitions_overall(report))
+    lines.append("")
+    lines.extend(_render_transitions_per_policy(report))
+    lines.append("")
+    lines.extend(_render_notable_deltas(report))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_policies_section(report: DiffReport) -> Iterable[str]:
+    all_policies = sorted(
+        set(report.baseline_policy_hashes) | set(report.proposed_policy_hashes)
+    )
+    yield "Policies under test:"
+    for name in all_policies:
+        baseline = report.baseline_policy_hashes.get(name, "<missing>")
+        proposed = report.proposed_policy_hashes.get(name, "<missing>")
+        changed = baseline != proposed
+        marker = " CHANGED" if changed else ""
+        yield f"  - {name}{marker}"
+        yield f"      baseline: {baseline}"
+        yield f"      proposed: {proposed}"
+
+
+def _render_transitions_overall(report: DiffReport) -> Iterable[str]:
+    yield "Transitions (all):"
+    for kind, label in (
+        ("allow_to_allow", "allow→allow"),
+        ("deny_to_deny", "deny→deny"),
+        ("allow_to_deny", "allow→deny  ⚠ tightening"),
+        ("deny_to_allow", "deny→allow  ⚠ loosening"),
+        ("error", "error"),
+    ):
+        count = report.transitions.get(kind, 0)  # type: ignore[arg-type]
+        yield f"  {label}: {count}"
+
+
+def _render_transitions_per_policy(report: DiffReport) -> Iterable[str]:
+    yield "Transitions per policy:"
+    for policy in sorted(report.transitions_by_policy):
+        counts = report.transitions_by_policy[policy]
+        total = sum(counts.values())
+        parts = [
+            f"{label}={counts.get(kind, 0)}"
+            for kind, label in (
+                ("allow_to_allow", "allow→allow"),
+                ("allow_to_deny", "allow→deny"),
+                ("deny_to_allow", "deny→allow"),
+                ("deny_to_deny", "deny→deny"),
+                ("error", "error"),
+            )
+            if counts.get(kind, 0)
+        ]
+        summary = ", ".join(parts) if parts else "no transitions"
+        yield f"  - {policy}: {total} scenario(s) ({summary})"
+
+
+def _render_notable_deltas(report: DiffReport) -> Iterable[str]:
+    notables = report.notable_deltas
+    if not notables:
+        yield "Notable deltas: none"
+        return
+    yield "Notable deltas:"
+    for delta in sorted(notables, key=lambda d: d.scenario_id):
+        yield f"  - [{delta.transition}] {delta.scenario_id} " f"({delta.target_policy_name})"
+        if delta.violation_diff.added:
+            yield f"      added violations: {sorted(delta.violation_diff.added)}"
+        if delta.violation_diff.removed:
+            yield f"      removed violations: {sorted(delta.violation_diff.removed)}"
+        if delta.baseline.error_detail:
+            yield f"      baseline error: {delta.baseline.error_detail}"
+        if delta.proposed.error_detail:
+            yield f"      proposed error: {delta.proposed.error_detail}"
+
+
+def has_tightening(report: DiffReport) -> bool:
+    """Return True iff the report carries at least one
+    ``allow_to_deny`` transition — triggers CLI exit code 3."""
+    return any(
+        report.transitions.get(kind, 0) > 0  # type: ignore[arg-type]
+        for kind in _TIGHTENING_KINDS
+    )
+
+
+def write_atomic(output_path: Path, content: str) -> None:
+    """Atomic write: tmp + rename, mkdir parents as needed.
+
+    Used by the CLI after simulation has exited the purity
+    context; direct writes inside the context would trip the
+    guard.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = output_path.with_name(output_path.name + ".tmp")
+    with tmp_path.open("w", encoding="utf-8") as fh:
+        fh.write(content)
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp_path, output_path)
+
+
+def load_policies_from_dir(directory: Path) -> Mapping[str, Mapping]:
+    """Load every ``*.json`` file in ``directory`` as
+    ``{filename: parsed_dict}``.
+
+    Used by the CLI to materialise ``--proposed-policies`` and
+    ``--baseline-overrides`` arguments into the Mapping shapes
+    ``simulate_policy_change`` expects.
+    """
+    mapping: dict[str, Mapping] = {}
+    if not directory.exists():
+        return mapping
+    for path in sorted(directory.glob("*.json")):
+        with path.open("r", encoding="utf-8") as fh:
+            mapping[path.name] = json.load(fh)
+    return mapping
+
+
+__all__ = [
+    "ReportFormat",
+    "has_tightening",
+    "load_policies_from_dir",
+    "render",
+    "write_atomic",
+]
+
+
+# Reference silence for helper that would otherwise be reported
+# as unused by some lint passes; kept inline for discoverability.
+_ = sorted([ScenarioDelta])

--- a/ao_kernel/policy_sim/scenario.py
+++ b/ao_kernel/policy_sim/scenario.py
@@ -1,0 +1,199 @@
+"""Scenario model for the policy simulation harness (PR-B4 C2).
+
+Scenarios are JSON documents (plan v3 Q1 absorb — JSON-only v1)
+describing an input pair (policy, inputs) and the expected
+baseline decision. The simulator evaluates each scenario twice
+per run — once under the baseline policy set, once under the
+proposed policy set — and diffs the decisions.
+
+Per-scenario ``target_policy_name`` (plan v3 bulgu 1 absorb) keeps
+multi-policy ScenarioSets tractable: a single set may include
+`executor_primitive` scenarios targeting
+``policy_worktree_profile.v1.json`` alongside ``governance_policy``
+scenarios targeting ``policy_autonomy.v1.json``, without forcing
+operators to partition by policy.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Mapping
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError as _JsonSchemaValidationError
+
+from ao_kernel.config import load_default
+from ao_kernel.policy_sim.errors import ScenarioValidationError
+
+
+ScenarioKind = Literal["executor_primitive", "governance_policy", "combined"]
+
+
+_SCENARIO_SCHEMA_CACHE: dict[str, Any] | None = None
+
+
+def _scenario_schema() -> dict[str, Any]:
+    global _SCENARIO_SCHEMA_CACHE
+    if _SCENARIO_SCHEMA_CACHE is None:
+        _SCENARIO_SCHEMA_CACHE = load_default(
+            "schemas",
+            "policy-sim-scenario.schema.v1.json",
+        )
+    return _SCENARIO_SCHEMA_CACHE
+
+
+@dataclass(frozen=True)
+class ExpectedBaseline:
+    """Expected baseline decision + violation list for a scenario."""
+
+    decision_expected: Literal["allow", "deny"]
+    violations_expected: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ScenarioInputs:
+    """Inputs presented to the primitive(s) a scenario exercises.
+
+    Fields mirror ``policy-sim-scenario.schema.v1.json::inputs`` one
+    to one. ``adapter_manifest_ref`` resolves against the
+    pre-simulation AdapterRegistry snapshot; ``action`` is the
+    string passed to ``governance.check_policy`` for
+    ``governance_policy`` scenarios.
+    """
+
+    adapter_manifest_ref: str | None = None
+    parent_env: Mapping[str, str] = field(default_factory=dict)
+    requested_command: str | None = None
+    requested_cwd: str | None = None
+    action: str | None = None
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """A single policy-simulation scenario.
+
+    ``target_policy_name`` is set for ``executor_primitive`` and
+    ``governance_policy`` kinds; ``target_policy_names`` is a
+    non-empty tuple for ``combined`` kind. The scenario schema
+    enforces the xor via ``allOf`` branches.
+    """
+
+    scenario_id: str
+    kind: ScenarioKind
+    inputs: ScenarioInputs
+    expected_baseline: ExpectedBaseline
+    description: str = ""
+    target_policy_name: str | None = None
+    target_policy_names: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ScenarioSet:
+    """An ordered collection of scenarios loaded from disk or
+    bundled defaults. ``name`` / ``version`` / ``description``
+    are informational only."""
+
+    scenarios: tuple[Scenario, ...]
+    name: str = "default"
+    version: str = "v1"
+    description: str = ""
+
+
+def _from_dict(doc: Mapping[str, Any]) -> Scenario:
+    inputs_raw: Mapping[str, Any] = doc.get("inputs") or {}
+    inputs = ScenarioInputs(
+        adapter_manifest_ref=inputs_raw.get("adapter_manifest_ref"),
+        parent_env=dict(inputs_raw.get("parent_env") or {}),
+        requested_command=inputs_raw.get("requested_command"),
+        requested_cwd=inputs_raw.get("requested_cwd"),
+        action=inputs_raw.get("action"),
+    )
+    expected_raw = doc["expected_baseline"]
+    expected = ExpectedBaseline(
+        decision_expected=expected_raw["decision_expected"],
+        violations_expected=tuple(expected_raw.get("violations_expected", [])),
+    )
+    return Scenario(
+        scenario_id=doc["scenario_id"],
+        kind=doc["kind"],
+        inputs=inputs,
+        expected_baseline=expected,
+        description=doc.get("description", ""),
+        target_policy_name=doc.get("target_policy_name"),
+        target_policy_names=tuple(doc.get("target_policy_names", [])),
+    )
+
+
+def _validate(doc: Mapping[str, Any]) -> None:
+    Draft202012Validator(_scenario_schema()).validate(doc)
+
+
+def _load_scenario_dict(doc: Mapping[str, Any]) -> Scenario:
+    scenario_id = str(doc.get("scenario_id", "<no-id>"))
+    try:
+        _validate(doc)
+    except _JsonSchemaValidationError as exc:
+        raise ScenarioValidationError(
+            scenario_id=scenario_id,
+            reason=exc.message,
+        ) from exc
+    return _from_dict(doc)
+
+
+def load_scenario_file(path: Path) -> Scenario:
+    """Load + validate a single scenario file.
+
+    v1 is JSON-only (plan v3 Q1 absorb): any non-``.json`` suffix
+    raises :class:`ScenarioValidationError` without opening the
+    file. YAML support is deferred to a post-B4 optional extra.
+    """
+    suffix = path.suffix.lower()
+    if suffix != ".json":
+        raise ScenarioValidationError(
+            scenario_id=path.stem,
+            reason=f"unsupported scenario extension {suffix!r}; v1 is JSON-only",
+        )
+    with path.open("r", encoding="utf-8") as fh:
+        doc: Mapping[str, Any] = json.load(fh)
+    return _load_scenario_dict(doc)
+
+
+def load_scenarios_from_dir(directory: Path) -> tuple[Scenario, ...]:
+    """Load every ``*.json`` file under ``directory`` (sorted)."""
+    files = sorted(directory.glob("*.json"))
+    return tuple(load_scenario_file(f) for f in files)
+
+
+def load_bundled_scenarios() -> tuple[Scenario, ...]:
+    """Load the three reference scenarios shipped under
+    ``ao_kernel/defaults/policies/policy_sim_scenarios/``.
+
+    Used by the bundled-fixture regression test and by the CLI
+    when no ``--scenarios`` flag is supplied.
+    """
+    manifest = load_default(
+        "policies/policy_sim_scenarios",
+        "__manifest__.v1.json",
+    )
+    scenarios: list[Scenario] = []
+    for entry in manifest["scenarios"]:
+        loaded = load_default(
+            "policies/policy_sim_scenarios",
+            entry,
+        )
+        scenarios.append(_load_scenario_dict(loaded))
+    return tuple(sorted(scenarios, key=lambda s: s.scenario_id))
+
+
+__all__ = [
+    "ExpectedBaseline",
+    "Scenario",
+    "ScenarioInputs",
+    "ScenarioKind",
+    "ScenarioSet",
+    "load_bundled_scenarios",
+    "load_scenario_file",
+    "load_scenarios_from_dir",
+]

--- a/ao_kernel/policy_sim/scenario.py
+++ b/ao_kernel/policy_sim/scenario.py
@@ -161,9 +161,21 @@ def load_scenario_file(path: Path) -> Scenario:
 
 
 def load_scenarios_from_dir(directory: Path) -> tuple[Scenario, ...]:
-    """Load every ``*.json`` file under ``directory`` (sorted)."""
-    files = sorted(directory.glob("*.json"))
-    return tuple(load_scenario_file(f) for f in files)
+    """Load every scenario file under ``directory`` (sorted).
+
+    Non-JSON extensions are rejected by :func:`load_scenario_file`
+    per the JSON-only invariant (plan v3 Q1 absorb). Dotfiles
+    (``.DS_Store`` etc.) are silently skipped. Every remaining
+    entry must therefore be a ``.json`` scenario document.
+    """
+    scenarios: list[Scenario] = []
+    for path in sorted(directory.iterdir()):
+        if not path.is_file():
+            continue
+        if path.name.startswith("."):
+            continue
+        scenarios.append(load_scenario_file(path))
+    return tuple(scenarios)
 
 
 def load_bundled_scenarios() -> tuple[Scenario, ...]:

--- a/ao_kernel/policy_sim/simulator.py
+++ b/ao_kernel/policy_sim/simulator.py
@@ -290,8 +290,15 @@ def _run_governance_policy(
         )
 
     allowed = _extract_allowed_flag(result)
-    violations = _extract_reason_codes(result)
+    reason_codes = _extract_reason_codes(result)
     decision = "allow" if allowed else "deny"
+    # governance.check_policy returns informational codes (like
+    # "POLICY_PASSED") alongside the allowed=True flag. They are
+    # not denial reasons, so `violation_kinds` only records codes
+    # when the policy actually denied — keeping the combined-kind
+    # aggregator's "any violations → deny" semantics honest
+    # (iter-3 combined-semantic blocker absorb).
+    violations = reason_codes if not allowed else ()
     return SimulationResult(
         scenario_id=scenario.scenario_id,
         decision=decision,

--- a/ao_kernel/policy_sim/simulator.py
+++ b/ao_kernel/policy_sim/simulator.py
@@ -1,0 +1,486 @@
+"""Simulator core for the policy simulation harness (PR-B4 C3).
+
+Public entrypoint :func:`simulate_policy_change` evaluates each
+scenario against the baseline policy set AND the proposed policy
+set under :func:`pure_execution_context`, returning a
+:class:`DiffReport` that captures transitions plus per-policy
+breakdowns.
+
+Guiding invariants (plan v3 §2.3):
+
+- No workspace writes, no evidence emits, no subprocess spawns,
+  no network — the 23-sentinel purity guard fails closed on any
+  accidental side effect.
+- Adapter manifest resolution happens **before** entering the
+  purity context so bundled adapters do not trip the
+  ``importlib.resources.as_file`` sentinel.
+- Baseline and proposed policies are pinned per-scenario via
+  ``target_policy_name`` (plan v3 bulgu 1 absorb); a single
+  ``ScenarioSet`` can exercise multiple policies in one run.
+- ``check_policy`` invocations honor ``workspace=<sentinel>`` +
+  :func:`policy_override_context` monkey-patch so proposed
+  policies stream through :func:`load_with_override` without
+  disk I/O (plan v3 warning 2 absorb).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from ao_kernel.policy_sim._purity import pure_execution_context
+from ao_kernel.policy_sim.diff import (
+    DiffReport,
+    ScenarioDelta,
+    SimulationResult,
+    aggregate_transition_counts,
+    canonical_policy_hash,
+    make_scenario_delta,
+)
+from ao_kernel.policy_sim.errors import (
+    ScenarioAdapterMissingError,
+    TargetPolicyNotFoundError,
+)
+from ao_kernel.policy_sim.loader import (
+    BaselineSource,
+    policy_override_context,
+    resolve_target_policy,
+    validate_proposed_policy,
+)
+from ao_kernel.policy_sim.scenario import Scenario, ScenarioSet
+
+
+_EPHEMERAL_WORKTREE = Path("/__policy_sim_ephemeral__")
+_SENTINEL_WORKSPACE = Path("/__policy_sim_workspace_sentinel__")
+
+
+def _snapshot_adapters(
+    project_root: Path,
+) -> Mapping[str, Any]:
+    """Load bundled + workspace adapter manifests ahead of the
+    purity context and return a lookup-only snapshot.
+
+    ``importlib.resources.as_file`` is patched by the purity
+    guard; running this call before entering the context is the
+    sanctioned workaround (plan v3 §2.1 importlib note).
+    """
+    from ao_kernel.adapters import AdapterRegistry
+
+    reg = AdapterRegistry()
+    reg.load_bundled()
+    try:
+        reg.load_workspace(project_root)
+    except Exception:
+        # Workspace adapters are optional — absence is not fatal.
+        pass
+
+    snapshot: dict[str, Any] = {}
+    for manifest in reg.list_adapters():
+        snapshot[manifest.adapter_id] = manifest
+    return snapshot
+
+
+def _resolve_adapter_manifest(
+    scenario: Scenario,
+    adapter_snapshot: Mapping[str, Any],
+) -> Any | None:
+    """Look up the adapter manifest referenced by ``scenario``.
+
+    Returns ``None`` when the scenario carries no adapter ref;
+    raises :class:`ScenarioAdapterMissingError` when a ref is
+    set but the snapshot has no entry.
+    """
+    ref = scenario.inputs.adapter_manifest_ref
+    if ref is None:
+        return None
+    if ref not in adapter_snapshot:
+        raise ScenarioAdapterMissingError(
+            scenario_id=scenario.scenario_id,
+            adapter_ref=ref,
+        )
+    return adapter_snapshot[ref]
+
+
+def _run_executor_primitive(
+    scenario: Scenario,
+    policy: Mapping[str, Any],
+    adapter_manifest: Any | None,
+    include_host_fs_probes: bool,
+) -> SimulationResult:
+    """Evaluate ``build_sandbox`` + ``resolve_allowed_secrets``
+    + ``check_http_header_exposure`` for ``scenario`` against
+    ``policy`` (a ``policy_worktree_profile`` dict).
+
+    Errors from the primitives are wrapped as ``decision="error"``
+    results so the diff surface can still aggregate; full
+    traceback goes into ``error_detail``.
+    """
+    try:
+        from ao_kernel.executor import policy_enforcer
+
+        resolved_secrets, sv_violations = _safe_resolve_secrets(
+            policy_enforcer,
+            policy,
+            dict(scenario.inputs.parent_env),
+        )
+        sb_violations = _safe_build_sandbox(
+            policy_enforcer,
+            policy,
+            dict(scenario.inputs.parent_env),
+            resolved_secrets,
+        )
+        hh_violations = _safe_check_http_header(
+            policy_enforcer,
+            policy,
+            adapter_manifest,
+        )
+
+        violations = list(sv_violations) + list(sb_violations) + list(
+            hh_violations
+        )
+
+        # validate_command integration is deferred for simulator v1
+        # (plan v3 §2.3 notes it requires the full sandbox + resolved
+        # args wiring). host_fs_probes=True surfaces a fingerprint
+        # on the report but does not yet add violations.
+        _ = include_host_fs_probes
+    except Exception as exc:
+        return SimulationResult(
+            scenario_id=scenario.scenario_id,
+            decision="error",
+            error_detail=f"{type(exc).__name__}: {exc}",
+        )
+
+    decision = "deny" if violations else "allow"
+    return SimulationResult(
+        scenario_id=scenario.scenario_id,
+        decision=decision,
+        violation_kinds=tuple(violations),
+    )
+
+
+def _safe_resolve_secrets(
+    enforcer: Any,
+    policy: Mapping[str, Any],
+    parent_env: Mapping[str, str],
+) -> tuple[Mapping[str, str], Sequence[str]]:
+    """Call ``resolve_allowed_secrets(policy, all_env)``. Returns
+    ``(resolved_secrets_dict, violation_codes)``. Empty outputs on
+    any signature mismatch so the simulator keeps running."""
+    fn: Callable[..., Any] = getattr(enforcer, "resolve_allowed_secrets", None)
+    if fn is None:
+        return ({}, ())
+    try:
+        resolved, violations = fn(policy, parent_env)
+    except TypeError:
+        return ({}, ("resolve_allowed_secrets_signature_mismatch",))
+    return (resolved, _violation_codes(violations))
+
+
+def _safe_build_sandbox(
+    enforcer: Any,
+    policy: Mapping[str, Any],
+    parent_env: Mapping[str, str],
+    resolved_secrets: Mapping[str, str],
+) -> Sequence[str]:
+    fn: Callable[..., Any] = getattr(enforcer, "build_sandbox", None)
+    if fn is None:
+        return ()
+    try:
+        _sandbox, violations = fn(
+            policy=policy,
+            worktree_root=_EPHEMERAL_WORKTREE,
+            resolved_secrets=resolved_secrets,
+            parent_env=parent_env,
+        )
+    except TypeError:
+        return ("build_sandbox_signature_mismatch",)
+    return _violation_codes(violations)
+
+
+def _safe_check_http_header(
+    enforcer: Any,
+    policy: Mapping[str, Any],
+    adapter_manifest: Any | None,
+) -> Sequence[str]:
+    fn: Callable[..., Any] = getattr(enforcer, "check_http_header_exposure", None)
+    if fn is None or adapter_manifest is None:
+        return ()
+    invocation = getattr(adapter_manifest, "invocation", None)
+    if not isinstance(invocation, Mapping):
+        return ()
+    try:
+        violations = fn(
+            policy=policy,
+            adapter_manifest_invocation=invocation,
+        )
+    except TypeError:
+        return ()
+    return _violation_codes(violations)
+
+
+def _violation_codes(violations: Any) -> tuple[str, ...]:
+    """Normalise primitive violations into tuple of string codes.
+
+    Executor primitives return violation objects in a handful of
+    shapes across the codebase; the simulator's job is to
+    distil them to the canonical string kind. Missing / empty
+    inputs degrade to an empty tuple.
+    """
+    if not violations:
+        return ()
+    codes: list[str] = []
+    for violation in violations:
+        if isinstance(violation, str):
+            codes.append(violation)
+            continue
+        kind = getattr(violation, "kind", None)
+        if isinstance(kind, str):
+            codes.append(kind)
+            continue
+        if isinstance(violation, Mapping) and isinstance(
+            violation.get("kind"), str
+        ):
+            codes.append(violation["kind"])
+            continue
+        codes.append(type(violation).__name__)
+    return tuple(codes)
+
+
+def _run_governance_policy(
+    scenario: Scenario,
+    target_policy_name: str,
+) -> SimulationResult:
+    """Evaluate ``governance.check_policy`` against the current
+    (patched) policy source using the scenario's ``action``.
+
+    The caller wraps this in :func:`policy_override_context` so
+    that either baseline or proposed dicts flow through the
+    loader.
+    """
+    from ao_kernel import governance
+
+    action_str = scenario.inputs.action or ""
+    action_dict: dict[str, Any] = (
+        {"intent": action_str} if action_str else {}
+    )
+    try:
+        result = governance.check_policy(
+            target_policy_name,
+            action_dict,
+            workspace=_SENTINEL_WORKSPACE,
+        )
+    except Exception as exc:
+        return SimulationResult(
+            scenario_id=scenario.scenario_id,
+            decision="error",
+            error_detail=f"{type(exc).__name__}: {exc}",
+        )
+
+    allowed = _extract_allowed_flag(result)
+    violations = _extract_reason_codes(result)
+    decision = "allow" if allowed else "deny"
+    return SimulationResult(
+        scenario_id=scenario.scenario_id,
+        decision=decision,
+        violation_kinds=violations,
+    )
+
+
+def _extract_allowed_flag(result: Any) -> bool:
+    if isinstance(result, Mapping):
+        if "allowed" in result:
+            return bool(result["allowed"])
+        if "decision" in result:
+            return result["decision"] == "allow"
+    return bool(result)
+
+
+def _extract_reason_codes(result: Any) -> tuple[str, ...]:
+    if not isinstance(result, Mapping):
+        return ()
+    codes_raw = result.get("reason_codes") or result.get("violations") or ()
+    if isinstance(codes_raw, str):
+        return (codes_raw,)
+    codes: list[str] = []
+    for code in codes_raw:
+        if isinstance(code, str):
+            codes.append(code)
+    return tuple(codes)
+
+
+def _evaluate_scenario(
+    scenario: Scenario,
+    *,
+    target_policy_name: str,
+    policy: Mapping[str, Any],
+    adapter_manifest: Any | None,
+    include_host_fs_probes: bool,
+    active_policy_map: Mapping[str, Mapping[str, Any]],
+) -> SimulationResult:
+    """Dispatch a scenario to the right primitive path.
+
+    ``active_policy_map`` is the full overlay (baseline or
+    proposed) currently in effect; it's passed through to
+    :func:`policy_override_context` so ``check_policy`` reads it
+    from memory.
+    """
+    if scenario.kind == "executor_primitive":
+        return _run_executor_primitive(
+            scenario, policy, adapter_manifest, include_host_fs_probes
+        )
+    if scenario.kind == "governance_policy":
+        with policy_override_context(active_policy_map):
+            return _run_governance_policy(scenario, target_policy_name)
+    # kind == "combined": run both over the first target policy
+    # that is executor-targeted and first governance-targeted.
+    with policy_override_context(active_policy_map):
+        gov = _run_governance_policy(scenario, target_policy_name)
+    exec_ = _run_executor_primitive(
+        scenario, policy, adapter_manifest, include_host_fs_probes
+    )
+    combined_violations = tuple(exec_.violation_kinds) + tuple(
+        gov.violation_kinds
+    )
+    decision: str
+    if exec_.decision == "error" or gov.decision == "error":
+        decision = "error"
+    elif combined_violations:
+        decision = "deny"
+    else:
+        decision = "allow"
+    return SimulationResult(
+        scenario_id=scenario.scenario_id,
+        decision=decision,  # type: ignore[arg-type]
+        violation_kinds=combined_violations,
+        error_detail=(exec_.error_detail or gov.error_detail),
+    )
+
+
+def _policy_for_scenario(scenario: Scenario) -> str:
+    """Return the single ``target_policy_name`` used to look up
+    the policy dict. ``combined`` scenarios fall back to the
+    first entry in ``target_policy_names``."""
+    if scenario.target_policy_name is not None:
+        return scenario.target_policy_name
+    if scenario.target_policy_names:
+        return scenario.target_policy_names[0]
+    raise TargetPolicyNotFoundError(
+        scenario_id=scenario.scenario_id,
+        policy_name="<unspecified>",
+    )
+
+
+def simulate_policy_change(
+    *,
+    project_root: Path,
+    scenarios: ScenarioSet | Sequence[Scenario],
+    proposed_policies: Mapping[str, Mapping[str, Any]],
+    baseline_source: BaselineSource = BaselineSource.BUNDLED,
+    baseline_overrides: Mapping[str, Mapping[str, Any]] | None = None,
+    include_host_fs_probes: bool = False,
+) -> DiffReport:
+    """Evaluate each scenario twice (baseline + proposed) under
+    the purity contract and return a ``DiffReport``.
+
+    See the module docstring and plan v3 §2.3 for the full
+    contract. ``proposed_policies`` is validated against the
+    shape registry before simulation begins; structurally-broken
+    proposed policies raise :class:`ProposedPolicyInvalidError`
+    before any scenario runs.
+    """
+    # Structural shape validation runs OUTSIDE the purity context
+    # because it emits no I/O and we want fail-fast errors.
+    for name, policy in proposed_policies.items():
+        validate_proposed_policy(name, policy)
+
+    if isinstance(scenarios, ScenarioSet):
+        scenario_list = list(scenarios.scenarios)
+    else:
+        scenario_list = list(scenarios)
+
+    adapter_snapshot = _snapshot_adapters(project_root)
+
+    # Pre-resolve baseline + proposed policy dicts for every
+    # scenario so we can hash + pass through on the hot path.
+    baseline_map: dict[str, Mapping[str, Any]] = {}
+    proposed_map: dict[str, Mapping[str, Any]] = {}
+    adapter_manifests: dict[str, Any | None] = {}
+
+    for scenario in scenario_list:
+        policy_name = _policy_for_scenario(scenario)
+        adapter_manifests[scenario.scenario_id] = _resolve_adapter_manifest(
+            scenario, adapter_snapshot
+        )
+        if policy_name not in baseline_map:
+            baseline_map[policy_name] = resolve_target_policy(
+                policy_name=policy_name,
+                scenario_id=scenario.scenario_id,
+                proposed_policies=proposed_policies,
+                baseline_source=baseline_source,
+                baseline_overrides=baseline_overrides,
+            )
+        if policy_name not in proposed_map:
+            proposed_map[policy_name] = dict(
+                proposed_policies.get(policy_name)
+                or baseline_map[policy_name]
+            )
+
+    deltas: list[ScenarioDelta] = []
+    with pure_execution_context():
+        for scenario in scenario_list:
+            policy_name = _policy_for_scenario(scenario)
+            baseline_policy = baseline_map[policy_name]
+            proposed_policy = proposed_map[policy_name]
+
+            baseline_result = _evaluate_scenario(
+                scenario,
+                target_policy_name=policy_name,
+                policy=baseline_policy,
+                adapter_manifest=adapter_manifests[scenario.scenario_id],
+                include_host_fs_probes=include_host_fs_probes,
+                active_policy_map=baseline_map,
+            )
+            proposed_result = _evaluate_scenario(
+                scenario,
+                target_policy_name=policy_name,
+                policy=proposed_policy,
+                adapter_manifest=adapter_manifests[scenario.scenario_id],
+                include_host_fs_probes=include_host_fs_probes,
+                active_policy_map=proposed_map,
+            )
+            deltas.append(
+                make_scenario_delta(
+                    scenario_id=scenario.scenario_id,
+                    target_policy_name=policy_name,
+                    baseline=baseline_result,
+                    proposed=proposed_result,
+                )
+            )
+
+    overall, by_policy = aggregate_transition_counts(deltas)
+    baseline_hashes = {
+        name: canonical_policy_hash(policy)
+        for name, policy in baseline_map.items()
+    }
+    proposed_hashes = {
+        name: canonical_policy_hash(policy)
+        for name, policy in proposed_map.items()
+    }
+
+    return DiffReport(
+        baseline_policy_hashes=baseline_hashes,
+        proposed_policy_hashes=proposed_hashes,
+        scenarios_evaluated=len(deltas),
+        transitions=overall,
+        transitions_by_policy=by_policy,
+        deltas=tuple(deltas),
+        emitted_at=_dt.datetime.now(tz=_dt.timezone.utc).isoformat(),
+        host_fs_dependent=include_host_fs_probes,
+    )
+
+
+__all__ = [
+    "simulate_policy_change",
+]

--- a/ao_kernel/policy_sim/simulator.py
+++ b/ao_kernel/policy_sim/simulator.py
@@ -9,7 +9,7 @@ breakdowns.
 Guiding invariants (plan v3 §2.3):
 
 - No workspace writes, no evidence emits, no subprocess spawns,
-  no network — the 23-sentinel purity guard fails closed on any
+  no network — the 24-sentinel purity guard fails closed on any
   accidental side effect.
 - Adapter manifest resolution happens **before** entering the
   purity context so bundled adapters do not trip the
@@ -395,6 +395,19 @@ def _evaluate_scenario(
     )
 
 
+def _scenario_policy_names(scenario: Scenario) -> tuple[str, ...]:
+    """Return the full ordered list of policy names the scenario
+    references (primary target plus combined targets), with
+    duplicates preserved in their first-seen position."""
+    names: list[str] = []
+    if scenario.target_policy_name:
+        names.append(scenario.target_policy_name)
+    for name in scenario.target_policy_names:
+        if name and name not in names:
+            names.append(name)
+    return tuple(names)
+
+
 def _split_combined_targets(scenario: Scenario) -> tuple[str, str]:
     """Distribute a ``combined`` scenario's ``target_policy_names``
     across the executor and governance primitive targets.
@@ -465,24 +478,29 @@ def simulate_policy_change(
     adapter_manifests: dict[str, Any | None] = {}
 
     for scenario in scenario_list:
-        policy_name = _policy_for_scenario(scenario)
         adapter_manifests[scenario.scenario_id] = _resolve_adapter_manifest(
             scenario, adapter_snapshot
         )
-        if policy_name not in baseline_map:
-            baseline_map[policy_name] = resolve_target_policy(
-                policy_name=policy_name,
-                scenario_id=scenario.scenario_id,
-                project_root=project_root,
-                proposed_policies=proposed_policies,
-                baseline_source=baseline_source,
-                baseline_overrides=baseline_overrides,
-            )
-        if policy_name not in proposed_map:
-            proposed_map[policy_name] = dict(
-                proposed_policies.get(policy_name)
-                or baseline_map[policy_name]
-            )
+        # Preload every policy the scenario references. Combined
+        # kind carries multiple names in `target_policy_names`;
+        # collapsing to the first entry (iter-1 bug) meant the
+        # governance override context never saw the secondary
+        # target and proposed overrides for that policy never
+        # reached the simulation.
+        for name in _scenario_policy_names(scenario):
+            if name not in baseline_map:
+                baseline_map[name] = resolve_target_policy(
+                    policy_name=name,
+                    scenario_id=scenario.scenario_id,
+                    project_root=project_root,
+                    proposed_policies=proposed_policies,
+                    baseline_source=baseline_source,
+                    baseline_overrides=baseline_overrides,
+                )
+            if name not in proposed_map:
+                proposed_map[name] = dict(
+                    proposed_policies.get(name) or baseline_map[name]
+                )
 
     deltas: list[ScenarioDelta] = []
     with pure_execution_context():

--- a/ao_kernel/policy_sim/simulator.py
+++ b/ao_kernel/policy_sim/simulator.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import datetime as _dt
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, Literal, Mapping, Sequence
 
 from ao_kernel.policy_sim._purity import pure_execution_context
 from ao_kernel.policy_sim.diff import (
@@ -159,10 +159,10 @@ def _run_executor_primitive(
             error_detail=f"{type(exc).__name__}: {exc}",
         )
 
-    decision = "deny" if violations else "allow"
+    decision_lit: Literal["allow", "deny"] = "deny" if violations else "allow"
     return SimulationResult(
         scenario_id=scenario.scenario_id,
-        decision=decision,
+        decision=decision_lit,
         violation_kinds=tuple(violations),
     )
 
@@ -175,7 +175,7 @@ def _safe_resolve_secrets(
     """Call ``resolve_allowed_secrets(policy, all_env)``. Returns
     ``(resolved_secrets_dict, violation_codes)``. Empty outputs on
     any signature mismatch so the simulator keeps running."""
-    fn: Callable[..., Any] = getattr(enforcer, "resolve_allowed_secrets", None)
+    fn: Callable[..., Any] | None = getattr(enforcer, "resolve_allowed_secrets", None)
     if fn is None:
         return ({}, ())
     try:
@@ -191,7 +191,7 @@ def _safe_build_sandbox(
     parent_env: Mapping[str, str],
     resolved_secrets: Mapping[str, str],
 ) -> Sequence[str]:
-    fn: Callable[..., Any] = getattr(enforcer, "build_sandbox", None)
+    fn: Callable[..., Any] | None = getattr(enforcer, "build_sandbox", None)
     if fn is None:
         return ()
     try:
@@ -211,7 +211,7 @@ def _safe_check_http_header(
     policy: Mapping[str, Any],
     adapter_manifest: Any | None,
 ) -> Sequence[str]:
-    fn: Callable[..., Any] = getattr(enforcer, "check_http_header_exposure", None)
+    fn: Callable[..., Any] | None = getattr(enforcer, "check_http_header_exposure", None)
     if fn is None or adapter_manifest is None:
         return ()
     invocation = getattr(adapter_manifest, "invocation", None)
@@ -291,7 +291,6 @@ def _run_governance_policy(
 
     allowed = _extract_allowed_flag(result)
     reason_codes = _extract_reason_codes(result)
-    decision = "allow" if allowed else "deny"
     # governance.check_policy returns informational codes (like
     # "POLICY_PASSED") alongside the allowed=True flag. They are
     # not denial reasons, so `violation_kinds` only records codes
@@ -299,9 +298,12 @@ def _run_governance_policy(
     # aggregator's "any violations → deny" semantics honest
     # (iter-3 combined-semantic blocker absorb).
     violations = reason_codes if not allowed else ()
+    gov_decision: Literal["allow", "deny"] = (
+        "allow" if allowed else "deny"
+    )
     return SimulationResult(
         scenario_id=scenario.scenario_id,
-        decision=decision,
+        decision=gov_decision,
         violation_kinds=violations,
     )
 
@@ -311,8 +313,11 @@ def _extract_allowed_flag(result: Any) -> bool:
         if "allowed" in result:
             return bool(result["allowed"])
         if "decision" in result:
-            return result["decision"] == "allow"
-    return bool(result)
+            decision_val = result["decision"]
+            return isinstance(decision_val, str) and decision_val == "allow"
+    if result:
+        return True
+    return False
 
 
 def _extract_reason_codes(result: Any) -> tuple[str, ...]:
@@ -386,17 +391,18 @@ def _evaluate_scenario(
             any_error = True
             if r.error_detail:
                 error_details.append(r.error_detail)
+    combined_decision: Literal["allow", "deny", "error"]
     if not results:
-        decision = "error"
+        combined_decision = "error"
     elif any_error:
-        decision = "error"
+        combined_decision = "error"
     elif combined_violations:
-        decision = "deny"
+        combined_decision = "deny"
     else:
-        decision = "allow"
+        combined_decision = "allow"
     return SimulationResult(
         scenario_id=scenario.scenario_id,
-        decision=decision,  # type: ignore[arg-type]
+        decision=combined_decision,
         violation_kinds=combined_violations,
         error_detail="; ".join(error_details),
     )

--- a/ao_kernel/policy_sim/simulator.py
+++ b/ao_kernel/policy_sim/simulator.py
@@ -39,6 +39,8 @@ from ao_kernel.policy_sim.diff import (
     make_scenario_delta,
 )
 from ao_kernel.policy_sim.errors import (
+    PolicySimReentrantError,
+    PolicySimSideEffectError,
     ScenarioAdapterMissingError,
     TargetPolicyNotFoundError,
 )
@@ -145,6 +147,11 @@ def _run_executor_primitive(
         # args wiring). host_fs_probes=True surfaces a fingerprint
         # on the report but does not yet add violations.
         _ = include_host_fs_probes
+    except (PolicySimSideEffectError, PolicySimReentrantError):
+        # Purity-guard violations are structural simulator bugs —
+        # propagate so the CLI returns exit code 2 instead of
+        # masking them as per-scenario errors.
+        raise
     except Exception as exc:
         return SimulationResult(
             scenario_id=scenario.scenario_id,
@@ -271,6 +278,10 @@ def _run_governance_policy(
             action_dict,
             workspace=_SENTINEL_WORKSPACE,
         )
+    except (PolicySimSideEffectError, PolicySimReentrantError):
+        # See _run_executor_primitive — propagate purity-guard
+        # violations so the CLI can return exit code 2.
+        raise
     except Exception as exc:
         return SimulationResult(
             scenario_id=scenario.scenario_id,
@@ -333,18 +344,44 @@ def _evaluate_scenario(
     if scenario.kind == "governance_policy":
         with policy_override_context(active_policy_map):
             return _run_governance_policy(scenario, target_policy_name)
-    # kind == "combined": run both over the first target policy
-    # that is executor-targeted and first governance-targeted.
-    with policy_override_context(active_policy_map):
-        gov = _run_governance_policy(scenario, target_policy_name)
-    exec_ = _run_executor_primitive(
-        scenario, policy, adapter_manifest, include_host_fs_probes
+
+    # kind == "combined": distribute targets across the two
+    # primitive kinds. Convention (plan v3 §2.3): names containing
+    # 'worktree' → executor primitive target; any other name →
+    # governance_policy target. Aggregate violations union.
+    exec_target, gov_target = _split_combined_targets(scenario)
+    exec_policy = (
+        active_policy_map.get(exec_target, policy) if exec_target else None
     )
-    combined_violations = tuple(exec_.violation_kinds) + tuple(
-        gov.violation_kinds
+    exec_result = (
+        _run_executor_primitive(
+            scenario,
+            exec_policy,
+            adapter_manifest,
+            include_host_fs_probes,
+        )
+        if exec_policy is not None
+        else None
     )
-    decision: str
-    if exec_.decision == "error" or gov.decision == "error":
+    if gov_target:
+        with policy_override_context(active_policy_map):
+            gov_result = _run_governance_policy(scenario, gov_target)
+    else:
+        gov_result = None
+
+    results = [r for r in (exec_result, gov_result) if r is not None]
+    combined_violations: tuple[str, ...] = ()
+    error_details = []
+    any_error = False
+    for r in results:
+        combined_violations = combined_violations + tuple(r.violation_kinds)
+        if r.decision == "error":
+            any_error = True
+            if r.error_detail:
+                error_details.append(r.error_detail)
+    if not results:
+        decision = "error"
+    elif any_error:
         decision = "error"
     elif combined_violations:
         decision = "deny"
@@ -354,8 +391,27 @@ def _evaluate_scenario(
         scenario_id=scenario.scenario_id,
         decision=decision,  # type: ignore[arg-type]
         violation_kinds=combined_violations,
-        error_detail=(exec_.error_detail or gov.error_detail),
+        error_detail="; ".join(error_details),
     )
+
+
+def _split_combined_targets(scenario: Scenario) -> tuple[str, str]:
+    """Distribute a ``combined`` scenario's ``target_policy_names``
+    across the executor and governance primitive targets.
+
+    Convention: names containing ``"worktree"`` route to the
+    executor primitive; all other names route to
+    ``governance.check_policy``. Missing side returns an empty
+    string so ``_evaluate_scenario`` knows to skip that primitive.
+    """
+    exec_t = ""
+    gov_t = ""
+    for name in scenario.target_policy_names:
+        if "worktree" in name:
+            exec_t = name
+        else:
+            gov_t = name
+    return exec_t, gov_t
 
 
 def _policy_for_scenario(scenario: Scenario) -> str:
@@ -417,6 +473,7 @@ def simulate_policy_change(
             baseline_map[policy_name] = resolve_target_policy(
                 policy_name=policy_name,
                 scenario_id=scenario.scenario_id,
+                project_root=project_root,
                 proposed_policies=proposed_policies,
                 baseline_source=baseline_source,
                 baseline_overrides=baseline_overrides,

--- a/docs/POLICY-SIM.md
+++ b/docs/POLICY-SIM.md
@@ -1,6 +1,6 @@
 # Policy Simulation Harness
 
-`ao_kernel.policy_sim` runs dry-run evaluations of proposed policy changes against a set of scenario fixtures. It reuses the real `governance.check_policy` code path and the executor's policy primitives, but executes them under a 23-sentinel purity guard that fail-closes on any side effect (evidence emit, worktree creation, subprocess spawn, filesystem write, network I/O, tempfile allocation, importlib resource extraction).
+`ao_kernel.policy_sim` runs dry-run evaluations of proposed policy changes against a set of scenario fixtures. It reuses the real `governance.check_policy` code path and the executor's policy primitives, but executes them under a 24-sentinel purity guard that fail-closes on any side effect (evidence emit, worktree creation, subprocess spawn, filesystem write, network I/O, tempfile allocation, importlib resource extraction).
 
 The harness answers operator questions like:
 

--- a/docs/POLICY-SIM.md
+++ b/docs/POLICY-SIM.md
@@ -1,0 +1,242 @@
+# Policy Simulation Harness
+
+`ao_kernel.policy_sim` runs dry-run evaluations of proposed policy changes against a set of scenario fixtures. It reuses the real `governance.check_policy` code path and the executor's policy primitives, but executes them under a 23-sentinel purity guard that fail-closes on any side effect (evidence emit, worktree creation, subprocess spawn, filesystem write, network I/O, tempfile allocation, importlib resource extraction).
+
+The harness answers operator questions like:
+
+- "If I apply this `policy_worktree_profile.v1.json` patch, how many of my fixtures flip from allow to deny?"
+- "Does my proposed `policy_autonomy.v1.json` still block unknown intents?"
+- "My PR touches two policies at once — does the combined change tighten any scenario I currently allow?"
+
+## 1. Scope
+
+- **Mid-depth simulation** — `governance.check_policy` plus
+  `executor.policy_enforcer.build_sandbox` + `resolve_allowed_secrets` +
+  `check_http_header_exposure` are exercised. `validate_command`
+  is deferred for v1 (plan §2.3 Q2 — its host-FS dependence makes
+  results host-specific; a future opt-in surfaces a
+  `host_fs_fingerprint` on the report).
+- **Multi-policy per run** — a `ScenarioSet` can mix scenarios
+  targeting different policies; each scenario names its own
+  `target_policy_name` (plan v3 bulgu 1 absorb).
+- **Full-replacement proposed policies only** — RFC 7396 merge
+  patch is deferred. The simulator compares a baseline dict to a
+  proposed dict in full.
+- **JSON-only scenario format** (plan v3 Q1 absorb). YAML
+  support is a candidate for a post-B4 optional extra.
+
+## 2. Invariants
+
+- **No side effects** during simulation. `_purity.py` patches 23
+  sentinels spanning subprocess, filesystem, tempfile, socket,
+  `importlib.resources.as_file`, and every evidence-emit
+  re-export path. Any trip raises `PolicySimSideEffectError`
+  carrying the sentinel name.
+- **Policy loader fail-closed** per
+  `ao_kernel.cost.policy::_validate` + `load_cost_policy`
+  contract. The simulator never swallows loader exceptions;
+  structurally-broken proposed policies raise
+  `ProposedPolicyInvalidError` before any scenario runs.
+- **Canonical policy hash** matches `executor/artifacts.py:66-74`
+  — `sort_keys=True`, `ensure_ascii=False`,
+  `separators=(",", ":")`, UTF-8 + SHA-256 (plan v3 N3 absorb).
+  Cross-module drift surfaces as a contract-test failure.
+- **Adapter snapshot pre-captured** before entering the purity
+  context. Bundled adapters (`codex-stub` et al.) remain
+  discoverable without tripping the
+  `importlib.resources.as_file` sentinel (plan v3 iter-2
+  blocker absorb).
+- `_KINDS == 27` in `executor/evidence_emitter.py:46` is
+  preserved — simulation emits no new evidence kinds (plan v3
+  bulgu 6 absorb).
+
+## 3. Scenario Model
+
+Scenarios are JSON documents validated against `policy-sim-scenario.schema.v1.json`.
+
+```json
+{
+  "scenario_id": "adapter_http_with_secret",
+  "description": "HTTP adapter binds auth_secret_id_ref.",
+  "kind": "executor_primitive",
+  "target_policy_name": "policy_worktree_profile.v1.json",
+  "inputs": {
+    "adapter_manifest_ref": "codex-stub",
+    "parent_env": {
+      "PATH": "/usr/bin:/usr/local/bin",
+      "ANTHROPIC_API_KEY": "sk-test-redacted"
+    },
+    "requested_command": null,
+    "requested_cwd": null
+  },
+  "expected_baseline": {
+    "violations_expected": [],
+    "decision_expected": "allow"
+  }
+}
+```
+
+### Kinds
+
+- `executor_primitive` — invokes `build_sandbox` +
+  `resolve_allowed_secrets` + `check_http_header_exposure`
+  against `target_policy_name` (must be
+  `policy_worktree_profile.v1.json`).
+- `governance_policy` — invokes `governance.check_policy` against
+  `target_policy_name` with the scenario's `inputs.action` wrapped
+  into `{"intent": action}`.
+- `combined` — both; requires `target_policy_names` (plural).
+
+### Bundled fixtures
+
+Three reference scenarios ship under
+`ao_kernel/defaults/policies/policy_sim_scenarios/`:
+
+1. `adapter_http_with_secret` — executor_primitive, expect allow.
+2. `path_poisoned_python` — executor_primitive, expect deny when
+   `--enable-host-fs-probes` is on. Currently allow under v1
+   (validate_command deferred).
+3. `autonomy_unknown_intent` — governance_policy, expect deny.
+
+## 4. Public API
+
+```python
+from pathlib import Path
+from ao_kernel.policy_sim import (
+    BaselineSource,
+    load_bundled_scenarios,
+    simulate_policy_change,
+)
+
+report = simulate_policy_change(
+    project_root=Path.cwd(),
+    scenarios=load_bundled_scenarios(),
+    proposed_policies={
+        "policy_autonomy.v1.json": {
+            "version": "v1",
+            "intents": ["AUTONOMY_UNKNOWN_INTENT"],
+            "defaults": {"mode": "allow"},
+        },
+    },
+    baseline_source=BaselineSource.BUNDLED,
+)
+
+for delta in report.notable_deltas:
+    print(delta.scenario_id, delta.transition)
+```
+
+### Baseline sources
+
+- `BaselineSource.BUNDLED` — read baseline policies from
+  `ao_kernel/defaults/policies/`.
+- `BaselineSource.WORKSPACE_OVERRIDE` — read from
+  `<project_root>/.ao/policies/<name>` via
+  `load_with_override` (disk read).
+- `BaselineSource.EXPLICIT` — use the caller-supplied
+  `baseline_overrides` dict verbatim (no disk I/O).
+
+### Errors
+
+- `PolicySimSideEffectError(sentinel_name, context)` — the
+  purity guard tripped.
+- `PolicySimReentrantError` — a nested
+  `pure_execution_context` was attempted.
+- `ScenarioValidationError(scenario_id, reason)` — scenario JSON
+  failed schema checks.
+- `ScenarioAdapterMissingError(scenario_id, adapter_ref)` — the
+  scenario references an adapter the registry snapshot does not
+  know.
+- `TargetPolicyNotFoundError(scenario_id, policy_name)` — the
+  scenario's `target_policy_name` is not present in
+  `proposed_policies`, `baseline_overrides`, nor bundled
+  defaults.
+- `ProposedPolicyInvalidError(policy_name, violations)` —
+  structural shape checks (driven by
+  `_policy_shape_registry`) failed.
+- `SimulationAbortedError(scenario_ids, causes)` — aggregate
+  wrapper used when per-scenario evaluation raised one or more
+  unrecoverable errors.
+- `ReportSerializationError(field_path, value_type)` — a
+  non-normalisable value escaped
+  `DiffReport.to_dict`.
+
+## 5. CLI
+
+```
+ao-kernel policy-sim run \
+  --scenarios <file-or-dir> \
+  --proposed-policies <dir> \
+  [--baseline-source bundled|workspace_override|explicit] \
+  [--baseline-overrides <dir>] \
+  [--format json|text] \
+  [--output <path>] \
+  [--enable-host-fs-probes] \
+  [--project-root <path>]
+```
+
+### Exit codes
+
+- `0` — success, no tightening transitions.
+- `1` — user error (bad scenario file, structurally invalid
+  proposed policy, unknown baseline source, adapter reference
+  missing).
+- `2` — internal (purity violation, reentrancy, simulator
+  abort).
+- `3` — success with warning (≥1 allow→deny transition).
+
+## 6. Report Shape
+
+`DiffReport.to_dict()` normalises `Path` → `str`, `frozenset`
+→ sorted `list`, compiled regex → `.pattern`, and manifest
+`source_path` → relative string (plan v3 N4 absorb). Output
+example:
+
+```json
+{
+  "schema_version": "v1",
+  "emitted_at": "2026-04-18T00:55:19+00:00",
+  "scenarios_evaluated": 3,
+  "baseline_policy_hashes": {
+    "policy_autonomy.v1.json": "sha256:...",
+    "policy_worktree_profile.v1.json": "sha256:..."
+  },
+  "proposed_policy_hashes": { "...": "sha256:..." },
+  "transitions": {
+    "allow→allow": 2,
+    "deny→deny": 1,
+    "allow→deny": 0,
+    "deny→allow": 0,
+    "error": 0
+  },
+  "transitions_by_policy": {
+    "policy_autonomy.v1.json": { "deny→deny": 1 },
+    "policy_worktree_profile.v1.json": { "allow→allow": 2 }
+  },
+  "host_fs_dependent": false,
+  "host_fs_fingerprint": null,
+  "deltas": [...]
+}
+```
+
+## 7. Scope Dışı (post-B4)
+
+- **Full `Executor.run_step` dry-run** → benchmark-suite work
+  (B7 or later); requires adapter mock harness.
+- **RFC 7396 merge-patch proposed policies** → v2.
+- **YAML scenario support** → post-B4 optional extra.
+- **Auto-discovery of scenarios** from
+  `<workspace>/.ao/policy_sim/scenarios/` → post-B4 v1.1.
+- **Evidence emit for simulation runs** — **NEVER** under the
+  purity contract.
+- **Time-travel** (past policy versions from git history) →
+  FAZ-C.
+- **Web UI** — **NEVER**; CLI + library only.
+
+## 8. Related
+
+- `docs/WORKTREE-PROFILE.md` — baseline `policy_worktree_profile`
+  contract that executor_primitive scenarios exercise.
+- `docs/COST-MODEL.md` §6 — PR-B3 cost-aware routing; potential
+  future scenario target.
+- `.claude/plans/PR-B4-DRAFT-PLAN.md` v3 — Codex adversarial
+  review audit trail.

--- a/docs/POLICY-SIM.md
+++ b/docs/POLICY-SIM.md
@@ -27,7 +27,7 @@ The harness answers operator questions like:
 
 ## 2. Invariants
 
-- **No side effects** during simulation. `_purity.py` patches 23
+- **No side effects** during simulation. `_purity.py` patches 24
   sentinels spanning subprocess, filesystem, tempfile, socket,
   `importlib.resources.as_file`, and every evidence-emit
   re-export path. Any trip raises `PolicySimSideEffectError`

--- a/tests/test_policy_sim_cli.py
+++ b/tests/test_policy_sim_cli.py
@@ -1,0 +1,227 @@
+"""Tests for ``ao-kernel policy-sim run`` CLI (PR-B4 C4)."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from ao_kernel._internal.policy_sim.cli_handlers import cmd_policy_sim_run
+from ao_kernel.policy_sim import (
+    load_bundled_scenarios,
+    simulate_policy_change,
+)
+from ao_kernel.policy_sim.report import (
+    has_tightening,
+    load_policies_from_dir,
+    render,
+    write_atomic,
+)
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    base: dict[str, object] = {
+        "scenarios": None,
+        "proposed_policies": "/nonexistent",
+        "baseline_source": "bundled",
+        "baseline_overrides": None,
+        "format": "json",
+        "output": None,
+        "enable_host_fs_probes": False,
+        "project_root": None,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+# --- report.render / has_tightening / write_atomic --------------------
+
+
+class TestReportRender:
+    def test_render_json_matches_dump(self, tmp_path: Path) -> None:
+        report = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=load_bundled_scenarios(),
+            proposed_policies={},
+        )
+        rendered = render(report, "json")
+        # Valid JSON, same shape as to_dict output.
+        parsed = json.loads(rendered)
+        assert (
+            parsed["scenarios_evaluated"]
+            == report.scenarios_evaluated
+        )
+
+    def test_render_text_contains_header(self, tmp_path: Path) -> None:
+        report = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=load_bundled_scenarios(),
+            proposed_policies={},
+        )
+        rendered = render(report, "text")
+        assert "Policy Simulation Report" in rendered
+        assert "Transitions (all):" in rendered
+        assert "Transitions per policy:" in rendered
+
+    def test_render_unknown_format_raises(self, tmp_path: Path) -> None:
+        report = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=load_bundled_scenarios(),
+            proposed_policies={},
+        )
+        with pytest.raises(ValueError):
+            render(report, "yaml")  # type: ignore[arg-type]
+
+
+class TestHasTightening:
+    def test_bundled_empty_proposed_no_tightening(
+        self, tmp_path: Path
+    ) -> None:
+        report = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=load_bundled_scenarios(),
+            proposed_policies={},
+        )
+        assert has_tightening(report) is False
+
+
+class TestWriteAtomic:
+    def test_writes_content(self, tmp_path: Path) -> None:
+        target = tmp_path / "subdir" / "report.json"
+        write_atomic(target, '{"ok": true}')
+        assert target.read_text(encoding="utf-8") == '{"ok": true}'
+
+    def test_creates_parents(self, tmp_path: Path) -> None:
+        target = tmp_path / "a" / "b" / "c.txt"
+        write_atomic(target, "hi")
+        assert target.parent.is_dir()
+
+    def test_no_tmp_leftover(self, tmp_path: Path) -> None:
+        target = tmp_path / "report.json"
+        write_atomic(target, "{}")
+        leftovers = [p.name for p in tmp_path.iterdir() if p.name != "report.json"]
+        assert leftovers == []
+
+
+class TestLoadPoliciesFromDir:
+    def test_empty_dir_returns_empty_mapping(self, tmp_path: Path) -> None:
+        assert load_policies_from_dir(tmp_path) == {}
+
+    def test_nonexistent_dir_returns_empty(self, tmp_path: Path) -> None:
+        assert load_policies_from_dir(tmp_path / "missing") == {}
+
+    def test_loads_json_files(self, tmp_path: Path) -> None:
+        (tmp_path / "a.json").write_text(
+            json.dumps({"one": 1}), encoding="utf-8"
+        )
+        (tmp_path / "b.json").write_text(
+            json.dumps({"two": 2}), encoding="utf-8"
+        )
+        mapping = load_policies_from_dir(tmp_path)
+        assert mapping == {"a.json": {"one": 1}, "b.json": {"two": 2}}
+
+
+# --- cmd_policy_sim_run exit codes -----------------------------------
+
+
+class TestCmdPolicySimRun:
+    def test_bundled_smoke_exit_0(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Bundled scenarios + empty proposed + no tightening → 0."""
+        args = _args(proposed_policies=str(tmp_path))
+        rc = cmd_policy_sim_run(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed["scenarios_evaluated"] == 3
+
+    def test_unknown_baseline_source_exit_1(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        args = _args(
+            proposed_policies=str(tmp_path),
+            baseline_source="chaotic_neutral",
+        )
+        rc = cmd_policy_sim_run(args)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "baseline-source" in err
+
+    def test_scenarios_path_not_found_exit_1(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        args = _args(
+            scenarios=str(tmp_path / "not_there"),
+            proposed_policies=str(tmp_path),
+        )
+        rc = cmd_policy_sim_run(args)
+        assert rc == 1
+        assert "scenario load failed" in capsys.readouterr().err
+
+    def test_structural_invalid_proposed_exit_1(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        proposed_dir = tmp_path / "prop"
+        proposed_dir.mkdir()
+        (proposed_dir / "policy_worktree_profile.v1.json").write_text(
+            json.dumps({"version": "v1"}),  # missing required keys
+            encoding="utf-8",
+        )
+        args = _args(proposed_policies=str(proposed_dir))
+        rc = cmd_policy_sim_run(args)
+        assert rc == 1
+        assert "simulation input error" in capsys.readouterr().err
+
+    def test_output_file_written_atomic(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        out_path = tmp_path / "out" / "report.json"
+        args = _args(
+            proposed_policies=str(tmp_path),
+            output=str(out_path),
+        )
+        rc = cmd_policy_sim_run(args)
+        assert rc == 0
+        assert out_path.is_file()
+        parsed = json.loads(out_path.read_text(encoding="utf-8"))
+        assert parsed["scenarios_evaluated"] == 3
+        # Stdout empty when --output used.
+        assert capsys.readouterr().out == ""
+
+    def test_host_fs_probes_flag_propagates(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        args = _args(
+            proposed_policies=str(tmp_path),
+            enable_host_fs_probes=True,
+        )
+        rc = cmd_policy_sim_run(args)
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["host_fs_dependent"] is True
+
+    def test_format_text_output(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        args = _args(proposed_policies=str(tmp_path), format="text")
+        rc = cmd_policy_sim_run(args)
+        assert rc == 0
+        assert "Policy Simulation Report" in capsys.readouterr().out

--- a/tests/test_policy_sim_cli.py
+++ b/tests/test_policy_sim_cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import io
 import json
 from pathlib import Path
 

--- a/tests/test_policy_sim_integration.py
+++ b/tests/test_policy_sim_integration.py
@@ -1,0 +1,137 @@
+"""End-to-end integration tests for the policy-sim harness
+(PR-B4 C5).
+
+Exercises the full bundled-fixture pipeline via the public API
+and the CLI, asserts regression invariants (`_KINDS == 27`,
+policy hashes stable) and proposed-policy flip scenarios.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from ao_kernel._internal.policy_sim.cli_handlers import cmd_policy_sim_run
+from ao_kernel.policy_sim import (
+    BaselineSource,
+    load_bundled_scenarios,
+    simulate_policy_change,
+)
+from ao_kernel.policy_sim.diff import canonical_policy_hash
+
+
+class TestBundledFixtureEndToEnd:
+    def test_identity_when_proposed_empty(self, tmp_path: Path) -> None:
+        report = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=load_bundled_scenarios(),
+            proposed_policies={},
+        )
+        assert report.scenarios_evaluated == 3
+        assert all(
+            d.transition in {"allow_to_allow", "deny_to_deny"}
+            for d in report.deltas
+        )
+        assert report.host_fs_dependent is False
+
+    def test_proposed_autonomy_allow_triggers_flip(
+        self, tmp_path: Path
+    ) -> None:
+        """Proposed policy_autonomy with allow defaults should
+        flip the governance_policy scenario to allow."""
+        proposed = {
+            "policy_autonomy.v1.json": {
+                "version": "v1",
+                "intents": ["AUTONOMY_UNKNOWN_INTENT"],
+                "defaults": {"mode": "allow"},
+            }
+        }
+        report = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=load_bundled_scenarios(),
+            proposed_policies=proposed,
+            baseline_source=BaselineSource.BUNDLED,
+        )
+        assert report.scenarios_evaluated == 3
+        # At minimum the hashes must differ for the flipped policy.
+        baseline_hash = report.baseline_policy_hashes[
+            "policy_autonomy.v1.json"
+        ]
+        proposed_hash = report.proposed_policy_hashes[
+            "policy_autonomy.v1.json"
+        ]
+        assert baseline_hash != proposed_hash
+
+    def test_policy_hash_stable_across_runs(self, tmp_path: Path) -> None:
+        """Same inputs → same canonical hash (cross-run stability)."""
+        a = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=load_bundled_scenarios(),
+            proposed_policies={},
+        )
+        b = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=load_bundled_scenarios(),
+            proposed_policies={},
+        )
+        assert a.baseline_policy_hashes == b.baseline_policy_hashes
+
+    def test_canonical_hash_reproduces_contract_bytes(self) -> None:
+        """Policy-sim hash bytes must use sort_keys + ensure_ascii=False
+        + (",", ":") separators + UTF-8 + SHA-256, matching the
+        canonical form inlined in `executor/artifacts.py:74`."""
+        import hashlib
+
+        payload = {"b": 2, "nested": {"z": 1, "a": 2}, "a": 1}
+        expected_canonical = json.dumps(
+            payload,
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        expected_digest = hashlib.sha256(
+            expected_canonical.encode("utf-8")
+        ).hexdigest()
+        assert canonical_policy_hash(payload) == f"sha256:{expected_digest}"
+
+
+class TestKindsInvariant:
+    def test_kinds_is_27(self) -> None:
+        """Policy-sim emits ZERO new evidence kinds; the
+        executor's `_KINDS` count must stay at 27 after the
+        package lands (plan v3 §2.1 + §8)."""
+        from ao_kernel.executor import evidence_emitter
+
+        kinds = getattr(evidence_emitter, "_KINDS", None)
+        assert kinds is not None, "evidence_emitter._KINDS missing"
+        assert len(kinds) == 27
+
+
+class TestCliEndToEnd:
+    def test_run_writes_json_report(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        out_path = tmp_path / "report.json"
+        proposed_dir = tmp_path / "proposed"
+        proposed_dir.mkdir()
+
+        args = argparse.Namespace(
+            scenarios=None,
+            proposed_policies=str(proposed_dir),
+            baseline_source="bundled",
+            baseline_overrides=None,
+            format="json",
+            output=str(out_path),
+            enable_host_fs_probes=False,
+            project_root=None,
+        )
+        rc = cmd_policy_sim_run(args)
+        assert rc == 0
+        payload = json.loads(out_path.read_text(encoding="utf-8"))
+        assert payload["scenarios_evaluated"] == 3
+        assert payload["schema_version"] == "v1"

--- a/tests/test_policy_sim_integration.py
+++ b/tests/test_policy_sim_integration.py
@@ -45,7 +45,7 @@ class TestBundledFixtureEndToEnd:
         proposed = {
             "policy_autonomy.v1.json": {
                 "version": "v1",
-                "intents": ["AUTONOMY_UNKNOWN_INTENT"],
+                "intents": {"AUTONOMY_UNKNOWN_INTENT": {"mode": "allow"}},
                 "defaults": {"mode": "allow"},
             }
         }

--- a/tests/test_policy_sim_purity.py
+++ b/tests/test_policy_sim_purity.py
@@ -1,4 +1,4 @@
-"""Tests for ``ao_kernel.policy_sim._purity`` — the 23-sentinel
+"""Tests for ``ao_kernel.policy_sim._purity`` — the 24-sentinel
 no-side-effects guard (PR-B4 plan v3 §2.1)."""
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ class TestSentinelCoverage:
     def test_at_least_22_sentinels(self) -> None:
         """Plan v3 invariant: 22+ sentinel surface.
 
-        Actual count is 23 (4 emit_event paths + 1 worktree + 4
+        Actual count is 24 (4 emit_event paths + 1 worktree + 4
         subprocess + 4 pathlib + 4 os + 4 tempfile + 2 socket +
         1 importlib)."""
         assert len(PATCHED_SENTINEL_NAMES) >= 22

--- a/tests/test_policy_sim_purity.py
+++ b/tests/test_policy_sim_purity.py
@@ -1,0 +1,283 @@
+"""Tests for ``ao_kernel.policy_sim._purity`` — the 23-sentinel
+no-side-effects guard (PR-B4 plan v3 §2.1)."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import socket
+import subprocess
+import tempfile
+from importlib import resources as _importlib_resources
+
+import pytest
+
+from ao_kernel.policy_sim._purity import (
+    PATCHED_SENTINEL_NAMES,
+    pure_execution_context,
+)
+from ao_kernel.policy_sim.errors import (
+    PolicySimReentrantError,
+    PolicySimSideEffectError,
+)
+
+
+class TestSentinelCoverage:
+    def test_at_least_22_sentinels(self) -> None:
+        """Plan v3 invariant: 22+ sentinel surface.
+
+        Actual count is 23 (4 emit_event paths + 1 worktree + 4
+        subprocess + 4 pathlib + 4 os + 4 tempfile + 2 socket +
+        1 importlib)."""
+        assert len(PATCHED_SENTINEL_NAMES) >= 22
+
+    def test_emit_event_all_four_paths_covered(self) -> None:
+        """Pre-imported aliases + public facade re-export all
+        covered (plan v3 iter-2 warning 3 absorb)."""
+        expected = {
+            "ao_kernel.executor.evidence_emitter.emit_event",
+            "ao_kernel.executor.executor.emit_event",
+            "ao_kernel.executor.multi_step_driver.emit_event",
+            "ao_kernel.executor.emit_event",
+        }
+        assert expected.issubset(PATCHED_SENTINEL_NAMES)
+
+    def test_subprocess_family_covered(self) -> None:
+        expected = {
+            "subprocess.Popen.__init__",
+            "subprocess.run",
+            "subprocess.call",
+            "subprocess.check_output",
+        }
+        assert expected.issubset(PATCHED_SENTINEL_NAMES)
+
+    def test_filesystem_writes_covered(self) -> None:
+        expected = {
+            "pathlib.Path.write_text",
+            "pathlib.Path.write_bytes",
+            "pathlib.Path.mkdir",
+            "pathlib.Path.touch",
+            "os.replace",
+            "os.rename",
+            "os.remove",
+            "os.unlink",
+        }
+        assert expected.issubset(PATCHED_SENTINEL_NAMES)
+
+    def test_tempfile_family_covered(self) -> None:
+        expected = {
+            "tempfile.NamedTemporaryFile",
+            "tempfile.mkstemp",
+            "tempfile.TemporaryFile",
+            "tempfile.mkdtemp",
+        }
+        assert expected.issubset(PATCHED_SENTINEL_NAMES)
+
+    def test_socket_network_covered(self) -> None:
+        assert {"socket.socket.connect", "socket.socket.bind"}.issubset(
+            PATCHED_SENTINEL_NAMES
+        )
+
+    def test_importlib_resource_extraction_covered(self) -> None:
+        assert "importlib.resources.as_file" in PATCHED_SENTINEL_NAMES
+
+
+class TestSubprocessGuarded:
+    def test_run_raises(self) -> None:
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError) as exc_info:
+                subprocess.run(["true"])
+        assert exc_info.value.sentinel_name == "subprocess.run"
+
+    def test_call_raises(self) -> None:
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                subprocess.call(["true"])
+
+    def test_check_output_raises(self) -> None:
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                subprocess.check_output(["true"])
+
+    def test_popen_init_raises(self) -> None:
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                subprocess.Popen(["true"])
+
+
+class TestFilesystemGuarded:
+    def test_write_text_raises(self, tmp_path: pathlib.Path) -> None:
+        target = tmp_path / "forbidden.txt"
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError) as exc_info:
+                target.write_text("nope")
+        assert exc_info.value.sentinel_name == "pathlib.Path.write_text"
+
+    def test_write_bytes_raises(self, tmp_path: pathlib.Path) -> None:
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                (tmp_path / "x").write_bytes(b"nope")
+
+    def test_mkdir_raises(self, tmp_path: pathlib.Path) -> None:
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                (tmp_path / "subdir").mkdir()
+
+    def test_touch_raises(self, tmp_path: pathlib.Path) -> None:
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                (tmp_path / "x").touch()
+
+    def test_os_replace_raises(self, tmp_path: pathlib.Path) -> None:
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.write_text("hi")  # Setup OUTSIDE context.
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                os.replace(str(a), str(b))
+
+    def test_os_rename_raises(self, tmp_path: pathlib.Path) -> None:
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.write_text("hi")
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                os.rename(str(a), str(b))
+
+    def test_os_remove_raises(self, tmp_path: pathlib.Path) -> None:
+        target = tmp_path / "x"
+        target.write_text("x")
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                os.remove(str(target))
+
+    def test_os_unlink_raises(self, tmp_path: pathlib.Path) -> None:
+        target = tmp_path / "x"
+        target.write_text("x")
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                os.unlink(str(target))
+
+
+class TestTempfileGuarded:
+    def test_named_temporary_file_raises(self) -> None:
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                tempfile.NamedTemporaryFile()
+
+    def test_mkstemp_raises(self) -> None:
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                tempfile.mkstemp()
+
+    def test_temporary_file_raises(self) -> None:
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                tempfile.TemporaryFile()
+
+    def test_mkdtemp_raises(self) -> None:
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                tempfile.mkdtemp()
+
+
+class TestNetworkGuarded:
+    def test_socket_connect_raises(self) -> None:
+        sock = socket.socket()
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                sock.connect(("127.0.0.1", 1))
+        sock.close()
+
+    def test_socket_bind_raises(self) -> None:
+        sock = socket.socket()
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                sock.bind(("127.0.0.1", 0))
+        sock.close()
+
+
+class TestImportlibResourceGuarded:
+    def test_as_file_raises(self) -> None:
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                ctx = _importlib_resources.as_file(
+                    _importlib_resources.files("ao_kernel")
+                )
+                ctx.__enter__()
+
+
+class TestEmitEventGuarded:
+    def test_evidence_emitter_path_raises(self) -> None:
+        import ao_kernel.executor.evidence_emitter as em
+
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError) as exc_info:
+                em.emit_event("any_kind", {"foo": "bar"})
+        assert (
+            exc_info.value.sentinel_name
+            == "ao_kernel.executor.evidence_emitter.emit_event"
+        )
+
+    def test_multi_step_driver_alias_raises(self) -> None:
+        """Pre-imported alias must be patched too (plan v3 warning 3)."""
+        import ao_kernel.executor.multi_step_driver as driver_mod
+
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError) as exc_info:
+                driver_mod.emit_event("any_kind", {"foo": "bar"})
+        assert (
+            exc_info.value.sentinel_name
+            == "ao_kernel.executor.multi_step_driver.emit_event"
+        )
+
+    def test_public_facade_alias_raises(self) -> None:
+        """Public re-export must be patched too (plan v3 iter-2 warning 3)."""
+        import ao_kernel.executor as facade
+
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError) as exc_info:
+                facade.emit_event("any_kind", {"foo": "bar"})
+        assert (
+            exc_info.value.sentinel_name
+            == "ao_kernel.executor.emit_event"
+        )
+
+
+class TestReentrancy:
+    def test_nested_entry_raises(self) -> None:
+        with pure_execution_context():
+            with pytest.raises(PolicySimReentrantError):
+                with pure_execution_context():
+                    pass  # pragma: no cover
+
+    def test_can_re_enter_after_exit(self) -> None:
+        """Sequential entries are OK; only nested entries fail."""
+        with pure_execution_context():
+            pass
+        with pure_execution_context():
+            with pytest.raises(PolicySimSideEffectError):
+                subprocess.run(["true"])
+
+
+class TestRestoreOnExit:
+    def test_originals_restored_on_normal_exit(self) -> None:
+        original_run = subprocess.run
+        with pure_execution_context():
+            assert subprocess.run is not original_run
+        assert subprocess.run is original_run
+
+    def test_originals_restored_on_exception_propagation(self) -> None:
+        original_run = subprocess.run
+        with pytest.raises(RuntimeError):
+            with pure_execution_context():
+                assert subprocess.run is not original_run
+                raise RuntimeError("scenario failure")
+        assert subprocess.run is original_run
+
+    def test_write_text_restored(self, tmp_path: pathlib.Path) -> None:
+        """Post-exit filesystem writes must work normally."""
+        with pure_execution_context():
+            pass
+        (tmp_path / "sanity.txt").write_text("OK")
+        assert (tmp_path / "sanity.txt").read_text() == "OK"

--- a/tests/test_policy_sim_scenarios.py
+++ b/tests/test_policy_sim_scenarios.py
@@ -1,0 +1,232 @@
+"""Tests for ``ao_kernel.policy_sim.scenario`` — scenario model +
+loader + bundled JSON fixtures (PR-B4 C2)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ao_kernel.policy_sim.errors import ScenarioValidationError
+from ao_kernel.policy_sim.scenario import (
+    ExpectedBaseline,
+    Scenario,
+    ScenarioInputs,
+    ScenarioSet,
+    load_bundled_scenarios,
+    load_scenario_file,
+    load_scenarios_from_dir,
+)
+
+
+def _valid_scenario(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "scenario_id": "valid_scenario",
+        "kind": "executor_primitive",
+        "target_policy_name": "policy_worktree_profile.v1.json",
+        "inputs": {
+            "adapter_manifest_ref": "codex-stub",
+            "parent_env": {"PATH": "/usr/bin"},
+            "requested_command": None,
+            "requested_cwd": None,
+        },
+        "expected_baseline": {
+            "violations_expected": [],
+            "decision_expected": "allow",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+class TestBundledScenarios:
+    def test_all_three_load_clean(self) -> None:
+        scenarios = load_bundled_scenarios()
+        ids = {s.scenario_id for s in scenarios}
+        assert ids == {
+            "adapter_http_with_secret",
+            "autonomy_unknown_intent",
+            "path_poisoned_python",
+        }
+
+    def test_targets_point_at_expected_policies(self) -> None:
+        scenarios = {s.scenario_id: s for s in load_bundled_scenarios()}
+        assert (
+            scenarios["adapter_http_with_secret"].target_policy_name
+            == "policy_worktree_profile.v1.json"
+        )
+        assert (
+            scenarios["path_poisoned_python"].target_policy_name
+            == "policy_worktree_profile.v1.json"
+        )
+        assert (
+            scenarios["autonomy_unknown_intent"].target_policy_name
+            == "policy_autonomy.v1.json"
+        )
+
+    def test_decisions_match_expected_shape(self) -> None:
+        scenarios = {s.scenario_id: s for s in load_bundled_scenarios()}
+        assert (
+            scenarios["adapter_http_with_secret"]
+            .expected_baseline.decision_expected
+            == "allow"
+        )
+        assert (
+            scenarios["path_poisoned_python"]
+            .expected_baseline.decision_expected
+            == "deny"
+        )
+        assert (
+            scenarios["autonomy_unknown_intent"]
+            .expected_baseline.decision_expected
+            == "deny"
+        )
+
+
+class TestLoadScenarioFile:
+    def _write(self, path: Path, doc: Any) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(doc), encoding="utf-8")
+
+    def test_loads_valid_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.json"
+        self._write(target, _valid_scenario())
+        scenario = load_scenario_file(target)
+        assert scenario.scenario_id == "valid_scenario"
+        assert scenario.kind == "executor_primitive"
+        assert scenario.target_policy_name == "policy_worktree_profile.v1.json"
+
+    def test_rejects_non_json_extension(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.yaml"
+        target.write_text("scenario_id: x\n", encoding="utf-8")
+        with pytest.raises(ScenarioValidationError) as exc_info:
+            load_scenario_file(target)
+        assert "JSON-only" in exc_info.value.reason
+
+    def test_unknown_kind_raises(self, tmp_path: Path) -> None:
+        bad = _valid_scenario(kind="weirdo")
+        target = tmp_path / "x.json"
+        self._write(target, bad)
+        with pytest.raises(ScenarioValidationError):
+            load_scenario_file(target)
+
+    def test_missing_target_policy_for_executor_primitive(
+        self, tmp_path: Path
+    ) -> None:
+        bad = _valid_scenario()
+        del bad["target_policy_name"]
+        target = tmp_path / "x.json"
+        self._write(target, bad)
+        with pytest.raises(ScenarioValidationError):
+            load_scenario_file(target)
+
+    def test_both_target_fields_rejected(self, tmp_path: Path) -> None:
+        """Schema xor: can't provide both name and names."""
+        bad = _valid_scenario(
+            target_policy_names=["policy_worktree_profile.v1.json"],
+        )
+        target = tmp_path / "x.json"
+        self._write(target, bad)
+        with pytest.raises(ScenarioValidationError):
+            load_scenario_file(target)
+
+    def test_combined_without_target_names_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        bad = _valid_scenario(kind="combined")
+        del bad["target_policy_name"]
+        target = tmp_path / "x.json"
+        self._write(target, bad)
+        with pytest.raises(ScenarioValidationError):
+            load_scenario_file(target)
+
+    def test_invalid_scenario_id_pattern(self, tmp_path: Path) -> None:
+        bad = _valid_scenario(scenario_id="Bad-ID-With-Caps")
+        target = tmp_path / "x.json"
+        self._write(target, bad)
+        with pytest.raises(ScenarioValidationError):
+            load_scenario_file(target)
+
+    def test_invalid_decision_expected_enum(self, tmp_path: Path) -> None:
+        bad = _valid_scenario()
+        bad["expected_baseline"]["decision_expected"] = "maybe"
+        target = tmp_path / "x.json"
+        self._write(target, bad)
+        with pytest.raises(ScenarioValidationError):
+            load_scenario_file(target)
+
+    def test_additional_properties_rejected(self, tmp_path: Path) -> None:
+        bad = _valid_scenario(unknown_field="extra")
+        target = tmp_path / "x.json"
+        self._write(target, bad)
+        with pytest.raises(ScenarioValidationError):
+            load_scenario_file(target)
+
+
+class TestLoadScenariosFromDir:
+    def test_loads_sorted(self, tmp_path: Path) -> None:
+        for sid in ("zebra", "alpha", "mango"):
+            doc = _valid_scenario(scenario_id=sid)
+            (tmp_path / f"{sid}.json").write_text(
+                json.dumps(doc), encoding="utf-8"
+            )
+        scenarios = load_scenarios_from_dir(tmp_path)
+        assert [s.scenario_id for s in scenarios] == ["alpha", "mango", "zebra"]
+
+    def test_empty_dir_returns_empty(self, tmp_path: Path) -> None:
+        assert load_scenarios_from_dir(tmp_path) == ()
+
+
+class TestScenarioModel:
+    def test_frozen_dataclasses(self) -> None:
+        inputs = ScenarioInputs(adapter_manifest_ref="codex-stub")
+        with pytest.raises(Exception):  # FrozenInstanceError
+            inputs.adapter_manifest_ref = "other"  # type: ignore[misc]
+
+        expected = ExpectedBaseline(decision_expected="allow")
+        with pytest.raises(Exception):
+            expected.decision_expected = "deny"  # type: ignore[misc]
+
+        scenario = Scenario(
+            scenario_id="x",
+            kind="executor_primitive",
+            inputs=inputs,
+            expected_baseline=expected,
+        )
+        with pytest.raises(Exception):
+            scenario.scenario_id = "y"  # type: ignore[misc]
+
+        scenario_set = ScenarioSet(scenarios=(scenario,))
+        assert scenario_set.name == "default"
+        assert scenario_set.version == "v1"
+        with pytest.raises(Exception):
+            scenario_set.name = "other"  # type: ignore[misc]
+
+    def test_default_governance_policy_action_optional(
+        self, tmp_path: Path
+    ) -> None:
+        """governance_policy scenarios can omit adapter_manifest_ref
+        (set to null) and still validate."""
+        doc = _valid_scenario(
+            scenario_id="gov_no_adapter",
+            kind="governance_policy",
+            target_policy_name="policy_autonomy.v1.json",
+            inputs={
+                "adapter_manifest_ref": None,
+                "parent_env": {},
+                "requested_command": None,
+                "requested_cwd": None,
+                "action": "SOME_ACTION",
+            },
+            expected_baseline={
+                "violations_expected": [],
+                "decision_expected": "allow",
+            },
+        )
+        target = tmp_path / "x.json"
+        target.write_text(json.dumps(doc), encoding="utf-8")
+        scenario = load_scenario_file(target)
+        assert scenario.inputs.adapter_manifest_ref is None
+        assert scenario.inputs.action == "SOME_ACTION"

--- a/tests/test_policy_sim_simulator.py
+++ b/tests/test_policy_sim_simulator.py
@@ -12,7 +12,6 @@ import pytest
 from ao_kernel import config as _config
 from ao_kernel.policy_sim import (
     BaselineSource,
-    DiffReport,
     ScenarioSet,
     SimulationResult,
     canonical_policy_hash,

--- a/tests/test_policy_sim_simulator.py
+++ b/tests/test_policy_sim_simulator.py
@@ -377,6 +377,61 @@ class TestSimulatePolicyChange:
         )
         assert report.host_fs_dependent is True
 
+    def test_combined_kind_splits_targets(self, tmp_path: Path) -> None:
+        """Combined scenarios evaluate executor primitive against
+        the worktree target AND governance primitive against the
+        autonomy target in the same pass (plan v3 bulgu 1 + iter-2
+        multi-target absorb)."""
+        from ao_kernel.policy_sim.scenario import (
+            ExpectedBaseline,
+            Scenario,
+            ScenarioInputs,
+        )
+
+        combined = Scenario(
+            scenario_id="combined_smoke",
+            kind="combined",
+            inputs=ScenarioInputs(
+                adapter_manifest_ref="codex-stub",
+                parent_env={"PATH": "/usr/bin"},
+                action="AUTONOMY_UNKNOWN_INTENT",
+            ),
+            expected_baseline=ExpectedBaseline(decision_expected="deny"),
+            target_policy_names=(
+                "policy_worktree_profile.v1.json",
+                "policy_autonomy.v1.json",
+            ),
+        )
+
+        # Proposed autonomy allows the intent → governance flips.
+        proposed = {
+            "policy_autonomy.v1.json": {
+                "version": "v1",
+                "intents": {"AUTONOMY_UNKNOWN_INTENT": {"mode": "allow"}},
+                "defaults": {"mode": "allow"},
+            }
+        }
+        report = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=[combined],
+            proposed_policies=proposed,
+        )
+        assert report.scenarios_evaluated == 1
+
+        # Both target policies must appear in the baseline + proposed
+        # hash maps — the preload fix from absorb iter-2 ensures
+        # secondary targets are materialised.
+        assert (
+            "policy_worktree_profile.v1.json" in report.baseline_policy_hashes
+        )
+        assert "policy_autonomy.v1.json" in report.baseline_policy_hashes
+        assert "policy_autonomy.v1.json" in report.proposed_policy_hashes
+        # Proposed autonomy differs from bundled → hashes diverge.
+        assert (
+            report.baseline_policy_hashes["policy_autonomy.v1.json"]
+            != report.proposed_policy_hashes["policy_autonomy.v1.json"]
+        )
+
     def test_scenario_adapter_missing_raises(self, tmp_path: Path) -> None:
         """Synthesise a scenario referencing an adapter the
         snapshot has never seen."""

--- a/tests/test_policy_sim_simulator.py
+++ b/tests/test_policy_sim_simulator.py
@@ -1,0 +1,433 @@
+"""Tests for ``ao_kernel.policy_sim`` C3 — simulator + diff + loader
+(PR-B4 plan v3 §2.3/§2.4/§2.5)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ao_kernel import config as _config
+from ao_kernel.policy_sim import (
+    BaselineSource,
+    DiffReport,
+    ScenarioSet,
+    SimulationResult,
+    canonical_policy_hash,
+    dump_json,
+    load_bundled_scenarios,
+    policy_override_context,
+    simulate_policy_change,
+    validate_proposed_policy,
+)
+from ao_kernel.policy_sim.diff import (
+    compute_transition,
+    compute_violation_diff,
+    make_scenario_delta,
+)
+from ao_kernel.policy_sim.errors import (
+    ProposedPolicyInvalidError,
+    ScenarioAdapterMissingError,
+)
+from ao_kernel.policy_sim.loader import resolve_target_policy
+
+
+# --- Canonical policy hash --------------------------------------------
+
+
+class TestCanonicalPolicyHash:
+    def test_deterministic(self) -> None:
+        policy = {"a": 1, "b": [2, 3], "c": {"d": "x"}}
+        assert canonical_policy_hash(policy) == canonical_policy_hash(policy)
+
+    def test_key_order_irrelevant(self) -> None:
+        """Canonical sort_keys → same hash regardless of insertion order."""
+        p1 = {"b": 2, "a": 1}
+        p2 = {"a": 1, "b": 2}
+        assert canonical_policy_hash(p1) == canonical_policy_hash(p2)
+
+    def test_different_inputs_differ(self) -> None:
+        assert canonical_policy_hash({"a": 1}) != canonical_policy_hash(
+            {"a": 2}
+        )
+
+    def test_prefix(self) -> None:
+        h = canonical_policy_hash({"x": "y"})
+        assert h.startswith("sha256:")
+        assert len(h) == len("sha256:") + 64
+
+
+# --- Transition classification ----------------------------------------
+
+
+class TestComputeTransition:
+    def _result(
+        self, decision: str, violations: tuple[str, ...] = ()
+    ) -> SimulationResult:
+        return SimulationResult(
+            scenario_id="x",
+            decision=decision,  # type: ignore[arg-type]
+            violation_kinds=violations,
+        )
+
+    def test_allow_to_allow(self) -> None:
+        assert (
+            compute_transition(self._result("allow"), self._result("allow"))
+            == "allow_to_allow"
+        )
+
+    def test_allow_to_deny(self) -> None:
+        assert (
+            compute_transition(self._result("allow"), self._result("deny"))
+            == "allow_to_deny"
+        )
+
+    def test_deny_to_allow(self) -> None:
+        assert (
+            compute_transition(self._result("deny"), self._result("allow"))
+            == "deny_to_allow"
+        )
+
+    def test_deny_to_deny(self) -> None:
+        assert (
+            compute_transition(self._result("deny"), self._result("deny"))
+            == "deny_to_deny"
+        )
+
+    def test_baseline_error(self) -> None:
+        assert (
+            compute_transition(self._result("error"), self._result("allow"))
+            == "error"
+        )
+
+    def test_proposed_error(self) -> None:
+        assert (
+            compute_transition(self._result("allow"), self._result("error"))
+            == "error"
+        )
+
+
+class TestComputeViolationDiff:
+    def test_added(self) -> None:
+        base = SimulationResult(scenario_id="x", decision="allow")
+        prop = SimulationResult(
+            scenario_id="x", decision="deny", violation_kinds=("new_code",)
+        )
+        diff = compute_violation_diff(base, prop)
+        assert diff.added == frozenset({"new_code"})
+        assert diff.removed == frozenset()
+
+    def test_removed(self) -> None:
+        base = SimulationResult(
+            scenario_id="x", decision="deny", violation_kinds=("old_code",)
+        )
+        prop = SimulationResult(scenario_id="x", decision="allow")
+        diff = compute_violation_diff(base, prop)
+        assert diff.added == frozenset()
+        assert diff.removed == frozenset({"old_code"})
+
+    def test_symmetric_difference(self) -> None:
+        base = SimulationResult(
+            scenario_id="x",
+            decision="deny",
+            violation_kinds=("a", "b"),
+        )
+        prop = SimulationResult(
+            scenario_id="x",
+            decision="deny",
+            violation_kinds=("b", "c"),
+        )
+        diff = compute_violation_diff(base, prop)
+        assert diff.added == frozenset({"c"})
+        assert diff.removed == frozenset({"a"})
+
+
+class TestMakeScenarioDelta:
+    def test_notable_on_transition_change(self) -> None:
+        base = SimulationResult(scenario_id="x", decision="allow")
+        prop = SimulationResult(
+            scenario_id="x", decision="deny", violation_kinds=("v",)
+        )
+        delta = make_scenario_delta(
+            scenario_id="x",
+            target_policy_name="p.json",
+            baseline=base,
+            proposed=prop,
+        )
+        assert delta.notable
+        assert delta.transition == "allow_to_deny"
+
+    def test_not_notable_on_identity(self) -> None:
+        base = SimulationResult(scenario_id="x", decision="allow")
+        prop = SimulationResult(scenario_id="x", decision="allow")
+        delta = make_scenario_delta(
+            scenario_id="x",
+            target_policy_name="p.json",
+            baseline=base,
+            proposed=prop,
+        )
+        assert delta.notable is False
+
+
+# --- Shape-registry-backed validator ----------------------------------
+
+
+class TestValidateProposedPolicy:
+    def _worktree_policy(self, **overrides: Any) -> dict[str, Any]:
+        base: dict[str, Any] = {
+            "version": "v1",
+            "enabled": True,
+            "worktree": {},
+            "env_allowlist": {"allowed_keys": []},
+            "secrets": {"exposure_modes": []},
+            "command_allowlist": {"prefixes": []},
+            "cwd_confinement": {"allowed_prefixes": []},
+            "evidence_redaction": {"patterns": []},
+            "rollout": {},
+        }
+        base.update(overrides)
+        return base
+
+    def test_valid_passes(self) -> None:
+        # Well-formed policy must not raise; validator returns
+        # None on success, ProposedPolicyInvalidError otherwise.
+        result = validate_proposed_policy(
+            "policy_worktree_profile.v1.json", self._worktree_policy()
+        )
+        assert result is None
+
+    def test_missing_top_key_raises(self) -> None:
+        bad = self._worktree_policy()
+        del bad["env_allowlist"]
+        with pytest.raises(ProposedPolicyInvalidError):
+            validate_proposed_policy(
+                "policy_worktree_profile.v1.json", bad
+            )
+
+    def test_wrong_type_raises(self) -> None:
+        bad = self._worktree_policy()
+        bad["env_allowlist"] = {"allowed_keys": "not_a_list"}
+        with pytest.raises(ProposedPolicyInvalidError):
+            validate_proposed_policy(
+                "policy_worktree_profile.v1.json", bad
+            )
+
+    def test_unknown_policy_name_passes_through(self) -> None:
+        """No registry entry → no structural checks (schema gate
+        is authoritative for those). Validator returns None."""
+        result = validate_proposed_policy(
+            "policy_unknown.v1.json", {"arbitrary": True}
+        )
+        assert result is None
+
+
+# --- policy_override_context monkey-patch -----------------------------
+
+
+class TestPolicyOverrideContext:
+    def test_patches_and_restores(self) -> None:
+        original = _config.load_with_override
+        with policy_override_context({"policy_x.v1.json": {"custom": 1}}):
+            result = _config.load_with_override(
+                "policies", "policy_x.v1.json"
+            )
+            assert result == {"custom": 1}
+        assert _config.load_with_override is original
+
+    def test_falls_through_for_unpatched_names(self) -> None:
+        """Policies not in the override set reach the original loader."""
+        seen: list[tuple[str, str]] = []
+
+        def _fake(
+            resource_type: str, filename: str, workspace: Any = None
+        ) -> dict[str, Any]:
+            seen.append((resource_type, filename))
+            return {"from_real": filename}
+
+        original = _config.load_with_override
+        _config.load_with_override = _fake  # type: ignore[assignment]
+        try:
+            with policy_override_context(
+                {"override_one.v1.json": {"patched": True}}
+            ):
+                assert _config.load_with_override(
+                    "policies", "other.v1.json"
+                ) == {"from_real": "other.v1.json"}
+                assert _config.load_with_override(
+                    "policies", "override_one.v1.json"
+                ) == {"patched": True}
+        finally:
+            _config.load_with_override = original  # type: ignore[assignment]
+        assert ("policies", "other.v1.json") in seen
+
+    def test_exception_still_restores(self) -> None:
+        original = _config.load_with_override
+        with pytest.raises(RuntimeError):
+            with policy_override_context({"p.v1.json": {}}):
+                raise RuntimeError("boom")
+        assert _config.load_with_override is original
+
+
+# --- resolve_target_policy --------------------------------------------
+
+
+class TestResolveTargetPolicy:
+    def test_bundled_fallback(self) -> None:
+        p = resolve_target_policy(
+            policy_name="policy_autonomy.v1.json",
+            scenario_id="x",
+            proposed_policies={},
+            baseline_source=BaselineSource.BUNDLED,
+            baseline_overrides=None,
+        )
+        # Bundled autonomy policy is a dict (schema-valid).
+        assert isinstance(p, dict)
+
+    def test_explicit_wins(self) -> None:
+        explicit = {"policy_autonomy.v1.json": {"from": "explicit"}}
+        p = resolve_target_policy(
+            policy_name="policy_autonomy.v1.json",
+            scenario_id="x",
+            proposed_policies={},
+            baseline_source=BaselineSource.EXPLICIT,
+            baseline_overrides=explicit,
+        )
+        assert p == {"from": "explicit"}
+
+
+# --- simulate_policy_change end-to-end --------------------------------
+
+
+class TestSimulatePolicyChange:
+    def test_bundled_smoke(self, tmp_path: Path) -> None:
+        report = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=load_bundled_scenarios(),
+            proposed_policies={},
+        )
+        assert report.scenarios_evaluated == 3
+        # Proposed defaults to baseline when absent → identity transitions.
+        for delta in report.deltas:
+            assert delta.transition in {
+                "allow_to_allow",
+                "deny_to_deny",
+                "error",
+            }
+            assert delta.notable is False
+
+    def test_proposed_differing_triggers_notable(self, tmp_path: Path) -> None:
+        """Shove a clearly different policy for autonomy and the
+        governance_policy scenario should flip."""
+        scenarios = load_bundled_scenarios()
+        # Baseline autonomy blocks AUTONOMY_UNKNOWN_INTENT → deny.
+        # Proposed: policy with explicit allow for the intent.
+        proposed = {
+            "policy_autonomy.v1.json": {
+                "version": "v1",
+                "intents": ["AUTONOMY_UNKNOWN_INTENT"],
+                "defaults": {"mode": "allow"},
+            }
+        }
+        report = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=scenarios,
+            proposed_policies=proposed,
+        )
+        # Either the autonomy scenario flips or it stays deny — the
+        # shape-registry validator must have accepted the proposed
+        # dict (required keys + type contracts satisfied).
+        assert report.scenarios_evaluated == 3
+        proposed_hashes = dict(report.proposed_policy_hashes)
+        assert "policy_autonomy.v1.json" in proposed_hashes
+
+    def test_structural_invalid_proposed_raises(self, tmp_path: Path) -> None:
+        proposed = {
+            "policy_worktree_profile.v1.json": {
+                "version": "v1",
+                # Missing all the other required top-level keys.
+            }
+        }
+        with pytest.raises(ProposedPolicyInvalidError):
+            simulate_policy_change(
+                project_root=tmp_path,
+                scenarios=load_bundled_scenarios(),
+                proposed_policies=proposed,
+            )
+
+    def test_scenario_set_accepted(self, tmp_path: Path) -> None:
+        scenario_set = ScenarioSet(scenarios=load_bundled_scenarios())
+        report = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=scenario_set,
+            proposed_policies={},
+        )
+        assert report.scenarios_evaluated == 3
+
+    def test_host_fs_dependent_flag_propagated(self, tmp_path: Path) -> None:
+        """The report must echo ``include_host_fs_probes`` into
+        ``host_fs_dependent`` even though validate_command itself
+        is deferred for v1."""
+        report = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=load_bundled_scenarios(),
+            proposed_policies={},
+            include_host_fs_probes=True,
+        )
+        assert report.host_fs_dependent is True
+
+    def test_scenario_adapter_missing_raises(self, tmp_path: Path) -> None:
+        """Synthesise a scenario referencing an adapter the
+        snapshot has never seen."""
+        from ao_kernel.policy_sim.scenario import (
+            ExpectedBaseline,
+            Scenario,
+            ScenarioInputs,
+        )
+
+        bogus = Scenario(
+            scenario_id="bogus",
+            kind="executor_primitive",
+            inputs=ScenarioInputs(
+                adapter_manifest_ref="no-such-adapter-anywhere",
+            ),
+            expected_baseline=ExpectedBaseline(decision_expected="allow"),
+            target_policy_name="policy_worktree_profile.v1.json",
+        )
+        with pytest.raises(ScenarioAdapterMissingError):
+            simulate_policy_change(
+                project_root=tmp_path,
+                scenarios=[bogus],
+                proposed_policies={},
+            )
+
+
+# --- DiffReport serialisation -----------------------------------------
+
+
+class TestDiffReportSerialisation:
+    def test_to_dict_is_json_serialisable(self, tmp_path: Path) -> None:
+        report = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=load_bundled_scenarios(),
+            proposed_policies={},
+        )
+        payload = report.to_dict()
+        # Roundtrip through json.dumps/json.loads; no TypeError.
+        encoded = json.dumps(payload, sort_keys=True)
+        roundtripped = json.loads(encoded)
+        assert (
+            roundtripped["scenarios_evaluated"]
+            == report.scenarios_evaluated
+        )
+
+    def test_dump_json_stable(self, tmp_path: Path) -> None:
+        report = simulate_policy_change(
+            project_root=tmp_path,
+            scenarios=load_bundled_scenarios(),
+            proposed_policies={},
+        )
+        a = dump_json(report)
+        b = dump_json(report)
+        assert a == b

--- a/tests/test_policy_sim_simulator.py
+++ b/tests/test_policy_sim_simulator.py
@@ -431,6 +431,20 @@ class TestSimulatePolicyChange:
             report.baseline_policy_hashes["policy_autonomy.v1.json"]
             != report.proposed_policy_hashes["policy_autonomy.v1.json"]
         )
+        # Combined decision semantics (iter-3 blocker absorb):
+        # baseline autonomy denies AUTONOMY_UNKNOWN_INTENT → deny;
+        # proposed autonomy allows it → allow. Combined kind must
+        # reflect the governance flip despite the executor primitive
+        # returning allow in both cases.
+        delta = report.deltas[0]
+        assert delta.scenario_id == "combined_smoke"
+        assert delta.transition == "deny_to_allow"
+        assert delta.baseline.decision == "deny"
+        assert delta.proposed.decision == "allow"
+        # Proposed has no violation_kinds when check_policy returned
+        # allowed=True — informational `POLICY_PASSED` stays out of
+        # the aggregator input.
+        assert delta.proposed.violation_kinds == ()
 
     def test_scenario_adapter_missing_raises(self, tmp_path: Path) -> None:
         """Synthesise a scenario referencing an adapter the

--- a/tests/test_policy_sim_simulator.py
+++ b/tests/test_policy_sim_simulator.py
@@ -326,7 +326,7 @@ class TestSimulatePolicyChange:
         proposed = {
             "policy_autonomy.v1.json": {
                 "version": "v1",
-                "intents": ["AUTONOMY_UNKNOWN_INTENT"],
+                "intents": {"AUTONOMY_UNKNOWN_INTENT": {"mode": "allow"}},
                 "defaults": {"mode": "allow"},
             }
         }


### PR DESCRIPTION
## Summary

**FAZ-B Tranche B 4/9 — policy simulation harness.** `ao_kernel.policy_sim` runs dry-run evaluations of proposed policy changes against scenario fixtures using `governance.check_policy` + the executor's policy primitives, all under a 24-sentinel purity guard that fail-closes on any side effect (evidence emit, worktree creation, subprocess spawn, filesystem write, network I/O, tempfile allocation, `importlib.resources.as_file` extraction).

- New `ao_kernel.policy_sim/` public package: 9 typed errors, 24-sentinel `pure_execution_context`, policy shape registry, scenario model + bundled fixtures, simulator + diff + loader, reporter + CLI handler.
- New CLI surface `ao-kernel policy-sim run` with JSON + text formats, atomic `--output`, per-scenario `target_policy_name`, `BaselineSource` enum (BUNDLED | WORKSPACE_OVERRIDE | EXPLICIT), `--enable-host-fs-probes` opt-in. Exit codes: 0 (success), 1 (user error), 2 (internal), 3 (tightening detected).
- Bundled JSON scenarios: `adapter_http_with_secret.v1.json`, `autonomy_unknown_intent.v1.json`, `path_poisoned_python.v1.json` + manifest.
- New `docs/POLICY-SIM.md` + CHANGELOG entry.

### Adversarial review
- **Plan-time** (Codex CNS-20260418-038): v1 → v3 across 3 iterations — AGREE (ready_for_impl=true).
- **Post-impl** (Codex thread 019d9e1b): REVISE → PARTIAL → PARTIAL → **AGREE** over 4 iterations. Absorbed blockers (shape registry intents type contract, loader `project_root` + fail-closed triage, simulator `project_root` propagation, combined kind target split + preload, governance `allowed=True` POLICY_PASSED leak) plus metin + test coverage warnings.

### Commit DAG
- `10503dd` C1 — errors + 24-sentinel purity guard + shape registry + scenario schema + 34 purity tests
- `d62121b` C2 — scenario model + 3 bundled JSON + 16 tests
- `5361dc1` C3 — simulator + diff + loader + 32 integration tests
- `14261e6` C4 — reporter + CLI handler + 17 CLI tests
- `2615faa` C5 — docs/POLICY-SIM.md + CHANGELOG + 6 integration tests
- `3bc0ad8` post-impl iter-1 absorb (4 blockers + 4 warnings)
- `d2da60b` post-impl iter-2 absorb (combined preload + text sync + test)
- `b77984d` post-impl iter-3 absorb (combined governance decision semantics)

### Test coverage
- Full suite: **2135 passed / 0 failures** (pre-B4 baseline 2029 + 106 new policy-sim tests).
- Policy-sim: 106 tests across purity (34), scenarios (16), simulator (33 incl. new combined-decision test), CLI (17), integration (6).

### Locked invariants
- Purity guard NOT re-entrant; originals always restored in `finally`.
- Adapter snapshot pre-captured outside purity context; bundled `codex-stub` etc. remain discoverable.
- `_KINDS == 27` preserved (`executor/evidence_emitter.py:46`) — simulator emits zero new evidence kinds.
- Canonical policy hash bytes align with `executor/artifacts.py` (sort_keys + ensure_ascii=False + (",",":") + UTF-8 + SHA-256).
- JSON-only v1 — `.yaml` rejected at load (scenario loader + dir-glob).
- Loader fail-closed: `FileNotFoundError` → bundled fallback; `JSONDecodeError`/`ValidationError` propagate.
- Combined kind now supports multi-target split (worktree → executor primitive; others → governance_policy).
- `governance.check_policy` `allowed=True` reason_codes do NOT leak as `violation_kinds`.

## Test plan
- [ ] CI green (ruff + mypy + pytest matrix on py311/312/313)
- [ ] Manual smoke: `ao-kernel policy-sim run --proposed-policies <dir>` round-trip with bundled scenarios
- [ ] Verify exit code 3 surfaces on a deliberately-tightening proposed policy
- [ ] Verify `--baseline-source workspace_override` picks up `<project_root>/.ao/policies/` overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)