### PR TITLE
release(v3.2.0): FAZ-B ops hardening — 10 PRs / 2141 tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [3.2.0] — 2026-04-18
+
+**FAZ-B — Ops Hardening**: 10 PRs landed across 6 workstreams
+(agent coordination, cost runtime + routing, policy ops,
+observability, AI workflow steps, quality gate). Public test
+count 2141 (2135 main suite + 6 benchmark scenarios). Zero
+production code change in PR-B7; tests + CI + docs only.
+
+**Governance highlights**:
+- Adversarial plan-time review via Codex across every PR
+  (19 total iterations across B0-B7 plan-time + 14 across
+  post-impl). Each verdict + absorb cycle captured in
+  `.claude/plans/*.md` and `.ao/consultations/`.
+- Post-impl Codex review adopted as a second quality gate
+  before PR push (feedback_post_impl_review memory rule).
+- Branch protection: `enforce_admins=false` made permanent
+  (owner admin-bypass merge) after confirming CI gates (lint,
+  typecheck, 3.11/3.12/3.13 pytest matrix, coverage, extras-
+  install, benchmark-fast) are the actual ship contract.
+
+**Shipped workstreams**:
+
+- **Agent coordination (B1)**: `ao_kernel.coordination/` —
+  lease / fencing / takeover. 5 plan-iter + runtime hardening.
+- **Cost runtime + routing (B2, B2-e2e, B3)**:
+  `ao_kernel.cost/` price catalog + spend ledger +
+  `governed_call` wrapper; `cost-aware routing` via
+  `routing_by_cost.priority="lowest_cost"`; tuple-partition
+  helper + drop-if-any-known / fallback-if-none-known; new
+  `RoutingCatalogMissingError(CostTrackingError)`.
+- **Policy simulation (B4)**: `ao_kernel.policy_sim/` dry-run
+  harness with 24-sentinel purity guard, centralised shape
+  registry, canonical policy hash matching
+  `executor/artifacts.py`, and `ao-kernel policy-sim run` CLI.
+- **Metrics export (B5)**: `ao_kernel.metrics/` +
+  `[metrics]` optional extra shipping eight Prometheus metric
+  families derived from evidence; `ao-kernel metrics
+  {export,debug-query}` CLI; cumulative-only textfile
+  semantics; cost-disjunction + dormant banner policies.
+- **AI workflow steps (B6)**: thin-driver `review_ai_flow`
+  + `commit_ai_flow` runtimes with driver-owned capability
+  artifact materialisation (`step_record.capability_output_refs`)
+  + new `output_parse` contract on adapter manifests.
+- **Quality gate (B7)**: `tests/benchmarks/` regression suite
+  with mock transport (`invoke_cli`/`invoke_http` patch at
+  executor's local alias) + `governed_review` (bundled
+  workflow) + `governed_bugfix` (bench variant; full bundled
+  flow deferred to B7.1 pending git/pytest sandbox allowlist).
+
 ### Added — FAZ-B PR-B7 (agent benchmark / regression suite)
 
 **FAZ-B Tranche B 7/9 — `tests/benchmarks/` harness running

--- a/ao_kernel/__init__.py
+++ b/ao_kernel/__init__.py
@@ -1,6 +1,6 @@
 """ao-kernel — Governed AI orchestration runtime."""
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 from ao_kernel.client import AoKernelClient
 from ao_kernel.config import load_default, load_with_override, workspace_root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ao-kernel"
-version = "3.1.0"
+version = "3.2.0"
 description = "Governed AI orchestration runtime — policy-driven, fail-closed, evidence-trail"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_pr_a6_features.py
+++ b/tests/test_pr_a6_features.py
@@ -91,9 +91,9 @@ class TestLlmFallback:
 
 
 class TestVersionBump:
-    def test_version_is_3_1_0(self) -> None:
+    def test_version_is_3_2_0(self) -> None:
         import ao_kernel
-        assert ao_kernel.__version__ == "3.1.0"
+        assert ao_kernel.__version__ == "3.2.0"
 
     def test_pyproject_version_matches(self) -> None:
         import tomllib
@@ -102,7 +102,7 @@ class TestVersionBump:
             pyproject = Path(__file__).parent.parent / "pyproject.toml"
         with open(pyproject, "rb") as f:
             data = tomllib.load(f)
-        assert data["project"]["version"] == "3.1.0"
+        assert data["project"]["version"] == "3.2.0"
 
 
 class TestMetaExtras:


### PR DESCRIPTION
## Summary

**Release bump: v3.1.0 → v3.2.0** after FAZ-B tranche complete.

### FAZ-B landed (10 PRs)
- **#96 B0** foundation — schemas + docs + dormant policies
- **#97 B1** coordination runtime (lease / fencing / takeover)
- **#98** pre-B2 docfix (stale_after + OTEL scope)
- **#99 B2** cost runtime (price catalog + spend ledger + `governed_call`)
- **#100** B2 E2E (CNS-032 post-merge)
- **#101 B6** review / commit AI workflow runtime
- **#102 B5** metrics export (Prometheus textfile + `[metrics]` extra)
- **#103 B3** cost-aware routing (catalog-backed provider selection)
- **#104 B4** policy simulation harness (24-sentinel purity guard)
- **#105 B7** benchmark suite (governed_review + governed_bugfix)

### Release contents
- `pyproject.toml` `version = "3.2.0"` (`eba0ebe`)
- `CHANGELOG.md` `[Unreleased]` → `[3.2.0] — 2026-04-18` with six-workstream narrative (`2669e1e`)
- No production code change in this PR — version metadata + release notes only.

### Test plan
- [ ] CI green (lint + typecheck + py3.11/3.12/3.13 pytest + coverage + extras-install + benchmark-fast)
- [ ] Tag `v3.2.0` push after merge → `.github/workflows/publish.yml` → PyPI OIDC trusted publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)