### PR TITLE
feat(pr-b7.1): benchmark cost_usd shim + docs §9 recipe + FAZ-C routing

### DIFF
--- a/.claude/plans/PR-B7.1-DRAFT-PLAN.md
+++ b/.claude/plans/PR-B7.1-DRAFT-PLAN.md
@@ -1,0 +1,254 @@
+# PR-B7.1 Implementation Plan v2 — Minimal Follow-up
+
+**Minor release adayı v3.2.1. B7 v1 deferred item'larının 3'ü; 2 büyük item FAZ-C'ye taşındı.**
+
+**Head SHA**: `ca361f2` (v3.2.0). Base: `main`. Active branch: `claude/tranche-b-pr-b7.1`.
+
+---
+
+## v2 absorb summary (Codex CNS-20260418-040 iter-1 REVISE — 5 blocker + 5 warning)
+
+Codex v1 planını 5 katmanda runtime gap tespit etti. Savunulabilir scope: sadece **runtime LOC=0** tutulan dokümantasyon + benchmark-only shim işleri. Runtime integration gerektiren iki büyük item (full bundled bugfix + real full mode) **FAZ-C scope'una** taşındı.
+
+| # | v1 bulgu | v2 karar |
+|---|---|---|
+| B1 | Bundled `bug_fix_flow` E2E: `_load_pending_patch_content()` `record.intent.payload.patches[step_name]`'den okuyor; seed düz string geçiyor → patch plumbing runtime integration gap | **FAZ-C'ye taşındı** (PR-C1 adayı: patch plumbing + input_envelope + policy_loader injection birlikte ele alınır) |
+| B2 | Bench policy override file'ı etkisiz — `build_driver` Executor'a `policy_loader` vermez; bundled kullanılır | **FAZ-C'ye taşındı** (bench policy injection = Executor surface değişikliği) |
+| B3 | `cost_usd` reconcile **B2 gap gerçek** — adapter transport sadece `time_seconds`; cost_usd yalnız `governed_call` → `post_response_reconcile` hattında | **v2 scope içi — benchmark-only shim** (açıkça mock-katmanı olarak etiketli; runtime gap labeled) |
+| B4 | Full mode input_envelope gap: Executor `task_prompt+run_id` veriyor; manifestler `context_pack_ref` bekliyor; secret flow `env_allowlist` değil `secrets.allowlist_secret_ids + exposure_modes=['env']` | **FAZ-C'ye taşındı** (secret flow + input_envelope builder'ı FAZ-C'de ele alınır) |
+| B5 | Full-mode env namespace `AO_BENCHMARK_GH_TOKEN` manifest parity DEĞİL — gerçek `GH_TOKEN` / `ANTHROPIC_API_KEY` contract | **FAZ-C'ye taşındı** (B4 ile birlikte) |
+
+### v2 absorb warnings
+
+| # | v1 warning | v2 karar |
+|---|---|---|
+| W1 | cf8b30e zaten missing-payload testi unskip + docs §3.2 pin etmiş | C3 → sadece CHANGELOG note (yeni behavior yok; temizlik) |
+| W2 | "CI auto-picks up" mekanizması = pytest discovery; özel glob yok | Recipe §9 wording "pytest discovery otomatik bulur" olarak netleşir |
+| W3 | ci_pytest happy-path için dummy `test_smoke.py` gerekliliği — ancak B7.1 v2'de full bugfix drop edildiğinden moot | Moot (full bugfix FAZ-C) |
+| W4 | gh-cli-pr pr_url assertion convenience, contract değil | Moot (full bugfix FAZ-C) |
+| W5 | Bundled worktree policy zaten git/python/pytest içerir; asıl blocker patch plumbing + env flow | Moot (full bugfix FAZ-C) |
+
+### Codex Q answers → v2 kararlar
+
+- **Q1** (record_spend shim vs integration): Benchmark-only shim, clearly labeled comment + docstring.
+- **Q2** (policy override file vs inline): Moot — full bugfix FAZ-C.
+- **Q3** (full-mode CI): Moot — full mode FAZ-C.
+- **Q4** (env namespace): Moot — full mode FAZ-C.
+
+---
+
+## 1. Amaç (v2 daralmış)
+
+B7 v1 "deferred" etiketlerinin **docs-level** temizliği + benchmark harness'in `cost_usd` axis drain'i **mock-layer shim** ile ispatlanabilir hale getirilmesi:
+
+| # | Item | Scope | LOC |
+|---|---|---|---|
+| 1 | `cost_usd` benchmark-only reconcile shim | Mock dispatcher `cost_actual.cost_usd` → run_state budget axis `.remaining` decrement; benchmark-only labeled | ~80 |
+| 2 | Walker contract docs pin | cf8b30e absorb'un final note'u CHANGELOG'da | ~20 |
+| 3 | New-scenario recipe | `docs/BENCHMARK-SUITE.md §9` step-by-step 6 adım | ~100 |
+
+### Kapsam özeti
+
+- `tests/benchmarks/mock_transport.py` — shim: envelope `cost_actual.cost_usd` → state.v1.json `budget.cost_usd.remaining` decrement (after dispatcher return, before _cli_dispatcher tuple return).
+- `tests/benchmarks/assertions.py` — `assert_cost_consumed(run_state, axis, min_consumed=0.0)` helper.
+- `tests/benchmarks/test_governed_review.py` — `TestCostReconcile` class (1 happy test).
+- `docs/BENCHMARK-SUITE.md` — §9 recipe + §8.3 "deferred" list update (FAZ-C items explicit).
+- `CHANGELOG.md` — `[Unreleased]` PR-B7.1 entry.
+
+- Yeni evidence kind: **0**.
+- Yeni core dep: 0.
+- **Runtime LOC: 0** (benchmark harness + docs only; shim clearly label'ed "benchmark-only").
+
+---
+
+## 2. Scope İçi
+
+### 2.1 `cost_usd` benchmark-only shim (`mock_transport.py`)
+
+**Codex B3 absorb**: B2 integration gap explicit. Mock dispatcher envelope'un `cost_actual.cost_usd` alanını okur; `run_state.v1.json` budget `cost_usd` axis `remaining`'ini decrement eder.
+
+```python
+# tests/benchmarks/mock_transport.py — extension inside _cli_dispatcher
+def _maybe_consume_budget(
+    workspace_root: Path,
+    run_id: str,
+    envelope: Mapping[str, Any],
+) -> None:
+    """BENCHMARK-ONLY SHIM. Real cost_usd reconcile path lives in
+    ao_kernel.cost.middleware.post_response_reconcile, which is
+    only called from ao_kernel.llm.governed_call. The adapter
+    transport path (invoke_cli/invoke_http) does not reconcile
+    cost_usd — only time_seconds. Until that integration gap is
+    closed (FAZ-C), this shim is what lets benchmark assertions
+    observe cost_usd drain."""
+    cost_usd = (envelope.get("cost_actual") or {}).get("cost_usd")
+    if cost_usd is None:
+        return
+    state_path = workspace_root / ".ao" / "runs" / run_id / "state.v1.json"
+    if not state_path.is_file():
+        return
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    axis = (state.get("budget") or {}).get("cost_usd")
+    if not isinstance(axis, dict):
+        return
+    remaining = float(axis.get("remaining", 0.0)) - float(cost_usd)
+    axis["remaining"] = max(0.0, remaining)
+    state["revision"] = run_revision(state)
+    state_path.write_text(
+        json.dumps(state, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+```
+
+**Test**: `tests/benchmarks/test_governed_review.py::TestCostReconcile::test_cost_usd_drained`.
+
+### 2.2 Walker contract CHANGELOG pin
+
+cf8b30e post-impl absorb'u `docs/BENCHMARK-SUITE.md §3.2` pin etti + `test_missing_review_findings_fails_workflow` unskip edildi. B7.1'de **sadece CHANGELOG `[Unreleased]` PR-B7.1** içinde explicit "docs §3.2 reconciled with runtime (B7 v1 post-impl cf8b30e)" notu.
+
+Kod değişikliği YOK.
+
+### 2.3 New-scenario recipe (`docs/BENCHMARK-SUITE.md §9`)
+
+6 adım:
+
+```markdown
+## 9. Adding a New Benchmark Scenario
+
+1. **Workflow definition**: Bundled workflow varsa doğrudan
+   kullan; yoksa `tests/benchmarks/fixtures/workflows/` altına
+   `<scenario>_bench.v1.json` ekle (`governed_bugfix_bench` pattern).
+2. **Canned envelopes**: `tests/benchmarks/fixtures/` altına
+   `<scenario>_envelopes.py` — happy + error variant(s). Envelope
+   shape adapter manifest'inin `output_envelope` + `output_parse`
+   contract'ını takip eder.
+3. **Test module**: `tests/benchmarks/test_<scenario>.py` +
+   `TestHappyPath` + `TestTransportError` class'ları. Mock
+   `(scenario_id, adapter_id, attempt)` key pattern.
+4. **Assertions**: `tests/benchmarks/assertions.py` helpers
+   (`assert_workflow_completed`, `assert_capability_artifact`,
+   `assert_cost_consumed`, `assert_review_score`, `assert_budget_axis_seeded`).
+5. **Local run**: `pytest tests/benchmarks/test_<scenario>.py -q`.
+6. **CI**: `benchmark-fast` job `pytest tests/benchmarks/ -q`
+   çalıştırır; pytest discovery yeni dosyayı otomatik bulur,
+   workflow delta gerekmez.
+```
+
+### 2.4 `docs/BENCHMARK-SUITE.md §8.3` deferred list update
+
+v1'de "deferred to B7.1" idi; şimdi 2 item explicit FAZ-C etiketlenir:
+
+- Full bundled `bug_fix_flow` E2E → **FAZ-C PR-C1** (patch plumbing + input_envelope + policy_loader injection)
+- Real-adapter full mode → **FAZ-C PR-C2** (secret flow + context_pack_ref + env namespace manifest parity)
+
+### 2.5 CHANGELOG `[Unreleased]` PR-B7.1
+
+- `tests/benchmarks/mock_transport.py` shim — `cost_usd` drain (labeled benchmark-only; B2 integration gap deferred to FAZ-C).
+- `assertions.py::assert_cost_consumed` helper.
+- `test_governed_review.py::TestCostReconcile` (1 test).
+- `docs/BENCHMARK-SUITE.md §3.2` runtime contract pin (cf8b30e echo) + §8.3 FAZ-C deferred list + §9 recipe.
+
+---
+
+## 3. Write Order (2-commit DAG)
+
+1. **C1**: shim + helper + reconcile test (~140 LOC)
+2. **C2**: docs §9 recipe + §8.3 update + §3.2 note + CHANGELOG (~90 LOC)
+
+**Toplam ~230 LOC** (tests + docs; **runtime LOC = 0**).
+
+---
+
+## 4. Design Trade-offs (v2)
+
+| Seçim | Alternatif | Gerekçe |
+|---|---|---|
+| Shim labeled "benchmark-only" | Runtime integration | B2 gap FAZ-C'de; scope creep avoid |
+| `cost_usd` axis `.remaining` direct mutate | `record_spend` çağrısı (ledger append) | Benchmark evidence trail yerine run_state only — shim hedefi |
+| CHANGELOG echo (new docs §3.2 edit yok) | Docs §3.2 rewrite | Tutarsızlık yaratmaz; cf8b30e final |
+| Recipe 6-step inline | Separate file | Benchmark docs tek merkezde |
+
+---
+
+## 5. Acceptance Checklist
+
+### Shim
+- [ ] `mock_transport._maybe_consume_budget` envelope `cost_actual.cost_usd` okur
+- [ ] Run state `budget.cost_usd.remaining` decrement edilir (non-negative clamp)
+- [ ] Shim clearly label — docstring "BENCHMARK-ONLY" + FAZ-C reference
+- [ ] `state["revision"]` yeniden hesaplanır (`run_revision()`)
+
+### Helper + test
+- [ ] `assert_cost_consumed(run_state, axis, min_consumed=0.0)` → limit - remaining >= min_consumed
+- [ ] `TestCostReconcile::test_cost_usd_drained` happy path: consumed > 0 after governed_review
+
+### Docs
+- [ ] `docs/BENCHMARK-SUITE.md §9` 6-step recipe visible
+- [ ] `§8.3` deferred list explicit FAZ-C-routed for full bugfix + real full mode
+- [ ] `§3.2` missing-key runtime-docs alignment referenced to cf8b30e
+
+### Regression
+- [ ] B7 v1 tests (6/6 pass) preserved
+- [ ] Main suite 2135 pass unchanged
+- [ ] Ruff + mypy clean
+- [ ] `_KINDS == 27`
+
+---
+
+## 6. Risk Register (v2)
+
+| Risk | L | I | Mitigation |
+|---|---|---|---|
+| R1 Shim state.v1.json schema-invalid write | L | M | Re-validate via `run_revision()`; load_run round-trip test |
+| R2 Shim race with driver state writes | L | L | Dispatcher runs sequentially under test; no concurrency |
+| R3 Assertion false-positive (no spend reported in envelope) | L | L | Happy envelopes already carry `cost_actual.cost_usd` |
+| R4 Recipe staleness after FAZ-C | M | L | Recipe marks "live for B7 v1 patterns; FAZ-C may extend" |
+| R5 CHANGELOG echoing may confuse readers (dupe docs pin) | L | L | Explicit cross-reference to cf8b30e |
+
+---
+
+## 7. Scope Dışı (B7.1 v2 → FAZ-C)
+
+- **Full bundled `bug_fix_flow` E2E** (patch plumbing + input_envelope builder + workspace policy loader injection) → **FAZ-C PR-C1**
+- **Real-adapter full mode** (context_pack_ref + secret flow via `secrets.allowlist_secret_ids` + manifest env parity) → **FAZ-C PR-C2**
+- **`cost_usd` runtime integration** (adapter transport path reconcile; B2 gap closure) → **FAZ-C PR-C3**
+- Cross-class cost routing — FAZ-C stratejik
+- Merge-patch policy-sim (RFC 7396) — FAZ-C
+- Full `Executor.run_step` dry-run — FAZ-C
+- Vision/audio registry — FAZ-C/D
+
+---
+
+## 8. Cross-PR Conflict Resolution (v2)
+
+- **B2**: benchmark `cost_usd` shim B2 runtime integration gap'ini maskelemez; shim label + docstring açıkça gap'e referans.
+- **B4**: orthogonal.
+- **B5**: metric families benchmark output tüketebilir (FAZ-C'de metric assertion eklenebilir).
+- **B6**: review_ai_flow + bug_fix_flow contract'larına dokunmaz.
+- **B7 v1**: extend only (test + docs delta).
+
+---
+
+## 9. Codex iter-2 için açık soru: YOK
+
+v1'deki 4 Q Codex iter-1'de cevaplandı ve v2 absorb edildi (2 FAZ-C'ye, 2 moot). Yeni Q yok.
+
+---
+
+## 10. Audit Trail
+
+| Iter | Date | Verdict |
+|---|---|---|
+| v1 (Claude draft) | 2026-04-18 | Pre-Codex iter-1 submit |
+| **iter-1** (CNS-20260418-040, thread `019d9f63`) | 2026-04-18 | **REVISE** — 5 blocker (2 büyük item runtime gap, 3 contract yanlışı); 5 warning + Q1-Q4 cevap |
+| **v2 (iter-1 absorb)** | 2026-04-18 | Pre-iter-2 submit (scope halved; 2 item FAZ-C-bound) |
+| iter-2 | TBD | AGREE expected |
+
+### Plan revision history
+
+| Ver | Change |
+|---|---|
+| v1 | 5 B7 v1 deferred item; 3-commit ~630 LOC; full bundled bugfix E2E + real full mode + cost reconcile + walker pin + recipe |
+| **v2** | **iter-1 REVISE absorb** (scope trim): 2 büyük item (full bundled bugfix + real full mode) FAZ-C'ye; `cost_usd` reconcile **benchmark-only shim** olarak labeled; walker pin cf8b30e echo (new behavior yok); recipe 6-step. 2-commit ~230 LOC; runtime LOC=0. |
+
+**Status**: Plan v2 hazır. Codex thread `019d9f63` iter-2 submit için hazır. AGREE beklenir.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — FAZ-B PR-B7.1 (benchmark harness follow-up)
+
+**Minor follow-up to PR-B7 (v3.2.0). Test + docs layer only;
+runtime LOC unchanged.**
+
+- `tests/benchmarks/mock_transport.py::_maybe_consume_budget` —
+  benchmark-only shim that drains the run-state
+  `budget.cost_usd.remaining` by the envelope's
+  `cost_actual.cost_usd`. Docstring labels the shim explicitly
+  and points at the real reconcile path
+  (`ao_kernel.cost.middleware.post_response_reconcile` behind
+  `ao_kernel.llm.governed_call`); closing that integration gap
+  inside the adapter transport path (`invoke_cli` /
+  `invoke_http`) is routed to **FAZ-C PR-C3**.
+- `tests/benchmarks/assertions.py::assert_cost_consumed` — helper
+  returns consumed amount + asserts `>= min_consumed`.
+- `tests/benchmarks/test_governed_review.py::TestCostReconcile`
+  pins the shim contract (0.12 USD envelope → 0.12 drain).
+- `tests/benchmarks/fixtures/review_envelopes.py` +
+  `tests/benchmarks/fixtures/bug_envelopes.py` — `cost_actual`
+  now carries a `cost_usd` field on happy envelopes.
+- `docs/BENCHMARK-SUITE.md §8.3` rewritten to route full bundled
+  `bug_fix_flow` E2E → **FAZ-C PR-C1**, real-adapter full mode
+  → **FAZ-C PR-C2**, and cost_usd runtime reconcile → **FAZ-C
+  PR-C3**. The walker contract pin (cf8b30e) is reconciled with
+  docs §3.2 and the missing-payload test is noted as unskipped.
+- `docs/BENCHMARK-SUITE.md §9` new — 6-step "Adding a New
+  Benchmark Scenario" recipe.
+
+**Locked invariants**:
+- Zero production `ao_kernel/` delta.
+- Shim noop when `cost_actual.cost_usd` or `state.v1.json`
+  absent; run-state schema round-trip preserved via
+  `run_revision()` recompute.
+- B7 v1 tests (6/6) pass unchanged; one new cost-reconcile
+  test brings the benchmark total to 7.
+
 ## [3.2.0] — 2026-04-18
 
 **FAZ-B — Ops Hardening**: 10 PRs landed across 6 workstreams

--- a/docs/BENCHMARK-SUITE.md
+++ b/docs/BENCHMARK-SUITE.md
@@ -180,17 +180,26 @@ CI integrates these through the `benchmark-fast` job in `.github/workflows/test.
 
 `test_governed_review.py` parametrises the `review_findings.score` minimum against a default of 0.5. Tests include both a high-score pass (0.9 against 0.8 threshold) and a low-score negative (0.4 against 0.5 threshold) so the scoring helper itself is exercised. Raise the threshold to enforce tighter reviewer confidence; lower it to accept noisier adapter output.
 
-### 8.3 B7 v1 scope + deferred work
-
-PR-B7 v1 ships a trimmed scope:
+### 8.3 Scope + deferred work (post-B7.1)
 
 - **`governed_review`** exercises the bundled `review_ai_flow.v1.json` end-to-end — the three-step flow (compile + invoke review agent + await_acknowledgement) plays nicely with the default worktree-profile sandbox.
-- **`governed_bugfix`** uses a stripped-down bench variant (`tests/benchmarks/fixtures/workflows/governed_bugfix_bench.v1.json`) — the full bundled `bug_fix_flow` (`patch_preview` + `ci_pytest` + `apply_patch` + `gh-cli-pr`) needs workspace sandbox allowlist tuning for `git` and `pytest` invocations and is deferred to **B7.1**.
-- **Missing-payload walker behaviour** — a negative test is shipped as `pytest.mark.skip` pending a docs/runtime reconciliation of `_walk_output_parse` missing-key semantics; see `tests/benchmarks/test_governed_review.py::TestMissingPayload`.
-- **Full-mode real adapter dispatch**, **`cost_usd` reconcile assertion**, and **retry/branch variants** are deferred to **B7.1 / FAZ-C**. The current harness seeds the budget axis and asserts the seed; real spend reconciliation requires a follow-up to `record_spend` wiring inside the adapter transport path.
+- **`governed_bugfix`** uses a stripped-down bench variant (`tests/benchmarks/fixtures/workflows/governed_bugfix_bench.v1.json`). The full bundled `bug_fix_flow` (`patch_preview` + `ci_pytest` + `apply_patch` + `gh-cli-pr`) needs patch plumbing + input_envelope + policy_loader injection — routed to **FAZ-C PR-C1**.
+- **Missing-payload walker behaviour** — `_walk_output_parse` surfaces `AdapterOutputParseError` fail-closed when the canned envelope omits a declared `output_parse` field. `test_missing_review_findings_fails_workflow` exercises this end-to-end and is unskipped (docs §3.2 matches runtime).
+- **`cost_usd` reconcile** — B7.1 ships a benchmark-only shim (`mock_transport._maybe_consume_budget`) that drains the run-state `budget.cost_usd` axis so `assert_cost_consumed` can observe drain; the runtime gap (adapter transport reconcile inside `invoke_cli`/`invoke_http`) is routed to **FAZ-C PR-C3**.
+- **Real-adapter full mode** (`--benchmark-mode=full` + env-gated secrets + `context_pack_ref` input_envelope) is routed to **FAZ-C PR-C2**.
+- **Retry/branch variants**, **statistical perf tracking**, and **chaos-mode** remain post-FAZ-C.
 
 ### 8.4 Mock transport boundary
 
 The mock patches `ao_kernel.executor.executor.invoke_cli` + `invoke_http` at the executor's local-alias import site (not at `adapter_invoker` module level — the executor binds local references at load time). Orchestrator + driver + executor + adapter_invoker call chain stays real; only the final wrapper is substituted for tests. Canned envelopes delegate to the real `adapter_invoker._invocation_from_envelope` walker so `output_parse` contracts are exercised against the shipping code, not a mock approximation.
 
 See `tests/benchmarks/mock_transport.py` for `MockEnvelopeNotFoundError` (fixture/mock drift — a test-side bug signal) vs the `_TransportError` sentinel (deliberate `AdapterInvocationFailedError(reason="subprocess_crash")` negative path).
+
+## 9. Adding a New Benchmark Scenario
+
+1. **Workflow definition**: Use a bundled workflow when available; otherwise drop a `<scenario>_bench.v1.json` under `tests/benchmarks/fixtures/workflows/` (follow the `governed_bugfix_bench` pattern — minimal adapter + human-gate steps that stay within the default worktree-profile sandbox).
+2. **Canned envelopes**: Add `tests/benchmarks/fixtures/<scenario>_envelopes.py` with happy + transport-error variants. Envelope shape follows the adapter manifest's `output_envelope` plus every `output_parse` rule the manifest declares (for `codex-stub` that means both `review_findings` and `commit_message`).
+3. **Test module**: Create `tests/benchmarks/test_<scenario>.py` with `TestHappyPath` + `TestTransportError` classes. Mock lookup uses the `(scenario_id, adapter_id, attempt)` key pattern; reuse the shared fixtures (`workspace_root`, `seeded_run`, `benchmark_driver`).
+4. **Assertions**: Lean on the helpers in `tests/benchmarks/assertions.py` (`assert_workflow_completed`, `assert_capability_artifact`, `assert_cost_consumed`, `assert_review_score`, `assert_budget_axis_seeded`). Add new ones sparingly; the current set is meant to cover every success-criteria line above.
+5. **Local run**: `pytest tests/benchmarks/test_<scenario>.py -q`. The benchmark harness is fast-mode-only in the current release — it must exit green inside a few seconds against the mock transport.
+6. **CI**: The `benchmark-fast` job runs `pytest tests/benchmarks/ -q`, so pytest discovery picks up the new module automatically — no workflow edit needed.

--- a/tests/benchmarks/assertions.py
+++ b/tests/benchmarks/assertions.py
@@ -110,6 +110,36 @@ def assert_review_score(
     )
 
 
+def assert_cost_consumed(
+    run_state: Mapping[str, Any],
+    axis: str = "cost_usd",
+    *,
+    min_consumed: float = 0.0,
+) -> float:
+    """Assert that the given budget axis has been drained by at
+    least ``min_consumed``. Returns the consumed amount so callers
+    can make additional assertions.
+
+    v1 pairs with ``mock_transport._maybe_consume_budget``
+    (benchmark-only shim); once FAZ-C PR-C3 lands, this helper
+    also works against the real adapter transport reconcile path.
+    """
+    budget = run_state.get("budget") or {}
+    axis_data = budget.get(axis) or {}
+    limit = axis_data.get("limit")
+    remaining = axis_data.get("remaining")
+    assert limit is not None and remaining is not None, (
+        f"budget axis {axis!r} missing limit/remaining; "
+        f"run_state budget={budget!r}"
+    )
+    consumed = float(limit) - float(remaining)
+    assert consumed >= min_consumed, (
+        f"budget axis {axis!r} consumed {consumed!r} below "
+        f"min_consumed {min_consumed!r}"
+    )
+    return consumed
+
+
 def assert_budget_axis_seeded(
     run_state: Mapping[str, Any],
     axis: str,
@@ -185,6 +215,7 @@ __all__ = [
     "assert_adapter_ok",
     "assert_budget_axis_seeded",
     "assert_capability_artifact",
+    "assert_cost_consumed",
     "assert_review_score",
     "assert_workflow_completed",
     "assert_workflow_failed",

--- a/tests/benchmarks/fixtures/bug_envelopes.py
+++ b/tests/benchmarks/fixtures/bug_envelopes.py
@@ -45,6 +45,7 @@ def coding_agent_happy() -> dict[str, Any]:
             "tokens_input": 120,
             "tokens_output": 45,
             "time_seconds": 2.3,
+            "cost_usd": 0.05,
         },
     }
 

--- a/tests/benchmarks/fixtures/review_envelopes.py
+++ b/tests/benchmarks/fixtures/review_envelopes.py
@@ -51,6 +51,7 @@ def review_agent_happy(
             "tokens_input": 320,
             "tokens_output": 180,
             "time_seconds": 4.1,
+            "cost_usd": 0.12,
         },
     }
 

--- a/tests/benchmarks/mock_transport.py
+++ b/tests/benchmarks/mock_transport.py
@@ -36,6 +36,7 @@ from ao_kernel.executor.adapter_invoker import (
     InvocationResult,
     _invocation_from_envelope,
 )
+from ao_kernel.workflow.run_store import run_revision
 
 
 CannedKey = tuple[str, str, int]
@@ -129,6 +130,13 @@ def mock_adapter_transport(
         log_path = _benchmark_log_path(workspace_root, run_id, manifest.adapter_id)
         _ensure_log_parent(log_path)
         _write_empty_log(log_path)
+        # PR-B7.1 cost shim: pull the envelope back out (canned
+        # under the dispatcher key) so the budget axis update
+        # happens exactly when the adapter "returns" from the
+        # benchmark's perspective.
+        adapter_id = manifest.adapter_id
+        current_attempt = counters.get(adapter_id, 0) + 1
+        canned_entry = canned.get((scenario_id, adapter_id, current_attempt))
         try:
             result = _dispatch(
                 manifest=manifest,
@@ -139,6 +147,8 @@ def mock_adapter_transport(
             raise
         except AdapterInvocationFailedError:
             raise
+        if isinstance(canned_entry, Mapping):
+            _maybe_consume_budget(workspace_root, run_id, canned_entry)
         return result, budget
 
     def _http_dispatcher(
@@ -173,6 +183,50 @@ def mock_adapter_transport(
             side_effect=_http_dispatcher,
         ):
             yield
+
+
+def _maybe_consume_budget(
+    workspace_root: Path,
+    run_id: str,
+    envelope: Mapping[str, Any],
+) -> None:
+    """BENCHMARK-ONLY SHIM — drain ``budget.cost_usd.remaining``
+    by the envelope's ``cost_actual.cost_usd`` value.
+
+    The real reconcile path lives in
+    :func:`ao_kernel.cost.middleware.post_response_reconcile`,
+    which only runs behind :func:`ao_kernel.llm.governed_call`.
+    The adapter transport path (:func:`invoke_cli` /
+    :func:`invoke_http`) does not reconcile ``cost_usd`` — it
+    only accrues ``time_seconds``. Until **FAZ-C PR-C3** closes
+    that integration gap, this shim is what lets benchmark
+    assertions (`assert_cost_consumed`) observe budget drain
+    end-to-end.
+
+    Bypass note: this shim writes `state.v1.json` directly
+    rather than going through
+    :func:`ao_kernel.workflow.run_store.save_run`. Benchmark
+    scenarios are strictly single-threaded under pytest, so the
+    absence of `write_text_atomic` + file-lock is acceptable;
+    a real concurrency scenario would need the full store path.
+    """
+    cost_usd = (envelope.get("cost_actual") or {}).get("cost_usd")
+    if cost_usd is None:
+        return
+    state_path = workspace_root / ".ao" / "runs" / run_id / "state.v1.json"
+    if not state_path.is_file():
+        return
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    axis = (state.get("budget") or {}).get("cost_usd")
+    if not isinstance(axis, dict):
+        return
+    remaining = float(axis.get("remaining", 0.0)) - float(cost_usd)
+    axis["remaining"] = max(0.0, remaining)
+    state["revision"] = run_revision(state)
+    state_path.write_text(
+        json.dumps(state, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
 
 
 def _benchmark_log_path(

--- a/tests/benchmarks/test_governed_review.py
+++ b/tests/benchmarks/test_governed_review.py
@@ -19,6 +19,7 @@ from ao_kernel.workflow.run_store import load_run
 from tests.benchmarks.assertions import (
     assert_adapter_ok,
     assert_capability_artifact,
+    assert_cost_consumed,
     assert_review_score,
     assert_workflow_completed,
     assert_workflow_failed,
@@ -142,6 +143,46 @@ class TestHappyPath:
         else:
             with pytest.raises(AssertionError, match="below threshold"):
                 assert_review_score(artifact, expected_min_score=min_threshold)
+
+
+class TestCostReconcile:
+    """PR-B7.1: verify the benchmark-only cost shim drains the
+    `cost_usd` axis. The real adapter transport path does not
+    reconcile cost_usd (FAZ-C PR-C3); this test pins the
+    benchmark-layer contract instead."""
+
+    def test_cost_usd_drained_after_happy_review(
+        self,
+        workspace_root: Path,
+        seeded_run,
+        benchmark_driver,
+    ) -> None:
+        run_id = seeded_run(_WORKFLOW_ID, version=_WORKFLOW_VERSION)
+        canned = {
+            (_SCENARIO_ID, "codex-stub", 1): review_envelopes.review_agent_happy(
+                score=0.85,
+            ),
+        }
+
+        with mock_adapter_transport(canned, scenario_id=_SCENARIO_ID):
+            first = benchmark_driver.run_workflow(
+                run_id, _WORKFLOW_ID, _WORKFLOW_VERSION,
+            )
+            token = first.resume_token or read_awaiting_human_token(
+                _run_dir(workspace_root, run_id),
+            )
+            benchmark_driver.resume_workflow(
+                run_id, token, payload={"decision": "granted"},
+            )
+
+        record, _ = load_run(workspace_root, run_id)
+        consumed = assert_cost_consumed(record, "cost_usd", min_consumed=0.0)
+        # The envelope reports 0.12 USD; the shim should drain by
+        # exactly that amount (no other adapter call for this
+        # scenario).
+        assert abs(consumed - 0.12) < 1e-9, (
+            f"unexpected cost_usd consumption: {consumed}"
+        )
 
 
 class TestMissingPayload:


### PR DESCRIPTION
## Summary

**Minor follow-up to PR-B7 / v3.2.0** (`d6ab4a4`). Benchmark + docs only — **zero production `ao_kernel/` delta**. Codex plan-time REVISE→AGREE two iterations; scope halved (5 B7 v1 deferred items → 3 docs/shim items; full bundled bugfix + real full mode routed to FAZ-C PR-C1/C2/C3).

### Changes

- `tests/benchmarks/mock_transport.py::_maybe_consume_budget` — benchmark-only shim draining `budget.cost_usd.remaining` by envelope `cost_actual.cost_usd`. Docstring labels it BENCHMARK-ONLY + points at real reconcile path (`ao_kernel.cost.middleware.post_response_reconcile` behind `governed_call`) and routes runtime integration gap to **FAZ-C PR-C3**.
- `tests/benchmarks/assertions.py::assert_cost_consumed` — helper returns consumed amount + asserts `>= min_consumed`.
- `tests/benchmarks/test_governed_review.py::TestCostReconcile::test_cost_usd_drained_after_happy_review` — pins 0.12 USD envelope → 0.12 drain.
- Fixture additions: `review_envelopes` + `bug_envelopes` happy envelopes carry `cost_usd` under `cost_actual`.
- `docs/BENCHMARK-SUITE.md §8.3` rewritten: FAZ-C routing explicit for the two deferred big items + walker-contract pin reconciled with cf8b30e.
- `docs/BENCHMARK-SUITE.md §9` new — 6-step "Adding a New Benchmark Scenario" recipe.
- `CHANGELOG.md [Unreleased]` PR-B7.1 entry.
- `.claude/plans/PR-B7.1-DRAFT-PLAN.md` v2 archived.

### FAZ-C routing table (explicit)

| Item | Target PR | Gap |
|---|---|---|
| Full bundled `bug_fix_flow` E2E | FAZ-C PR-C1 | patch plumbing + input_envelope + policy_loader injection |
| Real-adapter full mode | FAZ-C PR-C2 | `secrets.allowlist_secret_ids` + `context_pack_ref` + manifest env parity |
| `cost_usd` runtime reconcile | FAZ-C PR-C3 | adapter transport `invoke_cli`/`invoke_http` reconcile path (currently only `time_seconds`) |

### Test plan

- [ ] CI green (lint + typecheck + 3.11/3.12/3.13 pytest + coverage + extras-install + benchmark-fast)
- [ ] `pytest tests/benchmarks/ -q` → **7 passed** locally (6 B7 v1 + 1 new `TestCostReconcile`)
- [ ] `pytest tests/ --ignore=tests/benchmarks -q` → 2135 passed unchanged
- [ ] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)