### PR TITLE
feat(pr-c1a): adapter artifact surface + context_compile materialisation

### DIFF
--- a/.claude/plans/PR-C1a-IMPLEMENTATION-PLAN.md
+++ b/.claude/plans/PR-C1a-IMPLEMENTATION-PLAN.md
@@ -1,10 +1,30 @@
-# PR-C1a Implementation Plan v2 — Adapter Artifact Surface + Context Compile Materialisation
+# PR-C1a Implementation Plan v3 — Adapter Artifact Surface + Context Compile Materialisation
 
 **Scope**: FAZ-C critical-path seri başı. Adapter-path output_ref garantisi + `context_compile` step real materialisation + `build_driver(policy_loader=...)` forward + `context_pack_ref` plumbing. Downstream PR'lar (C1b/C2/C3/C6) bu altyapıya bağımlı.
 
 **Base**: `main 5fb7f31` (PR #108 tooling merged). **Branch**: `feat/pr-c1a-adapter-surface`.
 
-**Status**: iter-1 PARTIAL absorb → iter-2 submit için hazır. Codex thread `019d9fc3-1b0b-76b2-b425-0f3dfd6efc66`.
+**Status**: iter-2 PARTIAL absorb → iter-3 submit için hazır. Codex thread `019d9fc3-1b0b-76b2-b425-0f3dfd6efc66`.
+
+---
+
+## v3 absorb summary (Codex iter-2 PARTIAL — 3 blocker + 3 warning)
+
+Iter-2 kod-okuması ile v2'de kaçırdığım 3 coupling hatası:
+
+| # | iter-2 bulgu | v3 fix |
+|---|---|---|
+| **B1** | v2 resolver `record["steps"]` üzerinde `operation` + `context_path` aradı — ama `step_record` schema `additionalProperties=false` (`workflow-run.schema.v1.json:154`), bu field'lar persist edilmiyor (`multi_step_driver.py:1414`). | v3: Resolver **artifact JSON read** — workflow_def'ten `operation=="context_compile"` step_name bul → `record.steps[step_name].output_ref` oku → o canonical JSON'un `context_path` field'ını parse et. Schema widen YOK. |
+| **B2** | v2 `_build_adapter_input_envelope()` mevcut çağrı zincirine bağlı değil. Envelope bugün `Executor.run_step()` içinde üretiliyor (`executor.py:383`); driver override vermiyor. Ayrıca `step_def.task_prompt` yok — kaynak `record.intent.payload` (`executor.py:384`). | v3: `Executor.run_step(..., input_envelope_override: Mapping \| None = None)` **additive kwarg** widen. Driver pre-compute + override pass. `task_prompt` kaynağı `record.intent.payload` pin (schema+kod contract). |
+| **B3** | v2 `context_compile` gerçek hale gelse bile `_record_step_completion()` `operation=="context_compile"` gördüğünde `payload.stub=True` + `context_preamble_bytes=0` hardcode ediyor (`multi_step_driver.py:1392`). Test bunu assert ediyor (`test_multi_step_driver.py:55`). | v3: §3 `_record_step_completion` hardcode absorb — step handler dönüş dict'inden gerçek değerler okunur. `test_context_compile_stub_emits_stub_marker` testi güncellenir (stub=False, bytes>0, context_path). |
+
+### v3 absorb warnings
+
+- **W1** (iter-2): v2 helper isimleri `load_canonical_decisions` / `load_workspace_facts` yok. Gerçek: `ao_kernel.context.canonical_store::query/load_store` (`agent_coordination.py:202` pattern) + workspace facts `.cache/index/workspace_facts.v1.json` direct JSON read. Run schema top-level `session_context` taşımıyor (`workflow-run.schema.v1.json:22`) → MVP `session_context={}`. v3 §2.3 code örneği düzeltildi.
+- **W2** (iter-2): Master plan v5 hâlâ `".ao/runs/{run_id}/context.md"` diyor (`FAZ-C-MASTER-PLAN.md:129`); C1a plan absolute evidence-dir path kullanıyor. Drift var. **Çözüm**: C1a merge ile birlikte master plan v6 ayrı commit — bu PR'dan sonra ya da paralel docs PR. C1a PR description'da drift not edilir.
+- **W3** (iter-2): `gh-cli-pr` manifest tutarsızlığı C1a out-of-scope. PR description'a explicit disclaimer: "C1a closes adapter artifact surface + context materialisation; `open_pr` chain full-flow proof C1b'de".
+
+---
 
 ---
 
@@ -128,20 +148,29 @@ if op == "context_compile":
 ```python
 if op == "context_compile":
     from ao_kernel.context.context_compiler import compile_context
-    from ao_kernel.context.canonical_store import load_canonical_decisions
-    from ao_kernel.context.workspace_facts import load_workspace_facts
+    from ao_kernel.context.canonical_store import load_store, query
     from ao_kernel._internal.shared.utils import write_text_atomic
+    import json as _json
     
-    # Load 3-lane context (existing pipeline)
-    session_context = dict(record.get("session_context") or {})
-    canonical = load_canonical_decisions(self._workspace_root)
-    facts = load_workspace_facts(self._workspace_root)
+    # MVP: session_context = {} (workflow-run schema top-level taşımıyor;
+    # session bridge ayrı PR'a bırakılır).
+    session_context: dict[str, Any] = {}
+    
+    # Canonical decisions: existing pipeline (agent_coordination.py:202 pattern).
+    canonical_store = load_store(self._workspace_root)
+    canonical = query(canonical_store, limit=100)
+    
+    # Workspace facts: direct JSON read (`.cache/index/workspace_facts.v1.json`).
+    facts_path = (
+        self._workspace_root / ".cache" / "index" / "workspace_facts.v1.json"
+    )
+    facts = _json.loads(facts_path.read_text()) if facts_path.is_file() else {}
     
     compiled = compile_context(
         session_context,
         canonical_decisions=canonical,
         workspace_facts=facts,
-        profile="TASK_EXECUTION",  # default; future: from step_def
+        profile="TASK_EXECUTION",
     )
     
     # Write markdown preamble (absolute path for adapter subprocess)
@@ -150,7 +179,7 @@ if op == "context_compile":
     )
     write_text_atomic(context_path, compiled.preamble)
     
-    # Canonical evidence JSON (existing pattern, now with real metadata)
+    # Canonical evidence JSON with real metadata (stub=False)
     payload = {
         "operation": "context_compile",
         "stub": False,
@@ -169,9 +198,47 @@ if op == "context_compile":
         "output_ref": output_ref,
         "output_sha256": output_sha256,
         "operation": op,
-        "context_path": str(context_path),  # downstream plumbing için
     }
 ```
+
+**`_record_step_completion` hardcode absorb (iter-2 B3)**:
+
+`multi_step_driver.py:1392` mevcut kod context_compile için stub=True hardcode ediyor. v3 değişikliği:
+```python
+# Before (multi_step_driver.py:1392-1400):
+if step_def.operation == "context_compile":
+    payload = {"stub": True, "context_preamble_bytes": 0}
+
+# After (v3):
+if step_def.operation == "context_compile":
+    # Step handler dönüş dict'inden gerçek değerler
+    # Handler artifact JSON yazdı; burada artifact'ı re-read etmek
+    # yerine step_state dict'inden (handler return'dan) çekeriz.
+    # Handler return dict'i zaten output_ref içeriyor; ek metadata
+    # için artifact JSON parse edilebilir ama daha pahalı.
+    # Minimal çözüm: step_state dict'ine payload alanlarını ekle
+    # (handler zaten yaratıyor; sadece propagate edilir).
+    payload = {
+        "stub": False,
+        "context_preamble_bytes": step_state.get(
+            "context_preamble_bytes", 0
+        ),
+        "context_path": step_state.get("context_path"),
+    }
+```
+
+Bu değişiklik test `test_context_compile_stub_emits_stub_marker` kontratını günceller — artık assertion:
+```python
+# Before
+assert payload["stub"] is True
+assert payload["context_preamble_bytes"] == 0
+# After  
+assert payload["stub"] is False
+assert payload["context_preamble_bytes"] > 0
+assert payload["context_path"].endswith(".md")
+```
+
+Step handler return dict'i `context_preamble_bytes` + `context_path` taşır (handler kendi payload'unda yazar; propagate için step_state'e de eklenir).
 
 **Path semantics (iter-1 B3 absorb)**: `context_path` **absolute path** (`{workspace_root}/.ao/evidence/workflows/{run_id}/context-{step_id}-attempt{attempt}.md`). Adapter subprocess worktree cwd'sinde çalışsa bile absolute path okunur. `run_dir` zaten `_run_ao_kernel_step` içinde hesaplanmış (line 588).
 
@@ -183,37 +250,103 @@ if op == "context_compile":
 
 **Before**: Workflow step zincirinde `context_compile` step çıkışı → sonraki adapter step envelope'ında `context_pack_ref` resolver'ı yok. Envelope `{context_pack_ref}` placeholder literal kalır.
 
-**After** (minimum viable plumbing):
+**After** (v3 — artifact JSON read + Executor override widen):
 
-`multi_step_driver` içinde adapter step envelope builder:
+**B1.1 — `Executor.run_step` additive `input_envelope_override` kwarg** (`executor.py:383`):
 ```python
-def _build_adapter_input_envelope(
-    self, run_id: str, step_def: StepDefinition, record: Mapping[str, Any],
-) -> dict[str, Any]:
-    """Build input_envelope for adapter step; resolve context_pack_ref
-    from most recent completed context_compile step in the run."""
-    envelope = {
-        "task_prompt": step_def.task_prompt or "",
-        "run_id": run_id,
-    }
-    # context_pack_ref resolution: scan prior completed steps for
-    # `operation == "context_compile"` → take the most recent
-    # `context_path`. If none → placeholder stays literal (backwards-
-    # compat: zero-prior-context-compile runs still work).
-    for prior in reversed(record.get("steps", [])):
-        if (
-            prior.get("state") == "completed"
-            and prior.get("operation") == "context_compile"
-            and prior.get("context_path")
-        ):
-            envelope["context_pack_ref"] = prior["context_path"]
-            break
-    return envelope
+def run_step(
+    self,
+    run_id: str,
+    step_def: StepDefinition,
+    *,
+    parent_env: Mapping[str, str] | None = None,
+    attempt: int = 1,
+    driver_managed: bool = False,
+    input_envelope_override: Mapping[str, Any] | None = None,  # YENI
+    ...
+) -> ExecutionResult:
+    ...
+    if input_envelope_override is not None:
+        input_envelope = dict(input_envelope_override)
+    else:
+        # Existing behavior: task_prompt = record.intent.payload 
+        input_envelope = {
+            "task_prompt": record.get("intent", {}).get("payload", ""),
+            "run_id": run_id,
+        }
+    ...
 ```
 
-**Resolver semantiği (iter-1 Q3 + B3 absorb)**: Adapter envelope'una `context_pack_ref` key'i konulursa, `_substitute_args` (`adapter_invoker.py:702`) plain string replace ile `"{context_pack_ref}"` → absolute path'ı literal geçirir. Key yoksa placeholder literal kalır (zero-prior-context-compile test case — backwards-compat).
+Backwards-compat: `input_envelope_override=None` → mevcut davranış. Mevcut caller'lar etkilenmez.
 
-**StepDefinition değişmez (iter-1 B2 absorb)**: `context_spec` yeni field yok. `input_envelope_template` yok. Envelope builder workflow record steps history'sinden türetir.
+**B1.2 — Driver resolver `MultiStepDriver._build_adapter_envelope_with_context` (yeni method)**:
+```python
+def _build_adapter_envelope_with_context(
+    self, run_id: str, step_def: StepDefinition, record: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Resolve context_pack_ref from prior context_compile step's artifact.
+    Returns envelope override dict OR None if no context to inject
+    (caller falls back to Executor default envelope)."""
+    # 1. Workflow tanımından context_compile step_name'ini bul
+    workflow_def = self._workflow_registry.get(
+        record["workflow_id"], record["workflow_version"],
+    )
+    compile_step_names = [
+        sd.step_name for sd in workflow_def.steps
+        if sd.operation == "context_compile"
+    ]
+    if not compile_step_names:
+        return None
+    
+    # 2. En son tamamlanan context_compile step_record'unu bul
+    compile_step_name = compile_step_names[0]  # Workflow'larda typically 1 tane
+    compile_record = record.get("steps", {}).get(compile_step_name)
+    if not compile_record or compile_record.get("state") != "completed":
+        return None
+    
+    output_ref = compile_record.get("output_ref")
+    if not output_ref:
+        return None
+    
+    # 3. Artifact JSON'dan context_path çek
+    artifact_path = self._workspace_root / output_ref
+    if not artifact_path.is_file():
+        return None
+    
+    artifact = _json.loads(artifact_path.read_text())
+    context_path = artifact.get("context_path")
+    if not context_path:
+        return None
+    
+    # 4. Envelope (task_prompt kaynak: record.intent.payload — iter-2 B2 pin)
+    return {
+        "task_prompt": record.get("intent", {}).get("payload", ""),
+        "run_id": run_id,
+        "context_pack_ref": context_path,  # absolute
+    }
+```
+
+**B1.3 — Driver `_run_adapter_step` override forward** (`multi_step_driver.py:467`):
+```python
+# Inside _run_adapter_step (before executor.run_step call)
+envelope_override = self._build_adapter_envelope_with_context(
+    run_id, step_def, record,
+)
+execution_result = self._executor.run_step(
+    run_id,
+    step_def,
+    parent_env=parent_env,
+    attempt=attempt,
+    driver_managed=False,
+    input_envelope_override=envelope_override,  # None | dict
+)
+```
+
+**Resolver semantiği (iter-1 Q3 + iter-2 B1 absorb)**: Adapter envelope'una `context_pack_ref` absolute path konulursa, `_substitute_args` (`adapter_invoker.py:702`) plain string replace ile `"{context_pack_ref}"` → absolute path'ı literal geçirir. Resolver `None` dönerse Executor default envelope kullanılır (placeholder literal kalır — zero-prior-context-compile test case).
+
+**StepDefinition değişmez (iter-1 B2 absorb)**: `context_spec` + `input_envelope_template` icat yok. `step_record` schema değişmez (iter-2 B1 absorb): `operation` / `context_path` alanları eklenmez. Context path discovery artifact JSON'dan türetilir (step_record.output_ref pointer).
+
+**`task_prompt` kaynağı pin (iter-2 B2 absorb)**: `record.intent.payload` — mevcut kontrat (`executor.py:384`).
 
 ---
 
@@ -297,15 +430,18 @@ def _build_adapter_input_envelope(
 | Iter | Date | Verdict |
 |---|---|---|
 | v1 (Claude draft) | 2026-04-18 | Pre-Codex submit (`c2b61d9`) |
-| iter-1 (thread `019d9fc3`) | 2026-04-18 | **PARTIAL** — 3 blocker (InvocationResult.output_ref yanlış kaynak, context_spec/input_envelope_template yok, relative path runtime'da çözmez) + 3 warning (gh-cli-pr manifest inconsistency, build_driver scope wording, existing context pipeline alignment) + Q1-Q5 net cevaplar |
-| **v2 (iter-1 absorb)** | 2026-04-18 | Pre-iter-2 submit. Executor-side output_ref + explicit context_compile step + absolute path + existing compile_context() reuse. |
-| iter-2 | TBD | AGREE expected (3 blocker + 3 warning tam absorb; dar scope revisions) |
+| iter-1 (thread `019d9fc3`) | 2026-04-18 | **PARTIAL** — 3 blocker (InvocationResult.output_ref yanlış, context_spec/input_envelope_template yok, relative path runtime'da çözmez) + 3 warning + Q1-Q5 net cevaplar |
+| v2 (iter-1 absorb) | 2026-04-18 | `734b81f` commit |
+| iter-2 | 2026-04-18 | **PARTIAL** — 3 blocker (step_record schema `operation`/`context_path` persist etmiyor, `_build_adapter_input_envelope` çağrı zincirinde yok + `step_def.task_prompt` yok, `_record_step_completion` stub hardcode) + 3 warning (helper names, master plan drift, gh-cli-pr disclaimer) |
+| **v3 (iter-2 absorb)** | 2026-04-18 | Pre-iter-3 submit. Artifact JSON read resolver + `input_envelope_override` widen + `_record_step_completion` hardcode absorb + helper names (canonical_store.query) + session_context={} MVP. |
+| iter-3 | TBD | AGREE expected (3 blocker concrete fix'ler + warnings netleşti) |
 
 ### Plan revision history
 
 | Ver | Change |
 |---|---|
 | v1 | 4 gap + 5 Q for Codex; InvocationResult.output_ref varsayımı + context_spec icat + relative path |
-| **v2** | iter-1 PARTIAL absorb: output_ref kaynağı Executor `write_artifact` (InvocationResult dokunulmaz), context_compile step handler scope (StepDefinition değişmez), absolute path semantic, mevcut `compile_context()` reuse (role/constraints/references drop), build_driver scope "Executor-only" daraltıldı. |
+| v2 | iter-1 absorb: output_ref kaynağı Executor write_artifact (InvocationResult dokunulmaz), context_compile step handler scope, absolute path, compile_context() reuse, build_driver Executor-only daraltıldı |
+| **v3** | iter-2 absorb: resolver artifact JSON read (step_record schema değişmez), `Executor.run_step(input_envelope_override=None)` additive widen, driver `_build_adapter_envelope_with_context` yeni method, `task_prompt` = `record.intent.payload` pin, `_record_step_completion` stub hardcode absorb + `test_context_compile_stub_emits_stub_marker` test kontrat güncellenir, helper names `canonical_store.query/load_store`, workspace_facts direct JSON read, `session_context={}` MVP (workflow-run schema genişletme gerekmez). |
 
-**Status**: Plan v2 hazır. Codex thread `019d9fc3` iter-2 submit için hazır. 3 blocker tam absorb; 3 warning netleşti. AGREE beklenir.
+**Status**: Plan v3 hazır. Codex thread `019d9fc3` iter-3 submit için hazır. 3 blocker concrete fix'ler (artifact read, envelope override, stub absorb); 3 warning netleşti. AGREE beklenir.

--- a/.claude/plans/PR-C1a-IMPLEMENTATION-PLAN.md
+++ b/.claude/plans/PR-C1a-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,254 @@
+# PR-C1a Implementation Plan — Adapter Artifact Surface + Context Compile Materialisation
+
+**Scope**: FAZ-C critical-path seri başı. Adapter-path output_ref garantisi + context_compile gerçek dosya üretimi + `build_driver(policy_loader=...)` forward + `input_envelope.context_pack_ref` resolve. Downstream PR'lar (C1b/C2/C3/C6) bu altyapıya bağımlı.
+
+**Base**: `main 5fb7f31` (PR #108 tooling merged). **Branch**: `feat/pr-c1a-adapter-surface`.
+
+**Status**: Pre-Codex iter-1 submit. FAZ-C master plan v5 `cce30c1` C1a scope'u bu PR'a decouple ediliyor (Codex iter-6 notes: "C1a izole PR başlatılması makul").
+
+---
+
+## 1. Problem
+
+FAZ-C master plan iter-1 Codex fact-check ile tespit edilen 4 runtime gap:
+
+| Kod yüzey | Bugünkü hâl | Gap |
+|---|---|---|
+| `tests/_driver_helpers.build_driver(root: Path)` | Sadece `root` alır; Executor default bundled policy ile kurulur (`_driver_helpers.py:100-119`). | Benchmark'lar ve FAZ-C testleri policy override gerektirir; `Executor(policy_loader=...)` kwarg zaten var ama driver helper forward etmez. |
+| `Executor.ExecutionResult` dataclass | `{new_state, step_state, invocation_result, evidence_event_ids, budget_after}` (`executor.py:68-74`). `output_ref` field YOK. | `multi_step_driver._update_step_record_with_output_ref` `getattr(exec_result, "output_ref", None)` ile okuyor (`multi_step_driver.py:1321-1323`) — driver-managed path'te dolu, adapter-path'te garanti değil. |
+| `_context_compile` stub (`multi_step_driver.py`) | Placeholder; `.ao/runs/{run_id}/context.md` üretmez. | `claude-code-cli` / `gh-cli-pr` manifest `context_pack_ref` literal placeholder olarak kalır → adapter envelope input yanlış. |
+| `input_envelope` builder | `{context_pack_ref}` placeholder string'i literal geçer (resolve yok). | `context_compile` materialisation sonrası dahi envelope'a relative path geçmez. |
+
+**Sonuç**: Adapter'lar context-driven full-flow'da kırılır (B6 review_ai_flow testinde workaround shim ile geçiyor; real path gap'i C1b full bundled bugfix'te ortaya çıkar).
+
+---
+
+## 2. Scope (atomic deliverable)
+
+### 2.1 `_driver_helpers.build_driver` widen
+
+**Before**:
+```python
+def build_driver(root: Path) -> MultiStepDriver:
+    wreg = WorkflowRegistry()
+    wreg.load_workspace(root)
+    areg = AdapterRegistry()
+    areg.load_workspace(root)
+    executor = Executor(
+        workspace_root=root,
+        workflow_registry=wreg,
+        adapter_registry=areg,
+    )
+    return MultiStepDriver(...)
+```
+
+**After** (additive keyword-only kwarg, default None → current behavior):
+```python
+def build_driver(
+    root: Path,
+    *,
+    policy_loader: Mapping[str, Any] | None = None,
+) -> MultiStepDriver:
+    wreg = WorkflowRegistry()
+    wreg.load_workspace(root)
+    areg = AdapterRegistry()
+    areg.load_workspace(root)
+    executor = Executor(
+        workspace_root=root,
+        workflow_registry=wreg,
+        adapter_registry=areg,
+        policy_loader=policy_loader,  # forward (None → Executor defaults to bundled)
+    )
+    return MultiStepDriver(...)
+```
+
+Callers:
+- Mevcut: `tests/benchmarks/conftest.py`, `tests/test_multi_step_driver.py` → tamamen dokunulmaz (kwarg default None, behavior korunur).
+- Yeni: `tests/benchmarks/fixtures.py::bench_policy_override()` helper + bench-scope workspace policy override testlerinde kullanılır (C1b + C2 için hazırlık).
+
+### 2.2 `ExecutionResult.output_ref` field
+
+**Before**:
+```python
+@dataclass(frozen=True)
+class ExecutionResult:
+    new_state: WorkflowState
+    step_state: str
+    invocation_result: InvocationResult | None
+    evidence_event_ids: tuple[str, ...]
+    budget_after: Mapping[str, Any]
+```
+
+**After** (additive Optional field):
+```python
+@dataclass(frozen=True)
+class ExecutionResult:
+    new_state: WorkflowState
+    step_state: str
+    invocation_result: InvocationResult | None
+    evidence_event_ids: tuple[str, ...]
+    budget_after: Mapping[str, Any]
+    output_ref: str | None = None  # run-relative path; driver-managed OR adapter path populated
+```
+
+**Executor.run_step adapter path populate**:
+Mevcut adapter path'te (`driver_managed=False`) `invocation_result.output_ref` InvocationResult'tan çıkar; yeni kod ExecutionResult.output_ref'e yansıtır. `write_artifact` çağrısı zaten driver-managed path'te var (line 601, 696, 800); adapter-path için aynı pattern:
+```python
+# executor.py run_step adapter branch
+if invocation_result is not None and invocation_result.output_ref:
+    exec_output_ref = invocation_result.output_ref  # envelope'tan gelen ref
+else:
+    exec_output_ref = None
+return ExecutionResult(..., output_ref=exec_output_ref)
+```
+
+Driver-managed path mevcut davranış korunur (B6 v4 `capability_output_refs` + `output_ref` plumbing değişmez).
+
+### 2.3 `_context_compile` materialisation
+
+**Before** (varsayım — stub/placeholder):
+```python
+def _context_compile(run_id, context_spec) -> str:
+    return "context_placeholder"  # Hypothetical stub
+```
+
+**After** (gerçek dosya yazımı, atomic):
+```python
+def _context_compile(
+    workspace_root: Path,
+    run_id: str,
+    context_spec: Mapping[str, Any],
+) -> str:
+    """Compile run context to .ao/runs/{run_id}/context.md.
+    
+    Returns run-relative path (e.g. '.ao/runs/abc123/context.md').
+    Content shape: markdown with sections from context_spec (role,
+    constraints, references). Atomic write via tmp + rename.
+    """
+    content = _render_context_markdown(context_spec)
+    path = workspace_root / ".ao" / "runs" / run_id / "context.md"
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    write_text_atomic(path, content)  # mevcut shared helper
+    return str(path.relative_to(workspace_root))
+```
+
+Minimal context_spec shape (v1):
+- `role: str` — system prompt benzeri
+- `constraints: list[str]` — YAPMAMASI gereken
+- `references: list[str]` — context materyali
+
+Markdown template (v1):
+```markdown
+# Run Context
+
+## Role
+{role}
+
+## Constraints
+{constraints_bulleted}
+
+## References
+{references_bulleted}
+```
+
+### 2.4 `input_envelope.context_pack_ref` placeholder resolve
+
+**Before**: `input_envelope` builder `{context_pack_ref}` placeholder'ı literal olarak geçer (test: `tests/test_adapter_envelope_compile.py` placeholder literal beklenir).
+
+**After**: `Executor.run_step` input_envelope builder içinde:
+```python
+if step_def.context_spec is not None:
+    context_ref = _context_compile(
+        self._workspace_root, run_id, step_def.context_spec
+    )
+    input_envelope["context_pack_ref"] = context_ref  # run-relative
+else:
+    # step'te context_spec yoksa placeholder korunur (backwards-compat)
+    pass
+```
+
+Placeholder interpolation pattern workflow step definition'daki `input_envelope_template` içinde mevcutsa resolve edilir; yoksa verbatim korunur.
+
+---
+
+## 3. Test Plan
+
+### 3.1 Yeni testler
+
+- `tests/test_driver_helpers_policy_loader.py` — `build_driver(root, policy_loader=override)` Executor'a forward eder; default call backwards-compat.
+- `tests/test_executor_adapter_output_ref.py` — Adapter path mock envelope → InvocationResult.output_ref → ExecutionResult.output_ref populate.
+- `tests/test_context_compile_materialisation.py` — `_context_compile(root, run_id, spec)` `.ao/runs/{run_id}/context.md` yazar; content role/constraints/references section'ları içerir; atomic write (tmp file kalmaz).
+- `tests/test_input_envelope_context_pack_ref.py` — step context_spec varsa `context_pack_ref` = relative path; yoksa placeholder korunur.
+
+### 3.2 Regression gate
+
+- `pytest tests/ -x` tüm mevcut 2142 test green kalmalı.
+- Özellikle `tests/benchmarks/test_governed_review.py` (B6/B7) — adapter-path output_ref yeni populate davranışıyla `capability_output_refs` plumbing değişmez.
+
+### 3.3 Coverage
+
+- `ao_kernel.executor.executor` coverage %70+ korunur (ExecutionResult delta).
+- `ao_kernel.executor.multi_step_driver` `_context_compile` + `input_envelope` resolver için yeni line coverage.
+
+---
+
+## 4. Out of Scope
+
+- **C1b** (full bundled `bug_fix_flow` E2E) — ayrı PR, C1a merge'den sonra.
+- **C2** (real adapter full mode + parent_env union) — C1a merge sonrası paralel.
+- **C3** (cost_usd reconcile + `post_adapter_reconcile` middleware) — C1a merge sonrası paralel.
+- **C6** (dry_run_step) — C1a merge sonrası paralel.
+- Kontrat genişletme, yeni schema, yeni adapter manifest alanları — hiçbiri.
+
+---
+
+## 5. Risk Register
+
+| Risk | L | I | Mitigation |
+|---|---|---|---|
+| R1 Executor adapter path output_ref adapter envelope schema'sına uygun değil | L | H | Adapter envelope `output_ref` field'ı `agent-adapter-contract.schema.v1.json`'da opsiyonel; mevcut adapter'lar boş bırakıyor → backwards-compat. |
+| R2 `_context_compile` atomic write benchmark concurrency'de ortak dir çakışması | L | M | Per-run directory (`.ao/runs/{run_id}/`) — run_id UUID; çakışma teorik yok. |
+| R3 B6 `capability_output_refs` plumbing C1a ExecutionResult değişikliği ile kırılır | M | H | B6 pattern `getattr(exec_result, "output_ref", None)` ile oku — yeni field eklemek pattern'i kırmaz. `tests/benchmarks/test_governed_review.py` green kalır. |
+| R4 `input_envelope` placeholder resolve mevcut testleri kırar | M | M | Step `context_spec` yoksa placeholder korunur; backwards-compat test eklenir. |
+
+---
+
+## 6. Codex iter-1 için Açık Sorular
+
+**Q1**: `ExecutionResult.output_ref: str | None = None` additive field — frozen dataclass backwards-compat için kwargs ile instantiate edilmeli mi? Mevcut callers positional arg kullanıyorsa dataclass ordering ile çelişir mi?
+
+**Q2**: `_context_compile` markdown template v1 shape (role/constraints/references) `claude-code-cli` + `gh-cli-pr` manifest'lerinin gerçekten beklediği context shape ile uyumlu mu? Bu manifest'ler JSON değil markdown consumes ediyor mu?
+
+**Q3**: `input_envelope.context_pack_ref` placeholder interpolation — mevcut workflow step `input_envelope_template` field'ında `{context_pack_ref}` string placeholder Python f-string formatında mı, yoksa özel interpolation syntax mı? (Mevcut implementasyonu fact-check.)
+
+**Q4**: `write_artifact` vs `write_text_atomic` — C1a context.md yazımı için hangi helper doğru? `write_artifact` SHA256 + JSONL manifest entry üretir; context.md markdown düz dosya. `write_text_atomic` shared helper varsa o daha uygun.
+
+**Q5**: Adapter envelope → `InvocationResult.output_ref` dönüşümü `_invocation_from_envelope` içinde mi, yoksa Executor adapter branch'inde mi? Mevcut `InvocationResult` dataclass'ına `output_ref` field'ı ekliyor muyum?
+
+---
+
+## 7. Implementation Order
+
+1. **`ExecutionResult.output_ref` + `InvocationResult.output_ref`** — dataclass field ekle + adapter envelope extraction.
+2. **`build_driver(policy_loader=)` forward** — tek satır değişikliği.
+3. **`_context_compile` materialisation** — markdown template + atomic write.
+4. **`input_envelope` placeholder resolve** — step context_spec varsa interpolate.
+5. **4 yeni test + regression** — pytest green.
+6. **Commit + Codex post-impl review + PR #109 open**.
+
+---
+
+## 8. LOC Estimate
+
+~450 satır (dataclass delta + context_compile fn + envelope resolve + 4 test).
+
+---
+
+## 9. Audit Trail
+
+| Iter | Date | Verdict |
+|---|---|---|
+| v1 (Claude draft) | 2026-04-18 | Pre-Codex iter-1 submit |
+| iter-1 | TBD | Adversarial plan-review beklenir |
+
+**Codex thread**: Yeni thread (C1a-specific). FAZ-C master plan thread `019d9f75` bu PR için kapandı (Codex notes'ta C1a bağımsız onaylandı).

--- a/.claude/plans/PR-C1a-IMPLEMENTATION-PLAN.md
+++ b/.claude/plans/PR-C1a-IMPLEMENTATION-PLAN.md
@@ -1,10 +1,30 @@
-# PR-C1a Implementation Plan v3 — Adapter Artifact Surface + Context Compile Materialisation
+# PR-C1a Implementation Plan v4 — Adapter Artifact Surface + Context Compile Materialisation
 
 **Scope**: FAZ-C critical-path seri başı. Adapter-path output_ref garantisi + `context_compile` step real materialisation + `build_driver(policy_loader=...)` forward + `context_pack_ref` plumbing. Downstream PR'lar (C1b/C2/C3/C6) bu altyapıya bağımlı.
 
 **Base**: `main 5fb7f31` (PR #108 tooling merged). **Branch**: `feat/pr-c1a-adapter-surface`.
 
-**Status**: iter-2 PARTIAL absorb → iter-3 submit için hazır. Codex thread `019d9fc3-1b0b-76b2-b425-0f3dfd6efc66`.
+**Status**: iter-3 PARTIAL absorb → iter-4 submit için hazır. Codex thread `019d9fc3-1b0b-76b2-b425-0f3dfd6efc66`.
+
+---
+
+## v4 absorb summary (Codex iter-3 PARTIAL — 4 blocker + 2 warning)
+
+Iter-3 fact-check ile 4 API/attribute isim hatası + handler return dict eksik:
+
+| # | iter-3 bulgu | v4 fix |
+|---|---|---|
+| **B1** | Driver call `driver_managed=False` yanlış — driver contract `driver_managed=True` (`multi_step_driver.py:434,468`, `executor.py:129,478`). | v4: `driver_managed=True` override. Driver-owned CAS + capability artifact akışı korunur. |
+| **B2** | Resolver repo gerçekleriyle uyuşmuyor: `self._workflow_registry` yok (`self._registry`), `record["steps"]` liste (dict değil), `output_ref` run-relative `artifacts/...` (workspace-relative değil). | v4: `self._registry`, list iteration, artifact path = `workspace_root/.ao/evidence/workflows/{run_id}/{output_ref}`. |
+| **B3** | `canonical_store.query(workspace_root: Path, *, ...)` — `limit` kwarg yok; list döner. `compile_context()` `canonical_decisions` için `.items()` çağırıyor (dict bekler). | v4: `query(self._workspace_root)` signature fix + list → dict wrap: `{item["decision_id"]: item for item in canonical_list}`. |
+| **B4** | Handler return dict `context_preamble_bytes` + `context_path` taşımıyor; `_record_step_completion` `step_state.get()` ile okuyor → mismatch. Test `bytes > 0` empty-fixture'da fail olur. | v4: Handler return dict'e `context_preamble_bytes` + `context_path` eklenir. Test assertion `bytes >= 0` + `context_path.is_file()` (dosya varlık kontratı). |
+
+### v4 absorb warnings
+
+- **W1** (iter-3): Resolver `compile_step_names[0]` "ilk tanımlı" step seçiyor → çok-adımlı flow'larda yanlış context seçme riski. v4: Workflow step execution ORDER'ına göre (workflow_def.steps listesi topological order) + completion filter; "en son completed context_compile before current step" semantik. Dar-scope test `test_multi_context_compile_steps.py` eklenir (MVP 1 context_compile; ama semantik pin'li).
+- **W2** (iter-3): Master plan v5 drift follow-up item. v4 §5'te açık: C1a merge sonrası master plan v6 docs sync commit (ayrı 1-satır PR). PR body'de explicit drift note.
+
+---
 
 ---
 
@@ -148,19 +168,22 @@ if op == "context_compile":
 ```python
 if op == "context_compile":
     from ao_kernel.context.context_compiler import compile_context
-    from ao_kernel.context.canonical_store import load_store, query
+    from ao_kernel.context.canonical_store import query
     from ao_kernel._internal.shared.utils import write_text_atomic
     import json as _json
     
-    # MVP: session_context = {} (workflow-run schema top-level taşımıyor;
-    # session bridge ayrı PR'a bırakılır).
+    # MVP: session_context = {} (workflow-run schema top-level taşımıyor)
     session_context: dict[str, Any] = {}
     
-    # Canonical decisions: existing pipeline (agent_coordination.py:202 pattern).
-    canonical_store = load_store(self._workspace_root)
-    canonical = query(canonical_store, limit=100)
+    # Canonical decisions: query signature (workspace_root: Path, *, ...)
+    # returns list; compile_context() expects dict with .items() so wrap.
+    canonical_list = query(self._workspace_root)
+    canonical = {
+        item.get("decision_id", f"_idx_{idx}"): item
+        for idx, item in enumerate(canonical_list)
+    }
     
-    # Workspace facts: direct JSON read (`.cache/index/workspace_facts.v1.json`).
+    # Workspace facts: direct JSON read
     facts_path = (
         self._workspace_root / ".cache" / "index" / "workspace_facts.v1.json"
     )
@@ -198,6 +221,10 @@ if op == "context_compile":
         "output_ref": output_ref,
         "output_sha256": output_sha256,
         "operation": op,
+        # v4 B4 absorb: propagate to step_state so _record_step_completion
+        # reads real values (not stub hardcode).
+        "context_preamble_bytes": len(compiled.preamble.encode("utf-8")),
+        "context_path": str(context_path),
     }
 ```
 
@@ -227,18 +254,19 @@ if step_def.operation == "context_compile":
     }
 ```
 
-Bu değişiklik test `test_context_compile_stub_emits_stub_marker` kontratını günceller — artık assertion:
+Bu değişiklik test `test_context_compile_stub_emits_stub_marker` kontratını günceller — artık assertion (v4 B4 absorb — empty-fixture tolerant):
 ```python
 # Before
 assert payload["stub"] is True
 assert payload["context_preamble_bytes"] == 0
-# After  
+# After (v4 — empty canonical/facts fixture için bytes 0 olabilir)
 assert payload["stub"] is False
-assert payload["context_preamble_bytes"] > 0
-assert payload["context_path"].endswith(".md")
+assert payload["context_preamble_bytes"] >= 0  # empty fixture tolerates
+assert payload["context_path"] is not None
+assert Path(payload["context_path"]).is_file()  # dosya gerçekten var
 ```
 
-Step handler return dict'i `context_preamble_bytes` + `context_path` taşır (handler kendi payload'unda yazar; propagate için step_state'e de eklenir).
+Step handler return dict'i `context_preamble_bytes` + `context_path` taşır (§2.3 "After" kod örneğinde eklendi).
 
 **Path semantics (iter-1 B3 absorb)**: `context_path` **absolute path** (`{workspace_root}/.ao/evidence/workflows/{run_id}/context-{step_id}-attempt{attempt}.md`). Adapter subprocess worktree cwd'sinde çalışsa bile absolute path okunur. `run_dir` zaten `_run_ao_kernel_step` içinde hesaplanmış (line 588).
 
@@ -284,32 +312,43 @@ Backwards-compat: `input_envelope_override=None` → mevcut davranış. Mevcut c
 def _build_adapter_envelope_with_context(
     self, run_id: str, step_def: StepDefinition, record: Mapping[str, Any],
 ) -> dict[str, Any] | None:
-    """Resolve context_pack_ref from prior context_compile step's artifact.
-    Returns envelope override dict OR None if no context to inject
-    (caller falls back to Executor default envelope)."""
-    # 1. Workflow tanımından context_compile step_name'ini bul
-    workflow_def = self._workflow_registry.get(
+    """Resolve context_pack_ref from most recent completed
+    context_compile step in the run. Returns envelope override dict
+    OR None if no context available (caller falls back to Executor
+    default envelope)."""
+    # 1. Workflow tanımından context_compile step_name'lerini bul
+    #    (v4 B2 absorb: self._registry — self._workflow_registry değil)
+    workflow_def = self._registry.get(
         record["workflow_id"], record["workflow_version"],
     )
-    compile_step_names = [
+    compile_step_names = {
         sd.step_name for sd in workflow_def.steps
         if sd.operation == "context_compile"
-    ]
+    }
     if not compile_step_names:
         return None
     
-    # 2. En son tamamlanan context_compile step_record'unu bul
-    compile_step_name = compile_step_names[0]  # Workflow'larda typically 1 tane
-    compile_record = record.get("steps", {}).get(compile_step_name)
-    if not compile_record or compile_record.get("state") != "completed":
+    # 2. steps LIST iteration (v4 B2 absorb: record["steps"] is list)
+    #    En son tamamlanan context_compile step (reverse order)
+    compile_record = None
+    for prior in reversed(record.get("steps", [])):
+        if (
+            prior.get("step_name") in compile_step_names
+            and prior.get("state") == "completed"
+            and prior.get("output_ref")
+        ):
+            compile_record = prior
+            break
+    if compile_record is None:
         return None
     
-    output_ref = compile_record.get("output_ref")
-    if not output_ref:
-        return None
-    
-    # 3. Artifact JSON'dan context_path çek
-    artifact_path = self._workspace_root / output_ref
+    # 3. Artifact path = evidence run_dir + run-relative output_ref
+    #    (v4 B2 absorb: output_ref is run-relative "artifacts/..."
+    #    per artifacts.py:50,108 — NOT workspace-relative)
+    run_dir = (
+        self._workspace_root / ".ao" / "evidence" / "workflows" / run_id
+    )
+    artifact_path = run_dir / compile_record["output_ref"]
     if not artifact_path.is_file():
         return None
     
@@ -318,13 +357,15 @@ def _build_adapter_envelope_with_context(
     if not context_path:
         return None
     
-    # 4. Envelope (task_prompt kaynak: record.intent.payload — iter-2 B2 pin)
+    # 4. Envelope (task_prompt = record.intent.payload; iter-2 B2 pin)
     return {
         "task_prompt": record.get("intent", {}).get("payload", ""),
         "run_id": run_id,
         "context_pack_ref": context_path,  # absolute
     }
 ```
+
+**Çok-adımlı workflow semantiği (iter-3 W1 absorb)**: Reverse iteration + completion filter → "en son completed context_compile before current step" semantiği. MVP workflow'larda 1 context_compile; ama çok-adımlı pattern desteklenir.
 
 **B1.3 — Driver `_run_adapter_step` override forward** (`multi_step_driver.py:467`):
 ```python
@@ -337,7 +378,7 @@ execution_result = self._executor.run_step(
     step_def,
     parent_env=parent_env,
     attempt=attempt,
-    driver_managed=False,
+    driver_managed=True,  # v4 B1 absorb: driver contract
     input_envelope_override=envelope_override,  # None | dict
 )
 ```

--- a/.claude/plans/PR-C1a-IMPLEMENTATION-PLAN.md
+++ b/.claude/plans/PR-C1a-IMPLEMENTATION-PLAN.md
@@ -1,4 +1,12 @@
-# PR-C1a Implementation Plan v4 — Adapter Artifact Surface + Context Compile Materialisation
+# PR-C1a Implementation Plan v5 — Adapter Artifact Surface + Context Compile Materialisation
+
+**v5 absorb (iter-4 PARTIAL — 3 blocker + 2 warning, all text-level)**: `exec_result` (not `step_state`) in `_record_step_completion`; canonical key is `"key"` (not `"decision_id"`); `parent_env` removed from `_run_adapter_step` example (stays `{}` — scope unchanged); test `>= 0` consistency; `_build_adapter_envelope_with_context` rename sync throughout.
+
+---
+
+# (v4 retained for history)
+
+## PR-C1a Implementation Plan v4 — Adapter Artifact Surface + Context Compile Materialisation
 
 **Scope**: FAZ-C critical-path seri başı. Adapter-path output_ref garantisi + `context_compile` step real materialisation + `build_driver(policy_loader=...)` forward + `context_pack_ref` plumbing. Downstream PR'lar (C1b/C2/C3/C6) bu altyapıya bağımlı.
 
@@ -179,7 +187,7 @@ if op == "context_compile":
     # returns list; compile_context() expects dict with .items() so wrap.
     canonical_list = query(self._workspace_root)
     canonical = {
-        item.get("decision_id", f"_idx_{idx}"): item
+        item.get("key", f"_idx_{idx}"): item
         for idx, item in enumerate(canonical_list)
     }
     
@@ -240,17 +248,17 @@ if step_def.operation == "context_compile":
 if step_def.operation == "context_compile":
     # Step handler dönüş dict'inden gerçek değerler
     # Handler artifact JSON yazdı; burada artifact'ı re-read etmek
-    # yerine step_state dict'inden (handler return'dan) çekeriz.
+    # yerine exec_result dict'inden (handler return'dan) çekeriz.
     # Handler return dict'i zaten output_ref içeriyor; ek metadata
     # için artifact JSON parse edilebilir ama daha pahalı.
-    # Minimal çözüm: step_state dict'ine payload alanlarını ekle
+    # Minimal çözüm: handler return dict'ine payload alanlarını ekle
     # (handler zaten yaratıyor; sadece propagate edilir).
     payload = {
         "stub": False,
-        "context_preamble_bytes": step_state.get(
+        "context_preamble_bytes": exec_result.get(
             "context_preamble_bytes", 0
         ),
-        "context_path": step_state.get("context_path"),
+        "context_path": exec_result.get("context_path"),
     }
 ```
 
@@ -376,7 +384,8 @@ envelope_override = self._build_adapter_envelope_with_context(
 execution_result = self._executor.run_step(
     run_id,
     step_def,
-    parent_env=parent_env,
+    # parent_env kept as {} per current contract (C2 scope widens later).
+    parent_env={},
     attempt=attempt,
     driver_managed=True,  # v4 B1 absorb: driver contract
     input_envelope_override=envelope_override,  # None | dict
@@ -405,7 +414,7 @@ execution_result = self._executor.run_step(
   - `context_compile` step → `.ao/evidence/workflows/{run_id}/context-{step_id}-attempt1.md` yazılır.
   - İçerik: `compile_context()` preamble (session_context + canonical + facts).
   - Atomic: tmp file process crash olsa kalmaz.
-  - Canonical evidence JSON `stub: false` + `context_preamble_bytes > 0` + `context_path` absolute.
+  - Canonical evidence JSON `stub: false` + `context_preamble_bytes >= 0` (empty-fixture tolerant) + `context_path` absolute + `Path(context_path).is_file()`.
 - `tests/test_context_pack_ref_plumbing.py`:
   - 2-step run: `context_compile` → `invoke_adapter`.
   - Adapter envelope `context_pack_ref` = prior step `context_path` (absolute).
@@ -442,7 +451,7 @@ execution_result = self._executor.run_step(
 | Risk | L | I | Mitigation |
 |---|---|---|---|
 | R1 `compile_context()` pipeline B6/B7 benchmark testlerinde unbounded side-effect üretir | M | M | `profile="TASK_EXECUTION"` bounded token budget + existing pipeline'a smoke test |
-| R2 `_build_adapter_input_envelope` scan prior steps performans concern (N-step run'larda O(N)) | L | L | Reverse iteration + early break — FAZ-C workflow'ları ≤10 step |
+| R2 `_build_adapter_envelope_with_context` scan prior steps performans concern (N-step run'larda O(N)) | L | L | Reverse iteration + early break — FAZ-C workflow'ları ≤10 step |
 | R3 `write_text_atomic` tmp dosyası concurrency'de çakışma | L | M | Per-(run_id, step_id, attempt) dosya adı UUID-scoped — çakışma teorik yok |
 | R4 B6 `capability_output_refs` plumbing C1a `ExecutionResult.output_ref` ekleme ile kırılır | M | H | Regression gate: `test_governed_review.py` green. B6 `getattr` pattern field eklemeyi tolere eder |
 | R5 `context_compile` step olmayan workflow'larda adapter envelope placeholder literal kalır → prod adapter `--prompt-file` okuyamaz | M | H | Placeholder literal = explicit "no context" kontrat; documented in C1a scope. C1b + C2'de real adapter manifest `--prompt-file` conditional (context varsa geçir) |
@@ -454,7 +463,7 @@ execution_result = self._executor.run_step(
 1. **`ExecutionResult.output_ref` field** — dataclass delta + Executor adapter + driver-managed branch populate.
 2. **`build_driver(policy_loader=)` forward** — tek satır.
 3. **`context_compile` step materialisation** — `compile_context()` integration + `write_text_atomic` + metadata evidence.
-4. **`_build_adapter_input_envelope` context_pack_ref resolver** — prior steps scan + envelope key populate.
+4. **`_build_adapter_envelope_with_context` context_pack_ref resolver** — prior steps scan + envelope key populate.
 5. **4 yeni test + regression (`pytest -x`)**.
 6. **Commit + Codex post-impl review (thread `019d9fc3`) + PR #109 open + admin merge (after CI green + Codex AGREE)**.
 
@@ -473,7 +482,7 @@ execution_result = self._executor.run_step(
 | v1 (Claude draft) | 2026-04-18 | Pre-Codex submit (`c2b61d9`) |
 | iter-1 (thread `019d9fc3`) | 2026-04-18 | **PARTIAL** — 3 blocker (InvocationResult.output_ref yanlış, context_spec/input_envelope_template yok, relative path runtime'da çözmez) + 3 warning + Q1-Q5 net cevaplar |
 | v2 (iter-1 absorb) | 2026-04-18 | `734b81f` commit |
-| iter-2 | 2026-04-18 | **PARTIAL** — 3 blocker (step_record schema `operation`/`context_path` persist etmiyor, `_build_adapter_input_envelope` çağrı zincirinde yok + `step_def.task_prompt` yok, `_record_step_completion` stub hardcode) + 3 warning (helper names, master plan drift, gh-cli-pr disclaimer) |
+| iter-2 | 2026-04-18 | **PARTIAL** — 3 blocker (step_record schema `operation`/`context_path` persist etmiyor, `_build_adapter_envelope_with_context` çağrı zincirinde yok + `step_def.task_prompt` yok, `_record_step_completion` stub hardcode) + 3 warning (helper names, master plan drift, gh-cli-pr disclaimer) |
 | **v3 (iter-2 absorb)** | 2026-04-18 | Pre-iter-3 submit. Artifact JSON read resolver + `input_envelope_override` widen + `_record_step_completion` hardcode absorb + helper names (canonical_store.query) + session_context={} MVP. |
 | iter-3 | TBD | AGREE expected (3 blocker concrete fix'ler + warnings netleşti) |
 

--- a/.claude/plans/PR-C1a-IMPLEMENTATION-PLAN.md
+++ b/.claude/plans/PR-C1a-IMPLEMENTATION-PLAN.md
@@ -430,7 +430,7 @@ execution_result = self._executor.run_step(
 
 - `ao_kernel.executor.executor::ExecutionResult` — field delta.
 - `ao_kernel.executor.multi_step_driver::_run_ao_kernel_step` context_compile branch — compile_context + write_text_atomic yeni path.
-- `ao_kernel.executor.multi_step_driver::_build_adapter_input_envelope` (yeni fonksiyon) — context_pack_ref resolver.
+- `ao_kernel.executor.multi_step_driver::_build_adapter_envelope_with_context` (yeni fonksiyon) — context_pack_ref resolver.
 
 ---
 

--- a/.claude/plans/PR-C1a-IMPLEMENTATION-PLAN.md
+++ b/.claude/plans/PR-C1a-IMPLEMENTATION-PLAN.md
@@ -1,39 +1,52 @@
-# PR-C1a Implementation Plan — Adapter Artifact Surface + Context Compile Materialisation
+# PR-C1a Implementation Plan v2 — Adapter Artifact Surface + Context Compile Materialisation
 
-**Scope**: FAZ-C critical-path seri başı. Adapter-path output_ref garantisi + context_compile gerçek dosya üretimi + `build_driver(policy_loader=...)` forward + `input_envelope.context_pack_ref` resolve. Downstream PR'lar (C1b/C2/C3/C6) bu altyapıya bağımlı.
+**Scope**: FAZ-C critical-path seri başı. Adapter-path output_ref garantisi + `context_compile` step real materialisation + `build_driver(policy_loader=...)` forward + `context_pack_ref` plumbing. Downstream PR'lar (C1b/C2/C3/C6) bu altyapıya bağımlı.
 
 **Base**: `main 5fb7f31` (PR #108 tooling merged). **Branch**: `feat/pr-c1a-adapter-surface`.
 
-**Status**: Pre-Codex iter-1 submit. FAZ-C master plan v5 `cce30c1` C1a scope'u bu PR'a decouple ediliyor (Codex iter-6 notes: "C1a izole PR başlatılması makul").
+**Status**: iter-1 PARTIAL absorb → iter-2 submit için hazır. Codex thread `019d9fc3-1b0b-76b2-b425-0f3dfd6efc66`.
+
+---
+
+## v2 absorb summary (Codex iter-1 PARTIAL — 3 blocker + 3 warning)
+
+Codex iter-1 fact-check ile v1'deki 3 tasarım hatası düzeltildi (kod-okuma: `adapter_invoker.py:514`, `executor.py:419-422`, `multi_step_driver.py:594-609`, `workflow-definition.schema.v1.json:101`, `registry.py:55`, `context_compiler.py:42`, `utils.py:47`).
+
+| # | iter-1 bulgu | v2 fix |
+|---|---|---|
+| **B1** | v1 "`InvocationResult.output_ref`" yanlış — alan yok, envelope parser populate etmiyor (`adapter_invoker.py:514`, `agent-adapter-contract.schema.v1.json:299`). Executor zaten `write_artifact()` ile local `output_ref` üretiyor (`executor.py:422`). | v2: `InvocationResult` değişmez. `ExecutionResult.output_ref`, Executor adapter branch'inde mevcut local `output_ref`'tan (line 422 `write_artifact` sonucu) doldurulur. Driver-managed path da aynı pattern. |
+| **B2** | v1 `step_def.context_spec` + `input_envelope_template` yüzeyleri yok — `StepDefinition` bunları taşımıyor (`registry.py:55`), workflow schema tanımlı değil (`workflow-definition.schema.v1.json:101`). | v2: Bu yüzeyleri icat etme. `context_compile` **zaten explicit ao-kernel step** olarak modellenmiş (`multi_step_driver.py:594`). Materialisation step handler içinde yapılır — Executor'a spec push edilmez. Adapter invocation sadece referans çözümler. |
+| **B3** | v1 `".ao/runs/{run_id}/context.md"` relative path yanlış. Adapter CLI subprocess worktree kökünde çalışır (`adapter_invoker.py:135`, `worktree_builder.py:91`: worktree = `.ao/runs/{run_id}/worktree`). Worktree-relative "../context.md" çözmez. | v2: Mutlak path kullan. `context.md` evidence dir'de yazılır (`.ao/evidence/workflows/{run_id}/context-{step_id}-{attempt}.md`), adapter envelope'ına absolute path geçer. `_substitute_args` plain string replace; absolute path'ı literal geçer, subprocess okuyabilir. |
+
+### v2 absorb warnings
+
+- **W1** (iter-1): `gh-cli-pr` manifest `args` `{context_pack_ref}` kullanıyor ama `input_envelope` shape deklare etmiyor (`gh-cli-pr.manifest.v1.json:9,15`). **C1a out-of-scope**: manifest tutarsızlığı C1b full bundled bug_fix_flow test'inde ortaya çıkacak; C1b kapsamında manifest shape düzeltilecek. C1a dokümantasyonu bu gap'i flag'ler.
+- **W2** (iter-1): `build_driver(policy_loader)` sadece Executor'a forward ediyor; driver'ın kendi policy yüzeyi ayrı (`multi_step_driver.py:189,1674`). C1a scope: **Executor-only override**. Plan §2.1 dili "Executor policy override forward" olarak daraltıldı.
+- **W3** (iter-1): Repo'da `context_compiler.compile_context()` pipeline mevcut (`context/context_compiler.py:53-90`). v1'in role/constraints/references markdown şablonu bu pipeline ile hizasız. v2: Mevcut `compile_context()` → `CompiledContext.preamble` serialize edilir; v1 şablonu drop.
 
 ---
 
 ## 1. Problem
 
-FAZ-C master plan iter-1 Codex fact-check ile tespit edilen 4 runtime gap:
+FAZ-C master plan iter-1 Codex fact-check + iter-6 C1a decouple karar sonrası tespit edilen 4 runtime gap:
 
 | Kod yüzey | Bugünkü hâl | Gap |
 |---|---|---|
-| `tests/_driver_helpers.build_driver(root: Path)` | Sadece `root` alır; Executor default bundled policy ile kurulur (`_driver_helpers.py:100-119`). | Benchmark'lar ve FAZ-C testleri policy override gerektirir; `Executor(policy_loader=...)` kwarg zaten var ama driver helper forward etmez. |
-| `Executor.ExecutionResult` dataclass | `{new_state, step_state, invocation_result, evidence_event_ids, budget_after}` (`executor.py:68-74`). `output_ref` field YOK. | `multi_step_driver._update_step_record_with_output_ref` `getattr(exec_result, "output_ref", None)` ile okuyor (`multi_step_driver.py:1321-1323`) — driver-managed path'te dolu, adapter-path'te garanti değil. |
-| `_context_compile` stub (`multi_step_driver.py`) | Placeholder; `.ao/runs/{run_id}/context.md` üretmez. | `claude-code-cli` / `gh-cli-pr` manifest `context_pack_ref` literal placeholder olarak kalır → adapter envelope input yanlış. |
-| `input_envelope` builder | `{context_pack_ref}` placeholder string'i literal geçer (resolve yok). | `context_compile` materialisation sonrası dahi envelope'a relative path geçmez. |
-
-**Sonuç**: Adapter'lar context-driven full-flow'da kırılır (B6 review_ai_flow testinde workaround shim ile geçiyor; real path gap'i C1b full bundled bugfix'te ortaya çıkar).
+| `tests/_driver_helpers.build_driver(root: Path)` | Sadece `root` alır; Executor default bundled policy ile kurulur (`_driver_helpers.py:100-119`). | Benchmark'lar + FAZ-C testleri policy override gerektirir. `Executor.__init__(policy_loader=...)` kwarg zaten var; helper forward etmez. |
+| `Executor.ExecutionResult` dataclass | `{new_state, step_state, invocation_result, evidence_event_ids, budget_after}` (`executor.py:68-74`). `output_ref` field YOK. | Executor adapter branch'i zaten local `output_ref` üretiyor (line 422, `write_artifact` dönüşü) ama ExecutionResult'a yansıtmıyor. `multi_step_driver._update_step_record_with_output_ref` `getattr(exec_result, "output_ref", None)` ile okuyor (line 1321-1323) — adapter-path'te hep None. |
+| `multi_step_driver._run_ao_kernel_step::context_compile` | A4b stub (`multi_step_driver.py:594-609`): `payload={"stub": True, "context_preamble_bytes": 0}`, `write_artifact` ile canonical JSON yazar, **gerçek preamble üretmez**. | `claude-code-cli` / `gh-cli-pr` manifest `{context_pack_ref}` CLI flag'ına `--prompt-file <path>` olarak geçer (`claude-code-cli.manifest.v1.json:9`). Path placeholder literal kalıyor → adapter prompt-file okuyamaz. |
+| `_substitute_args` envelope key resolver (`adapter_invoker.py:702`) | Plain string replace: her envelope key için `"{key}" -> value`. Eksik placeholder literal kalır. | Workflow DAG'da `context_compile` step çıkışı → sonraki adapter step envelope'ında `context_pack_ref` değeri olarak plumb edilmez. |
 
 ---
 
 ## 2. Scope (atomic deliverable)
 
-### 2.1 `_driver_helpers.build_driver` widen
+### 2.1 `_driver_helpers.build_driver` forward — Executor-only policy override
 
 **Before**:
 ```python
 def build_driver(root: Path) -> MultiStepDriver:
-    wreg = WorkflowRegistry()
-    wreg.load_workspace(root)
-    areg = AdapterRegistry()
-    areg.load_workspace(root)
+    ...
     executor = Executor(
         workspace_root=root,
         workflow_registry=wreg,
@@ -49,24 +62,19 @@ def build_driver(
     *,
     policy_loader: Mapping[str, Any] | None = None,
 ) -> MultiStepDriver:
-    wreg = WorkflowRegistry()
-    wreg.load_workspace(root)
-    areg = AdapterRegistry()
-    areg.load_workspace(root)
+    ...
     executor = Executor(
         workspace_root=root,
         workflow_registry=wreg,
         adapter_registry=areg,
-        policy_loader=policy_loader,  # forward (None → Executor defaults to bundled)
+        policy_loader=policy_loader,  # Executor-only override forward
     )
     return MultiStepDriver(...)
 ```
 
-Callers:
-- Mevcut: `tests/benchmarks/conftest.py`, `tests/test_multi_step_driver.py` → tamamen dokunulmaz (kwarg default None, behavior korunur).
-- Yeni: `tests/benchmarks/fixtures.py::bench_policy_override()` helper + bench-scope workspace policy override testlerinde kullanılır (C1b + C2 için hazırlık).
+**Scope netleştirme (iter-1 W2 absorb)**: Driver'ın kendi policy yüzeyi (`multi_step_driver.py:189,1674`) bu PR'da dokunulmaz. C1a scope = Executor-layer policy override forward. Driver-level override gerekirse ayrı PR (C1b veya sonraki).
 
-### 2.2 `ExecutionResult.output_ref` field
+### 2.2 `ExecutionResult.output_ref` additive field (Executor-side source)
 
 **Before**:
 ```python
@@ -79,7 +87,7 @@ class ExecutionResult:
     budget_after: Mapping[str, Any]
 ```
 
-**After** (additive Optional field):
+**After** (additive Optional field, default None):
 ```python
 @dataclass(frozen=True)
 class ExecutionResult:
@@ -88,86 +96,124 @@ class ExecutionResult:
     invocation_result: InvocationResult | None
     evidence_event_ids: tuple[str, ...]
     budget_after: Mapping[str, Any]
-    output_ref: str | None = None  # run-relative path; driver-managed OR adapter path populated
+    output_ref: str | None = None
 ```
 
-**Executor.run_step adapter path populate**:
-Mevcut adapter path'te (`driver_managed=False`) `invocation_result.output_ref` InvocationResult'tan çıkar; yeni kod ExecutionResult.output_ref'e yansıtır. `write_artifact` çağrısı zaten driver-managed path'te var (line 601, 696, 800); adapter-path için aynı pattern:
+**Populate policy (iter-1 B1 absorb)**:
+- **Adapter path** (`executor.py:422`): Mevcut `output_ref, output_sha256 = write_artifact(...)` satırı; ExecutionResult return satırında `output_ref=output_ref` yansıtılır.
+- **Driver-managed path** (`executor.py:601, 696, 800`): Mevcut `output_ref` zaten artifact-level; aynı şekilde ExecutionResult'a yansıtılır.
+- **InvocationResult değişmez**: Yeni alan eklenmez (iter-1 B1).
+- **Adapter manifest schema değişmez**: `agent-adapter-contract.schema.v1.json::output_ref` field yok, eklenmez (iter-1 B1).
+
+### 2.3 `context_compile` step real materialisation
+
+**Before** (`multi_step_driver.py:594-609`, A4b stub):
 ```python
-# executor.py run_step adapter branch
-if invocation_result is not None and invocation_result.output_ref:
-    exec_output_ref = invocation_result.output_ref  # envelope'tan gelen ref
-else:
-    exec_output_ref = None
-return ExecutionResult(..., output_ref=exec_output_ref)
+if op == "context_compile":
+    payload = {
+        "operation": "context_compile",
+        "stub": True,
+        "context_preamble_bytes": 0,
+    }
+    output_ref, output_sha256 = write_artifact(...)
+    return dict(record), {
+        "step_state": "completed",
+        "output_ref": output_ref,
+        "output_sha256": output_sha256,
+        "operation": op,
+    }
 ```
 
-Driver-managed path mevcut davranış korunur (B6 v4 `capability_output_refs` + `output_ref` plumbing değişmez).
-
-### 2.3 `_context_compile` materialisation
-
-**Before** (varsayım — stub/placeholder):
+**After** (gerçek compile + markdown materialisation):
 ```python
-def _context_compile(run_id, context_spec) -> str:
-    return "context_placeholder"  # Hypothetical stub
-```
-
-**After** (gerçek dosya yazımı, atomic):
-```python
-def _context_compile(
-    workspace_root: Path,
-    run_id: str,
-    context_spec: Mapping[str, Any],
-) -> str:
-    """Compile run context to .ao/runs/{run_id}/context.md.
+if op == "context_compile":
+    from ao_kernel.context.context_compiler import compile_context
+    from ao_kernel.context.canonical_store import load_canonical_decisions
+    from ao_kernel.context.workspace_facts import load_workspace_facts
+    from ao_kernel._internal.shared.utils import write_text_atomic
     
-    Returns run-relative path (e.g. '.ao/runs/abc123/context.md').
-    Content shape: markdown with sections from context_spec (role,
-    constraints, references). Atomic write via tmp + rename.
-    """
-    content = _render_context_markdown(context_spec)
-    path = workspace_root / ".ao" / "runs" / run_id / "context.md"
-    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    write_text_atomic(path, content)  # mevcut shared helper
-    return str(path.relative_to(workspace_root))
-```
-
-Minimal context_spec shape (v1):
-- `role: str` — system prompt benzeri
-- `constraints: list[str]` — YAPMAMASI gereken
-- `references: list[str]` — context materyali
-
-Markdown template (v1):
-```markdown
-# Run Context
-
-## Role
-{role}
-
-## Constraints
-{constraints_bulleted}
-
-## References
-{references_bulleted}
-```
-
-### 2.4 `input_envelope.context_pack_ref` placeholder resolve
-
-**Before**: `input_envelope` builder `{context_pack_ref}` placeholder'ı literal olarak geçer (test: `tests/test_adapter_envelope_compile.py` placeholder literal beklenir).
-
-**After**: `Executor.run_step` input_envelope builder içinde:
-```python
-if step_def.context_spec is not None:
-    context_ref = _context_compile(
-        self._workspace_root, run_id, step_def.context_spec
+    # Load 3-lane context (existing pipeline)
+    session_context = dict(record.get("session_context") or {})
+    canonical = load_canonical_decisions(self._workspace_root)
+    facts = load_workspace_facts(self._workspace_root)
+    
+    compiled = compile_context(
+        session_context,
+        canonical_decisions=canonical,
+        workspace_facts=facts,
+        profile="TASK_EXECUTION",  # default; future: from step_def
     )
-    input_envelope["context_pack_ref"] = context_ref  # run-relative
-else:
-    # step'te context_spec yoksa placeholder korunur (backwards-compat)
-    pass
+    
+    # Write markdown preamble (absolute path for adapter subprocess)
+    context_path = (
+        run_dir / f"context-{step_id}-attempt{attempt}.md"
+    )
+    write_text_atomic(context_path, compiled.preamble)
+    
+    # Canonical evidence JSON (existing pattern, now with real metadata)
+    payload = {
+        "operation": "context_compile",
+        "stub": False,
+        "context_preamble_bytes": len(compiled.preamble.encode("utf-8")),
+        "context_path": str(context_path),  # absolute
+        "total_tokens": compiled.total_tokens,
+        "items_included": compiled.items_included,
+        "items_excluded": compiled.items_excluded,
+        "profile_id": compiled.profile_id,
+    }
+    output_ref, output_sha256 = write_artifact(
+        run_dir=run_dir, step_id=step_id, attempt=attempt, payload=payload,
+    )
+    return dict(record), {
+        "step_state": "completed",
+        "output_ref": output_ref,
+        "output_sha256": output_sha256,
+        "operation": op,
+        "context_path": str(context_path),  # downstream plumbing için
+    }
 ```
 
-Placeholder interpolation pattern workflow step definition'daki `input_envelope_template` içinde mevcutsa resolve edilir; yoksa verbatim korunur.
+**Path semantics (iter-1 B3 absorb)**: `context_path` **absolute path** (`{workspace_root}/.ao/evidence/workflows/{run_id}/context-{step_id}-attempt{attempt}.md`). Adapter subprocess worktree cwd'sinde çalışsa bile absolute path okunur. `run_dir` zaten `_run_ao_kernel_step` içinde hesaplanmış (line 588).
+
+**Helper seçimi (iter-1 Q4 absorb)**: `write_text_atomic` (`_internal/shared/utils.py:47`) — markdown düz dosya için doğru. `write_artifact` canonical JSON + SHA256 + JSONL manifest; context.md için overkill.
+
+**Template shape (iter-1 W3 + Q2 absorb)**: `compile_context()` dönen `CompiledContext.preamble` directly serialize edilir. v1'in role/constraints/references manuel şablonu dropped — mevcut pipeline'ı tekrar icat etmek yanlış.
+
+### 2.4 `context_pack_ref` envelope plumbing
+
+**Before**: Workflow step zincirinde `context_compile` step çıkışı → sonraki adapter step envelope'ında `context_pack_ref` resolver'ı yok. Envelope `{context_pack_ref}` placeholder literal kalır.
+
+**After** (minimum viable plumbing):
+
+`multi_step_driver` içinde adapter step envelope builder:
+```python
+def _build_adapter_input_envelope(
+    self, run_id: str, step_def: StepDefinition, record: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build input_envelope for adapter step; resolve context_pack_ref
+    from most recent completed context_compile step in the run."""
+    envelope = {
+        "task_prompt": step_def.task_prompt or "",
+        "run_id": run_id,
+    }
+    # context_pack_ref resolution: scan prior completed steps for
+    # `operation == "context_compile"` → take the most recent
+    # `context_path`. If none → placeholder stays literal (backwards-
+    # compat: zero-prior-context-compile runs still work).
+    for prior in reversed(record.get("steps", [])):
+        if (
+            prior.get("state") == "completed"
+            and prior.get("operation") == "context_compile"
+            and prior.get("context_path")
+        ):
+            envelope["context_pack_ref"] = prior["context_path"]
+            break
+    return envelope
+```
+
+**Resolver semantiği (iter-1 Q3 + B3 absorb)**: Adapter envelope'una `context_pack_ref` key'i konulursa, `_substitute_args` (`adapter_invoker.py:702`) plain string replace ile `"{context_pack_ref}"` → absolute path'ı literal geçirir. Key yoksa placeholder literal kalır (zero-prior-context-compile test case — backwards-compat).
+
+**StepDefinition değişmez (iter-1 B2 absorb)**: `context_spec` yeni field yok. `input_envelope_template` yok. Envelope builder workflow record steps history'sinden türetir.
 
 ---
 
@@ -175,30 +221,45 @@ Placeholder interpolation pattern workflow step definition'daki `input_envelope_
 
 ### 3.1 Yeni testler
 
-- `tests/test_driver_helpers_policy_loader.py` — `build_driver(root, policy_loader=override)` Executor'a forward eder; default call backwards-compat.
-- `tests/test_executor_adapter_output_ref.py` — Adapter path mock envelope → InvocationResult.output_ref → ExecutionResult.output_ref populate.
-- `tests/test_context_compile_materialisation.py` — `_context_compile(root, run_id, spec)` `.ao/runs/{run_id}/context.md` yazar; content role/constraints/references section'ları içerir; atomic write (tmp file kalmaz).
-- `tests/test_input_envelope_context_pack_ref.py` — step context_spec varsa `context_pack_ref` = relative path; yoksa placeholder korunur.
+- `tests/test_driver_helpers_policy_loader.py`:
+  - `build_driver(root, policy_loader=custom)` → Executor custom policy kullanır.
+  - `build_driver(root)` → default bundled policy (backwards-compat).
+- `tests/test_executor_adapter_output_ref.py`:
+  - Adapter path mock invocation → `write_artifact` çağrısı → `ExecutionResult.output_ref` populated (run-relative path).
+  - Driver-managed path → `ExecutionResult.output_ref` aynı şekilde populated.
+- `tests/test_context_compile_materialisation.py`:
+  - `context_compile` step → `.ao/evidence/workflows/{run_id}/context-{step_id}-attempt1.md` yazılır.
+  - İçerik: `compile_context()` preamble (session_context + canonical + facts).
+  - Atomic: tmp file process crash olsa kalmaz.
+  - Canonical evidence JSON `stub: false` + `context_preamble_bytes > 0` + `context_path` absolute.
+- `tests/test_context_pack_ref_plumbing.py`:
+  - 2-step run: `context_compile` → `invoke_adapter`.
+  - Adapter envelope `context_pack_ref` = prior step `context_path` (absolute).
+  - Zero-prior-context-compile: `{context_pack_ref}` literal kalır.
 
 ### 3.2 Regression gate
 
-- `pytest tests/ -x` tüm mevcut 2142 test green kalmalı.
-- Özellikle `tests/benchmarks/test_governed_review.py` (B6/B7) — adapter-path output_ref yeni populate davranışıyla `capability_output_refs` plumbing değişmez.
+- `pytest tests/ -x` 2142 test green.
+- Özellikle B6 `tests/benchmarks/test_governed_review.py` — `capability_output_refs` plumbing (line 1321-1335) değişmez; ExecutionResult.output_ref ekleme mevcut davranışı kırmaz.
+- B7 `tests/benchmarks/test_governed_review.py::TestCostReconcile` — B7.1 cost_usd shim korunur (C3 scope değil).
 
 ### 3.3 Coverage
 
-- `ao_kernel.executor.executor` coverage %70+ korunur (ExecutionResult delta).
-- `ao_kernel.executor.multi_step_driver` `_context_compile` + `input_envelope` resolver için yeni line coverage.
+- `ao_kernel.executor.executor::ExecutionResult` — field delta.
+- `ao_kernel.executor.multi_step_driver::_run_ao_kernel_step` context_compile branch — compile_context + write_text_atomic yeni path.
+- `ao_kernel.executor.multi_step_driver::_build_adapter_input_envelope` (yeni fonksiyon) — context_pack_ref resolver.
 
 ---
 
 ## 4. Out of Scope
 
-- **C1b** (full bundled `bug_fix_flow` E2E) — ayrı PR, C1a merge'den sonra.
-- **C2** (real adapter full mode + parent_env union) — C1a merge sonrası paralel.
-- **C3** (cost_usd reconcile + `post_adapter_reconcile` middleware) — C1a merge sonrası paralel.
-- **C6** (dry_run_step) — C1a merge sonrası paralel.
-- Kontrat genişletme, yeni schema, yeni adapter manifest alanları — hiçbiri.
+- **C1b** (full bundled `bug_fix_flow` E2E + manifest shape fix `gh-cli-pr` — iter-1 W1) — ayrı PR, C1a merge sonrası.
+- **C2** (parent_env union: `allowlist_secret_ids ∪ env_allowlist.allowed_keys`) — C1a merge sonrası paralel.
+- **C3** (`cost_usd` reconcile + `post_adapter_reconcile` middleware) — C1a merge sonrası paralel.
+- **C6** (`dry_run_step`) — C1a merge sonrası paralel.
+- Driver-level policy override (iter-1 W2) — gerekirse ayrı PR.
+- Yeni StepDefinition field / workflow schema delta — hiçbiri.
+- Yeni InvocationResult field / adapter contract schema delta — hiçbiri.
 
 ---
 
@@ -206,49 +267,45 @@ Placeholder interpolation pattern workflow step definition'daki `input_envelope_
 
 | Risk | L | I | Mitigation |
 |---|---|---|---|
-| R1 Executor adapter path output_ref adapter envelope schema'sına uygun değil | L | H | Adapter envelope `output_ref` field'ı `agent-adapter-contract.schema.v1.json`'da opsiyonel; mevcut adapter'lar boş bırakıyor → backwards-compat. |
-| R2 `_context_compile` atomic write benchmark concurrency'de ortak dir çakışması | L | M | Per-run directory (`.ao/runs/{run_id}/`) — run_id UUID; çakışma teorik yok. |
-| R3 B6 `capability_output_refs` plumbing C1a ExecutionResult değişikliği ile kırılır | M | H | B6 pattern `getattr(exec_result, "output_ref", None)` ile oku — yeni field eklemek pattern'i kırmaz. `tests/benchmarks/test_governed_review.py` green kalır. |
-| R4 `input_envelope` placeholder resolve mevcut testleri kırar | M | M | Step `context_spec` yoksa placeholder korunur; backwards-compat test eklenir. |
+| R1 `compile_context()` pipeline B6/B7 benchmark testlerinde unbounded side-effect üretir | M | M | `profile="TASK_EXECUTION"` bounded token budget + existing pipeline'a smoke test |
+| R2 `_build_adapter_input_envelope` scan prior steps performans concern (N-step run'larda O(N)) | L | L | Reverse iteration + early break — FAZ-C workflow'ları ≤10 step |
+| R3 `write_text_atomic` tmp dosyası concurrency'de çakışma | L | M | Per-(run_id, step_id, attempt) dosya adı UUID-scoped — çakışma teorik yok |
+| R4 B6 `capability_output_refs` plumbing C1a `ExecutionResult.output_ref` ekleme ile kırılır | M | H | Regression gate: `test_governed_review.py` green. B6 `getattr` pattern field eklemeyi tolere eder |
+| R5 `context_compile` step olmayan workflow'larda adapter envelope placeholder literal kalır → prod adapter `--prompt-file` okuyamaz | M | H | Placeholder literal = explicit "no context" kontrat; documented in C1a scope. C1b + C2'de real adapter manifest `--prompt-file` conditional (context varsa geçir) |
 
 ---
 
-## 6. Codex iter-1 için Açık Sorular
+## 6. Implementation Order
 
-**Q1**: `ExecutionResult.output_ref: str | None = None` additive field — frozen dataclass backwards-compat için kwargs ile instantiate edilmeli mi? Mevcut callers positional arg kullanıyorsa dataclass ordering ile çelişir mi?
-
-**Q2**: `_context_compile` markdown template v1 shape (role/constraints/references) `claude-code-cli` + `gh-cli-pr` manifest'lerinin gerçekten beklediği context shape ile uyumlu mu? Bu manifest'ler JSON değil markdown consumes ediyor mu?
-
-**Q3**: `input_envelope.context_pack_ref` placeholder interpolation — mevcut workflow step `input_envelope_template` field'ında `{context_pack_ref}` string placeholder Python f-string formatında mı, yoksa özel interpolation syntax mı? (Mevcut implementasyonu fact-check.)
-
-**Q4**: `write_artifact` vs `write_text_atomic` — C1a context.md yazımı için hangi helper doğru? `write_artifact` SHA256 + JSONL manifest entry üretir; context.md markdown düz dosya. `write_text_atomic` shared helper varsa o daha uygun.
-
-**Q5**: Adapter envelope → `InvocationResult.output_ref` dönüşümü `_invocation_from_envelope` içinde mi, yoksa Executor adapter branch'inde mi? Mevcut `InvocationResult` dataclass'ına `output_ref` field'ı ekliyor muyum?
+1. **`ExecutionResult.output_ref` field** — dataclass delta + Executor adapter + driver-managed branch populate.
+2. **`build_driver(policy_loader=)` forward** — tek satır.
+3. **`context_compile` step materialisation** — `compile_context()` integration + `write_text_atomic` + metadata evidence.
+4. **`_build_adapter_input_envelope` context_pack_ref resolver** — prior steps scan + envelope key populate.
+5. **4 yeni test + regression (`pytest -x`)**.
+6. **Commit + Codex post-impl review (thread `019d9fc3`) + PR #109 open + admin merge (after CI green + Codex AGREE)**.
 
 ---
 
-## 7. Implementation Order
+## 7. LOC Estimate
 
-1. **`ExecutionResult.output_ref` + `InvocationResult.output_ref`** — dataclass field ekle + adapter envelope extraction.
-2. **`build_driver(policy_loader=)` forward** — tek satır değişikliği.
-3. **`_context_compile` materialisation** — markdown template + atomic write.
-4. **`input_envelope` placeholder resolve** — step context_spec varsa interpolate.
-5. **4 yeni test + regression** — pytest green.
-6. **Commit + Codex post-impl review + PR #109 open**.
+~500 satır (ExecutionResult +1 field, build_driver +3 satır, context_compile handler +40 satır, envelope builder +20 satır, 4 yeni test ~350 satır, helper imports +5).
 
 ---
 
-## 8. LOC Estimate
-
-~450 satır (dataclass delta + context_compile fn + envelope resolve + 4 test).
-
----
-
-## 9. Audit Trail
+## 8. Audit Trail
 
 | Iter | Date | Verdict |
 |---|---|---|
-| v1 (Claude draft) | 2026-04-18 | Pre-Codex iter-1 submit |
-| iter-1 | TBD | Adversarial plan-review beklenir |
+| v1 (Claude draft) | 2026-04-18 | Pre-Codex submit (`c2b61d9`) |
+| iter-1 (thread `019d9fc3`) | 2026-04-18 | **PARTIAL** — 3 blocker (InvocationResult.output_ref yanlış kaynak, context_spec/input_envelope_template yok, relative path runtime'da çözmez) + 3 warning (gh-cli-pr manifest inconsistency, build_driver scope wording, existing context pipeline alignment) + Q1-Q5 net cevaplar |
+| **v2 (iter-1 absorb)** | 2026-04-18 | Pre-iter-2 submit. Executor-side output_ref + explicit context_compile step + absolute path + existing compile_context() reuse. |
+| iter-2 | TBD | AGREE expected (3 blocker + 3 warning tam absorb; dar scope revisions) |
 
-**Codex thread**: Yeni thread (C1a-specific). FAZ-C master plan thread `019d9f75` bu PR için kapandı (Codex notes'ta C1a bağımsız onaylandı).
+### Plan revision history
+
+| Ver | Change |
+|---|---|
+| v1 | 4 gap + 5 Q for Codex; InvocationResult.output_ref varsayımı + context_spec icat + relative path |
+| **v2** | iter-1 PARTIAL absorb: output_ref kaynağı Executor `write_artifact` (InvocationResult dokunulmaz), context_compile step handler scope (StepDefinition değişmez), absolute path semantic, mevcut `compile_context()` reuse (role/constraints/references drop), build_driver scope "Executor-only" daraltıldı. |
+
+**Status**: Plan v2 hazır. Codex thread `019d9fc3` iter-2 submit için hazır. 3 blocker tam absorb; 3 warning netleşti. AGREE beklenir.

--- a/ao_kernel/executor/executor.py
+++ b/ao_kernel/executor/executor.py
@@ -72,6 +72,7 @@ class ExecutionResult:
     invocation_result: InvocationResult | None
     evidence_event_ids: tuple[str, ...]
     budget_after: Mapping[str, Any]
+    output_ref: str | None = None
 
 
 class Executor:
@@ -120,6 +121,7 @@ class Executor:
         step_id: str | None = None,
         fencing_token: int | None = None,
         fencing_resource_id: str | None = None,
+        input_envelope_override: Mapping[str, Any] | None = None,
     ) -> ExecutionResult:
         """Execute one workflow step.
 
@@ -235,6 +237,7 @@ class Executor:
                 attempt=attempt,
                 driver_managed=driver_managed,
                 step_id_override=step_id,
+                input_envelope_override=input_envelope_override,
             )
         # Non-adapter actors are PR-A4+; emit placeholder events and
         # record the step as completed. In driver-managed mode the
@@ -261,6 +264,7 @@ class Executor:
         attempt: int = 1,
         driver_managed: bool = False,
         step_id_override: str | None = None,
+        input_envelope_override: Mapping[str, Any] | None = None,
     ) -> ExecutionResult:
         if step_def.adapter_id is None:
             raise ValueError(
@@ -381,10 +385,15 @@ class Executor:
             evidence_event_ids.append(invoked.event_id)
 
             budget = budget_from_dict(record.get("budget", {}))
-            input_envelope = {
-                "task_prompt": record.get("intent", {}).get("payload", ""),
-                "run_id": run_id,
-            }
+            if input_envelope_override is not None:
+                # PR-C1a: driver pre-computes envelope with context_pack_ref
+                # resolved from prior context_compile step's artifact.
+                input_envelope = dict(input_envelope_override)
+            else:
+                input_envelope = {
+                    "task_prompt": record.get("intent", {}).get("payload", ""),
+                    "run_id": run_id,
+                }
             transport = manifest.invocation.get("transport")
             if transport == "cli":
                 invocation_result, budget_after = invoke_cli(
@@ -485,6 +494,7 @@ class Executor:
                 invocation_result=invocation_result,
                 evidence_event_ids=tuple(evidence_event_ids),
                 budget_after=budget_to_dict(budget_after),
+                output_ref=output_ref,
             )
 
         # CAS update run (A3 default path)
@@ -517,6 +527,7 @@ class Executor:
             invocation_result=invocation_result,
             evidence_event_ids=tuple(evidence_event_ids),
             budget_after=budget_to_dict(budget_after),
+            output_ref=output_ref,
         )
 
     # ------------------------------------------------------------------

--- a/ao_kernel/executor/multi_step_driver.py
+++ b/ao_kernel/executor/multi_step_driver.py
@@ -681,21 +681,29 @@ class MultiStepDriver:
             # Canonical: query (workspace_root: Path) returns list; wrap
             # as dict keyed by 'key' field (CanonicalDecision.key) so
             # compile_context().canonical_decisions .items() works.
-            canonical_list = _canonical_query(self._workspace_root)
+            # Corrupt store → degrade silently to empty (mirror the
+            # agent_coordination.py:208-214 tolerance pattern so run
+            # state doesn't escape with a raw exception).
+            try:
+                canonical_list = _canonical_query(self._workspace_root)
+            except Exception:  # noqa: BLE001
+                canonical_list = []
             canonical = {
                 item.get("key", f"_idx_{idx}"): item
                 for idx, item in enumerate(canonical_list)
             }
 
-            # Workspace facts: direct JSON read
+            # Workspace facts: direct JSON read; corrupt file → {}
             facts_path = (
                 self._workspace_root / ".cache" / "index"
                 / "workspace_facts.v1.json"
             )
-            facts = (
-                _json.loads(facts_path.read_text())
-                if facts_path.is_file() else {}
-            )
+            facts: dict[str, Any] = {}
+            if facts_path.is_file():
+                try:
+                    facts = _json.loads(facts_path.read_text())
+                except (OSError, _json.JSONDecodeError):
+                    facts = {}
 
             compiled = compile_context(
                 session_context,

--- a/ao_kernel/executor/multi_step_driver.py
+++ b/ao_kernel/executor/multi_step_driver.py
@@ -464,6 +464,12 @@ class MultiStepDriver:
             AdapterOutputParseError,
         )
 
+        # PR-C1a: resolve context_pack_ref from prior context_compile step's
+        # artifact; None → Executor default envelope (backwards-compat).
+        envelope_override = self._build_adapter_envelope_with_context(
+            run_id, step_def, record,
+        )
+
         try:
             exec_result = self._executor.run_step(
                 run_id=run_id,
@@ -474,6 +480,7 @@ class MultiStepDriver:
                 step_id=step_id,
                 fencing_token=fencing_token,
                 fencing_resource_id=fencing_resource_id,
+                input_envelope_override=envelope_override,
             )
         except PolicyViolationError as exc:
             raise _StepFailed(
@@ -574,6 +581,73 @@ class MultiStepDriver:
         refreshed, _ = load_run(self._workspace_root, run_id)
         return dict(refreshed), exec_result, capability_output_refs
 
+    def _build_adapter_envelope_with_context(
+        self,
+        run_id: str,
+        step_def: StepDefinition,
+        record: Mapping[str, Any],
+    ) -> dict[str, Any] | None:
+        """Resolve context_pack_ref from most recent completed
+        context_compile step's artifact JSON.
+
+        Returns envelope override dict with absolute context_pack_ref
+        OR ``None`` if no prior context is available (caller falls
+        back to Executor's default envelope — backwards-compat for
+        workflows without context_compile steps).
+        """
+        import json as _json
+
+        workflow_id = record.get("workflow_id")
+        workflow_version = record.get("workflow_version")
+        if not workflow_id or not workflow_version:
+            # Partial / malformed record (e.g. fencing-test fixtures).
+            # Fall back silently so executor's default envelope applies.
+            return None
+
+        workflow_def = self._registry.get(
+            workflow_id,
+            version=workflow_version,
+        )
+        compile_step_names = {
+            sd.step_name for sd in workflow_def.steps
+            if sd.operation == "context_compile"
+        }
+        if not compile_step_names:
+            return None
+
+        compile_record = None
+        for prior in reversed(record.get("steps", [])):
+            if (
+                prior.get("step_name") in compile_step_names
+                and prior.get("state") == "completed"
+                and prior.get("output_ref")
+            ):
+                compile_record = prior
+                break
+        if compile_record is None:
+            return None
+
+        run_dir = (
+            self._workspace_root / ".ao" / "evidence" / "workflows" / run_id
+        )
+        artifact_path = run_dir / compile_record["output_ref"]
+        if not artifact_path.is_file():
+            return None
+
+        try:
+            artifact = _json.loads(artifact_path.read_text(encoding="utf-8"))
+        except (OSError, _json.JSONDecodeError):
+            return None
+        context_path = artifact.get("context_path")
+        if not context_path:
+            return None
+
+        return {
+            "task_prompt": record.get("intent", {}).get("payload", ""),
+            "run_id": run_id,
+            "context_pack_ref": context_path,
+        }
+
     def _run_aokernel_step(
         self,
         run_id: str,
@@ -592,11 +666,61 @@ class MultiStepDriver:
             step_id=step_id)
 
         if op == "context_compile":
-            # A4b stub (W5 absorb): signal via payload
+            # PR-C1a: real materialisation replacing A4b stub. Uses
+            # existing compile_context() pipeline; writes markdown to
+            # evidence dir with absolute path for adapter subprocess.
+            from ao_kernel.context.context_compiler import compile_context
+            from ao_kernel.context.canonical_store import query as _canonical_query
+            from ao_kernel._internal.shared.utils import write_text_atomic
+            import json as _json
+
+            # MVP: session_context = {} (workflow-run schema top-level
+            # değişmez; session bridge ayrı PR'a bırakılır).
+            session_context: dict[str, Any] = {}
+
+            # Canonical: query (workspace_root: Path) returns list; wrap
+            # as dict keyed by 'key' field (CanonicalDecision.key) so
+            # compile_context().canonical_decisions .items() works.
+            canonical_list = _canonical_query(self._workspace_root)
+            canonical = {
+                item.get("key", f"_idx_{idx}"): item
+                for idx, item in enumerate(canonical_list)
+            }
+
+            # Workspace facts: direct JSON read
+            facts_path = (
+                self._workspace_root / ".cache" / "index"
+                / "workspace_facts.v1.json"
+            )
+            facts = (
+                _json.loads(facts_path.read_text())
+                if facts_path.is_file() else {}
+            )
+
+            compiled = compile_context(
+                session_context,
+                canonical_decisions=canonical,
+                workspace_facts=facts,
+                profile="TASK_EXECUTION",
+            )
+
+            # Absolute path for adapter subprocess (C1a B3 absorb).
+            context_path = (
+                run_dir / f"context-{step_id}-attempt{attempt}.md"
+            )
+            write_text_atomic(context_path, compiled.preamble)
+
             payload = {
                 "operation": "context_compile",
-                "stub": True,
-                "context_preamble_bytes": 0,
+                "stub": False,
+                "context_preamble_bytes": len(
+                    compiled.preamble.encode("utf-8")
+                ),
+                "context_path": str(context_path),
+                "total_tokens": compiled.total_tokens,
+                "items_included": compiled.items_included,
+                "items_excluded": compiled.items_excluded,
+                "profile_id": compiled.profile_id,
             }
             output_ref, output_sha256 = write_artifact(
                 run_dir=run_dir, step_id=step_id, attempt=attempt, payload=payload,
@@ -606,6 +730,11 @@ class MultiStepDriver:
                 "output_ref": output_ref,
                 "output_sha256": output_sha256,
                 "operation": op,
+                # PR-C1a propagate to _record_step_completion
+                "context_preamble_bytes": len(
+                    compiled.preamble.encode("utf-8")
+                ),
+                "context_path": str(context_path),
             }
 
         if op in ("patch_preview", "patch_apply", "patch_rollback"):
@@ -1390,7 +1519,7 @@ class MultiStepDriver:
         # path already emits step_completed via Executor.run_step when
         # driver_managed=True propagates a completed status).
         if step_def.actor in ("ao-kernel", "system"):
-            stub_flag = (
+            is_context_compile = (
                 isinstance(exec_result, Mapping)
                 and exec_result.get("operation") == "context_compile"
             )
@@ -1399,10 +1528,19 @@ class MultiStepDriver:
                 "final_state": "completed",
                 "attempt": attempt,
             }
-            if stub_flag:
-                payload["stub"] = True
+            if is_context_compile and isinstance(exec_result, Mapping):
+                # PR-C1a: context_compile real materialisation — read
+                # actual values from handler return dict. Empty fixture
+                # yields bytes=0 (no canonical + no facts + no session);
+                # stub=False regardless since handler wrote markdown.
+                payload["stub"] = False
                 payload["operation"] = "context_compile"
-                payload["context_preamble_bytes"] = 0
+                payload["context_preamble_bytes"] = exec_result.get(
+                    "context_preamble_bytes", 0
+                )
+                ctx_path = exec_result.get("context_path")
+                if ctx_path is not None:
+                    payload["context_path"] = ctx_path
             self._emit(run_id, "step_completed", payload, step_id=step_id)
 
         output_ref = None

--- a/tests/_driver_helpers.py
+++ b/tests/_driver_helpers.py
@@ -97,8 +97,17 @@ def write_stub_adapter_manifest(root: Path, adapter_id: str = "codex-stub") -> P
     return dest
 
 
-def build_driver(root: Path) -> MultiStepDriver:
-    """Build registry + adapter_registry + executor + driver pointing at ``root``."""
+def build_driver(
+    root: Path,
+    *,
+    policy_loader: Mapping[str, Any] | None = None,
+) -> MultiStepDriver:
+    """Build registry + adapter_registry + executor + driver pointing at ``root``.
+
+    ``policy_loader`` is forwarded to the Executor; ``None`` keeps the
+    Executor's default bundled-policy behavior. PR-C1a: benchmark + FAZ-C
+    testleri policy override'ı bu yolla aktarır.
+    """
     wreg = WorkflowRegistry()
     wreg.load_workspace(root)
 
@@ -109,6 +118,7 @@ def build_driver(root: Path) -> MultiStepDriver:
         workspace_root=root,
         workflow_registry=wreg,
         adapter_registry=areg,
+        policy_loader=policy_loader,
     )
 
     return MultiStepDriver(

--- a/tests/test_context_pack_ref_plumbing.py
+++ b/tests/test_context_pack_ref_plumbing.py
@@ -75,3 +75,90 @@ class TestEnvelopeResolverBackwardsCompat:
             record={"workflow_id": "some_wf", "state": "running"},
         )
         assert result is None
+
+
+class TestEnvelopeResolverSuccessPath:
+    """PR-C1a post-impl B2 absorb: resolver end-to-end success lock.
+
+    Simulates a workflow with context_compile → adapter chain; verifies
+    `_build_adapter_envelope_with_context()` reads the prior step's
+    artifact JSON, extracts `context_path`, and returns envelope
+    override with the absolute path bound to `context_pack_ref`.
+    """
+
+    def test_resolver_forwards_context_path_from_artifact(
+        self, tmp_path: Path,
+    ) -> None:
+        """Unit-level resolver success path: mock the workflow registry
+        so this test doesn't depend on fixture loading plumbing.
+        Exercises the full chain: compile_step_names lookup → steps
+        list iteration → artifact JSON read → context_path extraction →
+        envelope override."""
+        import json
+        from unittest.mock import MagicMock
+
+        # 1. Fake workflow_def with context_compile + adapter steps.
+        fake_steps = [
+            MagicMock(step_name="compile_ctx", operation="context_compile"),
+            MagicMock(step_name="adapter_step", operation=None),
+        ]
+        fake_workflow_def = MagicMock()
+        fake_workflow_def.steps = fake_steps
+
+        # 2. Write canned context artifact + markdown as if prior
+        #    context_compile step had just completed.
+        run_id = "00000000-0000-4000-8000-000000ddddd1"
+        run_dir = (
+            tmp_path / ".ao" / "evidence" / "workflows" / run_id
+        )
+        artifacts_dir = run_dir / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        context_md_path = run_dir / "context-compile_ctx-attempt1.md"
+        context_md_path.write_text(
+            "# Run Context\n\nTest preamble body.\n",
+            encoding="utf-8",
+        )
+        artifact_json_path = (
+            artifacts_dir / "compile_ctx-attempt1.json"
+        )
+        artifact_json_path.write_text(
+            json.dumps({
+                "operation": "context_compile",
+                "stub": False,
+                "context_preamble_bytes": 27,
+                "context_path": str(context_md_path),
+            }),
+            encoding="utf-8",
+        )
+
+        # 3. Build driver + inject mock registry.
+        driver = _minimal_driver(tmp_path)
+        driver._registry.get = MagicMock(return_value=fake_workflow_def)
+
+        record = {
+            "workflow_id": "ctx_plus_adapter_flow",
+            "workflow_version": "1.0.0",
+            "state": "running",
+            "intent": {"payload": "do the adapter thing"},
+            "steps": [
+                {
+                    "step_name": "compile_ctx",
+                    "state": "completed",
+                    "output_ref": "artifacts/compile_ctx-attempt1.json",
+                },
+            ],
+        }
+        step_def = _adapter_step_def()
+
+        # 4. Resolver reads artifact JSON and builds envelope override.
+        result = driver._build_adapter_envelope_with_context(
+            run_id=run_id, step_def=step_def, record=record,
+        )
+        assert result is not None
+        assert result["task_prompt"] == "do the adapter thing"
+        assert result["run_id"] == run_id
+        assert result["context_pack_ref"] == str(context_md_path)
+        # Absolute path invariant: adapter subprocess reads from worktree
+        # cwd via plain string replacement, so path must resolve regardless.
+        assert Path(result["context_pack_ref"]).is_absolute()
+        assert Path(result["context_pack_ref"]).is_file()

--- a/tests/test_context_pack_ref_plumbing.py
+++ b/tests/test_context_pack_ref_plumbing.py
@@ -1,0 +1,77 @@
+"""PR-C1a: context_pack_ref envelope plumbing via driver resolver.
+
+Focus: backwards-compat defensive paths (partial records, missing
+workflow fixture). Full integration testing lives in
+``test_multi_step_driver.py::test_context_compile_emits_real_materialisation_payload``
+which exercises the resolver end-to-end via ``simple_aokernel_flow``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ao_kernel.executor import MultiStepDriver
+from ao_kernel.executor.executor import Executor
+from ao_kernel.workflow.registry import WorkflowRegistry
+from ao_kernel.adapters import AdapterRegistry
+from ao_kernel.workflow import StepDefinition
+
+
+def _minimal_driver(tmp_path: Path) -> MultiStepDriver:
+    wreg = WorkflowRegistry()
+    wreg.load_workspace(tmp_path)
+    areg = AdapterRegistry()
+    areg.load_workspace(tmp_path)
+    executor = Executor(
+        workspace_root=tmp_path,
+        workflow_registry=wreg,
+        adapter_registry=areg,
+    )
+    return MultiStepDriver(
+        workspace_root=tmp_path,
+        registry=wreg,
+        adapter_registry=areg,
+        executor=executor,
+    )
+
+
+def _adapter_step_def() -> StepDefinition:
+    return StepDefinition(
+        step_name="adapter_step",
+        actor="adapter",
+        adapter_id="codex-stub",
+        required_capabilities=(),
+        policy_refs=(),
+        on_failure="transition_to_failed",
+        timeout_seconds=60,
+        human_interrupt_allowed=False,
+        gate=None,
+        operation=None,
+    )
+
+
+class TestEnvelopeResolverBackwardsCompat:
+    def test_missing_workflow_id_returns_none(self, tmp_path: Path) -> None:
+        """Fencing-test-style partial records (empty dict) must not
+        crash the resolver; return None so executor default envelope
+        applies. Regression gate for the KeyError fix."""
+        driver = _minimal_driver(tmp_path)
+        result = driver._build_adapter_envelope_with_context(
+            run_id="00000000-0000-4000-8000-0000000aaaaa",
+            step_def=_adapter_step_def(),
+            record={},
+        )
+        assert result is None
+
+    def test_partial_record_missing_version_returns_none(
+        self, tmp_path: Path,
+    ) -> None:
+        """Record has workflow_id but not workflow_version (malformed
+        intermediate state) → resolver returns None defensively."""
+        driver = _minimal_driver(tmp_path)
+        result = driver._build_adapter_envelope_with_context(
+            run_id="00000000-0000-4000-8000-0000000bbbbb",
+            step_def=_adapter_step_def(),
+            record={"workflow_id": "some_wf", "state": "running"},
+        )
+        assert result is None

--- a/tests/test_driver_helpers_policy_loader.py
+++ b/tests/test_driver_helpers_policy_loader.py
@@ -1,0 +1,76 @@
+"""PR-C1a: tests/_driver_helpers.build_driver(policy_loader=...) forward.
+
+Default call (no policy_loader) must preserve the pre-C1a behavior;
+explicit override must reach the Executor's effective policy surface.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests._driver_helpers import build_driver
+
+
+def _install_workflow(root: Path) -> None:
+    """Minimal bundled workflow for driver smoke (mirrors fixture
+    ``simple_aokernel_flow`` shape used across A4+ tests)."""
+    workflows_dir = root / ".ao" / "workflows"
+    workflows_dir.mkdir(parents=True, exist_ok=True)
+    # Build a tiny ao-kernel-only workflow so no adapter is required.
+    wf = {
+        "workflow_id": "smoke_flow",
+        "workflow_version": "1.0.0",
+        "initial_state": "created",
+        "steps": [
+            {
+                "step_name": "noop",
+                "actor": "ao-kernel",
+                "operation": "context_compile",
+            }
+        ],
+        "states": ["created", "running", "completed", "failed", "cancelled"],
+        "transitions": [
+            ["created", "running"],
+            ["running", "completed"],
+        ],
+    }
+    (workflows_dir / "smoke_flow.workflow.v1.json").write_text(
+        json.dumps(wf, indent=2), encoding="utf-8",
+    )
+
+
+class TestBuildDriverPolicyLoaderForward:
+    def test_default_call_no_override_baseline(self, tmp_path: Path) -> None:
+        """Default build_driver(root) signature unchanged: no kwarg
+        required, executor constructed with bundled policy defaults."""
+        _install_workflow(tmp_path)
+        driver = build_driver(tmp_path)
+        assert driver is not None
+        # Executor is available via driver internals
+        executor = driver._executor
+        assert executor is not None
+
+    def test_explicit_override_reaches_executor(self, tmp_path: Path) -> None:
+        """policy_loader kwarg forwards to Executor; custom policy
+        visible on the executor's effective policy surface."""
+        _install_workflow(tmp_path)
+        custom_policy = {
+            "_pr_c1a_sentinel": "policy_loader_forward_test",
+        }
+        driver = build_driver(tmp_path, policy_loader=custom_policy)
+        executor = driver._executor
+        # Executor stores policy on ``_policy`` attribute
+        assert executor._policy.get("_pr_c1a_sentinel") == (
+            "policy_loader_forward_test"
+        )
+
+    def test_none_kwarg_matches_default_behavior(self, tmp_path: Path) -> None:
+        """Passing policy_loader=None is identical to omitting it —
+        Executor falls back to bundled defaults."""
+        _install_workflow(tmp_path)
+        driver_default = build_driver(tmp_path)
+        driver_none = build_driver(tmp_path, policy_loader=None)
+        # Both executors share bundled-default policy keys
+        assert "_pr_c1a_sentinel" not in driver_default._executor._policy
+        assert "_pr_c1a_sentinel" not in driver_none._executor._policy

--- a/tests/test_executor_adapter_output_ref.py
+++ b/tests/test_executor_adapter_output_ref.py
@@ -1,0 +1,51 @@
+"""PR-C1a: ExecutionResult.output_ref additive field populated on
+both adapter-path (driver_managed=True + CAS) and driver-managed
+callback paths.
+
+The field is derived from Executor's local ``write_artifact(...)``
+output_ref (executor.py:419-422) — NOT from InvocationResult (Codex
+iter-1 B1 absorb).
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+
+from ao_kernel.executor.executor import ExecutionResult
+
+
+class TestExecutionResultOutputRefField:
+    def test_output_ref_is_additive_field(self) -> None:
+        """Regression gate: ExecutionResult has ``output_ref`` field
+        with default None so existing keyword-arg constructors
+        continue to work without migration."""
+        field_names = {f.name for f in fields(ExecutionResult)}
+        assert "output_ref" in field_names
+        field = next(f for f in fields(ExecutionResult) if f.name == "output_ref")
+        assert field.default is None
+        assert field.type in ("str | None", "Optional[str]")
+
+    def test_existing_constructors_default_to_none(self) -> None:
+        """Callers that don't pass output_ref see None (backwards-
+        compat shim)."""
+        result = ExecutionResult(
+            new_state="running",
+            step_state="completed",
+            invocation_result=None,
+            evidence_event_ids=(),
+            budget_after={},
+        )
+        assert result.output_ref is None
+
+    def test_explicit_output_ref_populate(self) -> None:
+        """When caller (Executor adapter branch) passes output_ref,
+        it surfaces on the dataclass."""
+        result = ExecutionResult(
+            new_state="running",
+            step_state="completed",
+            invocation_result=None,
+            evidence_event_ids=(),
+            budget_after={},
+            output_ref="artifacts/codex-stub_attempt1.json",
+        )
+        assert result.output_ref == "artifacts/codex-stub_attempt1.json"

--- a/tests/test_multi_step_driver.py
+++ b/tests/test_multi_step_driver.py
@@ -52,7 +52,14 @@ class TestSimpleHappyPath:
         assert result.steps_retried == ()
         assert result.resume_token is None
 
-    def test_context_compile_stub_emits_stub_marker(self, tmp_path: Path) -> None:
+    def test_context_compile_emits_real_materialisation_payload(
+        self, tmp_path: Path,
+    ) -> None:
+        """PR-C1a: context_compile step now materialises actual
+        preamble + writes markdown. Test renamed from stub-marker
+        pattern; payload.stub is False; context_preamble_bytes is
+        tolerant of empty fixture (>= 0); context_path points to
+        existing file."""
         driver, run_id = self._setup(tmp_path)
         driver.run_workflow(run_id, "simple_aokernel_flow", "1.0.0")
         events_path = (
@@ -61,12 +68,19 @@ class TestSimpleHappyPath:
         )
         assert events_path.exists()
         lines = [json.loads(ln) for ln in events_path.read_text().splitlines()]
-        completed = [
+        compile_completed = [
             e for e in lines
             if e.get("kind") == "step_completed"
-            and e.get("payload", {}).get("stub") is True
+            and e.get("payload", {}).get("operation") == "context_compile"
         ]
-        assert len(completed) == 2
+        assert len(compile_completed) == 2
+        for event in compile_completed:
+            payload = event["payload"]
+            assert payload["stub"] is False
+            assert payload["context_preamble_bytes"] >= 0
+            context_path = payload.get("context_path")
+            assert context_path is not None
+            assert Path(context_path).is_file()
 
     def test_artifact_written_for_each_step(self, tmp_path: Path) -> None:
         driver, run_id = self._setup(tmp_path)


### PR DESCRIPTION
## Summary

**FAZ-C critical-path seri başı.** Closes 4 runtime gaps from FAZ-C master plan iter-1 Codex fact-check; C1a validated as independent PR by Codex iter-6 master notes ("C1a izole PR başlatılması makul").

### Changes

1. **`ExecutionResult.output_ref: str | None = None`** — additive frozen-dataclass field. Adapter path populates from existing `write_artifact(...)` local `output_ref` (executor.py:422) — NOT from `InvocationResult` (Codex iter-1 B1 absorb). Driver-managed branch preserves B6 `capability_output_refs` plumbing untouched.
2. **`build_driver(root, *, policy_loader=None)`** — test driver helper forwards Executor policy override; `Executor.__init__` already accepted `policy_loader`, helper just threads it.
3. **`context_compile` step real materialisation** — replaces A4b stub at `multi_step_driver.py:594`. Uses existing `context_compiler.compile_context()` pipeline (3-lane: MVP empty session + `canonical_store.query()` dict-wrap on `key` + workspace_facts JSON read). Writes markdown via `write_text_atomic()` to **absolute** path `.ao/evidence/workflows/{run_id}/context-{step_id}-attempt{attempt}.md`. Corrupt canonical/facts paths degrade silently to empty (fail-clean).
4. **`Executor.run_step(input_envelope_override=None)`** — additive kwarg threads through `_run_adapter_step`; replaces default envelope built from `record.intent.payload` when override is supplied.
5. **`MultiStepDriver._build_adapter_envelope_with_context()`** — new resolver reads most-recent-completed context_compile step's artifact JSON, extracts `context_path`, returns envelope override with absolute `context_pack_ref`. Defensive: returns `None` on partial/malformed records (empty dict, missing workflow_version) so fencing-test fixtures keep passing.
6. **`_record_step_completion` stub hardcode absorb** — reads real values from `exec_result` dict instead of `stub=True` hardcode; payload now emits `stub=False`, actual `context_preamble_bytes`, and `context_path`. Existing regression test `test_context_compile_stub_emits_stub_marker` → `test_context_compile_emits_real_materialisation_payload`.

### Plan iteration summary

Codex plan-time thread `019d9fc3-1b0b-76b2-b425-0f3dfd6efc66`:
- iter-1: PARTIAL (3 blocker + 3 warning + Q1-Q5)
- iter-2: PARTIAL (3 blocker + 3 warning)
- iter-3: PARTIAL (4 blocker + 2 warning)
- iter-4: PARTIAL (3 blocker + 2 warning)
- **iter-5: AGREE** `914bd39` snapshot, `ready_for_impl=true`
- Post-impl PARTIAL (1 high + 1 medium + 1 low); high + medium absorbed in `f543670`.

## Test plan

- [x] `pytest tests/` — 2151/2151 green (2142 pre-C1a + 9 new)
- [x] `ruff check ao_kernel/ tests/` — clean
- [x] `ruff format --check ao_kernel/ tests/` — clean
- [x] `mypy ao_kernel/ --ignore-missing-imports` — clean (186 src files)
- [x] Benchmark `test_governed_review.py` (B6/B7 `capability_output_refs` plumbing) — unchanged
- [ ] CI green (pending push)

### New tests

- `test_driver_helpers_policy_loader.py` — 3 cases (forward proof + backwards-compat + None-kwarg)
- `test_executor_adapter_output_ref.py` — 3 cases (dataclass field contract + default-None + explicit populate)
- `test_context_pack_ref_plumbing.py` — 3 cases (partial-record None paths + end-to-end resolver success with mocked registry)
- Updated `test_multi_step_driver.py::test_context_compile_emits_real_materialisation_payload` — integration contract for new materialisation

## Out of Scope

- **C1b** (full bundled `bug_fix_flow` E2E + `gh-cli-pr` manifest shape fix) — next PR after merge. `open_pr` chain full-flow proof deferred to C1b.
- **C2** (parent_env union: `allowlist_secret_ids ∪ env_allowlist.allowed_keys`) — parallel after merge.
- **C3** (cost runtime reconcile: `post_adapter_reconcile` middleware) — parallel after merge.
- **C6** (`dry_run_step`) — parallel after merge.
- Driver-level policy override (Codex iter-1 W2) — separate PR if needed.
- Schema widens / new manifest fields — none.
- `write_text_atomic` parent-dir fsync + resolver context_path file-exists recheck (low residual, Codex post-impl B3).

## Master plan drift note

FAZ-C master plan v5 (`cce30c1` on `claude/faz-c-master-plan`) references `.ao/runs/{run_id}/context.md` relative path; C1a uses **absolute** evidence-dir path. Sync follow-up PR after C1a merge (1-line docs update).

## Evidence

- CNS-20260418-042 (this thread `019d9fc3`)
- Plan: `.claude/plans/PR-C1a-IMPLEMENTATION-PLAN.md` v5
- Base: `main 5fb7f31` (PR #108 tooling merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)