### PR TITLE
feat(pr-c4): resolve_route additive kwargs + _KINDS 27→28 plumbing-only

### DIFF
--- a/.claude/plans/PR-C4-IMPLEMENTATION-PLAN.md
+++ b/.claude/plans/PR-C4-IMPLEMENTATION-PLAN.md
@@ -1,35 +1,46 @@
-# PR-C4 Implementation Plan v1 — Cross-Class Routing (Additive Facade)
+# PR-C4 Implementation Plan v2 — Cross-Class Routing (Plumbing-Only, Runtime Dormant)
 
-**Scope**: FAZ-C strategic extension (bağımsız). `ao_kernel.llm.resolve_route` facade additive kwarg widen + internal `resolve` cross_class_downgrade consumer + `_KINDS` 27→28 `route_cross_class_downgrade`. Default-off backwards-compat.
+**Scope**: FAZ-C strategic extension. C4'ün **plumbing katmanı**: `ao_kernel.llm.resolve_route` facade additive kwargs + internal `resolve` request-dict plumbing + `_KINDS` 27→28. **Runtime downgrade dormant**: threshold source schema'da yok (`routing_by_cost.class_thresholds` eksik) + `soft_degrade.rules` directional semantiği pin'lenmemiş. Gerçek downgrade aktivasyonu **follow-up PR C4.1** (threshold schema widen + rule filter).
 
 **Base**: `main a581fb5` (PR #111 C2 merged). **Branch**: `feat/pr-c4-resolve-route-kwargs`.
 
-**Status**: Pre-Codex iter-1 submit.
+**Status**: iter-1 PARTIAL absorb → iter-2 submit. Codex thread `019da035-0472-7773-a765-d66a149222a6`.
 
 ---
 
-## 1. Problem
+## v2 absorb summary (Codex iter-1 PARTIAL — 3 blocker + 4 warning)
 
-`llm_resolver_rules.v1.json` `soft_degrade.enabled=true` + rules var ama runtime tüketmiyor. `ao_kernel.llm.resolve_route` public facade'ı (`llm.py:23-46`) `budget_remaining`/`cross_class_downgrade`/`soft_degrade` kwarg'larını almıyor.
+| # | iter-1 bulgu | v2 fix |
+|---|---|---|
+| **B1** (threshold source yok) | `policy_cost_tracking.schema.v1.json` `routing_by_cost.{enabled, priority, fail_closed_on_catalog_missing}` — `class_thresholds` alanı YOK. `_budget_below_threshold()` kaynağa dayanamaz. | v2: Runtime downgrade **dormant**. Threshold schema widen + `_budget_below_threshold` logic follow-up PR C4.1'e taşındı. v1 plumbing facade kwargs'ı alır, internal resolve request-dict'i okur ama `downgrade_applied=False` her zaman döner (no-op path). |
+| **B2** (rules yönsüz) | `soft_degrade.rules` içinde `BALANCED_TEXT→FAST_TEXT` (cost↓) VE `FAST_TEXT→BALANCED_TEXT` (cost↑). Körü körüne iterate yanlış semantik → "downgrade" adında upgrade uygulanabilir. | v2: Runtime rule iteration YOK (dormant path). Directional filter helper (`_is_cost_downgrade(from_class, to_class)` + class cost ordering) C4.1 scope'una taşındı. |
+| **B3** (scope gap) | Hedef `CODE_AGENTIC → FAST_TEXT` mevcut ops JSON'da yok; `CODE_AGENTIC` için `degrade_allowed=false`. Plan ops JSON değişimini kapsamıyor. | v2: Scope'u explicit daralt — C4 v1 sadece **plumbing** (facade kwargs + return contract + _KINDS). Ops JSON + threshold + aktif downgrade = C4.1 follow-up. |
+
+### v2 absorb warnings
+
+- **W1** (`soft_degrade` semantic) → **DROP**: `soft_degrade` kwarg kaldırıldı. JSON `resolver_rules["soft_degrade"]["enabled"]` tek authority; caller override etmez.
+- **W2** (request-dict doğru tercih) ✅: Internal `resolve` signature dokunulmaz; request dict genişletilir.
+- **W3** (_KINDS cascade plan overblown) → daraltıldı: Sadece `test_policy_sim_integration.py:101` + `docs/POLICY-SIM.md:49` exact-count pim'leri update edilecek. `test_cost_middleware_core.py:500` + `test_coordination_takeover_prune.py:377` floor test (auto-28). Docs COST-MODEL.md §7 "24→27" anlatısı "24→28"'e çekilir.
+- **W4** (intent_router FAST_TEXT opportunistic fallback) ✅: C4 bu caller'ı düzeltmeye kalkmıyor. Test "existing callers unchanged" davranışsal pin — route success DEĞİL.
 
 ---
 
-## 2. Scope (atomic deliverable)
+## 1. Problem (revised)
 
-### 2.1 `resolve_route` facade additive kwargs
+`ao_kernel.llm.resolve_route` facade'ı `budget_remaining`/`cross_class_downgrade` gibi kwargs'ı ALMIYOR. `_KINDS` 27 kind'ta; cross-class downgrade evidence kind'ı (`route_cross_class_downgrade`) yok. Plumbing katmanı tamamlanmazsa runtime downgrade (C4.1) eklemek için mevcut callers'ı kırmadan genişletme imkansız.
+
+---
+
+## 2. Scope v2 (atomic deliverable — plumbing only)
+
+### 2.1 `resolve_route` facade — 2 additive kwarg (`soft_degrade` drop)
 
 **Before** (`llm.py:23-46`):
 ```python
-def resolve_route(
-    *,
-    intent: str,
-    perspective: str | None = None,
-    provider_priority: list[str] | None = None,
-    workspace_root: str | None = None,
-) -> dict[str, Any]:
+def resolve_route(*, intent, perspective=None, provider_priority=None, workspace_root=None):
 ```
 
-**After** (v1 — 3 yeni optional kwarg):
+**After** (v2):
 ```python
 def resolve_route(
     *,
@@ -37,9 +48,9 @@ def resolve_route(
     perspective: str | None = None,
     provider_priority: list[str] | None = None,
     workspace_root: str | None = None,
-    budget_remaining: "Budget | None" = None,  # NEW
-    cross_class_downgrade: bool = False,       # NEW (runtime-only knob)
-    soft_degrade: bool = False,                # NEW (activate rules consumer)
+    # PR-C4 additive, default-off (plumbing-only — runtime dormant):
+    budget_remaining: "Budget | None" = None,
+    cross_class_downgrade: bool = False,
 ) -> dict[str, Any]:
     ...
     return resolve(
@@ -47,149 +58,118 @@ def resolve_route(
             "intent": intent,
             "perspective": perspective,
             "provider_priority": provider_priority or [],
-            # PR-C4 additive request keys (internal-only):
+            # Internal-only request keys (dormant v1):
             "budget_remaining": budget_remaining,
             "cross_class_downgrade": cross_class_downgrade,
-            "soft_degrade": soft_degrade,
         },
         workspace_root=workspace_root,
     )
 ```
 
-**Backwards-compat**: Default-off (`False`, `None`). 4 mevcut caller (`mcp_server.py:150,353`, `client.py:842`, `intent_router.py:364`) dokunulmaz — 3 yeni kwarg'ı geçmedikleri için davranış değişmez.
+Backwards-compat: 4 mevcut caller (mcp_server:150, 353; client:842; intent_router:364) dokunulmaz. Q1 absorb: `Budget` type hint string annotation (TYPE_CHECKING import) — `ao_kernel.workflow.Budget` importlanır; `ao_kernel.cost` export etmez.
 
-### 2.2 Internal `resolve` cross_class_downgrade consumer
+### 2.2 Internal `resolve` — request-dict plumbing (dormant)
 
-`_internal/prj_kernel_api/llm_router.py::resolve`:
+**`_internal/prj_kernel_api/llm_router.py::resolve`**:
 ```python
-def resolve(request, repo_root=None, now=None, workspace_root=None):
-    ...
-    # PR-C4: cross_class_downgrade runtime consumer (default-off)
-    cross_class_downgrade = bool(request.get("cross_class_downgrade", False))
-    soft_degrade_enabled = bool(request.get("soft_degrade", False))
-    budget_remaining = request.get("budget_remaining")
-    
-    # Determine target class (intent → class via resolver_rules)
-    target_class = resolver_rules["intent_to_class"].get(intent)
-    original_class = target_class
-    downgrade_applied = False
-    downgraded_class = None
-    
-    if (
-        cross_class_downgrade
-        and soft_degrade_enabled
-        and budget_remaining is not None
-        and _budget_below_threshold(budget_remaining, target_class)
-    ):
-        # Iterate soft_degrade.rules for matching from_class + intents
-        for rule in resolver_rules.get("soft_degrade", {}).get("rules", []):
-            if (
-                rule.get("from_class") == target_class
-                and intent in rule.get("intents", [])
-            ):
-                downgraded_class = rule.get("to_class")
-                target_class = downgraded_class
-                downgrade_applied = True
-                break
-    
-    # ... existing provider+model selection logic against target_class ...
-    
-    result = {
-        "status": "OK" if selected else "FAIL",
-        "selected_provider": provider,
-        "selected_model": model,
-        # PR-C4 additive response fields (default-off → False/None):
-        "downgrade_applied": downgrade_applied,
-        "original_class": original_class if downgrade_applied else None,
-        "downgraded_class": downgraded_class if downgrade_applied else None,
-        # ... existing fields ...
-    }
-    return result
+# Existing body unchanged for: intent, perspective, provider_priority.
+
+# PR-C4 plumbing: read but DO NOT act (runtime dormant in v1).
+# Real runtime consumer (threshold comparison + rule iteration) =
+# follow-up PR C4.1 after policy-cost-tracking schema widens.
+_budget_remaining = request.get("budget_remaining")  # ignored in v1
+_cross_class_downgrade = bool(
+    request.get("cross_class_downgrade", False)
+)  # ignored in v1
+
+# ... existing target_class + provider selection logic unchanged ...
+
+result = {
+    "status": "OK" if selected else "FAIL",
+    "selected_provider": provider,
+    "selected_model": model,
+    # PR-C4 additive response fields (v1: dormant → always False/None):
+    "downgrade_applied": False,
+    "original_class": None,
+    "downgraded_class": None,
+    # ... existing fields ...
+}
+return result
 ```
 
-`_budget_below_threshold(budget, class)` helper: basit karşılaştırma — policy `cost_policy.routing_by_cost.class_thresholds` (yoksa `{}`) → class için threshold `budget_remaining.cost_usd < threshold`. Threshold yoksa False (downgrade skip). v1 MVP.
+**Dormant invariant**: v1'de `downgrade_applied` her zaman `False`, `original_class`/`downgraded_class` her zaman `None`. Real runtime behavior v4.1'de aktifleşir.
 
-### 2.3 `route_cross_class_downgrade` evidence kind
+### 2.3 `_KINDS` 27 → 28
 
-`evidence_emitter.py:46` `_KINDS` frozenset'ine yeni kind ekle: `"route_cross_class_downgrade"`. **27 → 28**.
+`evidence_emitter.py:46` frozenset'ine `"route_cross_class_downgrade"` eklenir. Evidence emit call-site'ları v1'de eklenmez (C4.1 scope).
 
-Callers (run-aware): `governed_call` / `_run_llm_step` gibi — `resolve_route()` çağrısı sonrası return dict'te `downgrade_applied=True` ise `emit_event(run_id, 'route_cross_class_downgrade', {...})`. C4 scope'ta bu emit call-site'ları ayrıntılı incelenecek; v1 için sadece `_KINDS` bump + contract pin (gerçek emit follow-up PR'a kalabilir eğer karmaşıksa).
+### 2.4 Test invariant + docs update
 
-### 2.4 Docs update
-
-- `docs/POLICY-SIM.md:49-51` `_KINDS` count 27 → 28.
-- `docs/COST-MODEL.md §7` (veya yeni §) `routing_by_cost.cross_class_downgrade` knob.
-- `docs/MODEL-ROUTING.md §6` (veya yeni §) soft_degrade runtime consumer.
+- `tests/test_policy_sim_integration.py:101` — `_KINDS` exact-count 27 → 28 + kind listesinde `route_cross_class_downgrade` var.
+- `docs/POLICY-SIM.md:49` — `27` → `28`.
+- `docs/COST-MODEL.md §7` — "24→27 kinds" anlatısı "24→28 kinds" olur; `route_cross_class_downgrade` açıklama + "C4.1 follow-up: threshold source + rules filter".
 
 ---
 
-## 3. Test Plan
+## 3. Test Plan v2
 
-### 3.1 Yeni testler (`tests/test_resolve_route_kwargs.py`)
+### 3.1 Yeni testler (`tests/test_resolve_route_kwargs.py`, 5 test):
 
-- `test_defaults_off_preserves_existing_behavior` — mevcut callers (intent only) → existing return dict (downgrade_applied=False).
-- `test_additive_kwargs_accept_without_effect` — `budget_remaining=None, cross_class_downgrade=False` → behavior aynı.
-- `test_cross_class_downgrade_active_applies_soft_degrade_rule` — `cross_class_downgrade=True + budget_remaining below threshold` → `downgrade_applied=True`, `original_class=BALANCED_TEXT`, `downgraded_class=FAST_TEXT` (DISCOVERY intent için).
-- `test_cross_class_downgrade_without_budget_returns_original` — `cross_class_downgrade=True + budget_remaining=None` → downgrade skip.
-- `test_kinds_count_is_28` — `len(_KINDS) == 28`, `'route_cross_class_downgrade' in _KINDS`.
-- `test_existing_resolve_route_callers_unchanged` — mcp_server / client / intent_router pattern'ini verify (runtime argv inspection).
+- `test_defaults_off_preserves_existing_behavior` — 4 mevcut caller pattern'i (`intent="FAST_TEXT"` vb.) + return dict'te yeni alanlar var + default (False/None).
+- `test_additive_kwargs_accept_without_runtime_effect` — `budget_remaining=Budget(...)` + `cross_class_downgrade=True` → **DORMANT**: `downgrade_applied=False`, `original_class=None`, `downgraded_class=None`. Test C4 v1 plumbing'in runtime no-op invariant'ını pinler.
+- `test_request_dict_plumbing_forwards_kwargs` — mock internal resolve, resolve_route facade'ta geçen kwargs'ın request dict'e map edildiğini verify.
+- `test_kinds_count_is_28_and_includes_route_downgrade` — `len(_KINDS) == 28`, `"route_cross_class_downgrade" in _KINDS`.
+- `test_invariant_updates_consistent` — mevcut _KINDS invariant test dosyası (`test_policy_sim_integration.py`) güncel pass eder.
 
 ### 3.2 Regression gate
 
-- `pytest tests/ -x` — 2164 + 6 = ~2170 green.
-- Özellikle `test_policy_sim_integration.py::TestKindsInvariant` (27 → 28 update).
-- 4 caller: mcp_server + client + intent_router + runtime fail yok.
+- `pytest tests/ -x` — 2164 + 5 = 2169 green.
+- `test_policy_sim_integration.py::TestKindsInvariant` — 27→28 update.
+- `test_cost_middleware_core.py:500` + `test_coordination_takeover_prune.py:377` — floor test (auto-28 pass).
 
 ---
 
 ## 4. Out of Scope
 
-- `route_cross_class_downgrade` evidence emit call-site'ları — v1 sadece `_KINDS` bump + return contract. Emit run-aware caller'lara eklenir (follow-up veya C4 scope genişlemesi).
-- Cost policy `routing_by_cost.class_thresholds` schema — minimal; v1 default empty dict (threshold yok → downgrade skip).
-- C3/C5/C6 — paralel.
+- **C4.1 runtime downgrade** — threshold schema widen (`policy-cost-tracking.schema.v1.json` → add `routing_by_cost.class_thresholds`) + `_is_cost_downgrade(from_class, to_class)` directional filter + `soft_degrade.rules` iterate. **Ayrı PR**.
+- **Evidence emit call-sites** — `route_cross_class_downgrade` emit'i C4.1'de (run-aware caller'lara eklenir).
+- **Ops JSON `CODE_AGENTIC → FAST_TEXT` kuralı** — C4.1 scope.
+- C3 / C5 / C6 — paralel.
 
 ---
 
-## 5. Risk Register
+## 5. Risk Register v2
 
 | Risk | L | I | Mitigation |
 |---|---|---|---|
-| R1 `_KINDS` bump mevcut invariant testlerini kırar | M | L | `test_policy_sim_integration.py` + `test_cost_middleware_core.py` + `test_coordination_takeover_prune.py` _KINDS count update |
-| R2 `resolve_route` facade additive kwargs mevcut call-sites'a etki | L | H | Default-off; regression test her caller için |
-| R3 `_budget_below_threshold` helper empty policy durumu → ne döner | L | M | Threshold yoksa False (skip); test ile pin |
-| R4 `downgrade_applied` response key'i mevcut consumer'ları karıştırır | L | L | Additive; mevcut consumer'lar bu key'e bakmıyor |
+| R1 `_KINDS` 27 → 28 invariant test break | M | L | `test_policy_sim_integration.py:101` same-commit update + floor testler auto-pass |
+| R2 Facade additive kwargs mevcut callers'a etki | L | M | Default-off; behavioral regression test 4 caller için |
+| R3 Dormant path user confusion — "neden downgrade çalışmıyor" | M | L | Return dict docstring + `docs/COST-MODEL.md §7` "C4.1 follow-up" note |
+| R4 `Budget` import cycle risk | L | L | `TYPE_CHECKING` string annotation |
 
 ---
 
-## 6. Codex iter-1 için Açık Sorular
+## 6. Codex iter-2 için Açık Sorular
 
-**Q1 — `Budget` import yolu**: `ao_kernel.workflow.Budget` dataclass mi, yoksa `ao_kernel.cost.Budget` mi? Facade'ta type hint için hangisini import etmeli?
-
-**Q2 — `_budget_below_threshold` threshold kaynağı**: `cost_policy.routing_by_cost.class_thresholds` field schema'da var mı yoksa eklenecek mi? Yoksa threshold hardcoded default mu (ör. $0.10)?
-
-**Q3 — Evidence emit site v1 kapsamında mı**: `route_cross_class_downgrade` emit'i `governed_call` / `_run_llm_step` gibi caller'larda mı eklenecek v1'de? Yoksa _KINDS bump + contract yeter mi, emit follow-up?
-
-**Q4 — Internal `resolve` request dict genişlemesi**: `request["cross_class_downgrade"]` etc. dict key olarak geçirmek OK mi, yoksa signature widen (kwargs direct) daha temiz?
-
-**Q5 — `soft_degrade` kwarg gerekli mi**: `soft_degrade` knob'u default-off? Runtime'da `resolver_rules["soft_degrade"]["enabled"]` zaten var. Bu bayrak caller'ın soft_degrade'i AÇIKCA isteyip istemediğini mi gösterir, yoksa override mı?
+Bu iter'de yeni Q yok; iter-1 Q1-Q5 absorb edildi. Q2 (threshold source) + Q5 (soft_degrade semantic) özellikle: scope-down ile dormant path + soft_degrade kwarg drop.
 
 ---
 
 ## 7. Implementation Order
 
-1. `_KINDS` bump (`evidence_emitter.py:46-82` — 27 → 28).
-2. `llm.resolve_route` additive kwargs.
-3. Internal `resolve` consumer (downgrade logic + response fields).
-4. Mevcut _KINDS invariant test'leri update.
-5. 6 yeni test.
-6. Docs update (POLICY-SIM.md, COST-MODEL.md, MODEL-ROUTING.md).
+1. `_KINDS` bump (`evidence_emitter.py:46-82`).
+2. `llm.resolve_route` additive kwargs (+ TYPE_CHECKING `Budget`).
+3. Internal `resolve` request-dict plumbing (dormant).
+4. `test_policy_sim_integration.py:101` _KINDS invariant update.
+5. `docs/POLICY-SIM.md:49` + `docs/COST-MODEL.md §7` update.
+6. 5 yeni test.
 7. Regression + commit + post-impl Codex review + PR #112.
 
 ---
 
 ## 8. LOC Estimate
 
-~450 satır (_KINDS +1, facade +8, internal resolve +40, 6 test +300, docs +50, mevcut invariant test update +5).
+~300 satır (v1: 450 → v2: 300). _KINDS +1, facade +8, internal resolve +10 (dormant plumbing), _KINDS invariant test update +5, 5 test +200, docs +50.
 
 ---
 
@@ -197,6 +177,16 @@ Callers (run-aware): `governed_call` / `_run_llm_step` gibi — `resolve_route()
 
 | Iter | Date | Verdict |
 |---|---|---|
-| v1 (Claude draft) | 2026-04-18 | Pre-Codex iter-1 submit |
+| v1 (Claude draft) | 2026-04-18 | Pre-Codex submit (`4e07cfa`) |
+| iter-1 (thread `019da035`) | 2026-04-18 | **PARTIAL** — 3 blocker (threshold source yok, rules yönsüz, scope gap) + 4 warning |
+| **v2 (iter-1 absorb)** | 2026-04-18 | Pre-iter-2. Scope-down: plumbing-only + runtime dormant. `soft_degrade` kwarg drop; aktif downgrade C4.1 follow-up. |
+| iter-2 | TBD | AGREE expected (dar scope, runtime no-op invariant kod akışıyla pin'li) |
 
-**Codex thread**: Yeni (C4-specific).
+### Plan revision history
+
+| Ver | Change |
+|---|---|
+| v1 | 3 scope + 5 Q; runtime downgrade aktif, threshold assume, `soft_degrade` kwarg |
+| **v2** | iter-1 absorb: scope = plumbing-only; dormant invariant (downgrade_applied=False); soft_degrade kwarg drop; threshold source + rule iterate C4.1 follow-up. |
+
+**Status**: Plan v2 hazır. Dar scope plumbing-only; runtime downgrade invariant no-op. AGREE beklenir.

--- a/.claude/plans/PR-C4-IMPLEMENTATION-PLAN.md
+++ b/.claude/plans/PR-C4-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,202 @@
+# PR-C4 Implementation Plan v1 — Cross-Class Routing (Additive Facade)
+
+**Scope**: FAZ-C strategic extension (bağımsız). `ao_kernel.llm.resolve_route` facade additive kwarg widen + internal `resolve` cross_class_downgrade consumer + `_KINDS` 27→28 `route_cross_class_downgrade`. Default-off backwards-compat.
+
+**Base**: `main a581fb5` (PR #111 C2 merged). **Branch**: `feat/pr-c4-resolve-route-kwargs`.
+
+**Status**: Pre-Codex iter-1 submit.
+
+---
+
+## 1. Problem
+
+`llm_resolver_rules.v1.json` `soft_degrade.enabled=true` + rules var ama runtime tüketmiyor. `ao_kernel.llm.resolve_route` public facade'ı (`llm.py:23-46`) `budget_remaining`/`cross_class_downgrade`/`soft_degrade` kwarg'larını almıyor.
+
+---
+
+## 2. Scope (atomic deliverable)
+
+### 2.1 `resolve_route` facade additive kwargs
+
+**Before** (`llm.py:23-46`):
+```python
+def resolve_route(
+    *,
+    intent: str,
+    perspective: str | None = None,
+    provider_priority: list[str] | None = None,
+    workspace_root: str | None = None,
+) -> dict[str, Any]:
+```
+
+**After** (v1 — 3 yeni optional kwarg):
+```python
+def resolve_route(
+    *,
+    intent: str,
+    perspective: str | None = None,
+    provider_priority: list[str] | None = None,
+    workspace_root: str | None = None,
+    budget_remaining: "Budget | None" = None,  # NEW
+    cross_class_downgrade: bool = False,       # NEW (runtime-only knob)
+    soft_degrade: bool = False,                # NEW (activate rules consumer)
+) -> dict[str, Any]:
+    ...
+    return resolve(
+        request={
+            "intent": intent,
+            "perspective": perspective,
+            "provider_priority": provider_priority or [],
+            # PR-C4 additive request keys (internal-only):
+            "budget_remaining": budget_remaining,
+            "cross_class_downgrade": cross_class_downgrade,
+            "soft_degrade": soft_degrade,
+        },
+        workspace_root=workspace_root,
+    )
+```
+
+**Backwards-compat**: Default-off (`False`, `None`). 4 mevcut caller (`mcp_server.py:150,353`, `client.py:842`, `intent_router.py:364`) dokunulmaz — 3 yeni kwarg'ı geçmedikleri için davranış değişmez.
+
+### 2.2 Internal `resolve` cross_class_downgrade consumer
+
+`_internal/prj_kernel_api/llm_router.py::resolve`:
+```python
+def resolve(request, repo_root=None, now=None, workspace_root=None):
+    ...
+    # PR-C4: cross_class_downgrade runtime consumer (default-off)
+    cross_class_downgrade = bool(request.get("cross_class_downgrade", False))
+    soft_degrade_enabled = bool(request.get("soft_degrade", False))
+    budget_remaining = request.get("budget_remaining")
+    
+    # Determine target class (intent → class via resolver_rules)
+    target_class = resolver_rules["intent_to_class"].get(intent)
+    original_class = target_class
+    downgrade_applied = False
+    downgraded_class = None
+    
+    if (
+        cross_class_downgrade
+        and soft_degrade_enabled
+        and budget_remaining is not None
+        and _budget_below_threshold(budget_remaining, target_class)
+    ):
+        # Iterate soft_degrade.rules for matching from_class + intents
+        for rule in resolver_rules.get("soft_degrade", {}).get("rules", []):
+            if (
+                rule.get("from_class") == target_class
+                and intent in rule.get("intents", [])
+            ):
+                downgraded_class = rule.get("to_class")
+                target_class = downgraded_class
+                downgrade_applied = True
+                break
+    
+    # ... existing provider+model selection logic against target_class ...
+    
+    result = {
+        "status": "OK" if selected else "FAIL",
+        "selected_provider": provider,
+        "selected_model": model,
+        # PR-C4 additive response fields (default-off → False/None):
+        "downgrade_applied": downgrade_applied,
+        "original_class": original_class if downgrade_applied else None,
+        "downgraded_class": downgraded_class if downgrade_applied else None,
+        # ... existing fields ...
+    }
+    return result
+```
+
+`_budget_below_threshold(budget, class)` helper: basit karşılaştırma — policy `cost_policy.routing_by_cost.class_thresholds` (yoksa `{}`) → class için threshold `budget_remaining.cost_usd < threshold`. Threshold yoksa False (downgrade skip). v1 MVP.
+
+### 2.3 `route_cross_class_downgrade` evidence kind
+
+`evidence_emitter.py:46` `_KINDS` frozenset'ine yeni kind ekle: `"route_cross_class_downgrade"`. **27 → 28**.
+
+Callers (run-aware): `governed_call` / `_run_llm_step` gibi — `resolve_route()` çağrısı sonrası return dict'te `downgrade_applied=True` ise `emit_event(run_id, 'route_cross_class_downgrade', {...})`. C4 scope'ta bu emit call-site'ları ayrıntılı incelenecek; v1 için sadece `_KINDS` bump + contract pin (gerçek emit follow-up PR'a kalabilir eğer karmaşıksa).
+
+### 2.4 Docs update
+
+- `docs/POLICY-SIM.md:49-51` `_KINDS` count 27 → 28.
+- `docs/COST-MODEL.md §7` (veya yeni §) `routing_by_cost.cross_class_downgrade` knob.
+- `docs/MODEL-ROUTING.md §6` (veya yeni §) soft_degrade runtime consumer.
+
+---
+
+## 3. Test Plan
+
+### 3.1 Yeni testler (`tests/test_resolve_route_kwargs.py`)
+
+- `test_defaults_off_preserves_existing_behavior` — mevcut callers (intent only) → existing return dict (downgrade_applied=False).
+- `test_additive_kwargs_accept_without_effect` — `budget_remaining=None, cross_class_downgrade=False` → behavior aynı.
+- `test_cross_class_downgrade_active_applies_soft_degrade_rule` — `cross_class_downgrade=True + budget_remaining below threshold` → `downgrade_applied=True`, `original_class=BALANCED_TEXT`, `downgraded_class=FAST_TEXT` (DISCOVERY intent için).
+- `test_cross_class_downgrade_without_budget_returns_original` — `cross_class_downgrade=True + budget_remaining=None` → downgrade skip.
+- `test_kinds_count_is_28` — `len(_KINDS) == 28`, `'route_cross_class_downgrade' in _KINDS`.
+- `test_existing_resolve_route_callers_unchanged` — mcp_server / client / intent_router pattern'ini verify (runtime argv inspection).
+
+### 3.2 Regression gate
+
+- `pytest tests/ -x` — 2164 + 6 = ~2170 green.
+- Özellikle `test_policy_sim_integration.py::TestKindsInvariant` (27 → 28 update).
+- 4 caller: mcp_server + client + intent_router + runtime fail yok.
+
+---
+
+## 4. Out of Scope
+
+- `route_cross_class_downgrade` evidence emit call-site'ları — v1 sadece `_KINDS` bump + return contract. Emit run-aware caller'lara eklenir (follow-up veya C4 scope genişlemesi).
+- Cost policy `routing_by_cost.class_thresholds` schema — minimal; v1 default empty dict (threshold yok → downgrade skip).
+- C3/C5/C6 — paralel.
+
+---
+
+## 5. Risk Register
+
+| Risk | L | I | Mitigation |
+|---|---|---|---|
+| R1 `_KINDS` bump mevcut invariant testlerini kırar | M | L | `test_policy_sim_integration.py` + `test_cost_middleware_core.py` + `test_coordination_takeover_prune.py` _KINDS count update |
+| R2 `resolve_route` facade additive kwargs mevcut call-sites'a etki | L | H | Default-off; regression test her caller için |
+| R3 `_budget_below_threshold` helper empty policy durumu → ne döner | L | M | Threshold yoksa False (skip); test ile pin |
+| R4 `downgrade_applied` response key'i mevcut consumer'ları karıştırır | L | L | Additive; mevcut consumer'lar bu key'e bakmıyor |
+
+---
+
+## 6. Codex iter-1 için Açık Sorular
+
+**Q1 — `Budget` import yolu**: `ao_kernel.workflow.Budget` dataclass mi, yoksa `ao_kernel.cost.Budget` mi? Facade'ta type hint için hangisini import etmeli?
+
+**Q2 — `_budget_below_threshold` threshold kaynağı**: `cost_policy.routing_by_cost.class_thresholds` field schema'da var mı yoksa eklenecek mi? Yoksa threshold hardcoded default mu (ör. $0.10)?
+
+**Q3 — Evidence emit site v1 kapsamında mı**: `route_cross_class_downgrade` emit'i `governed_call` / `_run_llm_step` gibi caller'larda mı eklenecek v1'de? Yoksa _KINDS bump + contract yeter mi, emit follow-up?
+
+**Q4 — Internal `resolve` request dict genişlemesi**: `request["cross_class_downgrade"]` etc. dict key olarak geçirmek OK mi, yoksa signature widen (kwargs direct) daha temiz?
+
+**Q5 — `soft_degrade` kwarg gerekli mi**: `soft_degrade` knob'u default-off? Runtime'da `resolver_rules["soft_degrade"]["enabled"]` zaten var. Bu bayrak caller'ın soft_degrade'i AÇIKCA isteyip istemediğini mi gösterir, yoksa override mı?
+
+---
+
+## 7. Implementation Order
+
+1. `_KINDS` bump (`evidence_emitter.py:46-82` — 27 → 28).
+2. `llm.resolve_route` additive kwargs.
+3. Internal `resolve` consumer (downgrade logic + response fields).
+4. Mevcut _KINDS invariant test'leri update.
+5. 6 yeni test.
+6. Docs update (POLICY-SIM.md, COST-MODEL.md, MODEL-ROUTING.md).
+7. Regression + commit + post-impl Codex review + PR #112.
+
+---
+
+## 8. LOC Estimate
+
+~450 satır (_KINDS +1, facade +8, internal resolve +40, 6 test +300, docs +50, mevcut invariant test update +5).
+
+---
+
+## 9. Audit Trail
+
+| Iter | Date | Verdict |
+|---|---|---|
+| v1 (Claude draft) | 2026-04-18 | Pre-Codex iter-1 submit |
+
+**Codex thread**: Yeni (C4-specific).

--- a/ao_kernel/_internal/prj_kernel_api/llm_router.py
+++ b/ao_kernel/_internal/prj_kernel_api/llm_router.py
@@ -111,10 +111,31 @@ def resolve(
     repo_root = repo_root or Path(__file__).resolve().parents[2]
     now = now or datetime.now(timezone.utc)
 
+    # PR-C4 dormant plumbing (plumbing-only; runtime no-op in v1):
+    # Additive response fields are the single source of truth for
+    # the downgrade contract shape across all return paths below.
+    _c4_dormant: Dict[str, Any] = {
+        "downgrade_applied": False,
+        "original_class": None,
+        "downgraded_class": None,
+    }
+    # Read + ignore (consumed in C4.1 follow-up — threshold schema
+    # widen + directional rule filter).
+    _ = request.get("budget_remaining")
+    _ = bool(request.get("cross_class_downgrade", False))
+
     if "model" in request:
-        return {"status": "FAIL", "reason": "MODEL_OVERRIDE_NOT_ALLOWED"}
+        return {
+            "status": "FAIL",
+            "reason": "MODEL_OVERRIDE_NOT_ALLOWED",
+            **_c4_dormant,
+        }
     if "params_override" in request:
-        return {"status": "FAIL", "reason": "PROFILE_PARAM_OVERRIDE_NOT_ALLOWED"}
+        return {
+            "status": "FAIL",
+            "reason": "PROFILE_PARAM_OVERRIDE_NOT_ALLOWED",
+            **_c4_dormant,
+        }
 
     intent = request.get("intent")
     perspective = request.get("perspective")
@@ -131,7 +152,11 @@ def resolve(
     merged_map = _merge_state(provider_map, probe_state)
     intent_map = resolver_rules["intent_to_class"]
     if intent not in intent_map:
-        return {"status": "FAIL", "reason": "UNKNOWN_INTENT"}
+        return {
+            "status": "FAIL",
+            "reason": "UNKNOWN_INTENT",
+            **_c4_dormant,
+        }
     target_class = intent_map[intent]
 
     ttl_default = resolver_rules.get("ttl_hours_default", 72)
@@ -238,6 +263,7 @@ def resolve(
             "reason": reason,
             "selected_class": target_class,
             "provider_attempts": attempts,
+            **_c4_dormant,
         }
 
     sel_provider, sel_model_id, sel_model = selected
@@ -253,6 +279,7 @@ def resolve(
         "ttl_remaining_hours": None,  # compute optionally
         "intent": intent,
         "perspective": perspective,
+        **_c4_dormant,
     }
     return manifest
 

--- a/ao_kernel/executor/evidence_emitter.py
+++ b/ao_kernel/executor/evidence_emitter.py
@@ -80,6 +80,11 @@ _KINDS: Final[frozenset[str]] = frozenset({
     "llm_cost_estimated",   # pre-dispatch estimate emitted (governed_call step 4)
     "llm_spend_recorded",   # post-response actual cost computed + ledger appended
     "llm_usage_missing",    # adapter response missing tokens_input/output (audit flag)
+    # PR-C4 addition (cross-class routing, 27 → 28 kinds). Reserved for
+    # C4.1 follow-up runtime consumer (threshold schema widen + rule
+    # iterate); v1 plumbing only — _KINDS accepts the kind but cost
+    # runtime / route layer does NOT emit in this PR.
+    "route_cross_class_downgrade",
 })
 
 _REDACTED: Final[str] = "***REDACTED***"

--- a/ao_kernel/llm.py
+++ b/ao_kernel/llm.py
@@ -15,7 +15,10 @@ This module provides the stable public API surface.
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ao_kernel.workflow import Budget  # noqa: F401  (used in annotations)
 
 # ── Routing ──────────────────────────────────────────────────────────
 
@@ -26,13 +29,20 @@ def resolve_route(
     perspective: str | None = None,
     provider_priority: list[str] | None = None,
     workspace_root: str | None = None,
+    budget_remaining: "Budget | None" = None,
+    cross_class_downgrade: bool = False,
 ) -> dict[str, Any]:
     """Resolve the best provider/model for an LLM intent.
 
     Deterministic routing: intent → class → provider → model.
     Verified-only, TTL-gated. Fail-closed.
 
-    Returns dict with 'status' ('OK' or 'FAIL'), 'provider_id', 'model', etc.
+    Returns dict with 'status' ('OK' or 'FAIL'), 'provider_id', 'model',
+    and (PR-C4 plumbing) 'downgrade_applied', 'original_class',
+    'downgraded_class'. The latter three are always ``False``/``None``
+    in this PR — PR-C4 v1 is plumbing-only; runtime downgrade lands
+    in C4.1 follow-up (threshold schema widen + soft_degrade rules
+    directional filter).
     """
     from ao_kernel._internal.prj_kernel_api.llm_router import resolve
 
@@ -41,6 +51,9 @@ def resolve_route(
             "intent": intent,
             "perspective": perspective,
             "provider_priority": provider_priority or [],
+            # PR-C4 additive (plumbing-only — dormant in v1):
+            "budget_remaining": budget_remaining,
+            "cross_class_downgrade": cross_class_downgrade,
         },
         workspace_root=workspace_root,
     )

--- a/docs/COST-MODEL.md
+++ b/docs/COST-MODEL.md
@@ -232,12 +232,14 @@ Cost-layer errors **raise** (not envelope): `BudgetExhaustedError`, `CostTrackin
 
 ### 7.4 Evidence taxonomy
 
-3 additive kinds (24 → 27):
+3 additive kinds emitted by cost runtime (24 → 27):
 - `llm_cost_estimated` — pre-dispatch estimate, always emitted before transport.
 - `llm_spend_recorded` — post-response actual, emitted after ledger append.
 - `llm_usage_missing` — adapter response missing tokens_input/output; audit-only ledger entry precedes the raise when fail-closed.
 
 Emits are **fail-open** (wrapper swallows + warn-logs); ledger writes are **fail-closed** (raise on failure).
+
+**PR-C4 reservation (27 → 28)**: `route_cross_class_downgrade` is added to the `_KINDS` frozenset but **not emitted** by cost runtime or the route layer in this release. The kind is reserved for the C4.1 follow-up PR, which wires the runtime consumer (threshold schema widen + `soft_degrade.rules` directional filter). Total shipped emit kinds stay at **3** for cost runtime.
 
 ## 8. Identity Threading — `(run_id, step_id, attempt)`
 

--- a/docs/POLICY-SIM.md
+++ b/docs/POLICY-SIM.md
@@ -46,9 +46,12 @@ The harness answers operator questions like:
   discoverable without tripping the
   `importlib.resources.as_file` sentinel (plan v3 iter-2
   blocker absorb).
-- `_KINDS == 27` in `executor/evidence_emitter.py:46` is
+- `_KINDS == 28` in `executor/evidence_emitter.py:46` is
   preserved — simulation emits no new evidence kinds (plan v3
-  bulgu 6 absorb).
+  bulgu 6 absorb). PR-C4 bumped the total from 27 to 28 by
+  reserving `route_cross_class_downgrade` for the C4.1 runtime
+  consumer; the new kind is part of the taxonomy but is NOT
+  emitted by policy-sim or by the cost runtime in this release.
 
 ## 3. Scenario Model
 

--- a/tests/test_policy_sim_integration.py
+++ b/tests/test_policy_sim_integration.py
@@ -99,15 +99,17 @@ class TestBundledFixtureEndToEnd:
 
 
 class TestKindsInvariant:
-    def test_kinds_is_27(self) -> None:
+    def test_kinds_is_28(self) -> None:
         """Policy-sim emits ZERO new evidence kinds; the
-        executor's `_KINDS` count must stay at 27 after the
-        package lands (plan v3 §2.1 + §8)."""
+        executor's `_KINDS` count must stay exact (PR-C4 bumped
+        27 → 28 with reserved ``route_cross_class_downgrade`` kind,
+        C4.1 runtime consumer pending — plan v3 §2.1 + §8 + C4 v2)."""
         from ao_kernel.executor import evidence_emitter
 
         kinds = getattr(evidence_emitter, "_KINDS", None)
         assert kinds is not None, "evidence_emitter._KINDS missing"
-        assert len(kinds) == 27
+        assert len(kinds) == 28
+        assert "route_cross_class_downgrade" in kinds
 
 
 class TestCliEndToEnd:

--- a/tests/test_resolve_route_kwargs.py
+++ b/tests/test_resolve_route_kwargs.py
@@ -1,0 +1,134 @@
+"""PR-C4: resolve_route additive kwargs + _KINDS 27→28 plumbing.
+
+v1 is plumbing-only — runtime downgrade is DORMANT (always
+``downgrade_applied=False``, ``original_class=None``,
+``downgraded_class=None``). The runtime consumer (threshold
+comparison + directional ``soft_degrade.rules`` filter) lands in
+C4.1 follow-up PR after the ``policy-cost-tracking`` schema widens
+to include ``routing_by_cost.class_thresholds``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from ao_kernel.executor import evidence_emitter
+from ao_kernel.llm import resolve_route
+
+
+class TestDefaultsOffPreservesBehavior:
+    """Existing callers (mcp_server, client, intent_router) must not
+    see behavioral changes from PR-C4 additive kwargs."""
+
+    def test_existing_caller_pattern_unaffected(self) -> None:
+        """Contract: calling ``resolve_route`` with the old pre-C4
+        kwarg set returns a dict that still carries the legacy keys.
+        Note: ``intent_router._llm_classify`` passes
+        ``resolve_route(intent='FAST_TEXT')`` — 'FAST_TEXT' is a
+        class name, not a recognised intent. The resolver returns a
+        FAIL manifest with ``reason='UNKNOWN_INTENT'`` in this case;
+        C4 just guarantees the dormant contract fields travel along
+        every return path."""
+        result = resolve_route(intent="FAST_TEXT")
+        # Existing legacy contract: result is a dict with ``status``.
+        assert "status" in result
+        # C4 dormant contract: 3 additive keys present, all neutral.
+        assert result.get("downgrade_applied") is False
+        assert result.get("original_class") is None
+        assert result.get("downgraded_class") is None
+
+
+class TestAdditiveKwargsRuntimeNoOp:
+    """Even with the new kwargs set, v1 runtime remains dormant."""
+
+    def test_cross_class_downgrade_true_is_dormant(self) -> None:
+        """Setting ``cross_class_downgrade=True`` without a runtime
+        threshold source must still return the dormant contract
+        (downgrade_applied=False). Runtime activation is C4.1 scope."""
+        result = resolve_route(
+            intent="DISCOVERY",  # a real intent; maps to BALANCED_TEXT
+            cross_class_downgrade=True,
+            budget_remaining=None,  # no threshold source anyway
+        )
+        assert result.get("downgrade_applied") is False
+        assert result.get("original_class") is None
+        assert result.get("downgraded_class") is None
+
+
+class TestPlumbingForwardsKwargsToInternal:
+    """The facade must pass the new kwargs through the internal
+    ``resolve()`` request dict."""
+
+    def test_forwards_budget_remaining_and_flag(self) -> None:
+        from ao_kernel._internal.prj_kernel_api import llm_router
+
+        captured: dict = {}
+
+        def _fake_resolve(
+            request, repo_root=None, now=None, workspace_root=None,
+        ):
+            captured.update(request)
+            return {
+                "status": "OK",
+                "selected_class": "FAST_TEXT",
+                "selected_provider": "test",
+                "selected_model": "test-m",
+                "provider_attempts": [],
+                "probe_status_at_selection": "ok",
+                "verified_at": None,
+                "probe_last_at": None,
+                "ttl_remaining_hours": None,
+                "intent": "BASELINE",
+                "perspective": None,
+                "downgrade_applied": False,
+                "original_class": None,
+                "downgraded_class": None,
+            }
+
+        with patch.object(llm_router, "resolve", _fake_resolve):
+            resolve_route(
+                intent="BASELINE",
+                cross_class_downgrade=True,
+                budget_remaining="sentinel-budget-obj",  # plumbed through
+            )
+
+        # Both new keys forwarded to internal resolve's request dict.
+        assert captured["cross_class_downgrade"] is True
+        assert captured["budget_remaining"] == "sentinel-budget-obj"
+
+
+class TestKindsCountIs28:
+    def test_kinds_frozenset_has_new_kind(self) -> None:
+        kinds = evidence_emitter._KINDS
+        assert len(kinds) == 28
+        assert "route_cross_class_downgrade" in kinds
+
+
+class TestDormantContractOnAllReturnPaths:
+    """PR-C4 v2 §3: response fields travel on every return path
+    (success AND failure). Codex post-AGREE note #3 absorb."""
+
+    def test_model_override_fail_path_carries_dormant_contract(
+        self,
+    ) -> None:
+        from ao_kernel._internal.prj_kernel_api.llm_router import resolve
+
+        result = resolve(request={"model": "override-model-name"})
+        assert result["status"] == "FAIL"
+        assert result["reason"] == "MODEL_OVERRIDE_NOT_ALLOWED"
+        # Dormant contract present on this FAIL path too.
+        assert result["downgrade_applied"] is False
+        assert result["original_class"] is None
+        assert result["downgraded_class"] is None
+
+    def test_unknown_intent_fail_path_carries_dormant_contract(
+        self,
+    ) -> None:
+        from ao_kernel._internal.prj_kernel_api.llm_router import resolve
+
+        result = resolve(request={"intent": "UNKNOWN_INTENT_VALUE"})
+        assert result["status"] == "FAIL"
+        assert result["reason"] == "UNKNOWN_INTENT"
+        assert result["downgrade_applied"] is False
+        assert result["original_class"] is None
+        assert result["downgraded_class"] is None


### PR DESCRIPTION
## Summary

**FAZ-C strategic extension (bağımsız track).** Codex plan consensus: 2 iter → AGREE (thread \`019da035\`, plan sha \`95d0895\`) — fastest convergence in FAZ-C series.

### Changes (plumbing-only, runtime dormant)

1. **Facade additive kwargs** (\`ao_kernel/llm.py\`): \`resolve_route(..., budget_remaining, cross_class_downgrade)\` — 2 new optional kwargs, default-off. \`TYPE_CHECKING\` import for \`Budget\` to avoid cycle. 4 existing callers (\`mcp_server.py:150,353\`, \`client.py:842\`, \`intent_router.py:364\`) unaffected.

2. **Internal resolve request-dict plumbing** (\`_internal/prj_kernel_api/llm_router.py\`): request reads new keys but v1 takes **no runtime action** (dormant). All return paths (MODEL_OVERRIDE, PARAMS_OVERRIDE, UNKNOWN_INTENT, NO_VERIFIED_MODEL, success) carry the dormant contract fields \`downgrade_applied=False\`, \`original_class=None\`, \`downgraded_class=None\` — Codex post-AGREE note absorb.

3. **\`_KINDS\` 27 → 28** (\`evidence_emitter.py\`): reserves \`route_cross_class_downgrade\` kind. **Not emitted** by cost runtime or route layer in this PR; C4.1 follow-up wires runtime consumer.

4. **Invariant test + docs update**:
   - \`test_policy_sim_integration.py\` — \`test_kinds_is_27\` → \`test_kinds_is_28\` + kind name check.
   - \`docs/POLICY-SIM.md:49\` — count update + reservation context.
   - \`docs/COST-MODEL.md §7.4\` — narrative distinguishes taxonomy total (28) from shipped emit kinds (3 for cost runtime).

## Test plan

- [x] \`pytest tests/\` — **2170/2170** green (2164 prior + 6 new)
- [x] \`ruff check ao_kernel/ tests/\` — clean
- [x] \`mypy ao_kernel/ --ignore-missing-imports\` — clean (186 src)
- [ ] CI green (pending push)

### New tests (6)

- \`test_existing_caller_pattern_unaffected\` — behavioral pin (FAST_TEXT is a class name, not an intent; returns UNKNOWN_INTENT FAIL with dormant contract).
- \`test_cross_class_downgrade_true_is_dormant\` — runtime no-op invariant.
- \`test_forwards_budget_remaining_and_flag\` — plumbing forward via mock.
- \`test_kinds_frozenset_has_new_kind\` — \`len == 28\` + kind present.
- \`test_model_override_fail_path_carries_dormant_contract\` — FAIL path fields.
- \`test_unknown_intent_fail_path_carries_dormant_contract\` — FAIL path fields.

## Plan iteration summary

Codex thread \`019da035-0472-7773-a765-d66a149222a6\`:
- iter-1: PARTIAL (3 blocker: threshold source missing, rules undirected, scope gap + 4 warning)
- **iter-2: AGREE** \`95d0895\` snapshot, \`ready_for_impl=true\`
- Post-impl: PARTIAL → AGREE (2e76201 docs commit; 3 note all absorbed)

## Out of Scope (C4.1 follow-up PR)

- Threshold source: \`policy-cost-tracking.schema.v1.json\` \`routing_by_cost.class_thresholds\` widen.
- Runtime rule iterate with directional filter (\`_is_cost_downgrade\`).
- \`route_cross_class_downgrade\` emit call-sites.
- Ops JSON \`CODE_AGENTIC → FAST_TEXT\` rule addition.

## Evidence

- CNS-20260418-045 (thread \`019da035\`)
- Plan: \`.claude/plans/PR-C4-IMPLEMENTATION-PLAN.md\` v2
- Base: \`main a581fb5\` (PR #111 C2 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)