### PR TITLE
fix(pr-c2.1): MultiStepDriver default bundled policy fallback (driver/executor parity)

### DIFF
--- a/ao_kernel/executor/multi_step_driver.py
+++ b/ao_kernel/executor/multi_step_driver.py
@@ -50,7 +50,7 @@ from ao_kernel.adapters import AdapterRegistry
 from ao_kernel.executor.artifacts import write_artifact
 from ao_kernel.executor.errors import PolicyViolationError
 from ao_kernel.executor.evidence_emitter import emit_event
-from ao_kernel.executor.executor import Executor
+from ao_kernel.executor.executor import Executor, _load_bundled_policy
 from ao_kernel.executor.policy_enforcer import (
     SandboxedEnvironment,
     build_sandbox,
@@ -199,7 +199,17 @@ class MultiStepDriver:
         self._registry = registry
         self._adapter_registry = adapter_registry
         self._executor = executor
-        self._policy: Mapping[str, Any] = policy_config or {}
+        # PR-C2.1 (Codex deep-review `019da0b2` follow-up): mirror
+        # Executor's truthiness-based bundled fallback for semantic
+        # parity. Falsy ``policy_config`` (None OR empty dict) →
+        # bundled policy. Previously the driver used ``is not None``
+        # which let ``policy_config={}`` produce an empty policy
+        # while Executor's ``or _load_bundled_policy()`` fell back
+        # to bundled — reintroducing the driver/executor split
+        # flagged by Codex in retrospective bulgu 1.
+        self._policy: Mapping[str, Any] = (
+            policy_config or _load_bundled_policy()
+        )
 
     # ------------------------------------------------------------------
     # Public: run_workflow

--- a/tests/test_driver_policy_default.py
+++ b/tests/test_driver_policy_default.py
@@ -1,0 +1,115 @@
+"""PR-C2.1: MultiStepDriver default bundled-policy fallback.
+
+Regression gate for Codex retrospective `019da0b2` bulgu 1:
+MultiStepDriver previously defaulted to empty ``{}`` policy, so
+C2's security-split fix never engaged in benchmark/demo paths.
+This file pins:
+
+1. Default construction loads the bundled
+   ``policy_worktree_profile.v1.json`` shape.
+2. Explicit ``policy_config`` still wins (override semantics).
+3. Downstream ``_build_sandbox`` sees the real PATH-synth
+   command_allowlist prefixes, not an empty PATH.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ao_kernel.adapters import AdapterRegistry
+from ao_kernel.executor import Executor, MultiStepDriver
+from ao_kernel.workflow.registry import WorkflowRegistry
+
+
+def _build_driver(
+    workspace_root: Path,
+    *,
+    policy_config=None,
+) -> MultiStepDriver:
+    wreg = WorkflowRegistry()
+    wreg.load_workspace(workspace_root)
+    areg = AdapterRegistry()
+    areg.load_workspace(workspace_root)
+    executor = Executor(
+        workspace_root=workspace_root,
+        workflow_registry=wreg,
+        adapter_registry=areg,
+    )
+    return MultiStepDriver(
+        workspace_root=workspace_root,
+        registry=wreg,
+        adapter_registry=areg,
+        executor=executor,
+        policy_config=policy_config,
+    )
+
+
+class TestDefaultPolicyLoad:
+    def test_default_loads_bundled_policy(self, tmp_path: Path) -> None:
+        """Default construction (no policy_config) yields the
+        bundled ``policy_worktree_profile.v1.json`` — previously
+        gave empty ``{}``."""
+        driver = _build_driver(tmp_path)
+        policy = driver._policy
+        assert policy is not None
+        # Bundled policy ships these top-level keys:
+        for key in (
+            "worktree",
+            "env_allowlist",
+            "secrets",
+            "command_allowlist",
+            "cwd_confinement",
+            "evidence_redaction",
+        ):
+            assert key in policy, (
+                f"bundled policy missing top-level {key!r}"
+            )
+        # Bundled default is DORMANT (enabled=false).
+        assert policy.get("enabled") is False
+
+    def test_explicit_policy_config_overrides_bundled(
+        self, tmp_path: Path,
+    ) -> None:
+        """Non-empty ``policy_config`` kwarg still wins over the
+        bundled fallback — backwards-compat invariant."""
+        custom = {
+            "_c2_1_sentinel": "explicit_policy_wins",
+            "secrets": {"allowlist_secret_ids": ["X"]},
+        }
+        driver = _build_driver(tmp_path, policy_config=custom)
+        assert driver._policy is custom
+
+    def test_empty_dict_policy_config_falls_back_to_bundled(
+        self, tmp_path: Path,
+    ) -> None:
+        """Driver/Executor parity (Codex deep-review follow-up
+        note): both sides use truthiness-based fallback, so an
+        explicit empty ``{}`` is treated the same as ``None`` —
+        bundled policy loads. This prevents the subtle split where
+        ``build_driver(policy_loader={})`` would yield empty
+        driver-policy but bundled executor-policy."""
+        driver = _build_driver(tmp_path, policy_config={})
+        # Falsy {} → bundled (non-empty, with real scaffolding).
+        assert driver._policy != {}
+        assert "command_allowlist" in driver._policy
+        # Executor parity check: same empty dict path there too.
+        executor_policy = driver._executor._policy
+        assert "command_allowlist" in executor_policy
+
+    def test_default_policy_contains_command_prefixes(
+        self, tmp_path: Path,
+    ) -> None:
+        """The bundled policy's ``command_allowlist.prefixes`` is
+        what ``_build_sandbox`` uses to synthesise the sandbox PATH
+        (policy_enforcer.py:135-141). An empty-dict default would
+        leave PATH empty and break every ``ci_*`` / ``patch_*``
+        sandbox call; this pins that the default now includes real
+        prefixes."""
+        driver = _build_driver(tmp_path)
+        cmd_spec = driver._policy.get("command_allowlist", {})
+        prefixes = cmd_spec.get("prefixes", [])
+        assert isinstance(prefixes, list)
+        assert len(prefixes) > 0, (
+            "bundled command_allowlist.prefixes empty — sandbox PATH "
+            "would not resolve system binaries"
+        )


### PR DESCRIPTION
## Summary

**Codex deep-review follow-up** (thread \`019da0b2\`, retrospective \`bulgu 1\`). Closes the driver/executor policy source split flagged in the post-C6 retrospective: \`MultiStepDriver\` default-constructed with empty \`{}\` policy meant C2's security-split fix never engaged in benchmark fixtures and demo paths.

### Changes

1. **\`MultiStepDriver.__init__\`**: empty \`{}\` fallback replaced with \`policy_config or _load_bundled_policy()\` — **truthiness parity** with \`Executor\`'s \`policy_loader or _load_bundled_policy()\` (\`executor.py:107-109\`).
   - Falsy \`policy_config\` (\`None\` OR \`{}\`) → bundled \`policy_worktree_profile.v1.json\`.
   - Non-empty explicit mapping still wins.
   - Import: \`from ao_kernel.executor.executor import Executor, _load_bundled_policy\`.

### Post-impl Codex note absorb

Initial patch used \`is not None\` which would have left \`policy_config={}\` as empty while executor's \`or\` fallback would load bundled — re-introducing the split at a narrower path. Fixed to \`or\` pattern + added explicit parity test.

## Test plan

- [x] \`pytest tests/\` — **2202/2202** green (2198 prior + 4 new)
- [x] \`ruff check ao_kernel/ tests/\` — clean
- [x] \`mypy ao_kernel/ --ignore-missing-imports\` — clean (188 src)
- [ ] CI green (pending push)

### New tests (4)

- \`test_default_loads_bundled_policy\` — \`None\` → bundled; top-level keys + \`enabled=False\` dormant contract preserved.
- \`test_explicit_policy_config_overrides_bundled\` — non-empty \`policy_config\` wins (identity pin).
- \`test_empty_dict_policy_config_falls_back_to_bundled\` — parity: \`{}\` → bundled on **both** driver AND executor (prevents the split).
- \`test_default_policy_contains_command_prefixes\` — \`command_allowlist.prefixes\` non-empty (sandbox PATH synth precondition).

## Impact

- benchmark/demo default paths now engage C2 security split.
- **C1b full E2E candidate unlocked** (follow-up PR).
- C3 \`post_adapter_reconcile\` can build on real policy plumbing.
- Dry-run (C6) fidelity improvement candidate (still separate follow-up).

## Out of Scope (follow-ups)

- **C1b full 7-step E2E re-open** — root cause unblocked; actual re-enable is a separate PR.
- **Shared \`policy_defaults.py\` extraction** — cosmetic; defer until third consumer exists.
- **C3 / C6 parity / C4.1 / C8** — parallel tracks.

## Evidence

- Codex deep-review thread \`019da0b2-81b0-7d00-82b3-27b3788f403d\` — retrospective review of session's 5 PRs; bulgu 1 absorbed here.
- Base: \`main 65d5250\` (PR #114 C6 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)