### PR TITLE
fix(pr-c3.2): post-reconcile crash-window + double-drain (marker-driven idempotency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — PR-C3.2 crash-window double-drain fix
+
+**Context.** v3.3.0 shipped a post-reconcile idempotency bug: when `post_adapter_reconcile` / `post_response_reconcile` were invoked twice with the same `(run_id, step_id, attempt, billing_digest)`, `record_spend` correctly no-op'd (same-digest silent warn-log) but the subsequent `update_run` budget CAS ran unconditionally — a second identical reconcile double-drained the budget. Codex CNS-20260418-033 adversarial plan review (5 iterations) pinned the root cause; the refactor below closes it.
+
+**Changes.**
+
+- **New shared helper** `ao_kernel/cost/_reconcile.py::apply_spend_with_marker()` — unifies both cost reconcile paths (adapter + governed_call) behind a ledger-first + marker-guarded contract. Returns `True` when a NEW marker was committed; callers use the signal to gate evidence emit.
+- **Marker schema** `workflow-run.cost_reconciled` (additive field on `workflow-run.schema.v1.json`) — array of `{source, step_id, attempt, billing_digest, recorded_at}`. Keyed by 4-tuple to avoid cross-path / cross-step suppression. Source enum: `adapter_path | governed_call | usage_missing`.
+- **Order unification** — `post_response_reconcile` (governed_call path) now runs `record_spend` BEFORE `update_run`; previously budget-CAS ran first. `post_adapter_reconcile` was already ledger-first but now uses the shared helper. Crash semantics: ledger entry may exist without a marker (retry recovers), but NEVER the reverse.
+- **Evidence emit guard** — `llm_spend_recorded` and `llm_usage_missing` events are emitted only when the helper commits a new marker. Duplicate reconcile calls produce no duplicate audit events. On the governed_call path, the `fail_closed_on_missing_usage` raise still fires regardless of marker state (terminal error per caller contract); on the adapter_path, usage-missing returns silently after the audit emit (existing contract — adapter callers handle the terminal error via the driver catch matrix).
+- **Public digest helper** `ao_kernel.cost.compute_billing_digest()` — promoted from private `_compute_billing_digest`. Backward-compat alias retained. Callers invoke before `apply_spend_with_marker` to populate the marker key; helper raises `ValueError` on empty digest (Codex iter-5 precondition).
+- **New exports** `ao_kernel.cost.{apply_spend_with_marker, compute_billing_digest, post_adapter_reconcile}`.
+
+**Test baseline.** 2210 → **2222** (+12 new in `tests/test_cost_marker_idempotency.py`). Existing `test_same_digest_silent_no_op_on_second_call` extended with budget assertion — the v3.3.0 bug would have shown 9.90 remaining (double drain), now pinned to 9.95. Ruff + mypy clean. Scope explicitly excludes tam duplicate `governed_call` idempotency (reserve-phase problem, v3.4.0 follow-up); this PR closes post-reconcile phase only.
+
+### Deferred — out of v3.3.1 scope (v3.4.0)
+
+- Full reconciliation daemon / API (`reconcile_orphan_spends`)
+- Startup hook / CLI `ao-kernel cost reconcile`
+- `cost_reconciled` array compaction (unbounded in v3.3.1 — Codex iter-3 advice: safer not to purge on finalize because late retry/replay could re-apply spend)
+- Subprocess crash-kill test suite (mock-based crash coverage is sufficient for v3.3.1; subprocess tests pair with the reconciler daemon)
+
 ## [3.3.0] — 2026-04-18
 
 **FAZ-C Runtime Closure + Strategic Extensions**. 9 PRs shipped in one session (#109 through #117) + B7.1 absorb.

--- a/ao_kernel/cost/__init__.py
+++ b/ao_kernel/cost/__init__.py
@@ -31,11 +31,16 @@ from ao_kernel.cost.cost_math import (
     estimate_cost,
     estimate_output_tokens,
 )
+from ao_kernel.cost._reconcile import (
+    apply_spend_with_marker,
+)
 from ao_kernel.cost.ledger import (
     SpendEvent,
+    compute_billing_digest,
     record_spend,
 )
 from ao_kernel.cost.middleware import (
+    post_adapter_reconcile,
     post_response_reconcile,
     pre_dispatch_reserve,
 )
@@ -76,10 +81,14 @@ __all__ = [
     "estimate_output_tokens",
     # Ledger
     "SpendEvent",
+    "compute_billing_digest",
     "record_spend",
+    # Reconcile helper (PR-C3.2)
+    "apply_spend_with_marker",
     # Middleware
     "pre_dispatch_reserve",
     "post_response_reconcile",
+    "post_adapter_reconcile",
     # Policy
     "CostTrackingPolicy",
     "RoutingByCost",

--- a/ao_kernel/cost/_reconcile.py
+++ b/ao_kernel/cost/_reconcile.py
@@ -1,0 +1,195 @@
+"""Shared marker-driven spend reconcile helper (PR-C3.2).
+
+Both ``post_response_reconcile`` (governed_call path) and
+``post_adapter_reconcile`` (executor adapter path) now flow through
+:func:`apply_spend_with_marker`. The helper unifies three invariants
+that previously drifted between the two call sites:
+
+1. **Ledger-first ordering**: :func:`record_spend` runs BEFORE budget
+   CAS. Crash window semantics: ledger entry may exist without a
+   matching marker, but NEVER the reverse. Audit integrity preserved.
+
+2. **Marker-driven idempotency**: Budget mutation + evidence emit both
+   gate on ``workflow-run.cost_reconciled`` — a per-run array keyed by
+   ``(source, step_id, attempt, billing_digest)``. Source of truth is
+   the run record, NOT the ledger outcome, because a duplicate ledger
+   call could race a non-committed budget CAS (v3.3.0 shipped bug).
+
+3. **Path-specific budget mutation**: governed_call needs ``delta +
+   token axes``; adapter path needs ``cost_usd only``; usage_missing
+   needs ``no-op``. Caller provides the mutation callback; helper owns
+   the idempotency envelope.
+
+The helper returns ``True`` when a NEW marker was committed. Callers
+use that signal to emit evidence exactly once — duplicate calls (retry,
+crash-recovery) silently skip.
+
+Scope: post-reconcile phase idempotency. This PR does NOT address
+duplicate ``pre_dispatch_reserve`` (separate problem: reserve keys off
+``estimate_cost``, not billing digest).
+
+See ``.claude/plans/`` PR-C3.2 plan v4 for the adversarial Codex
+consultation record (CNS-20260418-033 thread).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+from typing import Any, Callable, Literal
+
+from ao_kernel.cost.ledger import (
+    SpendEvent,
+    record_spend,
+)
+from ao_kernel.cost.policy import CostTrackingPolicy
+from ao_kernel.workflow.run_store import update_run
+
+
+BudgetMutator = Callable[[dict[str, Any]], dict[str, Any]]
+"""Path-specific budget mutation callback.
+
+The callback is invoked INSIDE the run-store CAS mutator, so it must be
+pure (no I/O, no side effects). Raise ``CostTrackingConfigError`` for
+fail-closed config gaps; the exception propagates through
+``update_run`` to the caller.
+"""
+
+
+ReconcileSource = Literal["adapter_path", "governed_call", "usage_missing"]
+"""Discriminator recorded on each marker — lets operators trace which
+reconcile path produced a given budget drain."""
+
+
+def _iso_now() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S.%f+00:00"
+    )
+
+
+def apply_spend_with_marker(
+    workspace_root: Path,
+    run_id: str,
+    event: SpendEvent,
+    *,
+    policy: CostTrackingPolicy,
+    source: ReconcileSource,
+    budget_mutator: BudgetMutator,
+) -> bool:
+    """Ledger append + marker-guarded budget CAS.
+
+    Preconditions:
+
+    - ``event.billing_digest`` MUST be precomputed (non-empty). Callers
+      invoke :func:`compute_billing_digest` and use ``dataclasses.replace``
+      to populate before calling this helper. A marker key without the
+      digest would allow same-cost different-run-scope collisions to
+      suppress each other (Codex iter-3 bulgu #2).
+
+    Returns:
+
+    - ``True`` when a NEW marker was committed in the run record. The
+      caller SHOULD emit the ``llm_spend_recorded`` / ``llm_usage_missing``
+      evidence event.
+    - ``False`` when a matching marker already exists. The caller MUST
+      NOT emit evidence (duplicate emit would violate audit replay
+      invariants — Codex iter-3 bulgu #3).
+
+    Raises:
+
+    - :class:`ValueError` when ``billing_digest`` is empty.
+    - :class:`ao_kernel.cost.errors.CostTrackingConfigError` propagated
+      from ``budget_mutator`` (fail-closed).
+    - :class:`ao_kernel.cost.errors.BudgetExhaustedError` propagated
+      from ``record_budget_spend`` inside the mutator.
+    - :class:`ao_kernel.cost.errors.SpendLedgerDuplicateError` propagated
+      from ``record_spend`` when the caller retries with a different
+      digest under the same ``(run_id, step_id, attempt)`` key (caller
+      bug, distinct billing payload).
+
+    Crash semantics:
+
+    - Crash after ``record_spend`` and before marker stamp → next call
+      succeeds: ``record_spend`` is silent-no-op on matching digest,
+      marker is absent, mutator applies budget + stamps marker.
+    - Crash after marker stamp and before evidence emit → next call
+      returns ``False``: marker is present, mutator is no-op; caller
+      correctly skips duplicate emit.
+
+    Note on duplicate-call side effects: the budget + marker array are
+    unchanged on a duplicate call, BUT ``update_run`` unconditionally
+    stamps ``updated_at`` and recomputes ``revision`` ([run_store.py
+    _mutate_with_cas]). That is, a duplicate reconcile is a budget /
+    marker / ledger no-op AND an evidence no-op, but it does produce
+    one additional revision tick on the run record. This is intentional
+    and cheap; callers who care about strict write-once semantics
+    should gate the second call higher up.
+    """
+    if not event.billing_digest:
+        raise ValueError(
+            "apply_spend_with_marker requires precomputed billing_digest; "
+            "call compute_billing_digest() first and rebuild the event"
+        )
+
+    # 1. Ledger append — idempotent on (run_id, step_id, attempt,
+    #    billing_digest). Runs UNCONDITIONALLY; same-digest duplicate
+    #    is a silent warn-log inside record_spend. Marker is the
+    #    cursor, not the ledger outcome (Codex iter-2 bulgu #1).
+    record_spend(workspace_root, event, policy=policy)
+
+    committed = False
+
+    def _mutator(record: dict[str, Any]) -> dict[str, Any]:
+        nonlocal committed
+        markers = record.get("cost_reconciled", [])
+        marker_key = (
+            source,
+            event.step_id,
+            event.attempt,
+            event.billing_digest,
+        )
+        for existing in markers:
+            existing_key = (
+                existing.get("source"),
+                existing.get("step_id"),
+                existing.get("attempt"),
+                existing.get("billing_digest"),
+            )
+            if existing_key == marker_key:
+                return record  # already applied, committed stays False
+
+        # Apply path-specific budget mutation. The callback may raise
+        # fail-closed errors; the exception bubbles through update_run
+        # and this helper to the original caller.
+        new_record = budget_mutator(dict(record))
+
+        # Stamp marker AFTER budget success. Two-phase ordering inside
+        # a single CAS: the run-store revision lock guarantees atomic
+        # commit of both budget + marker.
+        new_markers = list(markers) + [
+            {
+                "source": source,
+                "step_id": event.step_id,
+                "attempt": event.attempt,
+                "billing_digest": event.billing_digest,
+                "recorded_at": _iso_now(),
+            }
+        ]
+        new_record["cost_reconciled"] = new_markers
+        committed = True
+        return new_record
+
+    update_run(
+        workspace_root,
+        run_id,
+        mutator=_mutator,
+        max_retries=3,
+    )
+    return committed
+
+
+__all__ = [
+    "apply_spend_with_marker",
+    "BudgetMutator",
+    "ReconcileSource",
+]

--- a/ao_kernel/cost/ledger.py
+++ b/ao_kernel/cost/ledger.py
@@ -91,8 +91,15 @@ class SpendEvent:
     billing_digest: str = ""  # computed by writer if empty
 
 
-def _compute_billing_digest(event: SpendEvent) -> str:
-    """Canonical SHA-256 over billing-relevant fields.
+def compute_billing_digest(event: SpendEvent) -> str:
+    """Canonical SHA-256 over billing-relevant fields (public helper).
+
+    Callers that need the digest BEFORE :func:`record_spend` (e.g. to key
+    a run-state idempotency marker — see PR-C3.2 marker-driven reconcile)
+    MUST precompute via this helper and pass the :class:`SpendEvent` with
+    ``billing_digest`` populated. ``record_spend`` itself will recompute
+    via :func:`_compute_billing_digest` when ``billing_digest == ""``, so
+    legacy callers still work.
 
     Decimal-stable: ``cost_usd`` is canonicalized via ``str(Decimal(...))``
     so float serialization round-trips do not break the comparison.
@@ -114,6 +121,12 @@ def _compute_billing_digest(event: SpendEvent) -> str:
         separators=(",", ":"),
     )
     return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# Backward-compat alias — legacy private name retained for existing
+# import sites (internal uses + test suite). PR-C3.2 promotes the
+# public spelling; both resolve to the same function object.
+_compute_billing_digest = compute_billing_digest
 
 
 def _event_to_dict(event: SpendEvent) -> dict[str, Any]:

--- a/ao_kernel/cost/middleware.py
+++ b/ao_kernel/cost/middleware.py
@@ -26,6 +26,7 @@ flow spec.
 
 from __future__ import annotations
 
+import dataclasses
 import datetime as _dt
 import logging
 from decimal import Decimal
@@ -48,9 +49,10 @@ from ao_kernel.cost.errors import (
     LLMUsageMissingError,
     PriceCatalogNotFoundError,
 )
+from ao_kernel.cost._reconcile import apply_spend_with_marker
 from ao_kernel.cost.ledger import (
     SpendEvent,
-    record_spend,
+    compute_billing_digest,
 )
 from ao_kernel.cost.policy import CostTrackingPolicy
 from ao_kernel.workflow.budget import (
@@ -273,7 +275,11 @@ def post_response_reconcile(
         missing_fields.append("tokens_output")
 
     if missing_fields:
-        # Usage-missing path: audit-only ledger entry + emit + optional raise.
+        # Usage-missing path: audit-only ledger entry + marker + emit +
+        # optional raise. PR-C3.2: marker-guarded so duplicate reconcile
+        # calls (retry / crash-recovery) don't re-emit evidence; the
+        # fail-closed raise still fires unconditionally (the caller
+        # treats the error as terminal regardless of marker state).
         event = SpendEvent(
             run_id=run_id,
             step_id=step_id,
@@ -287,21 +293,36 @@ def post_response_reconcile(
             vendor_model_id=catalog_entry.vendor_model_id,
             usage_missing=True,
         )
-        record_spend(workspace_root, event, policy=policy)
-        _safe_emit(
+        event = dataclasses.replace(
+            event, billing_digest=compute_billing_digest(event),
+        )
+
+        def _usage_missing_mutator(record: dict[str, Any]) -> dict[str, Any]:
+            return record  # audit-only path: no budget mutation
+
+        committed = apply_spend_with_marker(
             workspace_root,
             run_id,
-            "llm_usage_missing",
-            {
-                "run_id": run_id,
-                "step_id": step_id,
-                "attempt": attempt,
-                "provider_id": provider_id,
-                "model": model,
-                "missing_fields": list(missing_fields),
-                "ts": _iso_now(),
-            },
+            event,
+            policy=policy,
+            source="usage_missing",
+            budget_mutator=_usage_missing_mutator,
         )
+        if committed:
+            _safe_emit(
+                workspace_root,
+                run_id,
+                "llm_usage_missing",
+                {
+                    "run_id": run_id,
+                    "step_id": step_id,
+                    "attempt": attempt,
+                    "provider_id": provider_id,
+                    "model": model,
+                    "missing_fields": list(missing_fields),
+                    "ts": _iso_now(),
+                },
+            )
         if policy.fail_closed_on_missing_usage:
             raise LLMUsageMissingError(
                 run_id=run_id,
@@ -338,88 +359,11 @@ def post_response_reconcile(
     )
     delta = actual - est_cost
 
-    # Reconcile: add (actual - est) to cost_usd.spent. Negative delta
-    # (actual < est) is a refund; record_spend supports negative spend
-    # via Decimal arithmetic. Token axes are spent only when configured
-    # on the run's budget — unconfigured axes would raise ValueError in
-    # _spend_axis.
-    def _reconcile_mutator(record: dict[str, Any]) -> dict[str, Any]:
-        budget_dict = record.get("budget")
-        if budget_dict is None:
-            # Middleware already validated on pre_dispatch_reserve; this
-            # branch is defensive for CAS-racy mid-reconcile record
-            # reshape.
-            raise CostTrackingConfigError(
-                run_id=run_id,
-                details="run.budget dropped between reserve and reconcile",
-            )
-        budget = budget_from_dict(budget_dict)
-        if budget.cost_usd is None:
-            raise CostTrackingConfigError(
-                run_id=run_id,
-                details="run.budget.cost_usd dropped between reserve and reconcile",
-            )
-
-        # Compose spend kwargs only for axes actually configured on this
-        # run's budget. Unconfigured axes MUST NOT be spent on —
-        # _spend_axis raises ValueError for None axes.
-        #
-        # CNS-032 iter-1 blocker absorb (refined iter-2): legacy
-        # workflow-run records with aggregate `tokens` only stay
-        # aggregate-only in-memory (no synthesized granular axes). The
-        # middleware MUST route legacy token spend through the
-        # aggregate axis so completion tokens are actually counted.
-        # Three cases emerge:
-        #
-        # 1. Full granular (both tokens_input + tokens_output set):
-        #    spend granular; aggregate auto-adjusts in record_budget_spend.
-        # 2. Legacy or partial-with-aggregate (tokens set AND
-        #    tokens_output is None): spend the SUM on aggregate — the
-        #    tokens_input axis (a back-compat synth or partial config)
-        #    is not considered billable-tracking in this mode.
-        # 3. Partial granular-only input (tokens_input set but
-        #    tokens_output + aggregate both None): track only input.
-        spend_kwargs: dict[str, Any] = {"run_id": run_id}
-        if delta != 0:
-            spend_kwargs["cost_usd"] = delta
-
-        has_full_granular = (
-            budget.tokens_input is not None
-            and budget.tokens_output is not None
-        )
-        if has_full_granular:
-            spend_kwargs["tokens_input"] = tokens_input
-            spend_kwargs["tokens_output"] = tokens_output
-        elif budget.tokens is not None:
-            # Legacy aggregate-only (or partial granular + aggregate) —
-            # aggregate path. Total tokens = input + output.
-            spend_kwargs["tokens"] = tokens_input + tokens_output
-        elif budget.tokens_input is not None:
-            # Partial granular without aggregate: input-only tracking.
-            # tokens_output is intentionally unconfigured; operator
-            # accepts that output tokens are untracked in this mode.
-            spend_kwargs["tokens_input"] = tokens_input
-        # else: no token axes anywhere → no token spend.
-
-        # If no axis needs adjustment, skip the call entirely.
-        spendable = any(
-            k in spend_kwargs
-            for k in ("cost_usd", "tokens_input", "tokens_output", "tokens")
-        )
-        if spendable:
-            new_budget = record_budget_spend(budget, **spend_kwargs)
-        else:
-            new_budget = budget
-        return {**record, "budget": budget_to_dict(new_budget)}
-
-    update_run(
-        workspace_root,
-        run_id,
-        mutator=_reconcile_mutator,
-        max_retries=3,
-    )
-
-    # Ledger append with canonical billing digest.
+    # PR-C3.2: build SpendEvent + precompute billing_digest BEFORE the
+    # reconcile apply. Ledger-first ordering is enforced by
+    # apply_spend_with_marker; marker key = (source, step_id, attempt,
+    # billing_digest) — caller must precompute digest, helper raises
+    # ValueError on empty digest.
     event = SpendEvent(
         run_id=run_id,
         step_id=step_id,
@@ -434,33 +378,95 @@ def post_response_reconcile(
         cached_tokens=cached if cached > 0 else None,
         usage_missing=False,
     )
-    record_spend(workspace_root, event, policy=policy)
+    event = dataclasses.replace(
+        event, billing_digest=compute_billing_digest(event),
+    )
+
+    # Governed-call budget mutator: delta + token axes. Preserves the
+    # CNS-032 legacy aggregate-path handling verbatim — path-specific
+    # concerns stay in the callback, helper owns idempotency envelope.
+    def _governed_budget_mutator(record: dict[str, Any]) -> dict[str, Any]:
+        budget_dict = record.get("budget")
+        if budget_dict is None:
+            raise CostTrackingConfigError(
+                run_id=run_id,
+                details="run.budget dropped between reserve and reconcile",
+            )
+        budget = budget_from_dict(budget_dict)
+        if budget.cost_usd is None:
+            raise CostTrackingConfigError(
+                run_id=run_id,
+                details="run.budget.cost_usd dropped between reserve and reconcile",
+            )
+
+        # Compose spend kwargs only for axes actually configured on this
+        # run's budget. Three cases per CNS-032 iter-2:
+        # 1. Full granular → spend granular; aggregate auto-adjusts.
+        # 2. Legacy aggregate-only → spend SUM on aggregate.
+        # 3. Partial granular-only input → track only input.
+        spend_kwargs: dict[str, Any] = {"run_id": run_id}
+        if delta != 0:
+            spend_kwargs["cost_usd"] = delta
+
+        has_full_granular = (
+            budget.tokens_input is not None
+            and budget.tokens_output is not None
+        )
+        if has_full_granular:
+            spend_kwargs["tokens_input"] = tokens_input
+            spend_kwargs["tokens_output"] = tokens_output
+        elif budget.tokens is not None:
+            spend_kwargs["tokens"] = tokens_input + tokens_output
+        elif budget.tokens_input is not None:
+            spend_kwargs["tokens_input"] = tokens_input
+
+        spendable = any(
+            k in spend_kwargs
+            for k in ("cost_usd", "tokens_input", "tokens_output", "tokens")
+        )
+        if spendable:
+            new_budget = record_budget_spend(budget, **spend_kwargs)
+        else:
+            new_budget = budget
+        return {**record, "budget": budget_to_dict(new_budget)}
+
+    committed = apply_spend_with_marker(
+        workspace_root,
+        run_id,
+        event,
+        policy=policy,
+        source="governed_call",
+        budget_mutator=_governed_budget_mutator,
+    )
 
     # PR-B5 C2b: emit ``duration_ms`` when transport elapsed is known.
     # Canonical source for ``ao_llm_call_duration_seconds`` histogram;
     # omitted on legacy callers (backward-compat per plan v4 R13).
-    payload: dict[str, Any] = {
-        "run_id": run_id,
-        "step_id": step_id,
-        "attempt": attempt,
-        "provider_id": provider_id,
-        "model": model,
-        "tokens_input": tokens_input,
-        "tokens_output": tokens_output,
-        "cached_tokens": cached,
-        "cost_usd": float(actual),
-        "est_cost_usd": float(est_cost),
-        "delta_usd": float(delta),
-        "ts": _iso_now(),
-    }
-    if elapsed_ms is not None:
-        payload["duration_ms"] = round(float(elapsed_ms), 3)
-    _safe_emit(
-        workspace_root,
-        run_id,
-        "llm_spend_recorded",
-        payload,
-    )
+    # PR-C3.2: emit guarded on marker commit — duplicate reconcile
+    # skips evidence to prevent audit-replay dupes.
+    if committed:
+        payload: dict[str, Any] = {
+            "run_id": run_id,
+            "step_id": step_id,
+            "attempt": attempt,
+            "provider_id": provider_id,
+            "model": model,
+            "tokens_input": tokens_input,
+            "tokens_output": tokens_output,
+            "cached_tokens": cached,
+            "cost_usd": float(actual),
+            "est_cost_usd": float(est_cost),
+            "delta_usd": float(delta),
+            "ts": _iso_now(),
+        }
+        if elapsed_ms is not None:
+            payload["duration_ms"] = round(float(elapsed_ms), 3)
+        _safe_emit(
+            workspace_root,
+            run_id,
+            "llm_spend_recorded",
+            payload,
+        )
 
 
 def _build_adapter_spend_event(
@@ -553,83 +559,107 @@ def post_adapter_reconcile(
         model=model,
     )
 
-    # Usage-missing: audit-only ledger entry + llm_usage_missing emit
-    # (mirror post_response_reconcile contract).
+    # PR-C3.2: precompute billing_digest so the shared helper can use
+    # it as the marker key. Required by apply_spend_with_marker
+    # contract (ValueError on empty digest).
+    event = dataclasses.replace(
+        event, billing_digest=compute_billing_digest(event),
+    )
+
+    # Usage-missing: audit-only ledger entry + marker + llm_usage_missing
+    # emit (mirror post_response_reconcile contract, now marker-guarded).
     if event.usage_missing:
-        record_spend(workspace_root, event, policy=policy)
         missing_fields = [
             f for f, v in (
                 ("tokens_input", cost_actual.get("tokens_input")),
                 ("tokens_output", cost_actual.get("tokens_output")),
             ) if v is None
         ]
-        _safe_emit(
+
+        def _usage_missing_mutator(record: dict[str, Any]) -> dict[str, Any]:
+            return record  # audit-only path: no budget mutation
+
+        committed = apply_spend_with_marker(
             workspace_root,
             run_id,
-            "llm_usage_missing",
-            {
-                "source": "adapter_path",
-                "run_id": run_id,
-                "step_id": step_id,
-                "attempt": attempt,
-                "provider_id": provider_id,
-                "model": model,
-                "missing_fields": missing_fields,
-                "ts": event.ts,
-            },
+            event,
+            policy=policy,
+            source="usage_missing",
+            budget_mutator=_usage_missing_mutator,
         )
+        if committed:
+            _safe_emit(
+                workspace_root,
+                run_id,
+                "llm_usage_missing",
+                {
+                    "source": "adapter_path",
+                    "run_id": run_id,
+                    "step_id": step_id,
+                    "attempt": attempt,
+                    "provider_id": provider_id,
+                    "model": model,
+                    "missing_fields": missing_fields,
+                    "ts": event.ts,
+                },
+            )
         return
 
-    # Success path: record spend (idempotent per ledger digest) +
-    # CAS-drained budget. Cost errors propagate (fail-closed).
-    record_spend(workspace_root, event, policy=policy)
-
-    if event.cost_usd > 0:
-        def _adapter_mutator(record: dict[str, Any]) -> dict[str, Any]:
-            budget_dict = record.get("budget")
-            if budget_dict is None:
-                raise CostTrackingConfigError(
-                    run_id=run_id,
-                    details=(
-                        "run.budget dropped between adapter return "
-                        "and reconcile"
-                    ),
-                )
-            budget = budget_from_dict(budget_dict)
-            if budget.cost_usd is None:
-                raise CostTrackingConfigError(
-                    run_id=run_id,
-                    details=(
-                        "run.budget.cost_usd dropped between adapter "
-                        "return and reconcile"
-                    ),
-                )
-            new_budget = record_budget_spend(
-                budget, cost_usd=event.cost_usd, run_id=run_id,
+    # Success path: shared helper runs record_spend FIRST (ledger-first
+    # ordering), then CAS-wraps the per-path budget mutator with the
+    # marker guard. Duplicate calls return committed=False → caller
+    # skips evidence emit (prevents audit-replay dupes — v3.3.0 bug).
+    def _adapter_budget_mutator(record: dict[str, Any]) -> dict[str, Any]:
+        if event.cost_usd <= 0:
+            return record  # zero-cost: marker stamp only, budget untouched
+        budget_dict = record.get("budget")
+        if budget_dict is None:
+            raise CostTrackingConfigError(
+                run_id=run_id,
+                details=(
+                    "run.budget dropped between adapter return "
+                    "and reconcile"
+                ),
             )
-            return {**record, "budget": budget_to_dict(new_budget)}
-
-        update_run(
-            workspace_root, run_id,
-            mutator=_adapter_mutator,
-            max_retries=3,
+        budget = budget_from_dict(budget_dict)
+        if budget.cost_usd is None:
+            raise CostTrackingConfigError(
+                run_id=run_id,
+                details=(
+                    "run.budget.cost_usd dropped between adapter "
+                    "return and reconcile"
+                ),
+            )
+        new_budget = record_budget_spend(
+            budget, cost_usd=event.cost_usd, run_id=run_id,
         )
+        return {**record, "budget": budget_to_dict(new_budget)}
 
-    payload: dict[str, Any] = {
-        "source": "adapter_path",
-        "run_id": run_id,
-        "step_id": step_id,
-        "attempt": attempt,
-        "provider_id": provider_id,
-        "model": model,
-        "tokens_input": event.tokens_input,
-        "tokens_output": event.tokens_output,
-        "cost_usd": float(event.cost_usd),
-        "ts": event.ts,
-    }
-    if elapsed_ms is not None:
-        payload["duration_ms"] = round(float(elapsed_ms), 3)
-    _safe_emit(workspace_root, run_id, "llm_spend_recorded", payload)
+    committed = apply_spend_with_marker(
+        workspace_root,
+        run_id,
+        event,
+        policy=policy,
+        source="adapter_path",
+        budget_mutator=_adapter_budget_mutator,
+    )
+
+    if committed:
+        payload: dict[str, Any] = {
+            "source": "adapter_path",
+            "run_id": run_id,
+            "step_id": step_id,
+            "attempt": attempt,
+            "provider_id": provider_id,
+            "model": model,
+            "tokens_input": event.tokens_input,
+            "tokens_output": event.tokens_output,
+            "cost_usd": float(event.cost_usd),
+            "ts": event.ts,
+        }
+        if elapsed_ms is not None:
+            payload["duration_ms"] = round(float(elapsed_ms), 3)
+        _safe_emit(workspace_root, run_id, "llm_spend_recorded", payload)
 
 
 __all__ = [

--- a/ao_kernel/defaults/schemas/workflow-run.schema.v1.json
+++ b/ao_kernel/defaults/schemas/workflow-run.schema.v1.json
@@ -103,6 +103,26 @@
       "$ref": "#/$defs/budget",
       "description": "Run-level budget. Aggregated over all adapter invocations. fail_closed_on_exhaust enforced."
     },
+    "cost_reconciled": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source", "step_id", "attempt", "billing_digest", "recorded_at"],
+        "properties": {
+          "source": {
+            "type": "string",
+            "enum": ["adapter_path", "governed_call", "usage_missing"],
+            "description": "Reconcile path discriminator. Keyed with (step_id, attempt, billing_digest) to prevent cross-path marker suppression."
+          },
+          "step_id": {"type": "string", "minLength": 1},
+          "attempt": {"type": "integer", "minimum": 1},
+          "billing_digest": {"type": "string", "minLength": 1},
+          "recorded_at": {"type": "string", "format": "date-time"}
+        }
+      },
+      "description": "PR-C3.2 marker-driven idempotency cursor. Each entry stamps a single successful post-reconcile apply (ledger append + budget CAS). Used by ao_kernel.cost._reconcile.apply_spend_with_marker to decide whether a given (source, step_id, attempt, billing_digest) tuple has already been applied — duplicate calls (retry, crash-recovery) skip both budget drain AND evidence emit. Absent for pre-v3.3.1 runs; loader treats missing field as empty list. Unbounded in v3.3.1 (compaction deferred to v3.4.0)."
+    },
     "approvals": {
       "type": "array",
       "items": {"$ref": "#/$defs/approval"},

--- a/tests/test_cost_ledger_concurrent.py
+++ b/tests/test_cost_ledger_concurrent.py
@@ -277,7 +277,13 @@ class TestCASRetryExhaustion:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Same contract on the reconcile side — CAS exhaustion
-        during budget reconcile raises through the middleware."""
+        during budget reconcile raises through the middleware.
+
+        PR-C3.2: the update_run call now lives inside the shared helper
+        ``ao_kernel.cost._reconcile.apply_spend_with_marker``; patch
+        target updated accordingly.
+        """
+        from ao_kernel.cost import _reconcile as _reconcile_mod
         from ao_kernel.cost import middleware
         from ao_kernel.cost.catalog import PriceCatalogEntry
 
@@ -309,7 +315,7 @@ class TestCASRetryExhaustion:
                 actual_revision="actual",
             )
 
-        monkeypatch.setattr(middleware, "update_run", _always_conflict)
+        monkeypatch.setattr(_reconcile_mod, "update_run", _always_conflict)
 
         entry = PriceCatalogEntry(
             provider_id="anthropic",

--- a/tests/test_cost_marker_idempotency.py
+++ b/tests/test_cost_marker_idempotency.py
@@ -1,0 +1,572 @@
+"""PR-C3.2 marker-driven idempotency + crash-window fix tests.
+
+Verifies the shared ``apply_spend_with_marker`` helper fixes the
+v3.3.0 shipped bug: ``post_adapter_reconcile`` / ``post_response_reconcile``
+were double-draining the budget when called twice with the same
+``(step_id, attempt, billing_digest)`` because ``record_spend`` did a
+silent same-digest no-op but the subsequent ``update_run`` drain ran
+unconditionally.
+
+The marker (``workflow-run.cost_reconciled``) now gates both the
+budget CAS AND the evidence emit. Duplicate calls (retry / crash-
+recovery) leave the run state and emit stream untouched.
+
+Scope pins per Codex CNS-20260418 thread:
+
+1. Adapter path: 2× same call → 1× budget drain, 1× ledger entry,
+   1× marker, 1× ``llm_spend_recorded`` emit.
+2. Governed path: same contract (order flip verified: record_spend
+   runs before update_run).
+3. Usage-missing: marker gates emit; fail_closed raise fires regardless
+   of marker state.
+4. Different step / attempt / digest partition → each gets its own
+   marker row.
+5. ``compute_billing_digest`` precondition: helper raises ValueError on
+   empty digest.
+6. Schema widen: ``cost_reconciled`` field accepted by validator.
+7. Crash semantics (mock-based): crash between ledger append and
+   marker stamp → retry succeeds; crash between marker and emit → retry
+   is a silent no-op (no duplicate emit).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ao_kernel.cost import _reconcile as _reconcile_mod
+from ao_kernel.cost._reconcile import apply_spend_with_marker
+from ao_kernel.cost.errors import CostTrackingConfigError
+from ao_kernel.cost.ledger import SpendEvent, compute_billing_digest
+from ao_kernel.cost.middleware import post_adapter_reconcile
+from ao_kernel.cost.policy import CostTrackingPolicy
+
+
+# ─── Test fixtures ─────────────────────────────────────────────────────
+
+
+def _policy() -> CostTrackingPolicy:
+    return CostTrackingPolicy(
+        enabled=True,
+        price_catalog_path=".ao/cost/price-catalog.json",
+        spend_ledger_path=".ao/cost/spend.jsonl",
+        fail_closed_on_exhaust=True,
+        fail_closed_on_missing_usage=False,
+        strict_freshness=False,
+        idempotency_window_lines=100,
+    )
+
+
+def _seed_run(
+    root: Path,
+    run_id: str,
+    *,
+    cost_limit: float = 10.0,
+    cost_remaining: float = 10.0,
+    include_cost_usd_axis: bool = True,
+) -> None:
+    """Create a minimal valid run record on disk."""
+    from ao_kernel.workflow.run_store import run_revision
+
+    run_dir = root / ".ao" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    budget: dict[str, Any] = {"fail_closed_on_exhaust": True}
+    if include_cost_usd_axis:
+        budget["cost_usd"] = {
+            "limit": cost_limit,
+            "remaining": cost_remaining,
+        }
+    record: dict[str, Any] = {
+        "run_id": run_id,
+        "workflow_id": "test_flow",
+        "workflow_version": "1.0.0",
+        "state": "running",
+        "created_at": "2026-04-18T10:00:00+00:00",
+        "revision": "0" * 64,
+        "intent": {"kind": "inline_prompt", "payload": "test"},
+        "steps": [],
+        "policy_refs": [
+            "ao_kernel/defaults/policies/policy_worktree_profile.v1.json",
+        ],
+        "adapter_refs": [],
+        "evidence_refs": [
+            f".ao/evidence/workflows/{run_id}/events.jsonl",
+        ],
+        "budget": budget,
+    }
+    record["revision"] = run_revision(record)
+    (run_dir / "state.v1.json").write_text(
+        json.dumps(record, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _read_ledger(root: Path) -> list[dict[str, Any]]:
+    path = root / ".ao" / "cost" / "spend.jsonl"
+    if not path.is_file():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _read_events_of_kind(
+    root: Path, run_id: str, kind: str,
+) -> list[dict[str, Any]]:
+    path = (
+        root / ".ao" / "evidence" / "workflows" / run_id / "events.jsonl"
+    )
+    if not path.is_file():
+        return []
+    return [
+        ev for ev in (
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        )
+        if ev.get("kind") == kind
+    ]
+
+
+def _read_run(root: Path, run_id: str) -> dict[str, Any]:
+    from ao_kernel.workflow.run_store import load_run
+
+    record, _ = load_run(root, run_id)
+    return record
+
+
+def _cost_actual_fixed() -> dict[str, Any]:
+    return {"tokens_input": 100, "tokens_output": 50, "cost_usd": 0.05}
+
+
+# ─── 1. Adapter-path double-drain fix ──────────────────────────────────
+
+
+class TestAdapterPathIdempotency:
+    def test_double_call_single_drain_single_emit(
+        self, tmp_path: Path,
+    ) -> None:
+        run_id = "00000000-0000-4000-8000-0000c3d20001"
+        _seed_run(tmp_path, run_id)
+        kwargs = dict(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual=_cost_actual_fixed(), policy=_policy(),
+        )
+        post_adapter_reconcile(**kwargs)
+        post_adapter_reconcile(**kwargs)
+
+        # Ledger: single entry (same-digest no-op on 2nd)
+        ledger = _read_ledger(tmp_path)
+        assert len(ledger) == 1
+
+        # Budget: drained once (0.05), not twice
+        budget = _read_run(tmp_path, run_id).get("budget", {})
+        cost_axis = budget.get("cost_usd", {})
+        assert cost_axis.get("remaining") == pytest.approx(9.95)
+
+        # Marker: single entry
+        markers = _read_run(tmp_path, run_id).get("cost_reconciled", [])
+        assert len(markers) == 1
+        assert markers[0]["source"] == "adapter_path"
+        assert markers[0]["step_id"] == "s1"
+        assert markers[0]["attempt"] == 1
+
+        # Evidence: single llm_spend_recorded emit
+        emits = _read_events_of_kind(tmp_path, run_id, "llm_spend_recorded")
+        assert len(emits) == 1
+
+
+class TestAdapterPathPartitioning:
+    def test_different_step_same_cost_both_applied(
+        self, tmp_path: Path,
+    ) -> None:
+        run_id = "00000000-0000-4000-8000-0000c3d20002"
+        _seed_run(tmp_path, run_id)
+        # Two steps, same cost → different marker keys, both applied
+        post_adapter_reconcile(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual=_cost_actual_fixed(), policy=_policy(),
+        )
+        post_adapter_reconcile(
+            workspace_root=tmp_path, run_id=run_id, step_id="s2",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual=_cost_actual_fixed(), policy=_policy(),
+        )
+        budget = _read_run(tmp_path, run_id).get("budget", {})
+        assert budget["cost_usd"]["remaining"] == pytest.approx(9.90)  # 2× drain
+
+        markers = _read_run(tmp_path, run_id).get("cost_reconciled", [])
+        assert len(markers) == 2
+        assert {m["step_id"] for m in markers} == {"s1", "s2"}
+
+    def test_different_attempt_same_cost_both_applied(
+        self, tmp_path: Path,
+    ) -> None:
+        """Retry semantics: same step_id, different attempt → new marker."""
+        run_id = "00000000-0000-4000-8000-0000c3d20003"
+        _seed_run(tmp_path, run_id)
+        post_adapter_reconcile(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual=_cost_actual_fixed(), policy=_policy(),
+        )
+        post_adapter_reconcile(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=2, provider_id="codex", model="stub",
+            cost_actual=_cost_actual_fixed(), policy=_policy(),
+        )
+        budget = _read_run(tmp_path, run_id).get("budget", {})
+        assert budget["cost_usd"]["remaining"] == pytest.approx(9.90)
+
+        markers = _read_run(tmp_path, run_id).get("cost_reconciled", [])
+        assert len(markers) == 2
+        assert {m["attempt"] for m in markers} == {1, 2}
+
+
+# ─── 2. Usage-missing idempotency ──────────────────────────────────────
+
+
+class TestUsageMissingIdempotency:
+    def test_usage_missing_double_call_single_emit(
+        self, tmp_path: Path,
+    ) -> None:
+        run_id = "00000000-0000-4000-8000-0000c3d20010"
+        _seed_run(tmp_path, run_id)
+        # Adapter returned cost but no tokens → usage_missing path
+        kwargs = dict(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual={"cost_usd": 0.0},  # tokens_input/output absent
+            policy=_policy(),
+        )
+        post_adapter_reconcile(**kwargs)
+        post_adapter_reconcile(**kwargs)
+
+        # Ledger: single audit entry
+        assert len(_read_ledger(tmp_path)) == 1
+
+        # Marker: single usage_missing entry
+        markers = _read_run(tmp_path, run_id).get("cost_reconciled", [])
+        assert len(markers) == 1
+        assert markers[0]["source"] == "usage_missing"
+
+        # Evidence: single llm_usage_missing emit (not llm_spend_recorded)
+        missing_emits = _read_events_of_kind(
+            tmp_path, run_id, "llm_usage_missing",
+        )
+        assert len(missing_emits) == 1
+        spend_emits = _read_events_of_kind(
+            tmp_path, run_id, "llm_spend_recorded",
+        )
+        assert spend_emits == []
+
+        # Budget: untouched (audit-only path)
+        budget = _read_run(tmp_path, run_id).get("budget", {})
+        assert budget["cost_usd"]["remaining"] == pytest.approx(10.0)
+
+
+# ─── 3. Fail-closed preservation ───────────────────────────────────────
+
+
+class TestFailClosedOnMissingBudgetAxis:
+    def test_budget_cost_usd_missing_raises_after_ledger_append(
+        self, tmp_path: Path,
+    ) -> None:
+        """Per Codex iter-3 bulgu: fail-closed contract is preserved.
+
+        ``budget.cost_usd`` missing + positive event cost → mutator
+        raises CostTrackingConfigError inside update_run. Marker is
+        NOT stamped (mutator aborts before marker append). Ledger
+        append already completed (helper ledger-first), which is
+        audit-correct: the billable event is recorded.
+        """
+        run_id = "00000000-0000-4000-8000-0000c3d20020"
+        _seed_run(tmp_path, run_id, include_cost_usd_axis=False)
+
+        with pytest.raises(CostTrackingConfigError):
+            post_adapter_reconcile(
+                workspace_root=tmp_path, run_id=run_id, step_id="s1",
+                attempt=1, provider_id="codex", model="stub",
+                cost_actual=_cost_actual_fixed(), policy=_policy(),
+            )
+
+        # Ledger entry WAS appended (ledger-first ordering)
+        assert len(_read_ledger(tmp_path)) == 1
+        # Marker NOT stamped (mutator raised before marker append)
+        markers = _read_run(tmp_path, run_id).get("cost_reconciled", [])
+        assert markers == []
+
+
+# ─── 4. Order-uniform verification (spy-based, not mtime) ──────────────
+
+
+class TestOrderUniform:
+    def test_record_spend_runs_before_update_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Per Codex iter-5 note: mtime comparison is flaky under
+        write_text_atomic + os.replace; verify ordering via call-spy
+        instead."""
+        run_id = "00000000-0000-4000-8000-0000c3d20030"
+        _seed_run(tmp_path, run_id)
+
+        call_log: list[str] = []
+
+        real_record_spend = _reconcile_mod.record_spend
+        real_update_run = _reconcile_mod.update_run
+
+        def _spy_record_spend(*a: Any, **kw: Any) -> None:
+            call_log.append("record_spend")
+            return real_record_spend(*a, **kw)
+
+        def _spy_update_run(*a: Any, **kw: Any) -> Any:
+            call_log.append("update_run")
+            return real_update_run(*a, **kw)
+
+        monkeypatch.setattr(_reconcile_mod, "record_spend", _spy_record_spend)
+        monkeypatch.setattr(_reconcile_mod, "update_run", _spy_update_run)
+
+        post_adapter_reconcile(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual=_cost_actual_fixed(), policy=_policy(),
+        )
+        # record_spend first, then update_run (ledger-first contract)
+        assert call_log[0] == "record_spend"
+        assert "update_run" in call_log
+        assert call_log.index("record_spend") < call_log.index("update_run")
+
+
+# ─── 5. Helper precondition (ValueError on empty digest) ───────────────
+
+
+class TestHelperPrecondition:
+    def test_apply_spend_with_marker_requires_precomputed_digest(
+        self, tmp_path: Path,
+    ) -> None:
+        run_id = "00000000-0000-4000-8000-0000c3d20040"
+        _seed_run(tmp_path, run_id)
+
+        event = SpendEvent(
+            run_id=run_id,
+            step_id="s1",
+            attempt=1,
+            provider_id="codex",
+            model="stub",
+            tokens_input=100,
+            tokens_output=50,
+            cost_usd=Decimal("0.05"),
+            ts="2026-04-18T10:00:00+00:00",
+            billing_digest="",  # empty — helper must reject
+        )
+        with pytest.raises(ValueError, match="billing_digest"):
+            apply_spend_with_marker(
+                tmp_path, run_id, event,
+                policy=_policy(),
+                source="adapter_path",
+                budget_mutator=lambda r: r,
+            )
+
+    def test_apply_spend_with_marker_accepts_precomputed_digest(
+        self, tmp_path: Path,
+    ) -> None:
+        run_id = "00000000-0000-4000-8000-0000c3d20041"
+        _seed_run(tmp_path, run_id)
+
+        event = SpendEvent(
+            run_id=run_id,
+            step_id="s1",
+            attempt=1,
+            provider_id="codex",
+            model="stub",
+            tokens_input=100,
+            tokens_output=50,
+            cost_usd=Decimal("0.05"),
+            ts="2026-04-18T10:00:00+00:00",
+        )
+        event = replace(event, billing_digest=compute_billing_digest(event))
+        committed = apply_spend_with_marker(
+            tmp_path, run_id, event,
+            policy=_policy(),
+            source="adapter_path",
+            budget_mutator=lambda r: r,  # no-op for this probe
+        )
+        assert committed is True
+
+
+# ─── 6. Schema validation ──────────────────────────────────────────────
+
+
+class TestSchemaAcceptsCostReconciled:
+    def test_validator_accepts_cost_reconciled_field(self) -> None:
+        """workflow-run.schema.v1.json widen — marker array accepted."""
+        from ao_kernel.workflow.schema_validator import validate_workflow_run
+
+        run_id = "00000000-0000-4000-8000-0000c3d20050"
+        record: dict[str, Any] = {
+            "run_id": run_id,
+            "workflow_id": "test_flow",
+            "workflow_version": "1.0.0",
+            "state": "running",
+            "created_at": "2026-04-18T10:00:00+00:00",
+            "revision": "0" * 64,
+            "intent": {"kind": "inline_prompt", "payload": "x"},
+            "steps": [],
+            "policy_refs": [
+                "ao_kernel/defaults/policies/policy_worktree_profile.v1.json",
+            ],
+            "adapter_refs": [],
+            "evidence_refs": [
+                f".ao/evidence/workflows/{run_id}/events.jsonl",
+            ],
+            "budget": {"fail_closed_on_exhaust": True},
+            "cost_reconciled": [
+                {
+                    "source": "adapter_path",
+                    "step_id": "s1",
+                    "attempt": 1,
+                    "billing_digest": "sha256:abc123",
+                    "recorded_at": "2026-04-18T10:00:01+00:00",
+                },
+            ],
+        }
+        # Should not raise — explicit "no error" pin satisfies test
+        # quality gate (BLK-002: bare callable check is advisory).
+        result = validate_workflow_run(record, run_id=run_id)
+        assert result is None  # validate_workflow_run returns None on success
+
+    def test_validator_rejects_unknown_marker_field(self) -> None:
+        from ao_kernel.workflow.errors import WorkflowSchemaValidationError
+        from ao_kernel.workflow.schema_validator import validate_workflow_run
+
+        run_id = "00000000-0000-4000-8000-0000c3d20051"
+        record: dict[str, Any] = {
+            "run_id": run_id,
+            "workflow_id": "test_flow",
+            "workflow_version": "1.0.0",
+            "state": "running",
+            "created_at": "2026-04-18T10:00:00+00:00",
+            "revision": "0" * 64,
+            "intent": {"kind": "inline_prompt", "payload": "x"},
+            "steps": [],
+            "policy_refs": [
+                "ao_kernel/defaults/policies/policy_worktree_profile.v1.json",
+            ],
+            "adapter_refs": [],
+            "evidence_refs": [
+                f".ao/evidence/workflows/{run_id}/events.jsonl",
+            ],
+            "budget": {"fail_closed_on_exhaust": True},
+            "cost_reconciled": [
+                {
+                    "source": "adapter_path",
+                    "step_id": "s1",
+                    "attempt": 1,
+                    "billing_digest": "sha256:abc",
+                    "recorded_at": "2026-04-18T10:00:01+00:00",
+                    "unknown_field": "bad",  # additionalProperties:false
+                },
+            ],
+        }
+        with pytest.raises(WorkflowSchemaValidationError):
+            validate_workflow_run(record, run_id=run_id)
+
+
+# ─── 7. Crash-semantics (mock-based) ───────────────────────────────────
+
+
+class TestCrashSemantics:
+    def test_crash_after_ledger_before_marker_retry_succeeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Phase-1 crash: ledger appended, marker not stamped yet.
+
+        Retry: ledger no-op (same digest), marker absent → mutator runs,
+        budget drained, marker stamped.
+        """
+        run_id = "00000000-0000-4000-8000-0000c3d20060"
+        _seed_run(tmp_path, run_id)
+
+        real_update_run = _reconcile_mod.update_run
+        call_count = {"n": 0}
+
+        def _flaky_update_run(*a: Any, **kw: Any) -> Any:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("simulated crash between ledger and marker")
+            return real_update_run(*a, **kw)
+
+        monkeypatch.setattr(_reconcile_mod, "update_run", _flaky_update_run)
+
+        # First call crashes inside update_run (after record_spend)
+        with pytest.raises(RuntimeError):
+            post_adapter_reconcile(
+                workspace_root=tmp_path, run_id=run_id, step_id="s1",
+                attempt=1, provider_id="codex", model="stub",
+                cost_actual=_cost_actual_fixed(), policy=_policy(),
+            )
+        # Ledger has entry; marker does NOT (mutator never committed)
+        assert len(_read_ledger(tmp_path)) == 1
+        assert _read_run(tmp_path, run_id).get("cost_reconciled", []) == []
+
+        # Retry: recovers cleanly
+        post_adapter_reconcile(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual=_cost_actual_fixed(), policy=_policy(),
+        )
+        # Ledger still 1 entry (silent same-digest no-op)
+        assert len(_read_ledger(tmp_path)) == 1
+        # Marker now present
+        markers = _read_run(tmp_path, run_id).get("cost_reconciled", [])
+        assert len(markers) == 1
+        # Budget drained exactly once
+        budget = _read_run(tmp_path, run_id).get("budget", {})
+        assert budget["cost_usd"]["remaining"] == pytest.approx(9.95)
+
+    def test_duplicate_call_after_commit_produces_no_duplicate_emit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Covers the emit-guard invariant: if a marker is already
+        committed, the caller MUST NOT re-emit evidence.
+
+        This is the retry/replay surface of the Phase-2 crash (marker
+        stamped, emit failed before durable flush). True crash injection
+        at the emit boundary is deferred to v3.4.0 (subprocess + os._exit
+        crash-kill harness, paired with the reconciler daemon); here we
+        verify the suppression path via a plain duplicate call.
+        """
+        run_id = "00000000-0000-4000-8000-0000c3d20061"
+        _seed_run(tmp_path, run_id)
+
+        # First call succeeds (marker stamped, emit successful)
+        post_adapter_reconcile(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual=_cost_actual_fixed(), policy=_policy(),
+        )
+        emits_after_first = _read_events_of_kind(
+            tmp_path, run_id, "llm_spend_recorded",
+        )
+        assert len(emits_after_first) == 1
+
+        # Second call — simulates retry after crash between marker and emit
+        post_adapter_reconcile(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual=_cost_actual_fixed(), policy=_policy(),
+        )
+        emits_after_second = _read_events_of_kind(
+            tmp_path, run_id, "llm_spend_recorded",
+        )
+        # Still exactly 1 — duplicate emit suppressed
+        assert len(emits_after_second) == 1

--- a/tests/test_cost_middleware_core.py
+++ b/tests/test_cost_middleware_core.py
@@ -280,6 +280,89 @@ class TestPostResponseReconcileHappyPath:
         assert lines[0]["usage_missing"] is False
         assert "billing_digest" in lines[0]
 
+    def test_duplicate_reconcile_single_drain_single_emit(
+        self, tmp_path: Path,
+    ) -> None:
+        """PR-C3.2 governed-path regression pin: 2× post_response_reconcile
+        with identical (run_id, step_id, attempt) + identical raw response
+        → budget drained once, single ledger entry, single marker,
+        single ``llm_spend_recorded`` emit.
+
+        The v3.3.0 bug would drain the budget twice; marker-guarded
+        ``apply_spend_with_marker`` prevents the second drain / emit.
+        """
+        run_id = _create_run_with_cost_budget(tmp_path)
+        policy = _policy()
+
+        est_cost, entry = pre_dispatch_reserve(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            prompt_messages=[{"role": "user", "content": "hello world"}],
+            max_tokens=100,
+            policy=policy,
+        )
+        raw = _ok_response(input_tokens=1000, output_tokens=500)
+
+        reconcile_kwargs: dict[str, Any] = dict(
+            workspace_root=tmp_path,
+            run_id=run_id,
+            step_id="step",
+            attempt=1,
+            provider_id="anthropic",
+            model="claude-3-5-sonnet",
+            catalog_entry=entry,
+            est_cost=est_cost,
+            raw_response_bytes=raw,
+            policy=policy,
+        )
+
+        post_response_reconcile(**reconcile_kwargs)
+        record_after_first, _ = load_run(tmp_path, run_id)
+        spent_after_first = Decimal(
+            str(record_after_first["budget"]["cost_usd"]["spent"])
+        )
+
+        post_response_reconcile(**reconcile_kwargs)
+        record_after_second, _ = load_run(tmp_path, run_id)
+        spent_after_second = Decimal(
+            str(record_after_second["budget"]["cost_usd"]["spent"])
+        )
+
+        # Budget: drained exactly once — spent is unchanged between calls
+        assert spent_after_second == spent_after_first
+
+        # Marker: single governed_call entry
+        markers = record_after_second.get("cost_reconciled", [])
+        assert len(markers) == 1
+        assert markers[0]["source"] == "governed_call"
+        assert markers[0]["step_id"] == "step"
+        assert markers[0]["attempt"] == 1
+
+        # Ledger: single entry (same-digest silent no-op on 2nd)
+        ledger = tmp_path / ".ao" / "cost" / "spend.jsonl"
+        lines = [
+            line for line in ledger.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(lines) == 1
+
+        # Events: single llm_spend_recorded emit
+        events_path = (
+            tmp_path / ".ao" / "evidence" / "workflows"
+            / run_id / "events.jsonl"
+        )
+        events = [
+            json.loads(line)
+            for line in events_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        spend_emits = [e for e in events if e.get("kind") == "llm_spend_recorded"]
+        assert len(spend_emits) == 1
+
     def test_refund_when_actual_less_than_estimate(self, tmp_path: Path) -> None:
         """actual < estimate → delta negative → budget refunded."""
         run_id = _create_run_with_cost_budget(tmp_path)

--- a/tests/test_post_adapter_reconcile.py
+++ b/tests/test_post_adapter_reconcile.py
@@ -262,6 +262,10 @@ class TestIdempotency:
         )
         # Ledger still has exactly ONE entry.
         assert len(_read_ledger(tmp_path)) == 1
+        # PR-C3.2: budget drained ONCE (the pre-fix v3.3.0 bug would
+        # have drained twice — 0.05 → 9.90 remaining).
+        budget = _read_run_budget(tmp_path, run_id)
+        assert budget["cost_usd"]["remaining"] == pytest.approx(9.95)
 
     def test_different_digest_raises_duplicate(
         self, tmp_path: Path,


### PR DESCRIPTION
## Summary

- **Fixes v3.3.0 double-drain bug**: `record_spend` same-digest silent no-op'd but `update_run` budget CAS ran unconditionally → duplicate reconcile drained budget twice
- **Marker-driven idempotency**: new `workflow-run.cost_reconciled` field (array of `{source, step_id, attempt, billing_digest, recorded_at}`) gates both budget CAS AND evidence emit
- **Order unification**: both reconcile paths now ledger-first via shared `apply_spend_with_marker` helper; governed-call flipped from budget-CAS-first to ledger-first

## Codex adversarial consensus

Plan-time CNS-20260418-033 thread — **5 iterations** (iter-1 REVISE → iter-2 REVISE → iter-3 REVISE → iter-4 PARTIAL → iter-5 implicit AGREE via "bu revizelerle impl'e girilir"). Post-impl review: **SUGGEST** (merge-able, 4 non-blocking items all absorbed).

Key Codex contributions:
- Iter-1: plan initially targeted wrong path (governed_call); real CHANGELOG #4 bug was adapter_path
- Iter-2: idempotency source of truth must be marker (not ledger outcome); marker key needs `(step_id, attempt, billing_digest)` minimum
- Iter-3: governed-path budget math is path-specific (delta + token axes); helper needs callback, not uniform drain
- Iter-4: marker key extended to include `source` to prevent cross-path suppression; `ValueError` instead of `assert`; fail-closed contract preserved
- Iter-5 post-impl: docstring + test naming + governed-path regression pin + CHANGELOG path-specific note

## Architecture

```
apply_spend_with_marker(event, source, budget_mutator):
  1. record_spend(...)   # ledger-first, idempotent via digest
  2. update_run(mutator): # single CAS for budget + marker
       if marker(source, step_id, attempt, digest) already exists → return record
       else: budget_mutator(record) → stamp marker → committed=True
  return committed
```

Callers use `committed` to gate evidence emit — duplicate calls produce zero duplicate events.

## Files changed

| File | Change |
|---|---|
| `ao_kernel/cost/_reconcile.py` | **New** — 180 LOC shared helper |
| `ao_kernel/cost/middleware.py` | Both reconcile paths refactored (adapter + governed + usage_missing) |
| `ao_kernel/cost/ledger.py` | `compute_billing_digest` promoted public (backward-compat alias retained) |
| `ao_kernel/cost/__init__.py` | 3 new exports |
| `ao_kernel/defaults/schemas/workflow-run.schema.v1.json` | `cost_reconciled` additive widen |
| `tests/test_cost_marker_idempotency.py` | **New** — 12 tests |
| `tests/test_cost_middleware_core.py` | +1 governed duplicate regression test |
| `tests/test_cost_ledger_concurrent.py` | Monkeypatch target updated |
| `tests/test_post_adapter_reconcile.py` | Existing idempotency test gains budget assertion |
| `CHANGELOG.md` | [Unreleased] C3.2 section + v3.4.0 deferred items |

## Scope boundary

**IN v3.3.1**: post-reconcile phase idempotency, order unification, marker schema, emit guard.

**OUT (deferred to v3.4.0)**: reconciler daemon, CLI `ao-kernel cost reconcile`, cursor-based candidate scan, `cost_reconciled` compaction, subprocess crash-kill harness, tam duplicate `governed_call` idempotency (reserve-phase is a separate problem).

## Test plan

- [x] `pytest tests/` — **2223/2223 pass** (2210 baseline + 13 new)
- [x] `ruff check ao_kernel/ tests/` — clean
- [x] `mypy ao_kernel/ --ignore-missing-imports` — clean (189 source files)
- [x] Double-drain regression pin: existing `test_same_digest_silent_no_op_on_second_call` extended with budget assertion (v3.3.0 would show 9.90; now 9.95)
- [x] Order-uniform verify via spy (not mtime — flaky per Codex iter-5)
- [x] Governed-path duplicate regression: `test_duplicate_reconcile_single_drain_single_emit`
- [x] Schema accept + reject: additive widen + additionalProperties:false
- [x] Precondition guard: `ValueError` on empty billing_digest
- [x] Crash-retry: phase-1 crash (ledger+mutator crash) recovers on retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)