### PR TITLE
fix(pr-c3.1): adapter-path vendor_model_id attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Migration.** No action required. Existing `soft_degrade.rules[]` without `budget_remaining_threshold_usd` are explicitly inert — pre-v3.3.1 dormant behavior is preserved. Operators who want budget-aware degradation add the threshold field to one or more rules in their workspace override.
 
+### Fixed — PR-C3.1 adapter-path vendor_model_id attribution
+
+**Enable + propagate.** v3.3.0 shipped `_build_adapter_spend_event` with `vendor_model_id=None` hardcoded — adapter-path spend events lost the concrete vendor model identity even when the adapter knew it. v3.3.1 makes the field adapter-reportable: `agent-adapter-contract.schema.v1.json::$defs/cost_record` gains an optional `vendor_model_id` (`minLength: 1` at the contract boundary), and the middleware propagates it into `SpendEvent`. Blank strings are normalized to `None` defensively in case a mal-formed producer writes whitespace. Codex CNS-20260418-035 post-AGREE with 3 clarity notes absorbed.
+
+**Backward compat.** Adapters that don't populate the field (bundled fixtures `codex-stub`, `claude-code-cli`, `gh-cli-pr` — all mock/non-LLM; external adapters until they opt in) continue to produce ledger events with `vendor_model_id` omitted. No forced re-issue of historical ledger rows.
+
+**Replay note.** If the same `(run_id, step_id, attempt)` tuple is reconciled a second time with a different `vendor_model_id`, the billing_digest changes → `SpendLedgerDuplicateError`. The digest already incorporates `vendor_model_id` (ledger.py:110); this is intentional behavior — attribution change is a caller bug, not a retry.
+
+**Test baseline.** 2242 → **2250** (+8 new in `tests/test_post_adapter_reconcile.py`): propagation, absence fallback, blank-string normalization, `usage_missing` branch preservation, digest-based duplicate detection, and 3 schema-level pins (accept with, accept without, reject empty).
+
+**Deferred to v3.4.0.**
+- `llm_spend_recorded` evidence payload enrichment with `vendor_model_id`
+- Cross-adapter reconciliation / audit replay keyed on `vendor_model_id`
+- Multi-vendor cost compare in routing decisions
+
 ### Deferred — out of v3.3.1 scope (v3.4.0)
 
 - Full reconciliation daemon / API (`reconcile_orphan_spends`)

--- a/ao_kernel/cost/middleware.py
+++ b/ao_kernel/cost/middleware.py
@@ -491,6 +491,20 @@ def _build_adapter_spend_event(
     tokens_in = cost_actual.get("tokens_input")
     tokens_out = cost_actual.get("tokens_output")
     cost_raw = cost_actual.get("cost_usd", 0)
+
+    # PR-C3.1: adapter-supplied vendor_model_id propagates to the
+    # spend ledger. Blank strings normalize to None (defensive — a
+    # well-behaved adapter emits a non-empty string or omits the field,
+    # but mal-formed producers should not persist empty strings into
+    # the audit trail). Contract schema enforces minLength:1 at the
+    # boundary; this normalization is belt + suspenders.
+    vmid_raw = cost_actual.get("vendor_model_id")
+    vendor_model_id: str | None
+    if isinstance(vmid_raw, str) and vmid_raw.strip():
+        vendor_model_id = vmid_raw.strip()
+    else:
+        vendor_model_id = None
+
     usage_missing = tokens_in is None or tokens_out is None
     return SpendEvent(
         run_id=run_id,
@@ -502,7 +516,7 @@ def _build_adapter_spend_event(
         tokens_output=int(tokens_out or 0),
         cost_usd=Decimal(str(cost_raw)),
         ts=_iso_now(),
-        vendor_model_id=None,
+        vendor_model_id=vendor_model_id,
         cached_tokens=None,
         usage_missing=usage_missing,
     )

--- a/ao_kernel/defaults/schemas/agent-adapter-contract.schema.v1.json
+++ b/ao_kernel/defaults/schemas/agent-adapter-contract.schema.v1.json
@@ -446,7 +446,12 @@
         "tokens_input": {"type": "integer", "minimum": 0},
         "tokens_output": {"type": "integer", "minimum": 0},
         "time_seconds": {"type": "number", "minimum": 0},
-        "cost_usd": {"type": "number", "minimum": 0}
+        "cost_usd": {"type": "number", "minimum": 0},
+        "vendor_model_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "PR-C3.1 additive: concrete vendor model identifier the adapter actually invoked (e.g., 'claude-3-5-sonnet-20241022'). Distinct from the caller's logical `model` request field — enables cross-adapter audit attribution. Optional: adapters that cannot reliably derive this omit it; the middleware normalizes blank strings to None defensively."
+        }
       },
       "description": "Adapter-reported actual resource consumption. Reconciled against budget on return."
     },

--- a/tests/test_post_adapter_reconcile.py
+++ b/tests/test_post_adapter_reconcile.py
@@ -295,6 +295,181 @@ class TestIdempotency:
             )
 
 
+class TestVendorModelIdAttribution:
+    """PR-C3.1 adapter-path catalog attribution.
+
+    Adapter-supplied ``cost_actual.vendor_model_id`` propagates to
+    the spend ledger. Blank strings normalize to ``None``. Schema
+    accepts the field optionally with ``minLength: 1``.
+    """
+
+    def test_vendor_model_id_propagates_to_ledger(
+        self, tmp_path: Path,
+    ) -> None:
+        run_id = "00000000-0000-4000-8000-0000c31a0001"
+        _seed_run(tmp_path, run_id)
+        post_adapter_reconcile(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual={
+                "tokens_input": 100,
+                "tokens_output": 50,
+                "cost_usd": 0.05,
+                "vendor_model_id": "claude-3-5-sonnet-20241022",
+            },
+            policy=_policy(),
+        )
+        ledger = _read_ledger(tmp_path)
+        assert len(ledger) == 1
+        assert ledger[0]["vendor_model_id"] == "claude-3-5-sonnet-20241022"
+
+    def test_vendor_model_id_absent_defaults_to_none(
+        self, tmp_path: Path,
+    ) -> None:
+        run_id = "00000000-0000-4000-8000-0000c31a0002"
+        _seed_run(tmp_path, run_id)
+        post_adapter_reconcile(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual={
+                "tokens_input": 100,
+                "tokens_output": 50,
+                "cost_usd": 0.05,
+                # no vendor_model_id key
+            },
+            policy=_policy(),
+        )
+        ledger = _read_ledger(tmp_path)
+        # omitted from ledger when None (per _event_to_dict)
+        assert "vendor_model_id" not in ledger[0]
+
+    def test_vendor_model_id_blank_string_normalized_to_none(
+        self, tmp_path: Path,
+    ) -> None:
+        """Defensive middleware normalization — adapter bug emits empty
+        string, ledger stores None (not empty)."""
+        run_id = "00000000-0000-4000-8000-0000c31a0003"
+        _seed_run(tmp_path, run_id)
+        post_adapter_reconcile(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual={
+                "tokens_input": 100,
+                "tokens_output": 50,
+                "cost_usd": 0.05,
+                "vendor_model_id": "   ",  # whitespace only → normalized
+            },
+            policy=_policy(),
+        )
+        ledger = _read_ledger(tmp_path)
+        assert "vendor_model_id" not in ledger[0]
+
+    def test_usage_missing_preserves_vendor_model_id(
+        self, tmp_path: Path,
+    ) -> None:
+        """Adapter reports vendor but no tokens → usage_missing path
+        still carries the attribution for audit."""
+        run_id = "00000000-0000-4000-8000-0000c31a0004"
+        _seed_run(tmp_path, run_id)
+        post_adapter_reconcile(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual={
+                "cost_usd": 0.0,
+                "vendor_model_id": "claude-3-5-sonnet-20241022",
+            },
+            policy=_policy(),
+        )
+        ledger = _read_ledger(tmp_path)
+        assert ledger[0]["vendor_model_id"] == "claude-3-5-sonnet-20241022"
+        assert ledger[0]["usage_missing"] is True
+
+    def test_different_vendor_same_tokens_raises_duplicate(
+        self, tmp_path: Path,
+    ) -> None:
+        """Digest includes vendor_model_id → same tokens/cost but
+        different vendor raise SpendLedgerDuplicateError on re-reconcile."""
+        run_id = "00000000-0000-4000-8000-0000c31a0005"
+        _seed_run(tmp_path, run_id)
+        post_adapter_reconcile(
+            workspace_root=tmp_path, run_id=run_id, step_id="s1",
+            attempt=1, provider_id="codex", model="stub",
+            cost_actual={
+                "tokens_input": 100, "tokens_output": 50, "cost_usd": 0.05,
+                "vendor_model_id": "v1",
+            },
+            policy=_policy(),
+        )
+        with pytest.raises(SpendLedgerDuplicateError):
+            post_adapter_reconcile(
+                workspace_root=tmp_path, run_id=run_id, step_id="s1",
+                attempt=1, provider_id="codex", model="stub",
+                cost_actual={
+                    "tokens_input": 100, "tokens_output": 50, "cost_usd": 0.05,
+                    "vendor_model_id": "v2",
+                },
+                policy=_policy(),
+            )
+
+
+class TestCostRecordSchema:
+    def test_cost_record_accepts_vendor_model_id(self) -> None:
+        """Schema additive widen: cost_record validates with vendor_model_id."""
+        from jsonschema import Draft202012Validator
+        from ao_kernel.config import load_default
+
+        schema = load_default(
+            "schemas", "agent-adapter-contract.schema.v1.json",
+        )
+        cost_record_schema = schema["$defs"]["cost_record"]
+        validator = Draft202012Validator(cost_record_schema)
+        doc = {
+            "tokens_input": 100,
+            "tokens_output": 50,
+            "cost_usd": 0.05,
+            "vendor_model_id": "claude-3-5-sonnet-20241022",
+        }
+        errors = list(validator.iter_errors(doc))
+        assert errors == []  # no validation issues
+
+    def test_cost_record_accepts_without_vendor_model_id(self) -> None:
+        """Backward-compat: cost_record valid without the new field."""
+        from jsonschema import Draft202012Validator
+        from ao_kernel.config import load_default
+
+        schema = load_default(
+            "schemas", "agent-adapter-contract.schema.v1.json",
+        )
+        cost_record_schema = schema["$defs"]["cost_record"]
+        validator = Draft202012Validator(cost_record_schema)
+        doc = {
+            "tokens_input": 100,
+            "tokens_output": 50,
+            "cost_usd": 0.05,
+        }
+        errors = list(validator.iter_errors(doc))
+        assert errors == []
+
+    def test_cost_record_rejects_empty_vendor_model_id(self) -> None:
+        """minLength:1 at contract boundary prevents empty strings
+        from entering the wire."""
+        from jsonschema import Draft202012Validator, ValidationError
+        from ao_kernel.config import load_default
+
+        schema = load_default(
+            "schemas", "agent-adapter-contract.schema.v1.json",
+        )
+        cost_record_schema = schema["$defs"]["cost_record"]
+        validator = Draft202012Validator(cost_record_schema)
+        with pytest.raises(ValidationError):
+            validator.validate({
+                "tokens_input": 100,
+                "tokens_output": 50,
+                "cost_usd": 0.05,
+                "vendor_model_id": "",  # empty → violates minLength:1
+            })
+
+
 class TestWireFormat:
     def test_cost_actual_wire_format_not_usage(
         self, tmp_path: Path,


### PR DESCRIPTION
## Summary

- **Fixes v3.3.0 hardcode** — `_build_adapter_spend_event` had `vendor_model_id=None` unconditionally because adapter contract had no field to carry it
- **Additive schema** — `cost_record.vendor_model_id` (optional, `minLength: 1`) on `agent-adapter-contract.schema.v1.json`
- **Defensive normalization** — middleware treats blank/whitespace strings as `None`

## Codex consensus

CNS-20260418-035 — **AGREE with 3 clarity notes** (bundled fixtures wording, replay note logic, schema-level pins). All absorbed in commit.

## Test baseline

- **2242 → 2250** (+8 new tests in `tests/test_post_adapter_reconcile.py`)
- Ruff + mypy clean

## Scope

**IN v3.3.1**: contract widen + middleware propagation + blank normalization + digest-based duplicate semantics.

**OUT (v3.4.0)**: `llm_spend_recorded` evidence enrichment, cross-adapter audit replay, multi-vendor cost compare.

## Test plan

- [x] Propagation: adapter-supplied `vendor_model_id` → SpendEvent → ledger
- [x] Absence fallback: omitted → None → ledger field dropped
- [x] Blank normalization: whitespace-only → None
- [x] `usage_missing` branch preserves vendor
- [x] Digest-based duplicate on vendor mismatch
- [x] Schema: accept with, accept without, reject empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)