### PR TITLE
feat(pr-c6.1): adapter-step dry-run parity (driver entry point + CLI dispatch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[codz]
 *$py.class
 
+# Claude Code runtime artifacts
+.claude/scheduled_tasks.lock
+
 # C extensions
 *.so
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,27 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Cross-adapter reconciliation / audit replay keyed on `vendor_model_id`
 - Multi-vendor cost compare in routing decisions
 
+### Added — PR-C6.1 adapter-step dry-run parity
+
+**Context.** v3.3.0 CLI `ao-kernel executor dry-run` routed directly through `Executor.dry_run_step`, which used a bare task-prompt envelope and an empty `parent_env` — driver-layer `context_pack_ref` + `parent_env` derivation was bypassed, so the preview did not match real adapter execution. Codex CNS-20260418-034 adversarial plan (5 iterations → AGREE) isolated the fix: add a driver entry point, widen the executor signature to pass through driver-managed context, and route adapter steps through the driver by default from the CLI.
+
+**Changes.**
+
+- **New driver method** `MultiStepDriver.dry_run_step(run_id, step_name, *, attempt=None)` — resolves the pinned workflow definition, applies 5 guards, and delegates to `Executor.dry_run_step` with the same `context_pack_ref` + `parent_env` the real `_run_adapter_step` path computes.
+- **`Executor.dry_run_step` signature widen** — additive `input_envelope_override`, `step_id`, `driver_managed` kwargs forwarded to `run_step`. Backward compat preserved.
+- **CLI actor-aware dispatch** — `ao-kernel executor dry-run` defaults to driver path for adapter actors; non-adapter actors (`aokernel`, `ci-runner`, `patch-apply`) use executor-only fallback (v3.3.0 behavior preserved). New `--executor-only` flag forces executor path. `--attempt` default flipped from `1` to `None` so the driver derives.
+
+**Gating guards** (all `ValueError` except non-adapter → `NotImplementedError`):
+1. Run-state guard: only `created` / `running`; terminal / `waiting_approval` / `interrupted` blocked.
+2. Completed-step guard: highest-attempt `completed` blocks even with explicit `attempt=`.
+3. Attempt validation: supplied `attempt` must equal `_next_attempt_number(record, step_name)`.
+4. Running-placeholder reuse: highest attempt in `running` state at derived attempt → existing `step_id` reused.
+5. Adapter-only (inner API): non-adapter raises `NotImplementedError`; CLI routes non-adapters to executor fallback.
+
+**Test baseline.** 2250 → **2262** (+10 new in `tests/test_dry_run_driver.py`). Backward compat: 8/8 `test_dry_run_step.py` still pass.
+
+**Scope boundary.** `v3.3.1` claim is **adapter-step parity**. Non-adapter full-fidelity, workflow-wide replay, canary runs, reverse-diff preview → v3.4.0.
+
 ### Deferred — out of v3.3.1 scope (v3.4.0)
 
 - Full reconciliation daemon / API (`reconcile_orphan_spends`)

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -111,9 +111,32 @@ def _cmd_executor_dry_run(args: argparse.Namespace) -> int:
         workflow_registry=wreg,
         adapter_registry=areg,
     )
-    result = executor.dry_run_step(
-        args.run_id, step_def, attempt=args.attempt,
-    )
+    # PR-C6.1: actor-aware dispatch. Default behavior for adapter
+    # steps routes through MultiStepDriver.dry_run_step so
+    # context_pack_ref + parent_env derivation matches the real
+    # execution path. Non-adapter actors continue to use the
+    # executor-only path (placeholder envelope) — scope pinned to
+    # adapter parity in v3.3.1 (full-actor parity: v3.4.0).
+    # ``--executor-only`` flag forces executor path for debugging /
+    # backward compat regardless of actor.
+    executor_only = getattr(args, "executor_only", False)
+    use_driver = (not executor_only) and step_def.actor == "adapter"
+    if use_driver:
+        from ao_kernel.executor.multi_step_driver import MultiStepDriver
+
+        driver = MultiStepDriver(
+            workspace_root=project_root,
+            registry=wreg,
+            adapter_registry=areg,
+            executor=executor,
+        )
+        result = driver.dry_run_step(
+            args.run_id, args.step_name, attempt=args.attempt,
+        )
+    else:
+        result = executor.dry_run_step(
+            args.run_id, step_def, attempt=args.attempt or 1,
+        )
     if args.format == "json":
         out = {
             "predicted_events": [
@@ -334,8 +357,22 @@ def _build_parser() -> argparse.ArgumentParser:
     dry_run_p.add_argument(
         "--attempt",
         type=int,
-        default=1,
-        help="Attempt number for retry-aware dry-run (default 1)",
+        default=None,
+        help=(
+            "Attempt number for retry-aware dry-run. When omitted, the "
+            "driver derives the next legal attempt; when supplied, must "
+            "match that value (PR-C6.1)."
+        ),
+    )
+    dry_run_p.add_argument(
+        "--executor-only",
+        action="store_true",
+        help=(
+            "PR-C6.1 debug opt-out: force Executor.dry_run_step directly "
+            "instead of the actor-aware dispatch. Useful for debugging "
+            "driver-layer derivation gaps or for actors that don't have "
+            "driver parity yet (non-adapter actors route here by default)."
+        ),
     )
     dry_run_p.add_argument(
         "--format",

--- a/ao_kernel/executor/executor.py
+++ b/ao_kernel/executor/executor.py
@@ -288,6 +288,9 @@ class Executor:
         step_def: StepDefinition,
         *,
         parent_env: Mapping[str, str] | None = None,
+        input_envelope_override: Mapping[str, Any] | None = None,
+        step_id: str | None = None,
+        driver_managed: bool = False,
         attempt: int = 1,
     ) -> Any:  # DryRunResult imported lazily; Any avoids TYPE_CHECKING cycle.
         """Preview a step's effects without real side-effects.
@@ -299,6 +302,13 @@ class Executor:
         record is NOT mutated. Policy violations surface in the
         returned :class:`DryRunResult` rather than as raised
         exceptions (PR-C6 v3 B1 absorb).
+
+        PR-C6.1: the ``input_envelope_override``, ``step_id`` and
+        ``driver_managed`` passthrough kwargs let ``MultiStepDriver.
+        dry_run_step`` inject the same ``context_pack_ref`` /
+        ``parent_env`` derivation the real execution path uses —
+        closing the adapter-step parity gap where executor-only
+        preview used a bare task-prompt envelope.
 
         See ``ao_kernel/executor/dry_run.py`` for the recorder +
         context manager contract.
@@ -323,7 +333,9 @@ class Executor:
                     step_def,
                     parent_env=parent_env,
                     attempt=attempt,
-                    driver_managed=False,
+                    driver_managed=driver_managed,
+                    input_envelope_override=input_envelope_override,
+                    step_id=step_id,
                 )
             except PolicyViolationError as exc:
                 # Real executor emits step_started + policy_checked

--- a/ao_kernel/executor/multi_step_driver.py
+++ b/ao_kernel/executor/multi_step_driver.py
@@ -1780,6 +1780,144 @@ class MultiStepDriver:
     # Helpers
     # ------------------------------------------------------------------
 
+    # ------------------------------------------------------------------
+    # PR-C6.1: Driver-level dry-run (adapter-step parity)
+    # ------------------------------------------------------------------
+
+    def dry_run_step(
+        self,
+        run_id: str,
+        step_name: str,
+        *,
+        attempt: int | None = None,
+    ) -> Any:  # DryRunResult — avoid type import cycle.
+        """Driver-level dry-run preview with adapter-step parity.
+
+        Mirrors the real execution path for adapter actors by wiring
+        the same ``context_pack_ref`` + ``parent_env`` derivation that
+        ``_run_adapter_step`` uses, then delegating to
+        :meth:`Executor.dry_run_step`. This closes the v3.3.0 gap
+        where executor-only preview used a bare task-prompt envelope.
+
+        Semantics (Codex CNS-20260418-034 iter-5 absorb):
+
+        * Run-state guard: preview only allowed on ``created`` /
+          ``running`` runs; terminal / waiting_approval / interrupted
+          states raise ``ValueError`` (driver would never invoke a
+          step in those states either).
+        * Completed-step guard: if ``step_name``'s highest-attempt
+          record is ``completed``, raise ``ValueError`` — the real
+          driver never re-executes a completed step_name and dry-run
+          MUST NOT synthesize an execution path production cannot
+          reach.
+        * ``attempt`` validation: when supplied, must equal the
+          driver-derived ``_next_attempt_number``; mismatches raise
+          ``ValueError`` to prevent previewing fictional retry paths.
+        * Running-placeholder reuse: if a highest-attempt record
+          exists in state ``running`` with the derived attempt, its
+          existing ``step_id`` is reused (mirrors driver resume
+          path); otherwise a fresh step_id is minted via
+          ``_step_id_for_attempt``.
+        * Adapter-only fidelity: for non-adapter actors
+          (``aokernel``, ``ci-runner``, ``patch-apply``) this method
+          raises ``NotImplementedError`` — CLI default dispatch
+          falls back to ``Executor.dry_run_step`` directly for
+          backward compat (v3.4.0 extends parity).
+        """
+        if attempt is not None and attempt < 1:
+            raise ValueError("attempt must be >= 1")
+
+        record, _ = load_run(self._workspace_root, run_id)
+
+        # Run-state guard: only runnable states
+        run_state = record.get("state")
+        if run_state not in ("created", "running"):
+            raise ValueError(
+                f"dry-run requires run in 'created' or 'running' state; "
+                f"current state={run_state!r}"
+            )
+
+        # Completed-step guard
+        completed = self._completed_step_names(record)
+        if step_name in completed:
+            raise ValueError(
+                f"step {step_name!r} highest attempt already completed; "
+                "dry-run cannot preview a step that will never re-execute"
+            )
+
+        # Resolve step_def from pinned workflow
+        workflow_id = record.get("workflow_id")
+        workflow_version = record.get("workflow_version")
+        if not workflow_id or not workflow_version:
+            raise ValueError(
+                f"run {run_id!r} lacks workflow_id/workflow_version"
+            )
+        definition = self._registry.get(
+            workflow_id, version=workflow_version,
+        )
+        step_def = next(
+            (s for s in definition.steps if s.step_name == step_name),
+            None,
+        )
+        if step_def is None:
+            raise KeyError(
+                f"step_name {step_name!r} not in workflow "
+                f"{workflow_id}@{workflow_version}"
+            )
+
+        # Attempt derivation + validation
+        legal_attempt = self._next_attempt_number(record, step_name)
+        if attempt is not None and attempt != legal_attempt:
+            raise ValueError(
+                f"attempt={attempt} does not match driver-derived "
+                f"next_attempt={legal_attempt}; dry-run preview must "
+                "match the path the real driver would take"
+            )
+        attempt = legal_attempt
+
+        # step_id: reuse running placeholder OR mint fresh
+        placeholder_step_id: str | None = None
+        for sr in record.get("steps", []):
+            if (
+                sr.get("step_name") == step_name
+                and sr.get("attempt", 1) == attempt
+                and sr.get("state") == "running"
+            ):
+                placeholder_step_id = sr.get("step_id")
+                break
+        step_id = (
+            placeholder_step_id
+            if placeholder_step_id
+            else self._step_id_for_attempt(step_name, attempt)
+        )
+
+        # Adapter-only parity; non-adapter defer to executor fallback
+        # (CLI routes them there explicitly; inner API call is strict).
+        if step_def.actor != "adapter":
+            raise NotImplementedError(
+                f"driver dry-run parity implemented for adapter actors "
+                f"only; got actor={step_def.actor!r}. Fall back to "
+                "Executor.dry_run_step directly for non-adapter steps "
+                "(CLI --executor-only or default dispatch for "
+                "non-adapter actors)"
+            )
+
+        # Adapter envelope + parent_env — same derivation as real path
+        envelope = self._build_adapter_envelope_with_context(
+            run_id, step_def, record,
+        )
+        parent_env = self._compute_adapter_parent_env(self._policy)
+
+        return self._executor.dry_run_step(
+            run_id,
+            step_def,
+            input_envelope_override=envelope,
+            parent_env=parent_env,
+            step_id=step_id,
+            driver_managed=True,
+            attempt=attempt,
+        )
+
     def _completed_step_names(self, record: Mapping[str, Any]) -> set[str]:
         """step_name's whose highest-attempt step_record.state == completed."""
         by_name: dict[str, dict[str, Any]] = {}

--- a/tests/test_dry_run_driver.py
+++ b/tests/test_dry_run_driver.py
@@ -1,0 +1,275 @@
+"""PR-C6.1 driver-layer dry-run parity tests.
+
+Verifies ``MultiStepDriver.dry_run_step`` wires context_pack_ref +
+parent_env + step_id + attempt derivation through to
+``Executor.dry_run_step`` — closing the v3.3.0 gap where executor-only
+preview used a bare task-prompt envelope.
+
+Adversarial-consulted via Codex CNS-20260418-034 (iter-1..5 AGREE).
+Six semantic guards pinned:
+
+1. Run-state guard: only ``created`` / ``running`` allowed
+2. Completed-step guard: ``step_name`` at highest-attempt=completed blocks
+3. Attempt validation: explicit attempt MUST equal driver-derived
+4. Running-placeholder reuse: existing step_id when state=running
+5. Adapter-only fidelity: non-adapter → NotImplementedError
+6. Happy path: envelope + parent_env forwarded to executor
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from ao_kernel.executor.dry_run import DryRunResult
+from ao_kernel.executor.multi_step_driver import MultiStepDriver
+
+from tests._driver_helpers import (
+    build_driver,
+    copy_workflow_fixture,
+    install_workspace,
+    seed_run,
+    write_stub_adapter_manifest,
+)
+
+
+# ─── Shared fixture: adapter-first workflow + seeded run ───────────────
+
+
+def _prepare_workspace(root: Path) -> tuple[MultiStepDriver, str]:
+    install_workspace(root)
+    copy_workflow_fixture(root, "adapter_plus_ci_flow")
+    write_stub_adapter_manifest(root)
+    driver = build_driver(root)
+    run_id = seed_run(
+        root,
+        workflow_id="adapter_plus_ci_flow",
+        workflow_version="1.0.0",
+    )
+    return driver, run_id
+
+
+# ─── 1. Happy path: adapter step parity ────────────────────────────────
+
+
+class TestAdapterDryRunHappyPath:
+    def test_driver_dry_run_returns_DryRunResult(
+        self, tmp_path: Path,
+    ) -> None:
+        driver, run_id = _prepare_workspace(tmp_path)
+        result = driver.dry_run_step(run_id, "invoke_agent")
+        assert isinstance(result, DryRunResult)
+
+    def test_forwards_step_id_to_executor(self, tmp_path: Path) -> None:
+        """First attempt → step_id = step_name (via _step_id_for_attempt)."""
+        driver, run_id = _prepare_workspace(tmp_path)
+        captured: dict[str, Any] = {}
+
+        real_exec = driver._executor.dry_run_step
+
+        def _spy(*a: Any, **kw: Any) -> Any:
+            captured.update(kw)
+            return real_exec(*a, **kw)
+
+        with patch.object(driver._executor, "dry_run_step", side_effect=_spy):
+            driver.dry_run_step(run_id, "invoke_agent")
+
+        assert captured.get("step_id") == "invoke_agent"
+        assert captured.get("driver_managed") is True
+        # parent_env forwarded (empty dict OK — depends on policy)
+        assert "parent_env" in captured
+        # attempt derived to 1 on fresh run
+        assert captured.get("attempt") == 1
+
+
+# ─── 2. Run-state guard ────────────────────────────────────────────────
+
+
+class TestRunStateGuard:
+    def test_terminal_state_blocks_dry_run(self, tmp_path: Path) -> None:
+        driver, run_id = _prepare_workspace(tmp_path)
+        # Mutate record to failed state
+        state_path = tmp_path / ".ao" / "runs" / run_id / "state.v1.json"
+        record = json.loads(state_path.read_text(encoding="utf-8"))
+        record["state"] = "failed"
+        from ao_kernel.workflow.run_store import run_revision
+        record["revision"] = run_revision(record)
+        state_path.write_text(
+            json.dumps(record, indent=2, sort_keys=True), encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="dry-run requires run in"):
+            driver.dry_run_step(run_id, "invoke_agent")
+
+    def test_waiting_approval_blocks_dry_run(self, tmp_path: Path) -> None:
+        driver, run_id = _prepare_workspace(tmp_path)
+        state_path = tmp_path / ".ao" / "runs" / run_id / "state.v1.json"
+        record = json.loads(state_path.read_text(encoding="utf-8"))
+        record["state"] = "waiting_approval"
+        from ao_kernel.workflow.run_store import run_revision
+        record["revision"] = run_revision(record)
+        state_path.write_text(
+            json.dumps(record, indent=2, sort_keys=True), encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="dry-run requires run in"):
+            driver.dry_run_step(run_id, "invoke_agent")
+
+
+# ─── 3. Completed-step guard ───────────────────────────────────────────
+
+
+class TestCompletedStepGuard:
+    def test_highest_completed_step_blocks_even_with_explicit_attempt(
+        self, tmp_path: Path,
+    ) -> None:
+        """Even with ``attempt=2``, a step_name whose highest-attempt
+        is ``completed`` blocks — the real driver would never spawn
+        attempt=2 for a completed step_name."""
+        driver, run_id = _prepare_workspace(tmp_path)
+        state_path = tmp_path / ".ao" / "runs" / run_id / "state.v1.json"
+        record = json.loads(state_path.read_text(encoding="utf-8"))
+        record["steps"] = [{
+            "step_name": "invoke_agent",
+            "step_id": "invoke_agent",
+            "attempt": 1,
+            "state": "completed",
+            "actor": "adapter",
+            "started_at": "2026-04-18T10:00:00+00:00",
+            "completed_at": "2026-04-18T10:00:01+00:00",
+        }]
+        from ao_kernel.workflow.run_store import run_revision
+        record["revision"] = run_revision(record)
+        state_path.write_text(
+            json.dumps(record, indent=2, sort_keys=True), encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="already completed"):
+            driver.dry_run_step(run_id, "invoke_agent", attempt=2)
+
+
+# ─── 4. Attempt validation ─────────────────────────────────────────────
+
+
+class TestAttemptValidation:
+    def test_negative_attempt_raises(self, tmp_path: Path) -> None:
+        driver, run_id = _prepare_workspace(tmp_path)
+        with pytest.raises(ValueError, match="attempt must be >= 1"):
+            driver.dry_run_step(run_id, "invoke_agent", attempt=0)
+
+    def test_explicit_attempt_must_match_derived(
+        self, tmp_path: Path,
+    ) -> None:
+        """On a fresh run, derived attempt is 1; passing attempt=2
+        without any prior step records is a fictional path → ValueError."""
+        driver, run_id = _prepare_workspace(tmp_path)
+        with pytest.raises(ValueError, match="does not match driver-derived"):
+            driver.dry_run_step(run_id, "invoke_agent", attempt=2)
+
+
+# ─── 5. Running-placeholder reuse ──────────────────────────────────────
+
+
+class TestRunningPlaceholderReuse:
+    def test_running_placeholder_reuses_step_id(
+        self, tmp_path: Path,
+    ) -> None:
+        """Mid-crash resume: record has attempt=2 state=running → dry-run
+        must reuse that placeholder's step_id, not mint a new one."""
+        driver, run_id = _prepare_workspace(tmp_path)
+        state_path = tmp_path / ".ao" / "runs" / run_id / "state.v1.json"
+        record = json.loads(state_path.read_text(encoding="utf-8"))
+        placeholder_id = "invoke_agent-a2-deadbe"
+        record["state"] = "running"
+        record["steps"] = [
+            {
+                "step_name": "invoke_agent",
+                "step_id": "invoke_agent",
+                "attempt": 1,
+                "state": "failed",
+                "actor": "adapter",
+                "started_at": "2026-04-18T10:00:00+00:00",
+                "completed_at": "2026-04-18T10:00:01+00:00",
+                "error": {
+                    "category": "other",
+                    "code": "SIMULATED_FAILURE",
+                    "message": "simulated for test fixture",
+                },
+            },
+            {
+                "step_name": "invoke_agent",
+                "step_id": placeholder_id,
+                "attempt": 2,
+                "state": "running",
+                "actor": "adapter",
+                "started_at": "2026-04-18T10:00:02+00:00",
+            },
+        ]
+        from ao_kernel.workflow.run_store import run_revision
+        record["revision"] = run_revision(record)
+        state_path.write_text(
+            json.dumps(record, indent=2, sort_keys=True), encoding="utf-8",
+        )
+
+        captured: dict[str, Any] = {}
+        real_exec = driver._executor.dry_run_step
+
+        def _spy(*a: Any, **kw: Any) -> Any:
+            captured.update(kw)
+            return real_exec(*a, **kw)
+
+        with patch.object(driver._executor, "dry_run_step", side_effect=_spy):
+            driver.dry_run_step(run_id, "invoke_agent")
+
+        assert captured.get("step_id") == placeholder_id
+        assert captured.get("attempt") == 2
+
+
+# ─── 6. Non-adapter scope (inner API) ──────────────────────────────────
+
+
+class TestNonAdapterScope:
+    def test_non_adapter_actor_raises_not_implemented(
+        self, tmp_path: Path,
+    ) -> None:
+        """Inner driver API is strict: non-adapter actor raises
+        NotImplementedError. CLI layer routes non-adapters to executor
+        directly; this test pins the inner contract."""
+        driver, run_id = _prepare_workspace(tmp_path)
+        with pytest.raises(NotImplementedError, match="adapter actors only"):
+            driver.dry_run_step(run_id, "lint_check")  # system actor
+
+
+# ─── 7. parent_env derivation ──────────────────────────────────────────
+
+
+class TestParentEnvDerivation:
+    def test_parent_env_includes_allowlisted_env_vars(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """parent_env = UNION(allowlist_secret_ids, env_allowlist.allowed_keys)
+        filtered to keys present in os.environ."""
+        # Ensure a known env var is set and in the policy allowlist
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+        driver, run_id = _prepare_workspace(tmp_path)
+
+        captured: dict[str, Any] = {}
+        real_exec = driver._executor.dry_run_step
+
+        def _spy(*a: Any, **kw: Any) -> Any:
+            captured.update(kw)
+            return real_exec(*a, **kw)
+
+        with patch.object(driver._executor, "dry_run_step", side_effect=_spy):
+            driver.dry_run_step(run_id, "invoke_agent")
+
+        parent_env = captured.get("parent_env") or {}
+        # Bundled policy has PATH in env_allowlist.allowed_keys
+        # (see ao_kernel/defaults/policies/policy_worktree_profile.v1.json)
+        assert "PATH" in parent_env
+        assert parent_env["PATH"] == os.environ["PATH"]


### PR DESCRIPTION
## Summary

- **Fixes v3.3.0 fidelity gap** — CLI `ao-kernel executor dry-run` routed directly through `Executor.dry_run_step` with bare task-prompt envelope + empty parent_env
- **New driver entry point** — `MultiStepDriver.dry_run_step(run_id, step_name, *, attempt=None)` with 5 gating guards
- **CLI actor-aware dispatch** — adapter steps default to driver path; non-adapter fall back to executor-only (preserves v3.3.0 behavior)

## Codex consensus

CNS-20260418-034 — **5 plan iterations → AGREE**. Each iteration fixed a specific architectural question:
- Iter-1: Option A (driver entry point) vs Option B (executor-embedded) — driver chosen
- Iter-2: `input_envelope_override` / `step_id` passthrough vs new `context_pack_ref` kwarg — passthrough chosen
- Iter-3: `_next_attempt_number(record, step_name)` signature + running-placeholder reuse
- Iter-4: Completed-step guard unconditional (step-name/highest-attempt, not step_id)
- Iter-5: Run-state guard + explicit-attempt validation

## Gating guards (all `ValueError` except non-adapter → `NotImplementedError`)

1. **Run-state**: only `created` / `running`; terminal / `waiting_approval` / `interrupted` blocked
2. **Completed-step**: highest-attempt `completed` blocks even with explicit `attempt=`
3. **Attempt validation**: supplied `attempt` must equal `_next_attempt_number(record, step_name)`
4. **Running-placeholder reuse**: derived attempt matches highest-running step → reuse existing `step_id`
5. **Adapter-only** (inner API): non-adapter `NotImplementedError`; CLI routes them to executor fallback

## Test plan

- [x] `pytest tests/` — **2252 → 2262 pass** (+10 in `test_dry_run_driver.py`)
- [x] `test_dry_run_step.py` — 8/8 still pass (backward compat preserved)
- [x] `ruff check` — clean
- [x] `mypy --ignore-missing-imports` — clean (189 source files)
- [x] Happy path: driver returns `DryRunResult`, forwards step_id + driver_managed + parent_env
- [x] Run-state guard: failed + waiting_approval
- [x] Completed-step guard with explicit attempt
- [x] Attempt validation (negative + mismatch)
- [x] Running-placeholder reuse
- [x] Non-adapter `NotImplementedError`
- [x] `parent_env` PATH propagation from bundled policy

## Scope boundary

**IN v3.3.1**: adapter-step parity, CLI actor-aware dispatch, 5 gating guards.

**OUT (v3.4.0)**: non-adapter full-fidelity (aokernel, ci-runner, patch-apply), workflow-wide replay, canary runs, reverse-diff preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)