### PR TITLE
feat(v3.4.0-6): per-workspace routing + soft_degrade overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — v3.4.0 #6 Per-workspace routing / `soft_degrade` overrides
+
+**Context.** v3.3.1 routing rules (`llm_resolver_rules.v1.json`, `llm_provider_map.v1.json`, `llm_class_registry.v1.json`) shipped only as bundled defaults. Operators who wanted custom intent mappings or soft-degrade rules had to fork the package. v3.4.0 #6 accepts workspace-scoped override files under `.ao/operations/` — the router reads them with priority over the bundled copies, falling back cleanly when no override exists.
+
+**Changes.**
+
+- `llm_router._load_operations_json(..., *, workspace_root=None)` — resolution priority: workspace override → repo-root (editable installs) → bundled wheel defaults.
+- `llm_router.resolve()` threads `workspace_root` through to all three operations loads so a workspace can override any subset without forking the others.
+- Malformed workspace override (invalid JSON) → `json.JSONDecodeError` — fail-closed on the operator's explicit override rather than silently falling back.
+
+**Test baseline.** +2 new pins in `tests/test_resolve_route_downgrade.py::TestWorkspaceOverride`: override takes priority, malformed override fails closed.
+
 ### Added — v3.4.0 #5 Multi-step downgrade chain (cascaded budget-aware routing)
 
 **Context.** v3.3.1 C4.1 applied exactly one downgrade hop — first matching rule → `break`. A catalog like `PREMIUM → BALANCED_TEXT → FAST_TEXT` configured with two thresholds (`5.0` and `2.0`) would only hop once even when budget undershoots both. v3.4.0 #5 collapses the cascade into a single `resolve` call and exposes the full chain in the response.

--- a/ao_kernel/_internal/prj_kernel_api/llm_router.py
+++ b/ao_kernel/_internal/prj_kernel_api/llm_router.py
@@ -41,11 +41,36 @@ def _resolve_workspace_root(repo_root: Path, workspace_root: str | Path | None) 
     return ws_root
 
 
-def _load_operations_json(filename: str, repo_root: Path) -> Dict[str, Any]:
-    """Load operations JSON — tries repo-root first, falls back to bundled defaults."""
+def _load_operations_json(
+    filename: str,
+    repo_root: Path,
+    *,
+    workspace_root: str | Path | None = None,
+) -> Dict[str, Any]:
+    """Load operations JSON with workspace override → repo-root → bundled.
+
+    Priority order (v3.4.0 #6):
+    1. Workspace override at ``{workspace_root}/.ao/operations/{filename}``
+       (operators override routing rules per-workspace without
+       forking the bundled defaults)
+    2. Repo root (editable install path)
+    3. Bundled defaults inside the wheel
+
+    Malformed workspace override (invalid JSON) surfaces as
+    ``json.JSONDecodeError`` — fail-closed on the operator's explicit
+    override rather than silently falling back.
+    """
+    if workspace_root is not None:
+        ws_path = Path(workspace_root)
+        override = ws_path / ".ao" / "operations" / filename
+        if override.is_file():
+            payload: Dict[str, Any] = json.loads(
+                override.read_text(encoding="utf-8"),
+            )
+            return payload
     from ao_kernel._internal.shared.resource_loader import load_resource
-    payload: Dict[str, Any] = load_resource("operations", filename)
-    return payload
+    resource_payload: Dict[str, Any] = load_resource("operations", filename)
+    return resource_payload
 
 
 _RESOLVER_RULES_SCHEMA_VALIDATED = False
@@ -177,10 +202,19 @@ def resolve(
     _, _, _, probe_state_path = _policy_paths(repo_root, workspace_root=workspace_root)
 
     # Load operations via resource_loader (bundled defaults fallback)
-    _load_operations_json("llm_class_registry.v1.json", repo_root)  # validate
-    resolver_rules = _load_operations_json("llm_resolver_rules.v1.json", repo_root)
+    _load_operations_json(
+        "llm_class_registry.v1.json", repo_root,
+        workspace_root=workspace_root,
+    )  # validate
+    resolver_rules = _load_operations_json(
+        "llm_resolver_rules.v1.json", repo_root,
+        workspace_root=workspace_root,
+    )
     _validate_resolver_rules_once(resolver_rules)
-    provider_map = _load_operations_json("llm_provider_map.v1.json", repo_root)
+    provider_map = _load_operations_json(
+        "llm_provider_map.v1.json", repo_root,
+        workspace_root=workspace_root,
+    )
     probe_state = _load_json(probe_state_path) if probe_state_path.exists() else {"classes": {}}
 
     merged_map = _merge_state(provider_map, probe_state)

--- a/tests/test_resolve_route_downgrade.py
+++ b/tests/test_resolve_route_downgrade.py
@@ -22,7 +22,9 @@ other preconditions hold.
 
 from __future__ import annotations
 
+import json
 from decimal import Decimal
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -155,7 +157,7 @@ def fake_ops(monkeypatch: pytest.MonkeyPatch):
         "llm_class_registry.v1.json": _fake_class_registry(),
     }
 
-    def _fake_loader(filename: str, _repo_root):
+    def _fake_loader(filename: str, _repo_root, *, workspace_root=None):
         return state[filename]
 
     monkeypatch.setattr(llm_router, "_load_operations_json", _fake_loader)
@@ -783,6 +785,90 @@ class TestMultiStepDowngradeChain:
         # now also exposes the chain shape
         if result["downgrade_applied"]:
             assert len(result["downgrade_chain"]) == 1
+
+
+class TestWorkspaceOverride:
+    """v3.4.0 #6: operators place workspace-specific routing rules
+    under ``.ao/operations/`` to override bundled defaults without
+    forking the package."""
+
+    def test_workspace_override_takes_priority(
+        self, tmp_path: Path,
+    ) -> None:
+        from ao_kernel._internal.prj_kernel_api import llm_router
+
+        ops_dir = tmp_path / ".ao" / "operations"
+        ops_dir.mkdir(parents=True, exist_ok=True)
+        override_rules = {
+            "policy_version": "v0.1-ws",
+            "intent_to_class": {"CUSTOM_INTENT": "CUSTOM_CLASS"},
+            "fallback_order_by_class": {"CUSTOM_CLASS": ["openai"]},
+            "ttl_hours_default": 72,
+        }
+        (ops_dir / "llm_resolver_rules.v1.json").write_text(
+            json.dumps(override_rules), encoding="utf-8",
+        )
+        (ops_dir / "llm_class_registry.v1.json").write_text(
+            json.dumps({"classes": []}), encoding="utf-8",
+        )
+        (ops_dir / "llm_provider_map.v1.json").write_text(
+            json.dumps({
+                "classes": {
+                    "CUSTOM_CLASS": {
+                        "providers": {
+                            "openai": {
+                                "pinned_model_id": "stub-model",
+                                "models": [{
+                                    "model_id": "stub-model",
+                                    "stage": "verified",
+                                    "probe_status": "ok",
+                                    "probe_last_at": "2099-01-01T00:00:00+00:00",
+                                    "verified_at": "2099-01-01T00:00:00+00:00",
+                                }],
+                            },
+                        },
+                    },
+                },
+            }),
+            encoding="utf-8",
+        )
+
+        llm_router._reset_resolver_rules_cache()
+        try:
+            from ao_kernel.llm import resolve_route
+
+            result = resolve_route(
+                intent="CUSTOM_INTENT",
+                workspace_root=str(tmp_path),
+            )
+            assert result["status"] == "OK"
+            assert result["selected_class"] == "CUSTOM_CLASS"
+        finally:
+            llm_router._reset_resolver_rules_cache()
+
+    def test_malformed_override_fails_closed(
+        self, tmp_path: Path,
+    ) -> None:
+        from ao_kernel._internal.prj_kernel_api import llm_router
+
+        ops_dir = tmp_path / ".ao" / "operations"
+        ops_dir.mkdir(parents=True, exist_ok=True)
+        (ops_dir / "llm_resolver_rules.v1.json").write_text(
+            "{this is not valid json",
+            encoding="utf-8",
+        )
+
+        llm_router._reset_resolver_rules_cache()
+        try:
+            from ao_kernel.llm import resolve_route
+
+            with pytest.raises(json.JSONDecodeError):
+                resolve_route(
+                    intent="DISCOVERY",
+                    workspace_root=str(tmp_path),
+                )
+        finally:
+            llm_router._reset_resolver_rules_cache()
 
 
 class TestSchemaValidation:


### PR DESCRIPTION
## Summary

- Workspace override at `.ao/operations/<filename>` takes priority over bundled
- Operators customize routing/soft_degrade without forking the package
- Malformed override fails-closed (explicit signal, not silent fallback)

## Resolution priority

1. `{workspace_root}/.ao/operations/<filename>`
2. Repo-root (editable install)
3. Bundled wheel defaults

## Test plan

- [x] Override takes priority (custom intent → custom class)
- [x] Malformed JSON → json.JSONDecodeError fail-closed
- [x] pytest / ruff / mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)