### PR TITLE
feat(v3.4.0-7): subprocess crash-kill test harness + reconciler recovery pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — v3.4.0 #7 Subprocess crash-kill test harness
+
+**Context.** Mock-based idempotency tests (`test_cost_marker_idempotency`, `test_reconcile_daemon`) cover the exception-handling branches but cannot catch issues that only surface when the OS really terminates an interpreter mid-write — unflushed buffers, fsync gaps, open-file leaks. v3.4.0 #7 adds a stdlib-only harness that spawns a fresh Python subprocess, runs partial work up to a chosen checkpoint, and calls `os._exit` so finalizers never run. The parent process then inspects surviving on-disk state and runs recovery.
+
+**Changes.**
+
+- **New helper** `tests/_subprocess_crash_helper.py::run_crash_scenario(*, script, workspace_root, expected_exit_code=77, timeout_seconds=30.0)` — runs the supplied script in a subprocess with `workspace_root` as `sys.argv[1]`; asserts the process exits with the expected code. Returns `CompletedProcess` for diagnostic inspection.
+- **New test** `tests/test_reconciler_crash_injection.py::TestReconcilerRealCrashRecovery` — end-to-end pin: real crash between ledger append (fsynced) and marker CAS leaves the ledger on disk, leaves `cost_reconciled` empty, and the reconcile daemon recovers in a parent-process scan (idempotent on second pass).
+
+**Scope.** One helper + one end-to-end pin. Additional crash scenarios (marker stamp → emit gap, compaction mid-write, etc.) can follow the same pattern when motivated; the harness itself is reusable with no framework dependencies beyond stdlib + pytest.
+
 ### Added — v3.4.0 #4 Non-adapter dry-run fidelity (system + ao-kernel actors)
 
 **Context.** v3.3.1 PR-C6.1 routed only `adapter` actors through `MultiStepDriver.dry_run_step`; `system` (ci-runner / patch-apply) and `ao-kernel` (context_compile / checkpoint) actors fell back to executor-only preview with no `parent_env` derivation. The CLI raised `NotImplementedError` for non-adapter via the driver entry point. v3.4.0 #4 closes that scope — all non-human actors now share a driver-managed dry-run path so the preview mirrors the real execution surface.

--- a/tests/_subprocess_crash_helper.py
+++ b/tests/_subprocess_crash_helper.py
@@ -1,0 +1,87 @@
+"""Subprocess crash-kill test harness (v3.4.0 #7).
+
+Shared helper for tests that need to prove a given I/O sequence is
+crash-safe: spawn a fresh Python subprocess that runs the target
+function up to a chosen checkpoint, then calls ``os._exit`` so the
+interpreter halts without running finalizers. The caller then
+inspects the surviving on-disk state and verifies a recovery call in
+the parent process reconstructs the intended outcome.
+
+Why this matters: mock-based "exception after line N" tests exercise
+the exception-handling branches but cannot catch problems that only
+surface when the OS really terminates mid-write (unflushed buffers,
+fsync gaps, open-file leaks). Subprocess + ``os._exit`` gives a
+realistic crash signal without destabilizing the test host.
+
+Design:
+
+- Caller supplies a string snippet of Python to execute inside the
+  subprocess. The snippet closes over ``workspace_root`` (passed via
+  CLI arg) and performs whatever setup + partial work it wants,
+  ending with ``os._exit(77)`` (or any non-zero code).
+- Harness runs the subprocess, asserts it exited with the expected
+  code, and returns the workspace so the parent process can perform
+  its recovery + verification.
+- No dependency on test frameworks other than stdlib subprocess +
+  pytest's tmp_path (injected by the caller).
+
+Intentionally minimal scope: one helper, not a full orchestration
+library. v3.4.0 #7 ships the harness + a single reconciler crash
+test that proves the end-to-end "ledger survived, marker did not,
+reconciler recovers" invariant under a real OS-level crash.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+_DEFAULT_CRASH_EXIT_CODE = 77
+
+
+def run_crash_scenario(
+    *,
+    script: str,
+    workspace_root: Path,
+    expected_exit_code: int = _DEFAULT_CRASH_EXIT_CODE,
+    timeout_seconds: float = 30.0,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``script`` in a fresh subprocess and assert it exits with
+    ``expected_exit_code``.
+
+    The subprocess receives ``str(workspace_root)`` as ``sys.argv[1]``
+    so the script can reuse that path. The script should end with
+    ``os._exit(<exit_code>)`` to simulate the crash — a clean
+    ``sys.exit`` would run finalizers and defeat the point of the
+    harness.
+
+    Returns the :class:`CompletedProcess` so the caller can inspect
+    stdout/stderr for diagnostic logging when a scenario regresses.
+
+    Raises ``AssertionError`` if the subprocess exits with any other
+    code (including 0) — a successful exit indicates the crash was
+    not injected, and the recovery assertion would be invalid.
+    """
+    wrapper = textwrap.dedent(f"""
+        import os, sys
+        workspace_root = sys.argv[1]
+        {textwrap.indent(textwrap.dedent(script), "        ").lstrip()}
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", wrapper, str(workspace_root)],
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+    )
+    assert result.returncode == expected_exit_code, (
+        f"crash harness expected exit {expected_exit_code}, got "
+        f"{result.returncode}. stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+    return result
+
+
+__all__ = ["run_crash_scenario"]

--- a/tests/test_reconciler_crash_injection.py
+++ b/tests/test_reconciler_crash_injection.py
@@ -1,0 +1,158 @@
+"""v3.4.0 #7: subprocess crash-kill harness + reconciler recovery pin.
+
+Mock-based idempotency tests (test_cost_marker_idempotency,
+test_reconcile_daemon) cover the exception-handling branches. This
+file adds a single end-to-end pin that a REAL OS-level crash between
+ledger append and marker CAS leaves the ledger intact on disk and
+the reconciler daemon successfully recovers. Catches issues that
+only surface when the interpreter halts without running finalizers
+(unflushed buffers, fsync gaps, open-file leaks).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from ao_kernel.cost.policy import CostTrackingPolicy
+from ao_kernel.cost.reconcile_daemon import scan_and_fix
+
+from tests._subprocess_crash_helper import run_crash_scenario
+
+
+def _policy() -> CostTrackingPolicy:
+    return CostTrackingPolicy(
+        enabled=True,
+        price_catalog_path=".ao/cost/price-catalog.json",
+        spend_ledger_path=".ao/cost/spend.jsonl",
+        fail_closed_on_exhaust=True,
+        fail_closed_on_missing_usage=False,
+        strict_freshness=False,
+        idempotency_window_lines=100,
+    )
+
+
+def _seed_run(root: Path, run_id: str) -> None:
+    from ao_kernel.workflow.run_store import run_revision
+
+    run_dir = root / ".ao" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    record: dict[str, Any] = {
+        "run_id": run_id,
+        "workflow_id": "test_flow",
+        "workflow_version": "1.0.0",
+        "state": "running",
+        "created_at": "2026-04-18T10:00:00+00:00",
+        "revision": "0" * 64,
+        "intent": {"kind": "inline_prompt", "payload": "x"},
+        "steps": [],
+        "policy_refs": [
+            "ao_kernel/defaults/policies/policy_worktree_profile.v1.json",
+        ],
+        "adapter_refs": [],
+        "evidence_refs": [
+            f".ao/evidence/workflows/{run_id}/events.jsonl",
+        ],
+        "budget": {
+            "fail_closed_on_exhaust": True,
+            "cost_usd": {"limit": 10.0, "remaining": 10.0},
+        },
+    }
+    record["revision"] = run_revision(record)
+    (run_dir / "state.v1.json").write_text(
+        json.dumps(record, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+class TestReconcilerRealCrashRecovery:
+    def test_crash_between_ledger_append_and_marker_survives(
+        self, tmp_path: Path,
+    ) -> None:
+        """Child process writes a ledger entry, fsyncs it, then
+        ``os._exit(77)`` BEFORE the marker CAS runs. Parent process
+        then runs the reconciler and verifies:
+
+        1. Ledger entry survived the crash (durability)
+        2. `cost_reconciled` marker was absent (mid-write terminate)
+        3. Daemon detects the orphan and stamps the marker
+        4. Second daemon pass is a no-op (idempotent recovery)
+        """
+        run_id = "00000000-0000-4000-8000-0000c7a50001"
+        _seed_run(tmp_path, run_id)
+
+        # Child script: write ledger line then os._exit(77) — this
+        # simulates a crash DURING `apply_spend_with_marker` where
+        # the ledger append completed but the marker CAS has not
+        # started yet. We call `record_spend` (which fsyncs) so the
+        # entry is guaranteed on disk, then kill the process.
+        script = """
+            from decimal import Decimal
+            from pathlib import Path
+            from ao_kernel.cost.ledger import (
+                SpendEvent, compute_billing_digest, record_spend,
+            )
+            from ao_kernel.cost.policy import CostTrackingPolicy
+            from dataclasses import replace
+
+            root = Path(workspace_root)
+            policy = CostTrackingPolicy(
+                enabled=True,
+                price_catalog_path=".ao/cost/price-catalog.json",
+                spend_ledger_path=".ao/cost/spend.jsonl",
+                fail_closed_on_exhaust=True,
+                fail_closed_on_missing_usage=False,
+                strict_freshness=False,
+                idempotency_window_lines=100,
+            )
+            event = SpendEvent(
+                run_id="00000000-0000-4000-8000-0000c7a50001",
+                step_id="crashed-step",
+                attempt=1,
+                provider_id="codex",
+                model="stub",
+                tokens_input=100,
+                tokens_output=50,
+                cost_usd=Decimal("0.05"),
+                ts="2026-04-18T10:00:01+00:00",
+            )
+            event = replace(event, billing_digest=compute_billing_digest(event))
+            record_spend(root, event, policy=policy)
+            # Mid-flight crash: ledger written + fsynced, marker NOT stamped.
+            os._exit(77)
+        """
+
+        run_crash_scenario(script=script, workspace_root=tmp_path)
+
+        # Post-crash assertions (parent process): ledger survived,
+        # marker absent.
+        ledger_path = tmp_path / ".ao" / "cost" / "spend.jsonl"
+        assert ledger_path.is_file(), "ledger did not survive the crash"
+        lines = [
+            line for line in ledger_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["step_id"] == "crashed-step"
+
+        from ao_kernel.workflow.run_store import load_run
+        record, _ = load_run(tmp_path, run_id)
+        assert record.get("cost_reconciled", []) == []
+
+        # Reconciler recovers
+        result = scan_and_fix(tmp_path, _policy())
+        assert result.orphans_found == 1
+        assert result.orphans_fixed == 1
+
+        # Second pass: idempotent no-op
+        result2 = scan_and_fix(tmp_path, _policy())
+        assert result2.orphans_found == 0
+        assert result2.orphans_fixed == 0
+
+        # Marker now present
+        record_after, _ = load_run(tmp_path, run_id)
+        markers = record_after.get("cost_reconciled", [])
+        assert len(markers) == 1
+        assert markers[0]["step_id"] == "crashed-step"


### PR DESCRIPTION
## Summary

- Real OS-level crash simulation (subprocess + `os._exit`) — not mock exceptions
- End-to-end pin: ledger append + fsync → crash → reconciler recovers
- Idempotent on second pass

## Harness API

```python
from tests._subprocess_crash_helper import run_crash_scenario

run_crash_scenario(
    script="...partial work ending in os._exit(77)...",
    workspace_root=tmp_path,
    expected_exit_code=77,
)
```

Script receives `workspace_root` as `sys.argv[1]`. Returns `CompletedProcess` for diagnostic output inspection.

## Test plan

- [x] Child writes fsynced ledger entry, `os._exit(77)` before marker CAS
- [x] Parent verifies ledger survived on disk
- [x] Parent verifies `cost_reconciled` empty (marker absent)
- [x] Daemon scan recovers the orphan
- [x] Second daemon pass: 0 orphans, idempotent no-op

## Scope

One helper + one end-to-end pin. Reusable for future crash scenarios (compaction mid-write, marker → emit gap, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)