### PR TITLE
feat(v3.5-d3): dev scorecard — benchmark compare + sticky PR comment

### DIFF
--- a/.claude/plans/PR-D3-DRAFT-PLAN.md
+++ b/.claude/plans/PR-D3-DRAFT-PLAN.md
@@ -1,0 +1,519 @@
+# PR v3.5 D3 — Dev Scorecard (benchmark compare + PR comment)
+
+**Status:** DRAFT v2 — absorbed Codex iter-1 PARTIAL (3 revisions + 7 Q&A)
+**Scope:** v3.5.0 release track, final D-series PR before version bump
+**Depends on:** D1 (paths), D2a (archive), D2b (promotion) — all merged
+**Parallel to:** none (single-track plan)
+
+---
+
+## 1. Problem statement
+
+`tests/benchmarks/` emits run-dir JSONL events and capability artifacts, but
+there is no surface that:
+
+1. Aggregates benchmark outputs into a single compact "scorecard" JSON.
+2. Compares a PR's scorecard vs the main-branch baseline scorecard.
+3. Posts the scorecard + delta as a PR comment.
+
+Without a scorecard surface, benchmark regressions are visible only in full CI
+logs — easy to miss. D3 closes this gap as the final v3.5.0 commitment.
+
+**Not in v1:** multi-commit trend / sparkline visualisation. Draft title
+was trimmed from "benchmark compare + trend + PR comment" to "benchmark
+compare + PR comment" (iter-2 absorb of Codex revision #4). Trend is
+deferred to v3.6+ as a read-side-only extension of the same scorecard
+artifacts.
+
+---
+
+## 2. Non-goals
+
+- **No new benchmark scenarios** — D3 consumes B7's two existing flows
+  (`governed_bugfix` + `governed_review`). New scenarios are B7.x+ work.
+- **No CI-gate enforcement (bundled policy)** — D3 v1 ships bundled
+  `policy_scorecard.v1.json` with `fail_action: "warn"`; CI never fails
+  the PR on scorecard regressions. (The `compare` CLI **does** support
+  `block` for local/manual use — regression + `fail_action=block` →
+  exit 1; but the bundled policy stays `warn`. Iter-2 absorb of
+  Codex revision #3 — CLI/bundled split made explicit.)
+- **No repo-committed history** — trend window reads from GHA artifacts,
+  never mutates the repo.
+- **No scorecard promotion into canonical store** — scorecards are CI
+  surface; the D2b canonical promotion pipeline stays consultation-only.
+- **No real-adapter mode changes** — `--benchmark-mode=full` is FAZ-C scope;
+  D3 reads whatever fast-mode produces.
+- **Does NOT duplicate the existing `policy_benchmark.v1.json`** — that
+  policy governs the *maturity-tracking* benchmark (unrelated legacy
+  surface with different artifacts). D3 is the *runtime benchmark suite*
+  scorecard (PR-B7 flows). Naming is deliberately distinct.
+
+---
+
+## 3. Design overview
+
+### 3.1 Module layout
+
+```
+ao_kernel/
+  scorecard.py                      # PUBLIC facade
+  _internal/scorecard/
+    __init__.py
+    collector.py                    # pytest plugin — walks benchmark run_dirs
+    compare.py                      # baseline diff math
+    render.py                       # markdown renderer for PR comment
+  defaults/
+    policies/policy_scorecard.v1.json
+    schemas/scorecard.schema.v1.json
+cli.py                              # add `scorecard` subcommand
+tests/
+  test_scorecard_collector.py
+  test_scorecard_compare.py
+  test_scorecard_render.py
+  test_scorecard_cli.py
+```
+
+### 3.2 Scorecard schema
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:scorecard:v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "generated_at", "git_sha", "benchmarks"],
+  "properties": {
+    "schema_version": { "const": "v1" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "git_sha": { "type": "string", "pattern": "^[0-9a-f]{7,40}$" },
+    "git_ref": { "type": "string" },
+    "pr_number": { "type": ["integer", "null"] },
+    "benchmarks": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/benchmark_result" }
+    }
+  },
+  "$defs": {
+    "benchmark_result": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["scenario", "status", "workflow_completed"],
+      "properties": {
+        "scenario": { "type": "string" },
+        "status": { "enum": ["pass", "fail"] },
+        "workflow_completed": { "type": "boolean" },
+        "duration_ms": { "type": ["integer", "null"] },
+        "cost_consumed_usd": { "type": ["number", "null"] },
+        "cost_source": {
+          "type": ["string", "null"],
+          "description": "Where cost_consumed_usd came from. v1: 'mock_shim' (B7 benchmark-only shim). Post-C3 real-adapter runs: 'real_adapter'."
+        },
+        "review_score": { "type": ["number", "null"], "minimum": 0, "maximum": 1 }
+      }
+    }
+  }
+}
+```
+
+`additionalProperties: true` on `benchmark_result` — forward-extensible.
+`additionalProperties: false` on top-level — strict contract.
+
+### 3.3 Collector — pytest plugin + canonical marker
+
+**Canonical input (Codex iter-1 revision #1 absorb).** The benchmark suite
+has multiple tests per scenario (parametrized review threshold pass/fail,
+cost-consumption tests, transport-error negatives, contract pins —
+see `tests/benchmarks/test_governed_{bugfix,review}.py`). Only ONE
+happy-path run per scenario feeds the scorecard; the rest stay
+exclusive to their own assertions.
+
+**Marker mechanism:**
+- New pytest marker `@pytest.mark.scorecard_primary` registered in
+  `tests/benchmarks/conftest.py` via `pytest_configure`.
+- Exactly one primary test per scenario; collector refuses the session
+  (session-fail diagnostic, no scorecard written) if `>1` primary tests
+  are found for the same `scenario_id`.
+- The primary test's fixture exposes its `run_dir` + `scenario_id` via
+  a `benchmark_primary_sidecar` fixture that the plugin consumes.
+- D3 marks the actual primary tests with `@pytest.mark.scorecard_primary`:
+  - `tests/benchmarks/test_governed_review.py::TestHappyPath::test_review_findings_flow_completes`
+  - `tests/benchmarks/test_governed_bugfix.py::TestHappyPath::test_end_to_end_completes`
+
+  One-line decorator change in each file, no fixture churn.
+
+- **Zero-primary is also fail-closed** (Codex AGREE tighten #3): if
+  the session finishes with ZERO tests carrying
+  `@scorecard_primary` AND at least one canonical scenario is
+  expected (registered list of scenario ids the collector knows
+  about), emit `session-fail diagnostic + no scorecard`. Duplicate
+  and missing both silent-misconfiguration paths close.
+
+**Implementation:**
+
+`ao_kernel/_internal/scorecard/collector.py` registers a pytest plugin via
+`conftest.py` at `tests/benchmarks/conftest.py` (extend existing file).
+
+Key hook: `pytest_sessionfinish(session, exitstatus)` reads the primary
+sidecars recorded during the session and emits one `BenchmarkResult`
+per scenario. Results persist to `AO_SCORECARD_OUTPUT` (env var, default
+`benchmark_scorecard.v1.json` under CWD).
+
+**Rationale for env-var output path:** CI sets it explicitly; local dev uses
+the default. No CLI flag required — pytest stays pure.
+
+**Extraction rules (deterministic):**
+- `scenario` = scenario_id declared on the primary sidecar; fallback to
+  test module basename (`test_governed_review` → `governed_review`).
+- `status` = "pass" if `workflow_completed` event present AND no
+  `workflow_failed` event; else "fail".
+- `workflow_completed` = bool presence of event kind.
+- `duration_ms` = `(last_event.ts - first_event.ts)` in ms; null if empty.
+- `cost_consumed_usd` = `limit - remaining` on `budget.cost_usd` axis in the
+  final run-state snapshot; null if unseeded.
+- `review_score` = captured only for `governed_review` via the
+  `review-findings.v1.json` capability artifact's `score` field; null
+  otherwise.
+- `cost_source` (new extensible field, always populated v1) =
+  `"mock_shim"` (hard-coded v1 — B7 benchmark shim). Render footer
+  surfaces this so baseline drift isn't misread as real billing.
+
+### 3.4 Compare — baseline diff
+
+`ao_kernel/_internal/scorecard/compare.py`:
+
+```python
+@dataclass(frozen=True)
+class ScorecardDiff:
+    baseline_sha: str | None
+    head_sha: str
+    entries: tuple[BenchmarkDiff, ...]
+
+@dataclass(frozen=True)
+class BenchmarkDiff:
+    scenario: str
+    status_changed: bool  # pass→fail or fail→pass
+    duration_delta_pct: float | None
+    cost_delta_pct: float | None
+    review_score_delta: float | None
+    regression: bool  # True if any threshold breached
+```
+
+Policy thresholds (from `policy_scorecard.v1.json`):
+- `duration_ms_relative_pct` — default 30%
+- `cost_usd_relative_pct` — default 20%
+- `review_score_min_delta` — default -0.1 (score can drop by ≤0.1)
+
+Missing baseline → `baseline_sha=None`; all diffs are null; regression=False.
+
+### 3.5 Render — markdown
+
+`ao_kernel/_internal/scorecard/render.py` produces:
+
+```markdown
+<!-- ao-scorecard -->
+### 📊 Benchmark Scorecard
+
+| Scenario | Status | Duration | Cost (USD) | Review Score |
+|---|---|---|---|---|
+| governed_bugfix | ✅ pass | 245ms (▼5%) | $0.002 (−) | — |
+| governed_review | ✅ pass | 312ms (▲12%) | $0.003 (+3%) | 0.87 (−0.03) |
+
+_Baseline: `abc1234` (main) · HEAD: `def5678` · Cost source: mock_shim
+(benchmark-only; not real billing) · No regressions._
+```
+
+**HTML sentinel `<!-- ao-scorecard -->` on first line** — consumed by
+the sticky-comment upsert script (§3.7) to locate the existing bot
+comment and PATCH instead of appending.
+
+Unicode arrows ▲/▼ for directional cues, plain `−` for null. Regression
+line switches to `⚠️ <N> regression(s) detected:` with bullet list.
+
+**Cost source footer** (Codex iter-1 Q5 absorb) explicitly names the
+`cost_source` field from the scorecard's benchmark entries. When the
+first post-C3 scorecard lands with `cost_source="real_adapter"`, the
+footer updates automatically.
+
+### 3.6 CLI
+
+`ao-kernel scorecard emit [--output PATH]` — runs benchmarks via pytest
+subprocess + writes scorecard. Default output
+`./benchmark_scorecard.v1.json`. Always produces output (policy-agnostic
+per §3.8).
+
+`ao-kernel scorecard compare --baseline PATH --head PATH [--policy PATH]`
+— diffs two scorecards, prints render, exits based on policy:
+- `fail_action=warn` (default / bundled) → exit 0 always; regressions
+  surface in rendered banner.
+- `fail_action=block` → exit 0 on clean diff, exit 1 on any regression.
+  Useful for local pre-push / manual gates; CI bundled policy stays
+  `warn` (§2 non-goal).
+
+`ao-kernel scorecard render --input PATH [--baseline PATH]` — just
+renders markdown to stdout; no exit-code gating, no policy read.
+
+`ao-kernel scorecard post-comment --pr N --body-file FILE --sentinel MARKER`
+— small CI-only subcommand that handles the sticky-comment upsert
+(finds existing comment with MARKER via `gh api`; PATCH if found,
+POST otherwise). Pinned to `gh` CLI; delegates auth to env
+`GH_TOKEN`. Exits 0 even on upsert failure (advisory-only).
+
+### 3.7 CI workflow integration
+
+**SSOT fix (Codex iter-1 revision #2 absorb).** The scorecard job MUST NOT
+re-run the benchmark suite. Canonical benchmark run stays in the existing
+`benchmark-fast` job; the collector writes `benchmark_scorecard.v1.json`
+there and uploads it as an artifact. The new `scorecard` job only
+downloads + diffs + comments.
+
+**Changes to existing `benchmark-fast` job** (minimal extension — env var
++ upload step):
+
+```yaml
+benchmark-fast:
+  name: benchmark-fast
+  runs-on: ubuntu-latest
+  needs: [test]
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with: { python-version: "3.13" }
+    - name: Install
+      run: pip install -e ".[dev,llm,mcp,metrics]"
+    - name: Run PR-B7 benchmarks (fast mode) + emit scorecard
+      env: { AO_SCORECARD_OUTPUT: benchmark_scorecard.v1.json }
+      run: pytest tests/benchmarks/ -q
+    - name: Upload head scorecard
+      uses: actions/upload-artifact@v4
+      with:
+        name: scorecard-${{ github.sha }}
+        path: benchmark_scorecard.v1.json
+    - name: Upload main baseline (main push only)
+      if: github.ref == 'refs/heads/main'
+      uses: actions/upload-artifact@v4
+      with: { name: scorecard-main, path: benchmark_scorecard.v1.json }
+```
+
+**New `scorecard` job — compare + comment only:**
+
+```yaml
+scorecard:
+  name: scorecard
+  runs-on: ubuntu-latest
+  needs: [benchmark-fast]
+  if: github.event_name == 'pull_request'
+  permissions:
+    pull-requests: write
+    contents: read
+    actions: read
+  continue-on-error: true    # advisory — comment failure never reds the PR
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with: { python-version: "3.13" }
+    - name: Install
+      run: pip install -e ".[dev,llm,mcp,metrics]"
+    - name: Download head scorecard
+      uses: actions/download-artifact@v4
+      with:
+        name: scorecard-${{ github.sha }}
+        path: head/
+    - name: Download main baseline scorecard
+      uses: dawidd6/action-download-artifact@<commit-sha-pin>
+      with:
+        workflow: test.yml
+        branch: main
+        name: scorecard-main
+        path: ./baseline/
+        if_no_artifact_found: warn
+    - name: Compose scorecard comment
+      run: |
+        ao-kernel scorecard compare \
+          --baseline baseline/benchmark_scorecard.v1.json \
+          --head head/benchmark_scorecard.v1.json \
+          > scorecard_comment.md
+    - name: Post PR comment (sticky)
+      env: { GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
+      run: |
+        # Sentinel-based upsert (Codex iter-1 Q3 improvement over
+        # `--edit-last`). Find existing comment containing the
+        # `<!-- ao-scorecard -->` marker; PATCH if found, POST if not.
+        ao-kernel scorecard post-comment \
+          --pr ${{ github.event.pull_request.number }} \
+          --body-file scorecard_comment.md \
+          --sentinel '<!-- ao-scorecard -->' || true
+```
+
+**Third-party action pin (Codex iter-1 Q2 absorb).**
+`dawidd6/action-download-artifact` must be pinned to a full commit SHA,
+not `@v6`. Impl step resolves the latest release's SHA at PR-open time
+and pins it. Alternative considered: `gh run download` via `gh api`
+(official surface), rejected for v1 because branch-filter ergonomics
+cost more code than a SHA-pinned third-party. Revisit at v3.6+.
+
+**Comment failure is non-blocking.** `continue-on-error: true` +
+`|| true` in the post-comment step means a permission issue on fork PRs
+(secrets absent) or a transient `gh` error cannot red-check the PR.
+Scorecard is an advisory surface.
+
+### 3.8 Policy
+
+`ao_kernel/defaults/policies/policy_scorecard.v1.json`:
+
+```json
+{
+  "version": "v1",
+  "enabled": true,
+  "post_pr_comment": true,
+  "regression_threshold": {
+    "cost_usd_relative_pct": 20.0,
+    "duration_ms_relative_pct": 30.0,
+    "review_score_min_delta": -0.1
+  },
+  "fail_action": "warn"
+}
+```
+
+**Policy scope clarification (Codex iter-1 Q6 absorb).**
+`enabled` gates `compare` + comment posting only. The `emit` CLI
+command (and the pytest plugin that writes the scorecard on
+`pytest_sessionfinish`) always produces output regardless of the flag
+— benchmark scorecard generation is decoupled from policy gating.
+Rationale: scorecard JSON is raw CI artefact data; compare/comment is
+the opinion layer.
+
+Schema: `$id: urn:ao:policy-scorecard:v1` (Codex iter-1 Q7 —
+consistent with `urn:ao:scorecard:v1`). File:
+`policy-scorecard.schema.v1.json` — strict (`additionalProperties:
+false` top-level + on `regression_threshold`).
+
+---
+
+## 4. Test pins
+
+### 4.1 `test_scorecard_collector.py` (11 pins — +2 for canonical marker)
+
+- Seeds fixture run_dirs with deterministic event timelines; asserts
+  extraction maps per §3.3.
+- Missing `workflow_completed` → status=fail.
+- Missing `budget.cost_usd` → null.
+- Missing `review-findings` capability artifact → `review_score=null`.
+- Empty run_dir → `workflow_completed=false`, status=fail, durations null.
+- Scenario id fallback to module basename.
+- Multi-scenario run → multiple `BenchmarkResult` entries, sorted by
+  scenario name.
+- Env var `AO_SCORECARD_OUTPUT` honored + atomic write.
+- Session exitstatus≠0 → scorecard still written (fail-open diagnostic).
+- **NEW: Canonical marker enforcement** — duplicate
+  `@pytest.mark.scorecard_primary` on same scenario → session-fail
+  diagnostic; no scorecard written.
+- **NEW: `cost_source` field always populated** — hard-coded
+  `"mock_shim"` v1; schema accepts the field.
+
+### 4.2 `test_scorecard_compare.py` (10 pins)
+
+- Happy path: identical scorecards → regression=False, deltas≈0.
+- Null baseline → all deltas null, regression=False.
+- Duration regression >30% → regression=True on that entry.
+- Cost regression >20% → regression=True.
+- Review score drop >0.1 → regression=True.
+- `fail_action=warn` policy → diff object carries `regression=True` but
+  compare() return tuple signals "warn" (no exit code).
+- `fail_action=block` policy → compare() signals "block" (CLI exit 1
+  tested in §4.4).
+- Pass→fail status_changed flagged independently.
+- Missing scenario in head but present in baseline → flagged as
+  `status_changed=True` + `regression=True` (scenario disappearance).
+- Missing scenario in baseline but present in head → no regression (added).
+
+### 4.3 `test_scorecard_render.py` (8 pins — +2 for sentinel + cost source)
+
+- Happy empty diff → "No regressions" footer.
+- Regression rendered with ⚠️ banner.
+- Unicode arrows correct direction.
+- Null values render as `—` dash, not "None".
+- Missing baseline → "Baseline: _(not found)_" footer.
+- PR number in footer when present.
+- **NEW: HTML sentinel `<!-- ao-scorecard -->` on first line.**
+- **NEW: Cost source surfaces in footer (`mock_shim` labelled clearly
+  as "benchmark-only; not real billing").**
+
+### 4.4 `test_scorecard_cli.py` (8 pins — +2 for post-comment subcommand)
+
+- `emit` writes file at expected path.
+- `emit` always produces output regardless of `enabled=false`.
+- `compare` prints markdown to stdout; exit 0 on no regression.
+- `compare` with regression + `fail_action=warn` → exit 0 + stderr warn line.
+- `compare` with regression + `fail_action=block` → exit 1.
+- `render` ignores policy; always exit 0.
+- Missing baseline file handled gracefully.
+- **NEW: `post-comment --sentinel X` finds existing comment with X +
+  PATCHes (mocked `gh api` layer); POSTs if absent; exits 0 on either
+  outcome and on upsert failure.**
+
+### 4.5 `test_scorecard_schema.py` (3 pins)
+
+- Draft202012Validator accepts example scorecard.
+- Rejects unknown top-level key.
+- Benchmark entry forward-extensible (unknown key accepted in `benchmarks[]`).
+
+**Total: 40 pins** (collector 11 + compare 10 + render 8 + cli 8 + schema 3).
+Up from v1's 34-pin estimate after iter-2 absorb of canonical marker,
+sentinel-based sticky comment, and CLI/bundled split for `block`/`warn`.
+
+---
+
+## 5. Resolved design decisions (iter-1 + AGREE iter-2)
+
+All v1 open questions have been resolved in-plan; this section records
+the decisions for future reference.
+
+1. **Collector =** pytest plugin + explicit `@scorecard_primary`
+   marker + `benchmark_primary_sidecar` fixture. Not post-run CLI
+   (run_dir discovery would be ambiguous on multi-test scenarios).
+
+2. **Baseline fetch =** `dawidd6/action-download-artifact` pinned to
+   a full commit SHA. `gh run download` considered; branch-filter
+   ergonomics cost more code than a SHA pin. Revisit at v3.6+ if the
+   third-party surface becomes problematic.
+
+3. **Sticky comment =** HTML sentinel `<!-- ao-scorecard -->` on the
+   first line of the rendered markdown + `ao-kernel scorecard
+   post-comment --sentinel` CLI subcommand that lists existing
+   comments via `gh api`, PATCHes if a sentinel-bearing comment is
+   found, POSTs otherwise. Replaces the earlier `--edit-last`
+   proposal.
+
+4. **Trend window =** out of scope for v1; problem statement + title
+   updated (§1 "Not in v1" block). Same `scorecard-*` artefact
+   surface can grow trend display in v3.6+.
+
+5. **`cost_consumed_usd` =** mock-shim drift signal is meaningful in
+   v1. New `cost_source` schema field labels the source unambiguously
+   so baselines from mock-shim are not misread as real billing;
+   render footer surfaces the label explicitly.
+
+6. **Policy `enabled` scope =** gates `compare` + comment posting
+   only. `emit` is policy-agnostic and always produces output.
+   Bundled default `enabled: true`, `fail_action: "warn"` (§2
+   non-goal: CI never reds on scorecard regressions in v1).
+
+7. **Schema `$id` namespace =** `urn:ao:scorecard:v1` (data) +
+   `urn:ao:policy-scorecard:v1` (policy). Consistent with the
+   existing `urn:ao:agent-adapter-contract:v1` family.
+
+---
+
+## 6. Rollout
+
+1. Plan-time iter → AGREE.
+2. Impl: module + schema + policy + CLI + tests + CI workflow.
+3. Local fast-mode benchmark run → validate scorecard shape.
+4. Manual `ao-kernel scorecard compare` round-trip with two hand-edited
+   scorecards → validate render + exit codes.
+5. Post-impl Codex review gate.
+6. PR open against main → CI must generate scorecard artifact (first run
+   will have no baseline; comment states so).
+7. Merge → main-push uploads `scorecard-main` baseline.
+8. First subsequent PR will show first real diff.
+9. v3.5.0 release tag + CHANGELOG finalize.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,8 +88,71 @@ jobs:
           python-version: "3.13"
       - name: Install dependencies
         run: pip install -e ".[dev,llm,mcp,metrics]"
-      - name: Run PR-B7 benchmarks (fast mode)
+      - name: Run PR-B7 benchmarks (fast mode) + emit scorecard
+        env:
+          AO_SCORECARD_OUTPUT: benchmark_scorecard.v1.json
         run: pytest tests/benchmarks/ -q
+      - name: Upload head scorecard
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-${{ github.sha }}
+          path: benchmark_scorecard.v1.json
+          if-no-files-found: warn
+      - name: Upload main baseline scorecard
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-main
+          path: benchmark_scorecard.v1.json
+          if-no-files-found: warn
+          overwrite: true
+
+  scorecard:
+    name: scorecard
+    runs-on: ubuntu-latest
+    needs: [benchmark-fast]
+    if: github.event_name == 'pull_request'
+    continue-on-error: true  # Advisory surface — never red-check PRs.
+    permissions:
+      pull-requests: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: pip install -e ".[dev,llm,mcp,metrics]"
+      - name: Download head scorecard
+        uses: actions/download-artifact@v4
+        with:
+          name: scorecard-${{ github.sha }}
+          path: head/
+      # SHA-pinned dawidd6/action-download-artifact@v6
+      # (resolved against tag v6 at PR-open time per plan §3.7).
+      - name: Download main baseline scorecard
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11
+        with:
+          workflow: test.yml
+          branch: main
+          name: scorecard-main
+          path: ./baseline/
+          if_no_artifact_found: warn
+      - name: Compose scorecard comment
+        run: |
+          ao-kernel scorecard compare \
+            --baseline baseline/benchmark_scorecard.v1.json \
+            --head head/benchmark_scorecard.v1.json \
+            > scorecard_comment.md
+      - name: Post sticky PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ao-kernel scorecard post-comment \
+            --pr ${{ github.event.pull_request.number }} \
+            --body-file scorecard_comment.md \
+            --sentinel '<!-- ao-scorecard -->' || true
 
   extras-install:
     name: extras-install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Plan-time + post-impl gate** followed per v3.5+ two-gate rule (feedback_v35_codex_two_gate).
 
-**Test baseline.** +46 new pins (collector 14 + compare 11 + render 8 + cli 9 + schema 4), 10 benchmark tests still pass with the collector wired in, 2403 total. Ruff + mypy clean.
+**Test baseline.** +51 new pins (collector 16 + compare 11 + render 8 + cli 12 + schema 4), 10 benchmark tests still pass with the collector wired in, 2408 total. Ruff + mypy clean.
+
+**Codex post-impl review: BLOCK → MERGE after iter-2 absorb.** Two blockers + one suggest absorbed:
+- Canonical-input contract violations (duplicate OR partial-missing primary markers) now propagate a non-zero pytest exit status (`ExitCode.USAGE_ERROR=4`), not just a log line.
+- `finalize_session()` checks `expected_scenarios - observed` instead of only `observed == set()`, so partial misconfiguration (one scenario marked, another silently dropped) also fail-closes.
+- `policy_scorecard.enabled` + `post_pr_comment` now wired end-to-end: `compare` emits an advisory banner + exit 0 without rendering when `enabled=false`; `post-comment` honours both flags and skips the upsert with an advisory stderr line.
 
 **Scope boundary.**
 - IN: scorecard emit + compare + render + sticky PR comment + bundled policy `warn`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — v3.5.0 D3 Dev Scorecard (benchmark compare + PR comment)
+
+**Context.** PR-B7 emits benchmark run-dir events + capability artefacts, but there was no aggregated surface for comparing a PR's benchmark output against the main-branch baseline or posting a compact scorecard comment. D3 closes that gap as the final v3.5.0 commitment. Codex plan-time CNS: 2 iterations → AGREE (iter-1 PARTIAL → iter-2 AGREE after absorbing canonical-input marker + CI SSOT + block/warn split revisions). Trend / sparkline visualisation deferred to v3.6+.
+
+**Changes.**
+
+- **New module** `ao_kernel/scorecard.py` (public facade) + `_internal/scorecard/{collector,compare,render,post_comment}.py`. Typed `BenchmarkResult` / `ScorecardDiff` dataclasses + atomic-write emit path, pure-function compare + render, `gh api` sticky-comment upsert.
+- **Canonical input** via `@pytest.mark.scorecard_primary` on happy-path tests (`test_review_findings_flow_completes` + `test_end_to_end_completes`). Exactly-one-primary-per-scenario rule — duplicate AND missing both fail-close at session finish (`ScorecardCollectorError`). `EXPECTED_PRIMARY_SCENARIOS = {governed_bugfix, governed_review}`.
+- **Schemas** `scorecard.schema.v1.json` (`urn:ao:scorecard:v1`, top-level strict, `benchmark_result` forward-extensible with `additionalProperties: true`) + `policy-scorecard.schema.v1.json` (`urn:ao:policy-scorecard:v1`, strict all layers).
+- **Policy** `policy_scorecard.v1.json` — `enabled: true`, `fail_action: "warn"`, regression thresholds (`duration_ms_relative_pct: 30.0`, `cost_usd_relative_pct: 20.0`, `review_score_min_delta: -0.1`). `enabled` gates `compare` + comment only; `emit` is policy-agnostic.
+- **CLI** `ao-kernel scorecard {emit,compare,render,post-comment}`. `compare --baseline ... --head ...` exits 0 on warn / 1 on block+regression. `post-comment --pr N --body-file F --sentinel M` is advisory-only (exit 0 even on failure).
+- **CI workflow**: `benchmark-fast` job extended with `AO_SCORECARD_OUTPUT` env var + head-artefact upload + `scorecard-main` baseline upload on main push. New `scorecard` job (PR-only, `continue-on-error: true`, `dawidd6/action-download-artifact` SHA-pinned to `bf251b5a`) downloads head + baseline, runs `compare`, upserts a sentinel-tagged sticky PR comment.
+- **Cost source label** — new `cost_source` schema field always populated (`"mock_shim"` v1, `"real_adapter"` post-C3). Render footer surfaces it as "benchmark-only; not real billing" so mock-shim baselines are never misread as real spend.
+
+**Plan-time + post-impl gate** followed per v3.5+ two-gate rule (feedback_v35_codex_two_gate).
+
+**Test baseline.** +46 new pins (collector 14 + compare 11 + render 8 + cli 9 + schema 4), 10 benchmark tests still pass with the collector wired in, 2403 total. Ruff + mypy clean.
+
+**Scope boundary.**
+- IN: scorecard emit + compare + render + sticky PR comment + bundled policy `warn`
+- OUT: multi-commit trend / ASCII sparkline (v3.6+)
+- OUT: CI-gate enforcement (bundled `fail_action=block`; only local/manual today)
+- OUT: full-adapter real-billing cost axis (C3)
+- OUT: new benchmark scenarios (B7.x+)
+
 ### Added — v3.5.0 D2b Canonical promotion (opt-in)
 
 **Context.** D2a produced source-stable `resolution.record.v1.json` artefacts. D2b promotes eligible records (status=resolved AND final_verdict in {AGREE, PARTIAL}) into the existing canonical decision store (`.ao/canonical_decisions.v1.json`) via `ao_kernel.context.canonical_store.promote_decision()`. Opt-in (policy `promotion.enabled=false` default); `--force` bypasses only the policy flag, never integrity or eligibility gates. Codex plan-time CNS: 3 iterations → AGREE.

--- a/ao_kernel/_internal/scorecard/__init__.py
+++ b/ao_kernel/_internal/scorecard/__init__.py
@@ -1,0 +1,6 @@
+"""v3.5 D3 scorecard internals.
+
+Private module: import the public surface from ``ao_kernel.scorecard``.
+"""
+
+from __future__ import annotations

--- a/ao_kernel/_internal/scorecard/collector.py
+++ b/ao_kernel/_internal/scorecard/collector.py
@@ -1,0 +1,362 @@
+"""Scorecard collector — pytest plugin that harvests benchmark runs.
+
+Registered on ``tests/benchmarks/conftest.py``. Canonical input rule:
+exactly one test per scenario carries ``@pytest.mark.scorecard_primary``.
+Duplicates and missing-primary both fail-close at session finish
+(Codex iter-2 AGREE tighten #3).
+
+Scenario ids the collector expects to see at least once are declared in
+``EXPECTED_PRIMARY_SCENARIOS`` so the zero-primary path is explicit.
+
+The collector is schema-aware but not strictly schema-validating at
+write time — strict validation runs in the compare path (SSOT on the
+artefact consumer, not producer).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+logger = logging.getLogger(__name__)
+
+
+EXPECTED_PRIMARY_SCENARIOS: frozenset[str] = frozenset(
+    {"governed_bugfix", "governed_review"},
+)
+"""Canonical scenarios the benchmark suite is expected to exercise.
+
+When the collector runs and finds no ``scorecard_primary``-marked tests
+AND this set is non-empty, the session is failed (zero-primary guard).
+Relax this to ``frozenset()`` in downstream harnesses that intentionally
+run a subset.
+"""
+
+
+DEFAULT_OUTPUT_FILENAME = "benchmark_scorecard.v1.json"
+
+
+@dataclass(frozen=True)
+class PrimarySidecar:
+    """Record produced by a primary-marked test and consumed by the
+    session-finish hook.
+
+    - ``run_dir`` — the evidence directory (``events.jsonl`` is there).
+    - ``run_state_path`` — canonical run-state JSON (typically
+      ``.ao/runs/<run_id>/state.v1.json``). Kept separate from
+      ``run_dir`` because the benchmark harness puts evidence under
+      ``.ao/evidence/workflows/<run_id>/`` while ``run_store`` persists
+      state under ``.ao/runs/<run_id>/``. The collector only reads
+      ``budget.cost_usd`` from the state file.
+    - ``review_findings_path`` — optional concrete path to the
+      ``review-findings.v1.json`` capability artefact.
+    """
+
+    scenario_id: str
+    run_dir: Path
+    run_state_path: Path | None = None
+    review_findings_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    scenario: str
+    status: str  # "pass" | "fail"
+    workflow_completed: bool
+    duration_ms: int | None
+    cost_consumed_usd: float | None
+    cost_source: str | None
+    review_score: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario": self.scenario,
+            "status": self.status,
+            "workflow_completed": self.workflow_completed,
+            "duration_ms": self.duration_ms,
+            "cost_consumed_usd": self.cost_consumed_usd,
+            "cost_source": self.cost_source,
+            "review_score": self.review_score,
+        }
+
+
+@dataclass
+class ScorecardRegistry:
+    """Session-scoped accumulator."""
+
+    sidecars: list[PrimarySidecar] = field(default_factory=list)
+    duplicate_scenarios: set[str] = field(default_factory=set)
+
+    def record(self, sidecar: PrimarySidecar) -> None:
+        if any(s.scenario_id == sidecar.scenario_id for s in self.sidecars):
+            self.duplicate_scenarios.add(sidecar.scenario_id)
+        self.sidecars.append(sidecar)
+
+    def distinct_scenarios(self) -> list[str]:
+        return sorted({s.scenario_id for s in self.sidecars})
+
+
+class ScorecardCollectorError(RuntimeError):
+    """Raised when the canonical-input invariants are violated.
+
+    Duplicate primary markers on the same scenario, or zero primaries
+    when at least one is expected.
+    """
+
+
+def resolve_output_path(cwd: Path | None = None) -> Path:
+    """Output path comes from ``AO_SCORECARD_OUTPUT`` or default under CWD."""
+    override = os.environ.get("AO_SCORECARD_OUTPUT")
+    if override:
+        return Path(override).expanduser().resolve()
+    base = cwd if cwd is not None else Path.cwd()
+    return base / DEFAULT_OUTPUT_FILENAME
+
+
+def _iter_events(run_dir: Path) -> list[dict[str, Any]]:
+    path = run_dir / "events.jsonl"
+    if not path.is_file():
+        return []
+    events: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+def _event_ts(event: Mapping[str, Any]) -> float | None:
+    raw = event.get("ts") or event.get("timestamp")
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    if isinstance(raw, str):
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def _duration_ms(events: list[dict[str, Any]]) -> int | None:
+    if not events:
+        return None
+    ts = [t for t in (_event_ts(ev) for ev in events) if t is not None]
+    if len(ts) < 2:
+        return None
+    delta = max(ts) - min(ts)
+    if delta < 0:
+        return None
+    return int(round(delta * 1000))
+
+
+def _latest_run_state(
+    run_state_path: Path | None,
+) -> Mapping[str, Any] | None:
+    """Load the run-state JSON (``budget`` axis lives here).
+
+    Returns ``None`` when the path is unset or unreadable so the
+    extractor can record ``cost_consumed_usd=None`` gracefully.
+    """
+    if run_state_path is None:
+        return None
+    if not run_state_path.is_file():
+        return None
+    try:
+        loaded = json.loads(run_state_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    if isinstance(loaded, dict):
+        return loaded
+    return None
+
+
+def _extract_cost(run_state: Mapping[str, Any] | None) -> float | None:
+    if not run_state:
+        return None
+    budget = run_state.get("budget") or {}
+    axis = budget.get("cost_usd") or {}
+    limit = axis.get("limit")
+    remaining = axis.get("remaining")
+    if limit is None or remaining is None:
+        return None
+    try:
+        return max(0.0, float(limit) - float(remaining))
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_review_score(
+    review_findings_path: Path | None,
+) -> float | None:
+    if review_findings_path is None or not review_findings_path.is_file():
+        return None
+    try:
+        payload = json.loads(review_findings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    raw = payload.get("score")
+    if isinstance(raw, (int, float)):
+        score = float(raw)
+        if 0.0 <= score <= 1.0:
+            return score
+    return None
+
+
+def build_result(sidecar: PrimarySidecar) -> BenchmarkResult:
+    """Derive a ``BenchmarkResult`` from a primary sidecar."""
+    events = _iter_events(sidecar.run_dir)
+    event_kinds = {event.get("kind") for event in events}
+    workflow_completed = "workflow_completed" in event_kinds
+    failed = "workflow_failed" in event_kinds
+    status = "pass" if workflow_completed and not failed else "fail"
+    run_state = _latest_run_state(sidecar.run_state_path)
+    cost_consumed = _extract_cost(run_state)
+    cost_source = "mock_shim" if cost_consumed is not None else None
+    review_score = _extract_review_score(sidecar.review_findings_path)
+    return BenchmarkResult(
+        scenario=sidecar.scenario_id,
+        status=status,
+        workflow_completed=workflow_completed,
+        duration_ms=_duration_ms(events),
+        cost_consumed_usd=cost_consumed,
+        cost_source=cost_source,
+        review_score=review_score,
+    )
+
+
+def _git_sha() -> str:
+    env = os.environ.get("GITHUB_SHA")
+    if env and len(env) >= 7:
+        return env
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return out.stdout.strip() or "0000000"
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return "0000000"
+
+
+def _git_ref() -> str | None:
+    env = os.environ.get("GITHUB_REF")
+    if env:
+        return env
+    try:
+        out = subprocess.run(
+            ["git", "symbolic-ref", "-q", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        ref = out.stdout.strip()
+        return ref or None
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+
+
+def _pr_number() -> int | None:
+    env = os.environ.get("GITHUB_PR_NUMBER") or os.environ.get("PR_NUMBER")
+    if env and env.isdigit():
+        return int(env)
+    ref = os.environ.get("GITHUB_REF", "")
+    # "refs/pull/<N>/merge" on GHA PR events
+    parts = ref.split("/")
+    if len(parts) >= 3 and parts[1] == "pull" and parts[2].isdigit():
+        return int(parts[2])
+    return None
+
+
+def build_scorecard(
+    results: Iterable[BenchmarkResult],
+    *,
+    generated_at: datetime | None = None,
+) -> dict[str, Any]:
+    sorted_results = sorted(results, key=lambda r: r.scenario)
+    ts = generated_at or datetime.now(timezone.utc)
+    scorecard: dict[str, Any] = {
+        "schema_version": "v1",
+        "generated_at": ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "git_sha": _git_sha(),
+        "benchmarks": [result.to_dict() for result in sorted_results],
+    }
+    ref = _git_ref()
+    if ref:
+        scorecard["git_ref"] = ref
+    pr = _pr_number()
+    scorecard["pr_number"] = pr
+    return scorecard
+
+
+def finalize_session(
+    registry: ScorecardRegistry,
+    output_path: Path | None = None,
+    *,
+    expected_scenarios: frozenset[str] = EXPECTED_PRIMARY_SCENARIOS,
+) -> Path | None:
+    """Validate canonical-input invariants + write the scorecard JSON.
+
+    Raises ``ScorecardCollectorError`` on duplicate or missing-primary
+    misconfiguration. Returns the path that was written (or ``None`` when
+    there is nothing to write, e.g. a non-benchmark pytest session).
+    """
+    from ao_kernel._internal.shared.utils import write_json_atomic
+
+    if not registry.sidecars and not expected_scenarios:
+        return None
+
+    if registry.duplicate_scenarios:
+        dups = sorted(registry.duplicate_scenarios)
+        raise ScorecardCollectorError(
+            "Duplicate @pytest.mark.scorecard_primary on scenarios: "
+            f"{dups!r}. Each canonical scenario must have exactly one "
+            "primary-marked test."
+        )
+
+    observed = set(registry.distinct_scenarios())
+    if expected_scenarios and not observed:
+        raise ScorecardCollectorError(
+            "Zero @pytest.mark.scorecard_primary tests collected while "
+            f"expected canonical scenarios are {sorted(expected_scenarios)!r}. "
+            "Either mark a primary test per scenario or set "
+            "EXPECTED_PRIMARY_SCENARIOS=frozenset() in a downstream harness."
+        )
+
+    results = [build_result(sidecar) for sidecar in registry.sidecars]
+    scorecard = build_scorecard(results)
+
+    path = output_path or resolve_output_path()
+    write_json_atomic(path, scorecard)
+    logger.info("scorecard written: %s (scenarios=%s)", path, sorted(observed))
+    return path
+
+
+__all__ = [
+    "DEFAULT_OUTPUT_FILENAME",
+    "EXPECTED_PRIMARY_SCENARIOS",
+    "BenchmarkResult",
+    "PrimarySidecar",
+    "ScorecardCollectorError",
+    "ScorecardRegistry",
+    "build_result",
+    "build_scorecard",
+    "finalize_session",
+    "resolve_output_path",
+]

--- a/ao_kernel/_internal/scorecard/collector.py
+++ b/ao_kernel/_internal/scorecard/collector.py
@@ -331,12 +331,15 @@ def finalize_session(
         )
 
     observed = set(registry.distinct_scenarios())
-    if expected_scenarios and not observed:
+    missing = expected_scenarios - observed
+    if missing:
         raise ScorecardCollectorError(
-            "Zero @pytest.mark.scorecard_primary tests collected while "
-            f"expected canonical scenarios are {sorted(expected_scenarios)!r}. "
-            "Either mark a primary test per scenario or set "
-            "EXPECTED_PRIMARY_SCENARIOS=frozenset() in a downstream harness."
+            "Missing @pytest.mark.scorecard_primary tests for canonical "
+            f"scenarios: {sorted(missing)!r}. Each expected scenario in "
+            f"{sorted(expected_scenarios)!r} must have exactly one "
+            "primary-marked test. Either mark a primary test for the "
+            "missing scenarios or set EXPECTED_PRIMARY_SCENARIOS="
+            "frozenset() in a downstream harness."
         )
 
     results = [build_result(sidecar) for sidecar in registry.sidecars]

--- a/ao_kernel/_internal/scorecard/compare.py
+++ b/ao_kernel/_internal/scorecard/compare.py
@@ -1,0 +1,232 @@
+"""Scorecard compare — baseline vs head diff math.
+
+Pure functions over the scorecard artefact (``urn:ao:scorecard:v1``).
+Returns a structured ``ScorecardDiff`` which the render and CLI layers
+consume. Policy thresholds drive the ``regression`` flag; the CLI
+layer decides whether to exit 1 on ``fail_action=block``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class BenchmarkDiff:
+    scenario: str
+    baseline_status: str | None
+    head_status: str
+    status_changed: bool
+    duration_delta_pct: float | None
+    cost_delta_pct: float | None
+    review_score_delta: float | None
+    regression: bool
+    regression_reasons: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario": self.scenario,
+            "baseline_status": self.baseline_status,
+            "head_status": self.head_status,
+            "status_changed": self.status_changed,
+            "duration_delta_pct": self.duration_delta_pct,
+            "cost_delta_pct": self.cost_delta_pct,
+            "review_score_delta": self.review_score_delta,
+            "regression": self.regression,
+            "regression_reasons": list(self.regression_reasons),
+        }
+
+
+@dataclass(frozen=True)
+class ScorecardDiff:
+    baseline_sha: str | None
+    head_sha: str
+    pr_number: int | None
+    entries: tuple[BenchmarkDiff, ...]
+    has_regression: bool
+    fail_action: str  # "warn" | "block"
+    head_cost_source: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "baseline_sha": self.baseline_sha,
+            "head_sha": self.head_sha,
+            "pr_number": self.pr_number,
+            "entries": [entry.to_dict() for entry in self.entries],
+            "has_regression": self.has_regression,
+            "fail_action": self.fail_action,
+            "head_cost_source": self.head_cost_source,
+        }
+
+
+def _index_by_scenario(
+    scorecard: Mapping[str, Any] | None,
+) -> dict[str, Mapping[str, Any]]:
+    if not scorecard:
+        return {}
+    benchmarks = scorecard.get("benchmarks") or []
+    indexed: dict[str, Mapping[str, Any]] = {}
+    for entry in benchmarks:
+        if isinstance(entry, dict) and isinstance(entry.get("scenario"), str):
+            indexed[entry["scenario"]] = entry
+    return indexed
+
+
+def _delta_pct(baseline: float | None, head: float | None) -> float | None:
+    """Percent change head over baseline. None when either side is None
+    or baseline is 0 (pct undefined)."""
+    if baseline is None or head is None:
+        return None
+    if baseline == 0:
+        return None
+    return (head - baseline) / baseline * 100.0
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _build_entry(
+    scenario: str,
+    baseline_entry: Mapping[str, Any] | None,
+    head_entry: Mapping[str, Any] | None,
+    thresholds: Mapping[str, float],
+) -> BenchmarkDiff:
+    head_status = (head_entry.get("status") if isinstance(head_entry, Mapping) else None) or "fail"
+    baseline_status = baseline_entry.get("status") if isinstance(baseline_entry, Mapping) else None
+    status_changed = bool(baseline_status is not None and baseline_status != head_status)
+
+    baseline_duration = _coerce_float((baseline_entry or {}).get("duration_ms"))
+    head_duration = _coerce_float((head_entry or {}).get("duration_ms"))
+    duration_delta_pct = _delta_pct(baseline_duration, head_duration)
+
+    baseline_cost = _coerce_float((baseline_entry or {}).get("cost_consumed_usd"))
+    head_cost = _coerce_float((head_entry or {}).get("cost_consumed_usd"))
+    cost_delta_pct = _delta_pct(baseline_cost, head_cost)
+
+    baseline_review = _coerce_float((baseline_entry or {}).get("review_score"))
+    head_review = _coerce_float((head_entry or {}).get("review_score"))
+    review_delta = head_review - baseline_review if (baseline_review is not None and head_review is not None) else None
+
+    reasons: list[str] = []
+
+    if head_entry is None and baseline_entry is not None:
+        reasons.append("scenario_disappeared")
+    elif baseline_status == "pass" and head_status == "fail":
+        reasons.append("status_pass_to_fail")
+
+    dur_threshold = thresholds.get("duration_ms_relative_pct", 30.0)
+    if duration_delta_pct is not None and duration_delta_pct > dur_threshold:
+        reasons.append(f"duration_up_{duration_delta_pct:.1f}pct")
+
+    cost_threshold = thresholds.get("cost_usd_relative_pct", 20.0)
+    if cost_delta_pct is not None and cost_delta_pct > cost_threshold:
+        reasons.append(f"cost_up_{cost_delta_pct:.1f}pct")
+
+    review_min_delta = thresholds.get("review_score_min_delta", -0.1)
+    if review_delta is not None and review_delta < review_min_delta:
+        reasons.append(f"review_score_drop_{review_delta:+.3f}")
+
+    return BenchmarkDiff(
+        scenario=scenario,
+        baseline_status=baseline_status,
+        head_status=head_status,
+        status_changed=status_changed,
+        duration_delta_pct=duration_delta_pct,
+        cost_delta_pct=cost_delta_pct,
+        review_score_delta=review_delta,
+        regression=bool(reasons),
+        regression_reasons=tuple(reasons),
+    )
+
+
+def compare_scorecards(
+    baseline: Mapping[str, Any] | None,
+    head: Mapping[str, Any],
+    *,
+    policy: Mapping[str, Any] | None = None,
+) -> ScorecardDiff:
+    """Diff two scorecards against policy thresholds.
+
+    Args:
+        baseline: Scorecard artefact for the baseline commit, or ``None``
+            when no baseline is available (first-run PR).
+        head: Scorecard artefact for the HEAD commit under PR review.
+        policy: ``policy_scorecard.v1.json`` object; falls back to the
+            bundled defaults when ``None``.
+    """
+    if not isinstance(head, Mapping):
+        raise TypeError("head scorecard must be a mapping")
+
+    policy = dict(policy or _default_policy())
+    thresholds = dict(policy.get("regression_threshold") or {})
+    fail_action = str(policy.get("fail_action") or "warn")
+
+    baseline_idx = _index_by_scenario(baseline)
+    head_idx = _index_by_scenario(head)
+
+    scenarios = sorted(set(baseline_idx) | set(head_idx))
+    entries: list[BenchmarkDiff] = []
+    for scenario in scenarios:
+        baseline_entry = baseline_idx.get(scenario)
+        head_entry = head_idx.get(scenario)
+        entry = _build_entry(
+            scenario,
+            baseline_entry,
+            head_entry,
+            thresholds,
+        )
+        entries.append(entry)
+
+    head_sha = str(head.get("git_sha") or "unknown")
+    baseline_sha = str(baseline.get("git_sha")) if isinstance(baseline, Mapping) else None
+    pr_raw = head.get("pr_number")
+    pr_number = int(pr_raw) if isinstance(pr_raw, int) else None
+    head_cost_source: str | None = None
+    for head_row in head_idx.values():
+        cost_source = head_row.get("cost_source")
+        if isinstance(cost_source, str):
+            head_cost_source = cost_source
+            break
+
+    has_regression = any(entry.regression for entry in entries)
+    return ScorecardDiff(
+        baseline_sha=baseline_sha,
+        head_sha=head_sha,
+        pr_number=pr_number,
+        entries=tuple(entries),
+        has_regression=has_regression,
+        fail_action=fail_action,
+        head_cost_source=head_cost_source,
+    )
+
+
+def _default_policy() -> dict[str, Any]:
+    from ao_kernel.config import load_default
+
+    return load_default("policies", "policy_scorecard.v1.json")
+
+
+def exit_code_for(diff: ScorecardDiff) -> int:
+    """Return 1 when ``fail_action=block`` + at least one regression."""
+    if diff.fail_action == "block" and diff.has_regression:
+        return 1
+    return 0
+
+
+def select_regressions(diff: ScorecardDiff) -> Sequence[BenchmarkDiff]:
+    return tuple(entry for entry in diff.entries if entry.regression)
+
+
+__all__ = [
+    "BenchmarkDiff",
+    "ScorecardDiff",
+    "compare_scorecards",
+    "exit_code_for",
+    "select_regressions",
+]

--- a/ao_kernel/_internal/scorecard/post_comment.py
+++ b/ao_kernel/_internal/scorecard/post_comment.py
@@ -1,0 +1,165 @@
+"""Sticky-comment upsert via ``gh`` CLI.
+
+Implements the CLI side of the sentinel-based sticky comment flow. Called
+from CI via ``ao-kernel scorecard post-comment``. All failures are
+advisory-only (caller expects exit 0 even on network error / permission
+drop) so benchmark PRs are never red-checked by comment failure.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PostCommentResult:
+    outcome: str  # "posted" | "patched" | "skipped" | "failed"
+    comment_id: int | None
+    message: str
+
+
+def _gh_available() -> bool:
+    return shutil.which("gh") is not None
+
+
+def _list_comments(repo: str, pr: int) -> list[dict[str, Any]]:
+    cmd = [
+        "gh",
+        "api",
+        f"repos/{repo}/issues/{pr}/comments",
+        "--paginate",
+        "--jq",
+        ".[]",
+    ]
+    try:
+        out = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError) as exc:
+        logger.warning("gh api list-comments failed: %s", exc)
+        return []
+    comments: list[dict[str, Any]] = []
+    for line in out.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            comments.append(payload)
+    return comments
+
+
+def _find_sentinel(
+    comments: Sequence[dict[str, Any]],
+    sentinel: str,
+) -> dict[str, Any] | None:
+    for comment in comments:
+        body = comment.get("body")
+        if isinstance(body, str) and sentinel in body:
+            return comment
+    return None
+
+
+def _post_new(repo: str, pr: int, body: str) -> PostCommentResult:
+    cmd = [
+        "gh",
+        "api",
+        f"repos/{repo}/issues/{pr}/comments",
+        "--method",
+        "POST",
+        "--field",
+        f"body={body}",
+    ]
+    try:
+        out = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError) as exc:
+        logger.warning("gh api post-comment failed: %s", exc)
+        return PostCommentResult("failed", None, str(exc))
+    payload: dict[str, Any] = {}
+    try:
+        loaded = json.loads(out.stdout or "{}")
+        if isinstance(loaded, dict):
+            payload = loaded
+    except json.JSONDecodeError:
+        pass
+    raw_id = payload.get("id")
+    comment_id = int(raw_id) if isinstance(raw_id, int) else None
+    return PostCommentResult("posted", comment_id, "created")
+
+
+def _patch_existing(
+    repo: str,
+    comment_id: int,
+    body: str,
+) -> PostCommentResult:
+    cmd = [
+        "gh",
+        "api",
+        f"repos/{repo}/issues/comments/{comment_id}",
+        "--method",
+        "PATCH",
+        "--field",
+        f"body={body}",
+    ]
+    try:
+        subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError) as exc:
+        logger.warning("gh api patch-comment failed: %s", exc)
+        return PostCommentResult("failed", comment_id, str(exc))
+    return PostCommentResult("patched", comment_id, "updated")
+
+
+def upsert_sticky_comment(
+    *,
+    repo: str,
+    pr: int,
+    body: str,
+    sentinel: str,
+) -> PostCommentResult:
+    """Upsert a PR comment bearing ``sentinel``.
+
+    If a comment containing the sentinel already exists, PATCH it.
+    Otherwise POST a new one. All failures are downgraded to
+    ``PostCommentResult(outcome="failed")`` — caller exits 0 regardless.
+    """
+    if not _gh_available():
+        return PostCommentResult("skipped", None, "gh CLI not on PATH")
+    if sentinel not in body:
+        return PostCommentResult("skipped", None, "body missing sentinel")
+    comments = _list_comments(repo, pr)
+    existing = _find_sentinel(comments, sentinel)
+    if existing is not None:
+        comment_id_raw = existing.get("id")
+        if isinstance(comment_id_raw, int):
+            return _patch_existing(repo, comment_id_raw, body)
+    return _post_new(repo, pr, body)
+
+
+__all__ = ["PostCommentResult", "upsert_sticky_comment"]

--- a/ao_kernel/_internal/scorecard/render.py
+++ b/ao_kernel/_internal/scorecard/render.py
@@ -1,0 +1,143 @@
+"""Scorecard render — markdown for PR comment.
+
+Consumes a :class:`ScorecardDiff` and produces a compact markdown
+block suitable for `gh pr comment --body-file`. The first line is the
+HTML sentinel ``<!-- ao-scorecard -->`` used by the sticky-comment
+upsert flow (see ``post_comment.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from ao_kernel._internal.scorecard.compare import BenchmarkDiff, ScorecardDiff
+
+
+SENTINEL = "<!-- ao-scorecard -->"
+_DASH = "—"
+
+
+def _fmt_delta_pct(value: float | None) -> str:
+    if value is None:
+        return _DASH
+    if abs(value) < 0.05:
+        return "(−)"
+    arrow = "▲" if value > 0 else "▼"
+    return f"({arrow}{abs(value):.1f}%)"
+
+
+def _fmt_score_delta(value: float | None) -> str:
+    if value is None:
+        return _DASH
+    if abs(value) < 0.005:
+        return "(−)"
+    sign = "+" if value > 0 else ""
+    return f"({sign}{value:.2f})"
+
+
+def _fmt_duration(ms: int | None, delta: str) -> str:
+    if ms is None:
+        return _DASH
+    return f"{ms}ms {delta}".strip()
+
+
+def _fmt_cost(usd: float | None, delta: str) -> str:
+    if usd is None:
+        return _DASH
+    return f"${usd:.4f} {delta}".strip()
+
+
+def _fmt_review_score(score: float | None, delta: str) -> str:
+    if score is None:
+        return _DASH
+    return f"{score:.2f} {delta}".strip()
+
+
+def _status_cell(status: str, changed: bool) -> str:
+    icon = "✅" if status == "pass" else "❌"
+    if changed:
+        return f"{icon} {status} ⚠️"
+    return f"{icon} {status}"
+
+
+def render_row(
+    entry: BenchmarkDiff,
+    head_entry: Mapping[str, Any] | None,
+) -> str:
+    status = _status_cell(entry.head_status, entry.status_changed)
+    dur_delta = _fmt_delta_pct(entry.duration_delta_pct)
+    cost_delta = _fmt_delta_pct(entry.cost_delta_pct)
+    score_delta = _fmt_score_delta(entry.review_score_delta)
+
+    entry_data: Mapping[str, Any] = head_entry or {}
+    dur = _fmt_duration(entry_data.get("duration_ms"), dur_delta)
+    cost = _fmt_cost(entry_data.get("cost_consumed_usd"), cost_delta)
+    score = _fmt_review_score(entry_data.get("review_score"), score_delta)
+    return f"| {entry.scenario} | {status} | {dur} | {cost} | {score} |"
+
+
+def _render_footer(
+    diff: ScorecardDiff,
+    regressions: Iterable[BenchmarkDiff],
+) -> str:
+    baseline = f"`{diff.baseline_sha}`" if diff.baseline_sha else "_(not found)_"
+    head = f"`{diff.head_sha}`"
+    cost_source_note = ""
+    if diff.head_cost_source == "mock_shim":
+        cost_source_note = " · Cost source: `mock_shim` (benchmark-only; not real billing)"
+    elif diff.head_cost_source:
+        cost_source_note = f" · Cost source: `{diff.head_cost_source}`"
+    pr_note = ""
+    if diff.pr_number is not None:
+        pr_note = f" · PR: #{diff.pr_number}"
+    regression_list = list(regressions)
+    if not regression_list:
+        summary = "No regressions."
+    else:
+        summary = f"⚠️ {len(regression_list)} regression(s) detected."
+    return f"_Baseline: {baseline} · HEAD: {head}{pr_note}{cost_source_note} · {summary}_"
+
+
+def _render_regression_list(regressions: Iterable[BenchmarkDiff]) -> str:
+    lines: list[str] = []
+    for entry in regressions:
+        reasons = ", ".join(entry.regression_reasons) or "regressed"
+        lines.append(f"- **{entry.scenario}**: {reasons}")
+    if not lines:
+        return ""
+    return "\n\n**Regressions:**\n\n" + "\n".join(lines)
+
+
+def render_diff(
+    diff: ScorecardDiff,
+    *,
+    head_scorecard: Mapping[str, Any] | None = None,
+) -> str:
+    """Render a PR-comment-ready markdown block for ``diff``.
+
+    ``head_scorecard`` is optional; when provided its benchmark entries
+    are used to surface absolute values (head duration/cost/score) next
+    to the deltas. Pass the parsed head scorecard JSON.
+    """
+    header = "### 📊 Benchmark Scorecard\n\n"
+    table = "| Scenario | Status | Duration | Cost (USD) | Review Score |\n|---|---|---|---|---|\n"
+    head_by_scenario: dict[str, Mapping[str, Any]] = {}
+    if isinstance(head_scorecard, Mapping):
+        for entry in head_scorecard.get("benchmarks") or []:
+            if isinstance(entry, Mapping) and isinstance(entry.get("scenario"), str):
+                head_by_scenario[entry["scenario"]] = entry
+
+    body_rows: list[str] = []
+    regressions: list[BenchmarkDiff] = []
+    for entry in diff.entries:
+        body_rows.append(render_row(entry, head_by_scenario.get(entry.scenario)))
+        if entry.regression:
+            regressions.append(entry)
+
+    body = table + "\n".join(body_rows) + "\n"
+    footer = _render_footer(diff, regressions)
+    regression_list = _render_regression_list(regressions)
+    return f"{SENTINEL}\n{header}{body}\n{footer}{regression_list}\n"
+
+
+__all__ = ["SENTINEL", "render_diff", "render_row"]

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -490,6 +490,20 @@ def _cmd_scorecard_compare(args: argparse.Namespace) -> int:
             )
 
     policy = _resolve_scorecard_policy(getattr(args, "project_root", None))
+    # Codex post-impl review SUGGEST absorb: `enabled=false` gates the
+    # compare/comment opinion layer. Emit an advisory banner + exit 0
+    # without rendering the full diff so downstream stages know the
+    # output is intentionally empty.
+    if not bool(policy.get("enabled", True)):
+        print("<!-- ao-scorecard -->")
+        print(
+            "### 📊 Benchmark Scorecard\n\n_Scorecard compare disabled via `policy_scorecard.enabled=false`._",
+        )
+        print(
+            "INFO: policy_scorecard.enabled=false; compare skipped.",
+            file=sys.stderr,
+        )
+        return 0
     diff = compare_scorecards(baseline, head, policy=policy)
     rendered = render_diff(diff, head_scorecard=head)
     print(rendered)
@@ -527,13 +541,34 @@ def _cmd_scorecard_render(args: argparse.Namespace) -> int:
 
 
 def _cmd_scorecard_post_comment(args: argparse.Namespace) -> int:
-    """CI-side sentinel-sticky upsert via gh; advisory-only (exit 0)."""
+    """CI-side sentinel-sticky upsert via gh; advisory-only (exit 0).
+
+    Codex post-impl review SUGGEST absorb: honour
+    ``policy_scorecard.enabled`` and ``policy_scorecard.post_pr_comment``.
+    When either flag is false, skip the upsert entirely with an
+    advisory stderr line. Policy is still resolved so operators can
+    override via workspace policy files.
+    """
     import os
     from pathlib import Path as _Path
 
     from ao_kernel._internal.scorecard.post_comment import (
         upsert_sticky_comment,
     )
+
+    policy = _resolve_scorecard_policy(getattr(args, "project_root", None))
+    if not bool(policy.get("enabled", True)):
+        print(
+            "INFO: policy_scorecard.enabled=false; post-comment skipped.",
+            file=sys.stderr,
+        )
+        return 0
+    if not bool(policy.get("post_pr_comment", True)):
+        print(
+            "INFO: policy_scorecard.post_pr_comment=false; upsert skipped.",
+            file=sys.stderr,
+        )
+        return 0
 
     body_path = _Path(args.body_file).expanduser().resolve()
     if not body_path.is_file():
@@ -1157,6 +1192,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--repo",
         default=None,
         help="`owner/name` slug (default: $GITHUB_REPOSITORY).",
+    )
+    post_sc_p.add_argument(
+        "--project-root",
+        default=None,
+        help="Project root (optional; resolves workspace policy override).",
     )
 
     return parser

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -22,11 +22,13 @@ def _cmd_version(args: argparse.Namespace) -> int:
 
 def _cmd_init(args: argparse.Namespace) -> int:
     from ao_kernel.init_cmd import run
+
     return run(workspace_root_override=args.workspace_root)
 
 
 def _cmd_migrate(args: argparse.Namespace) -> int:
     from ao_kernel.migrate_cmd import run
+
     return run(
         workspace_root_override=args.workspace_root,
         dry_run=args.dry_run,
@@ -36,6 +38,7 @@ def _cmd_migrate(args: argparse.Namespace) -> int:
 
 def _cmd_doctor(args: argparse.Namespace) -> int:
     from ao_kernel.doctor_cmd import run
+
     return run(workspace_root_override=args.workspace_root)
 
 
@@ -43,18 +46,22 @@ def _cmd_mcp_serve(args: argparse.Namespace) -> int:
     transport = getattr(args, "transport", "stdio")
     try:
         import asyncio
+
         if transport == "http":
             from ao_kernel.mcp_server import serve_http
+
             host = getattr(args, "host", "127.0.0.1")
             port = getattr(args, "port", 8080)
             asyncio.run(serve_http(host=host, port=port))
         else:
             from ao_kernel.mcp_server import serve_stdio
+
             asyncio.run(serve_stdio())
         return 0
     except ImportError as e:
         if "mcp" in str(e).lower():
             from ao_kernel.i18n import msg
+
             print(msg("error_mcp_missing"))
             return 1
         raise
@@ -102,10 +109,7 @@ def _cmd_cost_reconcile(args: argparse.Namespace) -> int:
             f"Reconciler {mode}: found={result.orphans_found} "
             f"fixed={result.orphans_fixed} skipped={result.orphans_skipped}"
         )
-        print(
-            f"Cursor: offset {result.cursor_offset_before} → "
-            f"{result.cursor_offset_after}"
-        )
+        print(f"Cursor: offset {result.cursor_offset_before} → {result.cursor_offset_after}")
         if result.errors:
             print("Errors:")
             for err in result.errors:
@@ -139,10 +143,7 @@ def _cmd_cost_compact_markers(args: argparse.Namespace) -> int:
             payload = {
                 "run_id": res.run_id,
                 "markers_archived": res.markers_archived,
-                "archive_path": (
-                    str(res.archive_path.relative_to(project_root))
-                    if res.archive_path else None
-                ),
+                "archive_path": (str(res.archive_path.relative_to(project_root)) if res.archive_path else None),
                 "already_compact": res.already_compact,
                 "dry_run": dry_run,
             }
@@ -152,11 +153,7 @@ def _cmd_cost_compact_markers(args: argparse.Namespace) -> int:
             if res.already_compact:
                 print(f"run {res.run_id}: already compact (no markers)")
             else:
-                print(
-                    f"run {res.run_id} [{status}]: archived "
-                    f"{res.markers_archived} marker(s) → "
-                    f"{res.archive_path}"
-                )
+                print(f"run {res.run_id} [{status}]: archived {res.markers_archived} marker(s) → {res.archive_path}")
         return 0
 
     bulk = compact_all_terminal_runs(project_root, dry_run=dry_run)
@@ -198,7 +195,8 @@ def _cmd_consultation_promote(args: argparse.Namespace) -> int:
 
     project_root = _Path(args.project_root or _Path.cwd()).resolve()
     policy = load_with_override(
-        "policies", "policy_agent_consultation.v1.json",
+        "policies",
+        "policy_agent_consultation.v1.json",
         workspace=project_root / ".ao",
     )
 
@@ -244,9 +242,7 @@ def _cmd_consultation_promote(args: argparse.Namespace) -> int:
             print("Errors:")
             for err in summary.errors:
                 print(f"  - {err}")
-    return 0 if (
-        not summary.errors and summary.skipped_disabled == 0
-    ) else (0 if summary.skipped_disabled else 1)
+    return 0 if (not summary.errors and summary.skipped_disabled == 0) else (0 if summary.skipped_disabled else 1)
 
 
 def _cmd_consultation_archive(args: argparse.Namespace) -> int:
@@ -266,15 +262,14 @@ def _cmd_consultation_archive(args: argparse.Namespace) -> int:
 
     project_root = _Path(args.project_root or _Path.cwd()).resolve()
     policy = load_with_override(
-        "policies", "policy_agent_consultation.v1.json",
+        "policies",
+        "policy_agent_consultation.v1.json",
         workspace=project_root / ".ao",
     )
 
     # --verify path: no mutation, integrity-only
     if getattr(args, "verify", False):
-        evidence_root = (
-            project_root / ".ao" / "evidence" / "consultations"
-        )
+        evidence_root = project_root / ".ao" / "evidence" / "consultations"
         verify_results: list[tuple[str, bool, list[str]]] = []
         overall_ok = True
         if evidence_root.is_dir():
@@ -291,17 +286,11 @@ def _cmd_consultation_archive(args: argparse.Namespace) -> int:
             payload = {
                 "ok": overall_ok,
                 "scanned": len(verify_results),
-                "results": [
-                    {"cns_id": name, "ok": ok, "errors": list(errs)}
-                    for name, ok, errs in verify_results
-                ],
+                "results": [{"cns_id": name, "ok": ok, "errors": list(errs)} for name, ok, errs in verify_results],
             }
             print(_json.dumps(payload, indent=2, sort_keys=True))
         else:
-            print(
-                f"Consultation verify: scanned={len(verify_results)} "
-                f"ok={overall_ok}"
-            )
+            print(f"Consultation verify: scanned={len(verify_results)} ok={overall_ok}")
             for name, ok, errs in verify_results:
                 if not ok:
                     print(f"  - {name}:")
@@ -360,7 +349,8 @@ def _cmd_consultation_migrate(args: argparse.Namespace) -> int:
     # resources live under `<project_root>/.ao/`; load_with_override
     # resolves to bundled default when no override exists.
     policy = load_with_override(
-        "policies", "policy_agent_consultation.v1.json",
+        "policies",
+        "policy_agent_consultation.v1.json",
         workspace=project_root / ".ao",
     )
 
@@ -378,10 +368,7 @@ def _cmd_consultation_migrate(args: argparse.Namespace) -> int:
             "copied": result.copied_count,
             "skipped_existing": result.skipped_existing,
             "skipped_invalid": result.skipped_invalid,
-            "backup_manifest": (
-                str(result.backup_manifest)
-                if result.backup_manifest else None
-            ),
+            "backup_manifest": (str(result.backup_manifest) if result.backup_manifest else None),
             "entries": [
                 {
                     "artefact": e.artefact,
@@ -405,6 +392,171 @@ def _cmd_consultation_migrate(args: argparse.Namespace) -> int:
         if result.backup_manifest:
             print(f"Backup manifest: {result.backup_manifest}")
     return 0
+
+
+def _resolve_scorecard_policy(
+    project_root: object = None,
+) -> "dict[str, object]":
+    """Load policy_scorecard.v1.json with optional workspace override."""
+    from pathlib import Path as _Path
+
+    from ao_kernel.config import load_with_override
+
+    workspace: _Path | None = None
+    if project_root is not None:
+        workspace = _Path(str(project_root)).expanduser().resolve() / ".ao"
+    return load_with_override(
+        "policies",
+        "policy_scorecard.v1.json",
+        workspace=workspace,
+    )
+
+
+def _cmd_scorecard_emit(args: argparse.Namespace) -> int:
+    """Run benchmarks + write scorecard. Policy-agnostic (plan §3.8)."""
+    import os
+    import subprocess
+    from pathlib import Path as _Path
+
+    from ao_kernel._internal.scorecard.collector import (
+        DEFAULT_OUTPUT_FILENAME,
+        resolve_output_path,
+    )
+
+    output = _Path(args.output_path).expanduser().resolve() if args.output_path else resolve_output_path()
+    env = os.environ.copy()
+    env["AO_SCORECARD_OUTPUT"] = str(output)
+    cmd = ["pytest", "tests/benchmarks/", "-q"]
+    if args.pytest_args:
+        cmd.extend(args.pytest_args)
+    try:
+        completed = subprocess.run(cmd, env=env, check=False)
+    except FileNotFoundError:
+        print(
+            "pytest binary not found; install the [dev] extra or run in a virtualenv.",
+            file=sys.stderr,
+        )
+        return 2
+    # Emit is advisory: even on pytest failure the scorecard is written by
+    # the pytest_sessionfinish hook (failure diagnostic carried in content).
+    if not output.is_file():
+        print(
+            f"scorecard output not produced at {output} (check benchmark session logs).",
+            file=sys.stderr,
+        )
+        return completed.returncode or 3
+    print(f"scorecard emitted: {output}")
+    if completed.returncode != 0:
+        print(
+            f"pytest exit={completed.returncode}; see benchmark logs above.",
+            file=sys.stderr,
+        )
+    if not args.output_path and output != resolve_output_path():
+        print(
+            f"(default filename would have been {DEFAULT_OUTPUT_FILENAME})",
+            file=sys.stderr,
+        )
+    return completed.returncode
+
+
+def _cmd_scorecard_compare(args: argparse.Namespace) -> int:
+    """Diff baseline vs head + render + exit per fail_action."""
+    import json as _json
+    from pathlib import Path as _Path
+
+    from ao_kernel._internal.scorecard.compare import (
+        compare_scorecards,
+        exit_code_for,
+    )
+    from ao_kernel._internal.scorecard.render import render_diff
+
+    head_path = _Path(args.head).expanduser().resolve()
+    if not head_path.is_file():
+        print(f"head scorecard not found: {head_path}", file=sys.stderr)
+        return 2
+    head = _json.loads(head_path.read_text(encoding="utf-8"))
+
+    baseline = None
+    baseline_sha = "_(not found)_"
+    if args.baseline:
+        baseline_path = _Path(args.baseline).expanduser().resolve()
+        if baseline_path.is_file():
+            baseline = _json.loads(baseline_path.read_text(encoding="utf-8"))
+            baseline_sha = baseline.get("git_sha", "unknown") if isinstance(baseline, dict) else "unknown"
+        else:
+            print(
+                f"baseline scorecard not found at {baseline_path}; rendering diff against empty baseline.",
+                file=sys.stderr,
+            )
+
+    policy = _resolve_scorecard_policy(getattr(args, "project_root", None))
+    diff = compare_scorecards(baseline, head, policy=policy)
+    rendered = render_diff(diff, head_scorecard=head)
+    print(rendered)
+    if diff.has_regression and policy.get("fail_action") == "warn":
+        print(
+            f"WARN: regression detected (baseline={baseline_sha}) — bundled policy is warn-only; exit 0.",
+            file=sys.stderr,
+        )
+    return exit_code_for(diff)
+
+
+def _cmd_scorecard_render(args: argparse.Namespace) -> int:
+    """Render markdown only — no policy evaluation, always exit 0."""
+    import json as _json
+    from pathlib import Path as _Path
+
+    from ao_kernel._internal.scorecard.compare import compare_scorecards
+    from ao_kernel._internal.scorecard.render import render_diff
+
+    head_path = _Path(args.input).expanduser().resolve()
+    if not head_path.is_file():
+        print(f"input scorecard not found: {head_path}", file=sys.stderr)
+        return 2
+    head = _json.loads(head_path.read_text(encoding="utf-8"))
+
+    baseline = None
+    if args.baseline:
+        baseline_path = _Path(args.baseline).expanduser().resolve()
+        if baseline_path.is_file():
+            baseline = _json.loads(baseline_path.read_text(encoding="utf-8"))
+
+    diff = compare_scorecards(baseline, head)
+    print(render_diff(diff, head_scorecard=head))
+    return 0
+
+
+def _cmd_scorecard_post_comment(args: argparse.Namespace) -> int:
+    """CI-side sentinel-sticky upsert via gh; advisory-only (exit 0)."""
+    import os
+    from pathlib import Path as _Path
+
+    from ao_kernel._internal.scorecard.post_comment import (
+        upsert_sticky_comment,
+    )
+
+    body_path = _Path(args.body_file).expanduser().resolve()
+    if not body_path.is_file():
+        print(f"body file not found: {body_path}", file=sys.stderr)
+        return 0  # advisory
+    body = body_path.read_text(encoding="utf-8")
+
+    repo = args.repo or os.environ.get("GITHUB_REPOSITORY") or ""
+    if not repo:
+        print(
+            "GITHUB_REPOSITORY env var or --repo flag required; skipping post.",
+            file=sys.stderr,
+        )
+        return 0  # advisory
+
+    result = upsert_sticky_comment(
+        repo=repo,
+        pr=int(args.pr),
+        body=body,
+        sentinel=args.sentinel,
+    )
+    print(f"post-comment {result.outcome}: {result.message}")
+    return 0  # always advisory
 
 
 def _cmd_executor_dry_run(args: argparse.Namespace) -> int:
@@ -447,8 +599,7 @@ def _cmd_executor_dry_run(args: argparse.Namespace) -> int:
     )
     if step_def is None:
         print(
-            f"step_name={args.step_name!r} not in workflow "
-            f"{record['workflow_id']}@{record['workflow_version']}",
+            f"step_name={args.step_name!r} not in workflow {record['workflow_id']}@{record['workflow_version']}",
             file=sys.stderr,
         )
         return 1
@@ -465,10 +616,7 @@ def _cmd_executor_dry_run(args: argparse.Namespace) -> int:
     # derivation matches the real run. `--executor-only` flag still
     # forces executor path for debugging / backward-compat.
     executor_only = getattr(args, "executor_only", False)
-    use_driver = (
-        (not executor_only)
-        and step_def.actor in ("adapter", "system", "ao-kernel")
-    )
+    use_driver = (not executor_only) and step_def.actor in ("adapter", "system", "ao-kernel")
     if use_driver:
         from ao_kernel.executor.multi_step_driver import MultiStepDriver
 
@@ -479,18 +627,19 @@ def _cmd_executor_dry_run(args: argparse.Namespace) -> int:
             executor=executor,
         )
         result = driver.dry_run_step(
-            args.run_id, args.step_name, attempt=args.attempt,
+            args.run_id,
+            args.step_name,
+            attempt=args.attempt,
         )
     else:
         result = executor.dry_run_step(
-            args.run_id, step_def, attempt=args.attempt or 1,
+            args.run_id,
+            step_def,
+            attempt=args.attempt or 1,
         )
     if args.format == "json":
         out = {
-            "predicted_events": [
-                {"kind": k, "payload": dict(p)}
-                for k, p in result.predicted_events
-            ],
+            "predicted_events": [{"kind": k, "payload": dict(p)} for k, p in result.predicted_events],
             "policy_violations": list(result.policy_violations),
             "simulated_budget_after": dict(result.simulated_budget_after),
             "simulated_outputs": dict(result.simulated_outputs),
@@ -548,8 +697,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     vm_p = ev_sub.add_parser("verify-manifest", help="Verify SHA-256 manifest")
     vm_p.add_argument("--run", dest="run_id", required=True, help="Run ID (UUID)")
-    vm_p.add_argument("--generate-if-missing", action="store_true",
-                       help="Generate manifest first if absent")
+    vm_p.add_argument("--generate-if-missing", action="store_true", help="Generate manifest first if absent")
 
     mcp_p = sub.add_parser("mcp", help="MCP server commands")
     mcp_sub = mcp_p.add_subparsers(dest="mcp_command")
@@ -586,19 +734,13 @@ def _build_parser() -> argparse.ArgumentParser:
 
     debug_p = metrics_sub.add_parser(
         "debug-query",
-        help=(
-            "Ad-hoc JSON query over evidence events "
-            "(never Prometheus textfile; for operator debugging)"
-        ),
+        help=("Ad-hoc JSON query over evidence events (never Prometheus textfile; for operator debugging)"),
     )
     debug_p.add_argument(
         "--since",
         type=parse_iso8601_strict,
         default=None,
-        help=(
-            "Filter events at or after this ISO-8601 timestamp; "
-            "timezone required (use 'Z' or '+HH:MM')"
-        ),
+        help=("Filter events at or after this ISO-8601 timestamp; timezone required (use 'Z' or '+HH:MM')"),
     )
     debug_p.add_argument(
         "--run",
@@ -646,10 +788,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _proposed_group.add_argument(
         "--proposed-patches",
         default=None,
-        help=(
-            "Directory containing RFC 7396 JSON Merge Patch files "
-            "(<name>.v1.patch.json → patches <name>.v1.json)"
-        ),
+        help=("Directory containing RFC 7396 JSON Merge Patch files (<name>.v1.patch.json → patches <name>.v1.json)"),
     )
     run_p.add_argument(
         "--baseline-source",
@@ -795,22 +934,28 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     migrate_cons_p.add_argument(
-        "--dry-run", action="store_true",
+        "--dry-run",
+        action="store_true",
         help="Report what WOULD be copied without touching disk.",
     )
     migrate_cons_p.add_argument(
-        "--force", action="store_true",
+        "--force",
+        action="store_true",
         help="Overwrite pre-existing canonical files (non-destructive by default).",
     )
     migrate_cons_p.add_argument(
-        "--include-invalid", action="store_true",
+        "--include-invalid",
+        action="store_true",
         help="Copy files flagged INVALID_JSON anyway (default: skipped).",
     )
     migrate_cons_p.add_argument(
-        "--output", choices=["json", "human"], default="human",
+        "--output",
+        choices=["json", "human"],
+        default="human",
     )
     migrate_cons_p.add_argument(
-        "--project-root", default=None,
+        "--project-root",
+        default=None,
         help="Project root (default: cwd)",
     )
 
@@ -825,11 +970,13 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     archive_cons_p.add_argument(
-        "--dry-run", action="store_true",
+        "--dry-run",
+        action="store_true",
         help="Report scope without touching disk.",
     )
     archive_cons_p.add_argument(
-        "--renormalize", action="store_true",
+        "--renormalize",
+        action="store_true",
         help=(
             "Force resolution record rebuild even if digest matches. "
             "Use after normalizer_version upgrade to backfill historical "
@@ -837,7 +984,8 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     archive_cons_p.add_argument(
-        "--verify", action="store_true",
+        "--verify",
+        action="store_true",
         help=(
             "Verify integrity manifests for all existing evidence "
             "directories under `.ao/evidence/consultations/`. No "
@@ -846,10 +994,13 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     archive_cons_p.add_argument(
-        "--output", choices=["json", "human"], default="human",
+        "--output",
+        choices=["json", "human"],
+        default="human",
     )
     archive_cons_p.add_argument(
-        "--project-root", default=None,
+        "--project-root",
+        default=None,
     )
 
     # v3.5 D2b: consultation promote subcommand
@@ -864,21 +1015,23 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     promote_cons_p.add_argument(
-        "--dry-run", action="store_true",
+        "--dry-run",
+        action="store_true",
         help="Count what WOULD be promoted without touching the store.",
     )
     promote_cons_p.add_argument(
-        "--force", action="store_true",
-        help=(
-            "Bypass the policy.promotion.enabled gate for this run "
-            "(integrity + eligibility still enforced)."
-        ),
+        "--force",
+        action="store_true",
+        help=("Bypass the policy.promotion.enabled gate for this run (integrity + eligibility still enforced)."),
     )
     promote_cons_p.add_argument(
-        "--output", choices=["json", "human"], default="human",
+        "--output",
+        choices=["json", "human"],
+        default="human",
     )
     promote_cons_p.add_argument(
-        "--project-root", default=None,
+        "--project-root",
+        default=None,
     )
 
     # v3.4.0 #3: cost compact-markers subcommand
@@ -894,18 +1047,12 @@ def _build_parser() -> argparse.ArgumentParser:
     compact_p.add_argument(
         "--run-id",
         default=None,
-        help=(
-            "Compact a single run by id. Mutually exclusive with "
-            "--all-terminal."
-        ),
+        help=("Compact a single run by id. Mutually exclusive with --all-terminal."),
     )
     compact_p.add_argument(
         "--all-terminal",
         action="store_true",
-        help=(
-            "Compact every on-disk run in a terminal state "
-            "(completed / failed / cancelled)."
-        ),
+        help=("Compact every on-disk run in a terminal state (completed / failed / cancelled)."),
     )
     compact_p.add_argument(
         "--dry-run",
@@ -922,6 +1069,94 @@ def _build_parser() -> argparse.ArgumentParser:
         "--project-root",
         default=None,
         help="Project root (default: cwd)",
+    )
+
+    # v3.5 D3: scorecard subcommand
+    scorecard_p = sub.add_parser(
+        "scorecard",
+        help=("Dev scorecard for PR-B7 benchmarks: emit, compare vs main baseline, render markdown, post-comment."),
+    )
+    scorecard_sub = scorecard_p.add_subparsers(dest="scorecard_command")
+
+    emit_sc_p = scorecard_sub.add_parser(
+        "emit",
+        help=("Run tests/benchmarks/ via pytest and write benchmark_scorecard.v1.json. Policy-agnostic."),
+    )
+    emit_sc_p.add_argument(
+        "--output",
+        dest="output_path",
+        default=None,
+        help=("Output path (default: $AO_SCORECARD_OUTPUT or ./benchmark_scorecard.v1.json)."),
+    )
+    emit_sc_p.add_argument(
+        "pytest_args",
+        nargs=argparse.REMAINDER,
+        help="Extra arguments forwarded to pytest after `--`.",
+    )
+
+    compare_sc_p = scorecard_sub.add_parser(
+        "compare",
+        help=("Diff baseline vs head scorecard, render markdown, exit per policy_scorecard.fail_action."),
+    )
+    compare_sc_p.add_argument(
+        "--baseline",
+        default=None,
+        help="Path to baseline scorecard JSON.",
+    )
+    compare_sc_p.add_argument(
+        "--head",
+        required=True,
+        help="Path to head scorecard JSON.",
+    )
+    compare_sc_p.add_argument(
+        "--project-root",
+        default=None,
+        help="Project root (optional; resolves workspace policy override).",
+    )
+
+    render_sc_p = scorecard_sub.add_parser(
+        "render",
+        help="Render diff markdown to stdout (no policy, always exit 0).",
+    )
+    render_sc_p.add_argument(
+        "--input",
+        required=True,
+        help="Path to head scorecard JSON.",
+    )
+    render_sc_p.add_argument(
+        "--baseline",
+        default=None,
+        help="Optional baseline scorecard JSON for delta columns.",
+    )
+
+    post_sc_p = scorecard_sub.add_parser(
+        "post-comment",
+        help=("Upsert a sentinel-tagged sticky comment on a PR. Advisory-only — exit 0 on any failure."),
+    )
+    post_sc_p.add_argument(
+        "--pr",
+        required=True,
+        type=int,
+        help="PR number.",
+    )
+    post_sc_p.add_argument(
+        "--body-file",
+        required=True,
+        help="Path to rendered markdown.",
+    )
+    post_sc_p.add_argument(
+        "--sentinel",
+        required=True,
+        help=(
+            "HTML sentinel string the body must contain. "
+            "Existing comments that include this string are PATCHed "
+            "instead of posted fresh."
+        ),
+    )
+    post_sc_p.add_argument(
+        "--repo",
+        default=None,
+        help="`owner/name` slug (default: $GITHUB_REPOSITORY).",
     )
 
     return parser
@@ -951,6 +1186,7 @@ def main(argv: list[str] | None = None) -> int:
             cmd_timeline,
             cmd_verify_manifest,
         )
+
         ev_dispatch = {
             "timeline": cmd_timeline,
             "replay": cmd_replay,
@@ -970,6 +1206,7 @@ def main(argv: list[str] | None = None) -> int:
         if mcp_cmd == "serve":
             return _cmd_mcp_serve(args)
         from ao_kernel.i18n import msg
+
         print(msg("usage_mcp_serve"))
         return 1
 
@@ -1017,6 +1254,23 @@ def main(argv: list[str] | None = None) -> int:
             return _cmd_cost_compact_markers(args)
         print(
             "Usage: ao-kernel cost {reconcile|compact-markers}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Scorecard subcommand (v3.5 D3)
+    if cmd == "scorecard":
+        sc_cmd = getattr(args, "scorecard_command", None)
+        if sc_cmd == "emit":
+            return _cmd_scorecard_emit(args)
+        if sc_cmd == "compare":
+            return _cmd_scorecard_compare(args)
+        if sc_cmd == "render":
+            return _cmd_scorecard_render(args)
+        if sc_cmd == "post-comment":
+            return _cmd_scorecard_post_comment(args)
+        print(
+            "Usage: ao-kernel scorecard {emit|compare|render|post-comment}",
             file=sys.stderr,
         )
         return 1

--- a/ao_kernel/defaults/policies/policy_scorecard.v1.json
+++ b/ao_kernel/defaults/policies/policy_scorecard.v1.json
@@ -1,0 +1,11 @@
+{
+  "version": "v1",
+  "enabled": true,
+  "post_pr_comment": true,
+  "regression_threshold": {
+    "cost_usd_relative_pct": 20.0,
+    "duration_ms_relative_pct": 30.0,
+    "review_score_min_delta": -0.1
+  },
+  "fail_action": "warn"
+}

--- a/ao_kernel/defaults/schemas/policy-scorecard.schema.v1.json
+++ b/ao_kernel/defaults/schemas/policy-scorecard.schema.v1.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:policy-scorecard:v1",
+  "title": "Policy Scorecard",
+  "description": "Schema for policy_scorecard.v1.json — governs dev scorecard compare + PR-comment behaviour. v3.5 D3. `enabled` gates compare + comment posting only; the collector `emit` step is policy-agnostic and always produces output.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "enabled", "post_pr_comment", "regression_threshold", "fail_action"],
+  "properties": {
+    "version": { "type": "string", "enum": ["v1"] },
+    "enabled": {
+      "type": "boolean",
+      "description": "When false, `ao-kernel scorecard compare` emits an advisory banner and skips comment posting. Scorecard `emit` is unaffected."
+    },
+    "post_pr_comment": {
+      "type": "boolean",
+      "description": "When false, compare prints the rendered markdown but never invokes `post-comment`."
+    },
+    "regression_threshold": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cost_usd_relative_pct", "duration_ms_relative_pct", "review_score_min_delta"],
+      "properties": {
+        "cost_usd_relative_pct": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Fractional cost increase (percent) at or above which a benchmark entry is flagged as regressed."
+        },
+        "duration_ms_relative_pct": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Fractional duration increase (percent) at or above which a benchmark entry is flagged as regressed."
+        },
+        "review_score_min_delta": {
+          "type": "number",
+          "maximum": 0,
+          "description": "Minimum allowable review_score delta (negative). A drop below this value (more negative) is flagged as regressed."
+        }
+      }
+    },
+    "fail_action": {
+      "type": "string",
+      "enum": ["warn", "block"],
+      "description": "`warn`: regressions rendered but exit 0. `block`: regression → exit 1 (CLI/local use). Bundled default `warn`; CI never sets `block` in v1."
+    }
+  }
+}

--- a/ao_kernel/defaults/schemas/scorecard.schema.v1.json
+++ b/ao_kernel/defaults/schemas/scorecard.schema.v1.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:scorecard:v1",
+  "title": "Benchmark Scorecard",
+  "description": "Typed scorecard artefact emitted by the v3.5 D3 collector after a `tests/benchmarks/` session. One entry per scenario that carries `@pytest.mark.scorecard_primary`. Top-level contract is strict; per-benchmark entries are forward-extensible so future axes (e.g. memory_rss_kib) can land without a schema bump.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "generated_at", "git_sha", "benchmarks"],
+  "properties": {
+    "schema_version": { "const": "v1" },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp of collector session finish."
+    },
+    "git_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,40}$",
+      "description": "HEAD commit SHA at scorecard generation time. Short (7) or full (40) hex accepted."
+    },
+    "git_ref": {
+      "type": "string",
+      "description": "Branch or tag ref, best-effort (e.g. `refs/heads/main`, `feat/v3.5-d3`). Optional — may be absent in local runs."
+    },
+    "pr_number": {
+      "type": ["integer", "null"],
+      "description": "GitHub PR number when running inside a PR CI run; null on main or local."
+    },
+    "benchmarks": {
+      "type": "array",
+      "description": "One entry per primary-marked scenario. Sorted by `scenario` for deterministic artefact diffing.",
+      "items": { "$ref": "#/$defs/benchmark_result" }
+    }
+  },
+  "$defs": {
+    "benchmark_result": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["scenario", "status", "workflow_completed"],
+      "properties": {
+        "scenario": {
+          "type": "string",
+          "description": "Scenario id (e.g. `governed_bugfix`, `governed_review`)."
+        },
+        "status": {
+          "enum": ["pass", "fail"],
+          "description": "Aggregate pass/fail derived from workflow_completed + workflow_failed event presence."
+        },
+        "workflow_completed": {
+          "type": "boolean",
+          "description": "True iff a `workflow_completed` event was observed in the primary run's events.jsonl."
+        },
+        "duration_ms": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Elapsed wall-clock milliseconds between first and last event in the primary run. Null when the run is empty."
+        },
+        "cost_consumed_usd": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "USD consumed from the `cost_usd` budget axis in the primary run's final state snapshot. Null when the axis was not seeded."
+        },
+        "cost_source": {
+          "type": ["string", "null"],
+          "description": "Where cost_consumed_usd originated. v1 always emits `mock_shim` (B7 benchmark-only shim). Post-C3 real-adapter runs will emit `real_adapter`."
+        },
+        "review_score": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Optional reviewer self-confidence score from the `review_findings` capability artefact. Null when the scenario does not produce a review-findings payload."
+        }
+      }
+    }
+  }
+}

--- a/ao_kernel/scorecard.py
+++ b/ao_kernel/scorecard.py
@@ -1,0 +1,81 @@
+"""v3.5 D3 — Dev Scorecard public facade.
+
+Consumes the PR-B7 benchmark suite output (run_dir events.jsonl + run
+state + capability artefacts) and emits a typed scorecard JSON. Three
+CLI verbs:
+
+- ``ao-kernel scorecard emit`` — runs benchmarks via pytest + writes
+  ``benchmark_scorecard.v1.json`` (honours ``AO_SCORECARD_OUTPUT``).
+  Policy-agnostic: always produces output regardless of
+  ``policy_scorecard.enabled``.
+- ``ao-kernel scorecard compare --baseline ... --head ...`` — diffs two
+  scorecards and prints the rendered markdown. Exit 1 on regression
+  when ``fail_action=block``; exit 0 + warn banner otherwise.
+- ``ao-kernel scorecard render --input ...`` — renders markdown only;
+  no policy evaluation, no exit-code gating.
+- ``ao-kernel scorecard post-comment --pr N --body-file F --sentinel M``
+  — CI-side sentinel-sticky upsert via ``gh``; advisory-only (exit 0
+  even on failure).
+
+Canonical scenario input is driven by ``@pytest.mark.scorecard_primary``
+on ``tests/benchmarks/test_governed_{bugfix,review}.py``. Duplicate or
+missing-primary both fail-close at session finish (§3.3 of the PR-D3
+plan).
+
+See ``.claude/plans/PR-D3-DRAFT-PLAN.md`` for the full design contract.
+"""
+
+from __future__ import annotations
+
+from ao_kernel._internal.scorecard.collector import (
+    DEFAULT_OUTPUT_FILENAME,
+    EXPECTED_PRIMARY_SCENARIOS,
+    BenchmarkResult,
+    PrimarySidecar,
+    ScorecardCollectorError,
+    ScorecardRegistry,
+    build_result,
+    build_scorecard,
+    finalize_session,
+    resolve_output_path,
+)
+from ao_kernel._internal.scorecard.compare import (
+    BenchmarkDiff,
+    ScorecardDiff,
+    compare_scorecards,
+    exit_code_for,
+    select_regressions,
+)
+from ao_kernel._internal.scorecard.post_comment import (
+    PostCommentResult,
+    upsert_sticky_comment,
+)
+from ao_kernel._internal.scorecard.render import (
+    SENTINEL,
+    render_diff,
+    render_row,
+)
+
+
+__all__ = [
+    "DEFAULT_OUTPUT_FILENAME",
+    "EXPECTED_PRIMARY_SCENARIOS",
+    "SENTINEL",
+    "BenchmarkDiff",
+    "BenchmarkResult",
+    "PostCommentResult",
+    "PrimarySidecar",
+    "ScorecardCollectorError",
+    "ScorecardDiff",
+    "ScorecardRegistry",
+    "build_result",
+    "build_scorecard",
+    "compare_scorecards",
+    "exit_code_for",
+    "finalize_session",
+    "render_diff",
+    "render_row",
+    "resolve_output_path",
+    "select_regressions",
+    "upsert_sticky_comment",
+]

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -57,14 +57,28 @@ def pytest_sessionfinish(
     session: pytest.Session,
     exitstatus: int,
 ) -> None:
+    """Finalize the scorecard at session end.
+
+    Codex post-impl review BLOCKER fix: canonical-input invariant
+    violations (duplicate or missing primary markers) MUST fail the
+    benchmark job. Previously the exception was log-only, which made
+    misconfiguration silently-green under CI. Now we propagate a
+    non-zero pytest exit code via ``session.exitstatus``.
+    """
     registry = _registry(session.config)
     try:
         finalize_session(registry)
-    except Exception as exc:  # pragma: no cover - diagnostic path
+    except Exception as exc:
         session.config.get_terminal_writer().line(
             f"scorecard finalize failed: {exc}",
             red=True,
         )
+        # pytest ExitCode.USAGE_ERROR=4 signals "misconfigured suite"
+        # which is the right category here (canonical marker contract
+        # broken). Respect pre-existing failures by taking the max.
+        misconfig = int(pytest.ExitCode.USAGE_ERROR)
+        if int(session.exitstatus or 0) < misconfig:
+            session.exitstatus = pytest.ExitCode(misconfig)
 
 
 @pytest.fixture

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -3,6 +3,11 @@
 `--benchmark-mode` flag intentionally NOT exposed — fast mode is
 the only mode B7 ships (full real-adapter mode deferred to B7.1
 per plan v5 §7).
+
+v3.5 D3: scorecard collector hooks are wired here via
+:mod:`ao_kernel._internal.scorecard.collector`. Primary tests tag
+themselves with ``@pytest.mark.scorecard_primary`` and expose a
+:class:`PrimarySidecar` via the ``benchmark_primary_sidecar`` fixture.
 """
 
 from __future__ import annotations
@@ -12,14 +17,80 @@ import shutil
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 import pytest
 
+from ao_kernel._internal.scorecard.collector import (
+    PrimarySidecar,
+    ScorecardRegistry,
+    finalize_session,
+)
 from tests._driver_helpers import build_driver, install_workspace
 
 
 _BUNDLED_ROOT = Path(__file__).resolve().parents[2] / "ao_kernel" / "defaults"
+
+_REGISTRY_ATTR = "_ao_scorecard_registry"
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "scorecard_primary(scenario_id=None): mark the canonical "
+        "happy-path test for a scorecard scenario. Exactly one per "
+        "canonical scenario; duplicates and missing primaries both "
+        "fail-close at session finish.",
+    )
+    setattr(config, _REGISTRY_ATTR, ScorecardRegistry())
+
+
+def _registry(config: pytest.Config) -> ScorecardRegistry:
+    reg = getattr(config, _REGISTRY_ATTR, None)
+    if reg is None:
+        reg = ScorecardRegistry()
+        setattr(config, _REGISTRY_ATTR, reg)
+    return reg
+
+
+def pytest_sessionfinish(
+    session: pytest.Session,
+    exitstatus: int,
+) -> None:
+    registry = _registry(session.config)
+    try:
+        finalize_session(registry)
+    except Exception as exc:  # pragma: no cover - diagnostic path
+        session.config.get_terminal_writer().line(
+            f"scorecard finalize failed: {exc}",
+            red=True,
+        )
+
+
+@pytest.fixture
+def benchmark_primary_sidecar(request: pytest.FixtureRequest) -> Callable[..., PrimarySidecar]:
+    """Factory fixture — primary-marked tests call this once per run
+    with the scenario_id + run_dir they exercised."""
+
+    registry = _registry(request.config)
+
+    def _record(
+        scenario_id: str,
+        run_dir: Path,
+        *,
+        run_state_path: Path | None = None,
+        review_findings_path: Path | None = None,
+    ) -> PrimarySidecar:
+        sidecar = PrimarySidecar(
+            scenario_id=scenario_id,
+            run_dir=Path(run_dir),
+            run_state_path=(Path(run_state_path) if run_state_path else None),
+            review_findings_path=(Path(review_findings_path) if review_findings_path else None),
+        )
+        registry.record(sidecar)
+        return sidecar
+
+    return _record
 
 
 def _now_iso() -> str:

--- a/tests/benchmarks/test_governed_bugfix.py
+++ b/tests/benchmarks/test_governed_bugfix.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from ao_kernel.workflow.run_store import load_run
 
 from tests._driver_helpers import _GIT_CFG
@@ -39,12 +41,14 @@ def _run_dir(workspace_root: Path, run_id: str) -> Path:
 
 
 class TestHappyPath:
+    @pytest.mark.scorecard_primary
     def test_end_to_end_completes(
         self,
         workspace_root: Path,
         seeded_run,
         benchmark_driver,
         seeded_budget,
+        benchmark_primary_sidecar,
     ) -> None:
         run_id = seeded_run(_WORKFLOW_ID, version=_WORKFLOW_VERSION)
         # Bench variant exercises codex-stub only; gh-cli-pr
@@ -55,7 +59,9 @@ class TestHappyPath:
 
         with mock_adapter_transport(canned, scenario_id=_SCENARIO_ID):
             first = benchmark_driver.run_workflow(
-                run_id, _WORKFLOW_ID, _WORKFLOW_VERSION,
+                run_id,
+                _WORKFLOW_ID,
+                _WORKFLOW_VERSION,
             )
             # `bug_fix_flow` carries an await_approval gate;
             # first run should exit awaiting_approval with a token.
@@ -66,7 +72,9 @@ class TestHappyPath:
                     _run_dir(workspace_root, run_id),
                 )
             second = benchmark_driver.resume_workflow(
-                run_id, token, payload={"decision": "granted"},
+                run_id,
+                token,
+                payload={"decision": "granted"},
             )
 
         assert second.final_state == "completed"
@@ -79,9 +87,7 @@ class TestHappyPath:
         # Adapter step records — only codex-stub step has
         # capability_output_refs (gh-cli-pr manifest has no
         # output_parse, v5 Codex W3 absorb).
-        step_records = {
-            step["step_name"]: step for step in record.get("steps", [])
-        }
+        step_records = {step["step_name"]: step for step in record.get("steps", [])}
         coding_step = step_records.get("invoke_coding_agent")
         assert coding_step is not None, step_records
         assert_adapter_ok(coding_step)
@@ -94,6 +100,19 @@ class TestHappyPath:
             coding_step,
             "commit_message",
             run_dir=_run_dir(workspace_root, run_id),
+        )
+
+        # Scorecard primary sidecar — governed_bugfix happy-path has
+        # no review-score contract (the codex-stub envelope carries
+        # review_findings but the scenario asserts only presence, not
+        # score). Pass review_findings_path=None so the collector
+        # records review_score=None. run_state_path points at the
+        # canonical run-state file so cost_consumed_usd extraction
+        # works off the `budget.cost_usd` axis.
+        benchmark_primary_sidecar(
+            _SCENARIO_ID,
+            _run_dir(workspace_root, run_id),
+            run_state_path=workspace_root / ".ao" / "runs" / run_id / "state.v1.json",
         )
 
 
@@ -114,7 +133,9 @@ class TestTransportError:
 
         with mock_adapter_transport(canned, scenario_id=_SCENARIO_ID):
             result = benchmark_driver.run_workflow(
-                run_id, _WORKFLOW_ID, _WORKFLOW_VERSION,
+                run_id,
+                _WORKFLOW_ID,
+                _WORKFLOW_VERSION,
             )
 
         assert result.final_state == "failed"
@@ -150,12 +171,13 @@ def _install_mini_repo(workspace_root: Path) -> None:
     # Commit baseline so worktree picks up the files
     subprocess.run(
         ["git", *_GIT_CFG, "-C", str(workspace_root), "add", "."],
-        check=True, capture_output=True,
+        check=True,
+        capture_output=True,
     )
     subprocess.run(
-        ["git", *_GIT_CFG, "-C", str(workspace_root), "commit",
-         "-q", "-m", "mini_repo baseline"],
-        check=True, capture_output=True,
+        ["git", *_GIT_CFG, "-C", str(workspace_root), "commit", "-q", "-m", "mini_repo baseline"],
+        check=True,
+        capture_output=True,
     )
 
 
@@ -208,10 +230,7 @@ class TestFullBundledBugFixFlow:
             "open_pr",
         ], f"unexpected step order: {step_order!r}"
         # Manifest parity check (C1b W4 absorb)
-        gh_manifest_path = (
-            workspace_root / ".ao" / "adapters"
-            / "gh-cli-pr.manifest.v1.json"
-        )
+        gh_manifest_path = workspace_root / ".ao" / "adapters" / "gh-cli-pr.manifest.v1.json"
         gh_manifest = _json.loads(gh_manifest_path.read_text())
         assert "context_pack_ref" in gh_manifest["input_envelope"], (
             "gh-cli-pr input_envelope must declare context_pack_ref"
@@ -236,17 +255,18 @@ class TestFullBundledBugFixFlow:
         run_id = seeded_run("bug_fix_flow", version="1.0.0")
 
         canned = {
-            ("full_bundled_bugfix", "codex-stub", 1):
-                bug_envelopes.coding_agent_happy(),
-            ("full_bundled_bugfix", "gh-cli-pr", 1):
-                bug_envelopes.open_pr_happy(),
+            ("full_bundled_bugfix", "codex-stub", 1): bug_envelopes.coding_agent_happy(),
+            ("full_bundled_bugfix", "gh-cli-pr", 1): bug_envelopes.open_pr_happy(),
         }
 
         with mock_adapter_transport(
-            canned, scenario_id="full_bundled_bugfix",
+            canned,
+            scenario_id="full_bundled_bugfix",
         ):
             first = benchmark_driver.run_workflow(
-                run_id, "bug_fix_flow", "1.0.0",
+                run_id,
+                "bug_fix_flow",
+                "1.0.0",
             )
             # If first run didn't reach the approval gate, surface
             # the reason with full context — CI environment drift
@@ -254,11 +274,9 @@ class TestFullBundledBugFixFlow:
             # platform-specific.
             if first.final_state != "waiting_approval":
                 from ao_kernel.workflow.run_store import load_run
+
                 record, _ = load_run(workspace_root, run_id)
-                step_records = {
-                    step["step_name"]: step
-                    for step in record.get("steps", [])
-                }
+                step_records = {step["step_name"]: step for step in record.get("steps", [])}
                 failed = [
                     {
                         "step_name": name,
@@ -277,9 +295,8 @@ class TestFullBundledBugFixFlow:
                 )
                 if failed:
                     import pytest as _pytest
-                    _pytest.skip(
-                        f"{pytest_skip_reason}; failed_steps={failed!r}"
-                    )
+
+                    _pytest.skip(f"{pytest_skip_reason}; failed_steps={failed!r}")
                 raise AssertionError(
                     f"expected waiting_approval, got "
                     f"{first.final_state!r}; no failed steps but flow "
@@ -290,32 +307,25 @@ class TestFullBundledBugFixFlow:
                 _run_dir(workspace_root, run_id),
             )
             final = benchmark_driver.resume_workflow(
-                run_id, token, payload={"decision": "granted"},
+                run_id,
+                token,
+                payload={"decision": "granted"},
             )
 
         from ao_kernel.workflow.run_store import load_run
+
         record, _ = load_run(workspace_root, run_id)
         if final.final_state != "completed":
-            step_records = {
-                step["step_name"]: step
-                for step in record.get("steps", [])
-            }
+            step_records = {step["step_name"]: step for step in record.get("steps", [])}
             failed = [
-                (name, step.get("error", {}))
-                for name, step in step_records.items()
-                if step.get("state") == "failed"
+                (name, step.get("error", {})) for name, step in step_records.items() if step.get("state") == "failed"
             ]
-            raise AssertionError(
-                f"expected completed, got {final.final_state!r}; "
-                f"failed_steps={failed!r}"
-            )
+            raise AssertionError(f"expected completed, got {final.final_state!r}; failed_steps={failed!r}")
 
         assert_workflow_completed(_run_dir(workspace_root, run_id))
 
         # All 7 steps should have run (some may be skipped if upstream failed).
-        step_records = {
-            step["step_name"]: step for step in record.get("steps", [])
-        }
+        step_records = {step["step_name"]: step for step in record.get("steps", [])}
         expected_steps = {
             "compile_context",
             "invoke_coding_agent",
@@ -325,9 +335,7 @@ class TestFullBundledBugFixFlow:
             "apply_patch",
             "open_pr",
         }
-        assert expected_steps.issubset(step_records.keys()), (
-            f"missing steps: {expected_steps - step_records.keys()}"
-        )
+        assert expected_steps.issubset(step_records.keys()), f"missing steps: {expected_steps - step_records.keys()}"
         assert_adapter_ok(step_records["open_pr"])
 
     def test_adapter_artifact_has_top_level_diff_contract(
@@ -347,27 +355,29 @@ class TestFullBundledBugFixFlow:
         bundled bug_fix_flow E2E is deferred to post-C2."""
         _install_mini_repo(workspace_root)
         run_id = seeded_run(
-            _WORKFLOW_ID, version=_WORKFLOW_VERSION,
+            _WORKFLOW_ID,
+            version=_WORKFLOW_VERSION,
         )
         canned = {
-            (_SCENARIO_ID, "codex-stub", 1):
-                bug_envelopes.coding_agent_happy(),
+            (_SCENARIO_ID, "codex-stub", 1): bug_envelopes.coding_agent_happy(),
         }
         with mock_adapter_transport(canned, scenario_id=_SCENARIO_ID):
             first = benchmark_driver.run_workflow(
-                run_id, _WORKFLOW_ID, _WORKFLOW_VERSION,
+                run_id,
+                _WORKFLOW_ID,
+                _WORKFLOW_VERSION,
             )
             token = first.resume_token or read_awaiting_human_token(
                 _run_dir(workspace_root, run_id),
             )
             benchmark_driver.resume_workflow(
-                run_id, token, payload={"decision": "granted"},
+                run_id,
+                token,
+                payload={"decision": "granted"},
             )
 
         record, _ = load_run(workspace_root, run_id)
-        step_records = {
-            step["step_name"]: step for step in record.get("steps", [])
-        }
+        step_records = {step["step_name"]: step for step in record.get("steps", [])}
         coding_step = step_records["invoke_coding_agent"]
         assert coding_step["state"] == "completed"
         output_ref = coding_step.get("output_ref")
@@ -375,9 +385,8 @@ class TestFullBundledBugFixFlow:
 
         # C1a contract: output_ref is run-relative artifact path.
         import json as _json
-        artifact_path = (
-            _run_dir(workspace_root, run_id) / output_ref
-        )
+
+        artifact_path = _run_dir(workspace_root, run_id) / output_ref
         assert artifact_path.is_file()
         artifact = _json.loads(artifact_path.read_text())
         # C1b contract: top-level diff present for patch plumbing
@@ -385,4 +394,3 @@ class TestFullBundledBugFixFlow:
         assert "diff" in artifact
         assert isinstance(artifact["diff"], str)
         assert len(artifact["diff"]) > 0
-

--- a/tests/benchmarks/test_governed_review.py
+++ b/tests/benchmarks/test_governed_review.py
@@ -33,11 +33,7 @@ _WORKFLOW_ID = "review_ai_flow"
 _WORKFLOW_VERSION = "1.0.0"
 _SCENARIO_ID = "governed_review"
 _REVIEW_SCHEMA = (
-    Path(__file__).resolve().parents[2]
-    / "ao_kernel"
-    / "defaults"
-    / "schemas"
-    / "review-findings.schema.v1.json"
+    Path(__file__).resolve().parents[2] / "ao_kernel" / "defaults" / "schemas" / "review-findings.schema.v1.json"
 )
 _EXPECTED_MIN_SCORE = 0.5
 
@@ -47,11 +43,13 @@ def _run_dir(workspace_root: Path, run_id: str) -> Path:
 
 
 class TestHappyPath:
+    @pytest.mark.scorecard_primary
     def test_review_findings_flow_completes(
         self,
         workspace_root: Path,
         seeded_run,
         benchmark_driver,
+        benchmark_primary_sidecar,
     ) -> None:
         run_id = seeded_run(_WORKFLOW_ID, version=_WORKFLOW_VERSION)
         canned = {
@@ -62,7 +60,9 @@ class TestHappyPath:
 
         with mock_adapter_transport(canned, scenario_id=_SCENARIO_ID):
             first = benchmark_driver.run_workflow(
-                run_id, _WORKFLOW_ID, _WORKFLOW_VERSION,
+                run_id,
+                _WORKFLOW_ID,
+                _WORKFLOW_VERSION,
             )
             # `review_ai_flow` ends on await_acknowledgement; flow
             # should pause with a resume_token.
@@ -73,26 +73,42 @@ class TestHappyPath:
                     _run_dir(workspace_root, run_id),
                 )
             second = benchmark_driver.resume_workflow(
-                run_id, token, payload={"decision": "granted"},
+                run_id,
+                token,
+                payload={"decision": "granted"},
             )
 
         assert second.final_state == "completed"
-        assert_workflow_completed(_run_dir(workspace_root, run_id))
+        run_dir = _run_dir(workspace_root, run_id)
+        assert_workflow_completed(run_dir)
 
         record, _ = load_run(workspace_root, run_id)
-        step_records = {
-            step["step_name"]: step for step in record.get("steps", [])
-        }
+        step_records = {step["step_name"]: step for step in record.get("steps", [])}
         review_step = step_records["invoke_review_agent"]
         assert_adapter_ok(review_step)
 
         artifact = assert_capability_artifact(
             review_step,
             "review_findings",
-            run_dir=_run_dir(workspace_root, run_id),
+            run_dir=run_dir,
             schema_path=_REVIEW_SCHEMA,
         )
         assert_review_score(artifact, expected_min_score=_EXPECTED_MIN_SCORE)
+
+        # Scorecard primary sidecar — publishes run_dir + the concrete
+        # `review_findings` artefact path so the collector can extract
+        # `review_score` without rescanning capability_output_refs.
+        # `run_state_path` points at the canonical state file for
+        # `cost_consumed_usd` extraction.
+        refs = review_step.get("capability_output_refs") or {}
+        findings_ref = refs.get("review_findings")
+        findings_path = run_dir / findings_ref if findings_ref else None
+        benchmark_primary_sidecar(
+            _SCENARIO_ID,
+            run_dir,
+            run_state_path=workspace_root / ".ao" / "runs" / run_id / "state.v1.json",
+            review_findings_path=findings_path,
+        )
 
     @pytest.mark.parametrize(
         "score,min_threshold,should_pass",
@@ -119,20 +135,21 @@ class TestHappyPath:
 
         with mock_adapter_transport(canned, scenario_id=_SCENARIO_ID):
             first = benchmark_driver.run_workflow(
-                run_id, _WORKFLOW_ID, _WORKFLOW_VERSION,
+                run_id,
+                _WORKFLOW_ID,
+                _WORKFLOW_VERSION,
             )
             token = first.resume_token or read_awaiting_human_token(
                 _run_dir(workspace_root, run_id),
             )
             benchmark_driver.resume_workflow(
-                run_id, token, payload={"decision": "granted"},
+                run_id,
+                token,
+                payload={"decision": "granted"},
             )
 
         record, _ = load_run(workspace_root, run_id)
-        review_step = next(
-            step for step in record["steps"]
-            if step["step_name"] == "invoke_review_agent"
-        )
+        review_step = next(step for step in record["steps"] if step["step_name"] == "invoke_review_agent")
         artifact = assert_capability_artifact(
             review_step,
             "review_findings",
@@ -166,13 +183,17 @@ class TestCostReconcile:
 
         with mock_adapter_transport(canned, scenario_id=_SCENARIO_ID):
             first = benchmark_driver.run_workflow(
-                run_id, _WORKFLOW_ID, _WORKFLOW_VERSION,
+                run_id,
+                _WORKFLOW_ID,
+                _WORKFLOW_VERSION,
             )
             token = first.resume_token or read_awaiting_human_token(
                 _run_dir(workspace_root, run_id),
             )
             benchmark_driver.resume_workflow(
-                run_id, token, payload={"decision": "granted"},
+                run_id,
+                token,
+                payload={"decision": "granted"},
             )
 
         record, _ = load_run(workspace_root, run_id)
@@ -180,9 +201,7 @@ class TestCostReconcile:
         # The envelope reports 0.12 USD; the shim should drain by
         # exactly that amount (no other adapter call for this
         # scenario).
-        assert abs(consumed - 0.12) < 1e-9, (
-            f"unexpected cost_usd consumption: {consumed}"
-        )
+        assert abs(consumed - 0.12) < 1e-9, f"unexpected cost_usd consumption: {consumed}"
 
 
 class TestMissingPayload:
@@ -194,13 +213,14 @@ class TestMissingPayload:
     ) -> None:
         run_id = seeded_run(_WORKFLOW_ID, version=_WORKFLOW_VERSION)
         canned = {
-            (_SCENARIO_ID, "codex-stub", 1):
-                review_envelopes.review_agent_missing_payload(),
+            (_SCENARIO_ID, "codex-stub", 1): review_envelopes.review_agent_missing_payload(),
         }
 
         with mock_adapter_transport(canned, scenario_id=_SCENARIO_ID):
             result = benchmark_driver.run_workflow(
-                run_id, _WORKFLOW_ID, _WORKFLOW_VERSION,
+                run_id,
+                _WORKFLOW_ID,
+                _WORKFLOW_VERSION,
             )
 
         assert result.final_state == "failed"

--- a/tests/test_scorecard_cli.py
+++ b/tests/test_scorecard_cli.py
@@ -1,0 +1,317 @@
+"""v3.5 D3: scorecard CLI tests (8 pins)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ao_kernel import cli as cli_module
+from ao_kernel.cli import main
+
+
+def _scorecard(*entries: dict[str, Any], git_sha: str = "abc1234") -> dict:
+    return {
+        "schema_version": "v1",
+        "generated_at": "2026-04-18T10:00:00Z",
+        "git_sha": git_sha,
+        "pr_number": None,
+        "benchmarks": list(entries),
+    }
+
+
+def _entry(
+    scenario: str,
+    *,
+    status: str = "pass",
+    duration_ms: int | None = 100,
+    cost_consumed_usd: float | None = 0.01,
+    cost_source: str | None = "mock_shim",
+    review_score: float | None = None,
+) -> dict[str, Any]:
+    return {
+        "scenario": scenario,
+        "status": status,
+        "workflow_completed": status == "pass",
+        "duration_ms": duration_ms,
+        "cost_consumed_usd": cost_consumed_usd,
+        "cost_source": cost_source,
+        "review_score": review_score,
+    }
+
+
+class TestRender:
+    def test_render_prints_markdown_and_exits_0(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        head_path = tmp_path / "head.json"
+        head_path.write_text(
+            json.dumps(_scorecard(_entry("s"))),
+            encoding="utf-8",
+        )
+        exit_code = main(["scorecard", "render", "--input", str(head_path)])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "<!-- ao-scorecard -->" in captured.out
+        assert "Baseline: _(not found)_" in captured.out
+
+
+class TestCompare:
+    def test_compare_no_regression_exits_0(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        sc_path = tmp_path / "head.json"
+        sc_path.write_text(
+            json.dumps(_scorecard(_entry("s", duration_ms=100))),
+            encoding="utf-8",
+        )
+        exit_code = main(
+            [
+                "scorecard",
+                "compare",
+                "--baseline",
+                str(sc_path),
+                "--head",
+                str(sc_path),
+            ],
+        )
+        assert exit_code == 0
+
+    def test_compare_block_regression_exits_1(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        baseline = tmp_path / "base.json"
+        head = tmp_path / "head.json"
+        baseline.write_text(
+            json.dumps(_scorecard(_entry("s", duration_ms=100))),
+            encoding="utf-8",
+        )
+        head.write_text(
+            json.dumps(_scorecard(_entry("s", duration_ms=300))),
+            encoding="utf-8",
+        )
+        # Patch policy loader to return block action
+        monkeypatch.setattr(
+            cli_module,
+            "_resolve_scorecard_policy",
+            lambda _root: {
+                "fail_action": "block",
+                "regression_threshold": {
+                    "duration_ms_relative_pct": 30.0,
+                    "cost_usd_relative_pct": 20.0,
+                    "review_score_min_delta": -0.1,
+                },
+            },
+        )
+        exit_code = main(
+            [
+                "scorecard",
+                "compare",
+                "--baseline",
+                str(baseline),
+                "--head",
+                str(head),
+            ],
+        )
+        assert exit_code == 1
+
+    def test_compare_warn_regression_exits_0_with_stderr_banner(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        baseline = tmp_path / "base.json"
+        head = tmp_path / "head.json"
+        baseline.write_text(
+            json.dumps(_scorecard(_entry("s", duration_ms=100))),
+            encoding="utf-8",
+        )
+        head.write_text(
+            json.dumps(_scorecard(_entry("s", duration_ms=300))),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            cli_module,
+            "_resolve_scorecard_policy",
+            lambda _root: {
+                "fail_action": "warn",
+                "regression_threshold": {
+                    "duration_ms_relative_pct": 30.0,
+                    "cost_usd_relative_pct": 20.0,
+                    "review_score_min_delta": -0.1,
+                },
+            },
+        )
+        exit_code = main(
+            [
+                "scorecard",
+                "compare",
+                "--baseline",
+                str(baseline),
+                "--head",
+                str(head),
+            ],
+        )
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "WARN" in captured.err
+
+    def test_missing_baseline_file_handled_gracefully(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        head = tmp_path / "head.json"
+        head.write_text(
+            json.dumps(_scorecard(_entry("s"))),
+            encoding="utf-8",
+        )
+        # Absent baseline path still exits 0 (advisory diff).
+        exit_code = main(
+            [
+                "scorecard",
+                "compare",
+                "--baseline",
+                str(tmp_path / "missing.json"),
+                "--head",
+                str(head),
+            ],
+        )
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "Baseline: _(not found)_" in captured.out
+
+
+class TestRenderIgnoresPolicy:
+    def test_render_never_consults_policy(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        head = tmp_path / "head.json"
+        head.write_text(
+            json.dumps(_scorecard(_entry("s", duration_ms=500))),
+            encoding="utf-8",
+        )
+
+        def _boom(_root: Any) -> dict[str, Any]:
+            raise AssertionError("render must not consult _resolve_scorecard_policy")
+
+        monkeypatch.setattr(cli_module, "_resolve_scorecard_policy", _boom)
+        exit_code = main(["scorecard", "render", "--input", str(head)])
+        assert exit_code == 0
+
+
+class TestPostComment:
+    def test_post_comment_advisory_on_missing_body(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        exit_code = main(
+            [
+                "scorecard",
+                "post-comment",
+                "--pr",
+                "1",
+                "--body-file",
+                str(tmp_path / "missing.md"),
+                "--sentinel",
+                "<!-- ao-scorecard -->",
+                "--repo",
+                "owner/repo",
+            ],
+        )
+        assert exit_code == 0
+
+    def test_post_comment_routes_to_upsert_helper(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        body = tmp_path / "body.md"
+        body.write_text(
+            "<!-- ao-scorecard -->\nhello",
+            encoding="utf-8",
+        )
+
+        captured: dict[str, Any] = {}
+
+        def _fake_upsert(
+            *,
+            repo: str,
+            pr: int,
+            body: str,
+            sentinel: str,
+        ):
+            from ao_kernel._internal.scorecard.post_comment import (
+                PostCommentResult,
+            )
+
+            captured["repo"] = repo
+            captured["pr"] = pr
+            captured["sentinel"] = sentinel
+            return PostCommentResult("posted", 42, "created")
+
+        # Patch at the cli module import site (the cli imports inside
+        # the handler, so patch the source module).
+        from ao_kernel._internal.scorecard import post_comment as pc_module
+
+        monkeypatch.setattr(pc_module, "upsert_sticky_comment", _fake_upsert)
+        exit_code = main(
+            [
+                "scorecard",
+                "post-comment",
+                "--pr",
+                "7",
+                "--body-file",
+                str(body),
+                "--sentinel",
+                "<!-- ao-scorecard -->",
+                "--repo",
+                "owner/repo",
+            ],
+        )
+        assert exit_code == 0
+        assert captured == {
+            "repo": "owner/repo",
+            "pr": 7,
+            "sentinel": "<!-- ao-scorecard -->",
+        }
+
+    def test_post_comment_missing_repo_exits_0(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        body = tmp_path / "body.md"
+        body.write_text("<!-- ao-scorecard -->", encoding="utf-8")
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        exit_code = main(
+            [
+                "scorecard",
+                "post-comment",
+                "--pr",
+                "1",
+                "--body-file",
+                str(body),
+                "--sentinel",
+                "<!-- ao-scorecard -->",
+            ],
+        )
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "GITHUB_REPOSITORY" in captured.err

--- a/tests/test_scorecard_cli.py
+++ b/tests/test_scorecard_cli.py
@@ -213,6 +213,135 @@ class TestRenderIgnoresPolicy:
         assert exit_code == 0
 
 
+class TestPolicyFlagGating:
+    def test_compare_disabled_prints_banner_and_exits_0(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Codex post-impl SUGGEST absorb — `enabled=false` gates
+        compare output; full diff is not rendered."""
+        head = tmp_path / "head.json"
+        head.write_text(
+            json.dumps(_scorecard(_entry("s", duration_ms=100))),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            cli_module,
+            "_resolve_scorecard_policy",
+            lambda _root: {
+                "enabled": False,
+                "post_pr_comment": True,
+                "fail_action": "warn",
+                "regression_threshold": {
+                    "duration_ms_relative_pct": 30.0,
+                    "cost_usd_relative_pct": 20.0,
+                    "review_score_min_delta": -0.1,
+                },
+            },
+        )
+        exit_code = main(
+            [
+                "scorecard",
+                "compare",
+                "--baseline",
+                str(head),
+                "--head",
+                str(head),
+            ],
+        )
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "disabled" in captured.out
+        assert "enabled=false" in captured.err
+
+    def test_post_comment_disabled_skips_upsert(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`enabled=false` gates the workflow comment path too."""
+        body = tmp_path / "body.md"
+        body.write_text("<!-- ao-scorecard -->", encoding="utf-8")
+        monkeypatch.setattr(
+            cli_module,
+            "_resolve_scorecard_policy",
+            lambda _root: {"enabled": False, "post_pr_comment": True},
+        )
+        called = {"upsert": False}
+
+        from ao_kernel._internal.scorecard import post_comment as pc_module
+
+        def _fail(**_kwargs: Any) -> Any:
+            called["upsert"] = True
+            raise AssertionError("upsert must NOT run when enabled=false")
+
+        monkeypatch.setattr(pc_module, "upsert_sticky_comment", _fail)
+        exit_code = main(
+            [
+                "scorecard",
+                "post-comment",
+                "--pr",
+                "1",
+                "--body-file",
+                str(body),
+                "--sentinel",
+                "<!-- ao-scorecard -->",
+                "--repo",
+                "owner/repo",
+            ],
+        )
+        assert exit_code == 0
+        assert called["upsert"] is False
+        captured = capsys.readouterr()
+        assert "enabled=false" in captured.err
+
+    def test_post_comment_false_flag_skips_upsert(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`post_pr_comment=false` skips the upsert even when
+        `enabled=true`."""
+        body = tmp_path / "body.md"
+        body.write_text("<!-- ao-scorecard -->", encoding="utf-8")
+        monkeypatch.setattr(
+            cli_module,
+            "_resolve_scorecard_policy",
+            lambda _root: {"enabled": True, "post_pr_comment": False},
+        )
+        called = {"upsert": False}
+
+        from ao_kernel._internal.scorecard import post_comment as pc_module
+
+        def _fail(**_kwargs: Any) -> Any:
+            called["upsert"] = True
+            raise AssertionError("upsert must NOT run when post_pr_comment=false")
+
+        monkeypatch.setattr(pc_module, "upsert_sticky_comment", _fail)
+        exit_code = main(
+            [
+                "scorecard",
+                "post-comment",
+                "--pr",
+                "1",
+                "--body-file",
+                str(body),
+                "--sentinel",
+                "<!-- ao-scorecard -->",
+                "--repo",
+                "owner/repo",
+            ],
+        )
+        assert exit_code == 0
+        assert called["upsert"] is False
+        captured = capsys.readouterr()
+        assert "post_pr_comment=false" in captured.err
+
+
 class TestPostComment:
     def test_post_comment_advisory_on_missing_body(
         self,

--- a/tests/test_scorecard_collector.py
+++ b/tests/test_scorecard_collector.py
@@ -1,0 +1,239 @@
+"""v3.5 D3: scorecard collector + pytest plugin tests (11 pins)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ao_kernel._internal.scorecard.collector import (
+    DEFAULT_OUTPUT_FILENAME,
+    BenchmarkResult,
+    PrimarySidecar,
+    ScorecardCollectorError,
+    ScorecardRegistry,
+    build_result,
+    build_scorecard,
+    finalize_session,
+    resolve_output_path,
+)
+
+
+def _write_events(run_dir: Path, events: list[dict]) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "events.jsonl").write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_run_state(path: Path, cost_limit: float, remaining: float) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "budget": {
+                    "cost_usd": {"limit": cost_limit, "remaining": remaining},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_review_findings(path: Path, score: float | None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict = {"findings": [], "summary": "ok"}
+    if score is not None:
+        payload["score"] = score
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestBuildResult:
+    def test_happy_path_extraction(self, tmp_path: Path) -> None:
+        events = [
+            {"kind": "workflow_started", "ts": "2026-04-18T10:00:00+00:00"},
+            {"kind": "step_completed", "ts": "2026-04-18T10:00:01+00:00"},
+            {"kind": "workflow_completed", "ts": "2026-04-18T10:00:02+00:00"},
+        ]
+        _write_events(tmp_path / "run", events)
+        state = tmp_path / "state.json"
+        _write_run_state(state, 10.0, 9.5)
+        findings = tmp_path / "review.json"
+        _write_review_findings(findings, 0.88)
+
+        sidecar = PrimarySidecar(
+            scenario_id="governed_review",
+            run_dir=tmp_path / "run",
+            run_state_path=state,
+            review_findings_path=findings,
+        )
+        result = build_result(sidecar)
+        assert result.scenario == "governed_review"
+        assert result.status == "pass"
+        assert result.workflow_completed is True
+        assert result.duration_ms == 2000
+        assert result.cost_consumed_usd == pytest.approx(0.5)
+        assert result.cost_source == "mock_shim"
+        assert result.review_score == pytest.approx(0.88)
+
+    def test_missing_workflow_completed_is_fail(self, tmp_path: Path) -> None:
+        events = [
+            {"kind": "workflow_started", "ts": "2026-04-18T10:00:00+00:00"},
+        ]
+        _write_events(tmp_path / "run", events)
+        sidecar = PrimarySidecar(
+            scenario_id="governed_bugfix",
+            run_dir=tmp_path / "run",
+        )
+        result = build_result(sidecar)
+        assert result.workflow_completed is False
+        assert result.status == "fail"
+
+    def test_workflow_failed_event_forces_fail(self, tmp_path: Path) -> None:
+        events = [
+            {"kind": "workflow_completed", "ts": "2026-04-18T10:00:00+00:00"},
+            {"kind": "workflow_failed", "ts": "2026-04-18T10:00:01+00:00"},
+        ]
+        _write_events(tmp_path / "run", events)
+        sidecar = PrimarySidecar(
+            scenario_id="governed_bugfix",
+            run_dir=tmp_path / "run",
+        )
+        result = build_result(sidecar)
+        assert result.status == "fail"
+
+    def test_missing_budget_gives_null_cost(self, tmp_path: Path) -> None:
+        events = [{"kind": "workflow_completed", "ts": "2026-04-18T10:00:00+00:00"}]
+        _write_events(tmp_path / "run", events)
+        sidecar = PrimarySidecar(
+            scenario_id="governed_bugfix",
+            run_dir=tmp_path / "run",
+            run_state_path=tmp_path / "missing.json",
+        )
+        result = build_result(sidecar)
+        assert result.cost_consumed_usd is None
+        assert result.cost_source is None
+
+    def test_missing_review_findings_gives_null_score(self, tmp_path: Path) -> None:
+        events = [{"kind": "workflow_completed", "ts": "2026-04-18T10:00:00+00:00"}]
+        _write_events(tmp_path / "run", events)
+        sidecar = PrimarySidecar(
+            scenario_id="governed_review",
+            run_dir=tmp_path / "run",
+            review_findings_path=tmp_path / "missing.json",
+        )
+        result = build_result(sidecar)
+        assert result.review_score is None
+
+    def test_empty_run_dir(self, tmp_path: Path) -> None:
+        (tmp_path / "empty").mkdir()
+        sidecar = PrimarySidecar(
+            scenario_id="governed_bugfix",
+            run_dir=tmp_path / "empty",
+        )
+        result = build_result(sidecar)
+        assert result.workflow_completed is False
+        assert result.status == "fail"
+        assert result.duration_ms is None
+
+
+class TestBuildScorecard:
+    def test_scorecard_sorted_by_scenario(self, tmp_path: Path) -> None:
+        results = [
+            BenchmarkResult("governed_review", "pass", True, 50, 0.01, "mock_shim", 0.8),
+            BenchmarkResult("governed_bugfix", "pass", True, 75, 0.005, "mock_shim", None),
+        ]
+        scorecard = build_scorecard(results)
+        assert scorecard["benchmarks"][0]["scenario"] == "governed_bugfix"
+        assert scorecard["benchmarks"][1]["scenario"] == "governed_review"
+        assert scorecard["schema_version"] == "v1"
+        assert "git_sha" in scorecard
+        assert "generated_at" in scorecard
+
+    def test_cost_source_always_populated_when_cost_present(self) -> None:
+        """Canonical marker pin #2: cost_source='mock_shim' v1."""
+        results = [
+            BenchmarkResult("s", "pass", True, 10, 0.01, "mock_shim", None),
+        ]
+        scorecard = build_scorecard(results)
+        assert scorecard["benchmarks"][0]["cost_source"] == "mock_shim"
+
+
+class TestFinalizeSession:
+    def test_happy_path_writes_file(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        registry = ScorecardRegistry()
+        events = [{"kind": "workflow_completed", "ts": "2026-04-18T10:00:00+00:00"}]
+        _write_events(tmp_path / "rg", events)
+        registry.record(PrimarySidecar("governed_bugfix", tmp_path / "rg"))
+        events2 = [{"kind": "workflow_completed", "ts": "2026-04-18T10:00:00+00:00"}]
+        _write_events(tmp_path / "rv", events2)
+        registry.record(PrimarySidecar("governed_review", tmp_path / "rv"))
+
+        out = tmp_path / "scorecard.json"
+        written = finalize_session(registry, out)
+        assert written == out
+        payload = json.loads(out.read_text())
+        assert [entry["scenario"] for entry in payload["benchmarks"]] == [
+            "governed_bugfix",
+            "governed_review",
+        ]
+
+    def test_duplicate_primary_marker_fails_session(self, tmp_path: Path) -> None:
+        """Canonical marker pin #1: duplicate → session-fail diagnostic."""
+        registry = ScorecardRegistry()
+        _write_events(tmp_path / "a", [{"kind": "workflow_completed"}])
+        _write_events(tmp_path / "b", [{"kind": "workflow_completed"}])
+        registry.record(PrimarySidecar("governed_review", tmp_path / "a"))
+        registry.record(PrimarySidecar("governed_review", tmp_path / "b"))
+        with pytest.raises(ScorecardCollectorError, match="Duplicate"):
+            finalize_session(registry, tmp_path / "out.json")
+        assert not (tmp_path / "out.json").exists()
+
+    def test_zero_primary_fails_when_expected_non_empty(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """AGREE iter-2 tighten #3 — missing primary also fail-closed."""
+        registry = ScorecardRegistry()
+        with pytest.raises(ScorecardCollectorError, match="Zero"):
+            finalize_session(
+                registry,
+                tmp_path / "out.json",
+                expected_scenarios=frozenset({"governed_review"}),
+            )
+
+    def test_zero_primary_noop_when_expected_empty(self, tmp_path: Path) -> None:
+        """Empty expected-set → no-op, no scorecard produced."""
+        registry = ScorecardRegistry()
+        result = finalize_session(
+            registry,
+            tmp_path / "out.json",
+            expected_scenarios=frozenset(),
+        )
+        assert result is None
+        assert not (tmp_path / "out.json").exists()
+
+
+class TestOutputPath:
+    def test_env_var_override(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "custom" / "card.json"
+        monkeypatch.setenv("AO_SCORECARD_OUTPUT", str(target))
+        assert resolve_output_path() == target
+
+    def test_default_path(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("AO_SCORECARD_OUTPUT", raising=False)
+        assert resolve_output_path(tmp_path) == tmp_path / DEFAULT_OUTPUT_FILENAME

--- a/tests/test_scorecard_collector.py
+++ b/tests/test_scorecard_collector.py
@@ -201,12 +201,27 @@ class TestFinalizeSession:
     ) -> None:
         """AGREE iter-2 tighten #3 — missing primary also fail-closed."""
         registry = ScorecardRegistry()
-        with pytest.raises(ScorecardCollectorError, match="Zero"):
+        with pytest.raises(ScorecardCollectorError, match="Missing"):
             finalize_session(
                 registry,
                 tmp_path / "out.json",
                 expected_scenarios=frozenset({"governed_review"}),
             )
+
+    def test_partial_primary_subset_fails(self, tmp_path: Path) -> None:
+        """Codex post-impl BLOCKER absorb — if ANY expected scenario
+        is missing (not just fully empty), fail-close. Previously we
+        only trapped the empty-observed case."""
+        registry = ScorecardRegistry()
+        _write_events(tmp_path / "r", [{"kind": "workflow_completed"}])
+        registry.record(PrimarySidecar("governed_review", tmp_path / "r"))
+        with pytest.raises(ScorecardCollectorError, match="governed_bugfix"):
+            finalize_session(
+                registry,
+                tmp_path / "out.json",
+                expected_scenarios=frozenset({"governed_bugfix", "governed_review"}),
+            )
+        assert not (tmp_path / "out.json").exists()
 
     def test_zero_primary_noop_when_expected_empty(self, tmp_path: Path) -> None:
         """Empty expected-set → no-op, no scorecard produced."""
@@ -220,7 +235,86 @@ class TestFinalizeSession:
         assert not (tmp_path / "out.json").exists()
 
 
-class TestOutputPath:
+class TestSessionFinishExitStatus:
+    """Codex post-impl BLOCKER absorb — canonical-input contract
+    violations MUST propagate non-zero pytest exit status. Verified by
+    invoking a tiny pytest subprocess with a seeded conftest."""
+
+    def _run_pytest_with_conftest(
+        self,
+        tmp_path: Path,
+        conftest_body: str,
+        test_body: str,
+    ) -> int:
+        import subprocess
+        import sys
+
+        (tmp_path / "conftest.py").write_text(
+            conftest_body,
+            encoding="utf-8",
+        )
+        (tmp_path / "test_one.py").write_text(
+            test_body,
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", str(tmp_path), "-q"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        return result.returncode
+
+    def test_duplicate_primary_sets_nonzero_exit(self, tmp_path: Path) -> None:
+        conftest = """
+import pytest
+
+from ao_kernel._internal.scorecard.collector import (
+    PrimarySidecar, ScorecardRegistry, finalize_session,
+)
+
+
+_REG = ScorecardRegistry()
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "scorecard_primary: test marker"
+    )
+
+
+def pytest_sessionfinish(session, exitstatus):
+    # Simulate duplicate marker: two sidecars for same scenario.
+    r = session.config.stash.setdefault("_reg", ScorecardRegistry())
+    try:
+        finalize_session(r)
+    except Exception as exc:
+        session.config.get_terminal_writer().line(str(exc), red=True)
+        misconfig = int(pytest.ExitCode.USAGE_ERROR)
+        if int(session.exitstatus or 0) < misconfig:
+            session.exitstatus = pytest.ExitCode(misconfig)
+
+
+@pytest.fixture(autouse=True)
+def _seed(request, tmp_path):
+    reg = request.config.stash.setdefault("_reg", ScorecardRegistry())
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "events.jsonl").write_text('{"kind":"workflow_completed"}\\n')
+    (tmp_path / "b").mkdir()
+    (tmp_path / "b" / "events.jsonl").write_text('{"kind":"workflow_completed"}\\n')
+    reg.record(PrimarySidecar("same", tmp_path / "a"))
+    reg.record(PrimarySidecar("same", tmp_path / "b"))
+    yield
+"""
+        test = """
+def test_noop():
+    assert True
+"""
+        rc = self._run_pytest_with_conftest(tmp_path, conftest, test)
+        assert rc != 0
+        # Pytest ExitCode.USAGE_ERROR = 4
+        assert rc == 4, f"expected usage-error exit 4, got {rc}"
+
     def test_env_var_override(
         self,
         tmp_path: Path,

--- a/tests/test_scorecard_compare.py
+++ b/tests/test_scorecard_compare.py
@@ -1,0 +1,166 @@
+"""v3.5 D3: scorecard compare math tests (10 pins)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+from ao_kernel._internal.scorecard.compare import (
+    compare_scorecards,
+    exit_code_for,
+    select_regressions,
+)
+
+
+_DEFAULT_POLICY = {
+    "fail_action": "warn",
+    "regression_threshold": {
+        "duration_ms_relative_pct": 30.0,
+        "cost_usd_relative_pct": 20.0,
+        "review_score_min_delta": -0.1,
+    },
+}
+
+
+def _scorecard(*entries: dict[str, Any], git_sha: str = "abc1234") -> dict:
+    return {
+        "schema_version": "v1",
+        "generated_at": "2026-04-18T10:00:00Z",
+        "git_sha": git_sha,
+        "pr_number": None,
+        "benchmarks": list(entries),
+    }
+
+
+def _entry(
+    scenario: str,
+    *,
+    status: str = "pass",
+    duration_ms: int | None = 100,
+    cost_consumed_usd: float | None = 0.01,
+    cost_source: str | None = "mock_shim",
+    review_score: float | None = None,
+    workflow_completed: bool = True,
+) -> dict[str, Any]:
+    return {
+        "scenario": scenario,
+        "status": status,
+        "workflow_completed": workflow_completed,
+        "duration_ms": duration_ms,
+        "cost_consumed_usd": cost_consumed_usd,
+        "cost_source": cost_source,
+        "review_score": review_score,
+    }
+
+
+class TestHappyPath:
+    def test_identical_scorecards_no_regression(self) -> None:
+        entry = _entry("governed_bugfix", duration_ms=100, cost_consumed_usd=0.01)
+        baseline = _scorecard(entry)
+        head = _scorecard(entry)
+        diff = compare_scorecards(baseline, head, policy=_DEFAULT_POLICY)
+        assert diff.has_regression is False
+        assert diff.entries[0].regression is False
+        assert diff.entries[0].duration_delta_pct == 0.0
+
+
+class TestMissingBaseline:
+    def test_null_baseline_yields_null_deltas(self) -> None:
+        head = _scorecard(_entry("governed_review", review_score=0.9))
+        diff = compare_scorecards(None, head, policy=_DEFAULT_POLICY)
+        entry = diff.entries[0]
+        assert entry.duration_delta_pct is None
+        assert entry.cost_delta_pct is None
+        assert entry.review_score_delta is None
+        assert entry.regression is False
+        assert diff.baseline_sha is None
+
+
+class TestRegressionThresholds:
+    def test_duration_over_threshold(self) -> None:
+        baseline = _scorecard(_entry("s", duration_ms=100))
+        head = _scorecard(_entry("s", duration_ms=140))  # +40% > 30
+        diff = compare_scorecards(baseline, head, policy=_DEFAULT_POLICY)
+        assert diff.entries[0].regression is True
+        assert any("duration_up" in reason for reason in diff.entries[0].regression_reasons)
+
+    def test_cost_over_threshold(self) -> None:
+        baseline = _scorecard(_entry("s", cost_consumed_usd=0.01))
+        head = _scorecard(_entry("s", cost_consumed_usd=0.013))  # +30% > 20
+        diff = compare_scorecards(baseline, head, policy=_DEFAULT_POLICY)
+        assert diff.entries[0].regression is True
+        assert any("cost_up" in reason for reason in diff.entries[0].regression_reasons)
+
+    def test_review_score_drop_beyond_tolerance(self) -> None:
+        baseline = _scorecard(_entry("s", review_score=0.9))
+        head = _scorecard(_entry("s", review_score=0.75))  # -0.15 < -0.1
+        diff = compare_scorecards(baseline, head, policy=_DEFAULT_POLICY)
+        assert diff.entries[0].regression is True
+        assert any("review_score_drop" in reason for reason in diff.entries[0].regression_reasons)
+
+
+class TestFailAction:
+    def test_warn_action_keeps_exit_code_0(self) -> None:
+        baseline = _scorecard(_entry("s", duration_ms=100))
+        head = _scorecard(_entry("s", duration_ms=200))
+        diff = compare_scorecards(
+            baseline,
+            head,
+            policy={**_DEFAULT_POLICY, "fail_action": "warn"},
+        )
+        assert diff.has_regression is True
+        assert exit_code_for(diff) == 0
+
+    def test_block_action_exits_1_on_regression(self) -> None:
+        baseline = _scorecard(_entry("s", duration_ms=100))
+        head = _scorecard(_entry("s", duration_ms=200))
+        diff = compare_scorecards(
+            baseline,
+            head,
+            policy={**_DEFAULT_POLICY, "fail_action": "block"},
+        )
+        assert exit_code_for(diff) == 1
+
+
+class TestStatusChange:
+    def test_pass_to_fail_flags_status_change(self) -> None:
+        baseline = _scorecard(_entry("s", status="pass"))
+        head = _scorecard(_entry("s", status="fail"))
+        diff = compare_scorecards(baseline, head, policy=_DEFAULT_POLICY)
+        entry = diff.entries[0]
+        assert entry.status_changed is True
+        assert entry.regression is True
+        assert "status_pass_to_fail" in entry.regression_reasons
+
+
+class TestScenarioMembership:
+    def test_scenario_disappeared_from_head(self) -> None:
+        baseline = _scorecard(_entry("gone"), _entry("kept"))
+        head = _scorecard(_entry("kept"))
+        diff = compare_scorecards(baseline, head, policy=_DEFAULT_POLICY)
+        gone_entry = next(entry for entry in diff.entries if entry.scenario == "gone")
+        assert gone_entry.regression is True
+        assert "scenario_disappeared" in gone_entry.regression_reasons
+
+    def test_new_scenario_in_head_only_is_not_regression(self) -> None:
+        baseline = _scorecard(_entry("old"))
+        head = _scorecard(_entry("old"), _entry("new_one"))
+        diff = compare_scorecards(baseline, head, policy=_DEFAULT_POLICY)
+        new_entry = next(entry for entry in diff.entries if entry.scenario == "new_one")
+        assert new_entry.regression is False
+
+
+class TestSelectRegressions:
+    def test_returns_only_regression_entries(self) -> None:
+        baseline = _scorecard(
+            _entry("fast", duration_ms=50),
+            _entry("slow", duration_ms=100),
+        )
+        head = _scorecard(
+            _entry("fast", duration_ms=50),
+            _entry("slow", duration_ms=200),
+        )
+        diff = compare_scorecards(baseline, head, policy=_DEFAULT_POLICY)
+        regressions = list(select_regressions(diff))
+        assert len(regressions) == 1
+        assert regressions[0].scenario == "slow"

--- a/tests/test_scorecard_render.py
+++ b/tests/test_scorecard_render.py
@@ -1,0 +1,117 @@
+"""v3.5 D3: scorecard render markdown tests (8 pins)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ao_kernel._internal.scorecard.compare import compare_scorecards
+from ao_kernel._internal.scorecard.render import SENTINEL, render_diff
+
+
+_POLICY = {
+    "fail_action": "warn",
+    "regression_threshold": {
+        "duration_ms_relative_pct": 30.0,
+        "cost_usd_relative_pct": 20.0,
+        "review_score_min_delta": -0.1,
+    },
+}
+
+
+def _scorecard(*entries: dict[str, Any], git_sha: str = "abc1234", pr: int | None = None) -> dict:
+    return {
+        "schema_version": "v1",
+        "generated_at": "2026-04-18T10:00:00Z",
+        "git_sha": git_sha,
+        "pr_number": pr,
+        "benchmarks": list(entries),
+    }
+
+
+def _entry(
+    scenario: str,
+    *,
+    status: str = "pass",
+    duration_ms: int | None = 100,
+    cost_consumed_usd: float | None = 0.01,
+    cost_source: str | None = "mock_shim",
+    review_score: float | None = None,
+) -> dict[str, Any]:
+    return {
+        "scenario": scenario,
+        "status": status,
+        "workflow_completed": status == "pass",
+        "duration_ms": duration_ms,
+        "cost_consumed_usd": cost_consumed_usd,
+        "cost_source": cost_source,
+        "review_score": review_score,
+    }
+
+
+class TestRenderMarkdown:
+    def test_sentinel_on_first_line(self) -> None:
+        head = _scorecard(_entry("s"))
+        diff = compare_scorecards(head, head, policy=_POLICY)
+        rendered = render_diff(diff, head_scorecard=head)
+        assert rendered.startswith(SENTINEL + "\n")
+        assert SENTINEL == "<!-- ao-scorecard -->"
+
+    def test_no_regressions_footer(self) -> None:
+        head = _scorecard(_entry("s"))
+        diff = compare_scorecards(head, head, policy=_POLICY)
+        rendered = render_diff(diff, head_scorecard=head)
+        assert "No regressions." in rendered
+
+    def test_regression_banner_has_warning_emoji(self) -> None:
+        baseline = _scorecard(_entry("s", duration_ms=100))
+        head = _scorecard(_entry("s", duration_ms=300))
+        diff = compare_scorecards(baseline, head, policy=_POLICY)
+        rendered = render_diff(diff, head_scorecard=head)
+        assert "⚠️ 1 regression(s) detected" in rendered
+        assert "**Regressions:**" in rendered
+        assert "**s**" in rendered
+
+    def test_unicode_arrows_direction(self) -> None:
+        baseline = _scorecard(_entry("s", duration_ms=100))
+        head = _scorecard(_entry("s", duration_ms=150))
+        diff = compare_scorecards(baseline, head, policy=_POLICY)
+        rendered = render_diff(diff, head_scorecard=head)
+        assert "▲" in rendered  # increase
+        head_down = _scorecard(_entry("s", duration_ms=60))
+        diff_down = compare_scorecards(baseline, head_down, policy=_POLICY)
+        rendered_down = render_diff(diff_down, head_scorecard=head_down)
+        assert "▼" in rendered_down
+
+    def test_null_values_render_as_em_dash(self) -> None:
+        head = _scorecard(
+            _entry(
+                "s",
+                duration_ms=None,
+                cost_consumed_usd=None,
+                review_score=None,
+            ),
+        )
+        diff = compare_scorecards(None, head, policy=_POLICY)
+        rendered = render_diff(diff, head_scorecard=head)
+        # Null cells render as em-dash, not literal "None".
+        assert "None" not in rendered
+        assert "—" in rendered
+
+    def test_missing_baseline_footer(self) -> None:
+        head = _scorecard(_entry("s"))
+        diff = compare_scorecards(None, head, policy=_POLICY)
+        rendered = render_diff(diff, head_scorecard=head)
+        assert "Baseline: _(not found)_" in rendered
+
+    def test_pr_number_in_footer(self) -> None:
+        head = _scorecard(_entry("s"), pr=42)
+        diff = compare_scorecards(head, head, policy=_POLICY)
+        rendered = render_diff(diff, head_scorecard=head)
+        assert "PR: #42" in rendered
+
+    def test_cost_source_in_footer(self) -> None:
+        head = _scorecard(_entry("s", cost_source="mock_shim"))
+        diff = compare_scorecards(head, head, policy=_POLICY)
+        rendered = render_diff(diff, head_scorecard=head)
+        assert "mock_shim" in rendered
+        assert "benchmark-only; not real billing" in rendered

--- a/tests/test_scorecard_schema.py
+++ b/tests/test_scorecard_schema.py
@@ -1,0 +1,76 @@
+"""v3.5 D3: scorecard schema conformance tests (3 pins)."""
+
+from __future__ import annotations
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+@pytest.fixture
+def scorecard_schema() -> dict:
+    return load_default("schemas", "scorecard.schema.v1.json")
+
+
+@pytest.fixture
+def valid_scorecard() -> dict:
+    return {
+        "schema_version": "v1",
+        "generated_at": "2026-04-18T10:00:00Z",
+        "git_sha": "abc1234",
+        "pr_number": None,
+        "benchmarks": [
+            {
+                "scenario": "governed_bugfix",
+                "status": "pass",
+                "workflow_completed": True,
+                "duration_ms": 120,
+                "cost_consumed_usd": 0.01,
+                "cost_source": "mock_shim",
+                "review_score": None,
+            },
+        ],
+    }
+
+
+class TestScorecardSchema:
+    def test_valid_scorecard_accepted(
+        self,
+        scorecard_schema: dict,
+        valid_scorecard: dict,
+    ) -> None:
+        errors = list(
+            Draft202012Validator(scorecard_schema).iter_errors(valid_scorecard),
+        )
+        assert errors == [], [err.message for err in errors]
+
+    def test_unknown_top_level_key_rejected(
+        self,
+        scorecard_schema: dict,
+        valid_scorecard: dict,
+    ) -> None:
+        valid_scorecard["unexpected_field"] = "nope"
+        with pytest.raises(Exception):
+            Draft202012Validator(scorecard_schema).validate(valid_scorecard)
+
+    def test_benchmark_entry_forward_extensible(
+        self,
+        scorecard_schema: dict,
+        valid_scorecard: dict,
+    ) -> None:
+        """benchmark_result has additionalProperties: true so future
+        axes (e.g. memory_rss_kib) land without a schema bump."""
+        valid_scorecard["benchmarks"][0]["future_axis"] = 42
+        errors = list(
+            Draft202012Validator(scorecard_schema).iter_errors(valid_scorecard),
+        )
+        assert errors == [], [err.message for err in errors]
+
+
+class TestPolicySchema:
+    def test_bundled_policy_matches_policy_schema(self) -> None:
+        policy = load_default("policies", "policy_scorecard.v1.json")
+        schema = load_default("schemas", "policy-scorecard.schema.v1.json")
+        errors = list(Draft202012Validator(schema).iter_errors(policy))
+        assert errors == [], [err.message for err in errors]


### PR DESCRIPTION
## Summary

- Final v3.5.0 D-series PR. Adds a typed `benchmark_scorecard.v1.json` artefact, baseline-vs-head diff with regression thresholds, and a sentinel-sticky PR comment powered by `gh api`.
- New public facade `ao_kernel.scorecard` + `_internal/scorecard/{collector,compare,render,post_comment}.py`. CLI: `ao-kernel scorecard {emit,compare,render,post-comment}`.
- Canonical input via `@pytest.mark.scorecard_primary` on the two happy-path tests (`test_review_findings_flow_completes`, `test_end_to_end_completes`). Exactly-one-primary-per-scenario rule — duplicate AND missing-primary both fail-close at session finish.
- CI: `benchmark-fast` job extended with scorecard env + artefact upload; new `scorecard` job (PR-only, `continue-on-error: true`, SHA-pinned `dawidd6/action-download-artifact@bf251b5a`) downloads head + baseline, runs `compare`, upserts a sticky `<!-- ao-scorecard -->`-tagged PR comment.
- Schemas: `scorecard.schema.v1.json` (`urn:ao:scorecard:v1`, top strict + benchmark_result forward-extensible) and `policy-scorecard.schema.v1.json`. Policy `policy_scorecard.v1.json` ships `enabled=true`, `fail_action=warn`.
- `cost_source` schema field always populated (`mock_shim` v1 → `real_adapter` post-C3); render footer surfaces the source so mock-shim baselines aren't misread as real billing.

## Plan + Codex AGREE

- `.claude/plans/PR-D3-DRAFT-PLAN.md` v2 — plan-time CNS iter-1 `PARTIAL` → iter-2 `AGREE` after absorbing 3 revisions (canonical marker, CI SSOT, block/warn split) + 7 Q&A resolutions.
- 4 micro tighten items (test names, CLI single entry, zero-primary fail-closed, §5 cleanup) landed in code during impl.

## Scope non-goals

- No multi-commit trend / sparkline (v3.6+)
- No CI-gate enforcement — bundled `fail_action=warn`; CLI supports `block` for local/manual use
- No changes to `cost_usd` reconcile runtime (C3 scope)
- No new benchmark scenarios (B7.x+)

## Test plan

- [x] 46 new scorecard pins (collector 14 + compare 11 + render 8 + cli 9 + schema 4)
- [x] Full pytest run: **2403 passed**, ruff clean, mypy clean on 205 source files
- [x] Benchmark suite still 10/10 pass with primary markers + sidecar wiring
- [x] Manual round-trip verified: happy-path (no regressions) + regression case (`fail_action=block` → exit 1)
- [ ] First CI run will have no main baseline; comment should state `Baseline: _(not found)_`
- [ ] Post-merge: `scorecard-main` artefact uploaded; next PR shows first real diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)