### PR TITLE
release(v3.5.0): consultation canonicalization + dev scorecard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,4 @@ pytest-of-*/
 tmp[a-z0-9]*/
 # Stale src/ dir (removed in v2.0.0; gets re-created by some editor cache)
 /src/
+benchmark_scorecard.v1.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-04-19
+
 ### Added — v3.5.0 D3 Dev Scorecard (benchmark compare + PR comment)
 
 **Context.** PR-B7 emits benchmark run-dir events + capability artefacts, but there was no aggregated surface for comparing a PR's benchmark output against the main-branch baseline or posting a compact scorecard comment. D3 closes that gap as the final v3.5.0 commitment. Codex plan-time CNS: 2 iterations → AGREE (iter-1 PARTIAL → iter-2 AGREE after absorbing canonical-input marker + CI SSOT + block/warn split revisions). Trend / sparkline visualisation deferred to v3.6+.

--- a/ao_kernel/__init__.py
+++ b/ao_kernel/__init__.py
@@ -1,6 +1,6 @@
 """ao-kernel — Governed AI orchestration runtime."""
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 
 from ao_kernel.client import AoKernelClient
 from ao_kernel.config import load_default, load_with_override, workspace_root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ao-kernel"
-version = "3.4.0"
+version = "3.5.0"
 description = "Governed AI orchestration runtime — policy-driven, fail-closed, evidence-trail"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_pr_a6_features.py
+++ b/tests/test_pr_a6_features.py
@@ -25,6 +25,7 @@ class TestBundledAdapters:
         # Create workspace override with same adapter_id but different display_name
         # Read bundled codex-stub, modify version to prove override
         from importlib import resources as _res
+
         bundled_pkg = _res.files("ao_kernel.defaults.adapters")
         with _res.as_file(bundled_pkg.joinpath("codex-stub.manifest.v1.json")) as bp:
             override = json.loads(bp.read_text(encoding="utf-8"))
@@ -50,6 +51,7 @@ class TestGhPrStub:
         from ao_kernel.fixtures.gh_pr_stub import main
         import io
         import sys
+
         old_stdout = sys.stdout
         sys.stdout = buf = io.StringIO()
         try:
@@ -91,23 +93,26 @@ class TestLlmFallback:
 
 
 class TestVersionBump:
-    def test_version_is_3_4_0(self) -> None:
+    def test_version_is_3_5_0(self) -> None:
         import ao_kernel
-        assert ao_kernel.__version__ == "3.4.0"
+
+        assert ao_kernel.__version__ == "3.5.0"
 
     def test_pyproject_version_matches(self) -> None:
         import tomllib
+
         pyproject = Path("pyproject.toml")
         if not pyproject.exists():
             pyproject = Path(__file__).parent.parent / "pyproject.toml"
         with open(pyproject, "rb") as f:
             data = tomllib.load(f)
-        assert data["project"]["version"] == "3.4.0"
+        assert data["project"]["version"] == "3.5.0"
 
 
 class TestMetaExtras:
     def test_coding_extra_defined(self) -> None:
         import tomllib
+
         pyproject = Path("pyproject.toml")
         if not pyproject.exists():
             pyproject = Path(__file__).parent.parent / "pyproject.toml"


### PR DESCRIPTION
## Summary

v3.5.0 release PR: version bump + CHANGELOG date stamp after D1/D2a/D2b/D3 merges.

- **D1** (#132) — path canonicalization `.cache/...` → `.ao/consultations/` + migration CLI with legacy read fallback
- **D2a** (#133) — consultation archive + 5-bucket verdict normalization + SHA-256 integrity manifest + per-kind event identity dedupe
- **D2b** (#134) — opt-in canonical promotion of resolved AGREE/PARTIAL consultations into the existing decision store (policy-gated; `--force` overrides flag only, not integrity/eligibility)
- **D3** (#135) — dev scorecard: typed benchmark artefact, baseline diff with regression thresholds, sentinel-sticky PR comment via `gh api`, `@pytest.mark.scorecard_primary` canonical-input marker (duplicate AND missing both fail-close)

Plan-time + post-impl two-gate followed on all four D-series PRs.

## Test plan

- [x] Full pytest: 2408 passed, ruff clean, mypy clean on 205 source files
- [x] Version bump: `pyproject.toml` + `ao_kernel/__init__.py` → `3.5.0`
- [x] CHANGELOG `[Unreleased]` → `[3.5.0] - 2026-04-19`
- [x] TestVersionBump pins updated to assert `3.5.0`
- [x] Local `python -m build` wheel+sdist successful (`ao_kernel-3.5.0-py3-none-any.whl`)
- [ ] Merge → tag `v3.5.0` pushed → GitHub Actions → PyPI trusted publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)