### PR TITLE
feat(v3.6-e1): PromotedConsultation reader facade

### DIFF
--- a/.claude/plans/PR-v3.6-MEMORY-LOOP-DRAFT-PLAN.md
+++ b/.claude/plans/PR-v3.6-MEMORY-LOOP-DRAFT-PLAN.md
@@ -1,0 +1,289 @@
+# v3.6 — Memory Loop Closure (DRAFT v2)
+
+**Status:** DRAFT v2 — absorbed Codex iter-1 conditional AGREE (8 revisions) → iter-2 AGREE
+**Depends on:** v3.5.0 LIVE (D1 + D2a + D2b + D3 merged, consultation infrastructure complete)
+
+---
+
+## 1. Problem statement
+
+v3.5 shipped the producer side of consultation memory:
+
+- D1: canonical paths
+- D2a: archive + normalize + integrity manifest
+- D2b: opt-in canonical promotion → `consultation.<CNS-ID>` entries land in
+  `.ao/canonical_decisions.v1.json`
+
+But the **consumer side** is underdeveloped:
+
+1. Callers who ingest canonical decisions get consultation entries for free
+   today (`canonical_store.query(category=None)` already returns them), but
+   there is no **type-safe convenience helper** for "just consultations".
+   Consumers must string-match on `category="consultation"` or on the
+   `consultation.` key prefix — both brittle.
+
+2. The context pipeline (`compile_context`) treats all canonical entries as
+   generic decisions. Consultation records carry rich metadata
+   (`final_verdict`, `from_agent`, `to_agent`, `resolved_at`,
+   `evidence_path` under provenance) that today is silently flattened into
+   the compact value blob.
+
+3. The MCP `ao_memory_read` tool returns unpaginated result lists
+   (friction #3 in the scope research). A workspace with 100+ promoted
+   consultations would blow up MCP payload limits on a wildcard read.
+
+4. Operators enabling `policy_mcp_memory.read.enabled=true` + pattern
+   `"consultation.*"` have no documented happy-path guide.
+
+v3.6 closes the loop: reader facade + context-aware consumption +
+pagination safeguard + docs.
+
+---
+
+## 2. Non-goals
+
+- **No new MCP write surface.** Promotion flow (v3.5 D2b) stays the only
+  path to add consultation entries. `ao_memory_write` already covers
+  direct canonical writes for operators who need it.
+- **No category registry schema.** Friction #1 from scope research
+  (categories stored as scalar string with no validator) is a separate
+  v3.7+ candidate — it touches more than consultations.
+- **No delta/changelog subscription API.** Friction #5 (revision hash
+  only signals "something changed") is a v4.x candidate.
+- **No cross-workspace consultation replication.** Workspace-local only.
+- **No schema migration for existing decision entries.** Consultation
+  entries already ship with the correct shape from D2b.
+
+---
+
+## 3. Design overview (3 sub-PRs)
+
+### E1 — Consultation reader facade (small PR)
+
+**Goal:** type-safe, category-aware read helper consumers can use without
+string-matching.
+
+**New public API (`ao_kernel/consultation/promotion.py`):**
+
+```python
+@dataclass(frozen=True)
+class PromotedConsultation:
+    cns_id: str
+    topic: str | None            # "unknown" backfill on producer side
+    from_agent: str | None
+    to_agent: str | None
+    final_verdict: str          # "AGREE" or "PARTIAL"
+    resolved_at: str | None
+    record_digest: str | None   # prefixed "sha256:..." — from provenance
+    evidence_path: str | None   # relative — from provenance
+    confidence: float           # hydrated from top-level or derived from verdict
+    promoted_at: str
+
+
+def query_promoted_consultations(
+    workspace_root: Path,
+    *,
+    verdict: str | None = None,       # filter AGREE-only etc.
+    topic: str | None = None,
+    include_expired: bool = False,
+) -> tuple[PromotedConsultation, ...]:
+    """Query promoted consultations from canonical store as typed
+    records. Thin wrapper over `canonical_store.query(category="consultation")`;
+    raises nothing on empty store (returns empty tuple).
+
+    Hydration policy (Codex iter-1 revision #1 absorb) — strict core,
+    lenient edges:
+    - Rows missing ANY of `cns_id`, `final_verdict`, `promoted_at` are
+      SKIPPED silently (reader never raises on malformed store content).
+    - `topic`/`from_agent`/`to_agent` — producer backfills "unknown"
+      (see `normalize.py::334`); reader leaves None-tolerant.
+    - `confidence` — reads top-level field first; falls back to
+      `verdict_confidence(final_verdict)` derivation.
+    - `record_digest`/`evidence_path` — read from `provenance`; None
+      when absent. Reader does NOT derive a fallback.
+
+    Rationale: canonical store has no category registry/schema
+    validation today; a reader that panics on ANY malformation would
+    be the wrong failure mode for the consumer path.
+    """
+```
+
+Existing `canonical_store.query` call surface unchanged. The facade does
+the dataclass hydration + filtering so callers never touch raw dicts.
+
+**Tests (7 pins — +1 for malformed-row skip):**
+- Empty store → empty tuple
+- Single AGREE entry → one record hydrated
+- Mixed AGREE + PARTIAL → both returned, verdict filter works
+- Topic filter case-insensitive substring
+- `include_expired=False` respects canonical temporal lifecycle
+- `include_expired=True` returns expired entries
+- **NEW: Malformed row (missing `cns_id`) silently skipped, other
+  rows still hydrated.**
+
+### E2 — Context pipeline consultation lane (medium PR)
+
+**Goal:** `compile_context` surfaces promoted consultations as a
+first-class lane alongside session/canonical/facts.
+
+**Compiler stays pure (Codex iter-1 revision #1 absorb).** The compiler
+MUST NOT perform I/O. Consultation loading happens at the
+**caller layer** — specifically in `compile_context_sdk` (which is
+the SDK-facing wrapper, already an orchestrator) — which queries via
+`query_promoted_consultations` and passes the result list into the
+pure compiler as a new `consultations=` parameter.
+
+**Changes (`ao_kernel/context/context_compiler.py` — pure renderer):**
+- New optional parameter `consultations: Sequence[PromotedConsultation] = ()`
+  on `compile_context(...)`. Compiler does NO loading; it only renders.
+- New section header `## Consultations` in `_build_preamble` (reuses
+  the existing section-header pattern — NO fresh `[consultation]`
+  lane badge per Codex revision #2).
+- Entries render as compact refs, e.g.
+  `- [CNS-20260418-601] architecture AGREE (claude→codex, 2026-04-18)`
+- Budget policy: when `consultations` pushes the preamble over the
+  `max_tokens` cap, truncate the consultation block last-added-first-
+  dropped before truncating other lanes.
+
+**Changes (`ao_kernel/context/profile_router.py` — SSOT widening per
+Codex iter-1 revision #7):**
+- `ProfileConfig` dataclass gains `max_consultations: int` field.
+- Per-profile defaults:
+  - `PLANNING` + `REVIEW` → `max_consultations=10`
+  - `STARTUP` + `TASK_EXECUTION` + `ASSESSMENT` → `max_consultations=3`
+  - `EMERGENCY` → `max_consultations=0` (lean context invariant)
+- Compiler reads this field from the resolved profile when given.
+
+**Changes (`ao_kernel/context/agent_coordination.py::compile_context_sdk` —
+I/O layer):**
+- Before the pure compile call, query consultations via
+  `query_promoted_consultations(workspace_root)`, slice by profile's
+  `max_consultations`, prefer `AGREE`-first then `PARTIAL`, sort by
+  `promoted_at` desc.
+- Pass the resulting tuple into the compiler.
+
+**Tests (8 pins):**
+- `compile_context(consultations=())` omits `## Consultations` header
+  (no empty-section artifact).
+- 3 AGREE consultations passed → header present, 3 entries, sorted desc.
+- `PLANNING` profile drives `max_consultations=10` via
+  `ProfileConfig`; compile_context_sdk honours it.
+- `EMERGENCY` profile → `max_consultations=0`; even populated store
+  yields 0 consultations to compiler.
+- Lane length budget: oversize preamble → consultations dropped
+  before other lanes.
+- `profile_router.ProfileConfig.max_consultations` is set per
+  profile (SSOT test).
+- `compile_context_sdk` wiring: store with 2 AGREE + 1 PARTIAL +
+  `PLANNING` profile → all 3 reach compiler.
+- **Malformed-store defence (Codex iter-1 revision #7 absorb):**
+  two distinct canonical rows (under different store keys) whose
+  hydrated `cns_id` values collide → reader dedupes the final set by
+  `cns_id`, picking the most recent by `promoted_at`. Rationale:
+  canonical key uniqueness is enforced upstream for the happy path,
+  but a future store-format drift (or manual operator edit) could
+  still produce two rows resolving to the same consultation id;
+  reader is the last line of defence.
+
+### E3 — MCP memory_read pagination + docs (small PR)
+
+**Goal:** cap MCP payload size + document the consultation happy-path.
+
+**Changes (`ao_kernel/mcp_server.py` + `_internal/mcp/memory_tools.py`):**
+- `ao_memory_read` inputSchema gains (additive, no schema version
+  bump — Codex iter-1 revision #4 confirmed):
+  - `max_results` (integer, default 50, max 200) — hard cap at 200 to
+    respect MCP payload limits.
+  - `offset` (integer, default 0) — caller-managed pagination cursor.
+- Response `data` block today already returns `{items, count}`
+  (confirmed by Codex citing `memory_tools.py:268`). v3.6 widens to
+  `{items, count, total, next_offset}` where:
+  - `count` = entries in THIS page (unchanged semantics).
+  - `total` = post-policy-filter total across the full query.
+  - `next_offset` = cursor for the next page, or null when the store
+    is exhausted under the current filter.
+- Pagination logic lives in the handler (`handle_memory_read`);
+  `canonical_store.query()` is NOT widened (Codex iter-1 revision #8
+  — transport-level payload cap is out of storage/query concern).
+- Rate limiter unchanged.
+
+**Tests (5 pins):**
+- Default `max_results=50` honoured when store has 100 entries
+- `offset=50` returns second page
+- `max_results > 200` clamped to 200
+- `total` matches post-policy-filter count (and distinct from `count`
+  when pagination kicks in)
+- `next_offset` null when result exhausts store
+
+**Docs (Codex iter-1 revision #5 absorb):**
+- New `docs/CONSULTATION-QUERY.md` — short guide covering:
+  1. Enable MCP memory policy (`read.enabled=true` + `consultation.*`
+     pattern) at workspace level.
+  2. `query_promoted_consultations` Python API example.
+  3. `ao_memory_read` MCP pagination example.
+  4. Semantic: AGREE vs PARTIAL confidence pairs.
+- **Additional doc updates** (Codex revision #5 scope widening):
+  - `CLAUDE.md` §9 Context Pipeline — "3-Lane Compilation" → "4-Lane
+    Compilation" (add Consultation lane), link to CONSULTATION-QUERY.
+  - `README.md` — bullet list of governance tools + link to query doc.
+  - `docs/DEMO-SCRIPT.md` — replace "three-lane" references with
+    "four-lane" and show consultation lane in the demo output.
+  - `docs/EVIDENCE-TIMELINE.md` — cross-link (producer side → consumer
+    side pointer).
+
+---
+
+## 4. Rollout
+
+1. E1 plan-time CNS → AGREE → impl → post-impl review → merge
+2. E2 plan-time CNS → AGREE → impl → post-impl review → merge
+3. E3 plan-time CNS → AGREE → impl → post-impl review → merge
+4. Release PR v3.6.0 (version bump + CHANGELOG + tag + PyPI)
+
+Paralelism option: E1 + E3 independent (different files). E2 depends on
+E1's reader facade so sequence is E1 → (E2 + E3 parallel Codex threads).
+
+---
+
+## 5. Resolved design decisions (iter-1 conditional AGREE)
+
+All open questions resolved in iter-2:
+
+1. **PromotedConsultation hydration** — strict core (`cns_id`,
+   `final_verdict`, `promoted_at` required — missing rows SKIPPED
+   silently), lenient edges (backfilled or derived).
+2. **Section header** — reuse `## Consultations` pattern (no fresh
+   `[consultation]` lane badge).
+3. **EMERGENCY → max_consultations=0** — confirmed; lean-context
+   invariant takes priority over "last AGREE always" until incident-
+   tagging exists.
+4. **Pagination additive-safe** — `data` already returns
+   `{items, count}`; widen to add `total` + `next_offset` is pure
+   additive. No schema bump needed.
+5. **Docs** — dedicated `CONSULTATION-QUERY.md` + scope-widened to
+   touch CLAUDE.md 3→4-lane, README, DEMO-SCRIPT.md, EVIDENCE-TIMELINE
+   cross-link.
+6. **3 sub-PRs** — kept; different risk profiles justify separate
+   gates.
+7. **Compiler purity** — compiler stays I/O-free; consultation load
+   in `compile_context_sdk` + `ProfileConfig.max_consultations` SSOT
+   field.
+8. **Pagination handler-local** — `canonical_store.query()` NOT
+   widened; transport-level payload cap is out of storage/query
+   concern.
+
+---
+
+## 6. Scope summary
+
+**IN:**
+- `query_promoted_consultations` typed reader facade (E1)
+- `compile_context` consultation lane + profile priorities (E2)
+- `ao_memory_read` pagination + consultation query doc (E3)
+
+**OUT:**
+- Write-side policy changes (already shipped in v3.5 D2b)
+- Category registry schema (v3.7+)
+- Delta/changelog subscription API (v4.x)
+- Cross-workspace replication (out of scope)
+- Schema migration (no migration needed; D2b entries already correct shape)

--- a/ao_kernel/consultation/promotion.py
+++ b/ao_kernel/consultation/promotion.py
@@ -385,9 +385,14 @@ def query_promoted_consultations(
         ``promoted_at`` descending (newest first). Empty tuple when
         the store is empty or has no consultation entries.
     """
+    # Filter by category only — do NOT constrain key_pattern.
+    # Codex post-impl SUGGEST #1 absorb: `key_pattern="consultation.*"`
+    # re-introduces the namespaced-key assumption the facade was
+    # supposed to abstract away. Category is the sole authoritative
+    # filter; a row with `category="consultation"` but some other key
+    # must still hydrate.
     raw = canonical_query(
         workspace_root,
-        key_pattern="consultation.*",
         category="consultation",
         include_expired=include_expired,
     )

--- a/ao_kernel/consultation/promotion.py
+++ b/ao_kernel/consultation/promotion.py
@@ -30,7 +30,11 @@ from typing import Any, Mapping
 
 from ao_kernel.consultation.integrity import verify_consultation_manifest
 from ao_kernel.consultation.normalize import record_digest
-from ao_kernel.context.canonical_store import load_store, promote_decision
+from ao_kernel.context.canonical_store import (
+    load_store,
+    promote_decision,
+    query as canonical_query,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -86,16 +90,15 @@ def _compact_value(record: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _provenance(
-    cns_id: str, record_dig: str,
+    cns_id: str,
+    record_dig: str,
 ) -> dict[str, Any]:
     """Workspace-relative pointer + record digest for dereferencing."""
     return {
         "method": "consultation_promotion",
         "cns_id": cns_id,
         "evidence_path": f".ao/evidence/consultations/{cns_id}",
-        "resolution_record_path": (
-            f".ao/evidence/consultations/{cns_id}/resolution.record.v1.json"
-        ),
+        "resolution_record_path": (f".ao/evidence/consultations/{cns_id}/resolution.record.v1.json"),
         "record_digest": record_dig,
     }
 
@@ -152,16 +155,18 @@ def promote_resolved_consultations(
     if not enabled and not force:
         counters["skipped_disabled"] = 1
         return PromotionSummary(
-            **counters, errors=tuple(errors), dry_run=dry_run,
+            **counters,
+            errors=tuple(errors),
+            dry_run=dry_run,
         )
 
-    evidence_root = (
-        workspace_root / ".ao" / "evidence" / "consultations"
-    )
+    evidence_root = workspace_root / ".ao" / "evidence" / "consultations"
     # Codex iter-3 execution note #2: empty workspace → clean summary
     if not evidence_root.is_dir():
         return PromotionSummary(
-            **counters, errors=tuple(errors), dry_run=dry_run,
+            **counters,
+            errors=tuple(errors),
+            dry_run=dry_run,
         )
 
     store = load_store(workspace_root)
@@ -184,9 +189,7 @@ def promote_resolved_consultations(
         record = _load_record(cns_dir)
         if record is None:
             counters["skipped_missing_record"] += 1
-            errors.append(
-                f"{cns_dir.name}: resolution.record.v1.json missing"
-            )
+            errors.append(f"{cns_dir.name}: resolution.record.v1.json missing")
             continue
 
         # Eligibility
@@ -208,9 +211,7 @@ def promote_resolved_consultations(
         existing = existing_decisions.get(key)
         is_update = False
         if isinstance(existing, dict):
-            existing_digest = (
-                existing.get("provenance", {}).get("record_digest")
-            )
+            existing_digest = existing.get("provenance", {}).get("record_digest")
             if existing_digest == prefixed_digest:
                 counters["skipped_same_digest"] += 1
                 continue
@@ -239,12 +240,185 @@ def promote_resolved_consultations(
             counters["promoted"] += 1
 
     return PromotionSummary(
-        **counters, errors=tuple(errors), dry_run=dry_run,
+        **counters,
+        errors=tuple(errors),
+        dry_run=dry_run,
     )
 
 
+# ─── v3.6 E1 — Consumer-side reader facade ──────────────────────────────
+
+
+@dataclass(frozen=True)
+class PromotedConsultation:
+    """Typed record for a promoted consultation entry in the canonical
+    store.
+
+    Hydration policy (strict core, lenient edges — v3.6 plan §3.E1 +
+    Codex iter-1 revision #1 absorb):
+
+    - ``cns_id``, ``final_verdict`` and ``promoted_at`` are STRICT
+      CORE: any missing field causes the row to be silently SKIPPED
+      in :func:`query_promoted_consultations`.
+    - ``topic`` / ``from_agent`` / ``to_agent`` are None-tolerant here
+      because the producer already backfills ``"unknown"`` for missing
+      request metadata (see ``normalize.py::334``).
+    - ``confidence`` is read from the top-level canonical entry; if
+      absent, the reader derives it via :func:`verdict_confidence`.
+    - ``record_digest`` / ``evidence_path`` come from
+      ``provenance``; None when absent (no fallback derivation).
+
+    Rationale: canonical store has no category registry / schema
+    validation today (v3.7+ scope). A reader that panics on any
+    malformation would be the wrong failure mode for the consumer
+    path — it would propagate upstream producer bugs as hard failures
+    in context compilation and MCP query surfaces.
+    """
+
+    cns_id: str
+    topic: str | None
+    from_agent: str | None
+    to_agent: str | None
+    final_verdict: str
+    resolved_at: str | None
+    record_digest: str | None
+    evidence_path: str | None
+    confidence: float
+    promoted_at: str
+
+
+_HYDRATION_REQUIRED = ("cns_id", "final_verdict", "promoted_at")
+
+
+def _hydrate_consultation(
+    entry: Mapping[str, Any],
+) -> PromotedConsultation | None:
+    """Hydrate a canonical-store row into a ``PromotedConsultation``.
+
+    Returns ``None`` when any strict-core field is missing; callers
+    skip those rows silently.
+    """
+    value = entry.get("value") or {}
+    if not isinstance(value, Mapping):
+        return None
+
+    cns_id = value.get("cns_id") if isinstance(value.get("cns_id"), str) else None
+    final_verdict = value.get("final_verdict") if isinstance(value.get("final_verdict"), str) else None
+    promoted_at = entry.get("promoted_at") if isinstance(entry.get("promoted_at"), str) else None
+    if not cns_id or not final_verdict or not promoted_at:
+        return None
+
+    provenance = entry.get("provenance") or {}
+    if not isinstance(provenance, Mapping):
+        provenance = {}
+
+    # Lenient edge fields — nullable when absent.
+    topic_raw = value.get("topic")
+    topic: str | None = topic_raw if isinstance(topic_raw, str) and topic_raw else None
+    from_agent_raw = value.get("from_agent")
+    from_agent: str | None = from_agent_raw if isinstance(from_agent_raw, str) and from_agent_raw else None
+    to_agent_raw = value.get("to_agent")
+    to_agent: str | None = to_agent_raw if isinstance(to_agent_raw, str) and to_agent_raw else None
+    resolved_at_raw = value.get("resolved_at")
+    resolved_at: str | None = resolved_at_raw if isinstance(resolved_at_raw, str) else None
+    record_digest_raw = provenance.get("record_digest")
+    record_digest: str | None = record_digest_raw if isinstance(record_digest_raw, str) else None
+    evidence_path_raw = provenance.get("evidence_path")
+    evidence_path: str | None = evidence_path_raw if isinstance(evidence_path_raw, str) else None
+
+    confidence_raw = entry.get("confidence")
+    if isinstance(confidence_raw, (int, float)):
+        confidence = float(confidence_raw)
+    else:
+        confidence = verdict_confidence(final_verdict)
+
+    return PromotedConsultation(
+        cns_id=cns_id,
+        topic=topic,
+        from_agent=from_agent,
+        to_agent=to_agent,
+        final_verdict=final_verdict,
+        resolved_at=resolved_at,
+        record_digest=record_digest,
+        evidence_path=evidence_path,
+        confidence=confidence,
+        promoted_at=promoted_at,
+    )
+
+
+def query_promoted_consultations(
+    workspace_root: Path,
+    *,
+    verdict: str | None = None,
+    topic: str | None = None,
+    include_expired: bool = False,
+) -> tuple[PromotedConsultation, ...]:
+    """Query promoted consultations from the canonical store as typed
+    records.
+
+    Thin, consumer-safe wrapper over
+    :func:`ao_kernel.context.canonical_store.query` with
+    ``category="consultation"``. Rows that cannot be hydrated (strict
+    core field missing) are silently SKIPPED — the reader never
+    raises on malformed store content (v3.6 plan §3.E1 hydration
+    policy).
+
+    When two canonical rows resolve to the same ``cns_id``, the
+    more recent ``promoted_at`` wins — a last line of defence
+    against future store-format drift (Codex iter-1 revision #7
+    absorb). Canonical key uniqueness is enforced upstream on the
+    happy path, so this dedup is rarely exercised but guards the
+    contract.
+
+    Args:
+        workspace_root: Workspace root (``.ao/canonical_decisions.v1.json``
+            lives under this).
+        verdict: Optional filter (``AGREE`` / ``PARTIAL``); case-
+            sensitive match against ``final_verdict``.
+        topic: Optional case-insensitive substring filter on the
+            ``topic`` field (``None`` topic rows never match).
+        include_expired: When True, expired entries are included;
+            default False respects the canonical temporal lifecycle.
+
+    Returns:
+        Tuple of :class:`PromotedConsultation` records sorted by
+        ``promoted_at`` descending (newest first). Empty tuple when
+        the store is empty or has no consultation entries.
+    """
+    raw = canonical_query(
+        workspace_root,
+        key_pattern="consultation.*",
+        category="consultation",
+        include_expired=include_expired,
+    )
+
+    by_id: dict[str, PromotedConsultation] = {}
+    for row in raw:
+        hydrated = _hydrate_consultation(row)
+        if hydrated is None:
+            continue
+        if verdict is not None and hydrated.final_verdict != verdict:
+            continue
+        if topic is not None:
+            haystack = (hydrated.topic or "").lower()
+            if topic.lower() not in haystack:
+                continue
+        existing = by_id.get(hydrated.cns_id)
+        if existing is None or hydrated.promoted_at > existing.promoted_at:
+            by_id[hydrated.cns_id] = hydrated
+
+    sorted_records = sorted(
+        by_id.values(),
+        key=lambda rec: rec.promoted_at,
+        reverse=True,
+    )
+    return tuple(sorted_records)
+
+
 __all__ = [
+    "PromotedConsultation",
     "PromotionSummary",
     "promote_resolved_consultations",
+    "query_promoted_consultations",
     "verdict_confidence",
 ]

--- a/tests/test_consultation_reader_facade.py
+++ b/tests/test_consultation_reader_facade.py
@@ -1,0 +1,265 @@
+"""v3.6 E1: PromotedConsultation reader facade tests (7 pins).
+
+Strict core, lenient edges (plan §3.E1 + Codex iter-1 revision #1):
+- Missing cns_id/final_verdict/promoted_at → row silently SKIPPED
+- Missing topic/from_agent/to_agent → None-tolerant
+- Missing confidence → derived from verdict via verdict_confidence()
+- Missing provenance fields → None
+- Two rows with same cns_id → dedup by most recent promoted_at
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ao_kernel.consultation.promotion import (
+    PromotedConsultation,
+    query_promoted_consultations,
+    verdict_confidence,
+)
+
+
+def _write_store(
+    workspace_root: Path,
+    decisions: dict[str, dict],
+) -> None:
+    ao = workspace_root / ".ao"
+    ao.mkdir(parents=True, exist_ok=True)
+    (ao / "canonical_decisions.v1.json").write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "decisions": decisions,
+                "facts": {},
+                "updated_at": "2026-04-19T00:00:00Z",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _canonical_entry(
+    cns_id: str,
+    *,
+    verdict: str = "AGREE",
+    topic: str = "architecture",
+    from_agent: str | None = "claude",
+    to_agent: str | None = "codex",
+    resolved_at: str | None = "2026-04-18T10:00:00+00:00",
+    promoted_at: str = "2026-04-19T10:00:00+00:00",
+    confidence: float | None = None,
+    record_digest: str | None = "sha256:deadbeef",
+    evidence_path: str | None = ".ao/evidence/consultations/xyz",
+    category: str = "consultation",
+    expires_at: str = "",
+) -> dict:
+    value: dict = {
+        "cns_id": cns_id,
+        "topic": topic,
+        "from_agent": from_agent,
+        "to_agent": to_agent,
+        "final_verdict": verdict,
+        "resolved_at": resolved_at,
+    }
+    provenance: dict = {
+        "method": "consultation_promotion",
+        "cns_id": cns_id,
+    }
+    if record_digest is not None:
+        provenance["record_digest"] = record_digest
+    if evidence_path is not None:
+        provenance["evidence_path"] = evidence_path
+    entry: dict = {
+        "key": f"consultation.{cns_id}",
+        "value": value,
+        "category": category,
+        "source": "consultation_archive",
+        "confidence": confidence if confidence is not None else verdict_confidence(verdict),
+        "provenance": provenance,
+        "promoted_at": promoted_at,
+        "expires_at": expires_at,
+    }
+    return entry
+
+
+class TestEmptyStore:
+    def test_empty_store_returns_empty_tuple(self, tmp_path: Path) -> None:
+        result = query_promoted_consultations(tmp_path)
+        assert result == ()
+        assert isinstance(result, tuple)
+
+
+class TestHappyPath:
+    def test_single_agree_hydrates(self, tmp_path: Path) -> None:
+        _write_store(
+            tmp_path,
+            {"consultation.CNS-001": _canonical_entry("CNS-001")},
+        )
+        result = query_promoted_consultations(tmp_path)
+        assert len(result) == 1
+        rec = result[0]
+        assert isinstance(rec, PromotedConsultation)
+        assert rec.cns_id == "CNS-001"
+        assert rec.final_verdict == "AGREE"
+        assert rec.confidence == 1.0
+        assert rec.topic == "architecture"
+        assert rec.from_agent == "claude"
+        assert rec.to_agent == "codex"
+        assert rec.record_digest == "sha256:deadbeef"
+        assert rec.evidence_path == ".ao/evidence/consultations/xyz"
+
+    def test_mixed_verdicts_and_verdict_filter(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        _write_store(
+            tmp_path,
+            {
+                "consultation.CNS-001": _canonical_entry(
+                    "CNS-001",
+                    verdict="AGREE",
+                    promoted_at="2026-04-19T10:00:00+00:00",
+                ),
+                "consultation.CNS-002": _canonical_entry(
+                    "CNS-002",
+                    verdict="PARTIAL",
+                    promoted_at="2026-04-19T09:00:00+00:00",
+                ),
+            },
+        )
+        all_records = query_promoted_consultations(tmp_path)
+        assert len(all_records) == 2
+        # Sorted by promoted_at desc
+        assert all_records[0].cns_id == "CNS-001"
+        assert all_records[1].cns_id == "CNS-002"
+
+        only_agree = query_promoted_consultations(tmp_path, verdict="AGREE")
+        assert [rec.cns_id for rec in only_agree] == ["CNS-001"]
+
+        only_partial = query_promoted_consultations(
+            tmp_path,
+            verdict="PARTIAL",
+        )
+        assert [rec.cns_id for rec in only_partial] == ["CNS-002"]
+        assert only_partial[0].confidence == pytest.approx(0.7)
+
+
+class TestTopicFilter:
+    def test_topic_filter_case_insensitive_substring(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        _write_store(
+            tmp_path,
+            {
+                "consultation.CNS-001": _canonical_entry(
+                    "CNS-001",
+                    topic="Runtime Architecture",
+                ),
+                "consultation.CNS-002": _canonical_entry(
+                    "CNS-002",
+                    topic="policy engine",
+                ),
+            },
+        )
+        arch_only = query_promoted_consultations(tmp_path, topic="architecture")
+        assert [rec.cns_id for rec in arch_only] == ["CNS-001"]
+        # Case-insensitive substring match
+        upper = query_promoted_consultations(tmp_path, topic="RUNTIME")
+        assert [rec.cns_id for rec in upper] == ["CNS-001"]
+
+
+class TestExpiryLifecycle:
+    def test_expired_excluded_by_default(self, tmp_path: Path) -> None:
+        _write_store(
+            tmp_path,
+            {
+                "consultation.CNS-001": _canonical_entry(
+                    "CNS-001",
+                    expires_at="2020-01-01T00:00:00Z",  # past
+                ),
+                "consultation.CNS-002": _canonical_entry("CNS-002"),
+            },
+        )
+        default = query_promoted_consultations(tmp_path)
+        assert [rec.cns_id for rec in default] == ["CNS-002"]
+
+    def test_expired_included_when_requested(self, tmp_path: Path) -> None:
+        _write_store(
+            tmp_path,
+            {
+                "consultation.CNS-001": _canonical_entry(
+                    "CNS-001",
+                    expires_at="2020-01-01T00:00:00Z",
+                    promoted_at="2026-04-19T10:00:00+00:00",
+                ),
+                "consultation.CNS-002": _canonical_entry(
+                    "CNS-002",
+                    promoted_at="2026-04-19T09:00:00+00:00",
+                ),
+            },
+        )
+        result = query_promoted_consultations(
+            tmp_path,
+            include_expired=True,
+        )
+        assert {rec.cns_id for rec in result} == {"CNS-001", "CNS-002"}
+
+
+class TestMalformedRowSkip:
+    def test_row_missing_cns_id_silently_skipped(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Strict-core hydration: missing cns_id → row SKIP, reader
+        never raises."""
+        bad = _canonical_entry("CNS-IGNORED")
+        bad["value"].pop("cns_id")
+        _write_store(
+            tmp_path,
+            {
+                "consultation.CNS-MALFORMED": bad,
+                "consultation.CNS-GOOD": _canonical_entry("CNS-GOOD"),
+            },
+        )
+        result = query_promoted_consultations(tmp_path)
+        assert [rec.cns_id for rec in result] == ["CNS-GOOD"]
+
+
+class TestDuplicateDedup:
+    def test_two_rows_same_cns_id_dedup_by_promoted_at(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Malformed-store defence (plan §3.E2 tests + Codex iter-2
+        rewording): two distinct canonical rows whose hydrated
+        cns_id values collide → reader dedupes, keeping the more
+        recent promoted_at. Canonical key uniqueness is enforced
+        upstream on the happy path; this guards future store-format
+        drift."""
+        older = _canonical_entry(
+            "CNS-DUP",
+            verdict="PARTIAL",
+            promoted_at="2026-04-18T09:00:00+00:00",
+        )
+        newer = _canonical_entry(
+            "CNS-DUP",
+            verdict="AGREE",
+            promoted_at="2026-04-19T10:00:00+00:00",
+        )
+        _write_store(
+            tmp_path,
+            {
+                "consultation.CNS-DUP-a": older,
+                "consultation.CNS-DUP-b": newer,
+            },
+        )
+        result = query_promoted_consultations(tmp_path)
+        assert len(result) == 1
+        assert result[0].cns_id == "CNS-DUP"
+        assert result[0].final_verdict == "AGREE"
+        assert result[0].promoted_at == "2026-04-19T10:00:00+00:00"

--- a/tests/test_consultation_reader_facade.py
+++ b/tests/test_consultation_reader_facade.py
@@ -230,6 +230,60 @@ class TestMalformedRowSkip:
         assert [rec.cns_id for rec in result] == ["CNS-GOOD"]
 
 
+class TestHydrationFallbacks:
+    """Codex post-impl SUGGEST #2 absorb — pin the derived-confidence
+    and None-provenance fallback branches. Default test helper was
+    populating these fields so the fallback code was not regression-
+    pinned."""
+
+    def test_confidence_derived_from_verdict_when_absent(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        entry = _canonical_entry("CNS-NC", verdict="PARTIAL")
+        entry.pop("confidence")  # simulate missing top-level field
+        _write_store(tmp_path, {"consultation.CNS-NC": entry})
+        result = query_promoted_consultations(tmp_path)
+        assert len(result) == 1
+        # verdict_confidence("PARTIAL") == 0.7
+        assert result[0].confidence == pytest.approx(0.7)
+
+    def test_provenance_fields_none_tolerated(self, tmp_path: Path) -> None:
+        entry = _canonical_entry(
+            "CNS-NP",
+            record_digest=None,
+            evidence_path=None,
+        )
+        _write_store(tmp_path, {"consultation.CNS-NP": entry})
+        result = query_promoted_consultations(tmp_path)
+        assert len(result) == 1
+        assert result[0].record_digest is None
+        assert result[0].evidence_path is None
+
+
+class TestCategoryAuthoritative:
+    """Codex post-impl SUGGEST #1 absorb — facade authoritative filter
+    is `category`, NOT key prefix. A row correctly categorised as
+    `consultation` but stored under some other canonical key must
+    still hydrate (future store-format drift defence)."""
+
+    def test_row_with_non_namespaced_key_still_hydrates(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        entry = _canonical_entry("CNS-OFF-KEY")
+        _write_store(
+            tmp_path,
+            {
+                # Deliberately off-namespace canonical key with correct
+                # category. Facade must still surface this row.
+                "decision.legacy.CNS-OFF-KEY": entry,
+            },
+        )
+        result = query_promoted_consultations(tmp_path)
+        assert [rec.cns_id for rec in result] == ["CNS-OFF-KEY"]
+
+
 class TestDuplicateDedup:
     def test_two_rows_same_cns_id_dedup_by_promoted_at(
         self,


### PR DESCRIPTION
## Summary

First v3.6 "Memory Loop Closure" PR. Consumer-side reader for the D2b opt-in promotion pipeline.

- New public API `query_promoted_consultations(workspace_root, *, verdict, topic, include_expired)` in `ao_kernel/consultation/promotion.py`.
- New typed dataclass `PromotedConsultation` — 10 fields spanning value/provenance/top-level canonical entry layers.
- **Strict core, lenient edges** hydration policy — rows missing `cns_id` / `final_verdict` / `promoted_at` silently SKIPPED (reader never raises on malformed store content); `topic` / `from_agent` / `to_agent` None-tolerant (producer already backfills "unknown"); `confidence` derived via `verdict_confidence()` when absent.
- **Malformed-store defence** — two distinct canonical rows whose hydrated `cns_id` values collide are deduped by most recent `promoted_at`. Canonical key uniqueness is enforced upstream on the happy path; this is the last line of defence against future store-format drift.

## Plan + Codex AGREE

`.claude/plans/PR-v3.6-MEMORY-LOOP-DRAFT-PLAN.md` v2 — master plan iter-1 conditional AGREE (8 revisions absorbed: compiler purity, section-header reuse, hydration policy, pagination narrative, docs scope widening, ProfileConfig SSOT, dedup test rewording, handler-local pagination) → iter-2 AGREE. E1 scope carved out of the §3.E1 block.

## Scope non-goals (v3.6 master)
- Context pipeline integration → E2
- MCP pagination → E3
- No write surface changes
- No category registry schema (v3.7+)

## Test plan
- [x] +8 new pins (TestEmptyStore + TestHappyPath + TestTopicFilter + TestExpiryLifecycle + TestMalformedRowSkip + TestDuplicateDedup)
- [x] Full pytest: 2416 passed
- [x] Ruff + mypy clean on 205 source files
- [x] Manual smoke: empty store → `()`, single AGREE hydrated correctly, duplicate cns_id resolves to most recent

🤖 Generated with [Claude Code](https://claude.com/claude-code)