### PR TITLE
feat(v3.6-e2): context pipeline consultation lane

### DIFF
--- a/ao_kernel/context/agent_coordination.py
+++ b/ao_kernel/context/agent_coordination.py
@@ -139,6 +139,7 @@ def record_decision(
 
     if auto_promote and confidence >= promote_threshold:
         from ao_kernel.context.canonical_store import promote_decision
+
         promote_decision(
             workspace_root,
             key=key,
@@ -151,6 +152,7 @@ def record_decision(
         destination = "canonical"
     elif context is not None:
         from ao_kernel._internal.session.context_store import upsert_decision
+
         upsert_decision(
             context,
             key=key,
@@ -199,8 +201,13 @@ def compile_context_sdk(
     Returns:
         ``{preamble, total_tokens, profile_id, items_included, items_excluded}``
     """
+    from ao_kernel.consultation.promotion import (
+        PromotedConsultation,
+        query_promoted_consultations,
+    )
     from ao_kernel.context.canonical_store import query
     from ao_kernel.context.context_compiler import compile_context
+    from ao_kernel.context.profile_router import detect_profile, get_profile
 
     canonical_items = query(workspace_root, category=None)
     canonical_dict = {item["key"]: item for item in canonical_items}
@@ -213,10 +220,33 @@ def compile_context_sdk(
         except (json.JSONDecodeError, OSError):
             pass
 
+    # v3.6 E2 — load consultations at the caller layer (compiler stays
+    # pure, plan §3.E2 + Codex iter-1 revision #1). Resolve profile up
+    # front so we only query the store when the profile wants
+    # consultations (`max_consultations > 0`), then slice + prefer-AGREE
+    # sort before handing the tuple to the compiler.
+    resolved_profile_id = profile
+    if resolved_profile_id is None and messages:
+        resolved_profile_id = detect_profile(messages)
+    profile_config = get_profile(resolved_profile_id)
+    consultation_cap = max(0, profile_config.max_consultations)
+    consultation_records: tuple[PromotedConsultation, ...] = ()
+    if consultation_cap:
+        try:
+            all_consultations = query_promoted_consultations(workspace_root)
+        except Exception:  # noqa: BLE001 — consumer-side query must not raise
+            all_consultations = ()
+        # Prefer AGREE first, PARTIAL second; each already sorted by
+        # promoted_at desc inside the facade.
+        agree = tuple(r for r in all_consultations if r.final_verdict == "AGREE")
+        partial = tuple(r for r in all_consultations if r.final_verdict == "PARTIAL")
+        consultation_records = (agree + partial)[:consultation_cap]
+
     result = compile_context(
         session_context or {"ephemeral_decisions": []},
         canonical_decisions=canonical_dict,
         workspace_facts=workspace_facts,
+        consultations=consultation_records,
         profile=profile,
         messages=messages,
     )
@@ -281,6 +311,7 @@ def query_memory(
     modules.
     """
     from ao_kernel.context.canonical_store import query
+
     return query(workspace_root, key_pattern=key_pattern, category=category)
 
 

--- a/ao_kernel/context/agent_coordination.py
+++ b/ao_kernel/context/agent_coordination.py
@@ -210,7 +210,12 @@ def compile_context_sdk(
     from ao_kernel.context.profile_router import detect_profile, get_profile
 
     canonical_items = query(workspace_root, category=None)
-    canonical_dict = {item["key"]: item for item in canonical_items}
+    # v3.6 E2 iter-2 Codex BLOCK #1 absorb — exclude consultation-
+    # category rows from the canonical lane so they render exactly
+    # once under the dedicated `## Consultations` section instead of
+    # appearing as both a generic canonical blob AND a consultation
+    # line. The consultation surface is the typed one.
+    canonical_dict = {item["key"]: item for item in canonical_items if item.get("category") != "consultation"}
 
     facts_path = workspace_root / ".cache" / "index" / "workspace_facts.v1.json"
     workspace_facts = None

--- a/ao_kernel/context/context_compiler.py
+++ b/ao_kernel/context/context_compiler.py
@@ -23,10 +23,16 @@ import logging
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from ao_kernel.consultation.promotion import PromotedConsultation
 from ao_kernel.context.profile_router import ProfileConfig, get_profile
+
+if TYPE_CHECKING:
+    # Runtime-skipped to avoid a circular import: promotion.py imports
+    # canonical_store.query, which triggers ao_kernel.context.__init__,
+    # which loads this module. Annotations use string forward refs via
+    # `from __future__ import annotations` above.
+    from ao_kernel.consultation.promotion import PromotedConsultation
 
 logger = logging.getLogger(__name__)
 
@@ -163,17 +169,30 @@ def compile_context(
             }
         )
 
-    # Apply profile consultation cap (last-added-first-dropped when
-    # oversize, per plan §3.E2).
+    # Apply profile consultation cap (last-added-first-dropped per
+    # plan §3.E2) + enforce token budget (Codex iter-2 BLOCK #2 absorb
+    # — consultation lines must count toward max_tokens; previously
+    # they bypassed budget and also were not reflected in
+    # total_tokens / telemetry).
     cap = max(0, profile_config.max_consultations)
     capped_consultations = tuple(consultations[:cap]) if cap else ()
+    accepted_consultations: list[PromotedConsultation] = []
+    for record in capped_consultations:
+        rendered_line = _render_consultation(record)
+        line_chars = len(rendered_line) + 1  # trailing newline
+        if used_chars + line_chars > budget:
+            break
+        accepted_consultations.append(record)
+        used_chars += line_chars
 
-    # Build preamble from included items + capped consultations
+    # Build preamble from included items + budget-fit consultations
     preamble = _build_preamble(
         [i for i in items if i.included],
         profile_config,
-        consultations=capped_consultations,
+        consultations=tuple(accepted_consultations),
     )
+
+    total_tokens = used_chars // 4
 
     # Telemetry (optional subsystem per CLAUDE.md §7 — graceful fallback, debug log)
     try:
@@ -183,14 +202,14 @@ def compile_context(
             included_count,
             len(items) - included_count,
             profile=profile_config.profile_id,
-            total_tokens=used_chars // 4,
+            total_tokens=total_tokens,
         )
     except Exception as e:
         logger.debug("context telemetry record skipped: %s", e)
 
     return CompiledContext(
         preamble=preamble,
-        total_tokens=used_chars // 4,
+        total_tokens=total_tokens,
         items_included=included_count,
         items_excluded=len(items) - included_count,
         profile_id=profile_config.profile_id,

--- a/ao_kernel/context/context_compiler.py
+++ b/ao_kernel/context/context_compiler.py
@@ -1,8 +1,12 @@
-"""Context compiler — merge 3 lanes into relevance-scored, budget-aware context.
+"""Context compiler — merge 4 lanes into relevance-scored, budget-aware context.
 
 Lane 1: Active session decisions (most recent, ephemeral)
-Lane 2: Canonical decisions (promoted, permanent) — Faz 3 placeholder
+Lane 2: Canonical decisions (promoted, permanent) — from canonical_store
 Lane 3: Workspace facts (distilled cross-session) — from memory_distiller
+Lane 4: Promoted consultations (v3.6 E2) — typed agent-to-agent decisions
+        from ``ao_kernel.consultation.promotion.query_promoted_consultations``.
+        Caller supplies the already-loaded tuple; the compiler is pure and
+        does NOT perform any I/O (see plan §3.E2 + Codex iter-1 revision #1).
 
 Each item gets a relevance score based on:
     - Profile match (priority_prefixes)
@@ -16,10 +20,12 @@ Every included item carries selection_reason metadata.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from ao_kernel.consultation.promotion import PromotedConsultation
 from ao_kernel.context.profile_router import ProfileConfig, get_profile
 
 logger = logging.getLogger(__name__)
@@ -31,8 +37,8 @@ class ContextItem:
 
     key: str
     value: Any
-    source_lane: str       # "session" | "canonical" | "fact"
-    relevance_score: float # 0.0-1.0
+    source_lane: str  # "session" | "canonical" | "fact"
+    relevance_score: float  # 0.0-1.0
     selection_reason: str  # why included/excluded
     included: bool = False
     token_estimate: int = 0
@@ -55,18 +61,25 @@ def compile_context(
     *,
     canonical_decisions: dict[str, Any] | None = None,
     workspace_facts: dict[str, Any] | None = None,
+    consultations: Sequence[PromotedConsultation] = (),
     profile: str | None = None,
     messages: list[dict[str, Any]] | None = None,
     enable_semantic_search: bool | None = None,
     embedding_config: Any | None = None,
     vector_store: Any | None = None,
 ) -> CompiledContext:
-    """Compile context from 3 lanes with relevance scoring and budget enforcement.
+    """Compile context from 4 lanes with relevance scoring and budget enforcement.
 
     Args:
         session_context: Current session context dict
         canonical_decisions: Promoted permanent decisions (Faz 3 — optional now)
         workspace_facts: Distilled workspace facts (from memory_distiller)
+        consultations: Promoted consultations to render in the
+            ``## Consultations`` section (v3.6 E2). MUST be
+            pre-loaded by the caller (``compile_context_sdk`` or
+            equivalent); the compiler is pure and does NOT query the
+            canonical store itself. Ordering is preserved — render
+            respects caller-supplied sort.
         profile: Explicit profile ID or None (auto-detect from messages)
         messages: Conversation messages (for profile auto-detection)
         enable_semantic_search: Enable semantic reranking (None = use profile/env).
@@ -82,6 +95,7 @@ def compile_context(
     # Resolve profile
     if profile is None and messages:
         from ao_kernel.context.profile_router import detect_profile
+
         profile = detect_profile(messages)
     profile_config = get_profile(profile)
 
@@ -139,26 +153,37 @@ def compile_context(
             used_chars += chars_needed
             included_count += 1
 
-        selection_log.append({
-            "key": item.key,
-            "lane": item.source_lane,
-            "score": round(item.relevance_score, 3),
-            "included": item.included,
-            "reason": item.selection_reason,
-        })
+        selection_log.append(
+            {
+                "key": item.key,
+                "lane": item.source_lane,
+                "score": round(item.relevance_score, 3),
+                "included": item.included,
+                "reason": item.selection_reason,
+            }
+        )
 
-    # Build preamble from included items
+    # Apply profile consultation cap (last-added-first-dropped when
+    # oversize, per plan §3.E2).
+    cap = max(0, profile_config.max_consultations)
+    capped_consultations = tuple(consultations[:cap]) if cap else ()
+
+    # Build preamble from included items + capped consultations
     preamble = _build_preamble(
         [i for i in items if i.included],
         profile_config,
+        consultations=capped_consultations,
     )
 
     # Telemetry (optional subsystem per CLAUDE.md §7 — graceful fallback, debug log)
     try:
         from ao_kernel.telemetry import record_context_compile
+
         record_context_compile(
-            included_count, len(items) - included_count,
-            profile=profile_config.profile_id, total_tokens=used_chars // 4,
+            included_count,
+            len(items) - included_count,
+            profile=profile_config.profile_id,
+            total_tokens=used_chars // 4,
         )
     except Exception as e:
         logger.debug("context telemetry record skipped: %s", e)
@@ -310,10 +335,7 @@ def _apply_semantic_reranking(
         from ao_kernel.context.semantic_retrieval import semantic_search
 
         # Build decisions list from items for semantic_search
-        decisions_for_search = [
-            {"key": item.key, "value": item.value, "_embedding": None}
-            for item in items
-        ]
+        decisions_for_search = [{"key": item.key, "value": item.value, "_embedding": None} for item in items]
 
         # semantic_search needs pre-embedded decisions or API key;
         # if neither available, it returns [] — deterministic fallback
@@ -347,9 +369,28 @@ def _apply_semantic_reranking(
         pass  # Fail-open: semantic search is non-critical
 
 
-def _build_preamble(items: list[ContextItem], profile: ProfileConfig) -> str:
-    """Build formatted preamble from included items."""
-    if not items:
+def _render_consultation(record: PromotedConsultation) -> str:
+    """Compact one-line render for a promoted consultation entry.
+
+    Format: ``- [CNS-ID] topic VERDICT (from_agent→to_agent, resolved_at)``
+    with graceful fallback for any None edge field (strict core
+    guaranteed by the reader facade, lenient edges handled here).
+    """
+    topic = record.topic or "(topic unknown)"
+    from_agent = record.from_agent or "(from)"
+    to_agent = record.to_agent or "(to)"
+    resolved = record.resolved_at or "unresolved"
+    return f"- [{record.cns_id}] {topic} {record.final_verdict} ({from_agent}\u2192{to_agent}, {resolved})"
+
+
+def _build_preamble(
+    items: list[ContextItem],
+    profile: ProfileConfig,
+    *,
+    consultations: Sequence[PromotedConsultation] = (),
+) -> str:
+    """Build formatted preamble from included items + consultations."""
+    if not items and not consultations:
         return ""
 
     sections: dict[str, list[str]] = {"session": [], "canonical": [], "fact": []}
@@ -373,5 +414,9 @@ def _build_preamble(items: list[ContextItem], profile: ProfileConfig) -> str:
     if sections["fact"]:
         parts.append("## Workspace Facts")
         parts.extend(sections["fact"])
+
+    if consultations:
+        parts.append("## Consultations")
+        parts.extend(_render_consultation(rec) for rec in consultations)
 
     return "\n".join(parts)

--- a/ao_kernel/context/profile_router.py
+++ b/ao_kernel/context/profile_router.py
@@ -16,14 +16,21 @@ from typing import Any
 
 @dataclass(frozen=True)
 class ProfileConfig:
-    """Configuration for a context loading profile."""
+    """Configuration for a context loading profile.
+
+    v3.6 E2 adds ``max_consultations`` — per-profile cap on promoted
+    consultations rendered in the ``## Consultations`` section
+    (plan §3.E2 + Codex iter-1 revision #6 — SSOT on the profile,
+    not hardcoded in the compiler).
+    """
 
     profile_id: str
     description: str
     priority_prefixes: tuple[str, ...]  # key prefixes to prioritize
-    max_decisions: int                   # max decisions to inject
-    max_tokens: int                      # token budget for context preamble
+    max_decisions: int  # max decisions to inject
+    max_tokens: int  # token budget for context preamble
     enable_semantic_search: bool = False  # opt-in semantic reranking (default OFF)
+    max_consultations: int = 3  # v3.6 E2 — see per-profile overrides below
 
 
 PROFILES: dict[str, ProfileConfig] = {
@@ -33,6 +40,7 @@ PROFILES: dict[str, ProfileConfig] = {
         priority_prefixes=("workspace.", "config.", "setup."),
         max_decisions=10,
         max_tokens=1000,
+        max_consultations=3,
     ),
     "TASK_EXECUTION": ProfileConfig(
         profile_id="TASK_EXECUTION",
@@ -40,6 +48,7 @@ PROFILES: dict[str, ProfileConfig] = {
         priority_prefixes=("runtime.", "decision.", "approved.", "tool.", "llm."),
         max_decisions=30,
         max_tokens=4000,
+        max_consultations=3,
     ),
     "REVIEW": ProfileConfig(
         profile_id="REVIEW",
@@ -47,6 +56,7 @@ PROFILES: dict[str, ProfileConfig] = {
         priority_prefixes=("review.", "standard.", "quality.", "policy.", "architecture."),
         max_decisions=20,
         max_tokens=2000,
+        max_consultations=10,
     ),
     "EMERGENCY": ProfileConfig(
         profile_id="EMERGENCY",
@@ -54,6 +64,7 @@ PROFILES: dict[str, ProfileConfig] = {
         priority_prefixes=("error.", "incident.", "alert.", "hotfix.", "rollback."),
         max_decisions=15,
         max_tokens=2000,
+        max_consultations=0,  # lean context — see plan §3.E2 rationale
     ),
     "ASSESSMENT": ProfileConfig(
         profile_id="ASSESSMENT",
@@ -61,6 +72,7 @@ PROFILES: dict[str, ProfileConfig] = {
         priority_prefixes=("assessment.", "maturity.", "metric.", "benchmark.", "score."),
         max_decisions=25,
         max_tokens=3000,
+        max_consultations=3,
     ),
     "PLANNING": ProfileConfig(
         profile_id="PLANNING",
@@ -68,6 +80,7 @@ PROFILES: dict[str, ProfileConfig] = {
         priority_prefixes=("plan.", "roadmap.", "sprint.", "milestone.", "priority."),
         max_decisions=25,
         max_tokens=3000,
+        max_consultations=10,
     ),
 }
 
@@ -102,9 +115,7 @@ def detect_profile(messages: list[dict[str, Any]]) -> str:
                 user_text = content.lower()
                 break
             if isinstance(content, list):
-                user_text = " ".join(
-                    c.get("text", "") for c in content if isinstance(c, dict)
-                ).lower()
+                user_text = " ".join(c.get("text", "") for c in content if isinstance(c, dict)).lower()
                 break
 
     if not user_text:

--- a/tests/test_context_consultation_lane.py
+++ b/tests/test_context_consultation_lane.py
@@ -1,0 +1,247 @@
+"""v3.6 E2: context pipeline consultation lane tests (8 pins).
+
+Compiler stays pure (plan §3.E2 + Codex iter-1 revision #1): it
+accepts a pre-loaded ``consultations`` tuple and renders a
+``## Consultations`` section. I/O happens in
+``compile_context_sdk`` (agent_coordination).
+
+Coverage:
+- Empty consultations → no header emitted
+- Populated consultations → header + rendered lines, caller-supplied order preserved
+- `ProfileConfig.max_consultations` SSOT — per-profile cap applied
+- EMERGENCY profile → 0 consultations regardless of input
+- PLANNING profile → up to 10 consultations
+- Oversized input → capped (last-added-first-dropped)
+- Null-tolerant render (None topic/from_agent/to_agent → graceful)
+- `compile_context_sdk` wiring: AGREE first, PARTIAL second, then capped
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ao_kernel.consultation.promotion import PromotedConsultation
+from ao_kernel.context.context_compiler import compile_context
+from ao_kernel.context.profile_router import PROFILES
+
+
+def _mk_consultation(
+    cns_id: str,
+    *,
+    verdict: str = "AGREE",
+    topic: str | None = "architecture",
+    from_agent: str | None = "claude",
+    to_agent: str | None = "codex",
+    resolved_at: str | None = "2026-04-18T10:00:00+00:00",
+    promoted_at: str = "2026-04-19T10:00:00+00:00",
+    confidence: float | None = None,
+) -> PromotedConsultation:
+    from ao_kernel.consultation.promotion import verdict_confidence
+
+    return PromotedConsultation(
+        cns_id=cns_id,
+        topic=topic,
+        from_agent=from_agent,
+        to_agent=to_agent,
+        final_verdict=verdict,
+        resolved_at=resolved_at,
+        record_digest="sha256:deadbeef",
+        evidence_path=".ao/evidence/consultations/x",
+        confidence=confidence if confidence is not None else verdict_confidence(verdict),
+        promoted_at=promoted_at,
+    )
+
+
+class TestEmpty:
+    def test_no_consultations_omits_header(self) -> None:
+        """Empty tuple → no ## Consultations section (no empty header artefact)."""
+        result = compile_context(
+            {"ephemeral_decisions": []},
+            consultations=(),
+            profile="TASK_EXECUTION",
+        )
+        assert "## Consultations" not in result.preamble
+
+
+class TestPopulated:
+    def test_header_and_rendered_entries(self) -> None:
+        """Populated tuple → ## Consultations header + compact render."""
+        consultations = (
+            _mk_consultation("CNS-001", verdict="AGREE"),
+            _mk_consultation("CNS-002", verdict="PARTIAL", topic="cost"),
+        )
+        result = compile_context(
+            {"ephemeral_decisions": []},
+            consultations=consultations,
+            profile="PLANNING",
+        )
+        assert "## Consultations" in result.preamble
+        assert "[CNS-001] architecture AGREE" in result.preamble
+        assert "[CNS-002] cost PARTIAL" in result.preamble
+        # Arrow between agents
+        assert "claude\u2192codex" in result.preamble
+
+    def test_caller_supplied_order_preserved(self) -> None:
+        """Compiler renders in the order supplied by the caller —
+        no internal re-sort by promoted_at etc."""
+        consultations = (
+            _mk_consultation("CNS-AAA"),
+            _mk_consultation("CNS-BBB"),
+            _mk_consultation("CNS-CCC"),
+        )
+        result = compile_context(
+            {"ephemeral_decisions": []},
+            consultations=consultations,
+            profile="PLANNING",
+        )
+        idx_a = result.preamble.index("[CNS-AAA]")
+        idx_b = result.preamble.index("[CNS-BBB]")
+        idx_c = result.preamble.index("[CNS-CCC]")
+        assert idx_a < idx_b < idx_c
+
+
+class TestProfileCaps:
+    def test_profile_config_max_consultations_ssot(self) -> None:
+        """ProfileConfig exposes `max_consultations` per profile (SSOT
+        per plan §3.E2, Codex iter-1 revision #6)."""
+        assert PROFILES["PLANNING"].max_consultations == 10
+        assert PROFILES["REVIEW"].max_consultations == 10
+        assert PROFILES["EMERGENCY"].max_consultations == 0
+        assert PROFILES["TASK_EXECUTION"].max_consultations == 3
+        assert PROFILES["STARTUP"].max_consultations == 3
+        assert PROFILES["ASSESSMENT"].max_consultations == 3
+
+    def test_emergency_profile_suppresses_consultations(self) -> None:
+        """EMERGENCY profile → 0 consultations rendered even when
+        caller supplies a populated tuple (lean context invariant)."""
+        consultations = (_mk_consultation("CNS-EMERGENCY"),)
+        result = compile_context(
+            {"ephemeral_decisions": []},
+            consultations=consultations,
+            profile="EMERGENCY",
+        )
+        assert "## Consultations" not in result.preamble
+        assert "CNS-EMERGENCY" not in result.preamble
+
+    def test_oversized_input_capped_per_profile(self) -> None:
+        """TASK_EXECUTION has max_consultations=3; a 5-entry tuple
+        must be trimmed to 3, keeping caller-supplied order from the
+        top (last-added-first-dropped)."""
+        consultations = tuple(_mk_consultation(f"CNS-{i:03d}") for i in range(5))
+        result = compile_context(
+            {"ephemeral_decisions": []},
+            consultations=consultations,
+            profile="TASK_EXECUTION",
+        )
+        assert result.preamble.count("[CNS-") == 3
+        assert "CNS-000" in result.preamble
+        assert "CNS-001" in result.preamble
+        assert "CNS-002" in result.preamble
+        assert "CNS-003" not in result.preamble
+        assert "CNS-004" not in result.preamble
+
+
+class TestLenientRender:
+    def test_none_topic_and_agents_render_gracefully(self) -> None:
+        """Reader facade may emit None for lenient edges — render
+        must not crash or print literal ``None``."""
+        consultations = (
+            _mk_consultation(
+                "CNS-NONE",
+                topic=None,
+                from_agent=None,
+                to_agent=None,
+                resolved_at=None,
+            ),
+        )
+        result = compile_context(
+            {"ephemeral_decisions": []},
+            consultations=consultations,
+            profile="PLANNING",
+        )
+        assert "None" not in result.preamble
+        assert "[CNS-NONE]" in result.preamble
+        assert "(topic unknown)" in result.preamble
+        assert "unresolved" in result.preamble
+
+
+class TestSdkWiringAgreePreferred:
+    def test_compile_context_sdk_prefers_agree_then_partial(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Codex iter-1 revision #1 absorb — compile_context_sdk
+        is the I/O-layer that queries the store; it must prefer
+        AGREE over PARTIAL before feeding the pure compiler."""
+        from ao_kernel.context.agent_coordination import compile_context_sdk
+
+        # Seed canonical store directly.
+        ao = tmp_path / ".ao"
+        ao.mkdir()
+        store = {
+            "version": "v1",
+            "decisions": {
+                "consultation.CNS-PART": {
+                    "key": "consultation.CNS-PART",
+                    "value": {
+                        "cns_id": "CNS-PART",
+                        "topic": "partial-case",
+                        "from_agent": "claude",
+                        "to_agent": "codex",
+                        "final_verdict": "PARTIAL",
+                        "resolved_at": "2026-04-18T09:00:00+00:00",
+                    },
+                    "category": "consultation",
+                    "source": "consultation_archive",
+                    "confidence": 0.7,
+                    "provenance": {
+                        "method": "consultation_promotion",
+                        "cns_id": "CNS-PART",
+                    },
+                    "promoted_at": "2026-04-19T10:00:00+00:00",
+                    "expires_at": "",
+                },
+                "consultation.CNS-AGREE": {
+                    "key": "consultation.CNS-AGREE",
+                    "value": {
+                        "cns_id": "CNS-AGREE",
+                        "topic": "agreed-case",
+                        "from_agent": "claude",
+                        "to_agent": "codex",
+                        "final_verdict": "AGREE",
+                        "resolved_at": "2026-04-18T08:00:00+00:00",
+                    },
+                    "category": "consultation",
+                    "source": "consultation_archive",
+                    "confidence": 1.0,
+                    "provenance": {
+                        "method": "consultation_promotion",
+                        "cns_id": "CNS-AGREE",
+                    },
+                    "promoted_at": "2026-04-19T09:00:00+00:00",
+                    "expires_at": "",
+                },
+            },
+            "facts": {},
+            "updated_at": "2026-04-19T00:00:00Z",
+        }
+        (ao / "canonical_decisions.v1.json").write_text(
+            json.dumps(store, indent=2),
+            encoding="utf-8",
+        )
+
+        result = compile_context_sdk(
+            tmp_path,
+            session_context={"ephemeral_decisions": []},
+            messages=None,
+            profile="PLANNING",
+        )
+        # Both should be present; AGREE must appear before PARTIAL
+        preamble = result["preamble"]
+        idx_agree = preamble.index("[CNS-AGREE]")
+        idx_part = preamble.index("[CNS-PART]")
+        assert idx_agree < idx_part, "AGREE must render before PARTIAL"

--- a/tests/test_context_consultation_lane.py
+++ b/tests/test_context_consultation_lane.py
@@ -25,7 +25,7 @@ import pytest
 
 from ao_kernel.consultation.promotion import PromotedConsultation
 from ao_kernel.context.context_compiler import compile_context
-from ao_kernel.context.profile_router import PROFILES
+from ao_kernel.context.profile_router import PROFILES, ProfileConfig
 
 
 def _mk_consultation(
@@ -166,6 +166,119 @@ class TestLenientRender:
         assert "[CNS-NONE]" in result.preamble
         assert "(topic unknown)" in result.preamble
         assert "unresolved" in result.preamble
+
+
+class TestBlockAbsorb:
+    """Codex post-impl BLOCK iter-2 absorb.
+
+    BLOCK #1 — duplicate render: canonical lane + consultation lane
+    both contained consultation-category entries before the fix. SDK
+    layer now excludes `category=="consultation"` from canonical dict
+    so consultations appear exactly once under the typed section.
+
+    BLOCK #2 — budget bypass: consultation lines did not count toward
+    the `max_tokens` cap and were not reflected in `total_tokens`.
+    Compiler now reserves char-budget for each accepted consultation
+    line before rendering; anything that would push the preamble over
+    the cap is dropped tail-first.
+    """
+
+    def test_consultation_not_duplicated_in_canonical_lane(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from ao_kernel.context.agent_coordination import compile_context_sdk
+
+        ao = tmp_path / ".ao"
+        ao.mkdir()
+        store = {
+            "version": "v1",
+            "decisions": {
+                "consultation.CNS-DEDUP": {
+                    "key": "consultation.CNS-DEDUP",
+                    "value": {
+                        "cns_id": "CNS-DEDUP",
+                        "topic": "dedup",
+                        "from_agent": "claude",
+                        "to_agent": "codex",
+                        "final_verdict": "AGREE",
+                        "resolved_at": "2026-04-18T10:00:00+00:00",
+                    },
+                    "category": "consultation",
+                    "source": "consultation_archive",
+                    "confidence": 1.0,
+                    "provenance": {
+                        "method": "consultation_promotion",
+                        "cns_id": "CNS-DEDUP",
+                    },
+                    "promoted_at": "2026-04-19T10:00:00+00:00",
+                    "expires_at": "",
+                },
+            },
+            "facts": {},
+            "updated_at": "2026-04-19T00:00:00Z",
+        }
+        (ao / "canonical_decisions.v1.json").write_text(
+            json.dumps(store, indent=2),
+            encoding="utf-8",
+        )
+
+        result = compile_context_sdk(
+            tmp_path,
+            session_context={"ephemeral_decisions": []},
+            messages=None,
+            profile="PLANNING",
+        )
+        preamble = result["preamble"]
+        # Consultation row must be rendered in the typed section only,
+        # not in the ## Canonical Decisions blob.
+        assert "## Canonical Decisions" not in preamble
+        assert "## Consultations" in preamble
+        # Concretely ensure the CNS-DEDUP row appears exactly once.
+        assert preamble.count("CNS-DEDUP") == 1
+
+    def test_consultation_lines_respect_token_budget(self) -> None:
+        """Budget fit: a long consultation list tail-truncates before
+        the preamble exceeds the char budget (`max_tokens * 4`).
+        Also verifies `total_tokens` reflects consultation chars."""
+        # Moderate budget — each ~160-char long line fits 1-2 times
+        # in a 200-char budget (max_tokens=50). 5 lines cannot all
+        # fit, so the tail must drop.
+        custom = ProfileConfig(
+            profile_id="TIGHT",
+            description="tight budget",
+            priority_prefixes=(),
+            max_decisions=5,
+            max_tokens=50,  # 200-char budget
+            max_consultations=10,
+        )
+        PROFILES["TIGHT"] = custom
+        try:
+            consultations = tuple(
+                _mk_consultation(
+                    f"CNS-{i:03d}",
+                    topic="x" * 80,  # ~160-char line each
+                )
+                for i in range(5)
+            )
+            result = compile_context(
+                {"ephemeral_decisions": []},
+                consultations=consultations,
+                profile="TIGHT",
+            )
+            rendered_count = result.preamble.count("[CNS-")
+            assert rendered_count < 5, f"expected some consultations dropped, got {rendered_count}/5"
+            assert rendered_count >= 1, f"expected at least one consultation accepted, got {rendered_count}"
+            # total_tokens must reflect consultation chars, not 0.
+            assert result.total_tokens > 0
+            # Preamble length within budget (allow ~80 char slack for
+            # the `[Context Profile: TIGHT]` prefix + section header).
+            budget_chars = custom.max_tokens * 4
+            assert len(result.preamble) <= budget_chars + 80, (
+                f"preamble={len(result.preamble)} over budget={budget_chars}"
+            )
+        finally:
+            PROFILES.pop("TIGHT", None)
 
 
 class TestSdkWiringAgreePreferred:


### PR DESCRIPTION
## Summary

Second v3.6 Memory Loop Closure PR. Context compiler now surfaces promoted consultations as a 4th lane next to session / canonical / facts.

- **ProfileConfig SSOT** — new `max_consultations: int` field on `ProfileConfig` with per-profile defaults (PLANNING+REVIEW=10, STARTUP/TASK_EXECUTION/ASSESSMENT=3, EMERGENCY=0 — lean-context invariant). Plan §3.E2 + Codex iter-1 revision #6.
- **Compiler stays pure** (plan §3.E2 + Codex iter-1 revision #1). `compile_context` accepts a new `consultations: Sequence[PromotedConsultation]` parameter; it does NO I/O. `compile_context_sdk` (in `agent_coordination.py`) is the caller layer that queries via `query_promoted_consultations`, slices by profile cap, prefers AGREE over PARTIAL before feeding the tuple into the compiler.
- **`## Consultations` section** added to preamble with compact render: `- [CNS-ID] topic VERDICT (from→to, resolved_at)`. Null-tolerant: missing topic/agents/resolved_at render as `(topic unknown)` / `(from)` / `(to)` / `unresolved` — never prints literal `None`.

## Plan + Codex AGREE

`.claude/plans/PR-v3.6-MEMORY-LOOP-DRAFT-PLAN.md` v2 master plan (8 revisions → iter-2 AGREE); E2 scope carved from §3.E2.

## Test plan

- [x] +8 new pins (TestEmpty + TestPopulated + TestProfileCaps + TestLenientRender + TestSdkWiringAgreePreferred)
- [x] Full pytest: 2427 passed (up from 2419 post-E1)
- [x] Ruff + mypy clean on 205 source files
- [x] Manual smoke: empty preamble, populated lane, EMERGENCY suppresses, PLANNING caps at 10, None edges render gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)