### PR TITLE
feat(v3.6-e3): ao_memory_read pagination + consultation-query docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ ao_kernel/                ← PUBLIC FACADE
 
   context/                 ← CONTEXT PIPELINE — governed memory loop
     memory_pipeline.py     ← process_turn() orchestration
-    context_compiler.py    ← 3-lane compilation (session/canonical/facts)
+    context_compiler.py    ← 4-lane compilation (session/canonical/facts/consultations)
     profile_router.py      ← 6 profil (STARTUP, TASK_EXECUTION, REVIEW, EMERGENCY, ASSESSMENT, PLANNING)
     memory_tiers.py        ← HOT/WARM/COLD tier enforcement
     self_edit_memory.py    ← Agent-controlled memory (remember/update/forget/recall, 4 importance level)
@@ -117,7 +117,7 @@ ao_kernel/                ← PUBLIC FACADE
 ```
 1. resolve_route()                → provider/model seçimi
 2. check_capabilities()           → capability gap kontrolü
-3. compile_context + inject       → 3-lane context → messages'a enjekte
+3. compile_context + inject       → 4-lane context → messages'a enjekte
 4. build_request()                → Provider-native HTTP request body
 5. execute_request()              → HTTP + retry (tenacity) + circuit breaker
 6. normalize_response()           → text + usage + tool_calls extraction
@@ -219,11 +219,12 @@ Session End:
   compact → distill → promote_from_ephemeral (confidence >= 0.7) → save
 ```
 
-### 3-Lane Compilation
+### 4-Lane Compilation
 
 - **Session decisions** (ephemeral) — session context dict içinde yaşar
-- **Canonical decisions** (promoted) — `.ao/canonical_decisions.v1.json`'a yazılır
+- **Canonical decisions** (promoted) — `.ao/canonical_decisions.v1.json`'a yazılır; consultation-category kayıtları v3.6'dan itibaren bu lane'den filtrelenir (typed `## Consultations` section'ına taşınır)
 - **Workspace facts** (distilled) — cross-session fact promotion
+- **Consultations** (v3.6 E2) — promoted agent-to-agent consultations via `ao_kernel.consultation.promotion.query_promoted_consultations`; compiler stays pure (I/O at `compile_context_sdk`). Per-profile cap via `ProfileConfig.max_consultations` (PLANNING/REVIEW=10, STARTUP/TASK_EXECUTION/ASSESSMENT=3, EMERGENCY=0). Tüketici rehberi: `docs/CONSULTATION-QUERY.md`.
 
 ### 6 Context Profil
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ ao-kernel mcp serve --transport http --port 8080   # HTTP (needs ao-kernel[mcp-h
 |---|:---:|:---:|
 | Route resolution (provider/model) | ✅ | ✅ |
 | Capability gap check | ✅ | ✅ (inside build) |
-| Context injection (3-lane compile) | ✅ | ❌ |
+| Context injection (4-lane compile: session/canonical/facts/consultations) | ✅ | ❌ |
 | Transport + retry + circuit breaker | ✅ | ✅ |
 | Normalize (text/usage/tool_calls) | ✅ | ✅ |
 | Decision extraction + memory loop | ✅ | ❌ |

--- a/ao_kernel/_internal/mcp/memory_tools.py
+++ b/ao_kernel/_internal/mcp/memory_tools.py
@@ -60,6 +60,7 @@ _memory_rl_lock = threading.Lock()
 
 # ── Param-aware workspace resolver ──────────────────────────────────
 
+
 def _resolve_workspace_for_call(
     params: dict[str, Any] | None,
     *,
@@ -103,6 +104,7 @@ def _resolve_workspace_for_call(
 
 # ── Rate limit helpers ──────────────────────────────────────────────
 
+
 def _memory_rate_limiter_for(
     ws: Path,
     op: str,
@@ -133,6 +135,7 @@ def _memory_rate_limit_reset() -> None:
 
 
 # ── Validated policy loader ─────────────────────────────────────────
+
 
 def _load_memory_policy_validated(ws: Path | None) -> dict[str, Any]:
     """Load ``policy_mcp_memory.v1.json`` with schema validation.
@@ -265,6 +268,7 @@ def _error(tool: str, message: str) -> dict[str, Any]:
 
 # ── Handler: ao_memory_read ─────────────────────────────────────────
 
+
 def handle_memory_read(params: dict[str, Any]) -> dict[str, Any]:
     """Handler for the ``ao_memory_read`` MCP tool.
 
@@ -299,10 +303,7 @@ def handle_memory_read(params: dict[str, Any]) -> dict[str, Any]:
     allowed_patterns = read_cfg.get("allowed_patterns", ["*"])
     if not isinstance(allowed_patterns, list) or not allowed_patterns:
         return _deny(tool, "pattern_not_allowed")
-    if not any(
-        isinstance(p, str) and _fn.fnmatchcase(user_pattern, p)
-        for p in allowed_patterns
-    ):
+    if not any(isinstance(p, str) and _fn.fnmatchcase(user_pattern, p) for p in allowed_patterns):
         return _deny(tool, "pattern_not_allowed")
 
     rate_cfg = policy.get("rate_limit", {}) if isinstance(policy, dict) else {}
@@ -317,6 +318,28 @@ def handle_memory_read(params: dict[str, Any]) -> dict[str, Any]:
     if category is not None and not isinstance(category, str):
         return _deny(tool, "invalid_category")
 
+    # v3.6 E3 pagination (plan §3.E3 — handler-local, does NOT widen
+    # canonical_store.query). `max_results` is hard-capped at 200 to
+    # respect MCP payload limits; `offset` is a caller-managed cursor
+    # into the post-policy filtered result set.
+    raw_max = params.get("max_results", 50) if isinstance(params, dict) else 50
+    raw_offset = params.get("offset", 0) if isinstance(params, dict) else 0
+    try:
+        max_results = int(raw_max)
+    except (TypeError, ValueError):
+        return _deny(tool, "invalid_max_results")
+    try:
+        offset = int(raw_offset)
+    except (TypeError, ValueError):
+        return _deny(tool, "invalid_offset")
+    if max_results < 1:
+        return _deny(tool, "invalid_max_results")
+    if offset < 0:
+        return _deny(tool, "invalid_offset")
+    # Hard cap per inputSchema.
+    if max_results > 200:
+        max_results = 200
+
     try:
         items = query_memory(
             workspace_root=ws,
@@ -326,18 +349,32 @@ def handle_memory_read(params: dict[str, Any]) -> dict[str, Any]:
     except Exception as exc:  # noqa: BLE001 — surface runtime failures as error envelope
         return _error(tool, f"query_failure: {exc}")
 
+    total = len(items)
+    page = items[offset : offset + max_results]
+    next_offset: int | None
+    if offset + max_results < total:
+        next_offset = offset + max_results
+    else:
+        next_offset = None
+
     return {
         "api_version": _API_VERSION,
         "tool": tool,
         "allowed": True,
         "decision": "executed",
         "reason_codes": [],
-        "data": {"items": items, "count": len(items)},
+        "data": {
+            "items": page,
+            "count": len(page),
+            "total": total,
+            "next_offset": next_offset,
+        },
         "error": None,
     }
 
 
 # ── Handler: ao_memory_write ────────────────────────────────────────
+
 
 def handle_memory_write(params: dict[str, Any]) -> dict[str, Any]:
     """Handler for the ``ao_memory_write`` MCP tool.

--- a/ao_kernel/mcp_server.py
+++ b/ao_kernel/mcp_server.py
@@ -43,6 +43,7 @@ def _find_workspace_root() -> Path | None:
     to be sprinkled across this module.
     """
     from ao_kernel.workspace import project_root
+
     return project_root()
 
 
@@ -147,6 +148,7 @@ def handle_llm_route(params: dict[str, Any]) -> dict[str, Any]:
 
     try:
         from ao_kernel.llm import resolve_route
+
         result = resolve_route(
             intent=intent,
             perspective=params.get("perspective"),
@@ -203,6 +205,7 @@ def handle_quality_gate(params: dict[str, Any]) -> dict[str, Any]:
     if previous_decisions is None and ws:
         try:
             from ao_kernel.context.canonical_store import query as query_canonical
+
             previous_decisions = query_canonical(ws)
         except Exception:
             previous_decisions = None
@@ -300,6 +303,7 @@ def handle_resource(uri: str) -> dict[str, Any] | None:
 
     try:
         from ao_kernel.config import load_default
+
         return load_default(resource_type, name)
     except Exception:
         return None
@@ -369,8 +373,7 @@ def handle_llm_call(params: dict[str, Any]) -> dict[str, Any]:
                 import logging as _logging
 
                 _logging.getLogger(__name__).warning(
-                    "C4.1 MCP budget snapshot load failed "
-                    "(run=%s): %s; no-downgrade fallback",
+                    "C4.1 MCP budget snapshot load failed (run=%s): %s; no-downgrade fallback",
                     ao_run_id,
                     exc,
                 )
@@ -399,11 +402,7 @@ def handle_llm_call(params: dict[str, Any]) -> dict[str, Any]:
 
         # PR-C4.1: evidence emit on budget-triggered downgrade.
         # Fail-open wrap — evidence I/O issue must not cascade.
-        if (
-            route.get("downgrade_applied")
-            and ws is not None
-            and ao_run_id is not None
-        ):
+        if route.get("downgrade_applied") and ws is not None and ao_run_id is not None:
             try:
                 import datetime as _dt
                 from pathlib import Path as _Path
@@ -436,8 +435,8 @@ def handle_llm_call(params: dict[str, Any]) -> dict[str, Any]:
                 import logging as _logging
 
                 _logging.getLogger(__name__).warning(
-                    "route_cross_class_downgrade emit failed "
-                    "(fail-open): %s", exc,
+                    "route_cross_class_downgrade emit failed (fail-open): %s",
+                    exc,
                 )
 
     # Resolve API key via dual-read (factory > env fallback, D11/D0.3).
@@ -446,6 +445,7 @@ def handle_llm_call(params: dict[str, Any]) -> dict[str, Any]:
         env_names_for,
         resolve_api_key,
     )
+
     api_key = resolve_api_key(provider_id)
     if not api_key:
         env_candidates = env_names_for(provider_id)
@@ -460,6 +460,7 @@ def handle_llm_call(params: dict[str, Any]) -> dict[str, Any]:
 
     # Build + execute
     import uuid
+
     request_id = f"mcp-{uuid.uuid4().hex[:12]}"
 
     try:
@@ -589,7 +590,8 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
                 "intent": {"type": "string", "description": "LLM intent class"},
                 "perspective": {"type": "string", "description": "Optional perspective"},
                 "provider_priority": {
-                    "type": "array", "items": {"type": "string"},
+                    "type": "array",
+                    "items": {"type": "string"},
                     "description": "Provider priority order",
                 },
                 "workspace_root": {"type": "string"},
@@ -660,13 +662,26 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
     },
     {
         "name": "ao_memory_read",
-        "description": "Read canonical decisions and workspace facts. Policy-gated, fail-closed, read-only.",
+        "description": "Read canonical decisions and workspace facts. Policy-gated, fail-closed, read-only. v3.6 E3: supports `max_results` (default 50, hard cap 200) + `offset` pagination; response `data` adds `total` + `next_offset` alongside existing `items` + `count`.",
         "inputSchema": {
             "type": "object",
             "properties": {
                 "workspace_root": {"type": "string", "description": "Project root containing .ao/ (optional override)"},
                 "pattern": {"type": "string", "description": "Glob pattern for key match (fnmatch)", "default": "*"},
                 "category": {"type": "string", "description": "Optional category filter"},
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum entries to return in this page (default 50, hard capped at 200).",
+                    "default": 50,
+                    "minimum": 1,
+                    "maximum": 200,
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Pagination cursor (0-based offset into the post-policy filtered result set).",
+                    "default": 0,
+                    "minimum": 0,
+                },
             },
             "additionalProperties": False,
         },
@@ -679,14 +694,22 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
             "required": ["key", "value"],
             "properties": {
                 "workspace_root": {"type": "string", "description": "Project root containing .ao/ (optional override)"},
-                "key": {"type": "string", "description": "Canonical decision key (must match one of allowed_key_prefixes)"},
+                "key": {
+                    "type": "string",
+                    "description": "Canonical decision key (must match one of allowed_key_prefixes)",
+                },
                 "value": {"description": "Decision value (any JSON-serializable type; subject to max_value_bytes)"},
-                "source": {"type": "string", "description": "Source tag (must start with an allowed_source_prefix)", "default": "mcp:tool_write"},
+                "source": {
+                    "type": "string",
+                    "description": "Source tag (must start with an allowed_source_prefix)",
+                    "default": "mcp:tool_write",
+                },
             },
             "additionalProperties": False,
         },
     },
 ]
+
 
 def _with_evidence(tool_name: str, handler: Any) -> Any:
     """Wrap a raw handler so every dispatched call records a JSONL event.
@@ -707,6 +730,7 @@ def _with_evidence(tool_name: str, handler: Any) -> Any:
         try:
             from ao_kernel._internal.evidence.mcp_event_log import record_mcp_event
             from ao_kernel._internal.mcp.memory_tools import _resolve_workspace_for_call
+
             # Param-aware resolution roots evidence in the same workspace
             # the handler targeted (CNS-011 B1).
             ws = _resolve_workspace_for_call(params, fallback=_find_workspace_root)
@@ -726,9 +750,12 @@ def _with_evidence(tool_name: str, handler: Any) -> Any:
 
 def _lazy_memory_handler(fn_name: str) -> Any:
     """Factory: defers importing memory_tools until first call."""
+
     def proxy(params: dict[str, Any]) -> dict[str, Any]:
         from ao_kernel._internal.mcp import memory_tools
+
         return getattr(memory_tools, fn_name)(params)  # type: ignore[no-any-return]
+
     proxy.__name__ = fn_name
     return proxy
 
@@ -756,6 +783,7 @@ def create_tool_gateway() -> Any:
     # MCP governance tools are ALWAYS enabled (they ARE the governance layer)
     try:
         from ao_kernel.config import load_default
+
         tool_policy = load_default("policies", "policy_tool_calling.v1.json")
         policy = ToolCallPolicy.from_dict(tool_policy)
         policy.enabled = True  # MCP governance tools always enabled (override)
@@ -786,10 +814,7 @@ def create_mcp_server() -> Any:  # pragma: no cover — requires mcp package
         from mcp.server import Server
         from mcp.types import Resource, TextContent, Tool
     except ImportError:
-        raise ImportError(
-            "MCP server requires the 'mcp' package. "
-            "Install with: pip install ao-kernel[mcp]"
-        )
+        raise ImportError("MCP server requires the 'mcp' package. Install with: pip install ao-kernel[mcp]")
 
     server = Server("ao-kernel")
 
@@ -819,7 +844,9 @@ def create_mcp_server() -> Any:  # pragma: no cover — requires mcp package
 
             if gw_result.status == "DENIED":
                 deny_envelope = _decision_envelope(
-                    tool=name, allowed=False, decision="deny",
+                    tool=name,
+                    allowed=False,
+                    decision="deny",
                     reason_codes=[gw_result.reason],
                     error=f"ToolGateway denied: {gw_result.reason}",
                 )
@@ -849,8 +876,10 @@ def create_mcp_server() -> Any:  # pragma: no cover — requires mcp package
                     _resolve_workspace_for_call,
                     run_implicit_promote,
                 )
+
                 ws_root = _resolve_workspace_for_call(
-                    arguments or {}, fallback=_find_workspace_root,
+                    arguments or {},
+                    fallback=_find_workspace_root,
                 )
                 run_implicit_promote(name, result, ws_root)
             except Exception:
@@ -862,12 +891,14 @@ def create_mcp_server() -> Any:  # pragma: no cover — requires mcp package
     async def list_resources() -> list[Any]:
         resources = []
         for rtype in ("policies", "schemas", "registry"):
-            resources.append(Resource(
-                uri=f"ao://{rtype}/",  # type: ignore[arg-type]
-                name=f"ao-kernel {rtype}",
-                description=f"Bundled {rtype} JSON files",
-                mimeType="application/json",
-            ))
+            resources.append(
+                Resource(
+                    uri=f"ao://{rtype}/",  # type: ignore[arg-type]
+                    name=f"ao-kernel {rtype}",
+                    description=f"Bundled {rtype} JSON files",
+                    mimeType="application/json",
+                )
+            )
         return resources
 
     @server.read_resource()  # type: ignore[no-untyped-call,untyped-decorator]
@@ -885,10 +916,7 @@ async def serve_stdio() -> None:  # pragma: no cover — requires mcp package
     try:
         from mcp.server.stdio import stdio_server
     except ImportError:
-        raise ImportError(
-            "MCP server requires the 'mcp' package. "
-            "Install with: pip install ao-kernel[mcp]"
-        )
+        raise ImportError("MCP server requires the 'mcp' package. Install with: pip install ao-kernel[mcp]")
 
     server = create_mcp_server()
     async with stdio_server() as (read_stream, write_stream):
@@ -914,8 +942,7 @@ async def serve_http(  # pragma: no cover — requires mcp package
         import uvicorn
     except ImportError:
         raise ImportError(
-            "MCP HTTP transport requires starlette and uvicorn. "
-            "Install with: pip install ao-kernel[mcp-http]"
+            "MCP HTTP transport requires starlette and uvicorn. Install with: pip install ao-kernel[mcp-http]"
         ) from None
 
     server = create_mcp_server()

--- a/docs/CONSULTATION-QUERY.md
+++ b/docs/CONSULTATION-QUERY.md
@@ -1,0 +1,186 @@
+# Consultation Query — Consumer Side (v3.6)
+
+**Status:** v3.6 Memory Loop Closure — consumer-side surfaces for the opt-in consultation promotion pipeline that landed in v3.5.
+
+v3.5 D1/D2a/D2b shipped the **producer** half: consultation paths canonicalized, resolution records archived under `.ao/evidence/consultations/<CNS-ID>/`, and eligible `AGREE`/`PARTIAL` records optionally promoted into `.ao/canonical_decisions.v1.json` with keys like `consultation.<CNS-ID>`.
+
+v3.6 E1/E2/E3 close the loop on the **consumer** side:
+
+- **E1** — `query_promoted_consultations()` typed reader facade
+- **E2** — `compile_context` 4-lane integration (`## Consultations` section) with per-profile caps via `ProfileConfig.max_consultations`
+- **E3** — `ao_memory_read` MCP pagination (`max_results`, `offset`, `total`, `next_offset`)
+
+---
+
+## 1. Policy setup
+
+By default the MCP memory surface ships **fail-closed**: `policy_mcp_memory.v1.json` has `read.enabled: false`. To expose promoted consultations to external agents (or to run the CLI `memory_read` MCP tool manually), override at the workspace level:
+
+```jsonc
+// .ao/policies/policy_mcp_memory.v1.json  (workspace override)
+{
+  "version": "v1",
+  "read": {
+    "enabled": true,
+    "allowed_patterns": ["consultation.*"]
+  },
+  "write": {
+    "enabled": false,
+    "allowed_key_prefixes": [],
+    "max_value_bytes": 4096,
+    "allowed_source_prefixes": ["mcp:"]
+  },
+  "rate_limit": {
+    "reads_per_minute": 60,
+    "writes_per_minute": 10
+  }
+}
+```
+
+The bundled `policy_scorecard`-style "enabled by default" is **not** applied here; memory read is opt-in. Tight `allowed_patterns` scope lets you expose only consultations without lifting the rest of the canonical store.
+
+---
+
+## 2. Python API (E1 reader facade)
+
+```python
+from pathlib import Path
+from ao_kernel.consultation.promotion import query_promoted_consultations
+
+records = query_promoted_consultations(Path("."))
+for r in records:
+    print(r.cns_id, r.final_verdict, r.confidence, r.topic)
+```
+
+Filters:
+
+```python
+# AGREE-only
+agree = query_promoted_consultations(Path("."), verdict="AGREE")
+
+# Topic substring (case-insensitive)
+arch = query_promoted_consultations(Path("."), topic="architecture")
+
+# Include temporally expired entries (default False)
+all_time = query_promoted_consultations(Path("."), include_expired=True)
+```
+
+`PromotedConsultation` dataclass fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `cns_id` | `str` | strict core — missing → row skipped |
+| `final_verdict` | `str` | `AGREE` or `PARTIAL` |
+| `promoted_at` | `str` | ISO-8601 UTC; strict core |
+| `topic` | `str \| None` | producer backfills `"unknown"` |
+| `from_agent` | `str \| None` | producer backfills `"unknown"` |
+| `to_agent` | `str \| None` | producer backfills `"unknown"` |
+| `resolved_at` | `str \| None` | source-derived |
+| `record_digest` | `str \| None` | `"sha256:..."`; from provenance |
+| `evidence_path` | `str \| None` | relative workspace path; from provenance |
+| `confidence` | `float` | top-level or derived via `verdict_confidence` (AGREE=1.0, PARTIAL=0.7) |
+
+Malformed rows (missing strict-core fields) are silently skipped — the reader never raises on store content.
+
+---
+
+## 3. MCP API (E3 pagination)
+
+External agents query via the `ao_memory_read` MCP tool. Default page size is 50; hard-capped at 200.
+
+```jsonc
+// MCP call
+{
+  "tool": "ao_memory_read",
+  "params": {
+    "workspace_root": "/path/to/project",
+    "pattern": "consultation.*",
+    "max_results": 50,
+    "offset": 0
+  }
+}
+```
+
+Response envelope:
+
+```jsonc
+{
+  "api_version": "0.1.0",
+  "tool": "ao_memory_read",
+  "allowed": true,
+  "decision": "executed",
+  "reason_codes": [],
+  "data": {
+    "items": [ /* up to max_results canonical entries */ ],
+    "count": 50,
+    "total": 142,
+    "next_offset": 50
+  },
+  "error": null
+}
+```
+
+Paginate by looping while `data.next_offset` is non-null:
+
+```python
+next_offset = 0
+while next_offset is not None:
+    resp = mcp_call("ao_memory_read", {
+        "pattern": "consultation.*",
+        "max_results": 50,
+        "offset": next_offset,
+    })
+    for item in resp["data"]["items"]:
+        process(item)
+    next_offset = resp["data"]["next_offset"]
+```
+
+---
+
+## 4. Context pipeline integration (E2)
+
+The context compiler renders up to `ProfileConfig.max_consultations` promoted consultations under a `## Consultations` section in the preamble. Profile defaults:
+
+| Profile | `max_consultations` |
+|---|---|
+| `PLANNING` | 10 |
+| `REVIEW` | 10 |
+| `TASK_EXECUTION` | 3 |
+| `STARTUP` | 3 |
+| `ASSESSMENT` | 3 |
+| `EMERGENCY` | 0 (lean-context invariant) |
+
+Loading happens at the caller layer (`compile_context_sdk`); the compiler itself is pure and I/O-free. When consultations are present:
+
+1. The SDK queries via `query_promoted_consultations(workspace_root)`.
+2. Results are split AGREE-first, PARTIAL-second.
+3. Sliced to `max_consultations` for the resolved profile.
+4. Fed into the pure compiler, which accepts lines into the budget-aware `max_tokens * 4` char cap (tail-first drop on overflow).
+
+Rendered line format:
+
+```
+- [CNS-ID] topic VERDICT (from_agent→to_agent, resolved_at)
+```
+
+Lenient edges render gracefully: `None` topic → `"(topic unknown)"`, `None` agents → `"(from)"` / `"(to)"`, `None` resolved_at → `"unresolved"`. Literal `"None"` never appears.
+
+---
+
+## 5. AGREE vs PARTIAL semantics
+
+The producer confidence map (v3.5 D2b) ships:
+
+- `AGREE` → confidence `1.0`
+- `PARTIAL` → confidence `0.7`
+
+Consumers should treat `PARTIAL` records as weaker signals (agent-to-agent agreement with caveats). The reader facade does NOT filter by confidence — callers decide policy. Typical pattern: `verdict="AGREE"` for hard gates, include PARTIAL for advisory lanes.
+
+---
+
+## 6. See also
+
+- [`docs/EVIDENCE-TIMELINE.md`](EVIDENCE-TIMELINE.md) — producer-side consultation archive + integrity manifest (v3.5 D2a)
+- [`ao_kernel/consultation/promotion.py`](../ao_kernel/consultation/promotion.py) — `promote_resolved_consultations` + `query_promoted_consultations`
+- [`ao_kernel/context/context_compiler.py`](../ao_kernel/context/context_compiler.py) — 4-lane compile + `## Consultations` section
+- [`ao_kernel/_internal/mcp/memory_tools.py`](../ao_kernel/_internal/mcp/memory_tools.py) — `handle_memory_read` handler (pagination lives here)

--- a/docs/DEMO-SCRIPT.md
+++ b/docs/DEMO-SCRIPT.md
@@ -109,7 +109,7 @@ worktree: .ao/runs/a1b2c3d4.../worktree
 # Automatic; triggered by workflow start. No separate command needed.
 ```
 
-ao-kernel's context compiler compiles a three-lane context pack: canonical decisions, session transcript, workspace facts (see [CLAUDE.md §9](../CLAUDE.md)).
+ao-kernel's context compiler compiles a four-lane context pack: canonical decisions, session transcript, workspace facts, and promoted consultations (see [CLAUDE.md §9](../CLAUDE.md) and [docs/CONSULTATION-QUERY.md](CONSULTATION-QUERY.md)).
 
 **Evidence events:**
 - `step_started` for `compile_context`

--- a/docs/EVIDENCE-TIMELINE.md
+++ b/docs/EVIDENCE-TIMELINE.md
@@ -4,6 +4,10 @@ Every governed workflow run in ao-kernel emits an append-only JSONL stream of ev
 
 This document is the contract: what events exist, what shape they take, where they land on disk, and what replay guarantees hold.
 
+**Related surfaces:**
+- Consultation archive + resolution records (producer side) live under `.ao/evidence/consultations/<CNS-ID>/` (v3.5 D2a). Integrity manifest is `integrity.manifest.v1.json`.
+- The **consumer side** — promoted consultations, typed reader facade, `compile_context` 4-lane integration, and MCP pagination — is documented at [`docs/CONSULTATION-QUERY.md`](CONSULTATION-QUERY.md) (v3.6 E1/E2/E3).
+
 ---
 
 ## 1. Purpose

--- a/tests/test_mcp_memory_read_pagination.py
+++ b/tests/test_mcp_memory_read_pagination.py
@@ -1,0 +1,221 @@
+"""v3.6 E3: ao_memory_read pagination tests (5 pins).
+
+Covers:
+- Default max_results=50 honoured when store has many entries
+- Explicit offset returns later page
+- max_results > 200 clamped to 200
+- total reflects post-policy-filtered count (distinct from page count)
+- next_offset=null when the last page is reached
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ao_kernel._internal.mcp.memory_tools import handle_memory_read
+
+
+def _write_policy(ws: Path, *, reads_per_minute: int = 6000) -> None:
+    """High rate-limit so pagination tests can hit multiple reads."""
+    policies_dir = ws / ".ao" / "policies"
+    policies_dir.mkdir(parents=True, exist_ok=True)
+    doc: dict[str, Any] = {
+        "version": "v1",
+        "read": {"enabled": True, "allowed_patterns": ["*"]},
+        "write": {
+            "enabled": False,
+            "allowed_key_prefixes": [],
+            "max_value_bytes": 4096,
+            "allowed_source_prefixes": ["mcp:"],
+        },
+        "rate_limit": {
+            "reads_per_minute": reads_per_minute,
+            "writes_per_minute": 10,
+        },
+    }
+    (policies_dir / "policy_mcp_memory.v1.json").write_text(
+        json.dumps(doc),
+        encoding="utf-8",
+    )
+
+
+def _seed_store(ws: Path, *, count: int) -> None:
+    """Write `count` canonical decisions under distinct keys."""
+    ao = ws / ".ao"
+    ao.mkdir(parents=True, exist_ok=True)
+    decisions: dict[str, dict[str, Any]] = {}
+    for i in range(count):
+        key = f"runtime.test.k{i:04d}"
+        decisions[key] = {
+            "key": key,
+            "value": f"v{i}",
+            "category": "runtime",
+            "source": "test",
+            "confidence": 0.8,
+            "provenance": {},
+            "promoted_at": f"2026-04-19T{i % 24:02d}:00:00Z",
+            "expires_at": "",
+        }
+    (ao / "canonical_decisions.v1.json").write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "decisions": decisions,
+                "facts": {},
+                "updated_at": "2026-04-19T00:00:00Z",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def ws_populated(tmp_path: Path) -> Path:
+    """Workspace with enabled policy + 100 seeded decisions."""
+    _write_policy(tmp_path)
+    _seed_store(tmp_path, count=100)
+    return tmp_path
+
+
+class TestPagination:
+    def test_default_max_results_caps_at_50(self, ws_populated: Path) -> None:
+        """Default max_results=50 honoured when store has 100 entries."""
+        result = handle_memory_read(
+            {"workspace_root": str(ws_populated), "pattern": "*"},
+        )
+        assert result["decision"] == "executed"
+        data = result["data"]
+        assert data["count"] == 50
+        assert len(data["items"]) == 50
+        assert data["total"] == 100
+        assert data["next_offset"] == 50
+
+    def test_explicit_offset_returns_second_page(
+        self,
+        ws_populated: Path,
+    ) -> None:
+        """offset=50 + default max_results=50 returns the rest."""
+        result = handle_memory_read(
+            {
+                "workspace_root": str(ws_populated),
+                "pattern": "*",
+                "offset": 50,
+            },
+        )
+        assert result["decision"] == "executed"
+        data = result["data"]
+        assert data["count"] == 50
+        assert data["total"] == 100
+        # Last page exhausted → no further cursor.
+        assert data["next_offset"] is None
+
+    def test_max_results_over_cap_clamped_to_200(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """max_results > 200 silently clamped to 200 — MCP payload limit."""
+        _write_policy(tmp_path)
+        _seed_store(tmp_path, count=250)
+        result = handle_memory_read(
+            {
+                "workspace_root": str(tmp_path),
+                "pattern": "*",
+                "max_results": 500,
+            },
+        )
+        assert result["decision"] == "executed"
+        data = result["data"]
+        assert data["count"] == 200
+        assert data["total"] == 250
+        assert data["next_offset"] == 200
+
+    def test_total_distinct_from_count_when_paginating(
+        self,
+        ws_populated: Path,
+    ) -> None:
+        """`count` = page size, `total` = post-policy-filter total."""
+        result = handle_memory_read(
+            {
+                "workspace_root": str(ws_populated),
+                "pattern": "*",
+                "max_results": 10,
+                "offset": 20,
+            },
+        )
+        data = result["data"]
+        assert data["count"] == 10  # this page
+        assert data["total"] == 100  # full store
+        assert data["count"] != data["total"]
+        assert data["next_offset"] == 30
+
+    def test_next_offset_null_at_exhaustion(
+        self,
+        ws_populated: Path,
+    ) -> None:
+        """next_offset is null when the current page reaches total."""
+        result = handle_memory_read(
+            {
+                "workspace_root": str(ws_populated),
+                "pattern": "*",
+                "max_results": 100,
+            },
+        )
+        data = result["data"]
+        assert data["count"] == 100
+        assert data["total"] == 100
+        assert data["next_offset"] is None
+
+
+class TestInputValidation:
+    def test_invalid_max_results_zero_rejected(
+        self,
+        ws_populated: Path,
+    ) -> None:
+        """max_results < 1 → deny with invalid_max_results reason."""
+        result = handle_memory_read(
+            {
+                "workspace_root": str(ws_populated),
+                "pattern": "*",
+                "max_results": 0,
+            },
+        )
+        assert result["decision"] == "deny"
+        assert "invalid_max_results" in result["reason_codes"]
+
+    def test_invalid_offset_negative_rejected(
+        self,
+        ws_populated: Path,
+    ) -> None:
+        """offset < 0 → deny with invalid_offset reason."""
+        result = handle_memory_read(
+            {
+                "workspace_root": str(ws_populated),
+                "pattern": "*",
+                "offset": -5,
+            },
+        )
+        assert result["decision"] == "deny"
+        assert "invalid_offset" in result["reason_codes"]
+
+
+class TestBackwardCompat:
+    def test_no_pagination_params_still_returns_items_and_count(
+        self,
+        ws_populated: Path,
+    ) -> None:
+        """Pre-E3 callers that only read `data.items`/`data.count`
+        still work; the new `total`/`next_offset` fields are additive."""
+        result = handle_memory_read(
+            {"workspace_root": str(ws_populated), "pattern": "*"},
+        )
+        data = result["data"]
+        assert "items" in data
+        assert "count" in data
+        # New fields additive — present but callers may ignore.
+        assert "total" in data
+        assert "next_offset" in data


### PR DESCRIPTION
## Summary

Final v3.6 Memory Loop Closure PR. Caps MCP payload size + publishes the consumer-side docs.

- **MCP `ao_memory_read` pagination** (handler-local; `canonical_store.query` signature unchanged per plan §3.E3 + Codex iter-1 revision #8): new `max_results` (default 50, hard cap 200) + `offset` (default 0) input params; response `data` now carries `{items, count, total, next_offset}`. Invalid params deny with `invalid_max_results` / `invalid_offset`; oversize `max_results` silently clamped to 200 per schema.
- **New `docs/CONSULTATION-QUERY.md`** — consumer-side guide: policy opt-in, E1 Python API (`query_promoted_consultations`), E3 MCP pagination loop, AGREE vs PARTIAL semantics.
- **4-lane doc updates** (Codex iter-1 revision #5):
  - `CLAUDE.md` §9 "3-Lane" → "4-Lane" with consultation-category filtering note
  - `README.md` governance table row updated
  - `docs/DEMO-SCRIPT.md` "three-lane" → "four-lane" + cross-link
  - `docs/EVIDENCE-TIMELINE.md` cross-link to consumer-side doc

## Test plan

- [x] +8 new pins (TestPagination x5, TestInputValidation x2, TestBackwardCompat x1)
- [x] Full pytest: 2437 passed
- [x] Ruff + mypy clean on 205 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)