### PR TITLE
chore(v3.8-h4): remove dead quality_waiver pytest marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,9 +118,7 @@ ignore_errors = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--strict-markers"
-markers = [
-    "quality_waiver: exempt from test quality gate (requires justification)",
-]
+markers = []
 
 [tool.coverage.run]
 source = ["ao_kernel"]


### PR DESCRIPTION
## Summary

v3.8 Rolling Hardening H4 (smallest PR in the tranche). Removes a declared-but-never-consumed pytest marker from `pyproject.toml`.

Codex plan-time AGREE iter-1: **dead-remove only**, no revival. Reviving would require a full design pass (marker + collection reporter + gate integration) which is out of v3.8 cleanup scope.

## Changes

- `pyproject.toml::tool.pytest.ini_options.markers`: drop `quality_waiver` line. Marker list now empty (static-only; dynamic markers in conftest.py unaffected).

## Test plan

- [x] Full pytest: **2447 passed, 1 skipped** (unchanged from pre-H4)
- [x] Ruff + mypy clean on 205 source files
- [x] Benchmark suite still passes: 15 passed, 1 skipped
- [x] `grep -rn quality_waiver` returns 0 matches in code/tests/docs

## Plan + Codex AGREE

`.claude/plans/PR-v3.8-ROLLING-HARDENING-DRAFT-PLAN.md` §3 H4. Master plan AGREE with 3 revisions absorbed (H4 = dead-cleanup only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)