### PR TITLE
feat(v3.8-h2): emit_adapter_log FS lock parity

### DIFF
--- a/ao_kernel/executor/evidence_emitter.py
+++ b/ao_kernel/executor/evidence_emitter.py
@@ -43,50 +43,52 @@ from ao_kernel.executor.errors import EvidenceEmitError
 from ao_kernel.executor.policy_enforcer import RedactionConfig
 
 
-_KINDS: Final[frozenset[str]] = frozenset({
-    "workflow_started",
-    "workflow_completed",
-    "workflow_failed",
-    "step_started",
-    "step_completed",
-    "step_failed",
-    "adapter_invoked",
-    "adapter_returned",
-    "diff_previewed",
-    "diff_applied",
-    # PR-A4 addition: rollback of a previously applied patch. Idempotent
-    # at the driver layer; emitted only when an actual reverse-diff apply
-    # occurs (not on idempotent_skip no-ops).
-    "diff_rolled_back",
-    "approval_requested",
-    "approval_granted",
-    "approval_denied",
-    "test_executed",
-    "pr_opened",
-    "policy_checked",
-    "policy_denied",
-    # PR-B1 additions (coordination runtime, 18 → 24 kinds). Additive:
-    # the PR-A invariants stay intact; no existing kind is renamed or
-    # re-semanticised. See docs/COORDINATION.md §7 for payload contracts.
-    "claim_acquired",     # fresh acquire (new resource or reclaim-of-released)
-    "claim_released",     # owner-initiated release
-    "claim_heartbeat",    # liveness keep-alive (audit only, not used for decisions)
-    "claim_expired",      # prune_expired_claims cleaned a past-grace claim
-    "claim_takeover",     # past-grace reclaim by a different agent (distinct from claim_acquired)
-    "claim_conflict",     # acquire/takeover blocked by live or in-grace owner
-    # PR-B2 additions (cost runtime, 24 → 27 kinds). Additive; neither
-    # renames nor re-semanticises any existing kind. See
-    # docs/COST-MODEL.md §5 + PR-B2 plan v7 §2.8 for payload contracts.
-    "llm_cost_estimated",   # pre-dispatch estimate emitted (governed_call step 4)
-    "llm_spend_recorded",   # post-response actual cost computed + ledger appended
-    "llm_usage_missing",    # adapter response missing tokens_input/output (audit flag)
-    # PR-C4 plumbing + PR-C4.1 active runtime (cross-class routing,
-    # 27 → 28 kinds). Emitted by `client.llm_call` and
-    # `mcp_server.handle_llm_call` on auto-route paths when the router
-    # applies a budget-triggered class downgrade per
-    # `llm_resolver_rules.soft_degrade.rules[].budget_remaining_threshold_usd`.
-    "route_cross_class_downgrade",
-})
+_KINDS: Final[frozenset[str]] = frozenset(
+    {
+        "workflow_started",
+        "workflow_completed",
+        "workflow_failed",
+        "step_started",
+        "step_completed",
+        "step_failed",
+        "adapter_invoked",
+        "adapter_returned",
+        "diff_previewed",
+        "diff_applied",
+        # PR-A4 addition: rollback of a previously applied patch. Idempotent
+        # at the driver layer; emitted only when an actual reverse-diff apply
+        # occurs (not on idempotent_skip no-ops).
+        "diff_rolled_back",
+        "approval_requested",
+        "approval_granted",
+        "approval_denied",
+        "test_executed",
+        "pr_opened",
+        "policy_checked",
+        "policy_denied",
+        # PR-B1 additions (coordination runtime, 18 → 24 kinds). Additive:
+        # the PR-A invariants stay intact; no existing kind is renamed or
+        # re-semanticised. See docs/COORDINATION.md §7 for payload contracts.
+        "claim_acquired",  # fresh acquire (new resource or reclaim-of-released)
+        "claim_released",  # owner-initiated release
+        "claim_heartbeat",  # liveness keep-alive (audit only, not used for decisions)
+        "claim_expired",  # prune_expired_claims cleaned a past-grace claim
+        "claim_takeover",  # past-grace reclaim by a different agent (distinct from claim_acquired)
+        "claim_conflict",  # acquire/takeover blocked by live or in-grace owner
+        # PR-B2 additions (cost runtime, 24 → 27 kinds). Additive; neither
+        # renames nor re-semanticises any existing kind. See
+        # docs/COST-MODEL.md §5 + PR-B2 plan v7 §2.8 for payload contracts.
+        "llm_cost_estimated",  # pre-dispatch estimate emitted (governed_call step 4)
+        "llm_spend_recorded",  # post-response actual cost computed + ledger appended
+        "llm_usage_missing",  # adapter response missing tokens_input/output (audit flag)
+        # PR-C4 plumbing + PR-C4.1 active runtime (cross-class routing,
+        # 27 → 28 kinds). Emitted by `client.llm_call` and
+        # `mcp_server.handle_llm_call` on auto-route paths when the router
+        # applies a budget-triggered class downgrade per
+        # `llm_resolver_rules.soft_degrade.rules[].budget_remaining_threshold_usd`.
+        "route_cross_class_downgrade",
+    }
+)
 
 _REDACTED: Final[str] = "***REDACTED***"
 
@@ -136,15 +138,9 @@ def emit_event(
     - ``EvidenceEmitError`` on lock / write / fsync failure.
     """
     if kind not in _KINDS:
-        raise ValueError(
-            f"Unknown evidence event kind: {kind!r}; allowed: "
-            f"{sorted(_KINDS)}"
-        )
+        raise ValueError(f"Unknown evidence event kind: {kind!r}; allowed: {sorted(_KINDS)}")
     if actor not in {"adapter", "ao-kernel", "human", "system"}:
-        raise ValueError(
-            f"Unknown evidence actor: {actor!r}; allowed: adapter, "
-            f"ao-kernel, human, system"
-        )
+        raise ValueError(f"Unknown evidence actor: {actor!r}; allowed: adapter, ao-kernel, human, system")
 
     events_dir = workspace_root / ".ao" / "evidence" / "workflows" / run_id
     events_path = events_dir / "events.jsonl"
@@ -204,26 +200,22 @@ def emit_adapter_log(
     a single structured record.
 
     Returns the path. One adapter invocation writes one JSONL line; a
-    second call appends another line. No lock (single-writer during an
-    invocation); fsync after append.
+    second call appends another line.
+
+    v3.8 H2: the append is now guarded by a POSIX ``file_lock`` on a
+    sibling ``.lock`` sidecar so multiple concurrent step attempts (or
+    a future DAG-parallel driver) can safely append to the same
+    per-run adapter log. The previous "single-writer during an
+    invocation" comment was a dormant assumption — pinned as a
+    contract lock now that FS lock parity is the v3.8 bar.
     """
-    adapter_log_path = (
-        workspace_root
-        / ".ao"
-        / "evidence"
-        / "workflows"
-        / run_id
-        / f"adapter-{adapter_id}.jsonl"
-    )
+    adapter_log_path = workspace_root / ".ao" / "evidence" / "workflows" / run_id / f"adapter-{adapter_id}.jsonl"
     try:
         adapter_log_path.parent.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
         raise EvidenceEmitError(
             run_id=run_id,
-            detail=(
-                f"could not create adapter log dir "
-                f"{adapter_log_path.parent}: {exc}"
-            ),
+            detail=(f"could not create adapter log dir {adapter_log_path.parent}: {exc}"),
         ) from exc
 
     record = {
@@ -234,8 +226,12 @@ def emit_adapter_log(
     }
     line = json.dumps(record, sort_keys=True, ensure_ascii=False) + "\n"
 
+    lock_path = adapter_log_path.with_suffix(
+        adapter_log_path.suffix + ".lock",
+    )
     try:
-        _append_line_with_fsync(adapter_log_path, line)
+        with file_lock(lock_path):
+            _append_line_with_fsync(adapter_log_path, line)
     except OSError as exc:
         raise EvidenceEmitError(
             run_id=run_id,
@@ -336,10 +332,7 @@ def _redact_payload(
         elif isinstance(value, dict):
             redacted[key] = _redact_payload(value, redaction)
         elif isinstance(value, list):
-            redacted[key] = [
-                _redact_text(v, redaction) if isinstance(v, str) else v
-                for v in value
-            ]
+            redacted[key] = [_redact_text(v, redaction) if isinstance(v, str) else v for v in value]
         else:
             redacted[key] = value
     return redacted

--- a/tests/test_emit_adapter_log_concurrent.py
+++ b/tests/test_emit_adapter_log_concurrent.py
@@ -1,0 +1,126 @@
+"""v3.8 H2: concurrent writer regression pin for ``emit_adapter_log``.
+
+The adapter log append is now serialised by a sibling ``.lock``
+sidecar. Prior to v3.8 the append was comment-only "single-writer";
+multiple concurrent step attempts (or a future DAG-parallel driver)
+could interleave bytes within the same ``adapter-<id>.jsonl``.
+
+Pattern mirrors ``tests/test_cost_ledger_concurrent.py`` — thread-based
+contention + line-count + JSONL parse invariant.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from ao_kernel.executor.evidence_emitter import (
+    RedactionConfig,
+    emit_adapter_log,
+)
+
+
+def _default_redaction() -> RedactionConfig:
+    """Empty RedactionConfig — tests don't exercise redaction path."""
+    return RedactionConfig(
+        env_keys_matching=(),
+        stdout_patterns=(),
+        file_content_patterns=(),
+    )
+
+
+class TestEmitAdapterLogConcurrent:
+    def test_parallel_writers_produce_no_interleave(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """N threads all append to the same adapter log. With the
+        v3.8 H2 file lock the resulting JSONL must:
+        1. Contain exactly N lines (one per append call)
+        2. Parse every line as valid JSON
+        3. Preserve every writer's payload (no byte interleave)
+        """
+        workspace_root = tmp_path
+        run_id = "11111111-2222-3333-4444-555555555555"
+        adapter_id = "test-adapter"
+        evidence_dir = workspace_root / ".ao" / "evidence" / "workflows" / run_id
+        evidence_dir.mkdir(parents=True, exist_ok=True)
+        redaction = _default_redaction()
+
+        # 8 threads × 4 appends each → 32 total appends.
+        threads_count = 8
+        appends_per_thread = 4
+        barrier = threading.Barrier(threads_count)
+        errors: list[Exception] = []
+        errors_lock = threading.Lock()
+
+        def worker(worker_idx: int) -> None:
+            barrier.wait()  # all threads start simultaneously
+            for call_idx in range(appends_per_thread):
+                try:
+                    emit_adapter_log(
+                        workspace_root,
+                        run_id=run_id,
+                        adapter_id=adapter_id,
+                        captured_stdout=(f"worker={worker_idx} call={call_idx} stdout"),
+                        captured_stderr=(f"worker={worker_idx} call={call_idx} stderr"),
+                        redaction=redaction,
+                    )
+                except Exception as exc:  # noqa: BLE001 — test harness
+                    with errors_lock:
+                        errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(threads_count)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15.0)
+
+        assert not errors, f"worker errors: {errors}"
+        log_path = evidence_dir / f"adapter-{adapter_id}.jsonl"
+        assert log_path.is_file()
+
+        lines = log_path.read_text(encoding="utf-8").splitlines()
+        expected_total = threads_count * appends_per_thread
+        assert len(lines) == expected_total, (
+            f"expected {expected_total} JSONL lines, got {len(lines)} — lock may have failed"
+        )
+        # Every line is valid JSON and carries the expected shape.
+        parsed = []
+        for line in lines:
+            try:
+                parsed.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                pytest.fail(f"interleaved write produced invalid JSON line: {line!r} (error: {exc})")
+        # Every line has stdout + stderr that parses as a worker/call
+        # tag (i.e. no byte-level interleave stripped a field).
+        for entry in parsed:
+            assert "stdout" in entry and "stderr" in entry
+            assert entry["adapter_id"] == adapter_id
+
+    def test_lock_sidecar_created_alongside_log(self, tmp_path: Path) -> None:
+        """The lock sidecar file (``.jsonl.lock``) is created as a
+        distinct artefact so the same fd isn't held by both the
+        readers and the lock holder (CNS-20260414-010 pattern)."""
+        workspace_root = tmp_path
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        adapter_id = "solo-adapter"
+        evidence_dir = workspace_root / ".ao" / "evidence" / "workflows" / run_id
+        evidence_dir.mkdir(parents=True, exist_ok=True)
+        redaction = _default_redaction()
+
+        emit_adapter_log(
+            workspace_root,
+            run_id=run_id,
+            adapter_id=adapter_id,
+            captured_stdout="hello",
+            captured_stderr="",
+            redaction=redaction,
+        )
+        log_path = evidence_dir / f"adapter-{adapter_id}.jsonl"
+        lock_path = log_path.with_suffix(log_path.suffix + ".lock")
+        assert log_path.is_file()
+        assert lock_path.is_file()


### PR DESCRIPTION
## Summary

v3.8 H2 — Codex plan-time scope pivot saved this PR. My initial audit (via `spawn_task` Explore agent) surface-level and enumerated 3 false positives + missed the actual live gap. Codex's deeper grep identified the real one:

**Real live gap:** `ao_kernel/executor/evidence_emitter.py::emit_adapter_log` appended to `adapter-<id>.jsonl` with only a comment-level "single-writer during invocation" assumption. Future DAG-parallel driver (already a known direction) would silently interleave bytes across concurrent adapter invocations.

**Fix:** Wrap append in `file_lock(adapter_log_path + ".lock")` — sidecar-lock pattern per CNS-20260414-010.

**Dropped from original scope** (all were non-gaps per Codex):
- `consultation/evidence.py::append_event` — already under `archive.py` outer lock
- `_internal/evidence/writer.py` — dormant module (test-only)
- `cost/ledger.py` — already sidecar-locked
- `init_cmd.py` / `migrate_cmd.py` — helper refactor territory, not concurrency

## Test plan

- [x] +2 new pins `tests/test_emit_adapter_log_concurrent.py`:
  - `test_parallel_writers_produce_no_interleave`: 8 threads × 4 appends, line-count/parse/no-interleave invariants
  - `test_lock_sidecar_created_alongside_log`: CNS-20260414-010 sidecar pattern pin
- [x] Full pytest: **2454 passed, 1 skipped** (+2 H2 pins from 2452)
- [x] Ruff + mypy clean on 205 source files
- [x] Thread-based test pattern follows `test_cost_ledger_concurrent.py` precedent

## Plan-time value

This PR is a canonical example of the two-gate rule's worth. My initial audit had 3 false positives + missed the real gap; Codex catch at plan-time saved an entire wasted impl cycle. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)