### PR TITLE
feat(post-v3.9-m2): ToolCallPolicy.from_dict legacy field bool-strict + max_tool_rounds schema alignment

### DIFF
--- a/ao_kernel/tool_gateway.py
+++ b/ao_kernel/tool_gateway.py
@@ -73,10 +73,30 @@ class ToolCallPolicy:
         no sort, no case-folding. Semantic interpretation (precedence,
         empty-allowlist meaning, etc.) is B2's responsibility.
         """
-        # Existing fields (unchanged behavior)
-        enabled = policy.get("enabled", True)
-        max_rounds = int(policy.get("max_tool_rounds", 10))
-        allow_unknown = policy.get("allow_unknown", False)
+        # v3.9 post-release M2: legacy fields now strict-validated.
+        # Pre-M2 behavior silently coerced "true"/"false" strings, 0/1
+        # ints, and other non-bool / non-int payloads. That defeats the
+        # "contract absorb + validation" point for the B1 dormant-field
+        # fix, and diverges from the stricter handling we already
+        # apply to the B1 fields below. `max_tool_rounds` gains the
+        # schema-matching `1 <= x <= 10` bounds (explicit alignment;
+        # B1 plan-time note absorbed).
+        raw_enabled = policy.get("enabled", True)
+        if not isinstance(raw_enabled, bool):
+            raise ValueError(f"enabled must be bool, got {type(raw_enabled).__name__}")
+        enabled = raw_enabled
+
+        raw_max_rounds = policy.get("max_tool_rounds", 10)
+        if not isinstance(raw_max_rounds, int) or isinstance(raw_max_rounds, bool):
+            raise ValueError(f"max_tool_rounds must be int, got {type(raw_max_rounds).__name__}")
+        if raw_max_rounds < 1 or raw_max_rounds > 10:
+            raise ValueError(f"max_tool_rounds must be between 1 and 10 inclusive, got {raw_max_rounds}")
+        max_rounds = raw_max_rounds
+
+        raw_allow_unknown = policy.get("allow_unknown", False)
+        if not isinstance(raw_allow_unknown, bool):
+            raise ValueError(f"allow_unknown must be bool, got {type(raw_allow_unknown).__name__}")
+        allow_unknown = raw_allow_unknown
 
         # max_calls_per_request: positive int
         raw_max_calls = policy.get("max_tool_calls_per_request", 5)

--- a/tests/test_tool_gateway.py
+++ b/tests/test_tool_gateway.py
@@ -301,6 +301,51 @@ class TestToolCallPolicyAbsorbV39B1:
                 {"cycle_detection": {"enabled": 1}}  # int, not bool
             )
 
+    # ------------------------------------------------------------------
+    # v3.9 post-release M2 — legacy field bool-strict + max_tool_rounds
+    # schema alignment (1 <= x <= 10). Pre-M2, these silently coerced
+    # "true"/"false" strings, 0/1 ints, and other payloads. That
+    # diverged from the stricter B1 field handling in the same parser.
+    # ------------------------------------------------------------------
+
+    def test_from_dict_enabled_non_bool_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="enabled must be bool"):
+            ToolCallPolicy.from_dict({"enabled": "true"})
+
+    def test_from_dict_allow_unknown_non_bool_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="allow_unknown must be bool"):
+            ToolCallPolicy.from_dict({"allow_unknown": 1})  # int, not bool
+
+    def test_from_dict_max_tool_rounds_non_int_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="max_tool_rounds must be int"):
+            ToolCallPolicy.from_dict({"max_tool_rounds": "10"})
+
+    def test_from_dict_max_tool_rounds_zero_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="max_tool_rounds must be between 1 and 10 inclusive"):
+            ToolCallPolicy.from_dict({"max_tool_rounds": 0})
+
+    def test_from_dict_max_tool_rounds_above_ten_raises(self):
+        # Schema alignment: upper bound = 10 (inclusive).
+        import pytest
+
+        with pytest.raises(ValueError, match="max_tool_rounds must be between 1 and 10 inclusive"):
+            ToolCallPolicy.from_dict({"max_tool_rounds": 11})
+
+    def test_from_dict_max_tool_rounds_boundary_values_accepted(self):
+        # 1 and 10 must both be accepted (inclusive bounds).
+        p_lo = ToolCallPolicy.from_dict({"max_tool_rounds": 1})
+        p_hi = ToolCallPolicy.from_dict({"max_tool_rounds": 10})
+        assert p_lo.max_rounds == 1
+        assert p_hi.max_rounds == 10
+
 
 class TestCreateToolGatewayPolicyAbsorbV39B1:
     """v3.9 B1 — integration-level: absorbed fields survive `create_tool_gateway()`."""


### PR DESCRIPTION
## Summary

- Parser-hygiene follow-up to v3.9 B1/B2. Three legacy `ToolCallPolicy.from_dict` fields (`enabled`, `allow_unknown`, `max_tool_rounds`) were silently coercing non-conforming payloads. This PR makes them strict, matching how the B1 fields were already handled.
- `max_tool_rounds` also picks up the schema-matching `1 <= x <= 10` bounds.
- Codex plan-time CNS (v3.9 follow-up lane): AGREE. Explicit upper-bound choice absorbed: "yarım hizalama yapıp sonra unutma riski var — explicit olsun."

## Changes

### `ao_kernel/tool_gateway.py::ToolCallPolicy.from_dict`

| Field | Pre-M2 | Post-M2 |
|---|---|---|
| `enabled` | `.get("enabled", True)` (silent coerce) | `isinstance(bool)` or `ValueError` |
| `allow_unknown` | `.get("allow_unknown", False)` (silent coerce) | `isinstance(bool)` or `ValueError` |
| `max_tool_rounds` | `int(.get("max_tool_rounds", 10))` (coerces "10", no bounds) | `isinstance(int)` excluding bool, `1 <= x <= 10` or `ValueError` |

### Tests (+6 pins)

- `test_from_dict_enabled_non_bool_raises` — payload `{"enabled": "true"}`.
- `test_from_dict_allow_unknown_non_bool_raises` — payload `{"allow_unknown": 1}` (int).
- `test_from_dict_max_tool_rounds_non_int_raises` — payload `{"max_tool_rounds": "10"}`.
- `test_from_dict_max_tool_rounds_zero_raises` — payload `{"max_tool_rounds": 0}`.
- `test_from_dict_max_tool_rounds_above_ten_raises` — payload `{"max_tool_rounds": 11}` (schema alignment).
- `test_from_dict_max_tool_rounds_boundary_values_accepted` — 1 and 10 both valid (inclusive).

## Gates

- pytest: **2549 passed** (+6 from v3.9.0 baseline 2543)
- ruff / mypy: clean
- coverage: stays ≥85%

## Backward compat

- Bundled `policy_tool_calling.v1.json` values already conform (`max_tool_rounds: 3`, booleans as booleans).
- Operator-written custom policies with silently-coerced values will now surface as `ValueError` at `from_dict()` time — fail-closed by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)