### PR TITLE
feat(v3.10-a1): claude-code-cli manifest review_findings capability + output_parse rule

### DIFF
--- a/ao_kernel/defaults/adapters/claude-code-cli.manifest.v1.json
+++ b/ao_kernel/defaults/adapters/claude-code-cli.manifest.v1.json
@@ -1,8 +1,8 @@
 {
   "adapter_id": "claude-code-cli",
   "adapter_kind": "claude-code-cli",
-  "version": "1.0.0",
-  "capabilities": ["read_repo", "write_diff", "run_tests", "stream_output"],
+  "version": "1.1.0",
+  "capabilities": ["read_repo", "write_diff", "run_tests", "stream_output", "review_findings"],
   "invocation": {
     "transport": "cli",
     "command": "claude",
@@ -27,6 +27,15 @@
   },
   "output_envelope": {
     "status": "ok"
+  },
+  "output_parse": {
+    "rules": [
+      {
+        "json_path": "$.review_findings",
+        "capability": "review_findings",
+        "schema_ref": "review-findings.schema.v1.json"
+      }
+    ]
   },
   "policy_refs": [
     "ao_kernel/defaults/policies/policy_worktree_profile.v1.json",

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -152,8 +152,8 @@ HTTP adapters must explicitly set `exposure_modes` to include `"http_header"` vi
 {
   "adapter_id": "claude-code-cli",
   "adapter_kind": "claude-code-cli",
-  "version": "1.0.0",
-  "capabilities": ["read_repo", "write_diff", "run_tests", "stream_output"],
+  "version": "1.1.0",
+  "capabilities": ["read_repo", "write_diff", "run_tests", "stream_output", "review_findings"],
   "invocation": {
     "transport": "cli",
     "command": "claude",

--- a/tests/benchmarks/test_full_mode_smoke.py
+++ b/tests/benchmarks/test_full_mode_smoke.py
@@ -11,12 +11,16 @@ bundled `policy_worktree_profile` is dormant. Wiring the first
 genuine real-adapter smoke requires:
 
 1. A bench workflow variant pointing at real adapter manifests.
-2. `claude-code-cli.manifest.v1.json` to advertise the
-   `review_findings` capability (currently absent).
+2. ~~`claude-code-cli.manifest.v1.json` to advertise the
+   `review_findings` capability (currently absent).~~ **DONE in
+   v3.10 A1 (#156)** — claude-code-cli now advertises
+   `review_findings` + an `output_parse` rule pointing at
+   `review-findings.schema.v1.json`.
 3. Workspace override that enables `policy_worktree_profile`.
 
-Those three items are routed to v3.7 F2; see
-`.claude/plans/PR-v3.7-BENCHMARK-REALISM-DRAFT-PLAN.md` §3.F2.
+Items 1 and 3 are scheduled for v3.10 A2 (workflow variant) and
+A3 (runbook); the original v3.7 F2 routing has been folded into
+the v3.10 A arc. See the master plan doc for the current split.
 
 What F1 pins here (all run in fast mode — default):
 

--- a/tests/test_adapter_manifest_loader.py
+++ b/tests/test_adapter_manifest_loader.py
@@ -256,8 +256,10 @@ class TestClaudeCodeCliReviewFindingsV310A1:
 
     Contract (enforced at runtime by adapter_invoker output_parse walker):
     the real `claude` CLI output MUST contain a `$.review_findings`
-    array matching the schema — see A3 runbook for the prompt contract
-    that the operator is expected to pass in.
+    object conforming to `review-findings.schema.v1.json` — a top-level
+    object with `schema_version`, `findings` (array), and `summary`
+    required. See A3 runbook for the prompt contract that the operator
+    is expected to pass in.
     """
 
     def test_bundled_manifest_declares_review_findings_capability(

--- a/tests/test_adapter_manifest_loader.py
+++ b/tests/test_adapter_manifest_loader.py
@@ -166,9 +166,7 @@ class TestReasonTaxonomy:
         reasons = [s.reason for s in rpt.skipped]
         assert "json_decode" in reasons
 
-    def test_duplicate_adapter_id_unreachable_under_strict_filename_match(
-        self, tmp_path: Path
-    ) -> None:
+    def test_duplicate_adapter_id_unreachable_under_strict_filename_match(self, tmp_path: Path) -> None:
         """With strict filename↔adapter_id matching, two files cannot
         share an ``adapter_id`` because filenames are unique per
         directory — any second file declaring the same id will have a
@@ -232,9 +230,7 @@ class TestCapabilities:
         _copy_fixtures(tmp_path, ["codex-stub.manifest.v1.json"])
         reg = AdapterRegistry()
         reg.load_workspace(tmp_path)
-        gap = reg.missing_capabilities(
-            "codex-stub", ["read_repo", "open_pr", "run_tests"]
-        )
+        gap = reg.missing_capabilities("codex-stub", ["read_repo", "open_pr", "run_tests"])
         assert gap == frozenset({"open_pr", "run_tests"})
 
     def test_missing_capabilities_empty_when_subset(self, tmp_path: Path) -> None:
@@ -247,3 +243,84 @@ class TestCapabilities:
         reg = AdapterRegistry()
         with pytest.raises(AdapterManifestNotFoundError):
             reg.supports_capabilities("no-such", ["read_repo"])
+
+
+class TestClaudeCodeCliReviewFindingsV310A1:
+    """v3.10 A1 — `claude-code-cli` review_findings capability advertise.
+
+    Bundled manifest (`claude-code-cli.manifest.v1.json`) declares
+    `review_findings` capability (version 1.1.0) plus an `output_parse`
+    rule pointing at `review-findings.schema.v1.json`. This lets the
+    upcoming `governed_review_claude_code_cli` workflow variant pick a
+    real adapter instead of the codex-stub placeholder.
+
+    Contract (enforced at runtime by adapter_invoker output_parse walker):
+    the real `claude` CLI output MUST contain a `$.review_findings`
+    array matching the schema — see A3 runbook for the prompt contract
+    that the operator is expected to pass in.
+    """
+
+    def test_bundled_manifest_declares_review_findings_capability(
+        self,
+    ) -> None:
+        reg = AdapterRegistry()
+        reg.load_bundled()
+        manifest = reg.get("claude-code-cli")
+        assert "review_findings" in manifest.capabilities
+
+    def test_bundled_manifest_output_parse_rule_for_review_findings(
+        self,
+    ) -> None:
+        # The rule must point the capability at the bundled schema.
+        # Walker downstream resolves schema_ref + json_path at runtime.
+        reg = AdapterRegistry()
+        reg.load_bundled()
+        manifest = reg.get("claude-code-cli")
+        assert manifest.output_parse is not None
+        rules = manifest.output_parse.get("rules", [])
+        assert any(
+            r.get("capability") == "review_findings"
+            and r.get("json_path") == "$.review_findings"
+            and r.get("schema_ref") == "review-findings.schema.v1.json"
+            for r in rules
+        ), f"expected review_findings output_parse rule; got {rules!r}"
+
+    def test_bundled_manifest_output_parse_schema_ref_resolves_to_bundled(
+        self,
+    ) -> None:
+        # The schema_ref must actually resolve to the bundled schema
+        # file — catches typo/rename at manifest-load time before a
+        # real workflow would fail opaquely inside the output_parse
+        # walker (Codex A1 post-impl expected: "manifestteki schema_ref'ler
+        # bundled schema'ya resolve oluyor" pini).
+        from importlib import resources as _res
+
+        reg = AdapterRegistry()
+        reg.load_bundled()
+        manifest = reg.get("claude-code-cli")
+        rules = manifest.output_parse.get("rules", []) if manifest.output_parse else []
+        for r in rules:
+            schema_ref = r.get("schema_ref", "")
+            if not schema_ref:
+                continue
+            schema_pkg = _res.files("ao_kernel.defaults.schemas")
+            with _res.as_file(schema_pkg.joinpath(schema_ref)) as sp:
+                assert sp.exists(), f"schema_ref {schema_ref!r} not bundled"
+
+    def test_bundled_manifest_version_bumped_to_1_1_0(self) -> None:
+        # Capability surface widened — minor bump per SemVer.
+        reg = AdapterRegistry()
+        reg.load_bundled()
+        manifest = reg.get("claude-code-cli")
+        assert manifest.version == "1.1.0"
+
+    def test_bundled_manifest_supports_capabilities_covers_review(
+        self,
+    ) -> None:
+        reg = AdapterRegistry()
+        reg.load_bundled()
+        # Regression: existing capabilities still present + new one.
+        assert reg.supports_capabilities(
+            "claude-code-cli",
+            ["read_repo", "write_diff", "run_tests", "stream_output", "review_findings"],
+        )


### PR DESCRIPTION
## Summary

- First PR in the **v3.10 External Real-Adapter Benchmark** arc. Advertises `review_findings` on the `claude-code-cli` adapter so the upcoming `governed_review_claude_code_cli` workflow variant (A2) and runbook (A3) can target a real adapter instead of the `codex-stub` placeholder.
- Codex plan-time CNS: Şartlı AGREE — BLOCKER (`output_parse` fail-closed risk for `commit_message` without evidence) absorbed by dropping `commit_message` from this PR. Scope revised **4 PR → 3 PR** (A1+A2+A3); A4 cut since bundled schemas already exist.

## v3.10 A scope context

| PR | Scope | Status |
|---|---|---|
| **A1** | `claude-code-cli` manifest — `review_findings` capability + `output_parse` rule | **this PR** |
| A2 | `governed_review_claude_code_cli.v1.json` workflow variant | next (sequential) |
| A3 | `BENCHMARK-REAL-ADAPTER-RUNBOOK.md` + workspace override + secret flow docs | last (sequential) |

Codex merge strategy: sequential (A1→A2→A3), not parallel — A2 depends on A1's advertised contract being real.

## Contract-first rationale

The manifest declares the **expected shape**; the real `claude` CLI output is expected to produce a JSON with a `$.review_findings` array matching `review-findings.schema.v1.json`. The `output_parse` walker is fail-closed — if the real adapter output doesn't match, the workflow fails with a parse error. The A3 runbook will document the prompt contract that the operator passes in to produce this shape.

`commit_message` stays OFF for now — Codex-flagged risk: no evidence that a default `claude` invocation produces a `$.commit_message` field, and adding an output_parse rule for it would fail-close every commit-ai workflow run.

## Changes

### `ao_kernel/defaults/adapters/claude-code-cli.manifest.v1.json`

- `version` 1.0.0 → 1.1.0 (capability surface widened, SemVer minor).
- `capabilities` += `review_findings`.
- New `output_parse.rules`:
  ```json
  {
    "json_path": "$.review_findings",
    "capability": "review_findings",
    "schema_ref": "review-findings.schema.v1.json"
  }
  ```

### Tests (+5 pins)

New `TestClaudeCodeCliReviewFindingsV310A1` class in `tests/test_adapter_manifest_loader.py`:

- `test_bundled_manifest_declares_review_findings_capability`
- `test_bundled_manifest_output_parse_rule_for_review_findings` — shape of the rule entry
- `test_bundled_manifest_output_parse_schema_ref_resolves_to_bundled` — **Codex expected pin**: `schema_ref` actually resolves to a bundled schema file (catches typos/renames before runtime)
- `test_bundled_manifest_version_bumped_to_1_1_0`
- `test_bundled_manifest_supports_capabilities_covers_review` — regression: existing capabilities still present + new one

## Gates

- pytest: **2561 passed** (+5 from main 2556)
- ruff / mypy: clean
- coverage: stays ≥85%

## Non-goals (explicit)

- No runtime change — the real `claude` CLI is not invoked in CI.
- No `commit_message` capability / output_parse rule.
- No new workflow (A2 ships that).
- No runbook (A3 ships that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)