### PR TITLE
feat(v3.10-a2): governed_review_claude_code_cli workflow variant

### DIFF
--- a/ao_kernel/defaults/workflows/governed_review_claude_code_cli.v1.json
+++ b/ao_kernel/defaults/workflows/governed_review_claude_code_cli.v1.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "urn:ao:workflow-definition:v1",
+  "workflow_id": "governed_review_claude_code_cli",
+  "workflow_version": "1.0.0",
+  "display_name": "Governed Review — claude-code-cli",
+  "description": "Real-adapter variant of review_ai_flow targeting the claude-code-cli adapter (v1.1.0+ which advertises review_findings + output_parse — see v3.10 A1 / PR #156). This workflow is the second piece of the v3.10 A arc (External Real-Adapter Benchmark): the runbook at docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md (A3) explains the operator-facing prereqs (workspace policy_worktree_profile override with enabled=true, ANTHROPIC_API_KEY secret allowlist, disposable sandbox repo, prompt contract). Contrast with review_ai_flow.v1.json which stays pinned at codex-stub for benchmark-baseline reproducibility. Runtime contract: the adapter output MUST contain a $.review_findings object matching review-findings.schema.v1.json — the adapter_invoker output_parse walker fails closed on shape mismatch, so an operator prompt that omits the required JSON envelope will surface as a workflow failure rather than a silent miss.",
+  "steps": [
+    {
+      "step_name": "compile_context",
+      "actor": "ao-kernel",
+      "operation": "context_compile",
+      "policy_refs": [
+        "ao_kernel/defaults/policies/policy_worktree_profile.v1.json"
+      ],
+      "on_failure": "transition_to_failed"
+    },
+    {
+      "step_name": "invoke_review_agent",
+      "actor": "adapter",
+      "adapter_id": "claude-code-cli",
+      "required_capabilities": ["read_repo", "review_findings"],
+      "policy_refs": [
+        "ao_kernel/defaults/policies/policy_worktree_profile.v1.json",
+        "ao_kernel/defaults/policies/policy_secrets.v1.json"
+      ],
+      "on_failure": "transition_to_failed",
+      "timeout_seconds": 600,
+      "human_interrupt_allowed": false
+    },
+    {
+      "step_name": "await_acknowledgement",
+      "actor": "human",
+      "gate": "custom",
+      "on_failure": "transition_to_failed"
+    }
+  ],
+  "expected_adapter_refs": ["claude-code-cli"],
+  "default_policy_refs": [
+    "ao_kernel/defaults/policies/policy_worktree_profile.v1.json",
+    "ao_kernel/defaults/policies/policy_secrets.v1.json"
+  ],
+  "required_capabilities": ["read_repo", "review_findings"],
+  "tags": ["review", "audit", "inspection", "real-adapter", "benchmark"],
+  "created_at": "2026-04-19T00:00:00+00:00"
+}

--- a/tests/test_pr_b0_contracts.py
+++ b/tests/test_pr_b0_contracts.py
@@ -112,11 +112,7 @@ class TestBundledDefaultsValidate:
         # workflow-definition is an existing PR-A2 schema, not "new in B0",
         # so load it via the defaults helper directly.
         flow_path = (
-            Path(__file__).resolve().parent.parent
-            / "ao_kernel"
-            / "defaults"
-            / "workflows"
-            / "review_ai_flow.v1.json"
+            Path(__file__).resolve().parent.parent / "ao_kernel" / "defaults" / "workflows" / "review_ai_flow.v1.json"
         )
         flow = json.loads(flow_path.read_text(encoding="utf-8"))
         schema = load_default("schemas", "workflow-definition.schema.v1.json")
@@ -154,6 +150,83 @@ class TestBundledDefaultsValidate:
         )
 
 
+class TestGovernedReviewClaudeCodeCliWorkflowV310A2:
+    """v3.10 A2 — real-adapter `governed_review_claude_code_cli` workflow.
+
+    Sibling of `review_ai_flow` pointing at the real `claude-code-cli`
+    adapter (now advertising `review_findings` — v3.10 A1 / #156)
+    instead of the `codex-stub` placeholder. The runbook at
+    docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md (A3) describes the
+    operator prerequisites (workspace policy_worktree_profile override,
+    ANTHROPIC_API_KEY secret allowlist, prompt contract).
+    """
+
+    def test_bundled_workflow_matches_schema(self) -> None:
+        flow_path = (
+            Path(__file__).resolve().parent.parent
+            / "ao_kernel"
+            / "defaults"
+            / "workflows"
+            / "governed_review_claude_code_cli.v1.json"
+        )
+        flow = json.loads(flow_path.read_text(encoding="utf-8"))
+        schema = load_default("schemas", "workflow-definition.schema.v1.json")
+        errors = list(Draft202012Validator(schema).iter_errors(flow))
+        assert errors == [], [e.message for e in errors]
+        # Declared capability requirement references review_findings.
+        assert "review_findings" in flow["required_capabilities"]
+        # Review step points at claude-code-cli, not codex-stub.
+        review_steps = [s for s in flow["steps"] if s.get("adapter_id") == "claude-code-cli"]
+        assert len(review_steps) == 1, f"expected exactly one claude-code-cli step; got {review_steps!r}"
+
+    def test_bundled_workflow_cross_ref_valid_against_bundled_adapters(
+        self,
+    ) -> None:
+        # Real-adapter analogue of the review_ai_flow cross-ref test.
+        # Requires v3.10 A1 (#156) to have landed — otherwise
+        # claude-code-cli manifest would miss the review_findings
+        # capability and this test would fail with a capability_gap.
+        from ao_kernel.adapters import AdapterRegistry
+        from ao_kernel.workflow.registry import WorkflowRegistry
+
+        adapters = AdapterRegistry()
+        adapters.load_bundled()
+
+        workflows = WorkflowRegistry()
+        workflows.load_bundled()
+
+        flow = workflows.get("governed_review_claude_code_cli")
+        issues = workflows.validate_cross_refs(flow, adapters)
+        assert issues == [], (
+            f"governed_review_claude_code_cli must be cross-ref-valid against "
+            f"bundled adapters; got "
+            f"{[(i.kind, i.step_name, i.missing_capabilities) for i in issues]}"
+        )
+
+    def test_bundled_workflow_expected_adapter_refs_is_claude_code_cli_only(
+        self,
+    ) -> None:
+        from ao_kernel.workflow.registry import WorkflowRegistry
+
+        workflows = WorkflowRegistry()
+        workflows.load_bundled()
+        flow = workflows.get("governed_review_claude_code_cli")
+        assert tuple(flow.expected_adapter_refs) == ("claude-code-cli",)
+
+    def test_bundled_workflow_tagged_real_adapter_and_benchmark(self) -> None:
+        # Discovery metadata: operators and benchmark tooling should be
+        # able to find the real-adapter variant by tag.
+        from ao_kernel.workflow.registry import WorkflowRegistry
+
+        workflows = WorkflowRegistry()
+        workflows.load_bundled()
+        flow = workflows.get("governed_review_claude_code_cli")
+        tags = set(flow.tags)
+        assert "real-adapter" in tags
+        assert "benchmark" in tags
+        assert "review" in tags  # sibling discoverability with review_ai_flow
+
+
 # ---------------------------------------------------------------------------
 # Rollout stance — all three B0 policies ship dormant
 # ---------------------------------------------------------------------------
@@ -174,8 +247,7 @@ class TestPoliciesShipDormant:
     def test_top_level_enabled_is_false(self, policy_name: str) -> None:
         policy = load_default("policies", policy_name)
         assert policy["enabled"] is False, (
-            f"{policy_name} must ship dormant (enabled=false); "
-            f"operators opt in via workspace override."
+            f"{policy_name} must ship dormant (enabled=false); operators opt in via workspace override."
         )
 
     def test_metrics_labels_advanced_also_off(self) -> None:
@@ -204,9 +276,7 @@ class TestReviewFindingsSchema:
         schema = _load_schema("review-findings.schema.v1.json")
         payload = {
             "schema_version": "1",
-            "findings": [
-                {"severity": "warning", "message": "tighten the bound"}
-            ],
+            "findings": [{"severity": "warning", "message": "tighten the bound"}],
             "summary": "Reviewed 1 file",
         }
         errors = list(Draft202012Validator(schema).iter_errors(payload))
@@ -226,9 +296,7 @@ class TestReviewFindingsSchema:
         schema = _load_schema("review-findings.schema.v1.json")
         payload = {
             "schema_version": "1",
-            "findings": [
-                {"severity": "critical", "message": "not an allowed value"}
-            ],
+            "findings": [{"severity": "critical", "message": "not an allowed value"}],
             "summary": "x",
         }
         errors = list(Draft202012Validator(schema).iter_errors(payload))


### PR DESCRIPTION
## Summary

- Second PR in the **v3.10 External Real-Adapter Benchmark** arc. Adds a real-adapter variant of `review_ai_flow` targeting the `claude-code-cli` adapter (now advertising `review_findings` + `output_parse` after v3.10 A1 / #156) instead of the `codex-stub` placeholder.
- Naming per Codex plan-time preference: adapter-specific (`governed_review_claude_code_cli`) rather than abstract (`governed_review_real_adapter`).

## v3.10 A scope progress

| PR | Scope | Status |
|---|---|---|
| #156 | A1: claude-code-cli manifest `review_findings` + output_parse | ✅ merged |
| **this** | A2: `governed_review_claude_code_cli.v1.json` workflow variant | **this PR** |
| A3 | `BENCHMARK-REAL-ADAPTER-RUNBOOK.md` + workspace override + prompt contract | next |

## Changes

### `ao_kernel/defaults/workflows/governed_review_claude_code_cli.v1.json` (new)

Steps (mirror of `review_ai_flow` but claude-code-cli-targeted):
1. `compile_context` (actor: ao-kernel)
2. `invoke_review_agent` (actor: adapter, `adapter_id=claude-code-cli`, required_capabilities: `["read_repo", "review_findings"]`)
3. `await_acknowledgement` (actor: human)

Distinguishing surface:
- `expected_adapter_refs=["claude-code-cli"]`
- `tags=["review", "audit", "inspection", "real-adapter", "benchmark"]` for operator discoverability
- Review step adds `policy_secrets.v1.json` to `policy_refs` (real calls need the secret-allowlist path live — runbook A3 documents operator setup)

### Tests (+4 pins)

New `TestGovernedReviewClaudeCodeCliWorkflowV310A2` class in `tests/test_pr_b0_contracts.py`:

- `test_bundled_workflow_matches_schema` — schema validates, `review_findings` required, exactly one claude-code-cli step
- `test_bundled_workflow_cross_ref_valid_against_bundled_adapters` — cross-ref against bundled adapters (requires A1 — else capability_gap)
- `test_bundled_workflow_expected_adapter_refs_is_claude_code_cli_only`
- `test_bundled_workflow_tagged_real_adapter_and_benchmark` — discovery metadata

## Gates

- pytest: **2565 passed** (+4 from main 2561)
- ruff / mypy: clean
- coverage: stays ≥85%

## Contrast with `review_ai_flow`

`review_ai_flow.v1.json` stays pinned at `codex-stub` for benchmark-baseline reproducibility (deterministic local stub). This new workflow is the operator-facing variant for real external adapter runs. Both coexist intentionally.

## Runtime contract note

`adapter_invoker` `output_parse` walker is fail-closed. An operator prompt that omits the required `$.review_findings` JSON envelope surfaces as a workflow failure with a clean signal — not a silent miss. A3 runbook documents the prompt contract that produces the required shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)