### PR TITLE
docs(v3.10-a3): BENCHMARK-REAL-ADAPTER-RUNBOOK operator guide

### DIFF
--- a/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
+++ b/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
@@ -102,7 +102,7 @@ Key deltas from bundled:
 - `enabled` false → **true** (engages the policy)
 - `secrets.allowlist_secret_ids` `[]` → `["ANTHROPIC_API_KEY"]`
 - `command_allowlist.exact` += `"claude"`
-- `rollout.mode_default` stays `report_only` for the first pass; flip to `block` after you've confirmed no spurious denies in evidence.
+- `rollout.mode_default` remains `report_only` in the override above, matching the bundled default. **Current runtime note**: the shipped executor (`ao_kernel/executor/executor.py`) does NOT yet branch on `rollout.mode_default` — when `policy_worktree_profile.enabled=true`, any violation emits `policy_checked` + `policy_denied` events AND fails the run closed regardless of the `mode_default` value. `rollout.mode_default` is therefore a **declarative policy-doc setting for now**, not a runtime switch. The intent (report_only = log but don't block; block = log + deny) is documented inside `policy_worktree_profile.v1.json` itself; honoring it is post-v3.10 runtime work.
 
 ### Note on `policy_secrets.v1.json`
 
@@ -118,10 +118,11 @@ The `claude-code-cli` manifest's `output_parse` rule is **fail-closed**:
 {"json_path": "$.review_findings", "capability": "review_findings", "schema_ref": "review-findings.schema.v1.json"}
 ```
 
-So the real `claude` output MUST end with (or contain) a JSON object whose top level includes `review_findings` matching `review-findings.schema.v1.json`:
+Runtime parser (`ao_kernel/executor/adapter_invoker.py`) reads the adapter's stdout, strips whitespace, calls `json.loads()` on the result, and requires a top-level dict with a valid `status` enum (`ok | declined | interrupted | failed | partial`). So the adapter's stdout MUST be a single JSON object — **no markdown code fences, no prose before or after**. The capability payload rides inside that envelope under the `review_findings` key:
 
 ```json
 {
+  "status": "ok",
   "review_findings": {
     "schema_version": "1",
     "findings": [
@@ -139,7 +140,9 @@ So the real `claude` output MUST end with (or contain) a JSON object whose top l
 }
 ```
 
-Minimum required fields per the schema:
+The `status` field is NOT optional — the runtime rejects any dict that lacks it, or carries a value outside the allowed enum, with `AdapterOutputParseError` before `output_parse` rules even run.
+
+Minimum required fields per `review-findings.schema.v1.json`:
 - `review_findings.schema_version` — const `"1"`.
 - `review_findings.findings` — array (empty is legal = "reviewed, no issues"; missing/wrong shape = workflow fails).
 - `review_findings.summary` — non-empty string.
@@ -152,9 +155,9 @@ Optional:
 
 Supply the prompt template to the adapter via `{context_pack_ref}` (the `compile_context` step produces this). Minimum guidance for the prompt body:
 
-> "At the very end of your response, emit a single JSON code fence with a top-level key `review_findings` whose value conforms to `review-findings.schema.v1.json`. Every `findings[]` entry MUST include `severity` (one of `error`, `warning`, `info`, `note`) and `message`. `summary` is mandatory and must be one line. Do not include any text after the closing JSON fence."
+> "Your entire response MUST be a single JSON object — no markdown, no code fences, no prose. The object MUST have `\"status\": \"ok\"` at the top level, plus a `\"review_findings\"` key whose value conforms to `review-findings.schema.v1.json`. Every `findings[]` entry MUST include `severity` (one of `error`, `warning`, `info`, `note`) and `message`. `summary` is mandatory and must be one line. Do not print anything before the opening `{` or after the closing `}`."
 
-If the adapter prose doesn't produce this envelope, the `adapter_invoker` output_parse walker raises a parse error and the workflow transitions to `failed` — a clean signal, not a silent miss.
+If the adapter's stdout doesn't parse as a single JSON dict with a valid `status`, `adapter_invoker` raises `AdapterOutputParseError` and the workflow transitions to `failed` — a clean signal, not a silent miss.
 
 ---
 
@@ -196,18 +199,22 @@ The `policy_worktree_profile.worktree.cleanup_on_completion = true` setting plus
 
 Every run writes JSONL evidence under `.ao/evidence/workflows/{run_id}/`:
 - `adapter-claude-code-cli.jsonl` — the adapter invocation envelope (redacted per `evidence_redaction` patterns).
-- `policy_checked` / `policy_denied` events — emitted when `policy_worktree_profile.rollout.mode_default` is `report_only` or `block`.
+- `policy_checked` / `policy_denied` events — emitted whenever `policy_worktree_profile.enabled=true` and the executor runs the policy check layer. `policy_denied.payload.violation_kinds` carries the list of `PolicyViolation.kind` values (closed taxonomy, see `ao_kernel/executor/errors.py`).
 
-Common denials and the fix:
+Common violation kinds and the fix:
 
-| Denial event | Cause | Fix |
+| `PolicyViolation.kind` | Cause | Fix |
 |---|---|---|
-| `secret_leak_detected` | Redaction regex hit a value in stdout / env / file. | Audit your prompt template; rotate the leaked credential; re-run. |
-| `cwd_escape_attempted` | Adapter tried to `cd ..` past worktree root or use an absolute path outside `{worktree_base}`. | Shouldn't happen with a well-behaved `claude` prompt; report upstream. |
-| `command_not_in_allowlist` | Adapter invoked `sh -c` / `bash` / tooling not in `command_allowlist`. | Extend `command_allowlist.exact` after judging whether the tool belongs in your sandbox. |
-| `unknown_env_key` | Adapter tried to read an env var not in `env_allowlist.allowed_keys`. | Add the key to `allowed_keys` if legitimate; don't add secret keys here (those go in `secrets.allowlist_secret_ids`). |
+| `secret_exposure_denied` | Secret value tried to reach a channel not in `policy.secrets.exposure_modes` (e.g. argv, stdin, file, http_header). | Audit the adapter invocation and the prompt template; if the leak is legitimate, extend `exposure_modes` explicitly. If it's accidental, rotate the credential. |
+| `secret_missing` | A `secret_id` listed in `allowlist_secret_ids` has no value in the resolved env. | Export the secret in the shell you launch the run from (`export ANTHROPIC_API_KEY=...`). |
+| `cwd_escape` | Adapter tried to `cd ..` past the worktree root or resolve a path outside `{worktree_base}`. | Shouldn't happen with a well-behaved `claude` prompt; if you see it, report upstream with the evidence JSONL excerpt. |
+| `command_not_allowlisted` | Adapter tried to execute a command not listed in `command_allowlist.exact` and not under any `command_allowlist.prefixes` directory. | Add the command to `exact` after judging whether the tool belongs in your sandbox. |
+| `command_path_outside_policy` | Command resolved via PATH to an absolute path outside all `command_allowlist.prefixes` entries (PATH-poisoning guard). | Fix your PATH so the command resolves inside one of the allowlisted prefixes (e.g. `/opt/homebrew/bin`), or add the actual prefix explicitly. |
+| `env_unknown` | Adapter tried to read an env var not in `env_allowlist.allowed_keys`. | Add the key to `allowed_keys` if legitimate; don't add secret keys here (those go in `secrets.allowlist_secret_ids`). |
+| `env_missing_required` | An env key listed as required has no value and no `explicit_additions` entry. | Either export the value in the shell or supply a default via `env_allowlist.explicit_additions`. |
+| `http_header_exposure_unauthorized` | An HTTP adapter tried to use a secret in a header but `secrets.exposure_modes` did not include `"http_header"`. | Add `"http_header"` to `exposure_modes` only if you've confirmed the adapter's HTTP transport is trusted with that surface. |
 
-During the first few runs, keep `rollout.mode_default = "report_only"` so violations are **logged but not blocking**. Once evidence shows no unintended denies, flip to `block`.
+Violations fail the run closed in the current runtime — `rollout.mode_default` is declarative-only until the post-v3.10 runtime work lands (see §2).
 
 ---
 

--- a/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
+++ b/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
@@ -1,0 +1,253 @@
+# Benchmark — Real-Adapter Runbook
+
+**Scope.** Operator-facing walkthrough for running the `governed_review_claude_code_cli` workflow (v3.10 A2, PR #157) against a real `claude` CLI instead of the `codex-stub` baseline. Paired with:
+
+- `governed_review_claude_code_cli.v1.json` (A2) — workflow variant that targets the `claude-code-cli` adapter.
+- `claude-code-cli.manifest.v1.json` v1.1.0+ (A1) — advertises `review_findings` capability + `output_parse` rule pointing at `review-findings.schema.v1.json`.
+- `policy_worktree_profile.v1.json` (bundled, dormant) — must be enabled via workspace override.
+
+**Status.** This runbook documents configuration only. The real-adapter path is NOT exercised in ao-kernel CI — benchmark-fast stays on the deterministic `codex-stub` path, and `review_ai_flow` keeps that behaviour for baseline reproducibility. Running the real adapter is an operator-driven, out-of-repo action.
+
+---
+
+## 1. Prerequisites
+
+1. **`claude` CLI** installed and authenticated. The manifest's invocation block is:
+   ```json
+   "invocation": {
+     "transport": "cli",
+     "command": "claude",
+     "args": ["code", "run", "--prompt-file", "{context_pack_ref}", "--run-id", "{run_id}"]
+   }
+   ```
+   Verify authentication with `claude --version` + a dry `claude code` call in a disposable directory before plugging in ao-kernel.
+
+2. **`ANTHROPIC_API_KEY` in env.** The key is resolved via env var; ao-kernel never reads it from argv, stdin, or file (enforced by `policy_worktree_profile.secrets.exposure_modes`).
+
+3. **Python 3.11+ with `ao-kernel` installed.** Existing requirement; no new extras needed.
+
+4. **Disposable sandbox repo.** The real adapter reads/writes inside a per-run git worktree (`policy_worktree_profile.worktree.strategy = new_per_run`). Point ao-kernel at a scratch repo you're comfortable rolling back; do NOT run the first real-adapter pass against a working branch you care about.
+
+---
+
+## 2. Workspace override — `policy_worktree_profile.v1.json`
+
+Bundled default ships **dormant** (`enabled=false`). Operator override lands in `.ao/policies/policy_worktree_profile.v1.json` (workspace-level, overrides bundled).
+
+Minimum viable override:
+
+```json
+{
+  "version": "v1",
+  "enabled": true,
+
+  "worktree": {
+    "strategy": "new_per_run",
+    "base_dir_template": ".ao/runs/{run_id}/worktree",
+    "cleanup_on_completion": true,
+    "max_concurrent": 4
+  },
+
+  "env_allowlist": {
+    "allowed_keys": ["PATH", "HOME", "USER", "LANG", "LC_ALL", "TZ", "SHELL", "TMPDIR"],
+    "inherit_from_parent": false,
+    "deny_on_unknown": true
+  },
+
+  "secrets": {
+    "deny_by_default": true,
+    "allowlist_secret_ids": ["ANTHROPIC_API_KEY"],
+    "exposure_modes": ["env"],
+    "denied_exposure_modes": ["argv", "stdin", "file", "http_header"]
+  },
+
+  "command_allowlist": {
+    "exact": ["git", "python", "python3", "pytest", "ruff", "mypy", "claude"],
+    "prefixes": ["/usr/bin/", "/usr/local/bin/", "/opt/homebrew/bin/"],
+    "deny_if_not_in_list": true
+  },
+
+  "cwd_confinement": {
+    "root_template": "{worktree_base}",
+    "allowed_subdirs": ["*"],
+    "deny_absolute_paths_outside_root": true,
+    "deny_parent_escape": true
+  },
+
+  "evidence_redaction": {
+    "env_keys_matching": ["(?i).*(token|secret|key|password|credential).*"],
+    "stdout_patterns": [
+      "sk-[A-Za-z0-9]{20,}",
+      "sk-ant-[A-Za-z0-9_-]{30,}",
+      "ghp_[A-Za-z0-9]{20,}",
+      "xoxb-[A-Za-z0-9-]+",
+      "Bearer\\s+[A-Za-z0-9._~+/=-]+",
+      "Basic\\s+[A-Za-z0-9+/=]+"
+    ]
+  },
+
+  "rollout": {
+    "mode_default": "report_only",
+    "promote_to_block_on": [
+      "secret_leak_detected",
+      "cwd_escape_attempted",
+      "command_not_in_allowlist",
+      "unknown_env_key"
+    ]
+  }
+}
+```
+
+Key deltas from bundled:
+- `enabled` false → **true** (engages the policy)
+- `secrets.allowlist_secret_ids` `[]` → `["ANTHROPIC_API_KEY"]`
+- `command_allowlist.exact` += `"claude"`
+- `rollout.mode_default` stays `report_only` for the first pass; flip to `block` after you've confirmed no spurious denies in evidence.
+
+### Note on `policy_secrets.v1.json`
+
+The workflow's `invoke_review_agent` step declares `policy_refs` that include `policy_secrets.v1.json`. In the current ao-kernel executor (`executor/policy_enforcer.py`), the **live secret gate is `policy_worktree_profile.secrets.allowlist_secret_ids`** — that's the single source the invoker reads. `policy_secrets.v1.json` is the **canonical declarative companion**: a registry of documented secret IDs + fail actions that downstream audits can cross-reference. Flipping fields in `policy_secrets.v1.json` alone will NOT change runtime behaviour today; the switch you want is inside `policy_worktree_profile`.
+
+---
+
+## 3. Prompt contract (required)
+
+The `claude-code-cli` manifest's `output_parse` rule is **fail-closed**:
+
+```json
+{"json_path": "$.review_findings", "capability": "review_findings", "schema_ref": "review-findings.schema.v1.json"}
+```
+
+So the real `claude` output MUST end with (or contain) a JSON object whose top level includes `review_findings` matching `review-findings.schema.v1.json`:
+
+```json
+{
+  "review_findings": {
+    "schema_version": "1",
+    "findings": [
+      {
+        "severity": "warning",
+        "file": "src/foo.py",
+        "line": 42,
+        "message": "Helper duplicates logic from utils/bar.py — consider dedup.",
+        "suggestion": "Extract common branch into shared_utils.normalise_path()"
+      }
+    ],
+    "summary": "One warning; no blocking errors.",
+    "score": 0.82
+  }
+}
+```
+
+Minimum required fields per the schema:
+- `review_findings.schema_version` — const `"1"`.
+- `review_findings.findings` — array (empty is legal = "reviewed, no issues"; missing/wrong shape = workflow fails).
+- `review_findings.summary` — non-empty string.
+
+Optional:
+- `review_findings.score` — 0.0..1.0.
+- Per-finding: `file`, `line`, `suggestion`.
+
+`severity` enum is closed: `error | warning | info | note`. **`critical` is deliberately not valid.**
+
+Supply the prompt template to the adapter via `{context_pack_ref}` (the `compile_context` step produces this). Minimum guidance for the prompt body:
+
+> "At the very end of your response, emit a single JSON code fence with a top-level key `review_findings` whose value conforms to `review-findings.schema.v1.json`. Every `findings[]` entry MUST include `severity` (one of `error`, `warning`, `info`, `note`) and `message`. `summary` is mandatory and must be one line. Do not include any text after the closing JSON fence."
+
+If the adapter prose doesn't produce this envelope, the `adapter_invoker` output_parse walker raises a parse error and the workflow transitions to `failed` — a clean signal, not a silent miss.
+
+---
+
+## 4. Disposable sandbox repo pattern
+
+The real adapter can mutate the worktree. Strongest isolation:
+
+```bash
+# 1. Clone your target repo into a disposable directory you will delete after.
+cd /tmp
+mkdir real-adapter-sandbox && cd real-adapter-sandbox
+git clone --depth 1 git@github.com:your-org/target-repo.git .
+
+# 2. Create your ao workspace here.
+ao-kernel init
+
+# 3. Drop your override into .ao/policies/
+mkdir -p .ao/policies
+cat > .ao/policies/policy_worktree_profile.v1.json <<'EOF'
+{ ...the override from §2... }
+EOF
+
+# 4. Export the API key for THIS shell only (no shell-rc leak).
+export ANTHROPIC_API_KEY='sk-ant-...'
+
+# 5. Run the benchmark workflow with the real-adapter variant.
+#    The exact ao-kernel bench entrypoint depends on your install; see
+#    `ao-kernel --help` and docs/BENCHMARK-SUITE.md for the current
+#    invocation surface.
+
+# 6. Inspect evidence, then rm -rf the whole sandbox directory.
+```
+
+The `policy_worktree_profile.worktree.cleanup_on_completion = true` setting plus `rm -rf` the sandbox directory after each run keeps the worktree off any persistent disk.
+
+---
+
+## 5. Evidence & troubleshooting
+
+Every run writes JSONL evidence under `.ao/evidence/workflows/{run_id}/`:
+- `adapter-claude-code-cli.jsonl` — the adapter invocation envelope (redacted per `evidence_redaction` patterns).
+- `policy_checked` / `policy_denied` events — emitted when `policy_worktree_profile.rollout.mode_default` is `report_only` or `block`.
+
+Common denials and the fix:
+
+| Denial event | Cause | Fix |
+|---|---|---|
+| `secret_leak_detected` | Redaction regex hit a value in stdout / env / file. | Audit your prompt template; rotate the leaked credential; re-run. |
+| `cwd_escape_attempted` | Adapter tried to `cd ..` past worktree root or use an absolute path outside `{worktree_base}`. | Shouldn't happen with a well-behaved `claude` prompt; report upstream. |
+| `command_not_in_allowlist` | Adapter invoked `sh -c` / `bash` / tooling not in `command_allowlist`. | Extend `command_allowlist.exact` after judging whether the tool belongs in your sandbox. |
+| `unknown_env_key` | Adapter tried to read an env var not in `env_allowlist.allowed_keys`. | Add the key to `allowed_keys` if legitimate; don't add secret keys here (those go in `secrets.allowlist_secret_ids`). |
+
+During the first few runs, keep `rollout.mode_default = "report_only"` so violations are **logged but not blocking**. Once evidence shows no unintended denies, flip to `block`.
+
+---
+
+## 6. Cost & budget
+
+Bundled adapter manifest sets a per-run budget:
+
+```json
+"budget": {
+  "tokens": {"limit": 100000, "remaining": 100000},
+  "time_seconds": {"limit": 600.0, "remaining": 600.0},
+  "fail_closed_on_exhaust": true
+}
+```
+
+At `sk-ant` pricing tiers (as of 2026-04), 100k tokens on a Sonnet tier run is ≈ $0.30–$1.50 per invocation depending on the output size. Multiply by the number of benchmark rows you plan to run. Keep `fail_closed_on_exhaust = true` so a runaway invocation can't blow the budget ceiling.
+
+---
+
+## 7. What this runbook does NOT ship
+
+- **An `ao-kernel bench init-sandbox` command.** Per Codex plan-time review, introducing new product surface here would balloon v3.10 A's scope. Use the manual steps in §4 instead; if a bootstrap command proves useful, it lands as a separate proposal.
+- **Automated real-adapter smoke in CI.** The ao-kernel CI stays on deterministic local stubs. Running the real adapter is explicitly operator-driven.
+- **Scoring / comparison harness.** The benchmark score pipeline is `review_ai_flow` + `codex-stub`; real-adapter runs produce the same `review_findings` shape that an external scoring tool can consume, but ao-kernel does not ship a cross-run comparison UI in v3.10.
+
+---
+
+## 8. Related docs
+
+- `docs/BENCHMARK-SUITE.md` — benchmark suite architecture, `review_ai_flow`, scorecard contract.
+- `docs/BENCHMARK-FULL-MODE.md` — `@pytest.mark.full_mode` + `--benchmark-mode` option contract.
+- `docs/ADAPTERS.md` — adapter manifest schema, capability enum, registry lookup.
+- `docs/WORKTREE-PROFILE.md` — full `policy_worktree_profile` field reference.
+
+---
+
+## 9. v3.10 A arc ship map
+
+- PR #156 (A1) — `claude-code-cli` manifest `review_findings` capability + `output_parse` rule + v1.0.0 → v1.1.0.
+- PR #157 (A2) — `governed_review_claude_code_cli.v1.json` workflow variant (contrast with `review_ai_flow` which stays pinned at `codex-stub`).
+- **This PR (A3)** — Operator runbook.
+
+v3.10.0 release ships A1 + A2 + A3 together. Post-v3.10 follow-ups tracked: `AoKernelClient.call_tool()` standalone reset (preexisting debt, deferred M3), additional `_internal/*` coverage tranches (providers, shared).

--- a/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
+++ b/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
@@ -205,7 +205,7 @@ Common violation kinds and the fix:
 
 | `PolicyViolation.kind` | Cause | Fix |
 |---|---|---|
-| `secret_exposure_denied` | Secret value tried to reach a channel not in `policy.secrets.exposure_modes` (e.g. argv, stdin, file, http_header). | Audit the adapter invocation and the prompt template; if the leak is legitimate, extend `exposure_modes` explicitly. If it's accidental, rotate the credential. |
+| `secret_exposure_denied` | Secret literal detected inside the resolved argv for the adapter invocation (current runtime scope). HTTP header leaks surface under the separate `http_header_exposure_unauthorized` kind; stdin/file exposure checks are deferred. | Audit the adapter invocation template; remove the secret from argv (the allowlisted channel is env). If the argv exposure is legitimate for this adapter, rotate the credential and reshape the invocation. |
 | `secret_missing` | A `secret_id` listed in `allowlist_secret_ids` has no value in the resolved env. | Export the secret in the shell you launch the run from (`export ANTHROPIC_API_KEY=...`). |
 | `cwd_escape` | Adapter tried to `cd ..` past the worktree root or resolve a path outside `{worktree_base}`. | Shouldn't happen with a well-behaved `claude` prompt; if you see it, report upstream with the evidence JSONL excerpt. |
 | `command_not_allowlisted` | Adapter tried to execute a command not listed in `command_allowlist.exact` and not under any `command_allowlist.prefixes` directory. | Add the command to `exact` after judging whether the tool belongs in your sandbox. |

--- a/docs/BENCHMARK-SUITE.md
+++ b/docs/BENCHMARK-SUITE.md
@@ -11,9 +11,10 @@ Two scenarios ship:
 | Scenario | Workflow (B7 v1) | Capability matrix | Runtime PR |
 |---|---|---|---|
 | `governed_bugfix` | `tests/benchmarks/fixtures/workflows/governed_bugfix_bench.v1.json` (bench variant — full bundled [`bug_fix_flow.v1.json`](../ao_kernel/defaults/workflows/bug_fix_flow.v1.json) deferred to B7.1 pending git/pytest sandbox allowlist) | `read_repo` + `write_diff` | PR-B7 v1 |
-| `governed_review` | [`review_ai_flow.v1.json`](../ao_kernel/defaults/workflows/review_ai_flow.v1.json) (bundled) | `read_repo` + `review_findings` | PR-B7 v1 |
+| `governed_review` | [`review_ai_flow.v1.json`](../ao_kernel/defaults/workflows/review_ai_flow.v1.json) (bundled, pinned at `codex-stub`) | `read_repo` + `review_findings` | PR-B7 v1 |
+| `governed_review_claude_code_cli` | [`governed_review_claude_code_cli.v1.json`](../ao_kernel/defaults/workflows/governed_review_claude_code_cli.v1.json) (bundled, real-adapter) | `read_repo` + `review_findings` | v3.10 A2 / PR #157 |
 
-Both run under `tests/benchmarks/` with a shared runner (PR-B7). See §8 for the runner invocation + scoring threshold contract + B7 v1 scope trim.
+Both run under `tests/benchmarks/` with a shared runner (PR-B7). See §8 for the runner invocation + scoring threshold contract + B7 v1 scope trim. The `governed_review_claude_code_cli` real-adapter variant is **operator-driven only** — ao-kernel CI stays on the deterministic `codex-stub` path. See [`BENCHMARK-REAL-ADAPTER-RUNBOOK.md`](./BENCHMARK-REAL-ADAPTER-RUNBOOK.md) for the full operator setup (workspace override, secret flow, prompt contract, disposable sandbox repo pattern).
 
 ## 2. Typed Artifact Contract (`governed_review`)
 


### PR DESCRIPTION
## Summary

- Third and final PR in the **v3.10 External Real-Adapter Benchmark** arc. Docs-only.
- Operator-facing walkthrough for running `governed_review_claude_code_cli` (A2, PR #157) against a real `claude` CLI instead of `codex-stub`.
- Per Codex plan-time review: **no new product surface** — no `ao-kernel bench init-sandbox` command, no automated real-adapter smoke in CI. Manual recipe only.

**Merge order:** must merge AFTER PR #157 (A2) so the runbook references a shipped workflow ID/path, not a forward-ref.

## v3.10 A ship map

| PR | Scope | Status |
|---|---|---|
| #156 | A1: claude-code-cli manifest `review_findings` + output_parse | ✅ merged |
| #157 | A2: `governed_review_claude_code_cli.v1.json` workflow variant | Codex MERGE; awaiting CI |
| **this** | **A3: operator runbook** | **this PR** |

## Changes

### `docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md` (new, 256 lines)

- **§1 Prerequisites** — `claude` CLI auth, `ANTHROPIC_API_KEY`, disposable sandbox repo.
- **§2 Workspace override** — full `policy_worktree_profile.v1.json` override with minimum viable deltas (`enabled=true`, `allowlist_secret_ids=["ANTHROPIC_API_KEY"]`, `command_allowlist` += `"claude"`, `rollout.mode_default=report_only` for first pass). **Includes Codex A2 post-impl note absorb**: `policy_secrets.v1.json` framed as "canonical declarative companion" — live gate today is `policy_worktree_profile.secrets.allowlist_secret_ids` inside the executor.
- **§3 Prompt contract (required)** — fail-closed `output_parse` walker documented: `claude` output MUST end with a JSON envelope whose top-level `$.review_findings` object matches `review-findings.schema.v1.json`. Minimum fields, severity enum (no "critical"), minimum prompt template guidance.
- **§4 Disposable sandbox repo pattern** — step-by-step recipe (`/tmp` clone + `ao-kernel init` + override + API key + `rm -rf`).
- **§5 Evidence & troubleshooting** — JSONL paths + 4-row denial/cause/fix table.
- **§6 Cost & budget** — adapter budget block + rough per-invocation cost + `fail_closed_on_exhaust`.
- **§7 What this runbook does NOT ship** — explicit non-goals.
- **§8 Related docs**, **§9 v3.10 A arc ship map**.

### `docs/BENCHMARK-SUITE.md`

- §1 benchmark matrix: annotated `review_ai_flow` entry as "pinned at codex-stub"; added new row for `governed_review_claude_code_cli` (real-adapter variant).
- Cross-ref to the new runbook for operator setup.

## Gates

- pytest: **2561 passed** (docs-only; unchanged baseline)
- ruff / mypy: clean (no code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)