### PR TITLE
feat(v3.11-p1): AoKernelClient.reset_tool_gateway_state() public helper

### DIFF
--- a/ao_kernel/client.py
+++ b/ao_kernel/client.py
@@ -1037,6 +1037,36 @@ class AoKernelClient:
         result = self._gateway.dispatch(name, arguments or {})
         return asdict(result)
 
+    def reset_tool_gateway_state(self) -> None:
+        """Reset transient per-request state on the tool gateway.
+
+        v3.11 P1: explicit public helper for consumers who chain
+        ``call_tool()`` outside the ``llm_call()`` boundary. The
+        ``llm_call()`` path resets the gateway state automatically at
+        every new LLM request (v3.9 B2 contract). This helper exists
+        for the **manual tool-use path** — standalone ``call_tool()``
+        chains that accumulate ``_request_call_count`` /
+        ``_recent_calls`` across invocations. The policy layer will
+        otherwise deny once ``max_calls_per_request`` is exhausted or a
+        cycle is detected, which is the correct failure for a single
+        agentic tool loop but wrong semantics when the caller treats
+        each standalone ``call_tool()`` as a fresh surface.
+
+        **Design note (Codex plan-time rejection of per-call auto-reset):**
+        Auto-resetting inside ``call_tool()`` would break the documented
+        agentic contract where multiple ``call_tool()`` invocations form
+        a single logical LLM-tool-use loop (tool_call → tool_result →
+        tool_call → ...). This opt-in helper is the correct escape
+        hatch: chain semantics stay intact by default; callers who
+        want a fresh session call this explicitly.
+
+        No-ops when no gateway has been created (no tools registered,
+        ``hasattr(self, '_gateway') is False``).
+        """
+        gw = getattr(self, "_gateway", None)
+        if gw is not None:
+            gw.reset_rounds()
+
     # ── Checkpoint/Resume ───────────────────────────────────────────
 
     def save_checkpoint(self, session_id: str | None = None) -> dict[str, Any]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -181,6 +181,79 @@ class TestToolDispatch:
         assert len(client._gateway._recent_calls) == 0
 
 
+class TestResetToolGatewayStateV311P1:
+    """v3.11 P1 — explicit public helper for manual tool-use chains.
+
+    Closes the Codex-flagged residual debt from v3.9 B2 iter-3:
+    standalone ``call_tool()`` chains accumulate gateway state across
+    invocations (``_request_call_count`` / ``_recent_calls``) because
+    auto-reset in ``call_tool()`` would break the documented agentic
+    tool-use contract. The ``reset_tool_gateway_state()`` helper is
+    the opt-in escape hatch.
+    """
+
+    def test_reset_clears_dirty_state(self, tmp_path: Path):
+        client = AoKernelClient(tmp_path)
+        client.register_tool("probe", lambda x: {"ok": True})
+        # Dirty the state directly to simulate accumulated chain.
+        client._gateway._request_call_count = 42
+        client._gateway._recent_calls.append("stale|{}")
+
+        client.reset_tool_gateway_state()
+
+        assert client._gateway._request_call_count == 0
+        assert len(client._gateway._recent_calls) == 0
+
+    def test_reset_is_noop_when_no_gateway(self, tmp_path: Path):
+        # No tools registered → no gateway attribute.
+        client = AoKernelClient(tmp_path)
+        assert not hasattr(client, "_gateway")
+        # Must not raise (ergonomics of the public helper — callers
+        # shouldn't have to probe for gateway existence).
+        client.reset_tool_gateway_state()
+        # Still no gateway after the no-op.
+        assert not hasattr(client, "_gateway")
+
+    def test_standalone_chain_flows_without_reset(self, tmp_path: Path):
+        # Chain semantics MUST stay intact by default: multiple
+        # call_tool() invocations on the default policy form a single
+        # logical tool-use loop, and the per-request cap / cycle
+        # detector should count across them. This pin locks in that
+        # the reset is NOT implicit — it's opt-in via the new helper.
+        client = AoKernelClient(tmp_path)
+        client.register_tool("counter", lambda x: {"n": x.get("n", 0)})
+
+        for n in range(5):
+            result = client.call_tool("counter", {"n": n})
+            assert result["status"] == "OK"
+
+        # Gateway state reflects all 5 invocations chained.
+        assert client._gateway._request_call_count == 5
+
+    def test_reset_between_chains_allows_fresh_session(self, tmp_path: Path):
+        # The motivating use case: one chain exhausts the cap; the
+        # operator then calls reset_tool_gateway_state() and starts a
+        # second independent chain which must succeed from scratch.
+        from ao_kernel.tool_gateway import ToolCallPolicy, ToolGateway
+
+        client = AoKernelClient(tmp_path)
+        # Replace default gateway with a tight policy to make the
+        # test deterministic without 5 calls.
+        client._gateway = ToolGateway(policy=ToolCallPolicy(enabled=True, max_calls_per_request=2))
+        client.register_tool("probe", lambda x: {"ok": True})
+
+        # First chain: hit the cap.
+        assert client.call_tool("probe", {"r": 1})["status"] == "OK"
+        assert client.call_tool("probe", {"r": 2})["status"] == "OK"
+        denied = client.call_tool("probe", {"r": 3})
+        assert denied["status"] == "DENIED"
+        assert denied["reason_code"] == "MAX_CALLS_PER_REQUEST_EXCEEDED"
+
+        # Reset and start fresh.
+        client.reset_tool_gateway_state()
+        assert client.call_tool("probe", {"r": 4})["status"] == "OK"
+
+
 class TestSelfEditMemory:
     def test_remember_and_recall(self, tmp_workspace: Path):
         ws_root = tmp_workspace.parent


### PR DESCRIPTION
## Summary

- First PR in the **v3.11 P (Runtime Polish)** lane. Closes v3.9 B2 iter-3 residual debt: standalone `call_tool()` chains accumulate gateway state across invocations; `llm_call()` resets automatically but manual tool-use chains don't.
- Opt-in escape hatch per Codex plan-time rejection of per-`call_tool()` auto-reset (would break agentic contract).

## v3.11 P scope context

| PR | Scope | Status |
|---|---|---|
| **P1** | `reset_tool_gateway_state()` public helper | **this PR** |
| P4 | `_internal/shared/*` coverage tranche | paralel (next) |
| P2 | `policy_worktree_profile` activation + rollout semantics honoring + stale names rewrite | serial after P1+P4 |
| P3 | `_internal/providers/*` coverage tranche | last |
| P5 | v3.11.0 release | — |

## Changes

### `ao_kernel/client.py`
- New public method `AoKernelClient.reset_tool_gateway_state()` — thin wrapper over `self._gateway.reset_rounds()` with `getattr` ergonomics (no-op when no gateway exists).
- Docstring documents Codex's rejection of auto-reset + the manual-tool-use contract rationale (agentic chains stay intact by default; callers opt in explicitly for fresh sessions).

### Tests (+4 pins)

`TestResetToolGatewayStateV311P1`:
- `test_reset_clears_dirty_state` — dirty counters + deque → reset → clean
- `test_reset_is_noop_when_no_gateway` — no tools registered → public helper must not raise (ergonomics pin, Codex-expected)
- `test_standalone_chain_flows_without_reset` — 5-chain `call_tool()` invocations accumulate `_request_call_count` (regression anchor: reset is NOT implicit)
- `test_reset_between_chains_allows_fresh_session` — tight policy (`max_calls_per_request=2`) → chain hits cap → reset → fresh chain succeeds (motivating use case)

## Gates

- pytest: **2569 passed** (+4 from main 2565)
- ruff / mypy: clean
- coverage: stays ≥85%

## Design rationale

Codex plan-time explicitly rejected per-`call_tool()` auto-reset: it would break the documented agentic contract where multiple `call_tool()` invocations form a single logical tool-use loop (`tool_call → tool_result → tool_call → ...`). The per-request cap + cycle detector are meaningful across those calls. An opt-in helper is the correct escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)