### PR TITLE
feat(v3.12-e1): prompt variant contract + registry loader (contract-only)

### DIFF
--- a/ao_kernel/defaults/registry/prompt_variant_registry.v1.json
+++ b/ao_kernel/defaults/registry/prompt_variant_registry.v1.json
@@ -1,0 +1,4 @@
+{
+  "version": "v1",
+  "variants": []
+}

--- a/ao_kernel/defaults/schemas/prompt-variant.schema.v1.json
+++ b/ao_kernel/defaults/schemas/prompt-variant.schema.v1.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:prompt-variant:v1",
+  "title": "Prompt Variant",
+  "description": "A named prompt template operators author when running A/B / multi-variant prompt experiments. v3.12 E1 ships the declarative contract only: operators load the registry, pick a variant, and when starting a workflow run they stamp `intent.metadata.variant_id` with the chosen `variant_id` (and optionally `experiment_id`). ao-kernel does NOT yet orchestrate the A/B dispatch — that lands in a future release once operator-validated real-adapter smokes exist (see docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md prereq). Downstream analysis uses `ao_kernel.experiments.compare_variants` (E2) to pair `variant_id` with `step_record.capability_output_refs['review_findings']`.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["variant_id", "version", "prompt_template"],
+  "properties": {
+    "variant_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]*$",
+      "description": "Stable identifier the operator references when stamping intent.metadata.variant_id. Must be unique within the registry; duplicates raise at load time."
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32,
+      "description": "Operator-controlled version string (e.g. '1.0.0', 'v3', '2026-04-19'). Not parsed — consumed as opaque metadata."
+    },
+    "prompt_template": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The literal prompt body the operator hands to the adapter (via `{context_pack_ref}` in the real-adapter flow). No template substitution is performed by ao-kernel."
+    },
+    "expected_capability": {
+      "type": "string",
+      "enum": ["review_findings", "commit_message", "write_diff"],
+      "description": "Which capability the operator expects the variant to exercise. Used by `ao_kernel.experiments.compare_variants` to filter matching `step_record.capability_output_refs` entries. Closed enum — unknown values rejected at load."
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Free-form operator metadata (e.g. experiment_id, branch, created_by, notes). Not validated beyond object shape."
+    }
+  }
+}

--- a/ao_kernel/prompts.py
+++ b/ao_kernel/prompts.py
@@ -1,0 +1,165 @@
+"""ao_kernel.prompts — Prompt variant registry + loader (v3.12 E1).
+
+Contract-only surface for operator-driven prompt experiments. ao-kernel
+does NOT orchestrate A/B dispatch at runtime — that is deferred until
+operator-validated real-adapter smokes exist (see
+``docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md`` prereq + ``docs/PROMPT-EXPERIMENTS-RUNBOOK.md``).
+
+This module ships three things:
+
+1. :class:`PromptVariant` dataclass — the typed shape operators write
+   into ``.ao/registry/prompt_variant_registry.v1.json``.
+2. :func:`load_prompt_variants` — workspace override + bundled fallback
+   registry loader with schema validation and duplicate-id guard.
+3. The ``intent.metadata.variant_id`` contract (documented below).
+
+Contract — operator flow:
+
+- Operator authors one or more ``PromptVariant`` entries in the
+  workspace registry (default: empty).
+- When starting a workflow run, operator stamps the chosen variant id
+  via ``create_run(... intent={"metadata": {"variant_id": "my.variant.v1"}})``.
+- Adapter dispatch is operator-driven: the variant's ``prompt_template``
+  is passed into the adapter's input (typically via the
+  ``{context_pack_ref}`` file for ``claude-code-cli``).
+- Post-run, :func:`ao_kernel.experiments.compare_variants` (v3.12 E2)
+  reads the run record and pairs ``intent.metadata.variant_id`` with
+  ``step_record.capability_output_refs['review_findings']`` to produce
+  a side-by-side comparison.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+from ao_kernel._internal.shared.resource_loader import load_resource
+
+
+# Bundled registry path pieces (for importlib.resources / direct file).
+_REGISTRY_FILENAME = "prompt_variant_registry.v1.json"
+_SCHEMA_FILENAME = "prompt-variant.schema.v1.json"
+
+# Workspace override path (relative to workspace root).
+_WORKSPACE_REL = Path(".ao") / "registry" / _REGISTRY_FILENAME
+
+
+class PromptVariantError(ValueError):
+    """Raised when the prompt variant registry violates its schema or
+    invariants (duplicate variant_id, unknown expected_capability,
+    missing required fields)."""
+
+
+@dataclass(frozen=True)
+class PromptVariant:
+    """Typed prompt variant record.
+
+    See ``prompt-variant.schema.v1.json`` for the full JSON contract.
+    Fields are held immutable (frozen=True) so callers can hash or
+    cache the variant safely.
+    """
+
+    variant_id: str
+    version: str
+    prompt_template: str
+    expected_capability: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> PromptVariant:
+        """Build a :class:`PromptVariant` from a registry entry dict.
+
+        Raises :class:`PromptVariantError` on missing required fields
+        or unknown ``expected_capability`` values. Extra metadata keys
+        pass through without validation (schema allows
+        ``additionalProperties`` on ``metadata``).
+        """
+        missing = [k for k in ("variant_id", "version", "prompt_template") if k not in raw]
+        if missing:
+            raise PromptVariantError(f"PromptVariant missing required field(s): {missing!r}")
+
+        expected = raw.get("expected_capability")
+        if expected is not None and expected not in (
+            "review_findings",
+            "commit_message",
+            "write_diff",
+        ):
+            raise PromptVariantError(
+                f"PromptVariant expected_capability must be one of "
+                f"('review_findings', 'commit_message', 'write_diff'); "
+                f"got {expected!r}"
+            )
+
+        metadata = raw.get("metadata") or {}
+        if not isinstance(metadata, Mapping):
+            raise PromptVariantError(f"PromptVariant metadata must be a mapping; got {type(metadata).__name__}")
+
+        return cls(
+            variant_id=str(raw["variant_id"]),
+            version=str(raw["version"]),
+            prompt_template=str(raw["prompt_template"]),
+            expected_capability=expected,
+            metadata=dict(metadata),
+        )
+
+
+def load_prompt_variants(workspace_root: Path | None = None) -> list[PromptVariant]:
+    """Load the prompt variant registry with workspace override.
+
+    Resolution order (same pattern as other bundled registries):
+
+    1. ``<workspace_root>/.ao/registry/prompt_variant_registry.v1.json``
+       (workspace override), when ``workspace_root`` is given and the
+       file exists.
+    2. Bundled default: ``ao_kernel/defaults/registry/prompt_variant_registry.v1.json``
+       (empty variants list in the bundled ship).
+
+    Raises :class:`PromptVariantError` on:
+
+    - Missing ``variants`` key (registry file must declare an array).
+    - Duplicate ``variant_id`` across entries.
+    - Any per-variant validation failure (see
+      :meth:`PromptVariant.from_dict`).
+
+    Returns an empty list when the bundled fallback is used and no
+    operator override is present.
+    """
+    import json
+
+    raw_registry: Mapping[str, Any] | None = None
+
+    if workspace_root is not None:
+        override_path = Path(workspace_root) / _WORKSPACE_REL
+        if override_path.is_file():
+            raw_registry = json.loads(override_path.read_text(encoding="utf-8"))
+
+    if raw_registry is None:
+        raw_registry = load_resource("registry", _REGISTRY_FILENAME)
+
+    if not isinstance(raw_registry, Mapping):
+        raise PromptVariantError(f"prompt_variant_registry must be a JSON object; got {type(raw_registry).__name__}")
+
+    variants_raw = raw_registry.get("variants")
+    if not isinstance(variants_raw, list):
+        raise PromptVariantError("prompt_variant_registry.variants must be an array")
+
+    variants: list[PromptVariant] = []
+    seen_ids: set[str] = set()
+    for entry in variants_raw:
+        if not isinstance(entry, Mapping):
+            raise PromptVariantError(f"prompt_variant_registry entries must be objects; got {type(entry).__name__}")
+        variant = PromptVariant.from_dict(entry)
+        if variant.variant_id in seen_ids:
+            raise PromptVariantError(f"Duplicate variant_id in registry: {variant.variant_id!r}")
+        seen_ids.add(variant.variant_id)
+        variants.append(variant)
+
+    return variants
+
+
+__all__ = [
+    "PromptVariant",
+    "PromptVariantError",
+    "load_prompt_variants",
+]

--- a/ao_kernel/prompts.py
+++ b/ao_kernel/prompts.py
@@ -115,17 +115,27 @@ def load_prompt_variants(workspace_root: Path | None = None) -> list[PromptVaria
     2. Bundled default: ``ao_kernel/defaults/registry/prompt_variant_registry.v1.json``
        (empty variants list in the bundled ship).
 
+    Each entry is validated against the bundled
+    ``prompt-variant.schema.v1.json`` (pattern + minLength + type +
+    closed enum) BEFORE the :meth:`PromptVariant.from_dict` field-level
+    guard runs. Schema violations surface as :class:`PromptVariantError`
+    with the first validator error rendered inline.
+
     Raises :class:`PromptVariantError` on:
 
     - Missing ``variants`` key (registry file must declare an array).
+    - Any schema validation failure on an individual entry (pattern,
+      type, minLength, closed enum).
     - Duplicate ``variant_id`` across entries.
-    - Any per-variant validation failure (see
+    - Any per-variant dataclass validation failure (see
       :meth:`PromptVariant.from_dict`).
 
     Returns an empty list when the bundled fallback is used and no
     operator override is present.
     """
     import json
+
+    from jsonschema import Draft202012Validator
 
     raw_registry: Mapping[str, Any] | None = None
 
@@ -144,11 +154,24 @@ def load_prompt_variants(workspace_root: Path | None = None) -> list[PromptVaria
     if not isinstance(variants_raw, list):
         raise PromptVariantError("prompt_variant_registry.variants must be an array")
 
+    # v3.12 E1 iter-2 absorb (Codex post-impl BLOCKER): enforce the
+    # JSON schema before the field-level guard. Loading the schema
+    # here (instead of import-time) keeps the module light when no
+    # registry is being read.
+    schema = load_resource("schemas", _SCHEMA_FILENAME)
+    validator = Draft202012Validator(schema)
+
     variants: list[PromptVariant] = []
     seen_ids: set[str] = set()
     for entry in variants_raw:
         if not isinstance(entry, Mapping):
             raise PromptVariantError(f"prompt_variant_registry entries must be objects; got {type(entry).__name__}")
+        # Schema-enforce BEFORE dataclass coercion.
+        schema_errors = sorted(validator.iter_errors(dict(entry)), key=lambda e: list(e.absolute_path))
+        if schema_errors:
+            first = schema_errors[0]
+            path = "$" + "".join(f".{p}" for p in first.absolute_path)
+            raise PromptVariantError(f"prompt-variant schema violation at {path}: {first.message}")
         variant = PromptVariant.from_dict(entry)
         if variant.variant_id in seen_ids:
             raise PromptVariantError(f"Duplicate variant_id in registry: {variant.variant_id!r}")

--- a/tests/test_prompts_variant_contract_v312_e1.py
+++ b/tests/test_prompts_variant_contract_v312_e1.py
@@ -222,6 +222,84 @@ class TestLoadPromptVariants:
         with pytest.raises(PromptVariantError, match="must be objects"):
             load_prompt_variants(workspace_root=tmp_path)
 
+    def test_invalid_variant_id_pattern_rejected_by_loader(self, tmp_path: Path) -> None:
+        # v3.12 E1 iter-2 (Codex BLOCKER absorb): loader now runs the
+        # JSON schema validator BEFORE the dataclass guard, so
+        # pattern/minLength/type violations surface as
+        # PromptVariantError with a schema-path excerpt. Pre-iter-2 the
+        # loader silently str(...)-coerced these.
+        from ao_kernel.prompts import load_prompt_variants, PromptVariantError
+
+        override_dir = tmp_path / ".ao" / "registry"
+        override_dir.mkdir(parents=True)
+        (override_dir / "prompt_variant_registry.v1.json").write_text(
+            json.dumps(
+                {
+                    "version": "v1",
+                    "variants": [
+                        {
+                            "variant_id": "-bad-starts-with-dash",
+                            "version": "1",
+                            "prompt_template": "x",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(PromptVariantError, match="schema violation"):
+            load_prompt_variants(workspace_root=tmp_path)
+
+    def test_non_string_version_rejected_by_loader(self, tmp_path: Path) -> None:
+        from ao_kernel.prompts import load_prompt_variants, PromptVariantError
+
+        override_dir = tmp_path / ".ao" / "registry"
+        override_dir.mkdir(parents=True)
+        (override_dir / "prompt_variant_registry.v1.json").write_text(
+            json.dumps(
+                {
+                    "version": "v1",
+                    "variants": [
+                        {
+                            "variant_id": "ok.v1",
+                            "version": 1,  # int, not string — schema violation
+                            "prompt_template": "x",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(PromptVariantError, match="schema violation"):
+            load_prompt_variants(workspace_root=tmp_path)
+
+    def test_empty_prompt_template_rejected_by_loader(self, tmp_path: Path) -> None:
+        # schema: prompt_template has minLength=1.
+        from ao_kernel.prompts import load_prompt_variants, PromptVariantError
+
+        override_dir = tmp_path / ".ao" / "registry"
+        override_dir.mkdir(parents=True)
+        (override_dir / "prompt_variant_registry.v1.json").write_text(
+            json.dumps(
+                {
+                    "version": "v1",
+                    "variants": [
+                        {
+                            "variant_id": "empty.tmpl.v1",
+                            "version": "1",
+                            "prompt_template": "",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(PromptVariantError, match="schema violation"):
+            load_prompt_variants(workspace_root=tmp_path)
+
 
 class TestIntentMetadataVariantIdContract:
     """`intent.metadata.variant_id` is supported by the existing

--- a/tests/test_prompts_variant_contract_v312_e1.py
+++ b/tests/test_prompts_variant_contract_v312_e1.py
@@ -1,0 +1,261 @@
+"""v3.12 E1 — Prompt variant contract + registry loader.
+
+Pins the declarative surface:
+
+- ``prompt-variant.schema.v1.json`` meta-validity + bundled registry
+  validates against it.
+- ``PromptVariant.from_dict`` contract (required fields, enum guard,
+  metadata shape).
+- ``load_prompt_variants`` workspace override precedence, bundled
+  fallback, duplicate-id guard, schema violations → ``PromptVariantError``.
+- ``intent.metadata.variant_id`` is a free-form field on the existing
+  workflow-run schema — operator responsibility to stamp, not a
+  runtime orchestration point (yet).
+
+E1 ships the contract only. E2 (compare helper) + E3 (runbook) wire
+the operator-facing workflow; A/B runtime orchestration itself is
+deferred until operator-validated real-adapter smokes exist (Codex
+plan-time precondition).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+class TestPromptVariantSchema:
+    def test_schema_is_draft_2020_12_meta_valid(self) -> None:
+        schema = load_default("schemas", "prompt-variant.schema.v1.json")
+        Draft202012Validator.check_schema(schema)
+        assert schema.get("$id", "").startswith("urn:ao:prompt-variant:")
+
+    def test_bundled_registry_validates_against_registry_shape(self) -> None:
+        # The bundled registry ships an empty `variants` array; its
+        # shape (object with `variants` list) must match operator
+        # expectations documented in the loader.
+        registry = load_default("registry", "prompt_variant_registry.v1.json")
+        assert isinstance(registry, dict)
+        assert "variants" in registry
+        assert isinstance(registry["variants"], list)
+        assert registry["variants"] == []  # bundled ships empty
+
+    def test_sample_variant_validates_against_schema(self) -> None:
+        schema = load_default("schemas", "prompt-variant.schema.v1.json")
+        sample = {
+            "variant_id": "review.concise.v1",
+            "version": "1.0.0",
+            "prompt_template": "Summarize findings in 3 bullets max.",
+            "expected_capability": "review_findings",
+            "metadata": {
+                "experiment_id": "exp-2026-04-19",
+                "branch": "feat/review-tuning",
+            },
+        }
+        errors = list(Draft202012Validator(schema).iter_errors(sample))
+        assert errors == [], [e.message for e in errors]
+
+    def test_invalid_variant_id_pattern_rejected(self) -> None:
+        schema = load_default("schemas", "prompt-variant.schema.v1.json")
+        # variant_id must start alphanumeric; `-foo` should fail the pattern.
+        bad = {
+            "variant_id": "-bad-starts-with-dash",
+            "version": "1",
+            "prompt_template": "x",
+        }
+        errors = list(Draft202012Validator(schema).iter_errors(bad))
+        assert errors, "pattern violation should surface as schema error"
+
+
+class TestPromptVariantDataclass:
+    def test_from_dict_accepts_minimum_required(self) -> None:
+        from ao_kernel.prompts import PromptVariant
+
+        v = PromptVariant.from_dict(
+            {
+                "variant_id": "minimum.v1",
+                "version": "1",
+                "prompt_template": "Hello",
+            }
+        )
+        assert v.variant_id == "minimum.v1"
+        assert v.version == "1"
+        assert v.prompt_template == "Hello"
+        assert v.expected_capability is None
+        assert v.metadata == {}
+
+    def test_from_dict_missing_required_raises(self) -> None:
+        from ao_kernel.prompts import PromptVariant, PromptVariantError
+
+        with pytest.raises(PromptVariantError, match="missing required field"):
+            PromptVariant.from_dict({"variant_id": "no-body.v1", "version": "1"})
+
+    def test_from_dict_unknown_expected_capability_raises(self) -> None:
+        from ao_kernel.prompts import PromptVariant, PromptVariantError
+
+        with pytest.raises(PromptVariantError, match="expected_capability"):
+            PromptVariant.from_dict(
+                {
+                    "variant_id": "bad-cap.v1",
+                    "version": "1",
+                    "prompt_template": "x",
+                    "expected_capability": "unknown_capability_xyz",
+                }
+            )
+
+    def test_from_dict_metadata_not_mapping_raises(self) -> None:
+        from ao_kernel.prompts import PromptVariant, PromptVariantError
+
+        with pytest.raises(PromptVariantError, match="metadata"):
+            PromptVariant.from_dict(
+                {
+                    "variant_id": "bad-meta.v1",
+                    "version": "1",
+                    "prompt_template": "x",
+                    "metadata": ["not", "a", "dict"],
+                }
+            )
+
+
+class TestLoadPromptVariants:
+    def test_bundled_fallback_returns_empty_list(self, tmp_path: Path) -> None:
+        # No workspace override → bundled empty registry used.
+        from ao_kernel.prompts import load_prompt_variants
+
+        variants = load_prompt_variants(workspace_root=tmp_path)
+        assert variants == []
+
+    def test_workspace_override_precedence(self, tmp_path: Path) -> None:
+        from ao_kernel.prompts import load_prompt_variants
+
+        override_dir = tmp_path / ".ao" / "registry"
+        override_dir.mkdir(parents=True)
+        (override_dir / "prompt_variant_registry.v1.json").write_text(
+            json.dumps(
+                {
+                    "version": "v1",
+                    "variants": [
+                        {
+                            "variant_id": "ws.a.v1",
+                            "version": "1",
+                            "prompt_template": "A prompt",
+                            "expected_capability": "review_findings",
+                        },
+                        {
+                            "variant_id": "ws.b.v1",
+                            "version": "1",
+                            "prompt_template": "B prompt",
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        variants = load_prompt_variants(workspace_root=tmp_path)
+        assert len(variants) == 2
+        ids = {v.variant_id for v in variants}
+        assert ids == {"ws.a.v1", "ws.b.v1"}
+
+    def test_duplicate_variant_id_raises(self, tmp_path: Path) -> None:
+        from ao_kernel.prompts import load_prompt_variants, PromptVariantError
+
+        override_dir = tmp_path / ".ao" / "registry"
+        override_dir.mkdir(parents=True)
+        (override_dir / "prompt_variant_registry.v1.json").write_text(
+            json.dumps(
+                {
+                    "version": "v1",
+                    "variants": [
+                        {
+                            "variant_id": "dup.v1",
+                            "version": "1",
+                            "prompt_template": "first",
+                        },
+                        {
+                            "variant_id": "dup.v1",  # same id
+                            "version": "2",
+                            "prompt_template": "second",
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(PromptVariantError, match="Duplicate variant_id"):
+            load_prompt_variants(workspace_root=tmp_path)
+
+    def test_missing_variants_key_raises(self, tmp_path: Path) -> None:
+        from ao_kernel.prompts import load_prompt_variants, PromptVariantError
+
+        override_dir = tmp_path / ".ao" / "registry"
+        override_dir.mkdir(parents=True)
+        (override_dir / "prompt_variant_registry.v1.json").write_text(
+            json.dumps({"version": "v1"}),  # no variants key
+            encoding="utf-8",
+        )
+
+        with pytest.raises(PromptVariantError, match="variants"):
+            load_prompt_variants(workspace_root=tmp_path)
+
+    def test_non_dict_variant_entry_raises(self, tmp_path: Path) -> None:
+        from ao_kernel.prompts import load_prompt_variants, PromptVariantError
+
+        override_dir = tmp_path / ".ao" / "registry"
+        override_dir.mkdir(parents=True)
+        (override_dir / "prompt_variant_registry.v1.json").write_text(
+            json.dumps(
+                {
+                    "version": "v1",
+                    "variants": ["not-a-dict"],  # string entry
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(PromptVariantError, match="must be objects"):
+            load_prompt_variants(workspace_root=tmp_path)
+
+
+class TestIntentMetadataVariantIdContract:
+    """`intent.metadata.variant_id` is supported by the existing
+    workflow-run schema without further changes — verify the field
+    passes through `create_run` and round-trips via `load_run`."""
+
+    def test_create_run_accepts_variant_id_in_intent_metadata(self, tmp_path: Path) -> None:
+        import uuid
+
+        from ao_kernel.workflow import create_run, load_run
+
+        run_id = str(uuid.uuid4())
+        create_run(
+            tmp_path,
+            run_id=run_id,
+            workflow_id="review_ai_flow",
+            workflow_version="1.0.0",
+            intent={
+                "kind": "inline_prompt",
+                "payload": "demo prompt",
+                "metadata": {
+                    "variant_id": "review.concise.v1",
+                    "experiment_id": "exp-2026-04-19",
+                },
+            },
+            budget={
+                "time_seconds": {"limit": 120.0, "spent": 0.0, "remaining": 120.0},
+                "fail_closed_on_exhaust": True,
+            },
+            policy_refs=["ao_kernel/defaults/policies/policy_worktree_profile.v1.json"],
+            evidence_refs=[f".ao/evidence/workflows/{run_id}/events.jsonl"],
+            adapter_refs=["codex-stub"],
+        )
+
+        record, _ = load_run(tmp_path, run_id)
+        assert record["intent"]["metadata"]["variant_id"] == "review.concise.v1"
+        assert record["intent"]["metadata"]["experiment_id"] == "exp-2026-04-19"


### PR DESCRIPTION
## Summary

First E-lane PR in v3.12. Declarative surface for operator-driven prompt experiments. ao-kernel does NOT yet orchestrate A/B dispatch — that lands after operator-validated real-adapter smokes exist (Codex plan-time precondition).

## Changes

- `ao_kernel/defaults/schemas/prompt-variant.schema.v1.json` (new): JSON Schema Draft 2020-12 for variant entries.
- `ao_kernel/defaults/registry/prompt_variant_registry.v1.json` (new): bundled empty registry; workspaces override via `.ao/registry/`.
- `ao_kernel/prompts.py` (new): `PromptVariant` frozen dataclass + `PromptVariantError` + `load_prompt_variants(workspace_root)` with override-precedence, bundled fallback, duplicate-id / enum / shape guards.
- `intent.metadata.variant_id` contract: documented + pinned via workflow-run schema passthrough (no schema change — existing `intent.metadata` map is freeform).

## Codex plan-time absorb (3 revisions)

1. E-prep scaffold contract-only OK for v3.12 (runtime A/B deferred).
2. `variant_id` as explicit stamp via `intent.metadata.variant_id`.
3. E2 lives in `ao_kernel.experiments` namespace (next PR in lane).

## Tests (+14 pins)

- `TestPromptVariantSchema` (×4): meta-valid, bundled registry shape, sample variant validates, variant_id pattern enforcement.
- `TestPromptVariantDataclass` (×4): minimum required, missing required → error, unknown enum → error, metadata must be mapping.
- `TestLoadPromptVariants` (×5): bundled fallback empty, workspace override precedence, duplicate variant_id, missing variants key, non-dict variant entry.
- `TestIntentMetadataVariantIdContract` (×1): create_run stamps variant_id + load_run round-trips.

## Gates

- pytest: **2636 passed** (+14 from main 2622)
- ruff / mypy: clean
- coverage: stays ≥85%

## v3.12 scope context

| PR | Scope | Status |
|---|---|---|
| #165 (H1) | dead kind prune | ✅ merged |
| #166 (H3) | session coverage tranche 6 | ✅ merged |
| #167 (H2a) | roadmap small coverage 5A | ✅ merged |
| **this (E1)** | **prompt variant contract** | **this PR** |
| E2 | `ao_kernel.experiments.compare_variants` helper | next (seq) |
| E3 | `PROMPT-EXPERIMENTS-RUNBOOK.md` operator guide | seq |

🤖 Generated with [Claude Code](https://claude.com/claude-code)