### PR TITLE
feat(v3.12-e2): ao_kernel.experiments.compare_variants read-only helper

### DIFF
--- a/ao_kernel/experiments/__init__.py
+++ b/ao_kernel/experiments/__init__.py
@@ -1,0 +1,36 @@
+"""ao_kernel.experiments — prompt / workflow experiment analysis helpers (v3.12 E2).
+
+Read-only helpers that pair ``intent.metadata.variant_id`` (stamped by
+the operator per :mod:`ao_kernel.prompts` E1 contract) with the
+review-findings artefact a workflow step produced
+(``step_record.capability_output_refs["review_findings"]``).
+
+The module is intentionally namespace-separate from
+``ao_kernel.scorecard`` — the latter is tied to benchmark scorecard
+JSON (`score` / `method` / `is_exact` fields), whereas this module
+deals with variant_id → run_id → capability-artefact pairing for
+operator-driven A/B experiments. Codex v3.12 plan-time directive:
+keep these concerns apart.
+
+v3.12 E2 ships only the read-only comparison surface. ao-kernel does
+NOT orchestrate A/B dispatch — that is deferred per
+:mod:`ao_kernel.prompts` docstring + the Codex plan-time precondition
+on operator-validated real-adapter smokes.
+"""
+
+from __future__ import annotations
+
+from ao_kernel.experiments.compare import (
+    VariantComparison,
+    VariantComparisonEntry,
+    VariantComparisonError,
+    compare_variants,
+)
+
+
+__all__ = [
+    "VariantComparison",
+    "VariantComparisonEntry",
+    "VariantComparisonError",
+    "compare_variants",
+]

--- a/ao_kernel/experiments/compare.py
+++ b/ao_kernel/experiments/compare.py
@@ -1,0 +1,179 @@
+"""Read-only variant comparison helper (v3.12 E2).
+
+Shape (v3.12 minimal, per Codex plan-time):
+
+- :class:`VariantComparisonEntry` — per-run row: ``variant_id``,
+  ``run_id``, optional ``experiment_id``, optional ``review_findings``
+  payload loaded from ``step_record.capability_output_refs``.
+- :class:`VariantComparison` — wrapper: ``entries`` (list), plus a
+  ``by_variant`` mapping for quick operator lookup.
+- :func:`compare_variants` — load each run record, extract variant
+  metadata + capability artefact, package into the comparison.
+
+The helper does NOT score. Operators write their own diff / threshold
+tooling on top; runbook (E3) gives walkthrough patterns. Additive
+helpers (``differing_findings()`` etc.) stay out of scope for v3.12.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+class VariantComparisonError(ValueError):
+    """Raised when a run record cannot be paired with a variant_id
+    (missing intent.metadata.variant_id) or when an artefact ref
+    cannot be resolved / parsed."""
+
+
+@dataclass(frozen=True)
+class VariantComparisonEntry:
+    """Single row in the variant comparison.
+
+    ``review_findings`` is ``None`` when the run either didn't produce
+    a ``review_findings`` capability artefact or the artefact file is
+    missing / malformed. The operator can inspect ``review_findings_ref``
+    and ``load_error`` to understand why.
+    """
+
+    run_id: str
+    variant_id: str
+    experiment_id: str | None
+    review_findings_ref: str | None
+    review_findings: Mapping[str, Any] | None
+    load_error: str | None = None
+
+
+@dataclass(frozen=True)
+class VariantComparison:
+    """Bundle of :class:`VariantComparisonEntry` rows.
+
+    ``entries`` is in the same order as the ``run_ids`` argument to
+    :func:`compare_variants`. ``by_variant`` groups by ``variant_id``
+    (the common operator query).
+    """
+
+    entries: tuple[VariantComparisonEntry, ...]
+    by_variant: Mapping[str, tuple[VariantComparisonEntry, ...]] = field(default_factory=dict)
+
+
+def _load_run_record(workspace_root: Path, run_id: str) -> Mapping[str, Any]:
+    """Thin wrapper so tests can monkeypatch the loader without touching
+    the ao_kernel.workflow public surface.
+    """
+    from ao_kernel.workflow import load_run
+
+    record, _ = load_run(workspace_root, run_id)
+    return record
+
+
+def _extract_review_findings_ref(
+    record: Mapping[str, Any],
+) -> str | None:
+    """Return the first ``capability_output_refs["review_findings"]``
+    path from the record's step list, or ``None`` if no step emitted
+    one.
+    """
+    steps = record.get("steps") or []
+    if not isinstance(steps, list):
+        return None
+    for step in steps:
+        if not isinstance(step, Mapping):
+            continue
+        refs = step.get("capability_output_refs")
+        if isinstance(refs, Mapping):
+            ref = refs.get("review_findings")
+            if isinstance(ref, str) and ref:
+                return ref
+    return None
+
+
+def _read_artefact(workspace_root: Path, ref: str) -> tuple[Mapping[str, Any] | None, str | None]:
+    """Resolve ``ref`` against ``workspace_root`` and JSON-parse it.
+
+    Returns ``(payload, None)`` on success, ``(None, reason)`` on any
+    I/O or parse failure. Fail-open semantics — the comparison row
+    still ships, just without the payload.
+    """
+    try:
+        path = (workspace_root / ref).resolve()
+        if not path.is_file():
+            return None, f"artefact file not found: {ref!r}"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, Mapping):
+            return None, f"artefact is not a JSON object: {ref!r}"
+        return data, None
+    except Exception as exc:  # noqa: BLE001 — fail-open load for analysis helper
+        return None, f"artefact load failed: {type(exc).__name__}: {exc}"
+
+
+def compare_variants(
+    run_ids: Sequence[str],
+    *,
+    workspace_root: Path,
+) -> VariantComparison:
+    """Pair ``variant_id`` with ``review_findings`` artefacts across runs.
+
+    Args:
+        run_ids: Run identifiers to include. Order is preserved in
+            :attr:`VariantComparison.entries`.
+        workspace_root: The workspace that holds the run records +
+            artefacts (typically the project root that has ``.ao/``).
+
+    Raises :class:`VariantComparisonError` if any run record lacks
+    ``intent.metadata.variant_id`` — that field is the contract
+    stamp operators use to mark a variant run. Unstamped runs do not
+    belong in an experiment comparison; the call fails closed.
+
+    Artefact load failures are NOT raised — they're packaged into
+    :attr:`VariantComparisonEntry.load_error` so the operator sees
+    which runs produced analyzable payloads and which didn't.
+    """
+    entries: list[VariantComparisonEntry] = []
+    by_variant: dict[str, list[VariantComparisonEntry]] = {}
+
+    for run_id in run_ids:
+        record = _load_run_record(workspace_root, run_id)
+        intent = record.get("intent") or {}
+        metadata = intent.get("metadata") if isinstance(intent, Mapping) else None
+        if not isinstance(metadata, Mapping):
+            raise VariantComparisonError(f"run {run_id!r} has no intent.metadata — cannot pair with a variant")
+        variant_id = metadata.get("variant_id")
+        if not isinstance(variant_id, str) or not variant_id:
+            raise VariantComparisonError(f"run {run_id!r} is missing intent.metadata.variant_id")
+        experiment_id = metadata.get("experiment_id")
+        if not isinstance(experiment_id, str):
+            experiment_id = None
+
+        ref = _extract_review_findings_ref(record)
+        payload: Mapping[str, Any] | None = None
+        load_error: str | None = None
+        if ref is None:
+            load_error = "no step emitted review_findings artefact"
+        else:
+            payload, load_error = _read_artefact(workspace_root, ref)
+
+        entry = VariantComparisonEntry(
+            run_id=run_id,
+            variant_id=variant_id,
+            experiment_id=experiment_id,
+            review_findings_ref=ref,
+            review_findings=payload,
+            load_error=load_error,
+        )
+        entries.append(entry)
+        by_variant.setdefault(variant_id, []).append(entry)
+
+    by_variant_frozen: dict[str, tuple[VariantComparisonEntry, ...]] = {k: tuple(v) for k, v in by_variant.items()}
+    return VariantComparison(entries=tuple(entries), by_variant=by_variant_frozen)
+
+
+__all__ = [
+    "VariantComparison",
+    "VariantComparisonEntry",
+    "VariantComparisonError",
+    "compare_variants",
+]

--- a/ao_kernel/experiments/compare.py
+++ b/ao_kernel/experiments/compare.py
@@ -91,15 +91,31 @@ def _extract_review_findings_ref(
     return None
 
 
-def _read_artefact(workspace_root: Path, ref: str) -> tuple[Mapping[str, Any] | None, str | None]:
-    """Resolve ``ref`` against ``workspace_root`` and JSON-parse it.
+def _run_dir(workspace_root: Path, run_id: str) -> Path:
+    """Canonical per-run evidence directory.
+
+    Matches ``workflow-run.schema.v1.json`` contract for
+    ``step_record.capability_output_refs`` values: every ref is
+    **run-dir-relative**, not workspace-root-relative. See
+    ``ao_kernel/executor/artifacts.py`` for the writer side that
+    produces the refs.
+    """
+    return workspace_root / ".ao" / "evidence" / "workflows" / run_id
+
+
+def _read_artefact(workspace_root: Path, run_id: str, ref: str) -> tuple[Mapping[str, Any] | None, str | None]:
+    """Resolve ``ref`` against the run-dir and JSON-parse it.
+
+    ``ref`` comes from ``step_record.capability_output_refs``, which
+    is run-dir-relative per the workflow-run schema. Build the full
+    path via :func:`_run_dir(workspace_root, run_id) / ref`.
 
     Returns ``(payload, None)`` on success, ``(None, reason)`` on any
     I/O or parse failure. Fail-open semantics — the comparison row
     still ships, just without the payload.
     """
     try:
-        path = (workspace_root / ref).resolve()
+        path = (_run_dir(workspace_root, run_id) / ref).resolve()
         if not path.is_file():
             return None, f"artefact file not found: {ref!r}"
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -154,7 +170,7 @@ def compare_variants(
         if ref is None:
             load_error = "no step emitted review_findings artefact"
         else:
-            payload, load_error = _read_artefact(workspace_root, ref)
+            payload, load_error = _read_artefact(workspace_root, run_id, ref)
 
         entry = VariantComparisonEntry(
             run_id=run_id,

--- a/ao_kernel/experiments/compare.py
+++ b/ao_kernel/experiments/compare.py
@@ -108,14 +108,25 @@ def _read_artefact(workspace_root: Path, run_id: str, ref: str) -> tuple[Mapping
 
     ``ref`` comes from ``step_record.capability_output_refs``, which
     is run-dir-relative per the workflow-run schema. Build the full
-    path via :func:`_run_dir(workspace_root, run_id) / ref`.
+    path via :func:`_run_dir(workspace_root, run_id) / ref`, then
+    verify the resolved path stays **inside** the run directory — a
+    malformed or malicious record could carry ``../../../some.json``
+    as the ref and silently hand the operator an unrelated JSON file
+    stamped as ``review_findings``. The containment check turns that
+    into a clear ``load_error`` instead of a silent mis-pairing.
 
     Returns ``(payload, None)`` on success, ``(None, reason)`` on any
-    I/O or parse failure. Fail-open semantics — the comparison row
-    still ships, just without the payload.
+    I/O / parse / containment failure. Fail-open semantics — the
+    comparison row still ships, just without the payload.
     """
     try:
-        path = (_run_dir(workspace_root, run_id) / ref).resolve()
+        run_dir_resolved = _run_dir(workspace_root, run_id).resolve()
+        path = (run_dir_resolved / ref).resolve()
+        # Containment guard — reject any ref that escapes the run-dir
+        # after resolving. ``is_relative_to`` was added in 3.9; we
+        # target 3.11+.
+        if not path.is_relative_to(run_dir_resolved):
+            return None, (f"artefact ref escapes run directory: {ref!r}")
         if not path.is_file():
             return None, f"artefact file not found: {ref!r}"
         data = json.loads(path.read_text(encoding="utf-8"))

--- a/tests/test_experiments_compare_v312_e2.py
+++ b/tests/test_experiments_compare_v312_e2.py
@@ -115,9 +115,14 @@ class TestCompareVariantsArtefactResolution:
         assert entry.load_error == "no step emitted review_findings artefact"
 
     def test_missing_artefact_file_records_load_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Canonical ref format (run-dir-relative) per
+        # workflow-run.schema.v1.json. No file at the resolved path →
+        # load_error, row still ships.
         monkeypatch.setattr(
             "ao_kernel.experiments.compare._load_run_record",
-            lambda ws, rid: _fake_record(review_findings_ref=".ao/artefacts/r1/missing.json"),
+            lambda ws, rid: _fake_record(
+                review_findings_ref="artifacts/invoke_review_agent-review_findings-attempt1.json"
+            ),
         )
         result = compare_variants(["r1"], workspace_root=tmp_path)
         entry = result.entries[0]
@@ -126,35 +131,40 @@ class TestCompareVariantsArtefactResolution:
         assert "not found" in entry.load_error
 
     def test_malformed_artefact_records_load_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        art_ref = ".ao/artefacts/r1/rf.json"
-        (tmp_path / ".ao" / "artefacts" / "r1").mkdir(parents=True)
-        (tmp_path / art_ref).write_text("{not valid json", encoding="utf-8")
+        # Canonical layout: workspace_root/.ao/evidence/workflows/<run_id>/<ref>
+        run_id = "r1"
+        art_ref = "artifacts/invoke_review_agent-review_findings-attempt1.json"
+        run_dir = tmp_path / ".ao" / "evidence" / "workflows" / run_id / "artifacts"
+        run_dir.mkdir(parents=True)
+        (run_dir / Path(art_ref).name).write_text("{not valid json", encoding="utf-8")
 
         monkeypatch.setattr(
             "ao_kernel.experiments.compare._load_run_record",
             lambda ws, rid: _fake_record(review_findings_ref=art_ref),
         )
-        result = compare_variants(["r1"], workspace_root=tmp_path)
+        result = compare_variants([run_id], workspace_root=tmp_path)
         entry = result.entries[0]
         assert entry.review_findings is None
         assert entry.load_error is not None
         assert "artefact load failed" in entry.load_error
 
     def test_successful_artefact_load(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        art_ref = ".ao/artefacts/r1/rf.json"
-        (tmp_path / ".ao" / "artefacts" / "r1").mkdir(parents=True)
+        run_id = "r1"
+        art_ref = "artifacts/invoke_review_agent-review_findings-attempt1.json"
+        run_dir = tmp_path / ".ao" / "evidence" / "workflows" / run_id / "artifacts"
+        run_dir.mkdir(parents=True)
         payload = {
             "schema_version": "1",
             "findings": [{"severity": "warning", "message": "nit about import order"}],
             "summary": "1 warning, no blockers",
         }
-        (tmp_path / art_ref).write_text(json.dumps(payload), encoding="utf-8")
+        (run_dir / Path(art_ref).name).write_text(json.dumps(payload), encoding="utf-8")
 
         monkeypatch.setattr(
             "ao_kernel.experiments.compare._load_run_record",
             lambda ws, rid: _fake_record(review_findings_ref=art_ref),
         )
-        result = compare_variants(["r1"], workspace_root=tmp_path)
+        result = compare_variants([run_id], workspace_root=tmp_path)
         entry = result.entries[0]
         assert entry.review_findings == payload
         assert entry.load_error is None

--- a/tests/test_experiments_compare_v312_e2.py
+++ b/tests/test_experiments_compare_v312_e2.py
@@ -1,0 +1,198 @@
+"""v3.12 E2 — ``ao_kernel.experiments.compare_variants`` read-only helper.
+
+Pins the pairing contract:
+
+- ``intent.metadata.variant_id`` (stamped by operator per E1 contract)
+  is REQUIRED on every run passed to ``compare_variants`` — absence
+  fails closed.
+- ``step_record.capability_output_refs["review_findings"]`` is the
+  artefact source; the first such ref across the run's steps wins.
+- Artefact load failures (missing file, malformed JSON, non-dict
+  payload) are packaged into ``VariantComparisonEntry.load_error``
+  rather than raised — the row still ships with metadata.
+- ``by_variant`` groups entries in the same order they're discovered
+  across ``run_ids``.
+
+E2 is read-only; it does NOT orchestrate runs. Operators start each
+run manually per the E3 runbook.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ao_kernel.experiments import (
+    VariantComparisonError,
+    compare_variants,
+)
+
+
+def _fake_record(
+    *,
+    variant_id: str | None = "review.concise.v1",
+    experiment_id: str | None = "exp-2026-04-19",
+    review_findings_ref: str | None = None,
+    include_metadata: bool = True,
+) -> dict[str, Any]:
+    """Build a minimal workflow-run record dict for monkeypatching."""
+    intent: dict[str, Any] = {
+        "kind": "inline_prompt",
+        "payload": "test",
+    }
+    if include_metadata:
+        meta: dict[str, Any] = {}
+        if variant_id is not None:
+            meta["variant_id"] = variant_id
+        if experiment_id is not None:
+            meta["experiment_id"] = experiment_id
+        intent["metadata"] = meta
+
+    steps: list[dict[str, Any]] = []
+    if review_findings_ref is not None:
+        steps.append(
+            {
+                "step_id": "invoke_review_agent",
+                "step_name": "invoke_review_agent",
+                "state": "completed",
+                "capability_output_refs": {
+                    "review_findings": review_findings_ref,
+                },
+            }
+        )
+
+    return {
+        "run_id": "fake",
+        "intent": intent,
+        "steps": steps,
+    }
+
+
+class TestCompareVariantsContract:
+    def test_missing_intent_metadata_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Record has no intent.metadata → fail closed.
+        monkeypatch.setattr(
+            "ao_kernel.experiments.compare._load_run_record",
+            lambda ws, rid: _fake_record(include_metadata=False),
+        )
+        with pytest.raises(VariantComparisonError, match="intent.metadata"):
+            compare_variants(["r1"], workspace_root=tmp_path)
+
+    def test_missing_variant_id_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # intent.metadata exists but variant_id is None.
+        monkeypatch.setattr(
+            "ao_kernel.experiments.compare._load_run_record",
+            lambda ws, rid: _fake_record(variant_id=None),
+        )
+        with pytest.raises(VariantComparisonError, match="variant_id"):
+            compare_variants(["r1"], workspace_root=tmp_path)
+
+    def test_empty_variant_id_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "ao_kernel.experiments.compare._load_run_record",
+            lambda ws, rid: _fake_record(variant_id=""),
+        )
+        with pytest.raises(VariantComparisonError, match="variant_id"):
+            compare_variants(["r1"], workspace_root=tmp_path)
+
+
+class TestCompareVariantsArtefactResolution:
+    def test_no_review_findings_step_records_load_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Step list exists but no step has the capability ref.
+        monkeypatch.setattr(
+            "ao_kernel.experiments.compare._load_run_record",
+            lambda ws, rid: _fake_record(review_findings_ref=None),
+        )
+        result = compare_variants(["r1"], workspace_root=tmp_path)
+        assert len(result.entries) == 1
+        entry = result.entries[0]
+        assert entry.variant_id == "review.concise.v1"
+        assert entry.review_findings_ref is None
+        assert entry.review_findings is None
+        assert entry.load_error == "no step emitted review_findings artefact"
+
+    def test_missing_artefact_file_records_load_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "ao_kernel.experiments.compare._load_run_record",
+            lambda ws, rid: _fake_record(review_findings_ref=".ao/artefacts/r1/missing.json"),
+        )
+        result = compare_variants(["r1"], workspace_root=tmp_path)
+        entry = result.entries[0]
+        assert entry.review_findings is None
+        assert entry.load_error is not None
+        assert "not found" in entry.load_error
+
+    def test_malformed_artefact_records_load_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        art_ref = ".ao/artefacts/r1/rf.json"
+        (tmp_path / ".ao" / "artefacts" / "r1").mkdir(parents=True)
+        (tmp_path / art_ref).write_text("{not valid json", encoding="utf-8")
+
+        monkeypatch.setattr(
+            "ao_kernel.experiments.compare._load_run_record",
+            lambda ws, rid: _fake_record(review_findings_ref=art_ref),
+        )
+        result = compare_variants(["r1"], workspace_root=tmp_path)
+        entry = result.entries[0]
+        assert entry.review_findings is None
+        assert entry.load_error is not None
+        assert "artefact load failed" in entry.load_error
+
+    def test_successful_artefact_load(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        art_ref = ".ao/artefacts/r1/rf.json"
+        (tmp_path / ".ao" / "artefacts" / "r1").mkdir(parents=True)
+        payload = {
+            "schema_version": "1",
+            "findings": [{"severity": "warning", "message": "nit about import order"}],
+            "summary": "1 warning, no blockers",
+        }
+        (tmp_path / art_ref).write_text(json.dumps(payload), encoding="utf-8")
+
+        monkeypatch.setattr(
+            "ao_kernel.experiments.compare._load_run_record",
+            lambda ws, rid: _fake_record(review_findings_ref=art_ref),
+        )
+        result = compare_variants(["r1"], workspace_root=tmp_path)
+        entry = result.entries[0]
+        assert entry.review_findings == payload
+        assert entry.load_error is None
+
+
+class TestCompareVariantsGrouping:
+    def test_by_variant_groups_multiple_runs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # 3 runs: 2 share variant, 1 different.
+        records = {
+            "run-a": _fake_record(variant_id="v.concise.v1"),
+            "run-b": _fake_record(variant_id="v.concise.v1"),
+            "run-c": _fake_record(variant_id="v.detailed.v1"),
+        }
+        monkeypatch.setattr(
+            "ao_kernel.experiments.compare._load_run_record",
+            lambda ws, rid: records[rid],
+        )
+        result = compare_variants(["run-a", "run-b", "run-c"], workspace_root=tmp_path)
+        assert len(result.entries) == 3
+        # entries preserve order
+        assert [e.run_id for e in result.entries] == ["run-a", "run-b", "run-c"]
+        # by_variant correctly groups
+        assert set(result.by_variant.keys()) == {"v.concise.v1", "v.detailed.v1"}
+        assert len(result.by_variant["v.concise.v1"]) == 2
+        assert len(result.by_variant["v.detailed.v1"]) == 1
+
+    def test_experiment_id_passes_through(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "ao_kernel.experiments.compare._load_run_record",
+            lambda ws, rid: _fake_record(experiment_id="exp-42"),
+        )
+        result = compare_variants(["r1"], workspace_root=tmp_path)
+        assert result.entries[0].experiment_id == "exp-42"
+
+    def test_missing_experiment_id_is_none(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "ao_kernel.experiments.compare._load_run_record",
+            lambda ws, rid: _fake_record(experiment_id=None),
+        )
+        result = compare_variants(["r1"], workspace_root=tmp_path)
+        assert result.entries[0].experiment_id is None

--- a/tests/test_experiments_compare_v312_e2.py
+++ b/tests/test_experiments_compare_v312_e2.py
@@ -169,6 +169,32 @@ class TestCompareVariantsArtefactResolution:
         assert entry.review_findings == payload
         assert entry.load_error is None
 
+    def test_ref_escape_outside_run_dir_rejected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Codex iter-3 BLOCKER absorb: a malformed / malicious run
+        # record could carry `review_findings_ref="../../../evil.json"`;
+        # the helper MUST refuse rather than silently load an unrelated
+        # file stamped as review_findings.
+        run_id = "r1"
+        # Materialize a real JSON file OUTSIDE the run-dir so only the
+        # containment check (not `is_file` check) rejects it.
+        outside = tmp_path / "outside.json"
+        outside.write_text(
+            json.dumps({"schema_version": "1", "findings": [], "summary": "evil"}),
+            encoding="utf-8",
+        )
+        # ref climbs out of .ao/evidence/workflows/r1/ → tmp_path/outside.json
+        escape_ref = "../../../../outside.json"
+
+        monkeypatch.setattr(
+            "ao_kernel.experiments.compare._load_run_record",
+            lambda ws, rid: _fake_record(review_findings_ref=escape_ref),
+        )
+        result = compare_variants([run_id], workspace_root=tmp_path)
+        entry = result.entries[0]
+        assert entry.review_findings is None
+        assert entry.load_error is not None
+        assert "escapes run directory" in entry.load_error
+
 
 class TestCompareVariantsGrouping:
     def test_by_variant_groups_multiple_runs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Second E-lane PR. Pairs `intent.metadata.variant_id` (operator stamp, E1 contract) with the review-findings artefact a workflow step produced. Read-only — does NOT orchestrate runs.

## v3.12 scope context

| PR | Scope | Status |
|---|---|---|
| #165 (H1) | dead kind prune | ✅ |
| #166 (H3) | session coverage tranche 6 | ✅ |
| #167 (H2a) | roadmap small coverage 5A | ✅ |
| #168 (E1) | prompt variant contract + loader + schema validation (iter-2) | Codex MERGE |
| **this (E2)** | **compare_variants helper** | **this PR** |
| E3 | PROMPT-EXPERIMENTS-RUNBOOK.md | next |
| release | v3.12.0 | last |

## Codex plan-time absorb (E1 continuation)

1. ✅ Module lives in `ao_kernel.experiments` namespace (NOT `scorecard` — different concerns)
2. ✅ Minimum shape: `VariantComparisonEntry` + `VariantComparison`; no `differing_findings()` helper
3. ✅ `intent.metadata.variant_id` required — fail closed if missing (unstamped runs don't belong in an experiment)

## Changes

- `ao_kernel/experiments/__init__.py` (new) — public facade exports.
- `ao_kernel/experiments/compare.py` (new, ~180 LOC) — dataclasses + `compare_variants` function + internal helpers (`_load_run_record` for test monkeypatching, `_extract_review_findings_ref`, `_read_artefact`).

## Tests (+10 pins)

- `TestCompareVariantsContract` (×3): missing intent.metadata, missing variant_id, empty variant_id — all raise.
- `TestCompareVariantsArtefactResolution` (×4): no capability ref / missing file / malformed JSON / successful load — surface correctly via `load_error` or payload.
- `TestCompareVariantsGrouping` (×3): multi-run `by_variant` grouping, experiment_id passthrough, missing experiment_id → None.

## Gates

- pytest: **2632 passed** (+10 from main 2622)
- ruff / mypy: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)