### PR TITLE
docs(v3.13.1-d1): README + CLAUDE.md + examples drift fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,12 +60,14 @@ Tool spec'leri ve inputSchema'lar için: `mcp_server.py`
 
 ```bash
 ao-kernel init             # .ao/ workspace oluştur
-ao-kernel doctor           # sağlık kontrolü
+ao-kernel doctor           # sağlık kontrolü (8 kontrol)
 ao-kernel migrate          # workspace migration (--dry-run, --backup)
 ao-kernel mcp serve        # MCP server (stdio)
 ao-kernel mcp serve --transport http --port 8080
+ao-kernel evidence ...     # timeline / replay / manifest (run-level audit)
+ao-kernel metrics ...      # usage/cost aggregates (opt-in)
+ao-kernel policy-sim ...   # dry-run policy simulation
 ao-kernel version          # versiyon
-ao-kernel system-status    # workspace durumu
 ```
 
 ## 5. Mimari Genel Bakış

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ ao_kernel/                ← PUBLIC FACADE
     secrets/               ← Env provider, vault stub
     shared/, utils/        ← Logger, resource loader, JSON I/O
 
-  defaults/                ← Bundled JSON resources (policies, schemas, registry, extensions, operations)
+  defaults/                ← Bundled JSON resources (policies, schemas, registry, extensions, operations, adapters, workflows, catalogs, intent_rules)
 ```
 
 > Güncel sayılar: `pytest --co -q | tail -1` (test), `find ao_kernel/defaults -name "*.json" | wc -l` (bundled JSON), `ls tests/test_*.py | wc -l` (test dosyası)

--- a/README.md
+++ b/README.md
@@ -211,13 +211,15 @@ items = query_memory(ws, key_pattern="arch.*")
 
 | | ao-kernel | LangGraph | CrewAI | Pydantic AI |
 |---|---|---|---|---|
-| Policy engine | 96 policies | No | No | No |
+| Policy engine | 100+ policy files | No | No | No |
 | Fail-closed | Yes | No | No | No |
 | Evidence trail | Self-hosted JSONL | LangSmith SaaS | No | No |
 | Migration CLI | Yes | No | No | No |
 | Doctor | Yes | No | No | No |
 | MCP server | Yes | No | No | No |
 | Streaming | SSE (6 providers) | Yes | Yes | Yes |
+
+> Counts as of `v3.13.0`: `ao_kernel/defaults/` ships **377** bundled JSON files — 106 policies + 231 schemas + 19 extensions + 9 registry + 4 workflows + 3 operations + 3 adapters + 1 catalogs + 1 intent_rules. Run `find ao_kernel/defaults -name '*.json' | wc -l` for the live number.
 
 ## Architecture
 
@@ -229,7 +231,7 @@ ao_kernel/              <- Public facade (clean API)
   mcp_server.py         <- MCP server (7 tools, 3 resources)
   context/              <- Context pipeline (compile, inject, extract, promote)
   _internal/            <- Private implementation (do not import directly)
-  defaults/             <- 338 bundled JSON (policies, schemas, registry, extensions)
+  defaults/             <- 377 bundled JSON (policies, schemas, registry, extensions, operations, adapters, workflows, catalogs, intent_rules)
 ```
 
 ## Development

--- a/examples/demo_bugfix.py
+++ b/examples/demo_bugfix.py
@@ -32,12 +32,20 @@ def main(argv: list[str] | None = None) -> int:
     ws = Path(args.workspace_root).resolve()
     print(f"[demo] workspace: {ws}")
 
-    # 1. Ensure workspace init
+    # 1. Ensure workspace init.
+    # NOTE: `ao-kernel init` has asymmetric path semantics — passing
+    # `--workspace-root X` writes the workspace files *directly* under
+    # X rather than `X/.ao/`. That's tracked as a v3.13.1+ fix. In the
+    # demo we side-step it by chdir'ing into the target and invoking
+    # `init` with no override, which uses `cwd/.ao/` as expected.
     ao_dir = ws / ".ao"
     if not ao_dir.is_dir():
         print("[demo] initializing workspace...")
-        subprocess.run([sys.executable, "-m", "ao_kernel.cli", "init",
-                        "--workspace-root", str(ws)], check=True)
+        subprocess.run(
+            [sys.executable, "-m", "ao_kernel.cli", "init"],
+            cwd=str(ws),
+            check=True,
+        )
 
     # 2. Ensure adapter manifests
     adapters_dir = ao_dir / "adapters"

--- a/examples/hello-llm/README.md
+++ b/examples/hello-llm/README.md
@@ -82,7 +82,7 @@ After a successful run you will have:
 
 ## Troubleshooting
 
-- **`WorkspaceNotFoundError`** — you ran `main.py` without the init step. The example uses `AoKernelClient(workspace_root=".")` which creates `.ao/` on demand; if you deleted the directory mid-run, re-run cleanly from the example folder.
+- **`WorkspaceNotFoundError`** — the `.ao/` workspace is missing. The example passes `auto_init=True` to `AoKernelClient` so the first run will bootstrap `.ao/` in the example folder automatically. If you deleted the directory mid-run, re-run cleanly from the example folder — the next invocation will scaffold it again. (If you want the stricter "fail closed when `.ao/` is absent" behavior in your own code, omit `auto_init=True` — the default is `False`.)
 - **`401 Unauthorized` from provider** — your API key is wrong, expired, or missing. Double-check `.env` (or `echo $OPENAI_API_KEY`).
 - **`Policy violation`** — the bundled `policy_llm_routing.v1.json` denied the call. That is the fail-closed behavior; inspect the `decision` and `reason_codes` in the result dict.
 - **Silent hang** — a provider may be throttling you. Ctrl-C is safe; no partial state is persisted mid-call.

--- a/examples/hello-llm/main.py
+++ b/examples/hello-llm/main.py
@@ -53,8 +53,12 @@ def main() -> int:
     # Import here so --help-style checks do not require ao-kernel installed yet.
     from ao_kernel import AoKernelClient
 
-    # workspace_root="." means: create/use .ao/ in the current directory.
-    with AoKernelClient(workspace_root=str(here)) as client:
+    # AoKernelClient expects a project root that ALREADY contains a `.ao/`
+    # workspace. It does NOT auto-create one (the default `auto_init=False`
+    # is intentional so that mis-spelled paths don't silently scaffold a
+    # workspace somewhere unexpected). Pass `auto_init=True` if you want
+    # hello-llm to bootstrap `.ao/` in `here` on first run.
+    with AoKernelClient(workspace_root=str(here), auto_init=True) as client:
         print(f"✓ Workspace initialized at: {here}")
 
         session_id = client.start_session()


### PR DESCRIPTION
## Summary
- README.md: policy count `96` → `100+` with live table (377 bundled JSON); architecture `338` → `377` with category breakdown
- CLAUDE.md: drop stale `ao-kernel system-status` CLI entry (no handler in `cli.py`); add `evidence` / `metrics` / `policy-sim` commands
- examples/hello-llm: fix wrong auto-init claim (default `auto_init=False`); example now opts-in with `auto_init=True`
- examples/demo_bugfix.py: side-step `init --workspace-root X` asymmetric path bug (tracked for v3.13.1 P1 companion PR) by chdir'ing into target

## Drift source
External AI UX review (2026-04-20) flagged:
- README:214 said `96 policies` — live is 106 (policy files)
- README:232 said `338 bundled JSON` — live is 377
- CLAUDE.md:68 said `ao-kernel system-status` — no handler exists in `cli.py`
- examples/hello-llm/README.md:85 claimed `AoKernelClient("./")` auto-creates `.ao/` — it does NOT by default
- examples/demo_bugfix.py called `init --workspace-root str(ws)` expecting `.ao/` inside ws — init creates directly AT ws instead (asymmetric `init_cmd.run()` behavior)

Codex plan-time REVISE verdict absorbed: `PR-D1` (this PR, pure docs/examples) + `PR-P1` (follow-up, load_workspace_json fallback + central normalizer helper).

## Test plan
- [x] Full suite 2750 passed, 1 skipped (no test changes)
- [ ] CI 9/9 GREEN
- [ ] Codex post-impl review → MERGE

🤖 Generated with [Claude Code](https://claude.com/claude-code)