### PR TITLE
feat(v3.13.1-p1): resolve_workspace_dir normalizer + load_workspace_json fallback

### DIFF
--- a/ao_kernel/config.py
+++ b/ao_kernel/config.py
@@ -16,14 +16,16 @@ from typing import Any, cast
 
 from ao_kernel.errors import DefaultsNotFoundError, WorkspaceCorruptedError
 
-_VALID_RESOURCE_TYPES = frozenset({
-    "policies",
-    "schemas",
-    "registry",
-    "extensions",
-    "operations",
-    "catalogs",
-})
+_VALID_RESOURCE_TYPES = frozenset(
+    {
+        "policies",
+        "schemas",
+        "registry",
+        "extensions",
+        "operations",
+        "catalogs",
+    }
+)
 # "catalogs" added in FAZ-B PR-B0 (CNS-028v2 iter-5 W2/W4 absorb):
 # bundled ao_kernel/defaults/catalogs/*.v1.json carry reference data
 # (e.g. price-catalog.v1.json) that has the same wheel-safe discovery
@@ -56,28 +58,64 @@ def workspace_root(override: str | Path | None = None) -> Path | None:
     return None
 
 
+def resolve_workspace_dir(path: Path | str) -> Path:
+    """Normalize a user-supplied workspace reference to the actual
+    directory that contains ``workspace.json``.
+
+    ``path`` may be either:
+
+    - The **project root** (contains ``.ao/workspace.json``); the
+      function returns ``path / ".ao"``.
+    - The **workspace directory itself** (contains ``workspace.json``
+      directly); returned unchanged.
+
+    Historical drift: ``workspace_root(override=...)`` returns the
+    override path as-is, but ``ao-kernel init`` (with no override) and
+    most CLI users treat ``--workspace-root`` as the **project root**
+    with ``.ao/`` inside. The two conventions did not interop — e.g.
+    ``doctor --workspace-root .`` would fail while ``doctor
+    --workspace-root .ao`` would pass. This helper normalizes both
+    shapes so callers (``load_workspace_json``, doctor, migrate,
+    MCP workspace_status) tolerate either.
+
+    If neither ``path/workspace.json`` nor ``path/.ao/workspace.json``
+    exists, ``path`` is returned unchanged so downstream callers can
+    produce a clear fail-closed error with the user-supplied path in
+    the message.
+    """
+    p = Path(path).resolve()
+    if (p / "workspace.json").is_file():
+        return p
+    ao_candidate = p / ".ao"
+    if (ao_candidate / "workspace.json").is_file():
+        return ao_candidate
+    return p
+
+
 def load_workspace_json(workspace: Path) -> dict[str, Any]:
-    """Load and validate workspace.json from the given workspace directory."""
-    ws_file = workspace / "workspace.json"
+    """Load and validate ``workspace.json`` from the given directory.
+
+    Accepts either a **project root** (with ``.ao/workspace.json``
+    inside) or a **workspace directory** (with ``workspace.json``
+    directly). See :func:`resolve_workspace_dir` for the normalization
+    contract.
+    """
+    resolved = resolve_workspace_dir(workspace)
+    ws_file = resolved / "workspace.json"
     if not ws_file.is_file():
         raise WorkspaceCorruptedError(
-            f"workspace.json not found in {workspace}. "
-            "Run 'ao-kernel init' to create a workspace."
+            f"workspace.json not found in {workspace}. Run 'ao-kernel init' to create a workspace."
         )
     try:
         data = json.loads(ws_file.read_text(encoding="utf-8"))
     except json.JSONDecodeError as e:
-        raise WorkspaceCorruptedError(
-            f"workspace.json is not valid JSON: {e}"
-        ) from e
+        raise WorkspaceCorruptedError(f"workspace.json is not valid JSON: {e}") from e
 
     if not isinstance(data, dict):
         raise WorkspaceCorruptedError("workspace.json must be a JSON object")
     for key in ("version", "kind"):
         if key not in data:
-            raise WorkspaceCorruptedError(
-                f"workspace.json missing required field: {key!r}"
-            )
+            raise WorkspaceCorruptedError(f"workspace.json missing required field: {key!r}")
     return cast(dict[str, Any], data)
 
 
@@ -95,23 +133,16 @@ def load_default(resource_type: str, filename: str) -> dict[str, Any]:
     """
     base_type = resource_type.split("/")[0]
     if base_type not in _VALID_RESOURCE_TYPES:
-        raise ValueError(
-            f"resource_type base must be one of {sorted(_VALID_RESOURCE_TYPES)}, "
-            f"got {base_type!r}"
-        )
+        raise ValueError(f"resource_type base must be one of {sorted(_VALID_RESOURCE_TYPES)}, got {base_type!r}")
 
     resource = files("ao_kernel.defaults").joinpath(resource_type).joinpath(filename)
     try:
         text = resource.read_text(encoding="utf-8")
     except (FileNotFoundError, TypeError) as e:
-        raise DefaultsNotFoundError(
-            f"Bundled default not found: {resource_type}/{filename}"
-        ) from e
+        raise DefaultsNotFoundError(f"Bundled default not found: {resource_type}/{filename}") from e
     parsed = json.loads(text)
     if not isinstance(parsed, dict):
-        raise DefaultsNotFoundError(
-            f"Bundled default must be a JSON object: {resource_type}/{filename}"
-        )
+        raise DefaultsNotFoundError(f"Bundled default must be a JSON object: {resource_type}/{filename}")
     return cast(dict[str, Any], parsed)
 
 
@@ -130,8 +161,6 @@ def load_with_override(
         if override_path.is_file():
             parsed = json.loads(override_path.read_text(encoding="utf-8"))
             if not isinstance(parsed, dict):
-                raise DefaultsNotFoundError(
-                    f"Override must be a JSON object: {override_path}"
-                )
+                raise DefaultsNotFoundError(f"Override must be a JSON object: {override_path}")
             return cast(dict[str, Any], parsed)
     return load_default(resource_type, filename)

--- a/ao_kernel/migrate_cmd.py
+++ b/ao_kernel/migrate_cmd.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 import ao_kernel
-from ao_kernel.config import load_workspace_json, workspace_root
+from ao_kernel.config import load_workspace_json, resolve_workspace_dir, workspace_root
 from ao_kernel.errors import WorkspaceCorruptedError
 
 
@@ -43,6 +43,7 @@ def run(
     ws = workspace_root(override=workspace_root_override)
     if ws is None:
         from ao_kernel.i18n import msg
+
         print(msg("error_no_workspace"))
         return 1
 
@@ -50,8 +51,18 @@ def run(
         ws_data = load_workspace_json(ws)
     except WorkspaceCorruptedError as e:
         from ao_kernel.i18n import msg
+
         print(msg("error_corrupted", detail=str(e)))
         return 1
+
+    # v3.13.1 P1 iter-1 BLOCKER absorb (Codex): ``load_workspace_json``
+    # is now path-tolerant, but downstream mutation/backup/report paths
+    # must also operate on the *resolved* workspace directory. Without
+    # this line, ``migrate --workspace-root <project_root>`` reads
+    # `.ao/workspace.json` correctly but then writes a fresh
+    # ``workspace.json`` alongside the project root and stashes a
+    # ``.backup/`` sibling in the wrong place.
+    resolved_ws = resolve_workspace_dir(ws)
 
     ws_version = ws_data.get("version", "0.0.0")
     pkg_version = ao_kernel.__version__
@@ -61,22 +72,21 @@ def run(
     action_items: list[str] = []
 
     if ws_version != pkg_version:
-        mutations.append({
-            "type": "version_update",
-            "from": ws_version,
-            "to": pkg_version,
-            "file": str(ws / "workspace.json"),
-        })
-
-    if legacy_ws is not None and str(legacy_ws) != str(ws):
-        action_items.append(
-            f"Legacy workspace tespit edildi: {legacy_ws}. "
-            ".ao/ workspace'e gecis onerilir."
+        mutations.append(
+            {
+                "type": "version_update",
+                "from": ws_version,
+                "to": pkg_version,
+                "file": str(resolved_ws / "workspace.json"),
+            }
         )
+
+    if legacy_ws is not None and str(legacy_ws) != str(resolved_ws):
+        action_items.append(f"Legacy workspace tespit edildi: {legacy_ws}. .ao/ workspace'e gecis onerilir.")
 
     report = {
         "timestamp": _now_iso(),
-        "workspace_path": str(ws),
+        "workspace_path": str(resolved_ws),
         "workspace_version": ws_version,
         "package_version": pkg_version,
         "status": "UP_TO_DATE" if not mutations else "MIGRATION_NEEDED",
@@ -92,7 +102,7 @@ def run(
         return 0
 
     if backup and mutations:
-        backup_dir = ws / ".backup" / _now_iso().replace(":", "-")
+        backup_dir = resolved_ws / ".backup" / _now_iso().replace(":", "-")
         backup_dir.mkdir(parents=True, exist_ok=True)
         for m in mutations:
             src = Path(m["file"])

--- a/tests/test_resolve_workspace_dir_v3131_p1.py
+++ b/tests/test_resolve_workspace_dir_v3131_p1.py
@@ -130,11 +130,96 @@ class TestDoctorIntegration:
     "workspace.json valid"; after the normalizer, it passes."""
 
     def test_doctor_check_workspace_json_accepts_project_root(self, tmp_path: Path) -> None:
-        from ao_kernel.config import load_workspace_json
+        from ao_kernel.doctor_cmd import _check_workspace_json
 
         _write_ws_json(tmp_path / ".ao")
-        # doctor_cmd._check_workspace_json calls load_workspace_json
-        # on the result of workspace_root(override=ws). With the
-        # helper in place, project-root passthrough works.
-        data = load_workspace_json(tmp_path)
-        assert data["kind"] == "ao-workspace"
+        # Real doctor call path (Codex iter-1 feedback: pin the actual
+        # doctor_cmd helper, not a proxy through load_workspace_json).
+        # _check_workspace_json invokes workspace_root(override) →
+        # load_workspace_json(ws). With the P1 normalizer, project-root
+        # override resolves into .ao/ transparently and the check
+        # returns True.
+        assert _check_workspace_json(str(tmp_path)) is True
+
+
+class TestMigrateIntegration:
+    """Codex iter-1 BLOCKER absorb: after P1 ``load_workspace_json``
+    is path-tolerant, but migrate's mutation/backup/report paths must
+    ALSO operate on the resolved workspace directory. Otherwise
+    ``migrate --workspace-root <project_root>`` reads ``.ao/workspace.json``
+    correctly but writes a fresh ``workspace.json`` next to the project
+    root + a backup sibling in the wrong place."""
+
+    def test_dry_run_mutation_file_targets_resolved_ao_dir(self, tmp_path: Path) -> None:
+        """Dry-run report must carry the resolved ``.ao/workspace.json``
+        mutation file path, not ``<project_root>/workspace.json``."""
+        import ao_kernel
+        from ao_kernel.migrate_cmd import run as migrate_run
+
+        ao_dir = tmp_path / ".ao"
+        ao_dir.mkdir(parents=True)
+        # Force a version mismatch so a mutation is planned.
+        stale_payload = {"version": "3.0.0", "kind": "ao-workspace"}
+        (ao_dir / "workspace.json").write_text(json.dumps(stale_payload), encoding="utf-8")
+
+        # Capture stdout report JSON.
+        import io
+        import sys as _sys
+
+        buf = io.StringIO()
+        saved = _sys.stdout
+        _sys.stdout = buf
+        try:
+            rc = migrate_run(str(tmp_path), dry_run=True)
+        finally:
+            _sys.stdout = saved
+        assert rc == 0
+        report = json.loads(buf.getvalue())
+
+        assert report["status"] == "MIGRATION_NEEDED"
+        assert report["workspace_path"].endswith("/.ao")
+        assert report["mutations"], "expected a version_update mutation"
+        mutation_file = Path(report["mutations"][0]["file"])
+        assert mutation_file == (ao_dir / "workspace.json").resolve()
+        assert mutation_file.parent == ao_dir.resolve()
+        assert report["mutations"][0]["to"] == ao_kernel.__version__
+
+    def test_non_dry_run_writes_to_ao_workspace_json_and_backup_under_ao(self, tmp_path: Path) -> None:
+        """Non-dry-run must mutate the resolved ``.ao/workspace.json``
+        and stash the backup directory under ``.ao/.backup/``, not the
+        project root."""
+        import ao_kernel
+        from ao_kernel.migrate_cmd import run as migrate_run
+
+        ao_dir = tmp_path / ".ao"
+        ao_dir.mkdir(parents=True)
+        stale_payload = {"version": "3.0.0", "kind": "ao-workspace"}
+        (ao_dir / "workspace.json").write_text(json.dumps(stale_payload), encoding="utf-8")
+
+        import io
+        import sys as _sys
+
+        buf = io.StringIO()
+        saved = _sys.stdout
+        _sys.stdout = buf
+        try:
+            rc = migrate_run(str(tmp_path), dry_run=False, backup=True)
+        finally:
+            _sys.stdout = saved
+        assert rc == 0
+        report = json.loads(buf.getvalue())
+        assert report["status"] == "MIGRATED"
+
+        # Mutation happened in the resolved .ao dir.
+        updated = json.loads((ao_dir / "workspace.json").read_text(encoding="utf-8"))
+        assert updated["version"] == ao_kernel.__version__
+        assert "migrated_at" in updated
+
+        # Project root must NOT contain a stray workspace.json.
+        assert not (tmp_path / "workspace.json").is_file()
+
+        # Backup directory must live under resolved .ao/.backup/.
+        assert "backup_path" in report
+        backup_path = Path(report["backup_path"]).resolve()
+        assert ao_dir.resolve() in backup_path.parents
+        assert not (tmp_path / ".backup").is_dir()

--- a/tests/test_resolve_workspace_dir_v3131_p1.py
+++ b/tests/test_resolve_workspace_dir_v3131_p1.py
@@ -1,0 +1,140 @@
+"""v3.13.1 P1 — ``resolve_workspace_dir`` tolerant normalization.
+
+Pins the new helper exposed from :mod:`ao_kernel.config` that gives
+``load_workspace_json`` (and by extension doctor / migrate /
+workspace_status MCP tool) a single normalization contract:
+
+- Accept **project root** where workspace.json lives under ``.ao/``.
+- Accept **workspace directory** directly (legacy / explicit
+  ``--workspace-root .ao`` usage).
+- Return the argument unchanged when neither shape matches so the
+  downstream caller can fail-closed with the user-supplied path in
+  the message.
+
+This closes the `doctor --workspace-root .` fail path without
+changing the ``workspace_root(override=...)`` or ``init_cmd.run``
+contracts (those stay non-breaking; operators that explicitly point
+at ``.ao`` keep working).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+_WS_PAYLOAD = {"version": "3.13.0", "kind": "ao-workspace"}
+
+
+def _write_ws_json(directory: Path) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "workspace.json"
+    path.write_text(json.dumps(_WS_PAYLOAD), encoding="utf-8")
+    return path
+
+
+class TestResolveWorkspaceDirShape:
+    def test_project_root_with_ao_subdir_resolves_to_ao(self, tmp_path: Path) -> None:
+        from ao_kernel.config import resolve_workspace_dir
+
+        ao_dir = tmp_path / ".ao"
+        _write_ws_json(ao_dir)
+        resolved = resolve_workspace_dir(tmp_path)
+        assert resolved == ao_dir
+
+    def test_workspace_dir_directly_returned_unchanged(self, tmp_path: Path) -> None:
+        from ao_kernel.config import resolve_workspace_dir
+
+        ao_dir = tmp_path / ".ao"
+        _write_ws_json(ao_dir)
+        # Caller passes the .ao dir explicitly → return as-is.
+        resolved = resolve_workspace_dir(ao_dir)
+        assert resolved == ao_dir
+
+    def test_neither_shape_returns_input_unchanged(self, tmp_path: Path) -> None:
+        from ao_kernel.config import resolve_workspace_dir
+
+        # No workspace.json anywhere → return input path resolved so
+        # downstream error message carries the user-supplied path.
+        resolved = resolve_workspace_dir(tmp_path)
+        assert resolved == tmp_path
+
+    def test_accepts_string_input(self, tmp_path: Path) -> None:
+        from ao_kernel.config import resolve_workspace_dir
+
+        ao_dir = tmp_path / ".ao"
+        _write_ws_json(ao_dir)
+        resolved = resolve_workspace_dir(str(tmp_path))
+        assert resolved == ao_dir
+
+    def test_project_root_direct_workspace_json_takes_precedence(self, tmp_path: Path) -> None:
+        """Edge case: if project root contains both ``workspace.json``
+        AND ``.ao/workspace.json`` (legacy installs may have this),
+        the direct workspace.json wins — the assumption is the caller
+        already normalized explicitly."""
+        from ao_kernel.config import resolve_workspace_dir
+
+        _write_ws_json(tmp_path)
+        _write_ws_json(tmp_path / ".ao")
+        assert resolve_workspace_dir(tmp_path) == tmp_path
+
+
+class TestLoadWorkspaceJsonIntegration:
+    def test_project_root_override_now_loads_ao_workspace(self, tmp_path: Path) -> None:
+        """Core fix: ``load_workspace_json(project_root)`` used to
+        raise ``WorkspaceCorruptedError`` because it looked at
+        ``<project_root>/workspace.json``. After P1 it descends into
+        ``<project_root>/.ao/workspace.json`` transparently.
+        """
+        from ao_kernel.config import load_workspace_json
+
+        _write_ws_json(tmp_path / ".ao")
+        data = load_workspace_json(tmp_path)
+        assert data["version"] == "3.13.0"
+        assert data["kind"] == "ao-workspace"
+
+    def test_workspace_dir_override_still_works(self, tmp_path: Path) -> None:
+        """Back-compat: operators who pass the ``.ao`` dir explicitly
+        keep working — the helper returns them unchanged."""
+        from ao_kernel.config import load_workspace_json
+
+        ao_dir = tmp_path / ".ao"
+        _write_ws_json(ao_dir)
+        data = load_workspace_json(ao_dir)
+        assert data["version"] == "3.13.0"
+
+    def test_missing_workspace_fails_closed_with_user_path(self, tmp_path: Path) -> None:
+        """If neither shape matches, the error message must reference
+        the user-supplied path (not the normalized one) so operators
+        can reason about what they typed."""
+        from ao_kernel.config import WorkspaceCorruptedError, load_workspace_json
+
+        with pytest.raises(WorkspaceCorruptedError, match="workspace.json not found"):
+            load_workspace_json(tmp_path)
+
+    def test_malformed_workspace_json_still_fails(self, tmp_path: Path) -> None:
+        from ao_kernel.config import WorkspaceCorruptedError, load_workspace_json
+
+        ao_dir = tmp_path / ".ao"
+        ao_dir.mkdir(parents=True)
+        (ao_dir / "workspace.json").write_text("{not valid", encoding="utf-8")
+        with pytest.raises(WorkspaceCorruptedError, match="not valid JSON"):
+            load_workspace_json(tmp_path)
+
+
+class TestDoctorIntegration:
+    """Pin the end-to-end `doctor --workspace-root .` flow that
+    motivated P1. Previously this sequence would report a FAIL on
+    "workspace.json valid"; after the normalizer, it passes."""
+
+    def test_doctor_check_workspace_json_accepts_project_root(self, tmp_path: Path) -> None:
+        from ao_kernel.config import load_workspace_json
+
+        _write_ws_json(tmp_path / ".ao")
+        # doctor_cmd._check_workspace_json calls load_workspace_json
+        # on the result of workspace_root(override=ws). With the
+        # helper in place, project-root passthrough works.
+        data = load_workspace_json(tmp_path)
+        assert data["kind"] == "ao-workspace"


### PR DESCRIPTION
## Summary
- New public helper `ao_kernel.config.resolve_workspace_dir(path)` — tolerant normalization between project root and `.ao/` workspace dir
- `load_workspace_json()` now uses the helper first, so doctor + migrate + workspace.load_config + MCP `ao_workspace_status` benefit transparently
- +10 pins in `tests/test_resolve_workspace_dir_v3131_p1.py`
- Coverage 85.8% → 86.10%

## Why (external AI + Codex REVISE absorb)
Before P1:
- `workspace_root(override=X)` returned X as-is (assumed X was `.ao/`)
- `load_workspace_json(X)` expected `X/workspace.json`
- **`doctor --workspace-root .` FAILED** because `./workspace.json` is absent (`.ao/workspace.json` is where it really lives)
- `doctor --workspace-root .ao` passed

After P1:
- Both `doctor --workspace-root .` and `doctor --workspace-root .ao` work (**8/8 OK** verified manually)
- Back-compat preserved — operators pointing at `.ao/` directly keep working
- No change to `workspace_root()` or `init_cmd.run()` contracts

## Deferred (follow-up notes)
- `init_cmd.run(override)` WRITE-side same asymmetry (writes under override, not `override/.ao/`). Fixing would break operators who intentionally pass `.ao` as override; needs Codex consultation + migration note. Deferred to v3.14+.
- `system-status` CLI alias — Codex rejected (name collision with `tool_registry` kavramı). Docs-only fix already shipped in PR-D1 (#177).

## Test plan
- [x] 10 new pins pass
- [x] Full suite: 2760 passed, 1 skipped
- [x] Coverage 86.10% (gate ≥85%)
- [x] Manual verification: `doctor --workspace-root .` → 8/8 OK
- [ ] CI 9/9 GREEN
- [ ] Codex post-impl review → MERGE

🤖 Generated with [Claude Code](https://claude.com/claude-code)