### PR TITLE
[codex] docs: tighten support boundary truth parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Governed AI orchestration runtime — policy-driven, fail-closed, evidence-trail.
 
-ao-kernel is **not** a general-purpose agent framework. It is a **governed runtime** that enforces policies, records evidence, and provides deterministic LLM routing for production Python teams.
+ao-kernel is **not** a general-purpose agent framework or a blanket "production coding automation platform" claim. It is a **governed runtime** that enforces policies, records evidence, and provides deterministic LLM routing for production Python teams.
 
 ## Installation
 
@@ -79,9 +79,19 @@ stream_request = build_req(
 python3 examples/demo_review.py --cleanup
 ```
 
+Run this from an environment where `ao-kernel` is already installed (wheel, venv, or editable install). The script spins up a disposable workspace and invokes `python -m ao_kernel init` inside that temp checkout.
+
 Runs `review_ai_flow` end-to-end against a disposable workspace (`git init` + `ao-kernel init` + `codex-stub` deterministic adapter, no LLM required). The demo verifies the workflow completes (`workflow_completed` event), the `review_findings` artefact materializes and validates against `review-findings.schema.v1.json`, and the evidence timeline is emitted to `.ao/evidence/workflows/<run_id>/events.jsonl`.
 
 See [`docs/PUBLIC-BETA.md`](docs/PUBLIC-BETA.md) for the support matrix (Shipped / Beta / Deferred / Known Bugs). `bug_fix_flow` (full patch-preview flow) stays on the roadmap — see [`docs/roadmap/DEMO-SCRIPT-SPEC.md`](docs/roadmap/DEMO-SCRIPT-SPEC.md). For the opt-in real-adapter benchmark path, see [`docs/BENCHMARK-FULL-MODE.md`](docs/BENCHMARK-FULL-MODE.md).
+
+### Support Boundary
+
+Treat the repo in three layers:
+
+- **Runtime-backed / supported**: core CLI and SDK surfaces, evidence tooling, worktree policy enforcement, bundled `review_ai_flow`, and `examples/demo_review.py`.
+- **Operator / evaluation only**: benchmark docs, real-adapter runbooks, prompt experiment runbooks, and other opt-in validation paths that are intentionally outside the default deterministic CI/demo lane.
+- **Contract / reference inventory**: bundled JSON defaults, adapter manifests, registry files, and example code such as `examples/hello-llm/`. Their presence in the tree is useful reference material, not blanket proof that every surface is production-ready end to end.
 
 ## Python API
 
@@ -221,7 +231,7 @@ items = query_memory(ws, key_pattern="arch.*")
 | MCP server | Yes | No | No | No |
 | Streaming | SSE (6 providers) | Yes | Yes | Yes |
 
-> Counts as of `v3.13.0`: `ao_kernel/defaults/` ships **377** bundled JSON files — 106 policies + 231 schemas + 19 extensions + 9 registry + 4 workflows + 3 operations + 3 adapters + 1 catalogs + 1 intent_rules. Run `find ao_kernel/defaults -name '*.json' | wc -l` for the live number.
+> Counts as of `v3.13.0`: `ao_kernel/defaults/` ships **377** bundled JSON files — 106 policies + 231 schemas + 19 extensions + 9 registry + 4 workflows + 3 operations + 3 adapters + 1 catalogs + 1 intent_rules. Run `find ao_kernel/defaults -name '*.json' | wc -l` for the live number. This is an inventory count, not a support-matrix count; use [`docs/PUBLIC-BETA.md`](docs/PUBLIC-BETA.md) for what is actually supported.
 
 ## Architecture
 

--- a/ao_kernel/defaults/policies/policy_worktree_profile.v1.json
+++ b/ao_kernel/defaults/policies/policy_worktree_profile.v1.json
@@ -1,14 +1,14 @@
 {
   "version": "v1",
   "enabled": false,
-  "_comment": "Fail-closed. Bundled default DORMANT: enabled=false means enforcement dormant (no 'policy_checked' / 'policy_denied' evidence events, no fail on violations). Sandbox shaping is retained so the adapter still receives a scoped env / worktree / redaction profile. Workspace override required to engage enforcement (set enabled=true). Expanded minimum per CNS-016 D4: worktree + env_allowlist + secret deny-by-default + command_allowlist + cwd_confinement + evidence_redaction. OS-level network/egress sandboxing (cgroups, firejail, nsjail) and extended redaction catalog (AWS/Google/xAI/structured JWT) deferred to FAZ-B. See docs/WORKTREE-PROFILE.md for operator-facing walkthrough and demo override example. Pattern: policy_quality.v1.json (inline _comment, no external $schema). Validation schema lands in Tranche A PR-A3 worktree executor impl.",
+  "_comment": "Fail-closed. Bundled default DORMANT: enabled=false means enforcement dormant (no 'policy_checked' / 'policy_denied' evidence events, no fail on violations). Sandbox shaping is retained so the adapter still receives a scoped env / worktree / redaction profile. Workspace override required to engage enforcement (set enabled=true). Expanded minimum per CNS-016 D4: worktree + env_allowlist + secret deny-by-default + command_allowlist + cwd_confinement + evidence_redaction. OS-level network/egress sandboxing (cgroups, firejail, nsjail) and extended redaction catalog (AWS/Google/xAI/structured JWT) remain deferred. See docs/WORKTREE-PROFILE.md for operator-facing walkthrough and override examples. The supported deterministic Public Beta demo does not require this policy to be enabled; engage it for operator-managed adapter runs.",
 
   "worktree": {
     "strategy": "new_per_run",
     "base_dir_template": ".ao/runs/{run_id}/worktree",
     "cleanup_on_completion": true,
     "max_concurrent": 4,
-    "_strategy_note": "new_per_run: create a fresh git worktree per workflow run (default, strongest isolation). Alternatives at Tranche A PR-A3 impl: reuse_per_agent (one worktree per adapter_id, faster for repeated invocations), shared_readonly (mount-point analysis, no writes)."
+    "_strategy_note": "new_per_run: create a fresh git worktree per workflow run (default, strongest isolation). shared_readonly is implemented as a copied read-only tree for analysis-oriented runs. reuse_per_agent remains reserved and currently raises if selected."
   },
 
   "env_allowlist": {
@@ -16,7 +16,7 @@
     "inherit_from_parent": false,
     "explicit_additions": {},
     "deny_on_unknown": true,
-    "_env_note": "env_allowlist covers NON-SECRET environment variables only. Secrets (API keys, tokens) are handled via the secrets block below, NOT added here. deny_on_unknown=true: any env key not explicitly in allowed_keys or explicit_additions is stripped before adapter invocation. SSH agent forwarding (SSH_AUTH_SOCK) is NOT in the default allowlist; FAZ-A demos use HTTP-token auth via secrets.allowlist_secret_ids. SSH support is deferred to FAZ-A PR-A5 (evidence CLI) or later."
+    "_env_note": "env_allowlist covers NON-SECRET environment variables only. Secrets (API keys, tokens) are handled via the secrets block below, NOT added here. deny_on_unknown=true: any env key not explicitly in allowed_keys or explicit_additions is stripped before adapter invocation. SSH agent forwarding (SSH_AUTH_SOCK) is NOT in the default allowlist; current bundled demos and operator runbooks use HTTP-token auth via secrets.allowlist_secret_ids. SSH support remains deferred."
   },
 
   "secrets": {
@@ -24,7 +24,7 @@
     "allowlist_secret_ids": [],
     "exposure_modes": ["env"],
     "denied_exposure_modes": ["argv", "stdin", "file", "http_header"],
-    "_secret_note": "deny_by_default=true: no secret is available to the adapter unless its secret_id is explicitly added to allowlist_secret_ids. Resolution model mirrors policy_secrets.v1.json (allowed_secret_ids + fail_action). exposure_modes=['env'] means allowed secrets are injected ONLY as exported environment variables. denied_exposure_modes lists channels where secrets MUST NOT appear: argv (command arguments — visible in process listings), stdin (adapter prompt payload — captured in evidence), file (on-disk — accidental commit risk), http_header (HTTP adapter requests — requires explicit workspace override of exposure_modes to include 'http_header'). ao-kernel worktree executor (Tranche A PR-A3) enforces this at invocation time."
+    "_secret_note": "deny_by_default=true: no secret is available to the adapter unless its secret_id is explicitly added to allowlist_secret_ids. Resolution model mirrors policy_secrets.v1.json (allowed_secret_ids + fail_action). exposure_modes=['env'] means allowed secrets are injected ONLY as exported environment variables. denied_exposure_modes lists channels where secrets MUST NOT appear: argv (command arguments — visible in process listings), stdin (adapter prompt payload — captured in evidence), file (on-disk — accidental commit risk), http_header (HTTP adapter requests — requires explicit workspace override of exposure_modes to include 'http_header'). ao-kernel executor enforces this at invocation time."
   },
 
   "command_allowlist": {
@@ -39,7 +39,7 @@
     "allowed_subdirs": ["*"],
     "deny_absolute_paths_outside_root": true,
     "deny_parent_escape": true,
-    "_cwd_note": "root_template: per-run worktree root. allowed_subdirs=['*']: adapter may cd into any subdirectory under the root. deny_parent_escape=true: 'cd ..' past root, symlink escapes, and absolute paths outside root are all denied. Enforcement via chroot-like path normalization at Tranche A PR-A3."
+    "_cwd_note": "root_template: per-run worktree root. allowed_subdirs=['*']: adapter may cd into any subdirectory under the root. deny_parent_escape=true: 'cd ..' past root, symlink escapes, and absolute paths outside root are all denied. Enforcement happens through normalized path checks before adapter invocation."
   },
 
   "evidence_redaction": {
@@ -52,7 +52,7 @@
       "Bearer\\s+[A-Za-z0-9._~+/=-]+",
       "Basic\\s+[A-Za-z0-9+/=]+"
     ],
-    "_redaction_scope_note": "P0 pattern coverage: OpenAI (sk-), Anthropic (sk-ant-), GitHub PAT (ghp_), Slack bot (xoxb-), generic OAuth Bearer, HTTP Basic. FAZ-B extended catalog: AWS access key (AKIA...), Google API key (AIza...), xAI (xai-...), structured JWT payloads, private key blocks. Redaction replaces matches with '***REDACTED***' in JSONL evidence; redaction is unreachable for secret values in denied_exposure_modes (they never reach a logged surface).",
+    "_redaction_scope_note": "Bundled pattern coverage: OpenAI (sk-), Anthropic (sk-ant-), GitHub PAT (ghp_), Slack bot (xoxb-), generic OAuth Bearer, HTTP Basic. Extended catalog remains deferred: AWS access key (AKIA...), Google API key (AIza...), xAI (xai-...), structured JWT payloads, private key blocks. Redaction replaces matches with '***REDACTED***' in JSONL evidence; redaction is unreachable for secret values in denied_exposure_modes (they never reach a logged surface).",
     "file_content_patterns": []
   },
 
@@ -75,7 +75,7 @@
     "ssh_agent_forwarding": {
       "status": "deferred",
       "target": "FAZ-A_PR-A5_or_later",
-      "_note": "SSH_AUTH_SOCK env inheritance and agent forwarding are NOT supported in FAZ-A demo tier. Use HTTP-token auth via secrets.allowlist_secret_ids instead."
+      "_note": "SSH_AUTH_SOCK env inheritance and agent forwarding are NOT supported in the current bundled demo/operator tier. Use HTTP-token auth via secrets.allowlist_secret_ids instead."
     }
   },
 

--- a/ao_kernel/executor/executor.py
+++ b/ao_kernel/executor/executor.py
@@ -324,31 +324,34 @@ class Executor:
                 )
             except PolicyViolationError as exc:
                 # Real executor emits step_started + policy_checked
-                # + policy_denied + step_failed before raising; the
-                # first two are already captured by the mock emit
-                # during run_step pre-flight. Append the denial pair
-                # here to match the canonical event sequence.
+                # + policy_denied + step_failed before raising. Under
+                # the dry-run mocks those events are usually already
+                # captured, so only synthesize the denial tail if the
+                # mocked path did not record it.
                 recorder.record_policy_violation(str(exc))
-                recorder.predicted_events.append(
-                    (
-                        "policy_denied",
-                        {
-                            "step_name": step_def.step_name,
-                            "reason": str(exc),
-                        },
+                kinds = [kind for kind, _payload in recorder.predicted_events]
+                if "policy_denied" not in kinds:
+                    recorder.predicted_events.append(
+                        (
+                            "policy_denied",
+                            {
+                                "step_name": step_def.step_name,
+                                "reason": str(exc),
+                            },
+                        )
                     )
-                )
-                recorder.predicted_events.append(
-                    (
-                        "step_failed",
-                        {
-                            "step_name": step_def.step_name,
-                            "final_state": "failed",
-                            "error_category": "policy_denied",
-                            "error_detail": str(exc),
-                        },
+                if "step_failed" not in kinds:
+                    recorder.predicted_events.append(
+                        (
+                            "step_failed",
+                            {
+                                "step_name": step_def.step_name,
+                                "final_state": "failed",
+                                "error_category": "policy_denied",
+                                "error_detail": str(exc),
+                            },
+                        )
                     )
-                )
             except Exception:
                 # Any other dispatch error is intentionally swallowed;
                 # dry-run never raises. Downstream mock boundary

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -2,6 +2,8 @@
 
 An adapter is the bridge between an ao-kernel workflow and an external coding-agent runtime. The adapter contract is defined in [`ao_kernel/defaults/schemas/agent-adapter-contract.schema.v1.json`](../ao_kernel/defaults/schemas/agent-adapter-contract.schema.v1.json). This document is the human-readable companion: it explains the contract fields, walks through three reference adapters, and shows how to write a custom one.
 
+> **Support boundary.** This document describes the adapter contract and bundled reference shapes. It does **not** mean every adapter kind or bundled manifest is an end-to-end production-supported surface in this repo. The narrow shipped baseline is the deterministic `review_ai_flow` + bundled `codex-stub` path; real-adapter flows remain operator-managed unless [`PUBLIC-BETA.md`](PUBLIC-BETA.md) explicitly says otherwise.
+
 ---
 
 ## 1. Adapter Contract Overview
@@ -41,6 +43,15 @@ The `adapter_kind` field is a closed enum that tells ao-kernel how to route invo
 | `gh-cli-pr` | CLI | **Typed VCS/PR connector**, not a full coding agent. Wraps `gh` (GitHub CLI) for PR creation only. Declares `capabilities: ["open_pr"]` and does not produce diffs. |
 | `custom-cli` | CLI | User-defined CLI adapter. Escape hatch for runtimes not in the closed list. |
 | `custom-http` | HTTP | User-defined HTTP adapter. Same escape hatch for HTTP transport. |
+
+### Current repo support tiers
+
+| Surface | Current status | Meaning |
+|---|---|---|
+| Bundled `codex-stub` | Shipped baseline | Deterministic demo + CI surface; the default supported adapter path in this repo |
+| `claude-code-cli` walkthroughs and manifests | Operator-managed | Real-adapter evaluation surface; useful for runbooks and benchmarks, not the default support claim |
+| `gh-cli-pr` walkthroughs and manifests | Deferred / contract surface | Typed connector contract exists, but the full end-user E2E PR lane is not the current supported demo |
+| `custom-cli` / `custom-http` | Escape hatch | Operator-owned integration responsibility; contract-compatible does not mean ao-kernel ships vendor-specific production support |
 
 ### Promotion criteria for new enum values
 
@@ -224,7 +235,7 @@ HTTP adapters must explicitly set `exposure_modes` to include `"http_header"` vi
 
 ## 6. Walkthrough 2: Codex Stub
 
-The codex stub is an in-process adapter used for CI determinism and demos without real LLM calls. It ships with ao-kernel as a reference fixture.
+The codex stub is an in-process adapter used for CI determinism and demos without real LLM calls. It ships with ao-kernel as the repo's supported deterministic baseline.
 
 ### Manifest sketch
 
@@ -410,9 +421,9 @@ print('OK')
 "
 ```
 
-### 9.2 Demo script fixture
+### 9.2 Supported smoke vs roadmap spec
 
-Running `docs/DEMO-SCRIPT.md` with your adapter substituted for Claude Code CLI is the fastest end-to-end behavioral test. If all 11 steps emit the expected evidence events and the PR opens cleanly, the adapter is contract-conformant.
+For the shipped deterministic smoke, use [`examples/demo_review.py`](../examples/demo_review.py) together with [`docs/PUBLIC-BETA.md`](PUBLIC-BETA.md). The legacy 11-step multi-adapter flow is no longer the live demo contract; it survives as a roadmap/spec document at [`docs/roadmap/DEMO-SCRIPT-SPEC.md`](roadmap/DEMO-SCRIPT-SPEC.md).
 
 ### 9.3 CI-friendly testing
 
@@ -441,7 +452,8 @@ The workflow registry loads the union of all referenced policies for all adapter
 - [`ao_kernel/defaults/schemas/agent-adapter-contract.schema.v1.json`](../ao_kernel/defaults/schemas/agent-adapter-contract.schema.v1.json) — the normative schema this document describes.
 - [docs/WORKTREE-PROFILE.md](WORKTREE-PROFILE.md) — the sandbox every adapter runs in.
 - [docs/EVIDENCE-TIMELINE.md](EVIDENCE-TIMELINE.md) — the event taxonomy adapters contribute to.
-- [docs/DEMO-SCRIPT.md](DEMO-SCRIPT.md) — the end-to-end flow exercising three reference adapters.
+- [docs/PUBLIC-BETA.md](PUBLIC-BETA.md) — the authoritative support matrix for which adapter paths are actually supported.
+- [docs/roadmap/DEMO-SCRIPT-SPEC.md](roadmap/DEMO-SCRIPT-SPEC.md) — the legacy multi-adapter acceptance spec.
 - [docs/COMPETITOR-MATRIX.md](COMPETITOR-MATRIX.md) — the live list of adapter-target platforms.
 - `ao_kernel/defaults/policies/policy_worktree_profile.v1.json` — the sandbox policy referenced by every adapter.
 - `.claude/plans/TRANCHE-STRATEGY-V2.md` §3, §4 — FAZ-A feature roadmap and adapter scope.

--- a/docs/BENCHMARK-FULL-MODE.md
+++ b/docs/BENCHMARK-FULL-MODE.md
@@ -2,6 +2,8 @@
 
 **Status:** v3.7 F2 — **first runnable full-mode smoke** landed (codex-stub subprocess path; external adapter wiring stays scope-out). Default PR CI is unchanged (`--benchmark-mode=fast` remains the deterministic mock-transport surface; see [`BENCHMARK-SUITE.md`](BENCHMARK-SUITE.md)).
 
+> **Operator-only validation lane.** Full mode is useful to prove adapter-path reconcile behavior, but it is not the default release gate and it is not, by itself, a blanket claim that real-adapter end-to-end automation is production-ready.
+
 ## What F2 ships
 
 F2 extends the F1 scaffold with an actual runnable `@pytest.mark.full_mode` smoke:

--- a/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
+++ b/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
@@ -8,6 +8,8 @@
 
 **Status.** This runbook documents configuration only. The real-adapter path is NOT exercised in ao-kernel CI — benchmark-fast stays on the deterministic `codex-stub` path, and `review_ai_flow` keeps that behaviour for baseline reproducibility. Running the real adapter is an operator-driven, out-of-repo action.
 
+Successful completion here validates an operator setup, not the whole product support matrix. [`PUBLIC-BETA.md`](PUBLIC-BETA.md) remains the authoritative source for what ao-kernel currently supports as a shipped or beta surface.
+
 ---
 
 ## 1. Prerequisites

--- a/docs/BENCHMARK-SUITE.md
+++ b/docs/BENCHMARK-SUITE.md
@@ -2,6 +2,8 @@
 
 **Status:** FAZ-B PR-B0 contract pin (docs skeleton). Runtime implementation: PR-B6 (review AI workflow + review_ai_flow runtime) + PR-B7 (benchmark suite runner + scenarios).
 
+> **Operator/evaluator surface.** The benchmark suite exists to catch contract drift, policy regressions, and scoring changes. It is not the primary supported end-user quick start. For the narrow shipped demo surface, use [`examples/demo_review.py`](../examples/demo_review.py) and [`docs/PUBLIC-BETA.md`](PUBLIC-BETA.md).
+
 ## 1. Overview
 
 The benchmark suite exercises two governed end-to-end flows and scores them objectively. The goal is not raw model performance — it is to detect policy regressions, contract drift, and replay non-determinism in the ao-kernel runtime itself.
@@ -10,9 +12,9 @@ Two scenarios ship:
 
 | Scenario | Workflow (B7 v1) | Capability matrix | Runtime PR |
 |---|---|---|---|
-| `governed_bugfix` | `tests/benchmarks/fixtures/workflows/governed_bugfix_bench.v1.json` (bench variant — full bundled [`bug_fix_flow.v1.json`](../ao_kernel/defaults/workflows/bug_fix_flow.v1.json) deferred to B7.1 pending git/pytest sandbox allowlist) | `read_repo` + `write_diff` | PR-B7 v1 |
+| `governed_bugfix` | `tests/benchmarks/fixtures/workflows/governed_bugfix_bench.v1.json` (bench variant — full bundled [`bug_fix_flow.v1.json`](../ao_kernel/defaults/workflows/bug_fix_flow.v1.json) deferred to B7.1 pending git/pytest sandbox allowlist) | `read_repo` + `write_diff` | PR-B7 v1, benchmark-only surface |
 | `governed_review` | [`review_ai_flow.v1.json`](../ao_kernel/defaults/workflows/review_ai_flow.v1.json) (bundled, pinned at `codex-stub`) | `read_repo` + `review_findings` | PR-B7 v1 |
-| `governed_review_claude_code_cli` | [`governed_review_claude_code_cli.v1.json`](../ao_kernel/defaults/workflows/governed_review_claude_code_cli.v1.json) (bundled, real-adapter) | `read_repo` + `review_findings` | v3.10 A2 / PR #157 |
+| `governed_review_claude_code_cli` | [`governed_review_claude_code_cli.v1.json`](../ao_kernel/defaults/workflows/governed_review_claude_code_cli.v1.json) (bundled, real-adapter) | `read_repo` + `review_findings` | v3.10 A2 / PR #157, operator-managed |
 
 Both run under `tests/benchmarks/` with a shared runner (PR-B7). See §8 for the runner invocation + scoring threshold contract + B7 v1 scope trim. The `governed_review_claude_code_cli` real-adapter variant is **operator-driven only** — ao-kernel CI stays on the deterministic `codex-stub` path. See [`BENCHMARK-REAL-ADAPTER-RUNBOOK.md`](./BENCHMARK-REAL-ADAPTER-RUNBOOK.md) for the full operator setup (workspace override, secret flow, prompt contract, disposable sandbox repo pattern).
 

--- a/docs/COMPETITOR-MATRIX.md
+++ b/docs/COMPETITOR-MATRIX.md
@@ -98,6 +98,7 @@ The following were considered and explicitly excluded from the matrix, with reas
 ## 7. Cross-References
 
 - [docs/ADAPTERS.md](ADAPTERS.md) — adapter contract and walkthroughs for the `planned` / `shipped` entries above.
-- [docs/DEMO-SCRIPT.md](DEMO-SCRIPT.md) — the FAZ-A demo flow that exercises Claude Code CLI / codex-stub / gh-cli-pr adapters.
+- [docs/PUBLIC-BETA.md](PUBLIC-BETA.md) — the authoritative support matrix for live shipped and beta surfaces.
+- [docs/roadmap/DEMO-SCRIPT-SPEC.md](roadmap/DEMO-SCRIPT-SPEC.md) — the legacy multi-adapter acceptance spec.
 - [docs/WORKTREE-PROFILE.md](WORKTREE-PROFILE.md) — the sandbox each adapter runs inside.
 - `.claude/plans/TRANCHE-STRATEGY-V2.md` §1, §4 — the niche statement and build-vs-integrate classification that pin the positioning.

--- a/docs/EVIDENCE-TIMELINE.md
+++ b/docs/EVIDENCE-TIMELINE.md
@@ -4,6 +4,8 @@ Every governed workflow run in ao-kernel emits an append-only JSONL stream of ev
 
 This document is the contract: what events exist, what shape they take, where they land on disk, and what replay guarantees hold.
 
+It is a core runtime contract, not a blanket support claim for every bundled workflow, adapter, or extension. Rich evidence coverage means the event model is real; the support boundary for demo and operator surfaces still comes from [`docs/PUBLIC-BETA.md`](PUBLIC-BETA.md).
+
 **Related surfaces:**
 - Consultation archive + resolution records (producer side) live under `.ao/evidence/consultations/<CNS-ID>/` (v3.5 D2a). Integrity manifest is `integrity.manifest.v1.json`.
 - The **consumer side** — promoted consultations, typed reader facade, `compile_context` 4-lane integration, and MCP pagination — is documented at [`docs/CONSULTATION-QUERY.md`](CONSULTATION-QUERY.md) (v3.6 E1/E2/E3).
@@ -303,5 +305,6 @@ ao-kernel evidence verify-manifest --run <run_id> --generate-if-missing
 - `ao_kernel/defaults/schemas/agent-adapter-contract.schema.v1.json` — `output_envelope.evidence_events` is the adapter's handle into this timeline.
 - `ao_kernel/defaults/policies/policy_worktree_profile.v1.json` — `evidence_redaction` patterns this timeline honors.
 - `docs/WORKTREE-PROFILE.md` — operator-facing walkthrough of the redaction rules.
-- `docs/DEMO-SCRIPT.md` — the E2E flow that emits every event kind once.
+- `docs/PUBLIC-BETA.md` — the live support matrix for the shipped demo surface.
+- `docs/roadmap/DEMO-SCRIPT-SPEC.md` — the legacy acceptance spec that aims to exercise a wider event set.
 - `CLAUDE.md` §2 — the dual-form evidence invariant (workspace manifest vs MCP fsync-only).

--- a/docs/PROMPT-EXPERIMENTS-RUNBOOK.md
+++ b/docs/PROMPT-EXPERIMENTS-RUNBOOK.md
@@ -9,6 +9,8 @@
 
 **Status (v3.12).** This is a **contract-only** shipment. ao-kernel does **NOT** orchestrate A/B dispatch at runtime — operators start each variant run manually and pair them post-run via `compare_variants`. Runtime A/B automation is deferred until at least one operator-validated real-adapter smoke cycle exists (Codex v3.9+ plan-time precondition; tracked toward v3.13+).
 
+This runbook is an operator/evaluation surface, not a shipped experiment scheduler. A successful comparison here does not widen the default supported demo lane on its own.
+
 ---
 
 ## 1. Why a contract-only experiment surface

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -30,7 +30,7 @@ istemek gerekir.
 | `python -m ao_kernel version` | Shipped | Module entrypoint kontratı |
 | `python -m ao_kernel.cli version` | Shipped | CLI module kontratı |
 | Bundled `review_ai_flow` + bundled `codex-stub` | Shipped | Desteklenen demo workflow |
-| `examples/demo_review.py` | Shipped | Disposable workspace + canlı smoke `completed` |
+| `examples/demo_review.py` | Shipped | Disposable workspace + canlı smoke `completed`; komut, `ao-kernel` kurulu bir Python environment'ı içinde çalıştırılmalıdır |
 | `ao-kernel doctor` | Shipped | Workspace health check (8/8 OK) |
 | CI coverage gate 85% | Shipped | `pyproject.toml` ile hizalı (`test.yml --fail-under=85`) |
 | Adapter CLI command enforcement | Shipped | `policy_checked` / `policy_denied` artık resolved command ihlallerini de içerir; canonical sıra `step_started -> policy_checked -> adapter_invoked` korunur |
@@ -43,6 +43,14 @@ istemek gerekir.
 |---|---|---|
 | Public Beta yüzeyinin tamamı | Beta | Stable kanal hâlâ `3.13.3`; genel kullanım için pre-release install gerekir |
 | Real-adapter benchmark tam modu | Beta | Operator-managed yüzey; deterministik stub lane kadar stabil değil |
+
+## Contract / Inventory Layer
+
+| Yüzey | Durum | Not |
+|---|---|---|
+| Extension loader + manifest validation | Shipped infra | Loader/validator kodu ve temel dispatch wiring'i gerçektir; bu, her bundled manifestin end-to-end production-ready olduğu anlamına gelmez |
+| Bundled `defaults/registry`, `defaults/extensions`, `defaults/operations`, `defaults/adapters` içeriği | Contract inventory | Ağaçta görünmesi destek vaadi değildir; ancak ilgili doküman/test/Public Beta matrisi o yüzeyi ayrıca işaretliyorsa destekli sayılır |
+| `examples/hello-llm/` | Example-only | SDK kullanım örneğidir; Public Beta destek vaadinin parçası değildir |
 
 ## Deferred
 
@@ -65,5 +73,8 @@ istemek gerekir.
 
 - Public Beta “hemen çalışır” iddiası yalnızca bundled
   `review_ai_flow` + bundled `codex-stub` yolu için geçerlidir.
+- Bu doküman, ao-kernel'in genel amaçlı bir production coding automation
+  platformu olduğunu iddia etmez; destek vaadi dar ve açıkça tablolanmış
+  yüzeyler içindir.
 - `docs/roadmap/DEMO-SCRIPT-SPEC.md` roadmap/spec dokümanıdır; canlı
   CLI komut listesi değildir.

--- a/docs/WORKTREE-PROFILE.md
+++ b/docs/WORKTREE-PROFILE.md
@@ -240,7 +240,7 @@ These are left off FAZ-A so the P0 redaction list stays focused on the providers
 | OS-level network egress sandbox | FAZ-B | cgroups / firejail / nsjail are platform-specific; needs per-OS testing surface. |
 | OS-level resource / namespace sandbox | FAZ-B | Same as above. |
 | Extended redaction catalog | FAZ-B | Expands beyond the P0 demo providers. |
-| **SSH agent forwarding** | **FAZ-A PR-A5 or later** | `SSH_AUTH_SOCK` inheritance is NOT supported in the FAZ-A demo tier. Demo flow uses HTTP-token auth (`GH_TOKEN`) via `secrets.allowlist_secret_ids`. Workspaces that need SSH for git push/pull must wait for a later FAZ-A PR (or provide their own override with explicit acknowledgement). |
+| **SSH agent forwarding** | **FAZ-A PR-A5 or later** | `SSH_AUTH_SOCK` inheritance is NOT supported in the current bundled demo/operator tier. Current documented flows use HTTP-token auth (`GH_TOKEN`) via `secrets.allowlist_secret_ids`. Workspaces that need SSH for git push/pull must wait for a later implementation (or provide their own override with explicit acknowledgement). |
 
 ---
 

--- a/docs/WORKTREE-PROFILE.md
+++ b/docs/WORKTREE-PROFILE.md
@@ -2,7 +2,7 @@
 
 `policy_worktree_profile.v1.json` is the operator-facing contract for ao-kernel's external-agent sandbox. It defines the FAZ-A **expanded minimum** policy surface: worktree isolation, env allowlist, secret deny-by-default, command allowlist, cwd confinement, and evidence redaction. In `v4.0.0b1`, the live pre-invocation scope includes secret resolution, sandbox env shaping, HTTP header exposure checks, and adapter CLI command validation. OS-level network/egress sandboxing is deferred to FAZ-B.
 
-This document is the plain-English companion to the policy JSON. Read this to decide how to engage the policy, configure it for a demo, or promote it to production mode.
+This document is the plain-English companion to the policy JSON. Read this to decide how to engage the policy, configure it for a demo, or promote it to production mode. It describes runtime governance only; it does **not** make every bundled adapter, extension, or roadmap demo a supported production surface by itself.
 
 ---
 
@@ -54,13 +54,13 @@ FAZ-B closes the network/egress and OS-level gaps with platform-specific sandbox
 
 ## 3. Demo Workspace Override
 
-The bundled default policy is **dormant** (`enabled: false`). To run the DEMO-SCRIPT.md end-to-end flow, place the following override at `.ao/policies/policy_worktree_profile.v1.json` inside the workspace:
+The bundled default policy is **dormant** (`enabled: false`). The supported deterministic Public Beta demo (`examples/demo_review.py`) does **not** require enabling this policy. To exercise an operator-managed adapter path or the roadmap/spec multi-adapter stack, place the following override at `.ao/policies/policy_worktree_profile.v1.json` inside the workspace:
 
 ```json
 {
   "version": "v1",
   "enabled": true,
-  "_comment": "Demo workspace override for DEMO-SCRIPT.md E2E. Activates full sandbox in block mode with minimal secret allowlist.",
+  "_comment": "Operator demo override for real-adapter / roadmap-spec flows. Activates full sandbox in block mode with minimal secret allowlist.",
 
   "rollout": {
     "mode_default": "block"
@@ -74,7 +74,7 @@ The bundled default policy is **dormant** (`enabled: false`). To run the DEMO-SC
 
 The override shallow-merges with the bundled default: only `enabled`, `rollout.mode_default`, and `secrets.allowlist_secret_ids` are replaced. Everything else (worktree strategy, env allowlist, command allowlist, cwd confinement, evidence redaction) comes from the bundled default.
 
-Demo prerequisites must be set in the environment before launching:
+Operator-managed adapter prerequisites must be set in the environment before launching:
 
 - `ANTHROPIC_API_KEY` — Anthropic API key for the Claude Code CLI adapter.
 - `GH_TOKEN` — GitHub personal access token for the `gh-cli-pr` adapter.
@@ -264,6 +264,7 @@ Current shipped executor exercises the secret, HTTP-header, and command-path sur
 - `ao_kernel/defaults/policies/policy_worktree_profile.v1.json` — the bundled policy this doc describes.
 - `docs/ADAPTERS.md` — how adapters declare `policy_refs` that include this policy.
 - `docs/EVIDENCE-TIMELINE.md` — the `policy_checked` and `policy_denied` events this policy emits.
-- `docs/DEMO-SCRIPT.md` — the E2E demo that exercises the demo override above.
+- `docs/PUBLIC-BETA.md` — the live support matrix for the shipped deterministic demo surface.
+- `docs/roadmap/DEMO-SCRIPT-SPEC.md` — the legacy multi-adapter spec that can exercise this override in operator-managed runs.
 - `ao_kernel/defaults/policies/policy_secrets.v1.json` — the allowed-secret-ids + fail-action pattern this policy mirrors for secret resolution.
 - `ao_kernel/defaults/schemas/agent-adapter-contract.schema.v1.json` — the adapter contract whose `invocation.cli.env_allowlist_ref` and `invocation.http.auth_secret_id_ref` point into this policy.

--- a/tests/test_executor_policy_rollout_v311_p2.py
+++ b/tests/test_executor_policy_rollout_v311_p2.py
@@ -191,6 +191,10 @@ def _read_events(workspace_root: Path, run_id: str) -> list[dict[str, Any]]:
     return events
 
 
+def _event_kinds(events: list[dict[str, Any]]) -> list[str]:
+    return [e.get("kind") for e in events]
+
+
 class TestTierDormant:
     """`enabled=false` → policy layer bypassed entirely."""
 
@@ -233,25 +237,45 @@ class TestTierReportOnly:
         policy = _policy_with_secret_missing_violation(enabled=True, mode_default="report_only")
         ex, step = _build_executor(tmp_path, policy)
         rid = str(uuid.uuid4())
+        placeholder_step_id = "invoke_agent-a2-report0001"
         _create_run_record(tmp_path, rid)
 
-        result = ex.run_step(rid, step, parent_env={"OTHER_KEY": "triggers_secret_missing"})
+        result = ex.run_step(
+            rid,
+            step,
+            parent_env={"OTHER_KEY": "triggers_secret_missing"},
+            attempt=2,
+            step_id=placeholder_step_id,
+        )
         assert result.step_state == "completed"
         assert result.invocation_result is not None
         assert result.invocation_result.status == "ok"
 
         events = _read_events(tmp_path, rid)
+        kinds = _event_kinds(events)
+        assert kinds[:5] == [
+            "step_started",
+            "policy_checked",
+            "adapter_invoked",
+            "adapter_returned",
+            "step_completed",
+        ]
         checked = next((e for e in events if e.get("kind") == "policy_checked"), None)
         assert checked is not None, "policy_checked must be emitted"
         payload = checked.get("payload", {})
         assert payload.get("mode") == "report_only"
+        assert payload.get("violations_count") == 1
         assert payload.get("would_block") is True
-        assert "secret_missing" in payload.get("violation_kinds", [])
+        assert payload.get("violation_kinds") == ["secret_missing"]
         assert payload.get("promoted_to_block") is False
+        assert {e.get("step_id") for e in events[:5]} == {placeholder_step_id}
 
         # policy_denied NOT emitted in report_only + no escalation.
         denied = [e for e in events if e.get("kind") == "policy_denied"]
         assert denied == [], f"policy_denied must not fire in report_only without escalation; got {denied!r}"
+        record, _ = load_run(tmp_path, rid)
+        assert record["steps"][-1]["step_id"] == placeholder_step_id
+        assert record["steps"][-1]["attempt"] == 2
 
     def test_report_only_command_violation_emits_checked_and_continues(
         self, tmp_path: Path
@@ -303,21 +327,45 @@ class TestTierReportOnly:
         )
         ex, step = _build_executor(tmp_path, policy)
         rid = str(uuid.uuid4())
+        placeholder_step_id = "invoke_agent-a2-escalate0001"
         _create_run_record(tmp_path, rid)
         _transition_run_to_running(tmp_path, rid)
 
         with pytest.raises(PolicyViolationError):
-            ex.run_step(rid, step, parent_env={"OTHER_KEY": "escalates"})
+            ex.run_step(
+                rid,
+                step,
+                parent_env={"OTHER_KEY": "escalates"},
+                attempt=2,
+                step_id=placeholder_step_id,
+            )
 
         events = _read_events(tmp_path, rid)
+        kinds = _event_kinds(events)
+        assert kinds[:4] == [
+            "step_started",
+            "policy_checked",
+            "policy_denied",
+            "step_failed",
+        ]
         checked = next((e for e in events if e.get("kind") == "policy_checked"), None)
         assert checked is not None
         assert checked.get("payload", {}).get("promoted_to_block") is True
         # Effective mode in the emitted payload is now block.
-        assert checked.get("payload", {}).get("mode") == "block"
+        payload = checked.get("payload", {})
+        assert payload.get("mode") == "block"
+        assert payload.get("violations_count") == 1
+        assert payload.get("violation_kinds") == ["secret_missing"]
+        assert payload.get("would_block") is True
 
         denied = next((e for e in events if e.get("kind") == "policy_denied"), None)
         assert denied is not None, "escalation must emit policy_denied"
+        assert "adapter_invoked" not in kinds
+        assert {e.get("step_id") for e in events[:4]} == {placeholder_step_id}
+
+        record, _ = load_run(tmp_path, rid)
+        assert record["steps"][-1]["step_id"] == placeholder_step_id
+        assert record["steps"][-1]["state"] == "failed"
 
 
 class TestTierBlock:
@@ -327,15 +375,40 @@ class TestTierBlock:
         policy = _policy_with_secret_missing_violation(enabled=True, mode_default="block")
         ex, step = _build_executor(tmp_path, policy)
         rid = str(uuid.uuid4())
+        placeholder_step_id = "invoke_agent-a2-secretblock0001"
         _create_run_record(tmp_path, rid)
         _transition_run_to_running(tmp_path, rid)
 
         with pytest.raises(PolicyViolationError):
-            ex.run_step(rid, step, parent_env={"OTHER_KEY": "triggers_block"})
+            ex.run_step(
+                rid,
+                step,
+                parent_env={"OTHER_KEY": "triggers_block"},
+                attempt=2,
+                step_id=placeholder_step_id,
+            )
 
         events = _read_events(tmp_path, rid)
-        assert any(e.get("kind") == "policy_checked" for e in events)
-        assert any(e.get("kind") == "policy_denied" for e in events)
+        kinds = _event_kinds(events)
+        assert kinds[:4] == [
+            "step_started",
+            "policy_checked",
+            "policy_denied",
+            "step_failed",
+        ]
+        checked = events[1]
+        payload = checked.get("payload", {})
+        assert payload.get("mode") == "block"
+        assert payload.get("violations_count") == 1
+        assert payload.get("violation_kinds") == ["secret_missing"]
+        assert payload.get("would_block") is True
+        assert payload.get("promoted_to_block") is False
+        assert "adapter_invoked" not in kinds
+        assert {e.get("step_id") for e in events[:4]} == {placeholder_step_id}
+
+        record, _ = load_run(tmp_path, rid)
+        assert record["steps"][-1]["step_id"] == placeholder_step_id
+        assert record["steps"][-1]["state"] == "failed"
 
     def test_block_command_violation_fails_before_adapter_invocation(
         self, tmp_path: Path
@@ -376,11 +449,34 @@ class TestUnknownModeFallback:
         policy = _policy_with_secret_missing_violation(enabled=True, mode_default="audit_only_v7")
         ex, step = _build_executor(tmp_path, policy)
         rid = str(uuid.uuid4())
+        placeholder_step_id = "invoke_agent-a2-fallback0001"
         _create_run_record(tmp_path, rid)
         _transition_run_to_running(tmp_path, rid)
 
         with pytest.raises(PolicyViolationError):
-            ex.run_step(rid, step, parent_env={"OTHER_KEY": "triggers_fallback"})
+            ex.run_step(
+                rid,
+                step,
+                parent_env={"OTHER_KEY": "triggers_fallback"},
+                attempt=2,
+                step_id=placeholder_step_id,
+            )
+
+        events = _read_events(tmp_path, rid)
+        kinds = _event_kinds(events)
+        assert kinds[:4] == [
+            "step_started",
+            "policy_checked",
+            "policy_denied",
+            "step_failed",
+        ]
+        payload = events[1].get("payload", {})
+        assert payload.get("mode") == "block"
+        assert payload.get("violations_count") == 1
+        assert payload.get("violation_kinds") == ["secret_missing"]
+        assert payload.get("promoted_to_block") is False
+        assert "adapter_invoked" not in kinds
+        assert {e.get("step_id") for e in events[:4]} == {placeholder_step_id}
 
 
 class TestDryRunParityReportOnly:
@@ -404,10 +500,38 @@ class TestDryRunParityReportOnly:
         ]
         checked_payload = result.predicted_events[1][1]
         assert checked_payload["mode"] == "report_only"
+        assert checked_payload["violations_count"] == 1
         assert checked_payload["would_block"] is True
-        assert "secret_missing" in checked_payload["violation_kinds"]
+        assert checked_payload["violation_kinds"] == ["secret_missing"]
         assert checked_payload["promoted_to_block"] is False
         assert result.policy_violations == ()
+
+
+class TestDryRunParityBlock:
+    """Block-mode dry-run should predict denial order and surface violation details."""
+
+    def test_dry_run_block_command_violation_predicts_denial(self, tmp_path: Path) -> None:
+        policy = _policy_with_command_violation(enabled=True, mode_default="block")
+        ex, step = _build_executor(tmp_path, policy)
+        rid = str(uuid.uuid4())
+        _create_run_record(tmp_path, rid)
+
+        result = ex.dry_run_step(rid, step, parent_env={})
+        kinds = [kind for kind, _payload in result.predicted_events]
+        assert kinds == [
+            "step_started",
+            "policy_checked",
+            "policy_denied",
+            "step_failed",
+        ]
+        checked_payload = result.predicted_events[1][1]
+        assert checked_payload["mode"] == "block"
+        assert checked_payload["violations_count"] == 1
+        assert checked_payload["violation_kinds"] == ["command_path_outside_policy"]
+        assert checked_payload["would_block"] is True
+        assert checked_payload["promoted_to_block"] is False
+        assert len(result.policy_violations) == 1
+        assert "command_path_outside_policy" in result.policy_violations[0]
 
 
 class TestPolicyCheckedAdditivePayload:


### PR DESCRIPTION
## Özet
Bu PR, WP-1 truth patch kapsamında ao-kernel'in destek sınırını dokümanlarda mevcut runtime gerçeğine hizalar.

Ana değişiklikler:
- README ve PUBLIC-BETA, repo'yu blanket bir "production coding automation platform" gibi sunmak yerine dar destekli yüzeyi açıkça ayırıyor.
- Adapter, benchmark ve operator runbook dokümanları artık shipped demo ile operator/evaluation surface ayrımını açık yazıyor.
- Eski çok-adımlı demo referansları canlı destek yüzeyi gibi görünmeyecek şekilde PUBLIC-BETA ve roadmap/spec ayrımına taşındı.
- `examples/demo_review.py` için önemli kullanım kontratı netleştirildi: komut, `ao-kernel` kurulu bir Python environment'ında çalıştırılmalı.

## Neden
Repo ağacında çok sayıda contract/reference artifact bulunuyor. Bu durum operator veya son kullanıcı için iki yanlış izlenim üretiyordu:
- ağaçta görünen her manifest/extension/example production-ready destekli yüzeymiş gibi algılanabiliyordu
- benchmark/runbook/spec dokümanları ile canlı shipped demo yüzeyi birbirine karışıyordu

Bu drift, özellikle "ne gerçekten destekleniyor" ve "hangi komut son kullanıcı için güvenilir" sorularında yanlış güven üretiyordu.

## Kullanıcı etkisi
Bu PR runtime davranışını değiştirmez. Etki tamamen doğruluk ve beklenti yönetimi üzerinedir:
- son kullanıcı daha dar ama doğru bir destek sınırı görür
- operator, benchmark ve real-adapter dokümanlarını default ürün yüzeyi ile karıştırmaz
- inventory/contract layer ile shipped support matrix daha net ayrılır

## Doğrulama
Çalıştırılan kontroller:
- `python3 -m pytest tests/test_cli_entrypoints.py tests/test_evidence_cli.py tests/test_executor_policy_rollout_v311_p2.py -q`
- `python3 scripts/packaging_smoke.py`

Önemli doğrulama notu:
- checkout içinden doğrudan `python3 examples/demo_review.py --cleanup` çalıştırıldığında, global shell environment bu makinede `ao-kernel==3.13.1` gösterdiği için alt subprocess `python -m ao_kernel init` adımında drift sinyali verdi
- packaging smoke içindeki clean wheel install doğrulamasında ise `ao-kernel 4.0.0b1` entrypointleri ve `examples/demo_review.py --cleanup` başarılı şekilde geçti
- bu nedenle PR, desteklenen kullanım yolunu açıkça "kurulu environment" olarak belgeledi
