### PR TITLE
[codex] extensions: surface runtime truth inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install ao-kernel[llm,mcp,otel]  # Everything
 
 **For production-grade live LLM calls**, install the `[llm]` extra. Without it the runtime still dispatches requests, but two guarantees weaken: **retry / backoff** (`tenacity`) degrades to a single-attempt call so transient 429 / 5xx responses fail the request instead of being retried, and **exact token counting** (`tiktoken`) falls back to a heuristic estimator (~4 chars/token) so budget accounting is approximate. The core install is fully sufficient for policy evaluation, evidence replay, workflow inspection, and MCP server hosting.
 
-`ao-kernel doctor` surfaces the missing extra via a `tenacity/tiktoken (optional)` check that shows `WARN` when the extra is missing. That WARN is **expected** on the core install and clears once you run `pip install 'ao-kernel[llm]'`.
+`ao-kernel doctor` surfaces the missing extra via a `tenacity/tiktoken (optional)` check that shows `WARN` when the extra is missing. That WARN is **expected** on the core install and clears once you run `pip install 'ao-kernel[llm]'`. The same command now also prints a bundled extension truth inventory so operators can see which manifests are runtime-backed versus contract-only or quarantined candidates.
 
 Requires Python 3.11+. POSIX-only at the moment (Windows support scheduled for a future major release; see `LockPlatformNotSupported` in `docs/COORDINATION.md`).
 
@@ -64,7 +64,7 @@ stream_request = build_req(
 | Command | Description |
 |---|---|
 | `ao-kernel init` | Create `.ao/` workspace |
-| `ao-kernel doctor` | Workspace health check (8 checks) |
+| `ao-kernel doctor` | Workspace health check + extension truth audit |
 | `ao-kernel migrate [--dry-run] [--backup]` | Version migration |
 | `ao-kernel version` | Print version |
 | `ao-kernel mcp serve` | Start MCP server (stdio) |
@@ -91,7 +91,7 @@ Treat the repo in three layers:
 
 - **Runtime-backed / supported**: core CLI and SDK surfaces, evidence tooling, worktree policy enforcement, bundled `review_ai_flow`, and `examples/demo_review.py`.
 - **Operator / evaluation only**: benchmark docs, real-adapter runbooks, prompt experiment runbooks, and other opt-in validation paths that are intentionally outside the default deterministic CI/demo lane.
-- **Contract / reference inventory**: bundled JSON defaults, adapter manifests, registry files, and example code such as `examples/hello-llm/`. Their presence in the tree is useful reference material, not blanket proof that every surface is production-ready end to end.
+- **Contract / reference inventory**: bundled JSON defaults, adapter manifests, registry files, and example code such as `examples/hello-llm/`. Their presence in the tree is useful reference material, not blanket proof that every surface is production-ready end to end. The bundled extension inventory is especially narrow at runtime today: `PRJ-HELLO` is the explicit bootstrap-backed smoke path; the rest of the bundled manifests should be treated as contract inventory unless a support doc says otherwise.
 
 ## Python API
 

--- a/ao_kernel/client.py
+++ b/ao_kernel/client.py
@@ -174,9 +174,10 @@ class AoKernelClient:
         from ao_kernel.extensions.loader import ExtensionRegistry
 
         extensions = ExtensionRegistry()
-        refs_base = self._workspace_root
         try:
-            extensions.load_from_defaults(refs_base=refs_base)
+            # Bundled manifest refs must be audited against the installed
+            # distribution, not the operator workspace.
+            extensions.load_from_defaults()
         except Exception as exc:  # noqa: BLE001 — manifest path is best-effort
             logger.warning("extension defaults load failed: %s", exc)
         if self._workspace_root is not None:

--- a/ao_kernel/doctor_cmd.py
+++ b/ao_kernel/doctor_cmd.py
@@ -1,12 +1,13 @@
 """ao-kernel doctor — workspace health check.
 
-Runs 8 checks and reports OK/WARN/FAIL for each.
+Runs the core workspace checks plus a bundled-extension truth audit and
+reports OK/WARN/FAIL for each.
 """
 
 from __future__ import annotations
 
 import sys
-from typing import Callable
+from typing import Any, Callable, cast
 
 import ao_kernel
 from ao_kernel.config import workspace_root
@@ -81,20 +82,28 @@ def _check_internal_import() -> bool:
 
 
 def _check_extension_manifests() -> bool:
-    """Discover and validate ALL bundled extension manifests."""
-    from importlib.resources import files
+    """Discover bundled extension manifests.
 
-    extensions_pkg = files("ao_kernel.defaults.extensions")
-    found = 0
-    for item in extensions_pkg.iterdir():
-        if item.is_dir() and item.name.startswith("PRJ-"):
-            manifest = item.joinpath("extension.manifest.v1.json")
-            try:
-                manifest.read_text(encoding="utf-8")
-                found += 1
-            except (FileNotFoundError, TypeError):
-                return False
-    return found > 0
+    Truth and hygiene debt is surfaced by the separate extension-truth
+    audit; discovery itself stays a narrow presence/loadability check so
+    operators can distinguish inventory drift from a broken install.
+    """
+    from ao_kernel.extensions.loader import ExtensionRegistry
+
+    reg = ExtensionRegistry()
+    report = reg.load_from_defaults()
+    return report.loaded > 0
+
+
+def _bundled_extension_truth() -> tuple[bool, object]:
+    """Return ``(healthy, summary)`` for bundled extension truth inventory."""
+    from ao_kernel.extensions.loader import ExtensionRegistry
+
+    reg = ExtensionRegistry()
+    report = reg.load_from_defaults()
+    summary = reg.truth_summary()
+    healthy = report.loaded > 0 and summary.quarantined == 0
+    return healthy, summary
 
 
 def run(workspace_root_override: str | None = None) -> int:
@@ -109,6 +118,14 @@ def run(workspace_root_override: str | None = None) -> int:
         ("Internal modules import", _check_internal_import),
         ("Extension manifest discovery", _check_extension_manifests),
     ]
+    truth_ok, extension_truth = _bundled_extension_truth()
+    extension_truth = cast(Any, extension_truth)
+    checks.append(
+        (
+            "Bundled extension truth",
+            (lambda: True if truth_ok else "WARN"),
+        )
+    )
 
     print(f"ao-kernel doctor v{ao_kernel.__version__}")
     print("-" * 50)
@@ -125,6 +142,27 @@ def run(workspace_root_override: str | None = None) -> int:
     fail_count = sum(1 for _, s in results if s == "FAIL")
     warn_count = sum(1 for _, s in results if s == "WARN")
     ok_count = sum(1 for _, s in results if s == "OK")
+
+    if getattr(extension_truth, "total_extensions", None) is not None:
+        print("  Extension Truth Inventory")
+        print(
+            "    "
+            f"runtime_backed={extension_truth.runtime_backed} "
+            f"contract_only={extension_truth.contract_only} "
+            f"quarantined={extension_truth.quarantined}"
+        )
+        print(
+            "    "
+            f"remap_candidate_refs={extension_truth.remap_candidate_refs} "
+            f"missing_runtime_refs={extension_truth.missing_runtime_refs}"
+        )
+        runtime_ids = ", ".join(extension_truth.runtime_backed_ids) or "-"
+        print(f"    runtime_backed_ids={runtime_ids}")
+        if extension_truth.quarantined_ids:
+            preview = ", ".join(extension_truth.quarantined_ids[:5])
+            suffix = " ..." if len(extension_truth.quarantined_ids) > 5 else ""
+            print(f"    quarantined_ids={preview}{suffix}")
+        print("-" * 50)
 
     print(f"  {ok_count} OK, {warn_count} WARN, {fail_count} FAIL")
 

--- a/ao_kernel/extensions/bootstrap.py
+++ b/ao_kernel/extensions/bootstrap.py
@@ -55,6 +55,11 @@ def register_default_handlers(
     return registered
 
 
+def default_handler_extension_ids() -> frozenset[str]:
+    """Return the bundled extension IDs with explicit runtime handlers."""
+    return frozenset(extension_id for extension_id, _module_path in _DEFAULT_HANDLERS)
+
+
 def _manifest_activatable(
     extensions: "ExtensionRegistry | None", extension_id: str,
 ) -> bool:
@@ -80,4 +85,4 @@ _DEFAULT_HANDLERS: list[tuple[str, str]] = [
 ]
 
 
-__all__ = ["register_default_handlers"]
+__all__ = ["register_default_handlers", "default_handler_extension_ids"]

--- a/ao_kernel/extensions/loader.py
+++ b/ao_kernel/extensions/loader.py
@@ -34,6 +34,23 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+TRUTH_TIER_RUNTIME_BACKED = "runtime_backed"
+TRUTH_TIER_CONTRACT_ONLY = "contract_only"
+TRUTH_TIER_QUARANTINED = "quarantined"
+_BUNDLED_REF_KINDS = frozenset(
+    {
+        "adapters",
+        "catalogs",
+        "extensions",
+        "intent_rules",
+        "operations",
+        "policies",
+        "registry",
+        "schemas",
+        "workflows",
+    }
+)
+
 
 @dataclass(frozen=True)
 class ExtensionManifest:
@@ -78,6 +95,10 @@ class ExtensionManifest:
     content_hash: str = ""
     source: str = "bundled"  # "bundled" or "workspace"
     stale_refs: tuple[str, ...] = ()
+    remap_candidate_refs: tuple[str, ...] = ()
+    missing_runtime_refs: tuple[str, ...] = ()
+    runtime_handler_registered: bool = False
+    truth_tier: str = TRUTH_TIER_CONTRACT_ONLY
     activation_blockers: tuple[str, ...] = ()
 
 
@@ -98,6 +119,21 @@ class LoadReport:
     loaded: int
     skipped: list[dict[str, str]] = field(default_factory=list)
     conflicts: list[ConflictRecord] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ExtensionTruthSummary:
+    """Aggregated truth view over the loaded extension inventory."""
+
+    total_extensions: int
+    runtime_backed: int
+    contract_only: int
+    quarantined: int
+    remap_candidate_refs: int
+    missing_runtime_refs: int
+    runtime_backed_ids: tuple[str, ...]
+    contract_only_ids: tuple[str, ...]
+    quarantined_ids: tuple[str, ...]
 
 
 def _content_hash(raw_bytes: bytes) -> str:
@@ -226,23 +262,58 @@ def _compat_blockers(manifest: ExtensionManifest) -> tuple[str, ...]:
     return tuple(blockers)
 
 
-def _stale_ref_paths(manifest: ExtensionManifest, *, base: Path | None) -> tuple[str, ...]:
-    """Return manifest-declared paths that do not exist relative to base.
+def _distribution_root() -> Path:
+    """Return the installed package root used for bundled truth checks."""
+    return Path(__file__).resolve().parents[1]
 
-    Bundled manifests copied from the upstream autonomous-orchestrator repo
-    often reference paths (``src/prj_kernel_api/adapter.py``, etc.) that do
-    not exist in the ao-kernel package tree. Flagging them keeps the
-    registry honest without blocking activation.
+
+def _classify_ref_paths(
+    manifest: ExtensionManifest,
+    *,
+    base: Path | None,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return ``(remap_candidate_refs, missing_runtime_refs)``.
+
+    ``base`` is the authority root for the currently installed runtime.
+    For bundled manifests this is the ao-kernel package root, not the
+    operator workspace. Legacy refs like ``policies/foo.json`` may be
+    recoverable as ``defaults/policies/foo.json`` inside the wheel; those
+    are tracked separately from refs that are absent from the distribution
+    entirely.
     """
     if base is None or not base.is_dir():
-        return ()
+        return (), ()
     refs: list[str] = []
     refs.extend(manifest.ai_context_refs)
     if manifest.docs_ref:
         refs.append(manifest.docs_ref)
     refs.extend(manifest.tests_entrypoints)
-    stale = [r for r in refs if r and not (base / r).exists()]
-    return tuple(stale)
+    remap_candidates: list[str] = []
+    missing: list[str] = []
+    defaults_root = base / "defaults"
+    for ref in refs:
+        if not ref:
+            continue
+        if (base / ref).exists():
+            continue
+        head = ref.split("/", 1)[0]
+        if head in _BUNDLED_REF_KINDS and (defaults_root / ref).exists():
+            remap_candidates.append(ref)
+            continue
+        missing.append(ref)
+    return tuple(remap_candidates), tuple(missing)
+
+
+def _truth_tier(
+    *,
+    runtime_handler_registered: bool,
+    missing_runtime_refs: tuple[str, ...],
+) -> str:
+    if missing_runtime_refs:
+        return TRUTH_TIER_QUARANTINED
+    if runtime_handler_registered:
+        return TRUTH_TIER_RUNTIME_BACKED
+    return TRUTH_TIER_CONTRACT_ONLY
 
 
 class ExtensionRegistry:
@@ -259,8 +330,9 @@ class ExtensionRegistry:
     def load_from_defaults(self, *, refs_base: Path | None = None) -> LoadReport:
         """Load bundled manifests packaged under ao_kernel.defaults.extensions.
 
-        ``refs_base`` controls where stale-ref path checks resolve from.
-        Callers typically pass the project root; None skips the stale check.
+        ``refs_base`` controls bundled ref auditing. When omitted, bundled
+        manifests are checked against the installed ao-kernel package root so
+        the truth report reflects what the runtime actually ships.
         """
         schema = _load_schema()
         try:
@@ -269,6 +341,7 @@ class ExtensionRegistry:
         except (ImportError, ModuleNotFoundError):
             return LoadReport(loaded=0)
 
+        effective_refs_base = refs_base or _distribution_root()
         report = LoadReport(loaded=0)
         # Sorted iteration → deterministic first-wins conflict resolution.
         items = sorted(
@@ -281,7 +354,7 @@ class ExtensionRegistry:
                 manifest_file,
                 schema=schema,
                 source="bundled",
-                refs_base=refs_base,
+                refs_base=effective_refs_base,
                 report=report,
             )
         return report
@@ -328,6 +401,36 @@ class ExtensionRegistry:
             m for m in self.list_all()
             if m.enabled and not m.activation_blockers
         ]
+
+    def truth_summary(self) -> ExtensionTruthSummary:
+        """Return an aggregated runtime-truth summary for loaded manifests."""
+        manifests = self.list_all()
+        runtime_backed_ids = tuple(
+            m.extension_id
+            for m in manifests
+            if m.truth_tier == TRUTH_TIER_RUNTIME_BACKED
+        )
+        contract_only_ids = tuple(
+            m.extension_id
+            for m in manifests
+            if m.truth_tier == TRUTH_TIER_CONTRACT_ONLY
+        )
+        quarantined_ids = tuple(
+            m.extension_id
+            for m in manifests
+            if m.truth_tier == TRUTH_TIER_QUARANTINED
+        )
+        return ExtensionTruthSummary(
+            total_extensions=len(manifests),
+            runtime_backed=len(runtime_backed_ids),
+            contract_only=len(contract_only_ids),
+            quarantined=len(quarantined_ids),
+            remap_candidate_refs=sum(len(m.remap_candidate_refs) for m in manifests),
+            missing_runtime_refs=sum(len(m.missing_runtime_refs) for m in manifests),
+            runtime_backed_ids=runtime_backed_ids,
+            contract_only_ids=contract_only_ids,
+            quarantined_ids=quarantined_ids,
+        )
 
     def find_by_entrypoint(self, entrypoint_name: str) -> list[ExtensionManifest]:
         out: list[ExtensionManifest] = []
@@ -408,9 +511,28 @@ class ExtensionRegistry:
     def _enrich(self, manifest: ExtensionManifest, *, refs_base: Path | None) -> ExtensionManifest:
         """Attach compat blockers and stale refs to a freshly parsed manifest."""
         from dataclasses import replace
+        from ao_kernel.extensions.bootstrap import default_handler_extension_ids
+
         blockers = _compat_blockers(manifest)
-        stale = _stale_ref_paths(manifest, base=refs_base)
-        return replace(manifest, activation_blockers=blockers, stale_refs=stale)
+        remap_candidates, missing_runtime_refs = _classify_ref_paths(
+            manifest,
+            base=refs_base,
+        )
+        stale = tuple((*remap_candidates, *missing_runtime_refs))
+        runtime_handler_registered = manifest.extension_id in default_handler_extension_ids()
+        truth_tier = _truth_tier(
+            runtime_handler_registered=runtime_handler_registered,
+            missing_runtime_refs=missing_runtime_refs,
+        )
+        return replace(
+            manifest,
+            activation_blockers=blockers,
+            stale_refs=stale,
+            remap_candidate_refs=remap_candidates,
+            missing_runtime_refs=missing_runtime_refs,
+            runtime_handler_registered=runtime_handler_registered,
+            truth_tier=truth_tier,
+        )
 
     def _register_entrypoints(self, manifest: ExtensionManifest, *, report: LoadReport) -> None:
         for group, names in manifest.entrypoints.items():
@@ -446,4 +568,8 @@ __all__ = [
     "ExtensionRegistry",
     "ConflictRecord",
     "LoadReport",
+    "ExtensionTruthSummary",
+    "TRUTH_TIER_RUNTIME_BACKED",
+    "TRUTH_TIER_CONTRACT_ONLY",
+    "TRUTH_TIER_QUARANTINED",
 ]

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -31,7 +31,7 @@ istemek gerekir.
 | `python -m ao_kernel.cli version` | Shipped | CLI module kontratı |
 | Bundled `review_ai_flow` + bundled `codex-stub` | Shipped | Desteklenen demo workflow |
 | `examples/demo_review.py` | Shipped | Disposable workspace + canlı smoke `completed`; komut, `ao-kernel` kurulu bir Python environment'ı içinde çalıştırılmalıdır |
-| `ao-kernel doctor` | Shipped | Workspace health check (8/8 OK) |
+| `ao-kernel doctor` | Shipped | Workspace health check + bundled extension truth audit; may emit WARN while contract-only / quarantined inventory remains |
 | CI coverage gate 85% | Shipped | `pyproject.toml` ile hizalı (`test.yml --fail-under=85`) |
 | Adapter CLI command enforcement | Shipped | `policy_checked` / `policy_denied` artık resolved command ihlallerini de içerir; canonical sıra `step_started -> policy_checked -> adapter_invoked` korunur |
 | `{python_executable}` localized exception | Shipped | Yalnız manifest `command` alanı explicit `{python_executable}` kullandığında, yalnız resolved `sys.executable` realpath'i için geçerli; sandbox allowlist'ini mutate etmez |
@@ -48,7 +48,7 @@ istemek gerekir.
 
 | Yüzey | Durum | Not |
 |---|---|---|
-| Extension loader + manifest validation | Shipped infra | Loader/validator kodu ve temel dispatch wiring'i gerçektir; bu, her bundled manifestin end-to-end production-ready olduğu anlamına gelmez |
+| Extension loader + manifest validation | Shipped infra | Loader/validator kodu ve truth-tier audit gerçektir; bu, her bundled manifestin end-to-end production-ready olduğu anlamına gelmez |
 | Bundled `defaults/registry`, `defaults/extensions`, `defaults/operations`, `defaults/adapters` içeriği | Contract inventory | Ağaçta görünmesi destek vaadi değildir; ancak ilgili doküman/test/Public Beta matrisi o yüzeyi ayrıca işaretliyorsa destekli sayılır |
 | `examples/hello-llm/` | Example-only | SDK kullanım örneğidir; Public Beta destek vaadinin parçası değildir |
 
@@ -73,6 +73,10 @@ istemek gerekir.
 
 - Public Beta “hemen çalışır” iddiası yalnızca bundled
   `review_ai_flow` + bundled `codex-stub` yolu için geçerlidir.
+- Bundled extension inventory bugün dar runtime-backed yüzeye sahiptir:
+  explicit bootstrap-backed smoke `PRJ-HELLO` ile sınırlıdır; kalan
+  manifestler doctor truth audit'inde contract-only veya quarantined
+  olarak görülebilir.
 - Bu doküman, ao-kernel'in genel amaçlı bir production coding automation
   platformu olduğunu iddia etmez; destek vaadi dar ve açıkça tablolanmış
   yüzeyler içindir.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,9 @@ class TestDoctor:
         lines = [line for line in out.splitlines() if line.strip().startswith("[")]
         fail_lines = [line for line in lines if "[!]" in line]
         assert len(fail_lines) == 0
-        assert len(lines) >= 7  # At least 7 check lines
+        assert len(lines) >= 8
+        assert "Extension Truth Inventory" in out
+        assert "runtime_backed=" in out
 
 
 class TestMigrate:

--- a/tests/test_extension_dispatch.py
+++ b/tests/test_extension_dispatch.py
@@ -86,6 +86,8 @@ class TestBootstrapHelloExtension:
         ext = client.extensions.get("PRJ-HELLO")
         assert ext is not None
         assert ext.enabled is True
+        assert ext.truth_tier == "runtime_backed"
+        assert ext.runtime_handler_registered is True
         assert "hello_world" in ext.entrypoints.get("kernel_api_actions", [])
 
 

--- a/tests/test_extension_loader.py
+++ b/tests/test_extension_loader.py
@@ -56,6 +56,16 @@ class TestBundledDefaults:
         # SHA256 hex == 64 chars.
         assert len(ext.content_hash) == 64
 
+    def test_truth_summary_exposes_runtime_backed_and_quarantined_inventory(self):
+        reg = ExtensionRegistry()
+        reg.load_from_defaults()
+        summary = reg.truth_summary()
+        assert summary.total_extensions >= 1
+        assert summary.runtime_backed >= 1
+        assert "PRJ-HELLO" in summary.runtime_backed_ids
+        assert summary.quarantined >= 1
+        assert summary.missing_runtime_refs >= 1
+
     def test_list_enabled_filters_disabled_and_blocked(self):
         reg = ExtensionRegistry()
         reg.load_from_defaults()
@@ -136,6 +146,16 @@ class TestBundledDefaults:
         assert zanzibar.semver == "1.0.0"
         assert zanzibar.origin == "CORE"
         assert zanzibar.owner == "CORE"
+
+    def test_airunner_manifest_is_quarantined_candidate(self):
+        reg = ExtensionRegistry()
+        reg.load_from_defaults()
+        ext = reg.get("PRJ-AIRUNNER")
+        assert ext is not None
+        assert ext.truth_tier == "quarantined"
+        assert ext.runtime_handler_registered is False
+        assert ext.remap_candidate_refs
+        assert ext.missing_runtime_refs
 
 
 class TestWorkspaceOverride:


### PR DESCRIPTION
## Summary
- classify bundled extension manifests into runtime-backed, contract-only, and quarantined truth tiers
- surface bundled extension truth inventory in `ao-kernel doctor` and align docs with the narrower runtime-backed surface
- add tests that pin the new truth metadata and doctor reporting

## Validation
- pytest tests/test_extension_loader.py tests/test_extension_dispatch.py tests/test_cli.py -q
- ruff check ao_kernel/ tests/ README.md docs/PUBLIC-BETA.md
- mypy ao_kernel/
- python3 -m ao_kernel doctor
