### PR TITLE
doctor: expose structured truth report

### DIFF
--- a/ao_kernel/client.py
+++ b/ao_kernel/client.py
@@ -365,29 +365,12 @@ class AoKernelClient:
         return summary
 
     def doctor(self) -> dict[str, Any]:
-        """Run workspace health check. Returns check results."""
-        from ao_kernel.doctor_cmd import run as _doctor_run
-        import io
-        import sys
-        import json
+        """Run workspace health check and return the structured report."""
+        from ao_kernel.doctor_cmd import build_report as _doctor_report
 
-        old_stdout = sys.stdout
-        sys.stdout = buf = io.StringIO()
-        try:
-            rc = _doctor_run(
-                workspace_root_override=str(self._workspace_root) if self._workspace_root else None,
-            )
-        finally:
-            sys.stdout = old_stdout
-
-        output = buf.getvalue()
-        try:
-            parsed = json.loads(output)
-        except (json.JSONDecodeError, ValueError):
-            return {"exit_code": rc, "output": output}
-        if not isinstance(parsed, dict):
-            return {"exit_code": rc, "output": output}
-        return parsed
+        return _doctor_report(
+            workspace_root_override=str(self._workspace_root) if self._workspace_root else None,
+        )
 
     # ── Session Lifecycle ───────────────────────────────────────────
 

--- a/ao_kernel/doctor_cmd.py
+++ b/ao_kernel/doctor_cmd.py
@@ -1,7 +1,9 @@
 """ao-kernel doctor — workspace health check.
 
 Runs the core workspace checks plus a bundled-extension truth audit and
-reports OK/WARN/FAIL for each.
+reports OK/WARN/FAIL for each. The same data is also exposed as a
+structured report for SDK/test consumers so doctor semantics are not
+locked behind stdout parsing.
 """
 
 from __future__ import annotations
@@ -106,8 +108,25 @@ def _bundled_extension_truth() -> tuple[bool, object]:
     return healthy, summary
 
 
-def run(workspace_root_override: str | None = None) -> int:
-    """Run all health checks and print report."""
+def _extension_truth_payload(summary: Any) -> dict[str, Any] | None:
+    """Return a JSON-friendly truth payload when summary data is available."""
+    if getattr(summary, "total_extensions", None) is None:
+        return None
+    return {
+        "total_extensions": summary.total_extensions,
+        "runtime_backed": summary.runtime_backed,
+        "contract_only": summary.contract_only,
+        "quarantined": summary.quarantined,
+        "remap_candidate_refs": summary.remap_candidate_refs,
+        "missing_runtime_refs": summary.missing_runtime_refs,
+        "runtime_backed_ids": list(summary.runtime_backed_ids),
+        "contract_only_ids": list(summary.contract_only_ids),
+        "quarantined_ids": list(summary.quarantined_ids),
+    }
+
+
+def build_report(workspace_root_override: str | None = None) -> dict[str, Any]:
+    """Build a structured doctor report without writing to stdout."""
     checks = [
         ("Workspace found", lambda: _check_workspace(workspace_root_override)),
         ("workspace.json valid", lambda: _check_workspace_json(workspace_root_override)),
@@ -119,7 +138,6 @@ def run(workspace_root_override: str | None = None) -> int:
         ("Extension manifest discovery", _check_extension_manifests),
     ]
     truth_ok, extension_truth = _bundled_extension_truth()
-    extension_truth = cast(Any, extension_truth)
     checks.append(
         (
             "Bundled extension truth",
@@ -127,43 +145,70 @@ def run(workspace_root_override: str | None = None) -> int:
         )
     )
 
-    print(f"ao-kernel doctor v{ao_kernel.__version__}")
-    print("-" * 50)
-
     results = []
     for label, fn in checks:
-        status = _check(label, fn)
-        results.append((label, status))
+        results.append({"label": label, "status": _check(label, fn)})
+
+    fail_count = sum(1 for result in results if result["status"] == "FAIL")
+    warn_count = sum(1 for result in results if result["status"] == "WARN")
+    ok_count = sum(1 for result in results if result["status"] == "OK")
+
+    return {
+        "version": ao_kernel.__version__,
+        "checks": results,
+        "summary": {
+            "ok_count": ok_count,
+            "warn_count": warn_count,
+            "fail_count": fail_count,
+        },
+        "extension_truth": _extension_truth_payload(cast(Any, extension_truth)),
+        "exit_code": 1 if fail_count > 0 else 0,
+    }
+
+
+def run(workspace_root_override: str | None = None) -> int:
+    """Run all health checks and print report."""
+    report = build_report(workspace_root_override)
+    summary = cast(dict[str, int], report["summary"])
+    extension_truth = cast(dict[str, Any] | None, report["extension_truth"])
+
+    print(f"ao-kernel doctor v{report['version']}")
+    print("-" * 50)
+
+    for result in cast(list[dict[str, str]], report["checks"]):
+        label = result["label"]
+        status = result["status"]
         icon = {"OK": "+", "WARN": "~", "FAIL": "!"}[status]
         print(f"  [{icon}] {label:<35} {status}")
 
     print("-" * 50)
 
-    fail_count = sum(1 for _, s in results if s == "FAIL")
-    warn_count = sum(1 for _, s in results if s == "WARN")
-    ok_count = sum(1 for _, s in results if s == "OK")
-
-    if getattr(extension_truth, "total_extensions", None) is not None:
+    if extension_truth:
         print("  Extension Truth Inventory")
         print(
             "    "
-            f"runtime_backed={extension_truth.runtime_backed} "
-            f"contract_only={extension_truth.contract_only} "
-            f"quarantined={extension_truth.quarantined}"
+            f"runtime_backed={extension_truth['runtime_backed']} "
+            f"contract_only={extension_truth['contract_only']} "
+            f"quarantined={extension_truth['quarantined']}"
         )
         print(
             "    "
-            f"remap_candidate_refs={extension_truth.remap_candidate_refs} "
-            f"missing_runtime_refs={extension_truth.missing_runtime_refs}"
+            f"remap_candidate_refs={extension_truth['remap_candidate_refs']} "
+            f"missing_runtime_refs={extension_truth['missing_runtime_refs']}"
         )
-        runtime_ids = ", ".join(extension_truth.runtime_backed_ids) or "-"
+        runtime_ids = ", ".join(extension_truth["runtime_backed_ids"]) or "-"
         print(f"    runtime_backed_ids={runtime_ids}")
-        if extension_truth.quarantined_ids:
-            preview = ", ".join(extension_truth.quarantined_ids[:5])
-            suffix = " ..." if len(extension_truth.quarantined_ids) > 5 else ""
+        quarantined_ids = cast(list[str], extension_truth["quarantined_ids"])
+        if quarantined_ids:
+            preview = ", ".join(quarantined_ids[:5])
+            suffix = " ..." if len(quarantined_ids) > 5 else ""
             print(f"    quarantined_ids={preview}{suffix}")
         print("-" * 50)
 
-    print(f"  {ok_count} OK, {warn_count} WARN, {fail_count} FAIL")
+    print(
+        f"  {summary['ok_count']} OK, "
+        f"{summary['warn_count']} WARN, "
+        f"{summary['fail_count']} FAIL"
+    )
 
-    return 1 if fail_count > 0 else 0
+    return cast(int, report["exit_code"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,6 +71,9 @@ class TestDoctor:
         assert len(lines) >= 8
         assert "Extension Truth Inventory" in out
         assert "runtime_backed=" in out
+        assert "runtime_backed_ids=PRJ-HELLO" in out
+        truth_line = next(line for line in lines if "Bundled extension truth" in line)
+        assert "WARN" in truth_line
 
 
 class TestMigrate:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1023,8 +1023,21 @@ class TestSwallowLoggingA3:
 
 
 class TestDoctor:
-    def test_doctor_returns_dict(self, tmp_workspace: Path):
+    def test_doctor_returns_structured_report(self, tmp_workspace: Path):
         ws_root = tmp_workspace.parent
         client = AoKernelClient(ws_root)
         result = client.doctor()
         assert isinstance(result, dict)
+        assert result["exit_code"] == 0
+        assert result["version"]
+        checks = {item["label"]: item["status"] for item in result["checks"]}
+        assert checks["Workspace found"] == "OK"
+        assert checks["workspace.json valid"] == "OK"
+        assert checks["Bundled extension truth"] == "WARN"
+        summary = result["summary"]
+        assert summary["fail_count"] == 0
+        assert summary["warn_count"] >= 1
+        extension_truth = result["extension_truth"]
+        assert extension_truth["runtime_backed"] >= 1
+        assert "PRJ-HELLO" in extension_truth["runtime_backed_ids"]
+        assert extension_truth["quarantined"] >= 1

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -1,0 +1,33 @@
+"""Behavioral tests for the structured doctor report surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ao_kernel.doctor_cmd import build_report
+
+
+class TestDoctorReport:
+    def test_build_report_returns_truth_inventory(self, tmp_workspace: Path):
+        report = build_report(workspace_root_override=str(tmp_workspace.parent))
+
+        assert report["exit_code"] == 0
+        assert report["version"]
+        assert isinstance(report["checks"], list)
+        assert len(report["checks"]) >= 8
+
+        checks = {item["label"]: item["status"] for item in report["checks"]}
+        assert checks["Workspace found"] == "OK"
+        assert checks["workspace.json valid"] == "OK"
+        assert checks["Bundled extension truth"] == "WARN"
+
+        summary = report["summary"]
+        assert summary["ok_count"] >= 1
+        assert summary["warn_count"] >= 1
+        assert summary["fail_count"] == 0
+
+        extension_truth = report["extension_truth"]
+        assert extension_truth["total_extensions"] >= 1
+        assert extension_truth["runtime_backed"] >= 1
+        assert extension_truth["quarantined"] >= 1
+        assert "PRJ-HELLO" in extension_truth["runtime_backed_ids"]


### PR DESCRIPTION
## Summary
- expose a structured doctor report from `ao_kernel.doctor_cmd`
- stop `AoKernelClient.doctor()` from scraping stdout
- strengthen doctor/client/CLI tests around extension truth evidence

## Validation
- pytest tests/test_doctor_cmd.py tests/test_client.py tests/test_cli.py -q
- ruff check ao_kernel/doctor_cmd.py ao_kernel/client.py tests/test_doctor_cmd.py tests/test_client.py tests/test_cli.py
- mypy ao_kernel/client.py ao_kernel/doctor_cmd.py
- python3 -m ao_kernel doctor