### PR TITLE
[codex] ci: cover stacked PR retarget checks

### DIFF
--- a/.claude/scripts/trigger-test-workflow.sh
+++ b/.claude/scripts/trigger-test-workflow.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# trigger-test-workflow.sh — Test workflow'unu mevcut branch için manuel tetikle.
+#
+# Özellikle stacked PR retarget sonrası GitHub otomatik check üretmezse
+# kullanılır. Branch push'u normalde codex/* için CI üretir; bu script
+# manuel fallback'tir.
+#
+# Kullanım:
+#   bash .claude/scripts/trigger-test-workflow.sh
+#   bash .claude/scripts/trigger-test-workflow.sh <branch>
+#   bash .claude/scripts/trigger-test-workflow.sh <branch> --watch
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)" 2>/dev/null || {
+  echo "✗ Not in a git repository"
+  exit 2
+}
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "✗ gh CLI bulunamadı"
+  exit 1
+fi
+
+branch="${1:-$(git branch --show-current)}"
+watch_flag="${2:-}"
+
+if [ -z "$branch" ]; then
+  echo "✗ Detached HEAD — branch adı ver:"
+  echo "  bash .claude/scripts/trigger-test-workflow.sh <branch>"
+  exit 1
+fi
+
+if ! git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+  echo "✗ origin/$branch bulunamadı — önce push et:"
+  echo "  git push -u origin $branch"
+  exit 1
+fi
+
+echo "→ Test workflow tetikleniyor: branch=$branch"
+gh workflow run test.yml --ref "$branch" -f reason="manual-retarget-check"
+
+sleep 3
+run_id=$(gh run list \
+  --workflow test.yml \
+  --branch "$branch" \
+  --event workflow_dispatch \
+  --limit 1 \
+  --json databaseId \
+  --jq '.[0].databaseId')
+
+if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+  echo "⚠ Run kuyruğu doğrulanamadı. Şunu izle:"
+  echo "  gh run list --workflow test.yml --branch $branch --limit 5"
+  exit 0
+fi
+
+echo "✓ Queued run id: $run_id"
+echo "  İzlemek için:"
+echo "    gh run watch $run_id"
+
+if [ "$watch_flag" = "--watch" ]; then
+  gh run watch "$run_id"
+fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,14 +2,80 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - "codex/**"
   pull_request:
     branches: [main]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - edited
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Manual rerun reason (e.g. stacked retarget)"
+        required: false
+        type: string
 
 jobs:
+  event-gate:
+    name: event-gate
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      trigger_reason: ${{ steps.decide.outputs.trigger_reason }}
+    steps:
+      - id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          EVENT_PATH: ${{ github.event_path }}
+          DISPATCH_REASON: ${{ github.event.inputs.reason || '' }}
+        run: |
+          should_run=false
+          trigger_reason=ignored
+
+          case "$EVENT_NAME" in
+            push)
+              should_run=true
+              trigger_reason="push"
+              ;;
+            workflow_dispatch)
+              should_run=true
+              trigger_reason="workflow_dispatch:${DISPATCH_REASON:-manual}"
+              ;;
+            pull_request)
+              case "$EVENT_ACTION" in
+                opened|reopened|synchronize|ready_for_review)
+                  should_run=true
+                  trigger_reason="pull_request:$EVENT_ACTION"
+                  ;;
+                edited)
+                  # Retarget (`base` changed) must rerun the full PR gate.
+                  if jq -e '.changes.base.ref.from' "$EVENT_PATH" >/dev/null 2>&1; then
+                    should_run=true
+                    trigger_reason="pull_request:retargeted"
+                  fi
+                  ;;
+              esac
+              ;;
+          esac
+
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+          echo "trigger_reason=$trigger_reason" >> "$GITHUB_OUTPUT"
+      - name: Explain trigger decision
+        run: |
+          echo "should_run=${{ steps.decide.outputs.should_run }}"
+          echo "trigger_reason=${{ steps.decide.outputs.trigger_reason }}"
+
   lint:
     name: lint
     runs-on: ubuntu-latest
+    needs: [event-gate]
+    if: needs.event-gate.outputs.should_run == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -26,6 +92,8 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    needs: [event-gate]
+    if: needs.event-gate.outputs.should_run == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -45,6 +113,8 @@ jobs:
   coverage:
     name: coverage
     runs-on: ubuntu-latest
+    needs: [event-gate]
+    if: needs.event-gate.outputs.should_run == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -66,7 +136,8 @@ jobs:
   packaging-smoke:
     name: packaging-smoke
     runs-on: ubuntu-latest
-    needs: [test, coverage, lint, typecheck]
+    needs: [event-gate, test, coverage, lint, typecheck]
+    if: needs.event-gate.outputs.should_run == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -80,6 +151,8 @@ jobs:
   typecheck:
     name: typecheck
     runs-on: ubuntu-latest
+    needs: [event-gate]
+    if: needs.event-gate.outputs.should_run == 'true'
     # CNS-006 Q4: after the 131-error cleanup (PR #56), typecheck is a real
     # gate. _internal/* is still under per-module ignore (D13).
     #
@@ -100,7 +173,8 @@ jobs:
   benchmark-fast:
     name: benchmark-fast
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [event-gate, test]
+    if: needs.event-gate.outputs.should_run == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -131,8 +205,8 @@ jobs:
   scorecard:
     name: scorecard
     runs-on: ubuntu-latest
-    needs: [benchmark-fast]
-    if: github.event_name == 'pull_request'
+    needs: [event-gate, benchmark-fast]
+    if: needs.event-gate.outputs.should_run == 'true' && github.event_name == 'pull_request'
     continue-on-error: true  # Advisory surface — never red-check PRs.
     permissions:
       pull-requests: write
@@ -179,6 +253,8 @@ jobs:
   extras-install:
     name: extras-install
     runs-on: ubuntu-latest
+    needs: [event-gate]
+    if: needs.event-gate.outputs.should_run == 'true'
     continue-on-error: true  # Optional extras smoke — non-blocking
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
-          EVENT_PATH: ${{ github.event_path }}
           DISPATCH_REASON: ${{ github.event.inputs.reason || '' }}
         run: |
           should_run=false
@@ -55,7 +54,7 @@ jobs:
                   ;;
                 edited)
                   # Retarget (`base` changed) must rerun the full PR gate.
-                  if jq -e '.changes.base.ref.from' "$EVENT_PATH" >/dev/null 2>&1; then
+                  if jq -e '.changes.base.ref.from' "$GITHUB_EVENT_PATH" >/dev/null 2>&1; then
                     should_run=true
                     trigger_reason="pull_request:retargeted"
                   fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -470,3 +470,55 @@ chmod +x .git/hooks/pre-commit
 ```
 
 **Not:** git worktree paylaşılan `.git/` kullanır, hook tüm worktree'lerde aktif olur. Bir kez kurulur, tüm session'lar korunur.
+
+## 19. Stacked PR Merge Protocol (2026-04-21)
+
+Bu repo short-lived stacked PR zincirini destekler, ama merge güvenliği için
+tek bir protokol izlenir. Amaç: alt PR merge olurken üst PR diff'lerinin
+kirlenmemesi ve retarget sonrası CI boşluğu oluşmaması.
+
+### Branch zinciri
+
+- Her katman fresh `main` üstünden açılan bir short-lived branch'ten başlar.
+- Stack gerekiyorsa üst branch, bir alt branch'i base alır:
+  - `codex/wp2-*` → base `main`
+  - `codex/wp3-*` → base `codex/wp2-*`
+  - `codex/wp4-*` → base `codex/wp3-*`
+- Her katman kendi kapsamı kadar diff taşır; alt PR dosyaları üst PR'da
+  tekrar görünüyorsa zincir bozulmuştur.
+
+### CI kuralı
+
+- `.github/workflows/test.yml` artık `codex/*` branch push'larında da koşar.
+  Bu sayede stacked branch daha PR açılmadan gerçek check üretir.
+- `pull_request` tetikleyicisi `ready_for_review` ve `edited` olaylarını da
+  dinler. `edited` yalnızca retarget (`base` değişti) ise gate'i yeniden koşturur.
+- Otomatik run görünmüyorsa manuel fallback:
+
+```bash
+bash .claude/scripts/trigger-test-workflow.sh <branch>
+```
+
+### Merge metodu
+
+- **Varsayılan stacked merge metodu = merge commit.**
+- Alt PR squash edilmez; squash üst branch diff'lerini kirletir, çünkü üst
+  branch'in taşıdığı alt commit'ler `main` geçmişinde görünmez hale gelir.
+- Squash yalnız tekil/non-stacked PR için veya üst branch'ler önceden restack
+  edildiğinde kabul edilebilir.
+
+### Sıralı uygulama
+
+1. En alt PR review + CI green → merge commit ile merge et.
+2. Bir üst PR'ı `main`e retarget et: `gh pr edit <id> --base main`
+3. `gh pr diff <id> --name-only` ile diff'in yalnız kendi katmanını taşıdığını doğrula.
+4. Check'ler otomatik görünmezse `trigger-test-workflow.sh` ile manuel CI tetikle.
+5. Review/CI temizse bir sonraki PR'a geç.
+
+### No-go koşulları
+
+- Retarget sonrası PR diff'i alt katman dosyalarını tekrar gösteriyorsa merge ETME.
+- Head branch push edilmemişse manuel dispatch ETME.
+- Kullanıcıya ait dirty dosya stage/commit içine karışmışsa merge hazırlığı yapma.
+- Branch policy review onayı istiyorsa self-comment yeterli sanma; gerekli onay
+  yolu açıkça doğrulanmadan normal merge komutu deneme.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,3 +522,34 @@ bash .claude/scripts/trigger-test-workflow.sh <branch>
 - Kullanıcıya ait dirty dosya stage/commit içine karışmışsa merge hazırlığı yapma.
 - Branch policy review onayı istiyorsa self-comment yeterli sanma; gerekli onay
   yolu açıkça doğrulanmadan normal merge komutu deneme.
+
+## 20. Hardening Principles (2026-04-21)
+
+Bu bölüm yaşayan hardening ilkelerinin SSOT'udur. Geçici plan dosyalarına
+eklenen ama repo genelinde kalıcı kural olması gereken notlar burada tutulur.
+
+1. **Coverage gate parity opsiyonel hijyen değildir.**
+   `pyproject.toml` içindeki coverage eşiği ile CI workflow gate'i aynı
+   gerçeği söylemelidir. "Kod tabanında 85, CI'de 70" tipi ayrışmalar docs
+   drift değil release-truth problemidir.
+
+2. **Packaging smoke kontaminasyon savunmasıdır.**
+   Editable install, aktif worktree, kullanıcı PATH'i veya eski console-script
+   kalıntıları sahte yeşil üretebilir. Release kanıtı ancak wheel-only kurulum
+   + temiz venv + repo dışı temp cwd kombinasyonu ile kabul edilir.
+
+3. **Deterministic test hygiene görünür backlog'tur.**
+   Wall-clock'a bağlı fixture'lar, kullanılmayan `now` parametreleri veya
+   tarihle çürüyen test varsayımları "küçük test borcu" diye saklanmaz.
+   Beta-blocker değillerse bile görünür iş paketi, release notu veya backlog
+   kalemi olarak izlenir.
+
+4. **Support matrix tek anlamlı kalmalıdır.**
+   Aynı yüzey aynı sürüm dokümanında birden fazla lifecycle kategorisi
+   taşımaz. Bir şey aynı anda hem `Beta` hem `Deferred`, ya da hem
+   `operator-managed` hem de `unsupported` gibi konuşulmaz.
+
+5. **Karar ilkesi: daha az vaat, daha güçlü kanıt.**
+   Runtime closure tamamlanmadan anlatı genişletilmez. Bir yüzey ancak
+   code path + davranışsal test + packaging smoke + support matrix birlikte
+   mevcutsa "destekli" kabul edilir.


### PR DESCRIPTION
## Summary
- run `Test` on `codex/*` branch pushes and allow manual `workflow_dispatch` reruns
- gate `pull_request.edited` so only base-retarget events rerun the full PR suite
- document the stacked PR merge protocol and add a helper script for manual fallback

## Validation
- bash -n .claude/scripts/trigger-test-workflow.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml")'\n- push-triggered `Test` workflow started on `codex/stacked-pr-ci-safety`\n- manual fallback queued via `.claude/scripts/trigger-test-workflow.sh codex/stacked-pr-ci-safety`