### PR TITLE
[codex] tests: strengthen advisory assertions

### DIFF
--- a/tests/test_patch_errors.py
+++ b/tests/test_patch_errors.py
@@ -94,7 +94,8 @@ class TestPatchBinaryUnsupportedError:
 
 class TestValidatePatchId:
     def test_accepts_typical_token_urlsafe(self) -> None:
-        validate_patch_id("abc123_DEF-456")
+        result = validate_patch_id("abc123_DEF-456")
+        assert result is None
 
     def test_rejects_non_string(self) -> None:
         with pytest.raises(ValueError, match="must be a string"):

--- a/tests/test_resolve_route_downgrade.py
+++ b/tests/test_resolve_route_downgrade.py
@@ -647,7 +647,10 @@ class TestClientLlmCallEmit:
             intent="DISCOVERY",
             run_id=run_id,
         )
-        assert result is not None  # completed past the emit block
+        assert result["status"] == "OK"
+        assert result["text"] == ""
+        assert result["tool_calls"] == []
+        assert result["usage"] is None
 
 
 class TestMultiStepDowngradeChain:

--- a/tests/test_shared_utils_coverage.py
+++ b/tests/test_shared_utils_coverage.py
@@ -538,11 +538,13 @@ class TestFactoryBranches:
         """factory.py line 29-30: when `secrets_path` kwarg is absent,
         default Path('.secrets/vault.json') is used."""
         from ao_kernel._internal.secrets.factory import create_provider
+        from ao_kernel._internal.secrets.vault_stub_provider import (
+            VaultStubSecretsProvider,
+        )
 
         provider = create_provider("vault_stub")
-        # We only pin the factory branch; provider.get() on a missing
-        # default path returns None (vault_stub happy-path handled).
-        assert provider is not None
+        assert isinstance(provider, VaultStubSecretsProvider)
+        assert provider._secrets_path == Path(".secrets/vault.json")
 
     def test_vault_stub_with_string_path_coerced_to_Path(
         self,
@@ -551,10 +553,14 @@ class TestFactoryBranches:
         """factory.py line 31-32: str `secrets_path` kwarg is coerced
         via Path()."""
         from ao_kernel._internal.secrets.factory import create_provider
+        from ao_kernel._internal.secrets.vault_stub_provider import (
+            VaultStubSecretsProvider,
+        )
 
         string_path = str(tmp_path / "my_secrets.json")
         provider = create_provider("vault_stub", secrets_path=string_path)
-        assert provider is not None
+        assert isinstance(provider, VaultStubSecretsProvider)
+        assert provider._secrets_path == Path(string_path)
 
 
 class TestHashiCorpVaultProviderBranches:


### PR DESCRIPTION
## Summary
- replace advisory-only assertions with behavioral assertions in three test files
- pin fail-open llm_call behavior with concrete response assertions
- assert vault_stub factory path semantics instead of only non-null construction

## Verification
- pytest -q tests/test_patch_errors.py tests/test_resolve_route_downgrade.py tests/test_shared_utils_coverage.py