### PR TITLE
[codex] tests: remove remaining warning drift

### DIFF
--- a/tests/test_canonical_store.py
+++ b/tests/test_canonical_store.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from ao_kernel.context.canonical_store import (
     CanonicalDecision,
     load_store,
@@ -24,7 +26,8 @@ class TestStoreLifecycle:
     def test_save_and_load_roundtrip(self, tmp_path: Path):
         store = load_store(tmp_path)
         store["decisions"]["test.key"] = {"value": "hello"}
-        save_store(tmp_path, store)
+        with pytest.deprecated_call(match="save_store\\(\\) is deprecated"):
+            save_store(tmp_path, store)
 
         loaded = load_store(tmp_path)
         assert "test.key" in loaded["decisions"]

--- a/tests/test_internal_roadmap_small_trio_coverage.py
+++ b/tests/test_internal_roadmap_small_trio_coverage.py
@@ -469,7 +469,7 @@ class TestSanitizeScanDirectory:
         assert findings == []
 
     def test_email_detected_triggers_rule(self, tmp_path: Path) -> None:
-        """Codex iter-1 absorb: exercise the ``EMAIL_DETECTED`` branch
+        r"""Codex iter-1 absorb: exercise the ``EMAIL_DETECTED`` branch
         of ``scan_directory``.
 
         The email regex at ``sanitize.py:39`` is

--- a/tests/test_llm_router_internal.py
+++ b/tests/test_llm_router_internal.py
@@ -11,33 +11,32 @@ from ao_kernel._internal.prj_kernel_api.llm_router import (
     resolve,
 )
 
+NOW = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)
+NOW_ISO = NOW.isoformat().replace("+00:00", "Z")
+
 
 class TestHelpers:
     def test_is_stale_none_ts(self):
-        now = datetime.now(timezone.utc)
-        assert _is_stale(None, 72, now) is True
+        assert _is_stale(None, 72, NOW) is True
 
     def test_is_stale_within_ttl(self):
-        now = datetime.now(timezone.utc)
-        ts = now.isoformat().replace("+00:00", "Z")
-        assert _is_stale(ts, 72, now) is False
+        assert _is_stale(NOW_ISO, 72, NOW) is False
 
     def test_is_stale_expired(self):
-        now = datetime.now(timezone.utc)
         old_ts = "2020-01-01T00:00:00Z"
-        assert _is_stale(old_ts, 72, now) is True
+        assert _is_stale(old_ts, 72, NOW) is True
 
     def test_eligible_verified_ok(self):
-        model = {"stage": "verified", "probe_status": "ok", "probe_last_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")}
-        assert _eligible(model, 72, datetime.now(timezone.utc)) is True
+        model = {"stage": "verified", "probe_status": "ok", "probe_last_at": NOW_ISO}
+        assert _eligible(model, 72, NOW) is True
 
     def test_eligible_not_verified(self):
-        model = {"stage": "pending", "probe_status": "ok", "probe_last_at": datetime.now(timezone.utc).isoformat()}
-        assert _eligible(model, 72, datetime.now(timezone.utc)) is False
+        model = {"stage": "pending", "probe_status": "ok", "probe_last_at": NOW_ISO}
+        assert _eligible(model, 72, NOW) is False
 
     def test_eligible_probe_failed(self):
-        model = {"stage": "verified", "probe_status": "error", "probe_last_at": datetime.now(timezone.utc).isoformat()}
-        assert _eligible(model, 72, datetime.now(timezone.utc)) is False
+        model = {"stage": "verified", "probe_status": "error", "probe_last_at": NOW_ISO}
+        assert _eligible(model, 72, NOW) is False
 
 
 class TestMergeState:


### PR DESCRIPTION
## Summary
- remove the remaining suite warnings by making the deprecated canonical-store save explicit in tests
- make llm router helper tests deterministic with a fixed timestamp seam
- turn the roadmap sanitize regression docstring into a raw string so collection stays warning-free

## Verification
- pytest -q tests/test_internal_roadmap_small_trio_coverage.py tests/test_canonical_store.py tests/test_llm_router_internal.py
- pytest -q tests --ignore=tests/benchmarks