### PR TITLE
[codex] roadmap: fix sanitize email detection

### DIFF
--- a/.claude/plans/POLICY-COMMAND-ENFORCEMENT-PROGRAM-PLAN.md
+++ b/.claude/plans/POLICY-COMMAND-ENFORCEMENT-PROGRAM-PLAN.md
@@ -71,7 +71,6 @@ Stable support surface:
 - OS-level sandbox / egress enforcement
 - full PR automation surface
 - post-beta correctness patch seti:
-  - `sanitize.py:39`
   - `compiler.py:139`
   - `init_cmd.py:30-33`
 
@@ -180,7 +179,7 @@ Stable gövdede henüz live OLMAYAN:
 | `WP-12` | Blocking CI packaging smoke | Faz 3 | `4.0.0b1` | Completed in branch | `WP-11` | CI workflow |
 | `WP-13` | Publish pre-smoke | Faz 3 | `4.0.0b1` | Completed in branch | `WP-11` | publish workflow |
 | `WP-14` | `PUBLIC-BETA.md` classification cleanup | Faz 3 | `4.0.0b1` | Completed in branch | Faz 2 | doc audit |
-| `WP-15` | `sanitize.py:39` | Faz 4 | post-beta | Deferred | — | future patch |
+| `WP-15` | `sanitize.py:39` | Faz 4 | post-beta | Completed in branch | — | unit test + doc cleanup |
 | `WP-16` | `compiler.py:139` | Faz 4 | post-beta | Deferred | — | future patch |
 | `WP-17` | `init_cmd.py:30-33` | Faz 4 | post-beta | Deferred | — | future patch |
 | `WP-18` | `bug_fix_flow + codex-stub patch_preview` | Faz 4 | post-beta | Deferred | — | future patch |

--- a/ao_kernel/_internal/roadmap/sanitize.py
+++ b/ao_kernel/_internal/roadmap/sanitize.py
@@ -36,7 +36,7 @@ def scan_directory(
     tokens = [t for t in (forbidden_tokens or DEFAULT_FORBIDDEN_TOKENS) if isinstance(t, str) and t.strip()]
 
     # Keep rules deterministic and simple.
-    email_re = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}", re.IGNORECASE)
+    email_re = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.IGNORECASE)
     private_key_markers = [
         "-----BEGIN PRIVATE KEY-----",
         "-----BEGIN OPENSSH PRIVATE KEY-----",
@@ -87,4 +87,3 @@ def scan_directory(
 def findings_fingerprint(findings: list[SanitizeFinding]) -> str:
     raw = "\n".join([f"{f.path}:{f.rule}" for f in findings]).encode("utf-8")
     return sha256(raw).hexdigest()[:16]
-

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -65,7 +65,6 @@ istemek gerekir.
 
 | Konum | Etki | Workaround | Beta blocker? | Hedef |
 |---|---|---|---|---|
-| `ao_kernel/_internal/roadmap/sanitize.py:39` | E-posta regex algısı hatalı davranabilir | Public Beta demo bu yolu sürmez | Hayır | Post-beta correctness patch |
 | `ao_kernel/_internal/roadmap/compiler.py:139` | `id` alanı olmayan milestone girdisi `KeyError` üretebilir | Public Beta demo `compile_roadmap` no-id milestone ile çağırmaz | Hayır | Post-beta correctness patch |
 | `ao_kernel/init_cmd.py:30-33` | `workspace_root_override` write-side asimetrik | Public Beta dokümanlarında `--workspace-root X` örneği verilmez | Hayır | Post-beta correctness patch |
 

--- a/tests/test_internal_roadmap_small_trio_coverage.py
+++ b/tests/test_internal_roadmap_small_trio_coverage.py
@@ -469,38 +469,20 @@ class TestSanitizeScanDirectory:
         assert findings == []
 
     def test_email_detected_triggers_rule(self, tmp_path: Path) -> None:
-        r"""Codex iter-1 absorb: exercise the ``EMAIL_DETECTED`` branch
-        of ``scan_directory``.
-
-        The email regex at ``sanitize.py:39`` is
-        ``r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}"`` — the raw string's
-        ``\\.`` is two literal characters (``\`` + ``.``), which makes
-        the regex match only strings that literally contain a backslash
-        before the TLD (e.g. ``user@example\.com``). Normal emails do
-        NOT match. This pin documents current behaviour so a later
-        regex fix (tracked as a separate follow-up) will notice the
-        contract change.
-        """
+        """Real-world email addresses must trigger ``EMAIL_DETECTED``."""
         from ao_kernel._internal.roadmap.sanitize import scan_directory
 
-        # NB: the backslash is literal on disk — that's what the buggy
-        # regex currently requires to fire.
-        (tmp_path / "mail.txt").write_text(r"contact: user@example\.com", encoding="utf-8")
+        (tmp_path / "mail.txt").write_text("contact: user@example.com", encoding="utf-8")
         ok, findings = scan_directory(root=tmp_path)
         assert ok is False
         rules = {f.rule for f in findings}
         assert "EMAIL_DETECTED" in rules
 
-    def test_email_regex_current_does_not_match_normal_address(self, tmp_path: Path) -> None:
-        """Regression companion for the pin above: a *normal* email
-        address (no backslash before the TLD) currently does NOT fire
-        ``EMAIL_DETECTED`` because of the same raw-string bug. When the
-        regex is fixed, this pin flips to a failure and flags the
-        change — operator replaces the two-pin pair with a single
-        real-world pin."""
+    def test_email_regex_does_not_match_backslash_escaped_pseudo_address(self, tmp_path: Path) -> None:
+        """A literal backslash before the TLD is not a valid email match."""
         from ao_kernel._internal.roadmap.sanitize import scan_directory
 
-        (tmp_path / "plain.txt").write_text("contact: user@example.com", encoding="utf-8")
+        (tmp_path / "plain.txt").write_text(r"contact: user@example\.com", encoding="utf-8")
         _, findings = scan_directory(root=tmp_path)
         rules = {f.rule for f in findings}
         assert "EMAIL_DETECTED" not in rules


### PR DESCRIPTION
## Summary
- fix the roadmap sanitize email regex so normal addresses trigger EMAIL_DETECTED
- replace the old buggy-regex pins with real-world behavior assertions
- remove the stale sanitize deferred-bug note from PUBLIC-BETA and mark WP-15 complete in the program plan

## Verification
- pytest -q tests/test_internal_roadmap_small_trio_coverage.py
- pytest -q tests --ignore=tests/benchmarks