### PR TITLE
[codex] roadmap: skip milestones without ids

### DIFF
--- a/.claude/plans/POLICY-COMMAND-ENFORCEMENT-PROGRAM-PLAN.md
+++ b/.claude/plans/POLICY-COMMAND-ENFORCEMENT-PROGRAM-PLAN.md
@@ -71,7 +71,6 @@ Stable support surface:
 - OS-level sandbox / egress enforcement
 - full PR automation surface
 - post-beta correctness patch seti:
-  - `compiler.py:139`
   - `init_cmd.py:30-33`
 
 ## 5. Değişmez Kurallar
@@ -180,7 +179,7 @@ Stable gövdede henüz live OLMAYAN:
 | `WP-13` | Publish pre-smoke | Faz 3 | `4.0.0b1` | Completed in branch | `WP-11` | publish workflow |
 | `WP-14` | `PUBLIC-BETA.md` classification cleanup | Faz 3 | `4.0.0b1` | Completed in branch | Faz 2 | doc audit |
 | `WP-15` | `sanitize.py:39` | Faz 4 | post-beta | Completed in branch | — | unit test + doc cleanup |
-| `WP-16` | `compiler.py:139` | Faz 4 | post-beta | Deferred | — | future patch |
+| `WP-16` | `compiler.py:139` | Faz 4 | post-beta | Completed in branch | — | unit test + doc cleanup |
 | `WP-17` | `init_cmd.py:30-33` | Faz 4 | post-beta | Deferred | — | future patch |
 | `WP-18` | `bug_fix_flow + codex-stub patch_preview` | Faz 4 | post-beta | Deferred | — | future patch |
 | `WP-19` | deterministic test hygiene / time drift | Faz 4 | post-beta | Partial blocker absorbed in branch | — | full-suite verification |

--- a/ao_kernel/_internal/roadmap/compiler.py
+++ b/ao_kernel/_internal/roadmap/compiler.py
@@ -136,7 +136,12 @@ def compile_roadmap(
 
     plan_milestones: list[dict[str, Any]] = []
     for ms in milestones_filtered:
-        ms_id = str(ms["id"])
+        ms_id_raw = ms.get("id")
+        if ms_id_raw is None:
+            continue
+        if isinstance(ms_id_raw, str) and not ms_id_raw.strip():
+            continue
+        ms_id = str(ms_id_raw)
         title = str(ms.get("title", ""))
         constraints = ms.get("constraints") if isinstance(ms.get("constraints"), dict) else {}
         deliverables = []

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -65,7 +65,6 @@ istemek gerekir.
 
 | Konum | Etki | Workaround | Beta blocker? | Hedef |
 |---|---|---|---|---|
-| `ao_kernel/_internal/roadmap/compiler.py:139` | `id` alanı olmayan milestone girdisi `KeyError` üretebilir | Public Beta demo `compile_roadmap` no-id milestone ile çağırmaz | Hayır | Post-beta correctness patch |
 | `ao_kernel/init_cmd.py:30-33` | `workspace_root_override` write-side asimetrik | Public Beta dokümanlarında `--workspace-root X` örneği verilmez | Hayır | Post-beta correctness patch |
 
 ## Kapsam Dışı Notlar

--- a/tests/test_internal_roadmap_compiler_coverage.py
+++ b/tests/test_internal_roadmap_compiler_coverage.py
@@ -206,11 +206,6 @@ class TestCompileRoadmapHappyPath:
         (line 88-89); non-string-id dicts land in ``plan["milestones"]``
         but are excluded from ``milestones_included`` because
         ``isinstance(ms_id, str)`` is False.
-
-        Note: the compiler currently accesses ``ms["id"]`` unguarded at
-        line 139 inside the render loop — dicts with NO ``id`` key at
-        all crash with ``KeyError``. That shape is intentionally
-        excluded from this pin; it is tracked as a separate follow-up.
         """
         from ao_kernel._internal.roadmap.compiler import compile_roadmap
 
@@ -236,6 +231,41 @@ class TestCompileRoadmapHappyPath:
         assert result.milestones_included == ["MS-1"]
         # Both dict-shaped milestones appear in the plan header.
         assert len(result.plan["milestones"]) == 2
+
+    def test_no_filter_skips_dict_without_id_in_render_loop(self, tmp_path: Path) -> None:
+        """A dict-shaped milestone without ``id`` must be skipped instead
+        of crashing the compiler."""
+        from ao_kernel._internal.roadmap.compiler import compile_roadmap
+
+        schema_path = _write_schema(tmp_path, _PERMISSIVE_SCHEMA)
+        roadmap_path = _write_roadmap(
+            tmp_path,
+            {
+                "roadmap_id": "R1",
+                "version": "v1",
+                "milestones": [
+                    {"title": "missing-id", "steps": [{"type": "noop"}]},
+                    {"id": "MS-1", "title": "ok", "steps": [{"type": "noop"}]},
+                ],
+            },
+        )
+        result = compile_roadmap(
+            roadmap_path=roadmap_path,
+            schema_path=schema_path,
+            cache_root=tmp_path / ".cache",
+        )
+        assert result.status == "OK"
+        assert result.milestones_included == ["MS-1"]
+        assert result.plan["milestones"] == [
+            {
+                "id": "MS-1",
+                "title": "ok",
+                "constraints": {},
+                "deliverables_count": 1,
+                "gates_count": 0,
+            }
+        ]
+        assert all(step["milestone_id"] == "MS-1" for step in result.plan["steps"])
 
     def test_iso_core_required_injects_preflight_step(self, tmp_path: Path) -> None:
         from ao_kernel._internal.roadmap.compiler import compile_roadmap


### PR DESCRIPTION
## Summary
- stop compile_roadmap from crashing on dict-shaped milestones that omit id
- add a coverage pin that proves no-id milestones are skipped instead of raising KeyError
- remove the stale compiler deferred-bug note from PUBLIC-BETA and mark WP-16 complete in the program plan

## Verification
- pytest -q tests/test_internal_roadmap_compiler_coverage.py
- pytest -q tests --ignore=tests/benchmarks