### PR TITLE
[codex] init: normalize workspace root override writes

### DIFF
--- a/.claude/plans/POLICY-COMMAND-ENFORCEMENT-PROGRAM-PLAN.md
+++ b/.claude/plans/POLICY-COMMAND-ENFORCEMENT-PROGRAM-PLAN.md
@@ -71,7 +71,6 @@ Stable support surface:
 - OS-level sandbox / egress enforcement
 - full PR automation surface
 - post-beta correctness patch seti:
-  - `init_cmd.py:30-33`
 
 ## 5. Değişmez Kurallar
 
@@ -180,7 +179,7 @@ Stable gövdede henüz live OLMAYAN:
 | `WP-14` | `PUBLIC-BETA.md` classification cleanup | Faz 3 | `4.0.0b1` | Completed in branch | Faz 2 | doc audit |
 | `WP-15` | `sanitize.py:39` | Faz 4 | post-beta | Completed in branch | — | unit test + doc cleanup |
 | `WP-16` | `compiler.py:139` | Faz 4 | post-beta | Completed in branch | — | unit test + doc cleanup |
-| `WP-17` | `init_cmd.py:30-33` | Faz 4 | post-beta | Deferred | — | future patch |
+| `WP-17` | `init_cmd.py:30-33` | Faz 4 | post-beta | Completed in branch | — | init override tests + doc cleanup |
 | `WP-18` | `bug_fix_flow + codex-stub patch_preview` | Faz 4 | post-beta | Deferred | — | future patch |
 | `WP-19` | deterministic test hygiene / time drift | Faz 4 | post-beta | Partial blocker absorbed in branch | — | full-suite verification |
 

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -697,7 +697,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--workspace-root",
         default=None,
-        help="Override workspace root directory",
+        help="Override project root or explicit .ao workspace directory",
     )
 
     sub = parser.add_subparsers(dest="command")

--- a/ao_kernel/init_cmd.py
+++ b/ao_kernel/init_cmd.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import ao_kernel
+from ao_kernel.config import resolve_workspace_dir
 
 
 def _now_iso() -> str:
@@ -25,12 +26,31 @@ def _write_json_atomic(path: Path, data: dict[str, Any]) -> None:
     tmp.replace(path)
 
 
+def _resolve_init_target(workspace_root_override: str | None) -> Path:
+    """Normalize init writes to the same workspace shape the read side accepts.
+
+    Supported override shapes:
+    - project root: ``<root>/.ao`` is created/used
+    - workspace dir: existing ``workspace.json`` directory is used as-is
+    - explicit ``.ao`` path: used as-is even before first init
+    """
+    if not workspace_root_override:
+        return Path.cwd() / ".ao"
+
+    override = Path(workspace_root_override).resolve()
+    resolved = resolve_workspace_dir(override)
+    if resolved != override:
+        return resolved
+    if override.name == ".ao":
+        return override
+    if (override / "workspace.json").is_file():
+        return override
+    return override / ".ao"
+
+
 def run(workspace_root_override: str | None = None) -> int:
     """Create .ao/ workspace. Idempotent — safe to run multiple times."""
-    if workspace_root_override:
-        target = Path(workspace_root_override).resolve()
-    else:
-        target = Path.cwd() / ".ao"
+    target = _resolve_init_target(workspace_root_override)
 
     if target.is_dir():
         ws_json = target / "workspace.json"

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -65,7 +65,6 @@ istemek gerekir.
 
 | Konum | Etki | Workaround | Beta blocker? | Hedef |
 |---|---|---|---|---|
-| `ao_kernel/init_cmd.py:30-33` | `workspace_root_override` write-side asimetrik | Public Beta dokümanlarında `--workspace-root X` örneği verilmez | Hayır | Post-beta correctness patch |
 
 ## Kapsam Dışı Notlar
 

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -33,9 +33,27 @@ class TestInitCmd:
         rc = run()
         assert rc == 0
 
-    def test_custom_root(self, tmp_path: Path):
-        custom = tmp_path / "custom_ws"
-        custom.mkdir()
-        rc = run(workspace_root_override=str(custom))
+    def test_project_root_override_creates_nested_ao_workspace(self, tmp_path: Path):
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        rc = run(workspace_root_override=str(project_root))
         assert rc == 0
-        assert (custom / "workspace.json").is_file()
+        assert (project_root / ".ao" / "workspace.json").is_file()
+        assert not (project_root / "workspace.json").exists()
+
+    def test_explicit_ao_override_still_writes_directly(self, tmp_path: Path):
+        ao_dir = tmp_path / "project" / ".ao"
+        rc = run(workspace_root_override=str(ao_dir))
+        assert rc == 0
+        assert (ao_dir / "workspace.json").is_file()
+
+    def test_existing_workspace_dir_override_is_idempotent(self, tmp_path: Path, capsys):
+        ao_dir = tmp_path / "project" / ".ao"
+        rc1 = run(workspace_root_override=str(ao_dir))
+        assert rc1 == 0
+        capsys.readouterr()
+
+        rc2 = run(workspace_root_override=str(tmp_path / "project"))
+        assert rc2 == 0
+        out = capsys.readouterr().out
+        assert "already exists" in out.lower()


### PR DESCRIPTION
## Summary
- normalize init writes so workspace-root project-root overrides create or reuse project-root/.ao
- keep explicit .ao overrides and existing direct workspace dirs working
- remove the stale init deferred-bug note from PUBLIC-BETA and mark WP-17 complete in the program plan

## Verification
- pytest -q tests/test_init_cmd.py tests/test_cli.py tests/test_cli_concurrency.py tests/test_resolve_workspace_dir_v3131_p1.py
- pytest -q tests --ignore=tests/benchmarks