### PR TITLE
[codex] governance: add repo-side merge gates

### DIFF
--- a/.claude/plans/POLICY-COMMAND-ENFORCEMENT-PROGRAM-PLAN.md
+++ b/.claude/plans/POLICY-COMMAND-ENFORCEMENT-PROGRAM-PLAN.md
@@ -1,6 +1,12 @@
 # Policy Command Enforcement Closure — Program Plan
 
-**Durum:** Faz 1-3 implemented in branch, verification passed
+> **Tarihsel plan notu (2026-04-22):** Bu dosya policy-command-closure
+> programının tarihsel plan kaydıdır. Yaşayan execution backlog ve güncel
+> program durumu için
+> [`.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`](./PRODUCTION-HARDENING-PROGRAM-STATUS.md)
+> dosyasını kullanın.
+
+**Durum:** Tarihsel plan kaydı; Faz 1-3 closure daha sonra `main` hattına absorb edildi
 **Onay tarihi:** 2026-04-20
 **Plan sahibi:** Codex
 **Yürütme modu:** Kapsam disiplini

--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -1,0 +1,162 @@
+# Production Hardening Program Status
+
+**Durum tarihi:** 2026-04-22
+**Amaç:** `ao-kernel`'i dar ama kanıtlı Public Beta yüzeyinden, kontrollü
+adımlarla daha güvenilir ve sonunda daha genel amaçlı production-grade coding
+automation platform çizgisine taşımak.
+**Yürütme modu:** Kapsam disiplini
+**Bu dosyanın rolü:** yaşayan execution backlog + program status SSOT
+
+## 1. SSOT Sınırları
+
+- **Program execution status / backlog:** bu dosya
+- **Yaşayan hardening ilkeleri:** `CLAUDE.md` §20
+- **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
+- **Tarihsel policy-command closure planı:** `.claude/plans/POLICY-COMMAND-ENFORCEMENT-PROGRAM-PLAN.md`
+- **GitHub milestone:** [Production Hardening Program](https://github.com/Halildeu/ao-kernel/milestone/1)
+- **GitHub tracker issue:** [#201](https://github.com/Halildeu/ao-kernel/issues/201)
+
+## 2. Başlangıç Gerçeği
+
+- `WP-0` ile `WP-4` fiilen kapanmıştır.
+- `main` hattında truth parity, policy command enforcement, behavioral policy
+  tests ve wheel-first packaging smoke mevcuttur.
+- Repo bugün **dar ama kanıtlı bir governed runtime / Public Beta** seviyesindedir.
+- Repo bugün hâlâ **genel amaçlı production coding automation platformu**
+  seviyesinde değildir.
+
+## 3. Yürütme Kuralları
+
+1. Aynı anda en fazla `1 ana WP + 1 düşük riskli docs/test WP` açık olur.
+2. Her WP tek branch, tek PR, tek net kabul kriteri ile yürür.
+3. Runtime semantiği değiştiren WP, kendinden önceki aktif runtime WP merge
+   olmadan başlamaz.
+4. Her WP kapanışında zorunlu kayıt:
+   - status güncellemesi
+   - PR / commit referansı
+   - test kanıtı
+   - smoke / package kanıtı gerekiyorsa onun çıktısı
+   - kalan deferred notları
+5. Support boundary ancak code path + davranışsal test + CI gate + ilgili doc
+   birlikte mevcutsa genişletilir.
+
+## 4. Program Tahtası
+
+| WP | Faz | Durum | Hedef | Zorunlu kanıt |
+|---|---|---|---|---|
+| `WP-0` Authority/support matrix | Baseline | Completed on `main` | shipped / beta / deferred / inventory ayrımı | `docs/PUBLIC-BETA.md`, README parity |
+| `WP-1` Runtime/docs truth patch | Baseline | Completed on `main` | docs overclaim temizliği | docs diff + review |
+| `WP-2` Policy command enforcement | Baseline | Completed on `main` | adapter CLI command deny gerçekten live | runtime tests + deny repro |
+| `WP-3` Policy rollout test upgrade | Baseline | Completed on `main` | behavior-first governance testleri | rollout pytest paketi |
+| `WP-4` Packaging/install trust | Baseline | Completed on `main` | wheel-only smoke gerçek gate olur | `scripts/packaging_smoke.py` + CI |
+| `WP-5` Release governance hardening | Faz 3 | **Active** ([#196](https://github.com/Halildeu/ao-kernel/issues/196)) | branch protection / required checks / CODEOWNERS / merge gate sertliği | repo diff + GitHub settings checklist |
+| `WP-6` Worktree/branch safety control loop | Faz 3 | Planned ([#197](https://github.com/Halildeu/ao-kernel/issues/197)) | stale base / overlap / dirty worktree riskini operasyonel kapatmak | ops komutları + usage proof |
+| `WP-7` Path-scoped write ownership | Faz 3 | Planned ([#198](https://github.com/Halildeu/ao-kernel/issues/198)) | aynı path alanına iki aktif writer çakışmasın | ownership tests + takeover audit |
+| `WP-8` Real adapter certification | Faz 4 | Planned ([#199](https://github.com/Halildeu/ao-kernel/issues/199)) | en az 2 gerçek adapter prod-tier smoke ve failure-mode testlerinden geçsin | capability matrix + smoke logs |
+| `WP-9` Ops/runbook/incident readiness | Faz 4 | Planned ([#200](https://github.com/Halildeu/ao-kernel/issues/200)) | rollback / incident / support boundary / known bugs paketi | runbook + drill evidence |
+
+## 5. Şimdi
+
+### `WP-5` — Release Governance Hardening
+
+**Neden şimdi**
+- Teknik closure büyük ölçüde tamam; bundan sonraki ana risk yanlış merge,
+  yumuşak gate veya repo-policy bypass.
+
+**GitHub takip**
+- üst issue: [#196](https://github.com/Halildeu/ao-kernel/issues/196)
+- aktif slice: [#195](https://github.com/Halildeu/ao-kernel/issues/195)
+- canlı envanter: [`WP-5.1-GOVERNANCE-INVENTORY.md`](./WP-5.1-GOVERNANCE-INVENTORY.md)
+- repo-side governance SSOT: [`.github/REPO-GOVERNANCE.md`](../../.github/REPO-GOVERNANCE.md)
+
+**Adım sırası**
+1. `[x]` Repo içinden zorunlu check isimlerini ve merge protokolünü netleştir.
+2. `[x]` GitHub settings tarafında repo dışı kalan kontroller için yazılı checklist üret.
+3. `[x]` `.github/CODEOWNERS` eklendi; code-owner enforcement önkoşulu yazılı hale getirildi.
+4. `[x]` `main` release gate'inin hangi kısmı repoda, hangi kısmı platform ayarında
+   enforced bunu kalıcı governance dokümanına bağla.
+5. `[ ]` GitHub branch protection ayarlarını hedef konfigürasyona çek (`WP-5.3`).
+
+**Canlı snapshot**
+- required check'ler şu an: `lint`, `test (3.11)`, `test (3.12)`,
+  `test (3.13)`, `coverage`, `typecheck`
+- `packaging-smoke` workflow'da blocking ama branch protection'da required değil
+- `.github/CODEOWNERS` repo içinde var; platform enforcement için ikinci maintainer
+  veya açık istisna kararı gerekiyor
+- `dismiss_stale_reviews=false`
+- `require_code_owner_reviews=false`
+- `enforce_admins=false`
+
+**Definition of Done**
+- required checks listesi yazılı ve güncel
+- code-owner review beklentisi repo içinde görünür
+- admin bypass / stale review / strict merge için dış-ayar checklist'i mevcut
+- normal geliştirici akışını bozmadan merge güvenliği artmış
+
+## 6. Sonra
+
+### `WP-6` — Worktree/Branch Safety Control Loop
+
+**Amaç**
+- merge'de kaybolma, stale worktree ile ilerleme, overlap fark etmeme
+  problemlerini operasyona gömmek
+
+**Hedef slice'lar**
+1. `ops preflight`
+2. `ops overlap-check`
+3. `ops close-worktree`
+4. `ops archive-worktree`
+
+### `WP-7` — Path-Scoped Write Ownership
+
+**Amaç**
+- mevcut claim/fencing altyapısını path-grubu ownership seviyesine taşımak
+
+**Hedef slice'lar**
+1. ownership model ve resource namespace kararı
+2. claim / release / takeover / handoff kaydı
+3. executor veya orchestration girişinde write ownership enforcement
+
+## 7. En Son
+
+### `WP-8` — Real Adapter Certification
+
+**Amaç**
+- stub-demodan çıkıp gerçek adapter yüzeyini kanıtlı hale getirmek
+
+**Minimum kabul**
+- en az 2 gerçek adapter
+- timeout / cancel / retry / idempotency / secret handling / audit completeness
+- production-tier smoke + failure-mode testleri
+
+### `WP-9` — Operations / Runbook / Incident Readiness
+
+**Amaç**
+- ürünün sadece çalışması değil, işletilebilir olması
+
+**Minimum kabul**
+- incident runbook
+- rollback yolu
+- upgrade notes
+- support boundary
+- non-empty known bugs registry
+
+## 8. Anlık Öncelik
+
+Bugünden itibaren doğru sıra:
+
+1. `WP-5` Release governance hardening
+2. `WP-6` Worktree/branch safety control loop
+3. `WP-7` Path-scoped write ownership
+4. `WP-8` Real adapter certification
+5. `WP-9` Ops/runbook/incident readiness
+
+## 9. Güncelleme Protokolü
+
+Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
+
+- aktif WP
+- tamamlanan WP'nin durumu
+- kanıt referansı
+- yeni risk veya deferred notu
+- sıradaki tek aktif hat

--- a/.claude/plans/WP-5.1-GOVERNANCE-INVENTORY.md
+++ b/.claude/plans/WP-5.1-GOVERNANCE-INVENTORY.md
@@ -1,0 +1,158 @@
+# WP-5.1 — Governance Inventory and Merge Gate Checklist
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#195](https://github.com/Halildeu/ao-kernel/issues/195)
+**Üst WP:** [#196](https://github.com/Halildeu/ao-kernel/issues/196)
+**Milestone:** [Production Hardening Program](https://github.com/Halildeu/ao-kernel/milestone/1)
+
+## 1. Amaç
+
+Repo içindeki merge/review/check guard'larını tek yerde envanterlemek ve
+repo dışı GitHub settings tarafında kalan enforcement boşluklarını görünür
+hale getirmek.
+
+Bu slice runtime davranışı değiştirmez. Amacı, `WP-5` için gerçek
+başlangıç noktası ve sıradaki governance PR kapsamını kilitlemektir.
+
+## 2. Repo İçi Guard Envanteri
+
+### 2.1 CI / workflow yüzeyi
+
+`test.yml` şu işleri üretir:
+
+- `event-gate`
+- `lint`
+- `test (3.11)`
+- `test (3.12)`
+- `test (3.13)`
+- `coverage`
+- `typecheck`
+- `packaging-smoke`
+- `benchmark-fast`
+- `scorecard`
+- `extras-install`
+
+Canlı gözlem:
+
+- `packaging-smoke` workflow içinde blocking iş olarak tanımlı; `needs:
+  [event-gate, test, coverage, lint, typecheck]` ile ana test katmanına bağlı.
+- `scorecard` advisory (`continue-on-error: true`).
+- `extras-install` non-blocking (`continue-on-error: true`).
+- `push` için `main` ve `codex/**` branch'lerinde tetikleniyor.
+- `pull_request` için `opened`, `reopened`, `synchronize`,
+  `ready_for_review`, `edited` (retarget) olaylarında tetikleniyor.
+- `workflow_dispatch` fallback mevcut.
+
+### 2.2 Repo içi operasyon guard'ları
+
+- `.claude/scripts/check-branch-sync.sh`
+  - stale branch / forbidden branch pattern / detached HEAD kontrolü
+- `.claude/scripts/pre-commit-version-gate.sh`
+  - stale base üstünde version bump bloklama
+- `.claude/scripts/trigger-test-workflow.sh`
+  - retarget sonrası manuel workflow tetikleme fallback'i
+- `CLAUDE.md`
+  - branch discipline
+  - stacked PR merge protocol
+  - living hardening principles
+
+## 3. GitHub Protection Snapshot
+
+Kaynak: `gh api repos/Halildeu/ao-kernel/branches/main/protection`
+
+### 3.1 Aktif branch protection
+
+- Required status checks: **aktif**
+- Required review count: **1**
+- Required conversation resolution: **aktif**
+- Force push: **kapalı**
+- Branch deletion: **kapalı**
+
+### 3.2 Şu an required olan check'ler
+
+- `lint`
+- `test (3.11)`
+- `test (3.12)`
+- `test (3.13)`
+- `coverage`
+- `typecheck`
+
+### 3.3 Şu an required OLMAYAN ama kritik olanlar
+
+- `packaging-smoke`
+
+### 3.4 Şu an zayıf kalan protection ayarları
+
+- `required_status_checks.strict = false`
+- `dismiss_stale_reviews = false`
+- `require_code_owner_reviews = false`
+- `require_last_push_approval = false`
+- `enforce_admins = false`
+
+### 3.5 Şu an eksik repo artefaktı
+
+- `.github/CODEOWNERS` **yok**
+
+### 3.6 Ruleset durumu
+
+Kaynak: `gh api repos/Halildeu/ao-kernel/rules/branches/main`
+
+- `main` için ayrı branch ruleset dönmüyor (`[]`)
+- Mevcut enforcement klasik branch protection üstünden geliyor gibi görünüyor
+
+## 4. Hüküm
+
+Bugünkü governance resmi:
+
+- Repo tarafında CI, branch discipline ve stacked PR protokolü artık güçlü.
+- GitHub protection tarafı ise **temel seviyede**, ama henüz "sert" değil.
+- En kritik açıklık: `packaging-smoke` required değil.
+- İkinci kritik açıklık: `CODEOWNERS` yok, dolayısıyla code-owner review
+  beklentisi fiilen enforce edilemiyor.
+- Üçüncü kritik açıklık: stale review dismissal ve admin enforcement kapalı.
+
+## 5. WP-5 İçin Sıradaki Slice'lar
+
+### `WP-5.2` Repo-side governance PR
+
+Hedef:
+
+1. `.github/CODEOWNERS` ekle
+2. governance/readme/checklist dokümanını repo içinde görünür hale getir
+3. required check seti için önerilen hedef konfigürasyonu yaz
+4. tek-maintainer döneminde code-owner enforcement önkoşulunu açık yaz
+
+Beklenen repo diff:
+
+- `.github/CODEOWNERS`
+- `.github/REPO-GOVERNANCE.md`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- yaşayan status dosyasında `WP-5` ilerleme notu
+
+### `WP-5.3` GitHub settings enforcement pass
+
+Repo dışı uygulama checklist'i:
+
+1. `packaging-smoke` required check olarak ekle
+2. `strict=true`
+3. `dismiss_stale_reviews=true`
+4. `require_code_owner_reviews=true`
+5. `enforce_admins=true`
+
+Not:
+
+- `require_last_push_approval=true` isteğe bağlı sıkılaştırmadır; ayrı karar
+  ister. İlk governance pass'te zorunlu kabul edilmez.
+- `require_code_owner_reviews=true` ayarı, canlı collaborator seti tek maintainer
+  ise merge akışını kilitleyebilir; bu yüzden repo-side ownership yüzeyi ile
+  platform enforcement kararı bilinçli olarak ayrılır.
+
+## 6. Slice DoD
+
+`WP-5.1` tamamlandı sayılabilmesi için:
+
+1. Repo içi guard envanteri yazılı olmalı
+2. GitHub protection snapshot yazılı olmalı
+3. Açık boşluklar net listelenmiş olmalı
+4. Sıradaki repo-side PR (`WP-5.2`) kapsamı tek anlamlı olmalı
+5. Issue #195 ve yaşayan status dosyası bu snapshot'a bağlanmış olmalı

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owner
+* @Halildeu
+
+# Governance-sensitive surfaces
+/.github/ @Halildeu
+/.claude/ @Halildeu
+/CLAUDE.md @Halildeu
+/ao_kernel/defaults/policies/ @Halildeu
+/docs/ @Halildeu

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Scope
+
+- Issue:
+- Work package:
+- Why now:
+
+## Validation
+
+- [ ] Relevant tests:
+- [ ] Smoke or packaging proof (if required):
+- [ ] Docs or status updated:
+- [ ] Deferred risks noted:
+
+## Governance checks
+
+- [ ] Branch is short-lived and based on fresh `main`
+- [ ] No unrelated dirty files were included
+- [ ] If stacked: retarget + diff re-check completed
+- [ ] Required check impact reviewed (`lint`, `test (3.11)`, `test (3.12)`, `test (3.13)`, `coverage`, `typecheck`, `packaging-smoke`)
+- [ ] If governance changed: `.github/REPO-GOVERNANCE.md` updated
+
+## Merge notes
+
+- [ ] Merge method chosen deliberately (`merge commit` for stacked PRs)

--- a/.github/REPO-GOVERNANCE.md
+++ b/.github/REPO-GOVERNANCE.md
@@ -1,0 +1,120 @@
+# Repo Governance and Merge Gates
+
+**Durum tarihi:** 2026-04-22
+**Program status SSOT:** [`.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`](../.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md)
+**Operasyon protokolü:** `CLAUDE.md` §19 ve §20
+
+Bu doküman `main` hattı için repo tarafında görünen merge güvenliği
+yüzeylerinin kısa SSOT özetidir. Amaç, "hangi gate repoda", "hangi gate GitHub
+ayarında" ve "hangi sıkılaştırma henüz platformda açılmadı" sorularını tek
+bakışta cevaplamaktır.
+
+## 1. Repo İçinde Enforce Edilenler
+
+### 1.1 Workflow gate yüzeyi
+
+Kaynak: `.github/workflows/test.yml`
+
+Workflow içinde gerçek hard gate olarak ele alınan işler:
+
+- `lint`
+- `test (3.11)`
+- `test (3.12)`
+- `test (3.13)`
+- `coverage`
+- `typecheck`
+- `packaging-smoke`
+
+Bu yüzeyde ek CI sinyalleri de vardır:
+
+- `benchmark-fast`
+  - görünür regresyon sinyalidir; `main` hattında yeşil kalması beklenir
+- `scorecard`
+  - advisory, `continue-on-error: true`
+- `extras-install`
+  - optional smoke, `continue-on-error: true`
+
+### 1.2 Repo içi operasyon guard'ları
+
+- `.claude/scripts/check-branch-sync.sh`
+  - stale branch, yasak branch pattern'i, detached HEAD kontrolü
+- `.claude/scripts/pre-commit-version-gate.sh`
+  - stale base üstünde version bump bloklama
+- `.claude/scripts/trigger-test-workflow.sh`
+  - retarget sonrası manuel workflow tetikleme fallback'i
+- `.github/PULL_REQUEST_TEMPLATE.md`
+  - scope, validation ve governance checklist yüzeyi
+- `.github/CODEOWNERS`
+  - ownership SSOT
+
+## 2. GitHub Platform Ayarında Enforce Edilenler
+
+Kaynak: `gh api repos/Halildeu/ao-kernel/branches/main/protection`
+
+Şu an aktif branch protection unsurları:
+
+- required status checks
+- 1 approval
+- conversation resolution
+- force-push kapalı
+- branch deletion kapalı
+
+## 3. `main` İçin Hedef Protection Konfigürasyonu
+
+WP-5 hedefi olarak `main` branch protection için beklenen minimum set:
+
+### 3.1 Required checks
+
+- `lint`
+- `test (3.11)`
+- `test (3.12)`
+- `test (3.13)`
+- `coverage`
+- `typecheck`
+- `packaging-smoke`
+
+### 3.2 Review ve merge ayarları
+
+- `strict = true`
+- `dismiss_stale_reviews = true`
+- `required_approving_review_count = 1`
+- `required_conversation_resolution = true`
+- `enforce_admins = true`
+
+### 3.3 Code-owner notu
+
+`CODEOWNERS` dosyası repo içinde şimdi mevcuttur, ancak `require_code_owner_reviews = true`
+ayarının platformda açılması operasyonel bir önkoşula bağlıdır:
+
+- Şu an canlı GitHub collaborator görünümünde yalnız `@Halildeu` yazma/admin
+  yetkisi ile görünmektedir.
+- Bu durumda code-owner review zorunluluğu tek maintainer döneminde normal
+  merge akışını kilitleyebilir.
+
+Bu yüzden code-owner enforcement kararı iki şekilde ele alınmalıdır:
+
+1. en az bir ikinci write-access maintainer görünür hale geldiğinde platformda
+   `require_code_owner_reviews = true` açılır
+2. aksi durumda `CODEOWNERS` repo içi ownership ve review hedefi olarak kalır,
+   ama platform enforcement ayrı karar olarak tutulur
+
+Bu nüans `WP-5.3` sırasında açıkça yeniden değerlendirilmelidir.
+
+## 4. İşletim Kuralları
+
+- Stacked PR zincirlerinde varsayılan merge yöntemi `merge commit`tir.
+- Alt PR merge olduktan sonra üst PR retarget edilip diff yeniden doğrulanır.
+- Retarget sonrası otomatik check üretilmezse `.claude/scripts/trigger-test-workflow.sh`
+  fallback olarak kullanılır.
+- Runtime veya packaging yüzeyine dokunan değişikliklerde docs/runtime/test/CI
+  parity birlikte korunur; yalnız doküman yeşili release kanıtı sayılmaz.
+
+## 5. Bu Dokümanın Rolü
+
+Bu dosya yaşayan backlog değildir. Yaşayan execution durumu için:
+
+- `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
+
+Tarihsel inventory ve slice geçmişi için:
+
+- `.claude/plans/WP-5.1-GOVERNANCE-INVENTORY.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -527,6 +527,10 @@ bash .claude/scripts/trigger-test-workflow.sh <branch>
 
 Bu bölüm yaşayan hardening ilkelerinin SSOT'udur. Geçici plan dosyalarına
 eklenen ama repo genelinde kalıcı kural olması gereken notlar burada tutulur.
+Program execution status / backlog SSOT:
+`.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
+Repo-side merge governance özeti:
+`.github/REPO-GOVERNANCE.md`
 
 1. **Coverage gate parity opsiyonel hijyen değildir.**
    `pyproject.toml` içindeki coverage eşiği ile CI workflow gate'i aynı


### PR DESCRIPTION
## Summary

This PR turns `WP-5.2` into a repo-side governance slice. It does not change runtime behavior.

The diff adds three permanent repo governance surfaces:

- `.github/CODEOWNERS`
- `.github/REPO-GOVERNANCE.md`
- `.github/PULL_REQUEST_TEMPLATE.md`

It also lands the living production-hardening status artifacts and marks the older policy-command plan as historical, so maintainers have a single execution SSOT.

## Problem

`WP-5.1` showed that repo-side CI and branch-discipline guardrails were already stronger than the platform-side branch-protection settings, but the repo still lacked three important maintainer-facing surfaces:

- explicit ownership (`CODEOWNERS`)
- a permanent "repo gates vs GitHub settings" governance summary
- a PR-time checklist that makes merge discipline visible at review time

Without those surfaces, required-check intent, stacked PR expectations, and code-owner rollout constraints stayed too implicit.

## What changed

- add `.github/CODEOWNERS`
- add `.github/REPO-GOVERNANCE.md` as the maintainer-facing merge-gate SSOT
- add `.github/PULL_REQUEST_TEMPLATE.md` with scope, validation, and governance checks
- add `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md` as the living execution backlog/status SSOT
- add `.claude/plans/WP-5.1-GOVERNANCE-INVENTORY.md` as the recorded governance snapshot
- mark `.claude/plans/POLICY-COMMAND-ENFORCEMENT-PROGRAM-PLAN.md` as historical and point `CLAUDE.md` to the living SSOT files

## Operator impact

- no runtime semantics change
- no workflow/job logic change
- no branch-protection setting changed directly in this PR

One important nuance is now documented explicitly: `CODEOWNERS` can land immediately, but `require_code_owner_reviews=true` should not be enabled blindly while the live collaborator set is effectively single-maintainer, because that would risk deadlocking normal merges.

## Validation

- `bash .claude/scripts/check-branch-sync.sh`
- `git diff --check`
- `gh api 'repos/Halildeu/ao-kernel/collaborators?per_page=100' --jq '.[] | [.login, .permissions.admin, .permissions.push] | @tsv'`
- no local pytest run; this slice is docs/governance-only

## Refs

- Refs #196
- Refs #195
