### PR TITLE
[codex] ops: add session preflight command

### DIFF
--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -21,6 +21,9 @@ automation platform çizgisine taşımak.
 - `WP-0` ile `WP-4` fiilen kapanmıştır.
 - `main` hattında truth parity, policy command enforcement, behavioral policy
   tests ve wheel-first packaging smoke mevcuttur.
+- `WP-5` repo-side governance closure ve güvenli branch-protection tightening
+  uygulanmıştır; `enforce_admins` kişisel repo + tek maintainer kısıtı nedeniyle
+  bilinçli olarak deferred kalır.
 - Repo bugün **dar ama kanıtlı bir governed runtime / Public Beta** seviyesindedir.
 - Repo bugün hâlâ **genel amaçlı production coding automation platformu**
   seviyesinde değildir.
@@ -49,63 +52,46 @@ automation platform çizgisine taşımak.
 | `WP-2` Policy command enforcement | Baseline | Completed on `main` | adapter CLI command deny gerçekten live | runtime tests + deny repro |
 | `WP-3` Policy rollout test upgrade | Baseline | Completed on `main` | behavior-first governance testleri | rollout pytest paketi |
 | `WP-4` Packaging/install trust | Baseline | Completed on `main` | wheel-only smoke gerçek gate olur | `scripts/packaging_smoke.py` + CI |
-| `WP-5` Release governance hardening | Faz 3 | **Active** ([#196](https://github.com/Halildeu/ao-kernel/issues/196)) | branch protection / required checks / CODEOWNERS / merge gate sertliği | repo diff + GitHub settings checklist |
-| `WP-6` Worktree/branch safety control loop | Faz 3 | Planned ([#197](https://github.com/Halildeu/ao-kernel/issues/197)) | stale base / overlap / dirty worktree riskini operasyonel kapatmak | ops komutları + usage proof |
+| `WP-5` Release governance hardening | Faz 3 | Completed on `main` | branch protection / required checks / CODEOWNERS / merge gate sertliği | PR #202 + branch protection snapshot |
+| `WP-6` Worktree/branch safety control loop | Faz 3 | **Active** ([#197](https://github.com/Halildeu/ao-kernel/issues/197)) | stale base / overlap / dirty worktree riskini operasyonel kapatmak | ops komutları + usage proof |
 | `WP-7` Path-scoped write ownership | Faz 3 | Planned ([#198](https://github.com/Halildeu/ao-kernel/issues/198)) | aynı path alanına iki aktif writer çakışmasın | ownership tests + takeover audit |
 | `WP-8` Real adapter certification | Faz 4 | Planned ([#199](https://github.com/Halildeu/ao-kernel/issues/199)) | en az 2 gerçek adapter prod-tier smoke ve failure-mode testlerinden geçsin | capability matrix + smoke logs |
 | `WP-9` Ops/runbook/incident readiness | Faz 4 | Planned ([#200](https://github.com/Halildeu/ao-kernel/issues/200)) | rollback / incident / support boundary / known bugs paketi | runbook + drill evidence |
 
 ## 5. Şimdi
 
-### `WP-5` — Release Governance Hardening
-
-**Neden şimdi**
-- Teknik closure büyük ölçüde tamam; bundan sonraki ana risk yanlış merge,
-  yumuşak gate veya repo-policy bypass.
-
-**GitHub takip**
-- üst issue: [#196](https://github.com/Halildeu/ao-kernel/issues/196)
-- aktif slice: [#195](https://github.com/Halildeu/ao-kernel/issues/195)
-- canlı envanter: [`WP-5.1-GOVERNANCE-INVENTORY.md`](./WP-5.1-GOVERNANCE-INVENTORY.md)
-- repo-side governance SSOT: [`.github/REPO-GOVERNANCE.md`](../../.github/REPO-GOVERNANCE.md)
-
-**Adım sırası**
-1. `[x]` Repo içinden zorunlu check isimlerini ve merge protokolünü netleştir.
-2. `[x]` GitHub settings tarafında repo dışı kalan kontroller için yazılı checklist üret.
-3. `[x]` `.github/CODEOWNERS` eklendi; code-owner enforcement önkoşulu yazılı hale getirildi.
-4. `[x]` `main` release gate'inin hangi kısmı repoda, hangi kısmı platform ayarında
-   enforced bunu kalıcı governance dokümanına bağla.
-5. `[ ]` GitHub branch protection ayarlarını hedef konfigürasyona çek (`WP-5.3`).
-
-**Canlı snapshot**
-- required check'ler şu an: `lint`, `test (3.11)`, `test (3.12)`,
-  `test (3.13)`, `coverage`, `typecheck`
-- `packaging-smoke` workflow'da blocking ama branch protection'da required değil
-- `.github/CODEOWNERS` repo içinde var; platform enforcement için ikinci maintainer
-  veya açık istisna kararı gerekiyor
-- `dismiss_stale_reviews=false`
-- `require_code_owner_reviews=false`
-- `enforce_admins=false`
-
-**Definition of Done**
-- required checks listesi yazılı ve güncel
-- code-owner review beklentisi repo içinde görünür
-- admin bypass / stale review / strict merge için dış-ayar checklist'i mevcut
-- normal geliştirici akışını bozmadan merge güvenliği artmış
-
-## 6. Sonra
-
 ### `WP-6` — Worktree/Branch Safety Control Loop
 
-**Amaç**
-- merge'de kaybolma, stale worktree ile ilerleme, overlap fark etmeme
-  problemlerini operasyona gömmek
+**Neden şimdi**
+- Branch protection sertleşti; bundan sonraki ana risk yanlış worktree üzerinde
+  çalışma, dirty tree unutma ve stale base ile session başlatma.
 
-**Hedef slice'lar**
-1. `ops preflight`
-2. `ops overlap-check`
-3. `ops close-worktree`
-4. `ops archive-worktree`
+**GitHub takip**
+- üst issue: [#197](https://github.com/Halildeu/ao-kernel/issues/197)
+- aktif slice: [`WP-6.1-OPS-PREFLIGHT.md`](./WP-6.1-OPS-PREFLIGHT.md)
+
+**Adım sırası**
+1. `[x]` `ops.sh` dispatcher yüzeyi eklendi.
+2. `[x]` `preflight` branch freshness + current dirty tree + upstream +
+   other worktree snapshot'ını tek komutta topladı.
+3. `[x]` Clean / warning / fail path'leri subprocess testleriyle pinlendi.
+4. `[ ]` `WP-6.2` overlap-check yüzeyi eklenecek.
+5. `[ ]` `WP-6.3` close-worktree yüzeyi eklenecek.
+6. `[ ]` `WP-6.4` archive-worktree yüzeyi eklenecek.
+
+**Canlı snapshot**
+- session başlangıç komutu: `bash .claude/scripts/ops.sh preflight`
+- hard block: forbidden branch / detached HEAD / stale base / `main` drift
+- warning-only: current dirty tree / upstream yok / other worktree dirty
+- `check-branch-sync.sh` alttaki primitive olarak korunur
+
+**Definition of Done**
+- tek komutla session sağlık özeti alınabiliyor
+- yanlış base ile çalışmak hard fail olarak yakalanıyor
+- dirty tree ve other worktree riski görünür hale geliyor
+- bu davranış test veya smoke ile pinlenmiş
+
+## 6. Sonra
 
 ### `WP-7` — Path-Scoped Write Ownership
 
@@ -145,11 +131,10 @@ automation platform çizgisine taşımak.
 
 Bugünden itibaren doğru sıra:
 
-1. `WP-5` Release governance hardening
-2. `WP-6` Worktree/branch safety control loop
-3. `WP-7` Path-scoped write ownership
-4. `WP-8` Real adapter certification
-5. `WP-9` Ops/runbook/incident readiness
+1. `WP-6` Worktree/branch safety control loop
+2. `WP-7` Path-scoped write ownership
+3. `WP-8` Real adapter certification
+4. `WP-9` Ops/runbook/incident readiness
 
 ## 9. Güncelleme Protokolü
 

--- a/.claude/plans/WP-6.1-OPS-PREFLIGHT.md
+++ b/.claude/plans/WP-6.1-OPS-PREFLIGHT.md
@@ -1,0 +1,54 @@
+# WP-6.1 — Ops Preflight
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#197](https://github.com/Halildeu/ao-kernel/issues/197)
+**Üst WP:** [#197](https://github.com/Halildeu/ao-kernel/issues/197)
+
+## Amaç
+
+Session başlangıcında branch freshness, current worktree durumu ve diğer aktif
+worktree'lerin kısa sağlık özetini tek komutta görünür hale getirmek.
+
+Bu slice merge kaybını tek başına kapatmaz; ama stale branch veya unutulmuş
+dirty tree ile sessiz ilerleme riskini operasyonun giriş kapısında görünür
+yapar.
+
+## Komut
+
+```bash
+bash .claude/scripts/ops.sh preflight
+```
+
+## Kapsam
+
+`ops preflight` şu kontrolleri tek akışta çalıştırır:
+
+1. `check-branch-sync.sh` ile branch freshness / forbidden branch pattern / main
+   drift kontrolü
+2. current worktree için `staged / unstaged / untracked` özeti
+3. upstream görünürlüğü (`ahead/behind` veya henüz push edilmemiş branch uyarısı)
+4. diğer attached worktree'lerin `clean/dirty` snapshot'ı
+
+## Exit Semantiği
+
+- `0`
+  - branch freshness geçti; komut temiz veya warning'li özet verebilir
+- `1`
+  - branch freshness veya repo bağlamı güvenli değil; oturuma devam etme
+- `2`
+  - yanlış kullanım
+
+## Bu Slice'ın Kararı
+
+- Dirty worktree şu aşamada **warning**'dir, hard block değildir.
+- Hard block yalnız branch freshness / forbidden branch / detached HEAD /
+  `main` drift gibi session başlangıcında yanlış base ile çalışmaya yol açan
+  koşullarda uygulanır.
+- Daha agresif overlap / close / archive akışları `WP-6.2+` kapsamındadır.
+
+## Definition of Done
+
+1. `ops.sh preflight` repo içinde mevcut olmalı
+2. `CLAUDE.md` session başlangıç protokolü bu yüzeye işaret etmeli
+3. Yaşayan status dosyasında `WP-6` aktif hat olarak görünmeli
+4. En az clean + warning + fail path'lerinden örnekler test veya smoke ile pinlenmiş olmalı

--- a/.claude/scripts/ops.sh
+++ b/.claude/scripts/ops.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+#
+# ops.sh — WP-6 operasyon dispatcher'ı.
+#
+# İlk yüzey: `preflight`
+# - branch freshness (`check-branch-sync.sh`)
+# - current worktree dirtiness
+# - upstream divergence visibility
+# - other attached worktree snapshot
+#
+# Kullanım:
+#   bash .claude/scripts/ops.sh preflight
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash .claude/scripts/ops.sh preflight
+
+Available commands:
+  preflight   Session başlangıcı için branch/worktree sağlık özeti
+EOF
+}
+
+count_lines() {
+  awk 'NF {count += 1} END {print count + 0}'
+}
+
+run_preflight() {
+  local sync_output=""
+  local sync_status=0
+  local repo_root=""
+  local branch=""
+  local upstream=""
+  local upstream_state=""
+  local staged=0
+  local unstaged=0
+  local untracked=0
+  local warnings=0
+  local current_dirty=0
+  local other_count=0
+  local other_dirty=0
+  local block_path=""
+  local block_branch=""
+  local block_detached=0
+
+  set +e
+  sync_output="$("$SCRIPT_DIR/check-branch-sync.sh" 2>&1)"
+  sync_status=$?
+  set -e
+
+  printf '== ops preflight ==\n'
+  printf '%s\n' "$sync_output"
+
+  if [ "$sync_status" -ne 0 ]; then
+    return "$sync_status"
+  fi
+
+  repo_root="$(git rev-parse --show-toplevel)"
+  branch="$(git branch --show-current)"
+
+  if upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"; then
+    upstream_state="ahead $(git rev-list --count "${upstream}..HEAD"), behind $(git rev-list --count "HEAD..${upstream}")"
+  else
+    upstream="(none)"
+    upstream_state="not pushed yet"
+    if [ "$branch" != "main" ]; then
+      warnings=$((warnings + 1))
+    fi
+  fi
+
+  staged="$(git diff --cached --name-only | count_lines)"
+  unstaged="$(git diff --name-only | count_lines)"
+  untracked="$(git ls-files --others --exclude-standard | count_lines)"
+  if [ "$staged" -gt 0 ] || [ "$unstaged" -gt 0 ] || [ "$untracked" -gt 0 ]; then
+    current_dirty=1
+    warnings=$((warnings + 1))
+  fi
+
+  printf '\nRepo: %s\n' "$repo_root"
+  printf 'Branch: %s\n' "$branch"
+  printf 'Upstream: %s (%s)\n' "$upstream" "$upstream_state"
+  if [ "$current_dirty" -eq 1 ]; then
+    printf 'Current worktree: dirty (staged=%s, unstaged=%s, untracked=%s)\n' "$staged" "$unstaged" "$untracked"
+  else
+    printf 'Current worktree: clean\n'
+  fi
+
+  printf 'Other worktrees:\n'
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [ -z "$line" ]; then
+      if [ -n "$block_path" ] && [ "$block_path" != "$repo_root" ]; then
+        local wt_status="clean"
+        local wt_lines=""
+        other_count=$((other_count + 1))
+        wt_lines="$(git -C "$block_path" status --short --untracked-files=normal 2>/dev/null || true)"
+        if [ -n "$wt_lines" ]; then
+          wt_status="dirty"
+          other_dirty=$((other_dirty + 1))
+          warnings=$((warnings + 1))
+        fi
+        if [ "$block_detached" -eq 1 ] && [ -z "$block_branch" ]; then
+          block_branch="(detached)"
+        fi
+        printf '  - %s [%s] %s\n' "$block_path" "${block_branch:-unknown}" "$wt_status"
+      fi
+      block_path=""
+      block_branch=""
+      block_detached=0
+      continue
+    fi
+
+    case "$line" in
+      worktree\ *)
+        block_path="${line#worktree }"
+        ;;
+      branch\ refs/heads/*)
+        block_branch="${line#branch refs/heads/}"
+        ;;
+      detached)
+        block_detached=1
+        ;;
+    esac
+  done < <(git worktree list --porcelain)
+
+  if [ "$other_count" -eq 0 ]; then
+    printf '  - none\n'
+  fi
+
+  printf '\nSummary:\n'
+  if [ "$warnings" -eq 0 ]; then
+    printf '✓ Preflight clean\n'
+  else
+    printf '⚠ Preflight completed with warnings\n'
+    if [ "$current_dirty" -eq 1 ]; then
+      printf '  - current worktree dirty\n'
+    fi
+    if [ "$upstream" = "(none)" ] && [ "$branch" != "main" ]; then
+      printf '  - branch has no upstream yet\n'
+    fi
+    if [ "$other_dirty" -gt 0 ]; then
+      printf '  - %s other worktree(s) dirty\n' "$other_dirty"
+    fi
+  fi
+}
+
+main() {
+  local command="${1:-}"
+  case "$command" in
+    preflight)
+      run_preflight
+      ;;
+    ""|-h|--help|help)
+      usage
+      ;;
+    *)
+      printf 'Unknown command: %s\n\n' "$command" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,10 +386,17 @@ Bu repo multi-worktree + multi-agent (Claude Code + Codex) çalışıyor. Stale 
 Her yeni kod değişikliği session'ı — Claude Code VEYA Codex — infaza geçmeden önce:
 
 ```bash
-bash .claude/scripts/check-branch-sync.sh
+bash .claude/scripts/ops.sh preflight
 ```
 
-Script exit 1 dönerse DUR, kullanıcı ile karar ver:
+`ops.sh preflight` mevcut session için şu özeti verir:
+
+- branch freshness (`check-branch-sync.sh` primitive'i üstünden)
+- current worktree dirty/clean görünürlüğü
+- upstream push/divergence özeti
+- diğer attached worktree'lerin clean/dirty snapshot'ı
+
+Komut exit 1 dönerse DUR, kullanıcı ile karar ver:
 
 - Main'e rebase: `git rebase origin/main`
 - Yeni branch from main: `git checkout -b <new> origin/main`
@@ -433,7 +440,7 @@ git branch -D feat/X  # merge edildikten sonra
 
 Farklı worktree'lerde çalışan Claude/Codex session'ları için:
 
-- Her session **kendi worktree'sinin branch-freshness'ını kontrol eder** (`check-branch-sync.sh`)
+- Her session **kendi worktree'sinin preflight kontrolünü** çalıştırır (`ops.sh preflight`)
 - Shared implementation branch yok — her session fresh branch from main
 - Backup branch (`backup/*`) sadece kurtarma için, üstünde impl yapılmaz
 

--- a/tests/test_ops_preflight_script.py
+++ b/tests/test_ops_preflight_script.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+OPS_SCRIPT = (
+    Path(__file__).resolve().parents[1] / ".claude" / "scripts" / "ops.sh"
+)
+
+
+def _run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return _run(["git", *args], cwd=cwd)
+
+
+def _init_remote_clone(tmp_path: Path) -> Path:
+    remote = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    work = tmp_path / "work"
+
+    _run(["git", "init", "--bare", remote.as_posix()], cwd=tmp_path)
+    _run(["git", "clone", remote.as_posix(), seed.as_posix()], cwd=tmp_path)
+    _git(seed, "config", "user.email", "t@e")
+    _git(seed, "config", "user.name", "t")
+    (seed / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(seed, "add", "README.md")
+    _git(seed, "commit", "-m", "seed")
+    _git(seed, "branch", "-M", "main")
+    _git(seed, "push", "-u", "origin", "main")
+    _run(
+        [
+            "git",
+            "--git-dir",
+            remote.as_posix(),
+            "symbolic-ref",
+            "HEAD",
+            "refs/heads/main",
+        ],
+        cwd=tmp_path,
+    )
+    _run(["git", "clone", remote.as_posix(), work.as_posix()], cwd=tmp_path)
+    _git(work, "config", "user.email", "t@e")
+    _git(work, "config", "user.name", "t")
+    return work
+
+
+def _run_preflight(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(OPS_SCRIPT), "preflight"],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+
+def test_ops_preflight_clean_repo(tmp_path: Path) -> None:
+    work = _init_remote_clone(tmp_path)
+
+    proc = _run_preflight(work)
+
+    assert proc.returncode == 0
+    assert "== ops preflight ==" in proc.stdout
+    assert "Current worktree: clean" in proc.stdout
+    assert "Other worktrees:" in proc.stdout
+    assert "  - none" in proc.stdout
+    assert "✓ Preflight clean" in proc.stdout
+
+
+def test_ops_preflight_warns_on_dirty_worktree(tmp_path: Path) -> None:
+    work = _init_remote_clone(tmp_path)
+    (work / "README.md").write_text("dirty\n", encoding="utf-8")
+    (work / "notes.txt").write_text("untracked\n", encoding="utf-8")
+
+    proc = _run_preflight(work)
+
+    assert proc.returncode == 0
+    assert "Current worktree: dirty" in proc.stdout
+    assert "⚠ Preflight completed with warnings" in proc.stdout
+    assert "  - current worktree dirty" in proc.stdout
+
+
+def test_ops_preflight_fails_on_forbidden_branch_pattern(
+    tmp_path: Path,
+) -> None:
+    work = _init_remote_clone(tmp_path)
+    _git(work, "checkout", "-b", "claude/stale", "origin/main")
+
+    proc = _run_preflight(work)
+
+    assert proc.returncode == 1
+    assert "YASAK branch pattern: claude/stale" in proc.stdout


### PR DESCRIPTION
## Summary

This PR starts `WP-6` by adding the first operational control-loop surface: `ops preflight`.

It introduces a single session-start command:

```bash
bash .claude/scripts/ops.sh preflight
```

The command is intentionally small and operational. It does not change runtime semantics. It turns the existing branch-freshness primitive into a broader worktree/branch health check that operators can run before starting implementation.

## Problem

After `WP-5`, the repo-side and platform-side merge gates are materially stronger, but the next practical risk is not branch protection anymore. It is session-start drift:

- working on a stale branch
- forgetting a dirty worktree
- starting a new slice on a branch with no upstream visibility
- missing the fact that another attached worktree is already dirty

We already had `check-branch-sync.sh`, but that only covered branch freshness. `WP-6.1` turns that primitive into a single operator-facing preflight.

## What changed

- add `.claude/scripts/ops.sh` as the WP-6 dispatcher
- implement `ops.sh preflight`
- keep `check-branch-sync.sh` as the underlying hard-fail primitive
- add `tests/test_ops_preflight_script.py`
- add `.claude/plans/WP-6.1-OPS-PREFLIGHT.md`
- update `CLAUDE.md` session-start protocol to point to `ops.sh preflight`
- move the living hardening status from active `WP-5` to active `WP-6`

## Behavior

`ops preflight` now reports:

- branch freshness result
- current worktree dirty/clean summary
- upstream status (`ahead/behind` or no-upstream warning)
- other attached worktrees with a clean/dirty snapshot

Exit policy is deliberate:

- hard fail for wrong-base conditions (`detached HEAD`, forbidden branch pattern, stale branch, `main` drift)
- warning-only for dirty worktrees or missing upstream

This keeps the tool useful during normal development while still blocking the dangerous cases that historically caused stale-base work.

## Validation

- `bash .claude/scripts/ops.sh preflight`
- `pytest tests/test_ops_preflight_script.py -q`
- `git diff --check`

## Refs

- Refs #197
