### PR TITLE
[codex] ops: add worktree overlap check

### DIFF
--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -68,27 +68,31 @@ automation platform çizgisine taşımak.
 
 **GitHub takip**
 - üst issue: [#197](https://github.com/Halildeu/ao-kernel/issues/197)
-- aktif slice: [`WP-6.1-OPS-PREFLIGHT.md`](./WP-6.1-OPS-PREFLIGHT.md)
+- aktif slice: [`WP-6.2-OVERLAP-CHECK.md`](./WP-6.2-OVERLAP-CHECK.md)
 
 **Adım sırası**
 1. `[x]` `ops.sh` dispatcher yüzeyi eklendi.
 2. `[x]` `preflight` branch freshness + current dirty tree + upstream +
    other worktree snapshot'ını tek komutta topladı.
 3. `[x]` Clean / warning / fail path'leri subprocess testleriyle pinlendi.
-4. `[ ]` `WP-6.2` overlap-check yüzeyi eklenecek.
+4. `[x]` `WP-6.2` overlap-check yüzeyi eklendi.
 5. `[ ]` `WP-6.3` close-worktree yüzeyi eklenecek.
 6. `[ ]` `WP-6.4` archive-worktree yüzeyi eklenecek.
 
 **Canlı snapshot**
 - session başlangıç komutu: `bash .claude/scripts/ops.sh preflight`
+- çoklu worktree çakışma görünürlüğü: `bash .claude/scripts/ops.sh overlap-check`
 - hard block: forbidden branch / detached HEAD / stale base / `main` drift
 - warning-only: current dirty tree / upstream yok / other worktree dirty
+- overlap-check: exact file overlap ve shared top-level area sinyali üretir;
+  bu slice görünürlük verir, henüz hard-enforcement yapmaz
 - `check-branch-sync.sh` alttaki primitive olarak korunur
 
 **Definition of Done**
 - tek komutla session sağlık özeti alınabiliyor
 - yanlış base ile çalışmak hard fail olarak yakalanıyor
 - dirty tree ve other worktree riski görünür hale geliyor
+- çoklu worktree path çakışması görünür hale geliyor
 - bu davranış test veya smoke ile pinlenmiş
 
 ## 6. Sonra

--- a/.claude/plans/WP-6.2-OVERLAP-CHECK.md
+++ b/.claude/plans/WP-6.2-OVERLAP-CHECK.md
@@ -31,9 +31,9 @@ kaynaktan üretir:
 
 Base çözümleme sırası:
 
-1. branch upstream'i
-2. `origin/main`
-3. `main`
+1. `main` branch'i için upstream, sonra `origin/main`, sonra `main`
+2. kısa ömürlü non-main branch'ler için `origin/main`, sonra `main`
+3. yalnız mainline ref bulunamazsa branch upstream'i fallback olur
 
 Komut iki seviye sinyal üretir:
 

--- a/.claude/plans/WP-6.2-OVERLAP-CHECK.md
+++ b/.claude/plans/WP-6.2-OVERLAP-CHECK.md
@@ -1,0 +1,65 @@
+# WP-6.2 — Overlap Check
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#197](https://github.com/Halildeu/ao-kernel/issues/197)
+**Üst WP:** [#197](https://github.com/Halildeu/ao-kernel/issues/197)
+
+## Amaç
+
+Birden fazla attached worktree açıkken aynı path alanına sessizce dokunulmasını
+operasyon seviyesinde görünür yapmak.
+
+Bu slice ownership enforcement değildir. Ama merge öncesi veya paralel çalışma
+başlamadan önce aynı dosya ya da aynı üst alan üzerinde çakışma riski olup
+olmadığını tek komutta görünür kılar.
+
+## Komut
+
+```bash
+bash .claude/scripts/ops.sh overlap-check
+```
+
+## Overlap Modeli
+
+`ops overlap-check` her attached worktree için değişiklik kümesini şu dört
+kaynaktan üretir:
+
+1. base ref'e göre committed path farkı
+2. staged path'ler
+3. unstaged path'ler
+4. untracked path'ler
+
+Base çözümleme sırası:
+
+1. branch upstream'i
+2. `origin/main`
+3. `main`
+
+Komut iki seviye sinyal üretir:
+
+- **exact file overlap**
+  - aynı relative path birden fazla açık worktree'de değişiyor
+- **shared top-level area**
+  - aynı üst klasör/alan altında paralel değişim var
+
+## Exit Semantiği
+
+- `0`
+  - komut çalıştı; overlap bulunsa da görünürlük amacıyla warning semantiğinde
+    kalır
+- `2`
+  - yanlış kullanım
+
+## Bu Slice'ın Kararı
+
+- Overlap bu aşamada **görünürlük** üretir; hard block değildir.
+- Exact file overlap daha güçlü sinyaldir; shared area overlap daha zayıf ama
+  yine de koordinasyon ihtiyacını gösterir.
+- Hard enforcement / claim / release / takeover akışları `WP-7` kapsamındadır.
+
+## Definition of Done
+
+1. `ops.sh overlap-check` repo içinde mevcut olmalı
+2. Attached worktree'ler için changed-path seti görünür olmalı
+3. Exact file overlap ve shared area overlap ayrı raporlanmalı
+4. En az clean ve overlap path'leri subprocess testleriyle pinlenmiş olmalı

--- a/.claude/scripts/ops.sh
+++ b/.claude/scripts/ops.sh
@@ -2,14 +2,19 @@
 #
 # ops.sh — WP-6 operasyon dispatcher'ı.
 #
-# İlk yüzey: `preflight`
-# - branch freshness (`check-branch-sync.sh`)
-# - current worktree dirtiness
-# - upstream divergence visibility
-# - other attached worktree snapshot
+# İlk yüzeyler:
+# - `preflight`
+#   - branch freshness (`check-branch-sync.sh`)
+#   - current worktree dirtiness
+#   - upstream divergence visibility
+#   - other attached worktree snapshot
+# - `overlap-check`
+#   - attached worktree'lerin changed-path setlerini karşılaştırır
+#   - exact file overlap ve paylaşılan top-level alan sinyali üretir
 #
 # Kullanım:
 #   bash .claude/scripts/ops.sh preflight
+#   bash .claude/scripts/ops.sh overlap-check
 
 set -euo pipefail
 
@@ -19,9 +24,11 @@ usage() {
   cat <<'EOF'
 Usage:
   bash .claude/scripts/ops.sh preflight
+  bash .claude/scripts/ops.sh overlap-check
 
 Available commands:
-  preflight   Session başlangıcı için branch/worktree sağlık özeti
+  preflight      Session başlangıcı için branch/worktree sağlık özeti
+  overlap-check  Attached worktree'ler arası path-overlap riski görünürlüğü
 EOF
 }
 
@@ -147,11 +154,18 @@ run_preflight() {
   fi
 }
 
+run_overlap_check() {
+  python3 "$SCRIPT_DIR/ops_overlap_check.py"
+}
+
 main() {
   local command="${1:-}"
   case "$command" in
     preflight)
       run_preflight
+      ;;
+    overlap-check)
+      run_overlap_check
       ;;
     ""|-h|--help|help)
       usage

--- a/.claude/scripts/ops_overlap_check.py
+++ b/.claude/scripts/ops_overlap_check.py
@@ -92,10 +92,18 @@ def _resolve_base_label(path: Path) -> str:
         "@{upstream}",
         check=False,
     )
-    candidate_refs: list[str] = []
-    if upstream.returncode == 0:
-        candidate_refs.append(upstream.stdout.strip())
-    candidate_refs.extend(["origin/main", "main"])
+    branch = _git_value(path, "branch", "--show-current")
+    candidate_refs: list[str]
+
+    if branch == "main":
+        candidate_refs = []
+        if upstream.returncode == 0:
+            candidate_refs.append(upstream.stdout.strip())
+        candidate_refs.extend(["origin/main", "main"])
+    else:
+        candidate_refs = ["origin/main", "main"]
+        if upstream.returncode == 0:
+            candidate_refs.append(upstream.stdout.strip())
 
     for candidate in candidate_refs:
         if candidate and _ref_exists(path, candidate):

--- a/.claude/scripts/ops_overlap_check.py
+++ b/.claude/scripts/ops_overlap_check.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+
+@dataclass(frozen=True)
+class WorktreeInfo:
+    path: Path
+    branch: str
+
+
+@dataclass(frozen=True)
+class WorktreeSnapshot:
+    path: Path
+    branch: str
+    base_label: str
+    committed_paths: tuple[str, ...]
+    staged_paths: tuple[str, ...]
+    unstaged_paths: tuple[str, ...]
+    untracked_paths: tuple[str, ...]
+    changed_paths: tuple[str, ...]
+    areas: tuple[str, ...]
+
+
+def _run_git(path: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        ["git", "-C", path.as_posix(), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and proc.returncode != 0:
+        raise subprocess.CalledProcessError(
+            proc.returncode,
+            proc.args,
+            output=proc.stdout,
+            stderr=proc.stderr,
+        )
+    return proc
+
+
+def _git_lines(path: Path, *args: str) -> list[str]:
+    proc = _run_git(path, *args)
+    return [line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _git_value(path: Path, *args: str) -> str:
+    return _run_git(path, *args).stdout.strip()
+
+
+def _ref_exists(path: Path, ref: str) -> bool:
+    proc = _run_git(path, "rev-parse", "--verify", "--quiet", ref, check=False)
+    return proc.returncode == 0
+
+
+def _parse_worktrees(repo_root: Path) -> list[WorktreeInfo]:
+    lines = _run_git(repo_root, "worktree", "list", "--porcelain").stdout.splitlines()
+    entries: list[WorktreeInfo] = []
+    current_path: Path | None = None
+    current_branch: str | None = None
+
+    for line in lines + [""]:
+        if not line:
+            if current_path is not None:
+                entries.append(
+                    WorktreeInfo(
+                        path=current_path,
+                        branch=current_branch or "(detached)",
+                    )
+                )
+            current_path = None
+            current_branch = None
+            continue
+        if line.startswith("worktree "):
+            current_path = Path(line.removeprefix("worktree "))
+        elif line.startswith("branch refs/heads/"):
+            current_branch = line.removeprefix("branch refs/heads/")
+
+    return entries
+
+
+def _resolve_base_label(path: Path) -> str:
+    upstream = _run_git(
+        path,
+        "rev-parse",
+        "--abbrev-ref",
+        "--symbolic-full-name",
+        "@{upstream}",
+        check=False,
+    )
+    candidate_refs: list[str] = []
+    if upstream.returncode == 0:
+        candidate_refs.append(upstream.stdout.strip())
+    candidate_refs.extend(["origin/main", "main"])
+
+    for candidate in candidate_refs:
+        if candidate and _ref_exists(path, candidate):
+            return candidate
+    return "(none)"
+
+
+def _sorted_unique(paths: list[str]) -> tuple[str, ...]:
+    return tuple(sorted({path for path in paths if path}))
+
+
+def _path_area(path: str) -> str:
+    parts = PurePosixPath(path).parts
+    if not parts:
+        return "(unknown)"
+    return parts[0]
+
+
+def _collect_snapshot(info: WorktreeInfo) -> WorktreeSnapshot:
+    base_label = _resolve_base_label(info.path)
+    committed_paths: list[str] = []
+
+    if base_label != "(none)":
+        merge_base = _run_git(
+            info.path,
+            "merge-base",
+            "HEAD",
+            base_label,
+            check=False,
+        )
+        if merge_base.returncode == 0:
+            committed_paths = _git_lines(
+                info.path,
+                "diff",
+                "--name-only",
+                f"{merge_base.stdout.strip()}..HEAD",
+            )
+
+    staged_paths = _git_lines(info.path, "diff", "--cached", "--name-only")
+    unstaged_paths = _git_lines(info.path, "diff", "--name-only")
+    untracked_paths = _git_lines(
+        info.path,
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+    )
+    changed_paths = _sorted_unique(
+        committed_paths + staged_paths + unstaged_paths + untracked_paths
+    )
+    areas = _sorted_unique([_path_area(path) for path in changed_paths])
+
+    return WorktreeSnapshot(
+        path=info.path,
+        branch=info.branch,
+        base_label=base_label,
+        committed_paths=_sorted_unique(committed_paths),
+        staged_paths=_sorted_unique(staged_paths),
+        unstaged_paths=_sorted_unique(unstaged_paths),
+        untracked_paths=_sorted_unique(untracked_paths),
+        changed_paths=changed_paths,
+        areas=areas,
+    )
+
+
+def _format_sample(items: tuple[str, ...], limit: int = 5) -> str:
+    if not items:
+        return "none"
+    sample = ", ".join(items[:limit])
+    if len(items) > limit:
+        sample += ", ..."
+    return sample
+
+
+def _compute_exact_overlaps(
+    snapshots: list[WorktreeSnapshot],
+) -> list[tuple[str, list[str]]]:
+    overlaps: dict[str, list[str]] = {}
+    for snapshot in snapshots:
+        for path in snapshot.changed_paths:
+            overlaps.setdefault(path, []).append(snapshot.branch)
+    return sorted(
+        [
+            (path, sorted(branches))
+            for path, branches in overlaps.items()
+            if len(branches) > 1
+        ],
+        key=lambda item: (len(item[1]) * -1, item[0]),
+    )
+
+
+def _compute_area_overlaps(
+    snapshots: list[WorktreeSnapshot],
+) -> list[tuple[str, list[str]]]:
+    overlaps: dict[str, list[str]] = {}
+    for snapshot in snapshots:
+        for area in snapshot.areas:
+            overlaps.setdefault(area, []).append(snapshot.branch)
+    return sorted(
+        [
+            (area, sorted(branches))
+            for area, branches in overlaps.items()
+            if len(branches) > 1
+        ],
+        key=lambda item: (len(item[1]) * -1, item[0]),
+    )
+
+
+def main() -> int:
+    repo_root = Path(_git_value(Path.cwd(), "rev-parse", "--show-toplevel"))
+    snapshots = [
+        _collect_snapshot(info)
+        for info in sorted(_parse_worktrees(repo_root), key=lambda item: item.path.as_posix())
+    ]
+
+    exact_overlaps = _compute_exact_overlaps(snapshots)
+    area_overlaps = _compute_area_overlaps(snapshots)
+
+    print("== ops overlap-check ==")
+    print(f"Repo: {repo_root}")
+    print(f"Attached worktrees: {len(snapshots)}")
+    print()
+    print("Worktrees:")
+    for snapshot in snapshots:
+        print(f"  - {snapshot.path} [{snapshot.branch}]")
+        print(f"    base: {snapshot.base_label}")
+        print(
+            "    change-set: "
+            f"{len(snapshot.changed_paths)} path(s) "
+            f"(committed={len(snapshot.committed_paths)}, "
+            f"staged={len(snapshot.staged_paths)}, "
+            f"unstaged={len(snapshot.unstaged_paths)}, "
+            f"untracked={len(snapshot.untracked_paths)})"
+        )
+        print(f"    sample: {_format_sample(snapshot.changed_paths)}")
+        print(f"    areas: {_format_sample(snapshot.areas)}")
+
+    print()
+    print("Exact file overlaps:")
+    if exact_overlaps:
+        for path, branches in exact_overlaps:
+            print(f"  - {path}")
+            print(f"    worktrees: {', '.join(branches)}")
+    else:
+        print("  - none")
+
+    print()
+    print("Shared top-level areas:")
+    if area_overlaps:
+        for area, branches in area_overlaps:
+            print(f"  - {area}")
+            print(f"    worktrees: {', '.join(branches)}")
+    else:
+        print("  - none")
+
+    print()
+    print("Summary:")
+    if exact_overlaps or area_overlaps:
+        print("⚠ Overlap risk detected")
+        print(f"  - exact file overlaps: {len(exact_overlaps)}")
+        print(f"  - shared top-level areas: {len(area_overlaps)}")
+    else:
+        print("✓ No overlapping changed paths detected")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except subprocess.CalledProcessError as exc:
+        message = exc.stderr.strip() or exc.output.strip() or str(exc)
+        print(message, file=sys.stderr)
+        raise SystemExit(exc.returncode)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,6 +396,19 @@ bash .claude/scripts/ops.sh preflight
 - upstream push/divergence özeti
 - diğer attached worktree'lerin clean/dirty snapshot'ı
 
+Birden fazla aktif worktree varsa, edit veya merge öncesi ayrıca şu komutu
+çalıştır:
+
+```bash
+bash .claude/scripts/ops.sh overlap-check
+```
+
+`ops.sh overlap-check` attached worktree'lerin base'e göre changed-path
+setlerini karşılaştırır ve iki seviyede sinyal üretir:
+
+- **exact file overlap** — aynı dosyaya iki açık worktree dokunuyor
+- **shared top-level area** — aynı üst klasör alanında paralel değişim var
+
 Komut exit 1 dönerse DUR, kullanıcı ile karar ver:
 
 - Main'e rebase: `git rebase origin/main`
@@ -441,6 +454,8 @@ git branch -D feat/X  # merge edildikten sonra
 Farklı worktree'lerde çalışan Claude/Codex session'ları için:
 
 - Her session **kendi worktree'sinin preflight kontrolünü** çalıştırır (`ops.sh preflight`)
+- Birden fazla attached worktree varsa edit başlamadan önce `ops.sh overlap-check`
+  ile path-overlap görünürlüğü alınır
 - Shared implementation branch yok — her session fresh branch from main
 - Backup branch (`backup/*`) sadece kurtarma için, üstünde impl yapılmaz
 

--- a/tests/test_ops_preflight_script.py
+++ b/tests/test_ops_preflight_script.py
@@ -164,3 +164,41 @@ def test_ops_overlap_check_reports_exact_file_and_area_overlap(
     assert "pkg/shared.py" in proc.stdout
     assert "pkg" in proc.stdout
     assert "⚠ Overlap risk detected" in proc.stdout
+
+
+def test_ops_overlap_check_uses_mainline_base_for_pushed_feature_branches(
+    tmp_path: Path,
+) -> None:
+    work = _init_remote_clone(tmp_path)
+    wt_a = tmp_path / "wt-a"
+    wt_b = tmp_path / "wt-b"
+
+    _run(
+        ["git", "worktree", "add", "-b", "feature-a", wt_a.as_posix(), "origin/main"],
+        cwd=work,
+    )
+    _run(
+        ["git", "worktree", "add", "-b", "feature-b", wt_b.as_posix(), "origin/main"],
+        cwd=work,
+    )
+
+    (wt_a / "pkg").mkdir()
+    (wt_a / "pkg" / "shared.py").write_text("print('a')\n", encoding="utf-8")
+    _git(wt_a, "add", "pkg/shared.py")
+    _git(wt_a, "commit", "-m", "feature-a change")
+    _git(wt_a, "push", "-u", "origin", "feature-a")
+
+    (wt_b / "pkg").mkdir()
+    (wt_b / "pkg" / "shared.py").write_text("print('b')\n", encoding="utf-8")
+    _git(wt_b, "add", "pkg/shared.py")
+    _git(wt_b, "commit", "-m", "feature-b change")
+    _git(wt_b, "push", "-u", "origin", "feature-b")
+
+    proc = _run_overlap_check(work)
+
+    assert proc.returncode == 0
+    assert "base: origin/main" in proc.stdout
+    assert "pkg/shared.py" in proc.stdout
+    assert "feature-a" in proc.stdout
+    assert "feature-b" in proc.stdout
+    assert "⚠ Overlap risk detected" in proc.stdout

--- a/tests/test_ops_preflight_script.py
+++ b/tests/test_ops_preflight_script.py
@@ -65,6 +65,17 @@ def _run_preflight(cwd: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _run_overlap_check(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(OPS_SCRIPT), "overlap-check"],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+
 def test_ops_preflight_clean_repo(tmp_path: Path) -> None:
     work = _init_remote_clone(tmp_path)
 
@@ -101,3 +112,55 @@ def test_ops_preflight_fails_on_forbidden_branch_pattern(
 
     assert proc.returncode == 1
     assert "YASAK branch pattern: claude/stale" in proc.stdout
+
+
+def test_ops_overlap_check_clean_single_worktree(tmp_path: Path) -> None:
+    work = _init_remote_clone(tmp_path)
+
+    proc = _run_overlap_check(work)
+
+    assert proc.returncode == 0
+    assert "== ops overlap-check ==" in proc.stdout
+    assert "Attached worktrees: 1" in proc.stdout
+    assert "Exact file overlaps:" in proc.stdout
+    assert "Shared top-level areas:" in proc.stdout
+    assert "  - none" in proc.stdout
+    assert "✓ No overlapping changed paths detected" in proc.stdout
+
+
+def test_ops_overlap_check_reports_exact_file_and_area_overlap(
+    tmp_path: Path,
+) -> None:
+    work = _init_remote_clone(tmp_path)
+    wt_a = tmp_path / "wt-a"
+    wt_b = tmp_path / "wt-b"
+
+    _run(
+        ["git", "worktree", "add", "-b", "feature-a", wt_a.as_posix(), "origin/main"],
+        cwd=work,
+    )
+    _run(
+        ["git", "worktree", "add", "-b", "feature-b", wt_b.as_posix(), "origin/main"],
+        cwd=work,
+    )
+
+    (wt_a / "pkg").mkdir()
+    (wt_a / "pkg" / "shared.py").write_text("print('a')\n", encoding="utf-8")
+    (wt_a / "pkg" / "only_a.py").write_text("print('only a')\n", encoding="utf-8")
+    _git(wt_a, "add", "pkg/shared.py")
+    _git(wt_a, "commit", "-m", "add shared path in feature-a")
+
+    (wt_b / "pkg").mkdir()
+    (wt_b / "pkg" / "shared.py").write_text("print('b')\n", encoding="utf-8")
+    (wt_b / "tests").mkdir()
+    (wt_b / "tests" / "test_demo.py").write_text("def test_demo():\n    assert True\n", encoding="utf-8")
+
+    proc = _run_overlap_check(work)
+
+    assert proc.returncode == 0
+    assert "Attached worktrees: 3" in proc.stdout
+    assert "feature-a" in proc.stdout
+    assert "feature-b" in proc.stdout
+    assert "pkg/shared.py" in proc.stdout
+    assert "pkg" in proc.stdout
+    assert "⚠ Overlap risk detected" in proc.stdout


### PR DESCRIPTION
## Summary
- add `bash .claude/scripts/ops.sh overlap-check` to surface changed-path overlap risk across attached worktrees
- compare base-aware committed changes plus staged, unstaged and untracked paths; report exact file overlaps and shared top-level areas
- document and test the new WP-6.2 slice in CLAUDE/program status and subprocess coverage

## Testing
- pytest tests/test_ops_preflight_script.py -q
- bash .claude/scripts/ops.sh overlap-check
- bash .claude/scripts/ops.sh preflight

Refs #197