### PR TITLE
[codex] ops: add safe close-worktree flow

### DIFF
--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -68,7 +68,7 @@ automation platform çizgisine taşımak.
 
 **GitHub takip**
 - üst issue: [#197](https://github.com/Halildeu/ao-kernel/issues/197)
-- aktif slice: [`WP-6.2-OVERLAP-CHECK.md`](./WP-6.2-OVERLAP-CHECK.md)
+- aktif slice: [`WP-6.3-CLOSE-WORKTREE.md`](./WP-6.3-CLOSE-WORKTREE.md)
 
 **Adım sırası**
 1. `[x]` `ops.sh` dispatcher yüzeyi eklendi.
@@ -76,16 +76,19 @@ automation platform çizgisine taşımak.
    other worktree snapshot'ını tek komutta topladı.
 3. `[x]` Clean / warning / fail path'leri subprocess testleriyle pinlendi.
 4. `[x]` `WP-6.2` overlap-check yüzeyi eklendi.
-5. `[ ]` `WP-6.3` close-worktree yüzeyi eklenecek.
+5. `[x]` `WP-6.3` close-worktree yüzeyi eklendi.
 6. `[ ]` `WP-6.4` archive-worktree yüzeyi eklenecek.
 
 **Canlı snapshot**
 - session başlangıç komutu: `bash .claude/scripts/ops.sh preflight`
 - çoklu worktree çakışma görünürlüğü: `bash .claude/scripts/ops.sh overlap-check`
+- güvenli yardımcı worktree kapanışı: `bash .claude/scripts/ops.sh close-worktree <path>`
 - hard block: forbidden branch / detached HEAD / stale base / `main` drift
 - warning-only: current dirty tree / upstream yok / other worktree dirty
 - overlap-check: exact file overlap ve shared top-level area sinyali üretir;
   bu slice görünürlük verir, henüz hard-enforcement yapmaz
+- close-worktree: clean non-current target'ı kapatır; dirty/current target için
+  fail-closed davranır
 - `check-branch-sync.sh` alttaki primitive olarak korunur
 
 **Definition of Done**
@@ -93,6 +96,7 @@ automation platform çizgisine taşımak.
 - yanlış base ile çalışmak hard fail olarak yakalanıyor
 - dirty tree ve other worktree riski görünür hale geliyor
 - çoklu worktree path çakışması görünür hale geliyor
+- güvenli worktree kapanışı standart yüzeyden yapılabiliyor
 - bu davranış test veya smoke ile pinlenmiş
 
 ## 6. Sonra

--- a/.claude/plans/WP-6.3-CLOSE-WORKTREE.md
+++ b/.claude/plans/WP-6.3-CLOSE-WORKTREE.md
@@ -1,0 +1,54 @@
+# WP-6.3 — Close Worktree
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#197](https://github.com/Halildeu/ao-kernel/issues/197)
+**Üst WP:** [#197](https://github.com/Halildeu/ao-kernel/issues/197)
+
+## Amaç
+
+Yardımcı worktree kapanışını çıplak `git worktree remove` çağrısından çıkarıp
+fail-closed bir operasyon yüzeyine taşımak.
+
+Bu slice branch cleanup veya değişiklik arşivleme yapmaz. Ama yanlış target'ı
+kapatma ve dirty tree'yi sessizce düşürme riskini azaltır.
+
+## Komut
+
+```bash
+bash .claude/scripts/ops.sh close-worktree <path>
+```
+
+## Kapanış Modeli
+
+`ops close-worktree` şu sırayla karar verir:
+
+1. target path attached worktree mi?
+2. target current worktree mi?
+3. target dirty mi? (`staged`, `unstaged`, `untracked`)
+4. ancak bunlar güvenliyse `git worktree remove <path>`
+
+## Exit Semantiği
+
+- `0`
+  - target clean non-current attached worktree idi ve kapatıldı
+- `1`
+  - target current worktree
+  - target dirty worktree
+  - target bu repo için attached worktree değil
+- `2`
+  - yanlış kullanım
+
+## Bu Slice'ın Kararı
+
+- Current worktree asla kapatılmaz.
+- Dirty target kapatılmaz; önce kullanıcı bilinçli olarak temizlemeli veya daha
+  sonra gelecek archive akışına gitmelidir.
+- Branch silinmez; bu slice yalnız worktree lifecycle'ın kapanış kısmını
+  standartlaştırır.
+
+## Definition of Done
+
+1. `ops.sh close-worktree` repo içinde mevcut olmalı
+2. Clean secondary worktree başarıyla kapanmalı
+3. Dirty ve current target fail-closed davranmalı
+4. Bu kararlar subprocess testleriyle pinlenmiş olmalı

--- a/.claude/scripts/ops.sh
+++ b/.claude/scripts/ops.sh
@@ -11,10 +11,14 @@
 # - `overlap-check`
 #   - attached worktree'lerin changed-path setlerini karşılaştırır
 #   - exact file overlap ve paylaşılan top-level alan sinyali üretir
+# - `close-worktree`
+#   - clean non-current worktree'yi güvenli biçimde kapatır
+#   - dirty veya current target için fail-closed davranır
 #
 # Kullanım:
 #   bash .claude/scripts/ops.sh preflight
 #   bash .claude/scripts/ops.sh overlap-check
+#   bash .claude/scripts/ops.sh close-worktree <path>
 
 set -euo pipefail
 
@@ -25,10 +29,12 @@ usage() {
 Usage:
   bash .claude/scripts/ops.sh preflight
   bash .claude/scripts/ops.sh overlap-check
+  bash .claude/scripts/ops.sh close-worktree <path>
 
 Available commands:
-  preflight      Session başlangıcı için branch/worktree sağlık özeti
-  overlap-check  Attached worktree'ler arası path-overlap riski görünürlüğü
+  preflight       Session başlangıcı için branch/worktree sağlık özeti
+  overlap-check   Attached worktree'ler arası path-overlap riski görünürlüğü
+  close-worktree  Clean non-current worktree kapatma yüzeyi
 EOF
 }
 
@@ -158,6 +164,10 @@ run_overlap_check() {
   python3 "$SCRIPT_DIR/ops_overlap_check.py"
 }
 
+run_close_worktree() {
+  python3 "$SCRIPT_DIR/ops_close_worktree.py" "$@"
+}
+
 main() {
   local command="${1:-}"
   case "$command" in
@@ -166,6 +176,10 @@ main() {
       ;;
     overlap-check)
       run_overlap_check
+      ;;
+    close-worktree)
+      shift
+      run_close_worktree "$@"
       ;;
     ""|-h|--help|help)
       usage

--- a/.claude/scripts/ops_close_worktree.py
+++ b/.claude/scripts/ops_close_worktree.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class WorktreeInfo:
+    path: Path
+    branch: str
+
+
+def _run_git(path: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        ["git", "-C", path.as_posix(), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and proc.returncode != 0:
+        raise subprocess.CalledProcessError(
+            proc.returncode,
+            proc.args,
+            output=proc.stdout,
+            stderr=proc.stderr,
+        )
+    return proc
+
+
+def _git_value(path: Path, *args: str) -> str:
+    return _run_git(path, *args).stdout.strip()
+
+
+def _count_lines(path: Path, *args: str) -> int:
+    output = _run_git(path, *args).stdout.splitlines()
+    return sum(1 for line in output if line.strip())
+
+
+def _parse_worktrees(repo_root: Path) -> list[WorktreeInfo]:
+    lines = _run_git(repo_root, "worktree", "list", "--porcelain").stdout.splitlines()
+    entries: list[WorktreeInfo] = []
+    current_path: Path | None = None
+    current_branch: str | None = None
+
+    for line in lines + [""]:
+        if not line:
+            if current_path is not None:
+                entries.append(
+                    WorktreeInfo(
+                        path=current_path.resolve(),
+                        branch=current_branch or "(detached)",
+                    )
+                )
+            current_path = None
+            current_branch = None
+            continue
+        if line.startswith("worktree "):
+            current_path = Path(line.removeprefix("worktree "))
+        elif line.startswith("branch refs/heads/"):
+            current_branch = line.removeprefix("branch refs/heads/")
+
+    return entries
+
+
+def _print_usage() -> None:
+    print("Usage: bash .claude/scripts/ops.sh close-worktree <path>", file=sys.stderr)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        _print_usage()
+        return 2
+
+    cwd = Path.cwd().resolve()
+    repo_root = Path(_git_value(cwd, "rev-parse", "--show-toplevel")).resolve()
+    target = Path(argv[1]).expanduser().resolve()
+    worktrees = _parse_worktrees(repo_root)
+    known_paths = {entry.path: entry for entry in worktrees}
+
+    print("== ops close-worktree ==")
+    print(f"Repo: {repo_root}")
+    print(f"Requested target: {target}")
+
+    if target == repo_root:
+        print("Refusing to close current worktree")
+        return 1
+
+    if target not in known_paths:
+        print("Target is not an attached worktree for this repository")
+        return 1
+
+    info = known_paths[target]
+    staged = _count_lines(target, "diff", "--cached", "--name-only")
+    unstaged = _count_lines(target, "diff", "--name-only")
+    untracked = _count_lines(target, "ls-files", "--others", "--exclude-standard")
+
+    print(f"Target branch: {info.branch}")
+    print(
+        "Target status: "
+        f"staged={staged}, unstaged={unstaged}, untracked={untracked}"
+    )
+
+    if staged or unstaged or untracked:
+        print("Refusing to close dirty worktree")
+        print("Next step: commit/clean changes first; archive flow WP-6.4'te gelecek")
+        return 1
+
+    _run_git(repo_root, "worktree", "remove", target.as_posix())
+    print("✓ Worktree closed")
+    print(f"Closed path: {target}")
+    print(f"Branch retained: {info.branch}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv))
+    except subprocess.CalledProcessError as exc:
+        message = exc.stderr.strip() or exc.output.strip() or str(exc)
+        print(message, file=sys.stderr)
+        raise SystemExit(exc.returncode)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,6 +409,20 @@ setlerini karşılaştırır ve iki seviyede sinyal üretir:
 - **exact file overlap** — aynı dosyaya iki açık worktree dokunuyor
 - **shared top-level area** — aynı üst klasör alanında paralel değişim var
 
+Clean bir yardımcı worktree kapatılacaksa çıplak `git worktree remove` yerine şu
+yüzeyi kullan:
+
+```bash
+bash .claude/scripts/ops.sh close-worktree <path>
+```
+
+`ops.sh close-worktree` şu güvenlik kontratıyla çalışır:
+
+- current worktree'yi kapatmaz
+- dirty target'ı kapatmaz
+- yalnız attached ve clean non-current worktree'yi kapatır
+- branch'i silmez; yalnız worktree'yi kapatır
+
 Komut exit 1 dönerse DUR, kullanıcı ile karar ver:
 
 - Main'e rebase: `git rebase origin/main`
@@ -437,7 +451,7 @@ git checkout main && git pull
 git worktree add ../ao-kernel-feat-X -b feat/X origin/main
 
 # Bitince
-git worktree remove ../ao-kernel-feat-X
+bash .claude/scripts/ops.sh close-worktree ../ao-kernel-feat-X
 git branch -D feat/X  # merge edildikten sonra
 ```
 

--- a/tests/test_ops_preflight_script.py
+++ b/tests/test_ops_preflight_script.py
@@ -76,6 +76,17 @@ def _run_overlap_check(cwd: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _run_close_worktree(cwd: Path, target: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(OPS_SCRIPT), "close-worktree", target.as_posix()],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+
 def test_ops_preflight_clean_repo(tmp_path: Path) -> None:
     work = _init_remote_clone(tmp_path)
 
@@ -202,3 +213,62 @@ def test_ops_overlap_check_uses_mainline_base_for_pushed_feature_branches(
     assert "feature-a" in proc.stdout
     assert "feature-b" in proc.stdout
     assert "⚠ Overlap risk detected" in proc.stdout
+
+
+def test_ops_close_worktree_closes_clean_secondary_worktree(
+    tmp_path: Path,
+) -> None:
+    work = _init_remote_clone(tmp_path)
+    wt = tmp_path / "wt-close"
+
+    _run(
+        ["git", "worktree", "add", "-b", "feature-close", wt.as_posix(), "origin/main"],
+        cwd=work,
+    )
+
+    proc = _run_close_worktree(work, wt)
+
+    assert proc.returncode == 0
+    assert "== ops close-worktree ==" in proc.stdout
+    assert "✓ Worktree closed" in proc.stdout
+    assert not wt.exists()
+    assert wt.as_posix() not in _git(work, "worktree", "list", "--porcelain").stdout
+
+
+def test_ops_close_worktree_refuses_dirty_secondary_worktree(
+    tmp_path: Path,
+) -> None:
+    work = _init_remote_clone(tmp_path)
+    wt = tmp_path / "wt-dirty"
+
+    _run(
+        ["git", "worktree", "add", "-b", "feature-dirty", wt.as_posix(), "origin/main"],
+        cwd=work,
+    )
+    (wt / "notes.txt").write_text("dirty\n", encoding="utf-8")
+
+    proc = _run_close_worktree(work, wt)
+
+    assert proc.returncode == 1
+    assert "Refusing to close dirty worktree" in proc.stdout
+    assert wt.exists()
+    assert wt.as_posix() in _git(work, "worktree", "list", "--porcelain").stdout
+
+
+def test_ops_close_worktree_refuses_current_worktree(tmp_path: Path) -> None:
+    work = _init_remote_clone(tmp_path)
+
+    proc = _run_close_worktree(work, work)
+
+    assert proc.returncode == 1
+    assert "Refusing to close current worktree" in proc.stdout
+
+
+def test_ops_close_worktree_rejects_unknown_target(tmp_path: Path) -> None:
+    work = _init_remote_clone(tmp_path)
+    unknown = tmp_path / "missing"
+
+    proc = _run_close_worktree(work, unknown)
+
+    assert proc.returncode == 1
+    assert "Target is not an attached worktree for this repository" in proc.stdout


### PR DESCRIPTION
## Summary
- add `bash .claude/scripts/ops.sh close-worktree <path>` as a fail-closed wrapper for helper worktree shutdown
- refuse current, dirty, or unknown targets; close only clean non-current attached worktrees
- document WP-6.3 and extend subprocess coverage for clean/dirty/current/unknown target cases

## Testing
- pytest tests/test_ops_preflight_script.py -q
- bash .claude/scripts/ops.sh close-worktree .
- bash .claude/scripts/ops.sh preflight

Refs #197