### PR TITLE
[codex] ops: add archive-worktree flow

### DIFF
--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -68,7 +68,7 @@ automation platform çizgisine taşımak.
 
 **GitHub takip**
 - üst issue: [#197](https://github.com/Halildeu/ao-kernel/issues/197)
-- aktif slice: [`WP-6.3-CLOSE-WORKTREE.md`](./WP-6.3-CLOSE-WORKTREE.md)
+- aktif slice: [`WP-6.4-ARCHIVE-WORKTREE.md`](./WP-6.4-ARCHIVE-WORKTREE.md)
 
 **Adım sırası**
 1. `[x]` `ops.sh` dispatcher yüzeyi eklendi.
@@ -77,18 +77,21 @@ automation platform çizgisine taşımak.
 3. `[x]` Clean / warning / fail path'leri subprocess testleriyle pinlendi.
 4. `[x]` `WP-6.2` overlap-check yüzeyi eklendi.
 5. `[x]` `WP-6.3` close-worktree yüzeyi eklendi.
-6. `[ ]` `WP-6.4` archive-worktree yüzeyi eklenecek.
+6. `[x]` `WP-6.4` archive-worktree yüzeyi eklendi.
 
 **Canlı snapshot**
 - session başlangıç komutu: `bash .claude/scripts/ops.sh preflight`
 - çoklu worktree çakışma görünürlüğü: `bash .claude/scripts/ops.sh overlap-check`
 - güvenli yardımcı worktree kapanışı: `bash .claude/scripts/ops.sh close-worktree <path>`
+- dirty yardımcı worktree arşivleme + kaldırma: `bash .claude/scripts/ops.sh archive-worktree <path>`
 - hard block: forbidden branch / detached HEAD / stale base / `main` drift
 - warning-only: current dirty tree / upstream yok / other worktree dirty
 - overlap-check: exact file overlap ve shared top-level area sinyali üretir;
   bu slice görünürlük verir, henüz hard-enforcement yapmaz
 - close-worktree: clean non-current target'ı kapatır; dirty/current target için
   fail-closed davranır
+- archive-worktree: dirty non-current target için patch + untracked snapshot
+  alır, common git dir altına arşivler ve sonra target'ı kaldırır
 - `check-branch-sync.sh` alttaki primitive olarak korunur
 
 **Definition of Done**
@@ -97,6 +100,7 @@ automation platform çizgisine taşımak.
 - dirty tree ve other worktree riski görünür hale geliyor
 - çoklu worktree path çakışması görünür hale geliyor
 - güvenli worktree kapanışı standart yüzeyden yapılabiliyor
+- dirty worktree state'i repo kirletmeden arşivlenip güvenli kaldırılabiliyor
 - bu davranış test veya smoke ile pinlenmiş
 
 ## 6. Sonra

--- a/.claude/plans/WP-6.4-ARCHIVE-WORKTREE.md
+++ b/.claude/plans/WP-6.4-ARCHIVE-WORKTREE.md
@@ -1,0 +1,63 @@
+# WP-6.4 — Archive Worktree
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#197](https://github.com/Halildeu/ao-kernel/issues/197)
+**Üst WP:** [#197](https://github.com/Halildeu/ao-kernel/issues/197)
+
+## Amaç
+
+Dirty bir yardımcı worktree'yi sessiz veri kaybı olmadan düşürebilmek için
+dar, fail-closed bir archive+remove yüzeyi eklemek.
+
+Bu slice `close-worktree` ile çakışmaz. `close-worktree` clean helper target
+içindir; `archive-worktree` dirty helper target içindir.
+
+## Komut
+
+```bash
+bash .claude/scripts/ops.sh archive-worktree <path>
+```
+
+## Archive Modeli
+
+`ops archive-worktree` dirty non-current attached target için şunları üretir:
+
+1. `status.txt`
+2. `staged.patch`
+3. `unstaged.patch`
+4. `untracked-files.txt`
+5. `untracked/` altına untracked file snapshot'ı
+6. `archive-meta.json`
+7. `RESTORE.md`
+
+Arşiv konumu repo worktree içinde değil, common git dir altındadır:
+
+- `<git-common-dir>/ops-worktree-archives/<timestamp>-<branch>-<id>/`
+
+Arşiv yazıldıktan sonra target `git worktree remove --force` ile kaldırılır.
+
+## Exit Semantiği
+
+- `0`
+  - dirty non-current attached worktree arşivlendi ve kaldırıldı
+- `1`
+  - target current worktree
+  - target clean worktree
+  - target bu repo için attached worktree değil
+- `2`
+  - yanlış kullanım
+
+## Bu Slice'ın Kararı
+
+- Current worktree arşivlenmez.
+- Clean target arşivlenmez; `close-worktree`'ye yönlendirilir.
+- Branch silinmez; yalnız dirty state snapshot'ı alınır ve worktree kaldırılır.
+- Arşiv repo worktree'sini kirletmez; common git dir altında kalır.
+
+## Definition of Done
+
+1. `ops.sh archive-worktree` repo içinde mevcut olmalı
+2. Dirty secondary target için archive+remove başarıyla çalışmalı
+3. Clean/current/unknown target fail-closed davranmalı
+4. Arşivde patch, untracked snapshot ve meta dosyaları bulunmalı
+5. Bu davranış subprocess testleriyle pinlenmiş olmalı

--- a/.claude/scripts/ops.sh
+++ b/.claude/scripts/ops.sh
@@ -14,11 +14,15 @@
 # - `close-worktree`
 #   - clean non-current worktree'yi güvenli biçimde kapatır
 #   - dirty veya current target için fail-closed davranır
+# - `archive-worktree`
+#   - dirty non-current worktree'yi common git dir altında arşivler
+#   - arşiv sonrası worktree'yi force-remove eder
 #
 # Kullanım:
 #   bash .claude/scripts/ops.sh preflight
 #   bash .claude/scripts/ops.sh overlap-check
 #   bash .claude/scripts/ops.sh close-worktree <path>
+#   bash .claude/scripts/ops.sh archive-worktree <path>
 
 set -euo pipefail
 
@@ -30,11 +34,13 @@ Usage:
   bash .claude/scripts/ops.sh preflight
   bash .claude/scripts/ops.sh overlap-check
   bash .claude/scripts/ops.sh close-worktree <path>
+  bash .claude/scripts/ops.sh archive-worktree <path>
 
 Available commands:
-  preflight       Session başlangıcı için branch/worktree sağlık özeti
-  overlap-check   Attached worktree'ler arası path-overlap riski görünürlüğü
-  close-worktree  Clean non-current worktree kapatma yüzeyi
+  preflight         Session başlangıcı için branch/worktree sağlık özeti
+  overlap-check     Attached worktree'ler arası path-overlap riski görünürlüğü
+  close-worktree    Clean non-current worktree kapatma yüzeyi
+  archive-worktree  Dirty non-current worktree arşivleme + kaldırma yüzeyi
 EOF
 }
 
@@ -168,6 +174,10 @@ run_close_worktree() {
   python3 "$SCRIPT_DIR/ops_close_worktree.py" "$@"
 }
 
+run_archive_worktree() {
+  python3 "$SCRIPT_DIR/ops_archive_worktree.py" "$@"
+}
+
 main() {
   local command="${1:-}"
   case "$command" in
@@ -180,6 +190,10 @@ main() {
     close-worktree)
       shift
       run_close_worktree "$@"
+      ;;
+    archive-worktree)
+      shift
+      run_archive_worktree "$@"
       ;;
     ""|-h|--help|help)
       usage

--- a/.claude/scripts/ops_archive_worktree.py
+++ b/.claude/scripts/ops_archive_worktree.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+
+@dataclass(frozen=True)
+class WorktreeInfo:
+    path: Path
+    branch: str
+
+
+@dataclass(frozen=True)
+class DirtyStatus:
+    staged: int
+    unstaged: int
+    untracked: int
+
+    @property
+    def is_dirty(self) -> bool:
+        return bool(self.staged or self.unstaged or self.untracked)
+
+
+def _run_git(path: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        ["git", "-C", path.as_posix(), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and proc.returncode != 0:
+        raise subprocess.CalledProcessError(
+            proc.returncode,
+            proc.args,
+            output=proc.stdout,
+            stderr=proc.stderr,
+        )
+    return proc
+
+
+def _git_value(path: Path, *args: str) -> str:
+    return _run_git(path, *args).stdout.strip()
+
+
+def _git_lines(path: Path, *args: str) -> list[str]:
+    return [line for line in _run_git(path, *args).stdout.splitlines() if line.strip()]
+
+
+def _resolve_git_common_dir(repo_root: Path) -> Path:
+    value = Path(_git_value(repo_root, "rev-parse", "--git-common-dir"))
+    return value if value.is_absolute() else (repo_root / value).resolve()
+
+
+def _parse_worktrees(repo_root: Path) -> list[WorktreeInfo]:
+    lines = _run_git(repo_root, "worktree", "list", "--porcelain").stdout.splitlines()
+    entries: list[WorktreeInfo] = []
+    current_path: Path | None = None
+    current_branch: str | None = None
+
+    for line in lines + [""]:
+        if not line:
+            if current_path is not None:
+                entries.append(
+                    WorktreeInfo(
+                        path=current_path.resolve(),
+                        branch=current_branch or "(detached)",
+                    )
+                )
+            current_path = None
+            current_branch = None
+            continue
+        if line.startswith("worktree "):
+            current_path = Path(line.removeprefix("worktree "))
+        elif line.startswith("branch refs/heads/"):
+            current_branch = line.removeprefix("branch refs/heads/")
+
+    return entries
+
+
+def _count_lines(path: Path, *args: str) -> int:
+    return len(_git_lines(path, *args))
+
+
+def _dirty_status(path: Path) -> DirtyStatus:
+    return DirtyStatus(
+        staged=_count_lines(path, "diff", "--cached", "--name-only"),
+        unstaged=_count_lines(path, "diff", "--name-only"),
+        untracked=_count_lines(path, "ls-files", "--others", "--exclude-standard"),
+    )
+
+
+def _branch_slug(branch: str) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in branch)
+    return safe.strip("-") or "detached"
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _copy_untracked_files(target: Path, archive_dir: Path) -> list[str]:
+    copied: list[str] = []
+    for rel in _git_lines(target, "ls-files", "--others", "--exclude-standard"):
+        source = target / rel
+        if not source.is_file():
+            continue
+        destination = archive_dir / "untracked" / rel
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        copied.append(rel)
+    return copied
+
+
+def _print_usage() -> None:
+    print("Usage: bash .claude/scripts/ops.sh archive-worktree <path>", file=sys.stderr)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        _print_usage()
+        return 2
+
+    cwd = Path.cwd().resolve()
+    repo_root = Path(_git_value(cwd, "rev-parse", "--show-toplevel")).resolve()
+    target = Path(argv[1]).expanduser().resolve()
+    worktrees = _parse_worktrees(repo_root)
+    known_paths = {entry.path: entry for entry in worktrees}
+
+    print("== ops archive-worktree ==")
+    print(f"Repo: {repo_root}")
+    print(f"Requested target: {target}")
+
+    if target == repo_root:
+        print("Refusing to archive current worktree")
+        return 1
+
+    if target not in known_paths:
+        print("Target is not an attached worktree for this repository")
+        return 1
+
+    info = known_paths[target]
+    dirty = _dirty_status(target)
+    print(f"Target branch: {info.branch}")
+    print(
+        "Target status: "
+        f"staged={dirty.staged}, unstaged={dirty.unstaged}, untracked={dirty.untracked}"
+    )
+
+    if not dirty.is_dirty:
+        print("Refusing to archive clean worktree")
+        print("Next step: use `bash .claude/scripts/ops.sh close-worktree <path>`")
+        return 1
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    common_git_dir = _resolve_git_common_dir(repo_root)
+    archive_dir = (
+        common_git_dir
+        / "ops-worktree-archives"
+        / f"{timestamp}-{_branch_slug(info.branch)}-{uuid4().hex[:8]}"
+    )
+    archive_dir.mkdir(parents=True, exist_ok=False)
+
+    head_sha = _git_value(target, "rev-parse", "HEAD")
+    _write_text(archive_dir / "status.txt", _run_git(target, "status", "--short", "--branch").stdout)
+    _write_text(archive_dir / "staged.patch", _run_git(target, "diff", "--cached").stdout)
+    _write_text(archive_dir / "unstaged.patch", _run_git(target, "diff").stdout)
+    copied_untracked = _copy_untracked_files(target, archive_dir)
+    _write_text(
+        archive_dir / "untracked-files.txt",
+        "\n".join(copied_untracked) + ("\n" if copied_untracked else ""),
+    )
+    _write_text(
+        archive_dir / "RESTORE.md",
+        "\n".join(
+            [
+                "# Worktree Archive Restore Notes",
+                "",
+                f"- Branch: `{info.branch}`",
+                f"- Head SHA: `{head_sha}`",
+                f"- Original path: `{target}`",
+                "",
+                "Suggested restore flow:",
+                f"1. `git checkout -b {info.branch}-restore origin/main`",
+                "2. Apply `staged.patch` then `unstaged.patch` if needed",
+                "3. Copy files from `untracked/` back into the worktree",
+            ]
+        )
+        + "\n",
+    )
+    meta = {
+        "archive_version": "v1",
+        "archived_at": datetime.now(timezone.utc).isoformat(),
+        "repo_root": repo_root.as_posix(),
+        "git_common_dir": common_git_dir.as_posix(),
+        "target_path": target.as_posix(),
+        "branch": info.branch,
+        "head_sha": head_sha,
+        "dirty_status": {
+            "staged": dirty.staged,
+            "unstaged": dirty.unstaged,
+            "untracked": dirty.untracked,
+        },
+        "archive_dir": archive_dir.as_posix(),
+    }
+    _write_text(archive_dir / "archive-meta.json", json.dumps(meta, indent=2) + "\n")
+
+    _run_git(repo_root, "worktree", "remove", "--force", target.as_posix())
+
+    print("✓ Worktree archived and removed")
+    print(f"Archive dir: {archive_dir}")
+    print(f"Branch retained: {info.branch}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv))
+    except subprocess.CalledProcessError as exc:
+        message = exc.stderr.strip() or exc.output.strip() or str(exc)
+        print(message, file=sys.stderr)
+        raise SystemExit(exc.returncode)

--- a/.claude/scripts/ops_close_worktree.py
+++ b/.claude/scripts/ops_close_worktree.py
@@ -105,7 +105,10 @@ def main(argv: list[str]) -> int:
 
     if staged or unstaged or untracked:
         print("Refusing to close dirty worktree")
-        print("Next step: commit/clean changes first; archive flow WP-6.4'te gelecek")
+        print(
+            "Next step: use `bash .claude/scripts/ops.sh archive-worktree <path>` "
+            "veya önce bilinçli olarak temizle"
+        )
         return 1
 
     _run_git(repo_root, "worktree", "remove", target.as_posix())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,6 +423,21 @@ bash .claude/scripts/ops.sh close-worktree <path>
 - yalnız attached ve clean non-current worktree'yi kapatır
 - branch'i silmez; yalnız worktree'yi kapatır
 
+Dirty bir yardımcı worktree'yi düşürmeden önce state'i saklamak gerekiyorsa şu
+yüzeyi kullan:
+
+```bash
+bash .claude/scripts/ops.sh archive-worktree <path>
+```
+
+`ops.sh archive-worktree` şu dar kontratla çalışır:
+
+- current worktree'yi arşivlemez
+- clean target'ı arşivlemez; `close-worktree`'ye yönlendirir
+- dirty non-current attached worktree için patch + untracked snapshot üretir
+- arşivi common git dir altına yazar, repo worktree'sini kirletmez
+- arşiv sonrası target worktree'yi force-remove eder, branch'i silmez
+
 Komut exit 1 dönerse DUR, kullanıcı ile karar ver:
 
 - Main'e rebase: `git rebase origin/main`

--- a/tests/test_ops_preflight_script.py
+++ b/tests/test_ops_preflight_script.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -79,6 +80,17 @@ def _run_overlap_check(cwd: Path) -> subprocess.CompletedProcess[str]:
 def _run_close_worktree(cwd: Path, target: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["bash", str(OPS_SCRIPT), "close-worktree", target.as_posix()],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+
+def _run_archive_worktree(cwd: Path, target: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(OPS_SCRIPT), "archive-worktree", target.as_posix()],
         cwd=cwd,
         check=False,
         capture_output=True,
@@ -251,6 +263,7 @@ def test_ops_close_worktree_refuses_dirty_secondary_worktree(
 
     assert proc.returncode == 1
     assert "Refusing to close dirty worktree" in proc.stdout
+    assert "archive-worktree" in proc.stdout
     assert wt.exists()
     assert wt.as_posix() in _git(work, "worktree", "list", "--porcelain").stdout
 
@@ -269,6 +282,81 @@ def test_ops_close_worktree_rejects_unknown_target(tmp_path: Path) -> None:
     unknown = tmp_path / "missing"
 
     proc = _run_close_worktree(work, unknown)
+
+    assert proc.returncode == 1
+    assert "Target is not an attached worktree for this repository" in proc.stdout
+
+
+def test_ops_archive_worktree_archives_dirty_secondary_and_removes_it(
+    tmp_path: Path,
+) -> None:
+    work = _init_remote_clone(tmp_path)
+    wt = tmp_path / "wt-archive"
+
+    _run(
+        ["git", "worktree", "add", "-b", "feature-archive", wt.as_posix(), "origin/main"],
+        cwd=work,
+    )
+    (wt / "tracked.txt").write_text("dirty tracked\n", encoding="utf-8")
+    _git(wt, "add", "tracked.txt")
+    (wt / "tracked.txt").write_text("dirty tracked updated\n", encoding="utf-8")
+    (wt / "notes.txt").write_text("untracked note\n", encoding="utf-8")
+
+    proc = _run_archive_worktree(work, wt)
+
+    assert proc.returncode == 0
+    assert "== ops archive-worktree ==" in proc.stdout
+    assert "✓ Worktree archived and removed" in proc.stdout
+    assert not wt.exists()
+    assert wt.as_posix() not in _git(work, "worktree", "list", "--porcelain").stdout
+    assert "feature-archive" in _git(work, "branch", "--list").stdout
+
+    common_git_dir = (work / ".git").resolve()
+    archives = sorted((common_git_dir / "ops-worktree-archives").glob("*feature-archive*"))
+    assert len(archives) == 1
+    archive_dir = archives[0]
+    meta = json.loads((archive_dir / "archive-meta.json").read_text(encoding="utf-8"))
+    assert meta["branch"] == "feature-archive"
+    assert meta["dirty_status"] == {"staged": 1, "unstaged": 1, "untracked": 1}
+    assert "tracked.txt" in (archive_dir / "staged.patch").read_text(encoding="utf-8")
+    assert "tracked.txt" in (archive_dir / "unstaged.patch").read_text(encoding="utf-8")
+    assert (archive_dir / "untracked" / "notes.txt").read_text(encoding="utf-8") == "untracked note\n"
+    assert "notes.txt" in (archive_dir / "untracked-files.txt").read_text(encoding="utf-8")
+
+
+def test_ops_archive_worktree_refuses_clean_secondary_worktree(
+    tmp_path: Path,
+) -> None:
+    work = _init_remote_clone(tmp_path)
+    wt = tmp_path / "wt-clean-archive"
+
+    _run(
+        ["git", "worktree", "add", "-b", "feature-clean-archive", wt.as_posix(), "origin/main"],
+        cwd=work,
+    )
+
+    proc = _run_archive_worktree(work, wt)
+
+    assert proc.returncode == 1
+    assert "Refusing to archive clean worktree" in proc.stdout
+    assert "close-worktree" in proc.stdout
+    assert wt.exists()
+
+
+def test_ops_archive_worktree_refuses_current_worktree(tmp_path: Path) -> None:
+    work = _init_remote_clone(tmp_path)
+
+    proc = _run_archive_worktree(work, work)
+
+    assert proc.returncode == 1
+    assert "Refusing to archive current worktree" in proc.stdout
+
+
+def test_ops_archive_worktree_rejects_unknown_target(tmp_path: Path) -> None:
+    work = _init_remote_clone(tmp_path)
+    unknown = tmp_path / "missing"
+
+    proc = _run_archive_worktree(work, unknown)
 
     assert proc.returncode == 1
     assert "Target is not an attached worktree for this repository" in proc.stdout


### PR DESCRIPTION
## Summary
- add `bash .claude/scripts/ops.sh archive-worktree <path>` for dirty helper worktrees
- archive patches, status, meta, and untracked files under the common git dir, then force-remove the target worktree
- keep the state split explicit: clean targets use `close-worktree`, dirty targets use `archive-worktree`

## Testing
- pytest tests/test_ops_preflight_script.py -q
- bash .claude/scripts/ops.sh archive-worktree .
- git diff --check

Refs #197