### PR TITLE
[codex] add WP-7.1 path ownership namespace

### DIFF
--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -53,8 +53,8 @@ automation platform çizgisine taşımak.
 | `WP-3` Policy rollout test upgrade | Baseline | Completed on `main` | behavior-first governance testleri | rollout pytest paketi |
 | `WP-4` Packaging/install trust | Baseline | Completed on `main` | wheel-only smoke gerçek gate olur | `scripts/packaging_smoke.py` + CI |
 | `WP-5` Release governance hardening | Faz 3 | Completed on `main` | branch protection / required checks / CODEOWNERS / merge gate sertliği | PR #202 + branch protection snapshot |
-| `WP-6` Worktree/branch safety control loop | Faz 3 | **Active** ([#197](https://github.com/Halildeu/ao-kernel/issues/197)) | stale base / overlap / dirty worktree riskini operasyonel kapatmak | ops komutları + usage proof |
-| `WP-7` Path-scoped write ownership | Faz 3 | Planned ([#198](https://github.com/Halildeu/ao-kernel/issues/198)) | aynı path alanına iki aktif writer çakışmasın | ownership tests + takeover audit |
+| `WP-6` Worktree/branch safety control loop | Faz 3 | Completed on `main` | stale base / overlap / dirty worktree riskini operasyonel kapatmak | ops komutları + usage proof |
+| `WP-7` Path-scoped write ownership | Faz 3 | **Active** ([#198](https://github.com/Halildeu/ao-kernel/issues/198)) | aynı path alanına iki aktif writer çakışmasın | ownership tests + takeover audit |
 | `WP-8` Real adapter certification | Faz 4 | Planned ([#199](https://github.com/Halildeu/ao-kernel/issues/199)) | en az 2 gerçek adapter prod-tier smoke ve failure-mode testlerinden geçsin | capability matrix + smoke logs |
 | `WP-9` Ops/runbook/incident readiness | Faz 4 | Planned ([#200](https://github.com/Halildeu/ao-kernel/issues/200)) | rollback / incident / support boundary / known bugs paketi | runbook + drill evidence |
 
@@ -68,7 +68,7 @@ automation platform çizgisine taşımak.
 
 **GitHub takip**
 - üst issue: [#197](https://github.com/Halildeu/ao-kernel/issues/197)
-- aktif slice: [`WP-6.4-ARCHIVE-WORKTREE.md`](./WP-6.4-ARCHIVE-WORKTREE.md)
+- son slice: [`WP-6.4-ARCHIVE-WORKTREE.md`](./WP-6.4-ARCHIVE-WORKTREE.md)
 
 **Adım sırası**
 1. `[x]` `ops.sh` dispatcher yüzeyi eklendi.
@@ -110,10 +110,19 @@ automation platform çizgisine taşımak.
 **Amaç**
 - mevcut claim/fencing altyapısını path-grubu ownership seviyesine taşımak
 
+**GitHub takip**
+- üst issue: [#198](https://github.com/Halildeu/ao-kernel/issues/198)
+- aktif slice: [`WP-7.1-PATH-RESOURCE-NAMESPACE.md`](./WP-7.1-PATH-RESOURCE-NAMESPACE.md)
+
 **Hedef slice'lar**
-1. ownership model ve resource namespace kararı
-2. claim / release / takeover / handoff kaydı
-3. executor veya orchestration girişinde write ownership enforcement
+1. `[x]` ownership model ve resource namespace kararı
+2. `[ ]` claim / release / takeover / handoff kaydı
+3. `[ ]` executor veya orchestration girişinde write ownership enforcement
+
+**Bu slice’ın hedefi (`WP-7.1`)**
+- workspace-relative path -> top-level area -> deterministic `resource_id`
+- mevcut `ClaimRegistry` üstünden sequential acquire/release helper’ları
+- partial acquire rollback ve pytest kanıtı
 
 ## 7. En Son
 

--- a/.claude/plans/WP-7.1-PATH-RESOURCE-NAMESPACE.md
+++ b/.claude/plans/WP-7.1-PATH-RESOURCE-NAMESPACE.md
@@ -1,0 +1,42 @@
+# WP-7.1 — Path Resource Namespace
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#198](https://github.com/Halildeu/ao-kernel/issues/198)
+**Üst WP:** [#198](https://github.com/Halildeu/ao-kernel/issues/198)
+
+## Amaç
+
+Path-scoped write ownership için yeni paralel bir lock sistemi yazmadan,
+mevcut claim/fencing runtime’ı üstüne kanonik resource namespace katmanı
+eklemek.
+
+## Bu Slice’ın Kararı
+
+- v1 write ownership granularity’si **top-level area** olacak
+  - `pkg/a.py` ve `pkg/sub/b.py` aynı ownership alanına düşer
+- Area -> `resource_id` dönüşümü deterministik ve collision-safe olacak
+- Multi-area acquire **atomic olmayacak**
+  - sorted sequential acquire
+  - sonradan conflict olursa önceki acquire’lar reverse sırada rollback edilir
+
+## Public Surface
+
+- `ao_kernel.coordination.path_ownership`
+- `normalize_workspace_relative_path(...)`
+- `build_path_write_scopes(...)`
+- `acquire_path_write_claims(...)`
+- `release_path_write_claims(...)`
+
+## Definition of Done
+
+1. Aynı top-level area için tek claim resource namespace üretiliyor olmalı
+2. Relative ve absolute path input’ları aynı kanonik scope’a çözülmeli
+3. Aynı area’da ikinci writer conflict almalı
+4. Multi-area sequential acquire conflict’inde partial acquire rollback olmalı
+5. Bu davranış pytest ile pinlenmiş olmalı
+
+## Deferred
+
+- executor/orchestration girişinde hard enforcement
+- takeover/handoff ergonomics
+- daha dar granularity (`exact path`, `directory prefix`) seçenekleri

--- a/ao_kernel/coordination/__init__.py
+++ b/ao_kernel/coordination/__init__.py
@@ -54,6 +54,17 @@ from ao_kernel.coordination.policy import (
     load_coordination_policy,
     match_resource_pattern,
 )
+from ao_kernel.coordination.path_ownership import (
+    PathWriteLease,
+    PathWriteLeaseSet,
+    PathWriteScope,
+    acquire_path_write_claims,
+    build_path_write_resource_id,
+    build_path_write_scopes,
+    normalize_workspace_relative_path,
+    release_path_write_claims,
+    top_level_write_area,
+)
 from ao_kernel.coordination.registry import (
     AgentClaimIndex,
     ClaimRegistry,
@@ -85,6 +96,16 @@ __all__ = [
     "EvidenceRedaction",
     "load_coordination_policy",
     "match_resource_pattern",
+    # Path ownership
+    "PathWriteLease",
+    "PathWriteLeaseSet",
+    "PathWriteScope",
+    "acquire_path_write_claims",
+    "build_path_write_resource_id",
+    "build_path_write_scopes",
+    "normalize_workspace_relative_path",
+    "release_path_write_claims",
+    "top_level_write_area",
     # Registry
     "AgentClaimIndex",
     "ClaimRegistry",

--- a/ao_kernel/coordination/path_ownership.py
+++ b/ao_kernel/coordination/path_ownership.py
@@ -1,0 +1,233 @@
+"""Path-scoped write ownership helpers built on top of ``ClaimRegistry``.
+
+This module does not introduce a second coordination system. It projects
+workspace paths onto the existing claim/fencing runtime so callers can claim
+write ownership over path *areas* using the same SSOT, evidence, takeover and
+fencing machinery already shipped in :mod:`ao_kernel.coordination`.
+
+v1 scope model:
+
+- Granularity is **top-level area** (same signal model as ``ops overlap-check``).
+- Multiple paths under the same top-level area map to the same resource id.
+- Multi-area acquisition is **sequential, not atomic**. If one later acquire
+  fails, earlier acquired claims are released best-effort in reverse order.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+from ao_kernel.coordination.claim import Claim
+from ao_kernel.coordination.policy import CoordinationPolicy
+from ao_kernel.coordination.registry import ClaimRegistry
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PathWriteScope:
+    """Canonical top-level write scope for one or more workspace paths."""
+
+    area: str
+    resource_id: str
+    paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PathWriteLease:
+    """A claimed path scope together with the underlying coordination claim."""
+
+    scope: PathWriteScope
+    claim: Claim
+
+
+@dataclass(frozen=True)
+class PathWriteLeaseSet:
+    """Sequentially acquired write-scope leases for one owner agent."""
+
+    owner_agent_id: str
+    leases: tuple[PathWriteLease, ...]
+
+
+def _project_root(workspace_root: Path | str) -> Path:
+    """Accept either project root or ``.ao`` workspace dir and return project root."""
+    resolved = Path(workspace_root).resolve()
+    if resolved.name == ".ao":
+        return resolved.parent
+    return resolved
+
+
+def _ensure_matching_registry_root(
+    registry: ClaimRegistry,
+    workspace_root: Path | str,
+) -> Path:
+    """Fail closed when helper inputs point at different project roots."""
+    helper_root = _project_root(workspace_root)
+    registry_root = _project_root(registry._workspace_root)
+    if helper_root != registry_root:
+        raise ValueError(
+            "workspace_root does not match ClaimRegistry workspace root: "
+            f"{helper_root!s} != {registry_root!s}"
+        )
+    return helper_root
+
+
+def normalize_workspace_relative_path(
+    workspace_root: Path | str,
+    path: Path | str,
+) -> str:
+    """Return a canonical workspace-relative POSIX path.
+
+    ``workspace_root`` may be either the project root or the ``.ao`` directory.
+    ``path`` may be absolute or relative. Absolute paths must stay under the
+    project root after resolution; relative paths are resolved under it.
+    """
+    project_root = _project_root(workspace_root)
+    candidate = Path(path)
+    resolved = candidate.resolve() if candidate.is_absolute() else (project_root / candidate).resolve()
+
+    try:
+        relative = resolved.relative_to(project_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"path {candidate!s} resolves outside project root {project_root!s}"
+        ) from exc
+
+    relative_posix = PurePosixPath(relative.as_posix())
+    if not relative_posix.parts:
+        raise ValueError("path must point to a file or directory under the project root")
+    if any(part in {"", ".", ".."} for part in relative_posix.parts):
+        raise ValueError(
+            f"path {candidate!s} does not normalize to a stable workspace-relative path"
+        )
+    return relative_posix.as_posix()
+
+
+def top_level_write_area(relative_path: str) -> str:
+    """Return the v1 write-ownership area for a workspace-relative path."""
+    path = PurePosixPath(relative_path)
+    if not path.parts:
+        raise ValueError("relative_path must not be empty")
+    return path.parts[0]
+
+
+def build_path_write_resource_id(area: str) -> str:
+    """Build a deterministic, validator-safe resource id for a write area.
+
+    Human readability matters for audits, but the id also must be collision-safe
+    for arbitrary directory names. We therefore combine a readable slug with a
+    short content hash of the original area string.
+    """
+    if not area:
+        raise ValueError("area must not be empty")
+
+    slug_chars: list[str] = []
+    for ch in area:
+        if ch.isascii() and (ch.isalnum() or ch in "._-"):
+            slug_chars.append(ch)
+        else:
+            slug_chars.append("_")
+    slug = "".join(slug_chars).strip("._-")
+    if not slug:
+        slug = "area"
+
+    digest = hashlib.sha256(area.encode("utf-8")).hexdigest()[:12]
+    return f"write-area.{slug}.{digest}"
+
+
+def build_path_write_scopes(
+    workspace_root: Path | str,
+    paths: Iterable[Path | str],
+) -> tuple[PathWriteScope, ...]:
+    """Group paths into deterministic top-level-area write scopes."""
+    grouped: dict[str, set[str]] = {}
+    for path in paths:
+        relative = normalize_workspace_relative_path(workspace_root, path)
+        area = top_level_write_area(relative)
+        grouped.setdefault(area, set()).add(relative)
+
+    if not grouped:
+        raise ValueError("at least one path is required to build write scopes")
+
+    scopes = [
+        PathWriteScope(
+            area=area,
+            resource_id=build_path_write_resource_id(area),
+            paths=tuple(sorted(relative_paths)),
+        )
+        for area, relative_paths in grouped.items()
+    ]
+    return tuple(sorted(scopes, key=lambda item: (item.area, item.resource_id)))
+
+
+def acquire_path_write_claims(
+    registry: ClaimRegistry,
+    workspace_root: Path | str,
+    *,
+    owner_agent_id: str,
+    paths: Iterable[Path | str],
+    policy: CoordinationPolicy | None = None,
+) -> PathWriteLeaseSet:
+    """Acquire write ownership for the top-level areas covering ``paths``.
+
+    Acquisition is sequential and sorted by area/resource_id for deterministic
+    lock ordering across callers. If a later acquire fails, already-acquired
+    scopes are released best-effort in reverse order and the original exception
+    is re-raised.
+    """
+    project_root = _ensure_matching_registry_root(registry, workspace_root)
+    scopes = build_path_write_scopes(project_root, paths)
+    acquired: list[PathWriteLease] = []
+
+    try:
+        for scope in scopes:
+            claim = registry.acquire_claim(
+                scope.resource_id,
+                owner_agent_id,
+                policy,
+            )
+            acquired.append(PathWriteLease(scope=scope, claim=claim))
+    except Exception:
+        for lease in reversed(acquired):
+            try:
+                registry.release_claim(
+                    lease.scope.resource_id,
+                    lease.claim.claim_id,
+                    owner_agent_id,
+                )
+            except Exception as rollback_exc:
+                logger.warning(
+                    "path ownership rollback release failed: resource_id=%s owner=%s cause=%r",
+                    lease.scope.resource_id,
+                    owner_agent_id,
+                    rollback_exc,
+                    extra={
+                        "resource_id": lease.scope.resource_id,
+                        "owner_agent_id": owner_agent_id,
+                        "cause": repr(rollback_exc),
+                    },
+                )
+        raise
+
+    return PathWriteLeaseSet(
+        owner_agent_id=owner_agent_id,
+        leases=tuple(acquired),
+    )
+
+
+def release_path_write_claims(
+    registry: ClaimRegistry,
+    lease_set: PathWriteLeaseSet,
+) -> None:
+    """Release path write claims in reverse acquisition order."""
+    for lease in reversed(lease_set.leases):
+        registry.release_claim(
+            lease.scope.resource_id,
+            lease.claim.claim_id,
+            lease_set.owner_agent_id,
+        )

--- a/docs/COORDINATION.md
+++ b/docs/COORDINATION.md
@@ -136,6 +136,31 @@ registry.prune_expired_claims(policy=None, *, max_batch=None)
 
 Callers **MUST** hold onto the `Claim` dataclass returned by `acquire_claim` (or `takeover_claim`) — `heartbeat` and `release_claim` take both `resource_id` and `claim_id` (plus `owner_agent_id`) as arguments so the registry does O(1) direct file lookup rather than maintaining a reverse index.
 
+Path-scoped write ownership builds on the same registry rather than introducing a
+parallel lock layer:
+
+```python
+from ao_kernel.coordination import (
+    acquire_path_write_claims,
+    release_path_write_claims,
+)
+
+lease_set = acquire_path_write_claims(
+    registry,
+    workspace_root,
+    owner_agent_id="agent-alpha",
+    paths=["pkg/core.py", "pkg/sub/test_core.py"],
+)
+
+release_path_write_claims(registry, lease_set)
+```
+
+The v1 path-ownership granularity is **top-level area**. The helper maps
+workspace-relative paths onto deterministic `write-area.*` resource ids and
+acquires them sequentially in sorted order. Multi-area acquisition is **not
+atomic**; if a later area conflicts, earlier acquired areas are released
+best-effort in reverse order.
+
 ### 10.2 Fail-closed vs fail-open
 
 - **Fail-closed (raise, never silently absorb):**

--- a/tests/test_path_write_ownership.py
+++ b/tests/test_path_write_ownership.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ao_kernel.coordination import ClaimConflictError, ClaimRegistry
+from ao_kernel.coordination.path_ownership import (
+    acquire_path_write_claims,
+    build_path_write_resource_id,
+    build_path_write_scopes,
+    normalize_workspace_relative_path,
+    release_path_write_claims,
+)
+
+
+def _enabled_policy(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "version": "v1",
+        "enabled": True,
+        "heartbeat_interval_seconds": 30,
+        "expiry_seconds": 90,
+        "takeover_grace_period_seconds": 15,
+        "max_claims_per_agent": 5,
+        "claim_resource_patterns": ["*"],
+        "evidence_redaction": {"patterns": []},
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_workspace_policy(workspace_root: Path, doc: dict[str, object]) -> None:
+    policy_dir = workspace_root / ".ao" / "policies"
+    policy_dir.mkdir(parents=True, exist_ok=True)
+    (policy_dir / "policy_coordination_claims.v1.json").write_text(
+        json.dumps(doc, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+class TestPathNormalization:
+    def test_normalize_relative_path(self, tmp_path: Path) -> None:
+        assert (
+            normalize_workspace_relative_path(tmp_path, Path("pkg/demo.py"))
+            == "pkg/demo.py"
+        )
+
+    def test_normalize_absolute_path_under_workspace(self, tmp_path: Path) -> None:
+        target = tmp_path / "pkg" / "demo.py"
+        target.parent.mkdir(parents=True)
+        target.write_text("print('x')\n", encoding="utf-8")
+
+        assert normalize_workspace_relative_path(tmp_path, target) == "pkg/demo.py"
+
+    def test_rejects_path_outside_workspace(self, tmp_path: Path) -> None:
+        outside = tmp_path.parent / "outside.txt"
+        outside.write_text("x\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="outside project root"):
+            normalize_workspace_relative_path(tmp_path, outside)
+
+
+class TestScopeBuilding:
+    def test_same_area_collapses_to_single_scope(self, tmp_path: Path) -> None:
+        scopes = build_path_write_scopes(
+            tmp_path,
+            [
+                "pkg/a.py",
+                "pkg/sub/b.py",
+                tmp_path / "pkg" / "c.py",
+            ],
+        )
+
+        assert len(scopes) == 1
+        assert scopes[0].area == "pkg"
+        assert scopes[0].paths == ("pkg/a.py", "pkg/c.py", "pkg/sub/b.py")
+        assert scopes[0].resource_id.startswith("write-area.pkg.")
+
+    def test_multiple_areas_sorted_deterministically(self, tmp_path: Path) -> None:
+        scopes = build_path_write_scopes(
+            tmp_path,
+            [
+                "tests/test_demo.py",
+                "pkg/core.py",
+                "README.md",
+            ],
+        )
+
+        assert [scope.area for scope in scopes] == ["README.md", "pkg", "tests"]
+        assert scopes[0].paths == ("README.md",)
+        assert scopes[1].paths == ("pkg/core.py",)
+        assert scopes[2].paths == ("tests/test_demo.py",)
+
+    def test_resource_id_is_deterministic_for_weird_area_names(self) -> None:
+        rid_a = build_path_write_resource_id(".github")
+        rid_b = build_path_write_resource_id(".github")
+        rid_c = build_path_write_resource_id("docs v2")
+        rid_d = build_path_write_resource_id("çalışma")
+
+        assert rid_a == rid_b
+        assert rid_a.startswith("write-area.github.")
+        assert rid_c.startswith("write-area.docs_v2.")
+        assert rid_d.startswith("write-area.")
+        assert rid_d.isascii()
+        assert rid_a != rid_c
+
+
+class TestAcquireReleaseHelpers:
+    def test_acquire_same_area_produces_single_claim(self, tmp_path: Path) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+        registry = ClaimRegistry(tmp_path)
+
+        lease_set = acquire_path_write_claims(
+            registry,
+            tmp_path,
+            owner_agent_id="agent-alpha",
+            paths=["pkg/a.py", "pkg/b.py"],
+        )
+
+        assert len(lease_set.leases) == 1
+        lease = lease_set.leases[0]
+        assert lease.scope.area == "pkg"
+        assert lease.claim.resource_id == lease.scope.resource_id
+
+    def test_acquire_multiple_areas_claims_each_area(self, tmp_path: Path) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+        registry = ClaimRegistry(tmp_path)
+
+        lease_set = acquire_path_write_claims(
+            registry,
+            tmp_path,
+            owner_agent_id="agent-alpha",
+            paths=["pkg/a.py", "tests/test_demo.py"],
+        )
+
+        assert [lease.scope.area for lease in lease_set.leases] == ["pkg", "tests"]
+        live_claims = registry.list_agent_claims("agent-alpha")
+        assert {claim.resource_id for claim in live_claims} == {
+            lease.scope.resource_id for lease in lease_set.leases
+        }
+
+    def test_conflict_on_same_area_blocks_second_writer(self, tmp_path: Path) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+        registry = ClaimRegistry(tmp_path)
+
+        first = acquire_path_write_claims(
+            registry,
+            tmp_path,
+            owner_agent_id="agent-alpha",
+            paths=["pkg/a.py"],
+        )
+
+        with pytest.raises(ClaimConflictError):
+            acquire_path_write_claims(
+                registry,
+                tmp_path,
+                owner_agent_id="agent-beta",
+                paths=["pkg/other.py"],
+            )
+
+        release_path_write_claims(registry, first)
+
+    def test_partial_conflict_rolls_back_earlier_acquired_scopes(
+        self, tmp_path: Path,
+    ) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+        registry = ClaimRegistry(tmp_path)
+
+        blocked = acquire_path_write_claims(
+            registry,
+            tmp_path,
+            owner_agent_id="agent-beta",
+            paths=["tests/existing.py"],
+        )
+
+        with pytest.raises(ClaimConflictError):
+            acquire_path_write_claims(
+                registry,
+                tmp_path,
+                owner_agent_id="agent-alpha",
+                paths=["pkg/a.py", "tests/blocked.py"],
+            )
+
+        assert registry.list_agent_claims("agent-alpha") == []
+        remaining = registry.list_agent_claims("agent-beta")
+        assert [claim.resource_id for claim in remaining] == [
+            blocked.leases[0].scope.resource_id
+        ]
+
+    def test_release_reverses_claims_and_clears_registry(self, tmp_path: Path) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+        registry = ClaimRegistry(tmp_path)
+
+        lease_set = acquire_path_write_claims(
+            registry,
+            tmp_path,
+            owner_agent_id="agent-alpha",
+            paths=["pkg/a.py", "tests/test_demo.py"],
+        )
+
+        release_path_write_claims(registry, lease_set)
+
+        assert registry.list_agent_claims("agent-alpha") == []
+
+    def test_acquire_rejects_workspace_registry_root_mismatch(
+        self, tmp_path: Path,
+    ) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+        registry = ClaimRegistry(tmp_path)
+        other_root = tmp_path / "other"
+        other_root.mkdir()
+
+        with pytest.raises(ValueError, match="does not match ClaimRegistry"):
+            acquire_path_write_claims(
+                registry,
+                other_root,
+                owner_agent_id="agent-alpha",
+                paths=["pkg/a.py"],
+            )


### PR DESCRIPTION
## Summary
- add `ao_kernel.coordination.path_ownership` as the first WP-7 slice on top of the shipped claim/fencing runtime
- map workspace-relative paths to deterministic top-level-area `write-area.*` resource ids
- add sequential acquire/release helpers with partial-acquire rollback, plus status/docs alignment

## Testing
- `pytest -q tests/test_path_write_ownership.py tests/test_coordination_registry.py tests/test_coordination_takeover_prune.py`

## Scope
- closes WP-7.1 ownership model / resource namespace slice for #198
- does not yet add executor-side hard enforcement or takeover/handoff ergonomics
