### PR TITLE
[codex] add WP-7.2 coordination status visibility

### DIFF
--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -112,17 +112,22 @@ automation platform çizgisine taşımak.
 
 **GitHub takip**
 - üst issue: [#198](https://github.com/Halildeu/ao-kernel/issues/198)
-- aktif slice: [`WP-7.1-PATH-RESOURCE-NAMESPACE.md`](./WP-7.1-PATH-RESOURCE-NAMESPACE.md)
+- aktif slice: [`WP-7.2-CLAIM-VISIBILITY.md`](./WP-7.2-CLAIM-VISIBILITY.md)
 
 **Hedef slice'lar**
 1. `[x]` ownership model ve resource namespace kararı
 2. `[ ]` claim / release / takeover / handoff kaydı
 3. `[ ]` executor veya orchestration girişinde write ownership enforcement
 
-**Bu slice’ın hedefi (`WP-7.1`)**
+**Tamamlanan slice (`WP-7.1`)**
 - workspace-relative path -> top-level area -> deterministic `resource_id`
 - mevcut `ClaimRegistry` üstünden sequential acquire/release helper’ları
 - partial acquire rollback ve pytest kanıtı
+
+**Bu slice’ın hedefi (`WP-7.2`)**
+- canlı claim SSOT snapshot’ı
+- `ACTIVE` / `GRACE` / `TAKEOVER_READY` görünürlüğü
+- `ao-kernel coordination status` text/json yüzeyi
 
 ## 7. En Son
 

--- a/.claude/plans/WP-7.2-CLAIM-VISIBILITY.md
+++ b/.claude/plans/WP-7.2-CLAIM-VISIBILITY.md
@@ -1,0 +1,37 @@
+# WP-7.2 — Claim Visibility
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#198](https://github.com/Halildeu/ao-kernel/issues/198)
+**Üst WP:** [#198](https://github.com/Halildeu/ao-kernel/issues/198)
+
+## Amaç
+
+Path-scoped ownership claim’lerinin canlı durumunu operatöre görünür yapmak:
+kim neyi tutuyor, claim active mi, grace içinde mi, takeover-ready mi?
+
+## Bu Slice’ın Kararı
+
+- Bu dilim **read-only visibility** üretir
+- Yeni write semantics veya executor enforcement eklemez
+- Çıkış yüzeyi `ao-kernel coordination status` olur
+- JSON output mevcut `agent-handoff-status.schema.v1.json` üstüne genişletilmiş
+  claim-state alanlarıyla şekillenir
+
+## Public Surface
+
+- `ao_kernel.coordination.status`
+- `ao-kernel coordination status --format {text,json}`
+
+## Definition of Done
+
+1. Coordination disabled workspace için başarılı `IDLE` snapshot dönmeli
+2. Enabled workspace aktif claim’leri owner/resource/state ile göstermeli
+3. `ACTIVE`, `GRACE`, `TAKEOVER_READY` sınıflandırması görünür olmalı
+4. CLI text ve json output testle pinlenmeli
+5. Status/coordination docs yeni yüzeyi anlatmalı
+
+## Deferred
+
+- geçmiş release/takeover/handoff event geçmişi
+- executor-side hard enforcement
+- gerçek handoff primitive’i

--- a/ao_kernel/_internal/coordination/__init__.py
+++ b/ao_kernel/_internal/coordination/__init__.py
@@ -1,0 +1,2 @@
+"""Internal coordination CLI glue."""
+

--- a/ao_kernel/_internal/coordination/cli_handlers.py
+++ b/ao_kernel/_internal/coordination/cli_handlers.py
@@ -17,20 +17,20 @@ from ao_kernel.coordination.status import (
 def _resolve_workspace(args: Any) -> Path:
     ws = getattr(args, "workspace_root", None)
     if ws:
-        resolved = Path(ws).resolve()
-        if resolved.name == ".ao":
-            return resolved.parent
-        return resolved
+        explicit_root = Path(ws).resolve()
+        if explicit_root.name == ".ao":
+            return explicit_root.parent
+        return explicit_root
 
     from ao_kernel.config import workspace_root
 
-    resolved = workspace_root()
-    if resolved is None:
+    discovered_root = workspace_root()
+    if discovered_root is None:
         print("error: no .ao/ workspace found", file=sys.stderr)
         raise SystemExit(1)
-    if resolved.name == ".ao":
-        return resolved.parent
-    return resolved
+    if discovered_root.name == ".ao":
+        return discovered_root.parent
+    return discovered_root
 
 
 def _emit_output(payload: str, args: Any) -> None:

--- a/ao_kernel/_internal/coordination/cli_handlers.py
+++ b/ao_kernel/_internal/coordination/cli_handlers.py
@@ -1,0 +1,71 @@
+"""CLI handlers for ``ao-kernel coordination`` subcommands."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from ao_kernel.coordination.errors import ClaimCorruptedError
+from ao_kernel.coordination.status import (
+    build_coordination_status,
+    render_coordination_status,
+)
+
+
+def _resolve_workspace(args: Any) -> Path:
+    ws = getattr(args, "workspace_root", None)
+    if ws:
+        resolved = Path(ws).resolve()
+        if resolved.name == ".ao":
+            return resolved.parent
+        return resolved
+
+    from ao_kernel.config import workspace_root
+
+    resolved = workspace_root()
+    if resolved is None:
+        print("error: no .ao/ workspace found", file=sys.stderr)
+        raise SystemExit(1)
+    if resolved.name == ".ao":
+        return resolved.parent
+    return resolved
+
+
+def _emit_output(payload: str, args: Any) -> None:
+    output_path = getattr(args, "output", None)
+    if output_path:
+        from ao_kernel._internal.shared.utils import write_text_atomic
+
+        write_text_atomic(Path(output_path), payload)
+        return
+    sys.stdout.write(payload)
+    if not payload.endswith("\n"):
+        sys.stdout.write("\n")
+
+
+def cmd_coordination_status(args: Any) -> int:
+    """Handle ``ao-kernel coordination status``."""
+    workspace = _resolve_workspace(args)
+
+    try:
+        snapshot = build_coordination_status(workspace)
+    except ClaimCorruptedError as exc:
+        print(f"error: corrupt coordination state — {exc}", file=sys.stderr)
+        return 2
+
+    if getattr(args, "format", "text") == "json":
+        payload = json.dumps(snapshot, indent=2, sort_keys=True)
+    else:
+        payload = render_coordination_status(snapshot)
+
+    try:
+        _emit_output(payload, args)
+    except (OSError, PermissionError) as exc:
+        print(f"error: output write failed — {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+__all__ = ["cmd_coordination_status"]

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -795,6 +795,27 @@ def _build_parser() -> argparse.ArgumentParser:
         help="File path for atomic write; omit for stdout",
     )
 
+    coordination_p = sub.add_parser(
+        "coordination",
+        help="Coordination claim visibility",
+    )
+    coordination_sub = coordination_p.add_subparsers(dest="coordination_command")
+    coordination_status_p = coordination_sub.add_parser(
+        "status",
+        help="Show current claim ownership / grace / takeover snapshot",
+    )
+    coordination_status_p.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    coordination_status_p.add_argument(
+        "--output",
+        default=None,
+        help="File path for atomic write; omit for stdout",
+    )
+
     # Policy-sim subcommand (PR-B4)
     policy_sim_p = sub.add_parser(
         "policy-sim",
@@ -1334,6 +1355,17 @@ def main(argv: list[str] | None = None) -> int:
             print("Usage: ao-kernel metrics {export|debug-query}")
             return 1
         return handler(args)
+
+    if cmd == "coordination":
+        from ao_kernel._internal.coordination.cli_handlers import (
+            cmd_coordination_status,
+        )
+
+        coordination_cmd = getattr(args, "coordination_command", None)
+        if coordination_cmd == "status":
+            return cmd_coordination_status(args)
+        print("Usage: ao-kernel coordination status", file=sys.stderr)
+        return 1
 
     handler = dispatch.get(cmd)
     if handler is None:

--- a/ao_kernel/coordination/__init__.py
+++ b/ao_kernel/coordination/__init__.py
@@ -71,6 +71,11 @@ from ao_kernel.coordination.registry import (
     EvidenceSink,
     build_coordination_sink,
 )
+from ao_kernel.coordination.status import (
+    build_coordination_status,
+    coordination_status_schema,
+    render_coordination_status,
+)
 
 
 __all__ = [
@@ -106,6 +111,10 @@ __all__ = [
     "normalize_workspace_relative_path",
     "release_path_write_claims",
     "top_level_write_area",
+    # Status
+    "build_coordination_status",
+    "coordination_status_schema",
+    "render_coordination_status",
     # Registry
     "AgentClaimIndex",
     "ClaimRegistry",

--- a/ao_kernel/coordination/status.py
+++ b/ao_kernel/coordination/status.py
@@ -1,0 +1,237 @@
+"""Read-only coordination status snapshot for operator visibility.
+
+WP-7.2 scope is intentionally read-only: this module reports the live claim
+SSOT as seen under ``claims.lock`` without adding new write semantics or
+executor enforcement. The goal is to answer "who currently owns what, and is it
+active / in grace / takeover-ready?" using a deterministic snapshot surface.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from ao_kernel._internal.shared.lock import file_lock
+from ao_kernel.config import load_default
+from ao_kernel.coordination.policy import load_coordination_policy
+from ao_kernel.coordination.registry import (
+    ClaimRegistry,
+    _claims_dir,
+    _claims_lock_path,
+    _parse_iso,
+)
+
+
+def _project_root(workspace_root: Path | str) -> Path:
+    resolved = Path(workspace_root).resolve()
+    if resolved.name == ".ao":
+        return resolved.parent
+    return resolved
+
+
+def _describe_resource(resource_id: str) -> tuple[str, str]:
+    if resource_id.startswith("write-area."):
+        rest = resource_id.removeprefix("write-area.")
+        slug, _, _digest = rest.rpartition(".")
+        label = slug or rest or resource_id
+        return ("path-area", label)
+    return ("generic", resource_id)
+
+
+def _claim_state(
+    heartbeat_at: str,
+    *,
+    expiry_seconds: int,
+    takeover_grace_period_seconds: int,
+    now: datetime,
+) -> tuple[str, str, str]:
+    effective_expires = _parse_iso(heartbeat_at) + timedelta(
+        seconds=expiry_seconds,
+    )
+    grace_deadline = effective_expires + timedelta(
+        seconds=takeover_grace_period_seconds,
+    )
+    if now <= effective_expires:
+        state = "ACTIVE"
+    elif now <= grace_deadline:
+        state = "GRACE"
+    else:
+        state = "TAKEOVER_READY"
+    return (
+        state,
+        effective_expires.isoformat(),
+        grace_deadline.isoformat(),
+    )
+
+
+def build_coordination_status(workspace_root: Path | str) -> dict[str, Any]:
+    """Build a machine-readable coordination snapshot.
+
+    The snapshot is derived from the claim SSOT under ``claims.lock``. Dormant
+    coordination returns a successful IDLE payload rather than raising: status
+    visibility is allowed to say "nothing is active" without forcing an opt-in.
+    """
+    project_root = _project_root(workspace_root)
+    generated_at = datetime.now(timezone.utc).isoformat()
+    policy = load_coordination_policy(project_root)
+
+    if not policy.enabled:
+        return {
+            "version": "v1",
+            "generated_at": generated_at,
+            "workspace_root": str(project_root),
+            "coordination_enabled": False,
+            "claims": [],
+            "summary": {
+                "coordination_enabled": False,
+                "total_active": 0,
+                "total_reported": 0,
+                "by_agent": {},
+                "by_claim_state": {
+                    "ACTIVE": 0,
+                    "GRACE": 0,
+                    "TAKEOVER_READY": 0,
+                },
+                "conflicts": [],
+            },
+            "status": "IDLE",
+        }
+
+    registry = ClaimRegistry(project_root)
+    _claims_dir(project_root).mkdir(parents=True, exist_ok=True)
+
+    claims: list[dict[str, Any]] = []
+    by_agent: dict[str, int] = {}
+    by_claim_state = {
+        "ACTIVE": 0,
+        "GRACE": 0,
+        "TAKEOVER_READY": 0,
+    }
+
+    with file_lock(_claims_lock_path(project_root)):
+        registry._ensure_index_consistent()
+        index = registry._load_index()
+        now = datetime.now(timezone.utc)
+        for agent_id, resource_ids in sorted(index.agents.items()):
+            for resource_id in resource_ids:
+                claim = registry._load_claim_if_exists(resource_id)
+                if claim is None:
+                    continue
+                resource_kind, resource_label = _describe_resource(resource_id)
+                claim_state, effective_expires_at, grace_deadline_at = _claim_state(
+                    claim.heartbeat_at,
+                    expiry_seconds=policy.expiry_seconds,
+                    takeover_grace_period_seconds=policy.takeover_grace_period_seconds,
+                    now=now,
+                )
+                claims.append(
+                    {
+                        "work_item_id": resource_id,
+                        "claim_id": claim.claim_id,
+                        "owner_tag": claim.owner_agent_id,
+                        "agent_tag": claim.owner_agent_id,
+                        "acquired_at": claim.acquired_at,
+                        "ttl_seconds": policy.expiry_seconds,
+                        "expires_at": effective_expires_at,
+                        "heartbeat_at": claim.heartbeat_at,
+                        "grace_deadline_at": grace_deadline_at,
+                        "fencing_token": claim.fencing_token,
+                        "resource_kind": resource_kind,
+                        "resource_label": resource_label,
+                        "claim_state": claim_state,
+                    }
+                )
+                by_agent[agent_id] = by_agent.get(agent_id, 0) + 1
+                by_claim_state[claim_state] += 1
+
+    claims.sort(
+        key=lambda item: (
+            item["owner_tag"],
+            item["work_item_id"],
+            item["claim_id"],
+        )
+    )
+    total_active = by_claim_state["ACTIVE"] + by_claim_state["GRACE"]
+
+    return {
+        "version": "v1",
+        "generated_at": generated_at,
+        "workspace_root": str(project_root),
+        "coordination_enabled": True,
+        "claims": claims,
+        "summary": {
+            "coordination_enabled": True,
+            "total_active": total_active,
+            "total_reported": len(claims),
+            "by_agent": dict(sorted(by_agent.items())),
+            "by_claim_state": by_claim_state,
+            "conflicts": [],
+        },
+        "status": "IDLE" if not claims else "OK",
+    }
+
+
+def render_coordination_status(snapshot: dict[str, Any]) -> str:
+    """Render a human-readable coordination snapshot."""
+    summary = snapshot["summary"]
+    lines = [
+        "== coordination status ==",
+        f"Workspace: {snapshot['workspace_root']}",
+        f"Generated: {snapshot['generated_at']}",
+        f"Coordination enabled: {'yes' if snapshot.get('coordination_enabled') else 'no'}",
+        (
+            "Claims: "
+            f"reported={summary.get('total_reported', 0)} "
+            f"active={summary.get('total_active', 0)}"
+        ),
+        (
+            "Claim states: "
+            f"ACTIVE={summary['by_claim_state']['ACTIVE']} "
+            f"GRACE={summary['by_claim_state']['GRACE']} "
+            f"TAKEOVER_READY={summary['by_claim_state']['TAKEOVER_READY']}"
+        ),
+        f"Status: {snapshot['status']}",
+        "",
+        "Claims:",
+    ]
+
+    claims = snapshot.get("claims", [])
+    if not claims:
+        if snapshot.get("coordination_enabled"):
+            lines.append("  - none")
+        else:
+            lines.append("  - coordination disabled (policy_coordination_claims.enabled=false)")
+        return "\n".join(lines)
+
+    for claim in claims:
+        lines.append(
+            "  - "
+            f"{claim['work_item_id']} "
+            f"[{claim.get('resource_kind', 'generic')}:{claim.get('resource_label', claim['work_item_id'])}] "
+            f"owner={claim['owner_tag']} "
+            f"state={claim.get('claim_state', 'ACTIVE')} "
+            f"fencing={claim.get('fencing_token', '?')}"
+        )
+        lines.append(
+            "    "
+            f"claim_id={claim['claim_id']} "
+            f"acquired_at={claim.get('acquired_at', '')} "
+            f"heartbeat_at={claim.get('heartbeat_at', '')} "
+            f"expires_at={claim.get('expires_at', '')} "
+            f"grace_deadline_at={claim.get('grace_deadline_at', '')}"
+        )
+
+    return "\n".join(lines)
+
+
+def coordination_status_schema() -> dict[str, Any]:
+    """Load the bundled status schema for tests and callers."""
+    return load_default("schemas", "agent-handoff-status.schema.v1.json")
+
+
+__all__ = [
+    "build_coordination_status",
+    "render_coordination_status",
+    "coordination_status_schema",
+]

--- a/ao_kernel/defaults/schemas/agent-handoff-status.schema.v1.json
+++ b/ao_kernel/defaults/schemas/agent-handoff-status.schema.v1.json
@@ -10,6 +10,7 @@
     "version": { "const": "v1" },
     "generated_at": { "type": "string", "minLength": 1 },
     "workspace_root": { "type": "string", "minLength": 1 },
+    "coordination_enabled": { "type": "boolean" },
     "claims": {
       "type": "array",
       "items": {
@@ -25,7 +26,12 @@
           "acquired_at": { "type": "string" },
           "ttl_seconds": { "type": "integer", "minimum": 1 },
           "expires_at": { "type": "string" },
-          "heartbeat_at": { "type": "string" }
+          "heartbeat_at": { "type": "string" },
+          "grace_deadline_at": { "type": "string" },
+          "fencing_token": { "type": "integer", "minimum": 0 },
+          "resource_kind": { "type": "string", "enum": ["generic", "path-area"] },
+          "resource_label": { "type": "string" },
+          "claim_state": { "type": "string", "enum": ["ACTIVE", "GRACE", "TAKEOVER_READY"] }
         }
       }
     },
@@ -35,9 +41,20 @@
       "required": ["total_active"],
       "properties": {
         "total_active": { "type": "integer", "minimum": 0 },
+        "total_reported": { "type": "integer", "minimum": 0 },
+        "coordination_enabled": { "type": "boolean" },
         "by_agent": {
           "type": "object",
           "additionalProperties": { "type": "integer" }
+        },
+        "by_claim_state": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ACTIVE": { "type": "integer", "minimum": 0 },
+            "GRACE": { "type": "integer", "minimum": 0 },
+            "TAKEOVER_READY": { "type": "integer", "minimum": 0 }
+          }
         },
         "conflicts": {
           "type": "array",

--- a/docs/COORDINATION.md
+++ b/docs/COORDINATION.md
@@ -161,6 +161,17 @@ acquires them sequentially in sorted order. Multi-area acquisition is **not
 atomic**; if a later area conflicts, earlier acquired areas are released
 best-effort in reverse order.
 
+Read-only operator visibility for the current claim SSOT is available via:
+
+```bash
+ao-kernel coordination status
+ao-kernel coordination status --format json
+```
+
+The status surface reports the current claim owner plus derived state:
+`ACTIVE`, `GRACE`, or `TAKEOVER_READY`. This is a visibility-only surface; it
+does not change write semantics or executor enforcement.
+
 ### 10.2 Fail-closed vs fail-open
 
 - **Fail-closed (raise, never silently absorb):**

--- a/tests/test_coordination_cli.py
+++ b/tests/test_coordination_cli.py
@@ -1,0 +1,68 @@
+"""Tests for ``ao-kernel coordination status`` CLI handler."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from ao_kernel._internal.coordination.cli_handlers import cmd_coordination_status
+from ao_kernel.coordination import ClaimRegistry
+
+
+def _args(workspace: Path | None, **kwargs) -> SimpleNamespace:
+    return SimpleNamespace(
+        workspace_root=(str(workspace) if workspace is not None else None),
+        format=kwargs.get("format", "text"),
+        output=kwargs.get("output"),
+    )
+
+
+def _enabled_policy(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "version": "v1",
+        "enabled": True,
+        "heartbeat_interval_seconds": 30,
+        "expiry_seconds": 90,
+        "takeover_grace_period_seconds": 15,
+        "max_claims_per_agent": 5,
+        "claim_resource_patterns": ["*"],
+        "evidence_redaction": {"patterns": []},
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_workspace_policy(workspace_root: Path, doc: dict[str, object]) -> None:
+    policy_dir = workspace_root / ".ao" / "policies"
+    policy_dir.mkdir(parents=True, exist_ok=True)
+    (policy_dir / "policy_coordination_claims.v1.json").write_text(
+        json.dumps(doc, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+class TestCoordinationStatusCli:
+    def test_text_output_reports_disabled_workspace(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        rc = cmd_coordination_status(_args(tmp_path, format="text"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "coordination disabled" in out
+
+    def test_json_output_writes_snapshot_file(self, tmp_path: Path) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+        registry = ClaimRegistry(tmp_path)
+        registry.acquire_claim("worktree-a", "agent-alpha")
+        output_path = tmp_path / "coordination-status.json"
+
+        rc = cmd_coordination_status(
+            _args(tmp_path, format="json", output=str(output_path))
+        )
+
+        assert rc == 0
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+        assert payload["status"] == "OK"
+        assert payload["summary"]["by_agent"] == {"agent-alpha": 1}
+        assert payload["claims"][0]["work_item_id"] == "worktree-a"

--- a/tests/test_coordination_status.py
+++ b/tests/test_coordination_status.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.coordination import ClaimRegistry
+from ao_kernel.coordination.claim import claim_path
+from ao_kernel.coordination.path_ownership import acquire_path_write_claims
+from ao_kernel.coordination.status import (
+    build_coordination_status,
+    coordination_status_schema,
+    render_coordination_status,
+)
+
+
+def _enabled_policy(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "version": "v1",
+        "enabled": True,
+        "heartbeat_interval_seconds": 30,
+        "expiry_seconds": 90,
+        "takeover_grace_period_seconds": 15,
+        "max_claims_per_agent": 5,
+        "claim_resource_patterns": ["*"],
+        "evidence_redaction": {"patterns": []},
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_workspace_policy(workspace_root: Path, doc: dict[str, object]) -> None:
+    policy_dir = workspace_root / ".ao" / "policies"
+    policy_dir.mkdir(parents=True, exist_ok=True)
+    (policy_dir / "policy_coordination_claims.v1.json").write_text(
+        json.dumps(doc, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _validate_snapshot(snapshot: dict) -> None:
+    schema = coordination_status_schema()
+    errors = list(Draft202012Validator(schema).iter_errors(snapshot))
+    assert errors == []
+
+
+class TestCoordinationStatus:
+    def test_disabled_policy_returns_idle_snapshot(self, tmp_path: Path) -> None:
+        snapshot = build_coordination_status(tmp_path)
+
+        _validate_snapshot(snapshot)
+        assert snapshot["status"] == "IDLE"
+        assert snapshot["coordination_enabled"] is False
+        assert snapshot["claims"] == []
+        assert snapshot["summary"]["total_active"] == 0
+        assert snapshot["summary"]["total_reported"] == 0
+
+    def test_enabled_empty_workspace_returns_idle_enabled_snapshot(
+        self, tmp_path: Path,
+    ) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+
+        snapshot = build_coordination_status(tmp_path)
+
+        _validate_snapshot(snapshot)
+        assert snapshot["status"] == "IDLE"
+        assert snapshot["coordination_enabled"] is True
+        assert snapshot["summary"]["coordination_enabled"] is True
+
+    def test_path_area_claims_surface_resource_kind_and_label(
+        self, tmp_path: Path,
+    ) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+        registry = ClaimRegistry(tmp_path)
+        acquire_path_write_claims(
+            registry,
+            tmp_path,
+            owner_agent_id="agent-alpha",
+            paths=["pkg/a.py", "tests/test_demo.py"],
+        )
+
+        snapshot = build_coordination_status(tmp_path)
+
+        _validate_snapshot(snapshot)
+        assert snapshot["status"] == "OK"
+        assert snapshot["summary"]["total_active"] == 2
+        assert snapshot["summary"]["by_agent"] == {"agent-alpha": 2}
+        assert snapshot["summary"]["by_claim_state"]["ACTIVE"] == 2
+        labels = {(item["resource_kind"], item["resource_label"]) for item in snapshot["claims"]}
+        assert ("path-area", "pkg") in labels
+        assert ("path-area", "tests") in labels
+
+    def test_grace_and_takeover_ready_states_are_reported(
+        self, tmp_path: Path,
+    ) -> None:
+        _write_workspace_policy(
+            tmp_path,
+            _enabled_policy(expiry_seconds=10, takeover_grace_period_seconds=5),
+        )
+        registry = ClaimRegistry(tmp_path)
+        grace_claim = registry.acquire_claim("worktree-grace", "agent-alpha")
+        ready_claim = registry.acquire_claim("worktree-ready", "agent-beta")
+
+        grace_doc = json.loads(
+            claim_path(tmp_path, grace_claim.resource_id).read_text(encoding="utf-8")
+        )
+        ready_doc = json.loads(
+            claim_path(tmp_path, ready_claim.resource_id).read_text(encoding="utf-8")
+        )
+        now = datetime.now(timezone.utc)
+        grace_doc["heartbeat_at"] = (now - timedelta(seconds=12)).isoformat()
+        grace_doc["expires_at"] = (now - timedelta(seconds=2)).isoformat()
+        ready_doc["heartbeat_at"] = (now - timedelta(seconds=20)).isoformat()
+        ready_doc["expires_at"] = (now - timedelta(seconds=10)).isoformat()
+        from ao_kernel.coordination.claim import claim_revision
+
+        grace_doc["revision"] = claim_revision(grace_doc)
+        ready_doc["revision"] = claim_revision(ready_doc)
+        claim_path(tmp_path, grace_claim.resource_id).write_text(
+            json.dumps(grace_doc, sort_keys=True),
+            encoding="utf-8",
+        )
+        claim_path(tmp_path, ready_claim.resource_id).write_text(
+            json.dumps(ready_doc, sort_keys=True),
+            encoding="utf-8",
+        )
+
+        snapshot = build_coordination_status(tmp_path)
+
+        _validate_snapshot(snapshot)
+        by_id = {item["work_item_id"]: item for item in snapshot["claims"]}
+        assert by_id["worktree-grace"]["claim_state"] == "GRACE"
+        assert by_id["worktree-ready"]["claim_state"] == "TAKEOVER_READY"
+        assert snapshot["summary"]["total_active"] == 1
+        assert snapshot["summary"]["total_reported"] == 2
+        assert snapshot["summary"]["by_claim_state"]["GRACE"] == 1
+        assert snapshot["summary"]["by_claim_state"]["TAKEOVER_READY"] == 1
+
+    def test_rendered_status_mentions_state_and_owner(self, tmp_path: Path) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+        registry = ClaimRegistry(tmp_path)
+        registry.acquire_claim("worktree-a", "agent-alpha")
+
+        rendered = render_coordination_status(build_coordination_status(tmp_path))
+
+        assert "== coordination status ==" in rendered
+        assert "owner=agent-alpha" in rendered
+        assert "state=ACTIVE" in rendered
+        assert "worktree-a" in rendered


### PR DESCRIPTION
## Summary
- add a read-only `ao-kernel coordination status` CLI for live claim visibility
- report `ACTIVE` / `GRACE` / `TAKEOVER_READY` claim states from the claim SSOT under `claims.lock`
- align coordination docs, status tracking, and the handoff-status schema with the new snapshot surface

## Testing
- `pytest -q tests/test_coordination_status.py tests/test_coordination_cli.py tests/test_path_write_ownership.py tests/test_coordination_registry.py tests/test_cli_entrypoints.py tests/test_pr_b0_contracts.py`
- `ruff check ao_kernel/coordination/status.py ao_kernel/_internal/coordination/cli_handlers.py tests/test_coordination_status.py tests/test_coordination_cli.py`
- `python3 -m ao_kernel coordination status`
- `python3 -m ao_kernel coordination status --format json`

## Scope
- advances WP-7.2 for #198 with read-only claim/release/takeover visibility
- does not yet add historical event replay or executor-side enforcement
