### PR TITLE
[codex] Enforce patch apply write ownership

### DIFF
--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -60,86 +60,48 @@ automation platform çizgisine taşımak.
 
 ## 5. Şimdi
 
-### `WP-6` — Worktree/Branch Safety Control Loop
-
-**Neden şimdi**
-- Branch protection sertleşti; bundan sonraki ana risk yanlış worktree üzerinde
-  çalışma, dirty tree unutma ve stale base ile session başlatma.
-
-**GitHub takip**
-- üst issue: [#197](https://github.com/Halildeu/ao-kernel/issues/197)
-- son slice: [`WP-6.4-ARCHIVE-WORKTREE.md`](./WP-6.4-ARCHIVE-WORKTREE.md)
-
-**Adım sırası**
-1. `[x]` `ops.sh` dispatcher yüzeyi eklendi.
-2. `[x]` `preflight` branch freshness + current dirty tree + upstream +
-   other worktree snapshot'ını tek komutta topladı.
-3. `[x]` Clean / warning / fail path'leri subprocess testleriyle pinlendi.
-4. `[x]` `WP-6.2` overlap-check yüzeyi eklendi.
-5. `[x]` `WP-6.3` close-worktree yüzeyi eklendi.
-6. `[x]` `WP-6.4` archive-worktree yüzeyi eklendi.
-
-**Canlı snapshot**
-- session başlangıç komutu: `bash .claude/scripts/ops.sh preflight`
-- çoklu worktree çakışma görünürlüğü: `bash .claude/scripts/ops.sh overlap-check`
-- güvenli yardımcı worktree kapanışı: `bash .claude/scripts/ops.sh close-worktree <path>`
-- dirty yardımcı worktree arşivleme + kaldırma: `bash .claude/scripts/ops.sh archive-worktree <path>`
-- hard block: forbidden branch / detached HEAD / stale base / `main` drift
-- warning-only: current dirty tree / upstream yok / other worktree dirty
-- overlap-check: exact file overlap ve shared top-level area sinyali üretir;
-  bu slice görünürlük verir, henüz hard-enforcement yapmaz
-- close-worktree: clean non-current target'ı kapatır; dirty/current target için
-  fail-closed davranır
-- archive-worktree: dirty non-current target için patch + untracked snapshot
-  alır, common git dir altına arşivler ve sonra target'ı kaldırır
-- `check-branch-sync.sh` alttaki primitive olarak korunur
-
-**Definition of Done**
-- tek komutla session sağlık özeti alınabiliyor
-- yanlış base ile çalışmak hard fail olarak yakalanıyor
-- dirty tree ve other worktree riski görünür hale geliyor
-- çoklu worktree path çakışması görünür hale geliyor
-- güvenli worktree kapanışı standart yüzeyden yapılabiliyor
-- dirty worktree state'i repo kirletmeden arşivlenip güvenli kaldırılabiliyor
-- bu davranış test veya smoke ile pinlenmiş
-
-## 6. Sonra
-
 ### `WP-7` — Path-Scoped Write Ownership
 
-**Amaç**
-- mevcut claim/fencing altyapısını path-grubu ownership seviyesine taşımak
+**Neden şimdi**
+- Worktree/branch safety hattı kapandı. Bundan sonraki ana değişim riski,
+  aynı logical path alanına iki writer'ın sessizce girmesi.
 
 **GitHub takip**
 - üst issue: [#198](https://github.com/Halildeu/ao-kernel/issues/198)
-- aktif slice: [`WP-7.2-CLAIM-VISIBILITY.md`](./WP-7.2-CLAIM-VISIBILITY.md)
+- son merge: `WP-7.2` / PR #208
+- aktif slice: [`WP-7.3-EXECUTOR-ENFORCEMENT.md`](./WP-7.3-EXECUTOR-ENFORCEMENT.md)
 
-**Hedef slice'lar**
-1. `[x]` ownership model ve resource namespace kararı
-2. `[ ]` claim / release / takeover / handoff kaydı
-3. `[ ]` executor veya orchestration girişinde write ownership enforcement
+**Adım sırası**
+1. `[x]` `WP-7.1` path resource namespace kararı + acquire/release helper'ları
+2. `[x]` `WP-7.2` claim visibility (`coordination status`) yüzeyi
+3. `[~]` `WP-7.3` patch apply write-ownership enforcement
+4. `[ ]` handoff / takeover ergonomics ve daha geniş orchestration entry coverage
 
-**Tamamlanan slice (`WP-7.1`)**
-- workspace-relative path -> top-level area -> deterministic `resource_id`
-- mevcut `ClaimRegistry` üstünden sequential acquire/release helper’ları
-- partial acquire rollback ve pytest kanıtı
+**Canlı snapshot**
+- `patch_apply` artık coordination enabled workspace'te preview edilen
+  `files_changed` üstünden path-scoped write claim almaya hazırlanıyor
+- claim scope top-level area üstünden belirlenir (`src/*` -> tek claim alanı)
+- claim acquire/release event'leri workflow evidence akışına bağlanır
+- conflict path'i deterministic `_StepFailed(code=WRITE_OWNERSHIP_CONFLICT)`
+  olarak yüzeye çıkar
+- current scope yalnız gerçek write noktası olan `patch_apply`; read-only
+  preview/status yüzeyleri unchanged
 
-**Bu slice’ın hedefi (`WP-7.2`)**
-- canlı claim SSOT snapshot’ı
-- `ACTIVE` / `GRACE` / `TAKEOVER_READY` görünürlüğü
-- `ao-kernel coordination status` text/json yüzeyi
+**Definition of Done**
+- coordination enabled patch apply yolu claim acquire/release ile çalışıyor
+- conflict aynı path alanında deterministic fail üretiyor
+- dormant coordination semantics korunuyor
+- yeni davranış behavior-first testlerle pinleniyor
+- docs/runtime/story aynı şeyi söylüyor
 
-## 7. En Son
+## 6. Sonra
 
 ### `WP-8` — Real Adapter Certification
 
 **Amaç**
 - stub-demodan çıkıp gerçek adapter yüzeyini kanıtlı hale getirmek
 
-**Minimum kabul**
-- en az 2 gerçek adapter
-- timeout / cancel / retry / idempotency / secret handling / audit completeness
-- production-tier smoke + failure-mode testleri
+## 7. En Son
 
 ### `WP-9` — Operations / Runbook / Incident Readiness
 
@@ -157,10 +119,9 @@ automation platform çizgisine taşımak.
 
 Bugünden itibaren doğru sıra:
 
-1. `WP-6` Worktree/branch safety control loop
-2. `WP-7` Path-scoped write ownership
-3. `WP-8` Real adapter certification
-4. `WP-9` Ops/runbook/incident readiness
+1. `WP-7` Path-scoped write ownership
+2. `WP-8` Real adapter certification
+3. `WP-9` Ops/runbook/incident readiness
 
 ## 9. Güncelleme Protokolü
 

--- a/.claude/plans/WP-7.3-EXECUTOR-ENFORCEMENT.md
+++ b/.claude/plans/WP-7.3-EXECUTOR-ENFORCEMENT.md
@@ -1,0 +1,41 @@
+# WP-7.3 — Executor-Side Write Ownership Enforcement
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#198](https://github.com/Halildeu/ao-kernel/issues/198)
+**Üst WP:** [#198](https://github.com/Halildeu/ao-kernel/issues/198)
+
+## Amaç
+
+İlk gerçek write noktası olan `patch_apply` adımında, coordination enabled
+workspace'lerde path-scoped ownership claim'ini runtime davranışına bağlamak.
+
+## Bu Slice'ın Kararı
+
+- Enforcement ilk dilimde yalnız `patch_apply` üzerinde açılır
+- Claim scope, patch preview'den çıkan `files_changed` listesinden türetilir
+- Claim acquire/release, mevcut coordination evidence sink üstünden workflow
+  event akışına bağlanır
+- Conflict veya grace-conflict deterministic `_StepFailed` sinyaline çevrilir
+- Coordination disabled workspaces için mevcut dormant semantics korunur
+
+## Runtime Yüzeyi
+
+- `MultiStepDriver._run_patch_step()`
+- `claim_acquired` / `claim_conflict` / `claim_released` workflow evidence
+- `diff_applied` payload'ına additive audit alanları:
+  - `write_claim_areas`
+  - `write_claim_resource_ids`
+
+## Definition of Done
+
+1. Coordination enabled iken `patch_apply` claim acquire/release yapar
+2. Aynı path alanında ikinci writer deterministic conflict alır
+3. Dormant policy altında claim yüzeyi hiç engage olmaz
+4. `diff_applied` evidence'ı claim audit alanlarını taşır
+5. Bu davranış behavior-first pytest ile pinlenir
+
+## Deferred
+
+- `patch_apply` dışındaki write-capable orchestration entry'leri
+- handoff / takeover ergonomics
+- ownership claim'lerinin daha yüksek seviyeli scheduler/orchestrator kararlarına bağlanması

--- a/ao_kernel/executor/multi_step_driver.py
+++ b/ao_kernel/executor/multi_step_driver.py
@@ -908,6 +908,12 @@ class MultiStepDriver:
         from ao_kernel.patch import (  # lazy to avoid cycle through executor
             apply_patch, preview_diff, rollback_patch, PatchError,
         )
+        from ao_kernel.coordination import release_path_write_claims
+        from ao_kernel.coordination.errors import (
+            ClaimConflictError,
+            ClaimConflictGraceError,
+            CoordinationError,
+        )
         op = step_def.operation
         sandbox = self._build_sandbox(run_id)
         worktree = self._workspace_root / ".ao" / "runs" / run_id / "worktree"
@@ -920,6 +926,7 @@ class MultiStepDriver:
         patch_content = _load_pending_patch_content(
             record, step_def.step_name, workspace_root=self._workspace_root,
         )
+        ownership: tuple[Any, Any] | None = None
 
         try:
             if op == "patch_preview":
@@ -935,20 +942,42 @@ class MultiStepDriver:
                     "lines_removed": preview.lines_removed,
                 }
             elif op == "patch_apply":
-                apply_result = apply_patch(
-                    worktree, patch_content, sandbox, run_dir,
+                ownership = self._acquire_patch_write_claims(
+                    run_id=run_id,
+                    patch_content=patch_content,
+                    sandbox=sandbox,
+                    worktree=worktree,
                 )
+                ownership_payload = (
+                    self._ownership_payload(ownership[1])
+                    if ownership is not None
+                    else {}
+                )
+                try:
+                    apply_result = apply_patch(
+                        worktree, patch_content, sandbox, run_dir,
+                    )
+                except BaseException:
+                    if ownership is not None:
+                        registry, lease_set = ownership
+                        try:
+                            release_path_write_claims(registry, lease_set)
+                        except CoordinationError:
+                            pass
+                    raise
                 self._emit(run_id, "diff_applied",
                     {"step_name": step_def.step_name,
                      "patch_id": apply_result.patch_id,
                      "applied_sha": apply_result.applied_sha,
-                     "attempt": attempt},
+                     "attempt": attempt,
+                     **ownership_payload},
                     step_id=step_id)
                 artifact = {
                     "operation": op, "patch_id": apply_result.patch_id,
                     "reverse_diff_id": apply_result.reverse_diff_id,
                     "files_changed": list(apply_result.files_changed),
                     "applied_sha": apply_result.applied_sha,
+                    **ownership_payload,
                 }
             else:  # patch_rollback
                 reverse_diff_id = step_def.step_name  # test fixture convention
@@ -980,15 +1009,100 @@ class MultiStepDriver:
                 category="other",
                 code="POLICY_VIOLATION",
             ) from exc
+        except CoordinationError as exc:
+            code = (
+                "WRITE_OWNERSHIP_CONFLICT"
+                if isinstance(exc, (ClaimConflictError, ClaimConflictGraceError))
+                else "WRITE_OWNERSHIP_ERROR"
+            )
+            raise _StepFailed(
+                reason=f"write_ownership_{type(exc).__name__}: {exc}",
+                attempt=attempt,
+                category="other",
+                code=code,
+            ) from exc
 
         output_ref, output_sha256 = write_artifact(
             run_dir=run_dir, step_id=step_id, attempt=attempt, payload=artifact,
         )
+        if op == "patch_apply" and ownership is not None:
+            registry, lease_set = ownership
+            try:
+                release_path_write_claims(registry, lease_set)
+            except CoordinationError as exc:
+                code = (
+                    "WRITE_OWNERSHIP_CONFLICT"
+                    if isinstance(exc, (ClaimConflictError, ClaimConflictGraceError))
+                    else "WRITE_OWNERSHIP_ERROR"
+                )
+                raise _StepFailed(
+                    reason=f"write_ownership_{type(exc).__name__}: {exc}",
+                    attempt=attempt,
+                    category="other",
+                    code=code,
+                ) from exc
         return dict(record), {
             "step_state": "completed",
             "output_ref": output_ref,
             "output_sha256": output_sha256,
             "operation": op,
+        }
+
+    def _acquire_patch_write_claims(
+        self,
+        *,
+        run_id: str,
+        patch_content: str,
+        sandbox: SandboxedEnvironment,
+        worktree: Path,
+    ) -> tuple[Any, Any] | None:
+        """Acquire path-scoped write ownership for ``patch_apply``.
+
+        The claim scope is derived from the patch preview's
+        ``files_changed`` list and is always projected onto the shared
+        workspace root, so isolated run worktrees still serialize on
+        the same logical top-level areas.
+        """
+        from ao_kernel.coordination import (
+            ClaimRegistry,
+            acquire_path_write_claims,
+            build_coordination_sink,
+            load_coordination_policy,
+        )
+        from ao_kernel.patch import preview_diff
+
+        coordination_policy = load_coordination_policy(self._workspace_root)
+        if not coordination_policy.enabled:
+            return None
+
+        preview = preview_diff(worktree, patch_content, sandbox)
+        if not preview.files_changed:
+            return None
+
+        registry = ClaimRegistry(
+            self._workspace_root,
+            evidence_sink=build_coordination_sink(
+                self._workspace_root,
+                coordination_policy,
+                run_id=run_id,
+            ),
+        )
+        lease_set = acquire_path_write_claims(
+            registry,
+            self._workspace_root,
+            owner_agent_id=f"workflow-run:{run_id}",
+            paths=preview.files_changed,
+            policy=coordination_policy,
+        )
+        return registry, lease_set
+
+    def _ownership_payload(self, lease_set: Any) -> dict[str, Any]:
+        """Return additive audit fields for patch apply evidence."""
+        return {
+            "write_claim_areas": [lease.scope.area for lease in lease_set.leases],
+            "write_claim_resource_ids": [
+                lease.scope.resource_id for lease in lease_set.leases
+            ],
         }
 
     def _run_human_gate(

--- a/docs/COORDINATION.md
+++ b/docs/COORDINATION.md
@@ -169,8 +169,17 @@ ao-kernel coordination status --format json
 ```
 
 The status surface reports the current claim owner plus derived state:
-`ACTIVE`, `GRACE`, or `TAKEOVER_READY`. This is a visibility-only surface; it
-does not change write semantics or executor enforcement.
+`ACTIVE`, `GRACE`, or `TAKEOVER_READY`.
+
+Runtime enforcement now starts at the first real write point:
+`MultiStepDriver._run_patch_step()` acquires path-scoped claims before
+`patch_apply` when `policy_coordination_claims.enabled=true`. The claim scope is
+derived from the patch preview's `files_changed` list and projected onto the
+shared workspace root, so separate run worktrees still serialize on the same
+logical top-level areas. Successful apply emits additive audit fields on
+`diff_applied` (`write_claim_areas`, `write_claim_resource_ids`) and releases
+the claim afterwards. With coordination disabled, `patch_apply` keeps the old
+dormant behavior and does not engage the claim layer.
 
 ### 10.2 Fail-closed vs fail-open
 

--- a/tests/test_patch_write_ownership_enforcement.py
+++ b/tests/test_patch_write_ownership_enforcement.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ao_kernel.coordination import (
+    ClaimRegistry,
+    acquire_path_write_claims,
+    release_path_write_claims,
+)
+from ao_kernel.executor.multi_step_driver import _StepFailed
+from ao_kernel.workflow.registry import StepDefinition
+from tests._driver_helpers import _GIT_CFG, build_driver, install_workspace
+from tests._patch_helpers import make_patch_from_changes
+
+
+def _write_coordination_policy(workspace_root: Path, *, enabled: bool) -> None:
+    policy_dir = workspace_root / ".ao" / "policies"
+    policy_dir.mkdir(parents=True, exist_ok=True)
+    doc = {
+        "version": "v1",
+        "enabled": enabled,
+        "heartbeat_interval_seconds": 30,
+        "expiry_seconds": 90,
+        "takeover_grace_period_seconds": 15,
+        "max_claims_per_agent": 5,
+        "claim_resource_patterns": ["*"],
+        "evidence_redaction": {"patterns": []},
+    }
+    (policy_dir / "policy_coordination_claims.v1.json").write_text(
+        json.dumps(doc, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _install_patch_target_repo(workspace_root: Path) -> None:
+    src_dir = workspace_root / "src"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    (src_dir / "foo.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(
+        ["git", *_GIT_CFG, "-C", str(workspace_root), "add", "."],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", *_GIT_CFG, "-C", str(workspace_root), "commit", "-q", "-m", "patch target"],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _patch_step() -> StepDefinition:
+    return StepDefinition(
+        step_name="apply_patch",
+        actor="ao-kernel",
+        adapter_id=None,
+        required_capabilities=(),
+        policy_refs=(),
+        on_failure="transition_to_failed",
+        timeout_seconds=None,
+        human_interrupt_allowed=False,
+        gate=None,
+        operation="patch_apply",
+    )
+
+
+def _prime_adapter_artifact(
+    workspace_root: Path,
+    run_id: str,
+    *,
+    patch: str,
+) -> str:
+    run_dir = workspace_root / ".ao" / "evidence" / "workflows" / run_id
+    artifacts_dir = run_dir / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    output_ref = "artifacts/invoke_agent-attempt1.json"
+    (run_dir / output_ref).write_text(
+        json.dumps({"diff": patch}, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return output_ref
+
+
+def _record_with_adapter_output(run_id: str, output_ref: str) -> dict[str, object]:
+    return {
+        "run_id": run_id,
+        "state": "running",
+        "steps": [
+            {
+                "step_id": "invoke_agent",
+                "step_name": "invoke_agent",
+                "state": "completed",
+                "actor": "adapter",
+                "adapter_id": "fixture-agent",
+                "output_ref": output_ref,
+            }
+        ],
+    }
+
+
+def _events(workspace_root: Path, run_id: str) -> list[dict[str, Any]]:
+    events_path = (
+        workspace_root / ".ao" / "evidence" / "workflows" / run_id / "events.jsonl"
+    )
+    return [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines()]
+
+
+class TestPatchWriteOwnershipEnforcement:
+    def test_patch_apply_skips_claims_when_coordination_disabled(
+        self, tmp_path: Path,
+    ) -> None:
+        install_workspace(tmp_path)
+        _install_patch_target_repo(tmp_path)
+        _write_coordination_policy(tmp_path, enabled=False)
+        patch = make_patch_from_changes(tmp_path, {"src/foo.py": "x = 2\n"})
+        run_id = "00000000-0000-4000-8000-000000000701"
+        output_ref = _prime_adapter_artifact(tmp_path, run_id, patch=patch)
+        driver = build_driver(tmp_path)
+
+        _record, result = driver._run_aokernel_step(
+            run_id,
+            _record_with_adapter_output(run_id, output_ref),
+            _patch_step(),
+            attempt=1,
+            step_id="apply_patch",
+        )
+
+        assert result["step_state"] == "completed"
+        assert (tmp_path / "src" / "foo.py").read_text(encoding="utf-8") == "x = 2\n"
+        kinds = [event["kind"] for event in _events(tmp_path, run_id)]
+        assert kinds == ["step_started", "diff_applied"]
+        diff_applied = next(event for event in _events(tmp_path, run_id) if event["kind"] == "diff_applied")
+        assert "write_claim_areas" not in diff_applied["payload"]
+
+    def test_patch_apply_acquires_and_releases_write_claims(
+        self, tmp_path: Path,
+    ) -> None:
+        install_workspace(tmp_path)
+        _install_patch_target_repo(tmp_path)
+        patch = make_patch_from_changes(tmp_path, {"src/foo.py": "x = 2\n"})
+        _write_coordination_policy(tmp_path, enabled=True)
+        run_id = "00000000-0000-4000-8000-000000000702"
+        output_ref = _prime_adapter_artifact(tmp_path, run_id, patch=patch)
+        driver = build_driver(tmp_path)
+
+        _record, result = driver._run_aokernel_step(
+            run_id,
+            _record_with_adapter_output(run_id, output_ref),
+            _patch_step(),
+            attempt=1,
+            step_id="apply_patch",
+        )
+
+        assert result["step_state"] == "completed"
+        assert (tmp_path / "src" / "foo.py").read_text(encoding="utf-8") == "x = 2\n"
+
+        events = _events(tmp_path, run_id)
+        kinds = [event["kind"] for event in events]
+        assert kinds == [
+            "step_started",
+            "claim_acquired",
+            "diff_applied",
+            "claim_released",
+        ]
+
+        diff_applied = next(event for event in events if event["kind"] == "diff_applied")
+        assert diff_applied["payload"]["write_claim_areas"] == ["src"]
+        assert len(diff_applied["payload"]["write_claim_resource_ids"]) == 1
+
+        run_dir = tmp_path / ".ao" / "evidence" / "workflows" / run_id
+        artifact = json.loads(
+            (run_dir / result["output_ref"]).read_text(encoding="utf-8")
+        )
+        assert artifact["write_claim_areas"] == ["src"]
+
+        registry = ClaimRegistry(tmp_path)
+        assert registry.list_agent_claims(f"workflow-run:{run_id}") == []
+
+    def test_patch_apply_conflict_surfaces_as_step_failed_signal(
+        self, tmp_path: Path,
+    ) -> None:
+        install_workspace(tmp_path)
+        _install_patch_target_repo(tmp_path)
+        patch = make_patch_from_changes(tmp_path, {"src/foo.py": "x = 2\n"})
+        _write_coordination_policy(tmp_path, enabled=True)
+        run_id = "00000000-0000-4000-8000-000000000703"
+        output_ref = _prime_adapter_artifact(tmp_path, run_id, patch=patch)
+        driver = build_driver(tmp_path)
+        registry = ClaimRegistry(tmp_path)
+        blocked = acquire_path_write_claims(
+            registry,
+            tmp_path,
+            owner_agent_id="agent-existing",
+            paths=["src/foo.py"],
+        )
+
+        with pytest.raises(_StepFailed) as excinfo:
+            driver._run_aokernel_step(
+                run_id,
+                _record_with_adapter_output(run_id, output_ref),
+                _patch_step(),
+                attempt=1,
+                step_id="apply_patch",
+            )
+
+        assert excinfo.value.code == "WRITE_OWNERSHIP_CONFLICT"
+        assert "ClaimConflictError" in excinfo.value.reason
+        assert (tmp_path / "src" / "foo.py").read_text(encoding="utf-8") == "x = 1\n"
+
+        events = _events(tmp_path, run_id)
+        kinds = [event["kind"] for event in events]
+        assert kinds == ["step_started", "claim_conflict"]
+
+        remaining = registry.list_agent_claims("agent-existing")
+        assert [claim.resource_id for claim in remaining] == [
+            blocked.leases[0].scope.resource_id
+        ]
+        release_path_write_claims(registry, blocked)


### PR DESCRIPTION
## Özet
Bu PR, `WP-7.3`'ün ilk dar enforcement slice'ını açıyor: coordination enabled workspace'lerde `patch_apply` artık path-scoped write ownership claim'i alıyor. Böylece gerçek write noktası olan patch apply sırasında aynı logical top-level area'ya iki writer'ın sessizce girmesi engelleniyor.

## Kullanıcı etkisi
Bugüne kadar `WP-7.1` ve `WP-7.2` yalnız namespace + visibility sağlıyordu; gerçek runtime write noktasında enforcement yoktu. Bu PR ile `patch_apply` adımı coordination açıkken claim acquire/release yapıyor, conflict durumunu deterministik bir workflow failure'a çeviriyor ve evidence akışına claim audit alanlarını ekliyor.

## Kök neden
Repo'da path ownership primitive'leri ve `coordination status` görünürlüğü vardı, ancak bunlar `MultiStepDriver` içindeki gerçek write-capable operation'lara bağlanmamıştı. Sonuç olarak aynı path alanı üzerinde runtime serialization garantisi yoktu; operator yalnız görünürlük alıyor ama koruma almıyordu.

## Düzeltme
`MultiStepDriver._run_patch_step()` içinde `patch_apply` yolu artık:
- coordination policy enabled ise patch preview'den `files_changed` listesini çıkarıyor
- bu listeyi shared workspace root üzerinde path-scoped claim'e çeviriyor
- claim'i `workflow-run:{run_id}` owner kimliğiyle acquire ediyor
- apply başarılıysa `diff_applied` event/artifact'ına `write_claim_areas` ve `write_claim_resource_ids` alanlarını ekliyor
- apply sonrasında claim'i release ediyor
- conflict veya grace-conflict durumunu `_StepFailed(code=WRITE_OWNERSHIP_CONFLICT)` olarak yüzeye çıkarıyor
- dormant policy altında mevcut davranışı koruyor

Ayrıca yaşayan kayıtlar hizalandı:
- `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
- `.claude/plans/WP-7.3-EXECUTOR-ENFORCEMENT.md`
- `docs/COORDINATION.md`

## Doğrulama
Aşağıdaki kontroller bu branch üzerinde çalıştırıldı:
- `pytest -q tests/test_patch_write_ownership_enforcement.py`
- `pytest -q tests/test_path_write_ownership.py tests/test_patch_write_ownership_enforcement.py tests/test_multi_step_driver_integration.py::TestBundledBugFixFlow::test_real_codex_stub_completes_preview_diff`
- `ruff check ao_kernel/executor/multi_step_driver.py tests/test_patch_write_ownership_enforcement.py`
- `python3 -m mypy ao_kernel/executor/multi_step_driver.py tests/test_patch_write_ownership_enforcement.py`

## Kapsam dışı / Sonraki adım
Bu PR, enforcement'i yalnız ilk gerçek write noktası olan `patch_apply` üzerinde açar. Daha geniş orchestration entry coverage ve handoff/takeover ergonomics sonraki `WP-7.3` dilimlerinde ele alınacaktır.

Closes #198
