### PR TITLE
[codex] enforce rollback write ownership

### DIFF
--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -68,27 +68,28 @@ automation platform çizgisine taşımak.
 
 **GitHub takip**
 - üst issue: [#198](https://github.com/Halildeu/ao-kernel/issues/198)
-- son merge: `WP-7.2` / PR #208
+- son merge: `WP-7.3 slice 1` / PR #209
 - aktif slice: [`WP-7.3-EXECUTOR-ENFORCEMENT.md`](./WP-7.3-EXECUTOR-ENFORCEMENT.md)
 
 **Adım sırası**
 1. `[x]` `WP-7.1` path resource namespace kararı + acquire/release helper'ları
 2. `[x]` `WP-7.2` claim visibility (`coordination status`) yüzeyi
-3. `[~]` `WP-7.3` patch apply write-ownership enforcement
+3. `[~]` `WP-7.3` patch apply / patch rollback write-ownership enforcement
 4. `[ ]` handoff / takeover ergonomics ve daha geniş orchestration entry coverage
 
 **Canlı snapshot**
 - `patch_apply` artık coordination enabled workspace'te preview edilen
-  `files_changed` üstünden path-scoped write claim almaya hazırlanıyor
+  `files_changed` üstünden path-scoped write claim alıyor
 - claim scope top-level area üstünden belirlenir (`src/*` -> tek claim alanı)
 - claim acquire/release event'leri workflow evidence akışına bağlanır
 - conflict path'i deterministic `_StepFailed(code=WRITE_OWNERSHIP_CONFLICT)`
   olarak yüzeye çıkar
-- current scope yalnız gerçek write noktası olan `patch_apply`; read-only
-  preview/status yüzeyleri unchanged
+- aktif alt slice aynı kontratı `patch_rollback` yoluna genişletir
+- read-only preview/status yüzeyleri unchanged
 
 **Definition of Done**
-- coordination enabled patch apply yolu claim acquire/release ile çalışıyor
+- coordination enabled patch apply ve patch rollback yolları claim
+  acquire/release ile çalışıyor
 - conflict aynı path alanında deterministic fail üretiyor
 - dormant coordination semantics korunuyor
 - yeni davranış behavior-first testlerle pinleniyor

--- a/.claude/plans/WP-7.3-EXECUTOR-ENFORCEMENT.md
+++ b/.claude/plans/WP-7.3-EXECUTOR-ENFORCEMENT.md
@@ -6,13 +6,18 @@
 
 ## Amaç
 
-İlk gerçek write noktası olan `patch_apply` adımında, coordination enabled
-workspace'lerde path-scoped ownership claim'ini runtime davranışına bağlamak.
+Write-capable patch adımlarında (`patch_apply`, `patch_rollback`),
+coordination enabled workspace'lerde path-scoped ownership claim'ini runtime
+davranışına bağlamak.
 
 ## Bu Slice'ın Kararı
 
-- Enforcement ilk dilimde yalnız `patch_apply` üzerinde açılır
-- Claim scope, patch preview'den çıkan `files_changed` listesinden türetilir
+- İlk slice (`PR #209`) `patch_apply` üzerinde merge edildi
+- Bu slice enforcement'ı `patch_rollback` yoluna genişletir
+- `patch_apply` claim scope'u patch preview'den çıkan `files_changed`
+  listesinden türetilir
+- `patch_rollback` claim scope'u reverse diff içeriğindeki touched path
+  listesinden türetilir
 - Claim acquire/release, mevcut coordination evidence sink üstünden workflow
   event akışına bağlanır
 - Conflict veya grace-conflict deterministic `_StepFailed` sinyaline çevrilir
@@ -25,17 +30,23 @@ workspace'lerde path-scoped ownership claim'ini runtime davranışına bağlamak
 - `diff_applied` payload'ına additive audit alanları:
   - `write_claim_areas`
   - `write_claim_resource_ids`
+- `diff_rolled_back` payload'ına additive audit alanları:
+  - `write_claim_areas`
+  - `write_claim_resource_ids`
 
 ## Definition of Done
 
-1. Coordination enabled iken `patch_apply` claim acquire/release yapar
+1. Coordination enabled iken `patch_apply` ve `patch_rollback` claim
+   acquire/release yapar
 2. Aynı path alanında ikinci writer deterministic conflict alır
 3. Dormant policy altında claim yüzeyi hiç engage olmaz
-4. `diff_applied` evidence'ı claim audit alanlarını taşır
+4. `diff_applied` ve `diff_rolled_back` evidence'ları claim audit alanlarını
+   taşır
 5. Bu davranış behavior-first pytest ile pinlenir
 
 ## Deferred
 
-- `patch_apply` dışındaki write-capable orchestration entry'leri
+- `patch_apply` / `patch_rollback` dışındaki write-capable orchestration
+  entry'leri
 - handoff / takeover ergonomics
 - ownership claim'lerinin daha yüksek seviyeli scheduler/orchestrator kararlarına bağlanması

--- a/ao_kernel/executor/multi_step_driver.py
+++ b/ao_kernel/executor/multi_step_driver.py
@@ -39,6 +39,7 @@ idempotency key, NOT persisted to schema.
 from __future__ import annotations
 
 import os
+import re
 import time
 import uuid
 from dataclasses import dataclass
@@ -82,6 +83,9 @@ __all__ = [
     "MultiStepDriver",
     "WorkflowStateCorruptedError",
 ]
+
+
+_DIFF_PATH = re.compile(r"^(?:\+\+\+|---) [ab]/(.+)$", re.MULTILINE)
 
 
 @dataclass(frozen=True)
@@ -908,7 +912,6 @@ class MultiStepDriver:
         from ao_kernel.patch import (  # lazy to avoid cycle through executor
             apply_patch, preview_diff, rollback_patch, PatchError,
         )
-        from ao_kernel.coordination import release_path_write_claims
         from ao_kernel.coordination.errors import (
             ClaimConflictError,
             ClaimConflictGraceError,
@@ -927,6 +930,7 @@ class MultiStepDriver:
             record, step_def.step_name, workspace_root=self._workspace_root,
         )
         ownership: tuple[Any, Any] | None = None
+        ownership_payload: dict[str, Any] = {}
 
         try:
             if op == "patch_preview":
@@ -942,26 +946,22 @@ class MultiStepDriver:
                     "lines_removed": preview.lines_removed,
                 }
             elif op == "patch_apply":
-                ownership = self._acquire_patch_write_claims(
+                ownership = self._acquire_patch_apply_write_claims(
                     run_id=run_id,
                     patch_content=patch_content,
                     sandbox=sandbox,
                     worktree=worktree,
                 )
-                ownership_payload = (
-                    self._ownership_payload(ownership[1])
-                    if ownership is not None
-                    else {}
-                )
+                if ownership is not None:
+                    ownership_payload = self._ownership_payload(ownership[1])
                 try:
                     apply_result = apply_patch(
                         worktree, patch_content, sandbox, run_dir,
                     )
                 except BaseException:
                     if ownership is not None:
-                        registry, lease_set = ownership
                         try:
-                            release_path_write_claims(registry, lease_set)
+                            self._release_patch_write_claims(ownership)
                         except CoordinationError:
                             pass
                     raise
@@ -981,19 +981,36 @@ class MultiStepDriver:
                 }
             else:  # patch_rollback
                 reverse_diff_id = step_def.step_name  # test fixture convention
-                rb_result = rollback_patch(
-                    worktree, reverse_diff_id, sandbox, run_dir,
+                ownership = self._acquire_patch_rollback_write_claims(
+                    run_id=run_id,
+                    run_dir=run_dir,
+                    reverse_diff_id=reverse_diff_id,
                 )
+                if ownership is not None:
+                    ownership_payload = self._ownership_payload(ownership[1])
+                try:
+                    rb_result = rollback_patch(
+                        worktree, reverse_diff_id, sandbox, run_dir,
+                    )
+                except BaseException:
+                    if ownership is not None:
+                        try:
+                            self._release_patch_write_claims(ownership)
+                        except CoordinationError:
+                            pass
+                    raise
                 if rb_result.rolled_back:
                     self._emit(run_id, "diff_rolled_back",
                         {"step_name": step_def.step_name,
-                         "patch_id": rb_result.patch_id, "attempt": attempt},
+                         "patch_id": rb_result.patch_id, "attempt": attempt,
+                         **ownership_payload},
                         step_id=step_id)
                 artifact = {
                     "operation": op, "patch_id": rb_result.patch_id,
                     "rolled_back": rb_result.rolled_back,
                     "idempotent_skip": rb_result.idempotent_skip,
                     "files_reverted": list(rb_result.files_reverted),
+                    **ownership_payload,
                 }
         except PatchError as exc:
             raise _StepFailed(
@@ -1025,10 +1042,9 @@ class MultiStepDriver:
         output_ref, output_sha256 = write_artifact(
             run_dir=run_dir, step_id=step_id, attempt=attempt, payload=artifact,
         )
-        if op == "patch_apply" and ownership is not None:
-            registry, lease_set = ownership
+        if ownership is not None:
             try:
-                release_path_write_claims(registry, lease_set)
+                self._release_patch_write_claims(ownership)
             except CoordinationError as exc:
                 code = (
                     "WRITE_OWNERSHIP_CONFLICT"
@@ -1048,7 +1064,7 @@ class MultiStepDriver:
             "operation": op,
         }
 
-    def _acquire_patch_write_claims(
+    def _acquire_patch_apply_write_claims(
         self,
         *,
         run_id: str,
@@ -1063,20 +1079,52 @@ class MultiStepDriver:
         workspace root, so isolated run worktrees still serialize on
         the same logical top-level areas.
         """
+        from ao_kernel.patch import preview_diff
+
+        preview = preview_diff(worktree, patch_content, sandbox)
+        return self._acquire_write_claims_for_paths(
+            run_id=run_id,
+            paths=preview.files_changed,
+        )
+
+    def _acquire_patch_rollback_write_claims(
+        self,
+        *,
+        run_id: str,
+        run_dir: Path,
+        reverse_diff_id: str,
+    ) -> tuple[Any, Any] | None:
+        """Acquire path-scoped write ownership for ``patch_rollback``."""
+        revdiff_path = run_dir / "patches" / f"{reverse_diff_id}.revdiff"
+        try:
+            revdiff_content = revdiff_path.read_text(encoding="utf-8")
+        except OSError:
+            return None
+        return self._acquire_write_claims_for_paths(
+            run_id=run_id,
+            paths=_extract_paths_from_diff(revdiff_content),
+        )
+
+    def _acquire_write_claims_for_paths(
+        self,
+        *,
+        run_id: str,
+        paths: tuple[str, ...] | list[str],
+    ) -> tuple[Any, Any] | None:
+        """Acquire path-scoped write ownership for concrete workspace paths."""
         from ao_kernel.coordination import (
             ClaimRegistry,
             acquire_path_write_claims,
             build_coordination_sink,
             load_coordination_policy,
         )
-        from ao_kernel.patch import preview_diff
+
+        normalized_paths = tuple(paths)
+        if not normalized_paths:
+            return None
 
         coordination_policy = load_coordination_policy(self._workspace_root)
         if not coordination_policy.enabled:
-            return None
-
-        preview = preview_diff(worktree, patch_content, sandbox)
-        if not preview.files_changed:
             return None
 
         registry = ClaimRegistry(
@@ -1091,13 +1139,20 @@ class MultiStepDriver:
             registry,
             self._workspace_root,
             owner_agent_id=f"workflow-run:{run_id}",
-            paths=preview.files_changed,
+            paths=normalized_paths,
             policy=coordination_policy,
         )
         return registry, lease_set
 
+    def _release_patch_write_claims(self, ownership: tuple[Any, Any]) -> None:
+        """Release a previously acquired patch-operation write claim set."""
+        from ao_kernel.coordination import release_path_write_claims
+
+        registry, lease_set = ownership
+        release_path_write_claims(registry, lease_set)
+
     def _ownership_payload(self, lease_set: Any) -> dict[str, Any]:
-        """Return additive audit fields for patch apply evidence."""
+        """Return additive audit fields for patch-operation evidence."""
         return {
             "write_claim_areas": [lease.scope.area for lease in lease_set.leases],
             "write_claim_resource_ids": [
@@ -2296,3 +2351,14 @@ def _load_pending_patch_content(
             diff = artifact.get("diff", "")
             return diff if isinstance(diff, str) else ""
     return ""
+
+
+def _extract_paths_from_diff(diff_content: str) -> tuple[str, ...]:
+    """Pull touched-file paths from unified diff headers."""
+    seen: dict[str, None] = {}
+    for match in _DIFF_PATH.finditer(diff_content):
+        path = match.group(1)
+        if path == "/dev/null":
+            continue
+        seen.setdefault(path, None)
+    return tuple(seen.keys())

--- a/docs/COORDINATION.md
+++ b/docs/COORDINATION.md
@@ -171,15 +171,18 @@ ao-kernel coordination status --format json
 The status surface reports the current claim owner plus derived state:
 `ACTIVE`, `GRACE`, or `TAKEOVER_READY`.
 
-Runtime enforcement now starts at the first real write point:
+Runtime enforcement now covers the shipped write-capable patch points:
 `MultiStepDriver._run_patch_step()` acquires path-scoped claims before
-`patch_apply` when `policy_coordination_claims.enabled=true`. The claim scope is
-derived from the patch preview's `files_changed` list and projected onto the
+`patch_apply` and `patch_rollback` when
+`policy_coordination_claims.enabled=true`. For `patch_apply`, the claim scope is
+derived from the patch preview's `files_changed` list; for `patch_rollback`, it
+is derived from the reverse diff's touched paths. Both are projected onto the
 shared workspace root, so separate run worktrees still serialize on the same
-logical top-level areas. Successful apply emits additive audit fields on
-`diff_applied` (`write_claim_areas`, `write_claim_resource_ids`) and releases
-the claim afterwards. With coordination disabled, `patch_apply` keeps the old
-dormant behavior and does not engage the claim layer.
+logical top-level areas. Successful apply / rollback emits additive audit
+fields on `diff_applied` / `diff_rolled_back`
+(`write_claim_areas`, `write_claim_resource_ids`) and releases the claim
+afterwards. With coordination disabled, both patch operations keep the old
+dormant behavior and do not engage the claim layer.
 
 ### 10.2 Fail-closed vs fail-open
 

--- a/tests/test_patch_write_ownership_enforcement.py
+++ b/tests/test_patch_write_ownership_enforcement.py
@@ -13,9 +13,10 @@ from ao_kernel.coordination import (
     release_path_write_claims,
 )
 from ao_kernel.executor.multi_step_driver import _StepFailed
+from ao_kernel.patch import apply_patch
 from ao_kernel.workflow.registry import StepDefinition
 from tests._driver_helpers import _GIT_CFG, build_driver, install_workspace
-from tests._patch_helpers import make_patch_from_changes
+from tests._patch_helpers import build_test_sandbox, make_patch_from_changes
 
 
 def _write_coordination_policy(workspace_root: Path, *, enabled: bool) -> None:
@@ -53,6 +54,17 @@ def _install_patch_target_repo(workspace_root: Path) -> None:
     )
 
 
+def _prepare_run_worktree(workspace_root: Path, run_id: str) -> Path:
+    worktree = workspace_root / ".ao" / "runs" / run_id / "worktree"
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", *_GIT_CFG, "-C", str(workspace_root), "worktree", "add", "--detach", str(worktree), "HEAD"],
+        check=True,
+        capture_output=True,
+    )
+    return worktree
+
+
 def _patch_step() -> StepDefinition:
     return StepDefinition(
         step_name="apply_patch",
@@ -65,6 +77,21 @@ def _patch_step() -> StepDefinition:
         human_interrupt_allowed=False,
         gate=None,
         operation="patch_apply",
+    )
+
+
+def _rollback_step(reverse_diff_id: str) -> StepDefinition:
+    return StepDefinition(
+        step_name=reverse_diff_id,
+        actor="ao-kernel",
+        adapter_id=None,
+        required_capabilities=(),
+        policy_refs=(),
+        on_failure="transition_to_failed",
+        timeout_seconds=None,
+        human_interrupt_allowed=False,
+        gate=None,
+        operation="patch_rollback",
     )
 
 
@@ -99,6 +126,14 @@ def _record_with_adapter_output(run_id: str, output_ref: str) -> dict[str, objec
                 "output_ref": output_ref,
             }
         ],
+    }
+
+
+def _bare_record(run_id: str) -> dict[str, object]:
+    return {
+        "run_id": run_id,
+        "state": "running",
+        "steps": [],
     }
 
 
@@ -214,6 +249,163 @@ class TestPatchWriteOwnershipEnforcement:
         events = _events(tmp_path, run_id)
         kinds = [event["kind"] for event in events]
         assert kinds == ["step_started", "claim_conflict"]
+
+        remaining = registry.list_agent_claims("agent-existing")
+        assert [claim.resource_id for claim in remaining] == [
+            blocked.leases[0].scope.resource_id
+        ]
+        release_path_write_claims(registry, blocked)
+
+    def test_patch_rollback_skips_claims_when_coordination_disabled(
+        self, tmp_path: Path,
+    ) -> None:
+        install_workspace(tmp_path)
+        _install_patch_target_repo(tmp_path)
+        run_id = "00000000-0000-4000-8000-000000000704"
+        worktree = _prepare_run_worktree(tmp_path, run_id)
+        _write_coordination_policy(tmp_path, enabled=False)
+        patch = make_patch_from_changes(worktree, {"src/foo.py": "x = 2\n"})
+        run_dir = tmp_path / ".ao" / "evidence" / "workflows" / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        apply_result = apply_patch(
+            worktree,
+            patch,
+            build_test_sandbox(worktree),
+            run_dir,
+        )
+        subprocess.run(
+            ["git", *_GIT_CFG, "-C", str(worktree), "commit", "-q", "-am", "apply"],
+            check=True,
+            capture_output=True,
+        )
+        driver = build_driver(tmp_path)
+
+        _record, result = driver._run_aokernel_step(
+            run_id,
+            _bare_record(run_id),
+            _rollback_step(apply_result.reverse_diff_id),
+            attempt=1,
+            step_id="rollback_patch",
+        )
+
+        assert result["step_state"] == "completed"
+        assert (worktree / "src" / "foo.py").read_text(encoding="utf-8") == "x = 1\n"
+        events = _events(tmp_path, run_id)
+        assert [event["kind"] for event in events] == [
+            "step_started",
+            "diff_rolled_back",
+        ]
+        diff_rolled_back = next(
+            event for event in events if event["kind"] == "diff_rolled_back"
+        )
+        assert "write_claim_areas" not in diff_rolled_back["payload"]
+
+    def test_patch_rollback_acquires_and_releases_write_claims(
+        self, tmp_path: Path,
+    ) -> None:
+        install_workspace(tmp_path)
+        _install_patch_target_repo(tmp_path)
+        run_id = "00000000-0000-4000-8000-000000000705"
+        worktree = _prepare_run_worktree(tmp_path, run_id)
+        _write_coordination_policy(tmp_path, enabled=True)
+        patch = make_patch_from_changes(worktree, {"src/foo.py": "x = 2\n"})
+        run_dir = tmp_path / ".ao" / "evidence" / "workflows" / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        apply_result = apply_patch(
+            worktree,
+            patch,
+            build_test_sandbox(worktree),
+            run_dir,
+        )
+        subprocess.run(
+            ["git", *_GIT_CFG, "-C", str(worktree), "commit", "-q", "-am", "apply"],
+            check=True,
+            capture_output=True,
+        )
+        driver = build_driver(tmp_path)
+
+        _record, result = driver._run_aokernel_step(
+            run_id,
+            _bare_record(run_id),
+            _rollback_step(apply_result.reverse_diff_id),
+            attempt=1,
+            step_id="rollback_patch",
+        )
+
+        assert result["step_state"] == "completed"
+        assert (worktree / "src" / "foo.py").read_text(encoding="utf-8") == "x = 1\n"
+
+        events = _events(tmp_path, run_id)
+        assert [event["kind"] for event in events] == [
+            "step_started",
+            "claim_acquired",
+            "diff_rolled_back",
+            "claim_released",
+        ]
+
+        diff_rolled_back = next(
+            event for event in events if event["kind"] == "diff_rolled_back"
+        )
+        assert diff_rolled_back["payload"]["write_claim_areas"] == ["src"]
+        assert len(diff_rolled_back["payload"]["write_claim_resource_ids"]) == 1
+
+        artifact = json.loads(
+            (run_dir / result["output_ref"]).read_text(encoding="utf-8")
+        )
+        assert artifact["write_claim_areas"] == ["src"]
+
+        registry = ClaimRegistry(tmp_path)
+        assert registry.list_agent_claims(f"workflow-run:{run_id}") == []
+
+    def test_patch_rollback_conflict_surfaces_as_step_failed_signal(
+        self, tmp_path: Path,
+    ) -> None:
+        install_workspace(tmp_path)
+        _install_patch_target_repo(tmp_path)
+        run_id = "00000000-0000-4000-8000-000000000706"
+        worktree = _prepare_run_worktree(tmp_path, run_id)
+        _write_coordination_policy(tmp_path, enabled=True)
+        patch = make_patch_from_changes(worktree, {"src/foo.py": "x = 2\n"})
+        run_dir = tmp_path / ".ao" / "evidence" / "workflows" / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        apply_result = apply_patch(
+            worktree,
+            patch,
+            build_test_sandbox(worktree),
+            run_dir,
+        )
+        subprocess.run(
+            ["git", *_GIT_CFG, "-C", str(worktree), "commit", "-q", "-am", "apply"],
+            check=True,
+            capture_output=True,
+        )
+        driver = build_driver(tmp_path)
+        registry = ClaimRegistry(tmp_path)
+        blocked = acquire_path_write_claims(
+            registry,
+            tmp_path,
+            owner_agent_id="agent-existing",
+            paths=["src/foo.py"],
+        )
+
+        with pytest.raises(_StepFailed) as excinfo:
+            driver._run_aokernel_step(
+                run_id,
+                _bare_record(run_id),
+                _rollback_step(apply_result.reverse_diff_id),
+                attempt=1,
+                step_id="rollback_patch",
+            )
+
+        assert excinfo.value.code == "WRITE_OWNERSHIP_CONFLICT"
+        assert "ClaimConflictError" in excinfo.value.reason
+        assert (worktree / "src" / "foo.py").read_text(encoding="utf-8") == "x = 2\n"
+
+        events = _events(tmp_path, run_id)
+        assert [event["kind"] for event in events] == [
+            "step_started",
+            "claim_conflict",
+        ]
 
         remaining = registry.list_agent_claims("agent-existing")
         assert [claim.resource_id for claim in remaining] == [


### PR DESCRIPTION
## Summary
- extend path-scoped write ownership enforcement from `patch_apply` to `patch_rollback`
- add rollback-specific behavior tests for dormant, success, and conflict paths
- update WP-7.3 status/docs so runtime scope and plan language stay aligned

## Test
- `python3 -m pytest -q tests/test_patch_write_ownership_enforcement.py`
- `python3 -m pytest -q tests/test_path_write_ownership.py tests/test_patch_write_ownership_enforcement.py tests/test_multi_step_driver_integration.py::TestBundledBugFixFlow::test_real_codex_stub_completes_preview_diff`
- `ruff check ao_kernel/executor/multi_step_driver.py tests/test_patch_write_ownership_enforcement.py`
- `python3 -m mypy ao_kernel/executor/multi_step_driver.py tests/test_patch_write_ownership_enforcement.py`

## Context
- continues WP-7 issue #198 after PR #209
