### PR TITLE
[codex] add coordination takeover CLI

### DIFF
--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -68,14 +68,15 @@ automation platform çizgisine taşımak.
 
 **GitHub takip**
 - üst issue: [#198](https://github.com/Halildeu/ao-kernel/issues/198)
-- son merge: `WP-7.3 slice 1` / PR #209
-- aktif slice: [`WP-7.3-EXECUTOR-ENFORCEMENT.md`](./WP-7.3-EXECUTOR-ENFORCEMENT.md)
+- son merge: `WP-7.3 slice 2` / PR #210
+- aktif slice: [`WP-7.4-TAKEOVER-ERGONOMICS.md`](./WP-7.4-TAKEOVER-ERGONOMICS.md)
 
 **Adım sırası**
 1. `[x]` `WP-7.1` path resource namespace kararı + acquire/release helper'ları
 2. `[x]` `WP-7.2` claim visibility (`coordination status`) yüzeyi
-3. `[~]` `WP-7.3` patch apply / patch rollback write-ownership enforcement
-4. `[ ]` handoff / takeover ergonomics ve daha geniş orchestration entry coverage
+3. `[x]` `WP-7.3` patch apply / patch rollback write-ownership enforcement
+4. `[~]` `WP-7.4` handoff / takeover ergonomics
+5. `[ ]` daha geniş orchestration entry coverage
 
 **Canlı snapshot**
 - `patch_apply` artık coordination enabled workspace'te preview edilen
@@ -84,13 +85,16 @@ automation platform çizgisine taşımak.
 - claim acquire/release event'leri workflow evidence akışına bağlanır
 - conflict path'i deterministic `_StepFailed(code=WRITE_OWNERSHIP_CONFLICT)`
   olarak yüzeye çıkar
-- aktif alt slice aynı kontratı `patch_rollback` yoluna genişletir
-- read-only preview/status yüzeyleri unchanged
+- `patch_rollback` aynı ownership kontratıyla claim acquire/release yapar
+- aktif alt slice operatör için `coordination takeover` CLI yüzeyini ekler
+- read-only `coordination status` yüzeyi ownership state'ini snapshot olarak
+  vermeye devam eder
 
 **Definition of Done**
 - coordination enabled patch apply ve patch rollback yolları claim
   acquire/release ile çalışıyor
 - conflict aynı path alanında deterministic fail üretiyor
+- `coordination takeover` past-grace claim'i CLI üzerinden devralabiliyor
 - dormant coordination semantics korunuyor
 - yeni davranış behavior-first testlerle pinleniyor
 - docs/runtime/story aynı şeyi söylüyor

--- a/.claude/plans/WP-7.4-TAKEOVER-ERGONOMICS.md
+++ b/.claude/plans/WP-7.4-TAKEOVER-ERGONOMICS.md
@@ -1,0 +1,40 @@
+# WP-7.4 — Coordination Takeover Ergonomics
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#198](https://github.com/Halildeu/ao-kernel/issues/198)
+**Üst WP:** [#198](https://github.com/Halildeu/ao-kernel/issues/198)
+
+## Amaç
+
+Coordination runtime içindeki mevcut `takeover_claim(...)` primitive'ini
+operatör için doğrudan kullanılabilir ve denetlenebilir bir CLI yüzeyine
+bağlamak.
+
+## Bu Slice'ın Kararı
+
+- Yeni write semantics icat etmez; mevcut registry kontratını CLI'ye taşır
+- Çıkış yüzeyi `ao-kernel coordination takeover` olur
+- Komut yalnız exact `resource_id` ile çalışır; path-area label'ı değil,
+  `coordination status` çıktısındaki gerçek claim anahtarı kullanılır
+- Live claim, grace claim ve absent claim yolları non-zero exit + stderr ile
+  deterministik yüzeye çıkar
+- Corrupt SSOT fail-closed kalır ve exit code `2` ile ayrışır
+
+## Public Surface
+
+- `ao-kernel coordination takeover --resource-id <id> --owner-tag <tag>`
+- `ao-kernel coordination takeover --format json`
+
+## Definition of Done
+
+1. Past-grace claim takeover CLI üzerinden başarılı çalışır
+2. Başarılı yol text ve json output ile pinlenir
+3. Live / grace / absent claim yolları behavior-first testlerle pinlenir
+4. CLI parser dispatch gerçek `main(...)` çağrısı üzerinden doğrulanır
+5. Coordination dokümanı ve program-status yeni yüzeyi anlatır
+
+## Deferred
+
+- release / handoff ayrı operatör komutları
+- geçmiş takeover / handoff timeline query yüzeyi
+- orchestration entry coverage'ının `patch_apply` / `patch_rollback` ötesine genişlemesi

--- a/ao_kernel/_internal/coordination/cli_handlers.py
+++ b/ao_kernel/_internal/coordination/cli_handlers.py
@@ -7,7 +7,15 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from ao_kernel.coordination.errors import ClaimCorruptedError
+from ao_kernel.coordination import ClaimRegistry
+from ao_kernel.coordination.claim import claim_to_dict
+from ao_kernel.coordination.errors import (
+    ClaimConflictError,
+    ClaimConflictGraceError,
+    ClaimCoordinationDisabledError,
+    ClaimCorruptedError,
+    ClaimNotFoundError,
+)
 from ao_kernel.coordination.status import (
     build_coordination_status,
     render_coordination_status,
@@ -68,4 +76,67 @@ def cmd_coordination_status(args: Any) -> int:
     return 0
 
 
-__all__ = ["cmd_coordination_status"]
+def _takeover_payload(claim: Any, workspace: Path) -> dict[str, Any]:
+    payload = claim_to_dict(claim)
+    payload["version"] = "v1"
+    payload["workspace_root"] = str(workspace)
+    payload["owner_tag"] = payload.pop("owner_agent_id")
+    payload["status"] = "TAKEN_OVER"
+    return payload
+
+
+def _render_takeover(payload: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            "== coordination takeover ==",
+            f"Workspace: {payload['workspace_root']}",
+            f"Resource: {payload['resource_id']}",
+            f"New owner: {payload['owner_tag']}",
+            f"Claim id: {payload['claim_id']}",
+            f"Fencing token: {payload['fencing_token']}",
+            f"Acquired at: {payload['acquired_at']}",
+            f"Heartbeat at: {payload['heartbeat_at']}",
+            f"Status: {payload['status']}",
+        ]
+    )
+
+
+def cmd_coordination_takeover(args: Any) -> int:
+    """Handle ``ao-kernel coordination takeover``."""
+    workspace = _resolve_workspace(args)
+    registry = ClaimRegistry(workspace)
+
+    try:
+        claim = registry.takeover_claim(
+            getattr(args, "resource_id"),
+            getattr(args, "owner_tag"),
+        )
+    except ClaimCoordinationDisabledError:
+        print(
+            "error: coordination disabled — "
+            "policy_coordination_claims.enabled=false",
+            file=sys.stderr,
+        )
+        return 1
+    except (ClaimConflictError, ClaimConflictGraceError, ClaimNotFoundError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except ClaimCorruptedError as exc:
+        print(f"error: corrupt coordination state — {exc}", file=sys.stderr)
+        return 2
+
+    payload_doc = _takeover_payload(claim, workspace)
+    if getattr(args, "format", "text") == "json":
+        payload = json.dumps(payload_doc, indent=2, sort_keys=True)
+    else:
+        payload = _render_takeover(payload_doc)
+
+    try:
+        _emit_output(payload, args)
+    except (OSError, PermissionError) as exc:
+        print(f"error: output write failed — {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+__all__ = ["cmd_coordination_status", "cmd_coordination_takeover"]

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -815,6 +815,31 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="File path for atomic write; omit for stdout",
     )
+    coordination_takeover_p = coordination_sub.add_parser(
+        "takeover",
+        help="Take over a past-grace coordination claim for a new owner",
+    )
+    coordination_takeover_p.add_argument(
+        "--resource-id",
+        required=True,
+        help="Exact claim resource_id to take over",
+    )
+    coordination_takeover_p.add_argument(
+        "--owner-tag",
+        required=True,
+        help="New owner tag / agent id that will hold the claim",
+    )
+    coordination_takeover_p.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    coordination_takeover_p.add_argument(
+        "--output",
+        default=None,
+        help="File path for atomic write; omit for stdout",
+    )
 
     # Policy-sim subcommand (PR-B4)
     policy_sim_p = sub.add_parser(
@@ -1359,12 +1384,15 @@ def main(argv: list[str] | None = None) -> int:
     if cmd == "coordination":
         from ao_kernel._internal.coordination.cli_handlers import (
             cmd_coordination_status,
+            cmd_coordination_takeover,
         )
 
         coordination_cmd = getattr(args, "coordination_command", None)
         if coordination_cmd == "status":
             return cmd_coordination_status(args)
-        print("Usage: ao-kernel coordination status", file=sys.stderr)
+        if coordination_cmd == "takeover":
+            return cmd_coordination_takeover(args)
+        print("Usage: ao-kernel coordination {status|takeover}", file=sys.stderr)
         return 1
 
     handler = dispatch.get(cmd)

--- a/docs/COORDINATION.md
+++ b/docs/COORDINATION.md
@@ -166,10 +166,17 @@ Read-only operator visibility for the current claim SSOT is available via:
 ```bash
 ao-kernel coordination status
 ao-kernel coordination status --format json
+ao-kernel coordination takeover --resource-id worktree-a --owner-tag agent-beta
 ```
 
 The status surface reports the current claim owner plus derived state:
 `ACTIVE`, `GRACE`, or `TAKEOVER_READY`.
+
+`coordination takeover` exact `resource_id` ile çalışır; path-scoped ownership
+claim'lerinde human-friendly label değil, `coordination status --format json`
+çıktısındaki gerçek `work_item_id` / `resource_id` anahtarı kullanılmalıdır.
+Komut yalnızca claim past-grace durumuna geçtiğinde başarılı olur; live claim,
+grace window ve absent claim ayrı non-zero exit ile reddedilir.
 
 Runtime enforcement now covers the shipped write-capable patch points:
 `MultiStepDriver._run_patch_step()` acquires path-scoped claims before

--- a/tests/test_coordination_cli.py
+++ b/tests/test_coordination_cli.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
-from ao_kernel._internal.coordination.cli_handlers import cmd_coordination_status
+from ao_kernel._internal.coordination.cli_handlers import (
+    cmd_coordination_status,
+    cmd_coordination_takeover,
+)
+from ao_kernel.cli import main
 from ao_kernel.coordination import ClaimRegistry
+from ao_kernel.coordination.claim import claim_path, claim_revision
 
 
 def _args(workspace: Path | None, **kwargs) -> SimpleNamespace:
@@ -15,6 +21,8 @@ def _args(workspace: Path | None, **kwargs) -> SimpleNamespace:
         workspace_root=(str(workspace) if workspace is not None else None),
         format=kwargs.get("format", "text"),
         output=kwargs.get("output"),
+        resource_id=kwargs.get("resource_id"),
+        owner_tag=kwargs.get("owner_tag"),
     )
 
 
@@ -42,6 +50,21 @@ def _write_workspace_policy(workspace_root: Path, doc: dict[str, object]) -> Non
     )
 
 
+def _rewind_claim_heartbeat(
+    workspace_root: Path,
+    resource_id: str,
+    *,
+    seconds_ago: int,
+) -> None:
+    path = claim_path(workspace_root, resource_id)
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    now = datetime.now(timezone.utc)
+    doc["heartbeat_at"] = (now - timedelta(seconds=seconds_ago)).isoformat()
+    doc["expires_at"] = (now - timedelta(seconds=max(seconds_ago - 90, 0))).isoformat()
+    doc["revision"] = claim_revision(doc)
+    path.write_text(json.dumps(doc, sort_keys=True), encoding="utf-8")
+
+
 class TestCoordinationStatusCli:
     def test_text_output_reports_disabled_workspace(
         self, tmp_path: Path, capsys
@@ -66,3 +89,132 @@ class TestCoordinationStatusCli:
         assert payload["status"] == "OK"
         assert payload["summary"]["by_agent"] == {"agent-alpha": 1}
         assert payload["claims"][0]["work_item_id"] == "worktree-a"
+
+
+class TestCoordinationTakeoverCli:
+    def test_text_output_reports_successful_takeover(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+        registry = ClaimRegistry(tmp_path)
+        registry.acquire_claim("worktree-a", "agent-alpha")
+        _rewind_claim_heartbeat(tmp_path, "worktree-a", seconds_ago=120)
+
+        rc = cmd_coordination_takeover(
+            _args(
+                tmp_path,
+                format="text",
+                resource_id="worktree-a",
+                owner_tag="agent-beta",
+            )
+        )
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "== coordination takeover ==" in out
+        assert "Resource: worktree-a" in out
+        assert "New owner: agent-beta" in out
+        assert "Status: TAKEN_OVER" in out
+
+    def test_json_output_writes_claim_payload(self, tmp_path: Path) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+        registry = ClaimRegistry(tmp_path)
+        registry.acquire_claim("worktree-a", "agent-alpha")
+        _rewind_claim_heartbeat(tmp_path, "worktree-a", seconds_ago=120)
+        output_path = tmp_path / "coordination-takeover.json"
+
+        rc = cmd_coordination_takeover(
+            _args(
+                tmp_path,
+                format="json",
+                output=str(output_path),
+                resource_id="worktree-a",
+                owner_tag="agent-beta",
+            )
+        )
+
+        assert rc == 0
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+        assert payload["status"] == "TAKEN_OVER"
+        assert payload["resource_id"] == "worktree-a"
+        assert payload["owner_tag"] == "agent-beta"
+        assert payload["fencing_token"] == 1
+
+    def test_live_claim_conflict_is_nonzero(self, tmp_path: Path, capsys) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+        registry = ClaimRegistry(tmp_path)
+        registry.acquire_claim("worktree-a", "agent-alpha")
+
+        rc = cmd_coordination_takeover(
+            _args(
+                tmp_path,
+                resource_id="worktree-a",
+                owner_tag="agent-beta",
+            )
+        )
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "held by agent" in err
+        assert "agent-alpha" in err
+
+    def test_grace_claim_conflict_is_nonzero(self, tmp_path: Path, capsys) -> None:
+        _write_workspace_policy(
+            tmp_path,
+            _enabled_policy(expiry_seconds=60, takeover_grace_period_seconds=10),
+        )
+        registry = ClaimRegistry(tmp_path)
+        registry.acquire_claim("worktree-a", "agent-alpha")
+        _rewind_claim_heartbeat(tmp_path, "worktree-a", seconds_ago=65)
+
+        rc = cmd_coordination_takeover(
+            _args(
+                tmp_path,
+                resource_id="worktree-a",
+                owner_tag="agent-beta",
+            )
+        )
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "takeover grace" in err
+
+    def test_absent_claim_returns_nonzero(self, tmp_path: Path, capsys) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+
+        rc = cmd_coordination_takeover(
+            _args(
+                tmp_path,
+                resource_id="never-existed",
+                owner_tag="agent-beta",
+            )
+        )
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "no claim exists" in err
+
+    def test_main_dispatch_executes_takeover_command(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        _write_workspace_policy(tmp_path, _enabled_policy())
+        registry = ClaimRegistry(tmp_path)
+        registry.acquire_claim("worktree-a", "agent-alpha")
+        _rewind_claim_heartbeat(tmp_path, "worktree-a", seconds_ago=120)
+
+        rc = main(
+            [
+                "--workspace-root",
+                str(tmp_path),
+                "coordination",
+                "takeover",
+                "--resource-id",
+                "worktree-a",
+                "--owner-tag",
+                "agent-beta",
+            ]
+        )
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Status: TAKEN_OVER" in out


### PR DESCRIPTION
## Summary
- add `ao-kernel coordination takeover` for past-grace claim recovery
- cover success, conflict, grace, absent-claim, and main-dispatch paths with behavior-first tests
- update coordination docs and production-hardening status for WP-7.4

## Testing
- python3 -m pytest tests/test_coordination_cli.py tests/test_coordination_status.py tests/test_coordination_takeover_prune.py -q
- python3 -m ruff check ao_kernel/cli.py ao_kernel/_internal/coordination/cli_handlers.py tests/test_coordination_cli.py

Refs #198