### PR TITLE
[codex] pin orchestration ownership matrix

### DIFF
--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -68,15 +68,15 @@ automation platform çizgisine taşımak.
 
 **GitHub takip**
 - üst issue: [#198](https://github.com/Halildeu/ao-kernel/issues/198)
-- son merge: `WP-7.3 slice 2` / PR #210
-- aktif slice: [`WP-7.4-TAKEOVER-ERGONOMICS.md`](./WP-7.4-TAKEOVER-ERGONOMICS.md)
+- son merge: `WP-7.4` / PR #211
+- aktif slice: [`WP-7.5-ORCHESTRATION-COVERAGE-MATRIX.md`](./WP-7.5-ORCHESTRATION-COVERAGE-MATRIX.md)
 
 **Adım sırası**
 1. `[x]` `WP-7.1` path resource namespace kararı + acquire/release helper'ları
 2. `[x]` `WP-7.2` claim visibility (`coordination status`) yüzeyi
 3. `[x]` `WP-7.3` patch apply / patch rollback write-ownership enforcement
-4. `[~]` `WP-7.4` handoff / takeover ergonomics
-5. `[ ]` daha geniş orchestration entry coverage
+4. `[x]` `WP-7.4` handoff / takeover ergonomics
+5. `[~]` `WP-7.5` orchestration coverage matrix
 
 **Canlı snapshot**
 - `patch_apply` artık coordination enabled workspace'te preview edilen
@@ -86,7 +86,9 @@ automation platform çizgisine taşımak.
 - conflict path'i deterministic `_StepFailed(code=WRITE_OWNERSHIP_CONFLICT)`
   olarak yüzeye çıkar
 - `patch_rollback` aynı ownership kontratıyla claim acquire/release yapar
-- aktif alt slice operatör için `coordination takeover` CLI yüzeyini ekler
+- `coordination takeover` operatöre past-grace claim devralma yüzeyi verir
+- aktif alt slice mevcut ao-kernel operasyonlarını claim-free / claim-required
+  matrisi olarak behavior-first testlerle kilitler
 - read-only `coordination status` yüzeyi ownership state'ini snapshot olarak
   vermeye devam eder
 
@@ -95,6 +97,7 @@ automation platform çizgisine taşımak.
   acquire/release ile çalışıyor
 - conflict aynı path alanında deterministic fail üretiyor
 - `coordination takeover` past-grace claim'i CLI üzerinden devralabiliyor
+- `context_compile` ve `patch_preview` claim-free kaldığı testle pinleniyor
 - dormant coordination semantics korunuyor
 - yeni davranış behavior-first testlerle pinleniyor
 - docs/runtime/story aynı şeyi söylüyor

--- a/.claude/plans/WP-7.5-ORCHESTRATION-COVERAGE-MATRIX.md
+++ b/.claude/plans/WP-7.5-ORCHESTRATION-COVERAGE-MATRIX.md
@@ -1,0 +1,42 @@
+# WP-7.5 — Orchestration Coverage Matrix
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#198](https://github.com/Halildeu/ao-kernel/issues/198)
+**Üst WP:** [#198](https://github.com/Halildeu/ao-kernel/issues/198)
+
+## Amaç
+
+Mevcut shipped `ao-kernel` operasyonlarının ownership semantiğini açık ve
+testle pinli hale getirmek: hangi orchestration girişleri claim alır, hangileri
+bilinçli olarak claim almaz?
+
+## Bu Slice'ın Kararı
+
+- Yeni runtime write semantics eklemez
+- Şu anki shipped operasyon matrisi açıkça kilitlenir:
+  - `context_compile` -> claim-free
+  - `patch_preview` -> claim-free
+  - `patch_apply` -> claim-required
+  - `patch_rollback` -> claim-required
+- Böylece gelecekte yeni write-capable op eklendiğinde ownership wiring'i
+  olmadan “sessiz green” kalması zorlaşır
+
+## Public Surface
+
+- Davranışsal pytest matrisi
+- Coordination dokümanında operation classification notu
+- Yaşayan status dosyasında aktif slice kaydı
+
+## Definition of Done
+
+1. `context_compile` coordination enabled workspace'te claim acquire etmez
+2. `patch_preview` coordination enabled workspace'te claim acquire etmez
+3. `patch_apply` / `patch_rollback` claim-required yüzey olarak kalır
+4. Docs/status bu matrisi shipped gerçeklik olarak anlatır
+5. Gelecek write-capable op genişlemesi için açık deferred not bırakılır
+
+## Deferred
+
+- `release` / `handoff` operatör komutları
+- path ownership'in future write-capable workflow operasyonlarına genişletilmesi
+- operation metadata üstünden otomatik ownership classification enforcement

--- a/docs/COORDINATION.md
+++ b/docs/COORDINATION.md
@@ -191,6 +191,17 @@ fields on `diff_applied` / `diff_rolled_back`
 afterwards. With coordination disabled, both patch operations keep the old
 dormant behavior and do not engage the claim layer.
 
+Current shipped `ao-kernel` operation matrix is explicit:
+
+- `context_compile` -> claim-free (evidence/materialization only; no shared
+  workspace file mutation contract)
+- `patch_preview` -> claim-free (diff inspection only; no mutation)
+- `patch_apply` -> claim-required
+- `patch_rollback` -> claim-required
+
+Any future write-capable orchestration operation must either join the
+claim-required set or document why it is safely claim-free.
+
 ### 10.2 Fail-closed vs fail-open
 
 - **Fail-closed (raise, never silently absorb):**

--- a/tests/test_multi_step_driver.py
+++ b/tests/test_multi_step_driver.py
@@ -29,6 +29,25 @@ from tests._driver_helpers import (
 )
 
 
+def _write_coordination_policy(workspace_root: Path, *, enabled: bool) -> None:
+    policy_dir = workspace_root / ".ao" / "policies"
+    policy_dir.mkdir(parents=True, exist_ok=True)
+    doc = {
+        "version": "v1",
+        "enabled": enabled,
+        "heartbeat_interval_seconds": 30,
+        "expiry_seconds": 90,
+        "takeover_grace_period_seconds": 15,
+        "max_claims_per_agent": 5,
+        "claim_resource_patterns": ["*"],
+        "evidence_redaction": {"patterns": []},
+    }
+    (policy_dir / "policy_coordination_claims.v1.json").write_text(
+        json.dumps(doc, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Simple ao-kernel-only flow (no adapter subprocess required)
 # ---------------------------------------------------------------------------
@@ -81,6 +100,23 @@ class TestSimpleHappyPath:
             context_path = payload.get("context_path")
             assert context_path is not None
             assert Path(context_path).is_file()
+
+    def test_context_compile_remains_claim_free_when_coordination_enabled(
+        self, tmp_path: Path,
+    ) -> None:
+        driver, run_id = self._setup(tmp_path)
+        _write_coordination_policy(tmp_path, enabled=True)
+
+        driver.run_workflow(run_id, "simple_aokernel_flow", "1.0.0")
+
+        events_path = (
+            tmp_path / ".ao" / "evidence" / "workflows" / run_id / "events.jsonl"
+        )
+        events = [json.loads(line) for line in events_path.read_text().splitlines()]
+        kinds = [event["kind"] for event in events]
+        assert "claim_acquired" not in kinds
+        assert "claim_conflict" not in kinds
+        assert "claim_released" not in kinds
 
     def test_artifact_written_for_each_step(self, tmp_path: Path) -> None:
         driver, run_id = self._setup(tmp_path)

--- a/tests/test_patch_write_ownership_enforcement.py
+++ b/tests/test_patch_write_ownership_enforcement.py
@@ -80,6 +80,21 @@ def _patch_step() -> StepDefinition:
     )
 
 
+def _preview_step() -> StepDefinition:
+    return StepDefinition(
+        step_name="preview_diff",
+        actor="ao-kernel",
+        adapter_id=None,
+        required_capabilities=(),
+        policy_refs=(),
+        on_failure="transition_to_failed",
+        timeout_seconds=None,
+        human_interrupt_allowed=False,
+        gate=None,
+        operation="patch_preview",
+    )
+
+
 def _rollback_step(reverse_diff_id: str) -> StepDefinition:
     return StepDefinition(
         step_name=reverse_diff_id,
@@ -145,6 +160,37 @@ def _events(workspace_root: Path, run_id: str) -> list[dict[str, Any]]:
 
 
 class TestPatchWriteOwnershipEnforcement:
+    def test_patch_preview_remains_claim_free_when_coordination_enabled(
+        self, tmp_path: Path,
+    ) -> None:
+        install_workspace(tmp_path)
+        _install_patch_target_repo(tmp_path)
+        patch = make_patch_from_changes(tmp_path, {"src/foo.py": "x = 2\n"})
+        _write_coordination_policy(tmp_path, enabled=True)
+        run_id = "00000000-0000-4000-8000-000000000700"
+        output_ref = _prime_adapter_artifact(tmp_path, run_id, patch=patch)
+        driver = build_driver(tmp_path)
+
+        _record, result = driver._run_aokernel_step(
+            run_id,
+            _record_with_adapter_output(run_id, output_ref),
+            _preview_step(),
+            attempt=1,
+            step_id="preview_diff",
+        )
+
+        assert result["step_state"] == "completed"
+        events = _events(tmp_path, run_id)
+        assert [event["kind"] for event in events] == [
+            "step_started",
+            "diff_previewed",
+        ]
+        previewed = next(event for event in events if event["kind"] == "diff_previewed")
+        assert "src/foo.py" in previewed["payload"]["files_changed"]
+
+        registry = ClaimRegistry(tmp_path)
+        assert registry.list_agent_claims(f"workflow-run:{run_id}") == []
+
     def test_patch_apply_skips_claims_when_coordination_disabled(
         self, tmp_path: Path,
     ) -> None:


### PR DESCRIPTION
## Summary
- pin the current ao-kernel operation matrix as claim-free vs claim-required
- add behavior-first tests for `context_compile` and `patch_preview` remaining claim-free under enabled coordination
- update coordination docs and production-hardening status for WP-7.5

## Testing
- python3 -m pytest tests/test_multi_step_driver.py tests/test_patch_write_ownership_enforcement.py -q
- python3 -m ruff check tests/test_multi_step_driver.py tests/test_patch_write_ownership_enforcement.py

Refs #198