### PR TITLE
[codex] Add gh-cli-pr smoke baseline

### DIFF
--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -69,13 +69,13 @@ automation platform çizgisine taşımak.
 
 **GitHub takip**
 - üst issue: [#199](https://github.com/Halildeu/ao-kernel/issues/199)
-- son merge: `WP-8.1` / PR #213
-- aktif slice: [`WP-8.2-CLAUDE-CODE-CLI-SMOKE-BASELINE.md`](./WP-8.2-CLAUDE-CODE-CLI-SMOKE-BASELINE.md)
+- son merge: `WP-8.2` / PR #214
+- aktif slice: [`WP-8.3-GH-CLI-PR-SMOKE-BASELINE.md`](./WP-8.3-GH-CLI-PR-SMOKE-BASELINE.md)
 
 **Adım sırası**
 1. `[x]` `WP-8.1` certification baseline + candidate matrix
-2. `[~]` `WP-8.2` `claude-code-cli` smoke + failure-mode baseline
-3. `[ ]` `WP-8.3` ikinci gerçek adapter certification lane
+2. `[x]` `WP-8.2` `claude-code-cli` smoke + failure-mode baseline
+3. `[~]` `WP-8.3` `gh-cli-pr` side-effect-safe preflight baseline
 4. `[ ]` `WP-8.4` public capability/support matrix hizası
 
 **Canlı snapshot**
@@ -86,6 +86,11 @@ automation platform çizgisine taşımak.
   operator-managed durumdadır
 - aktif alt slice için `python3 scripts/claude_code_cli_smoke.py`
   helper'ı eklendi; smoke + manifest contract testleri yeşil
+- aktif alt slice için `python3 scripts/gh_cli_pr_smoke.py`
+  helper'ı eklendi; `gh` binary + auth + repo visibility + safe
+  `gh pr create --dry-run` preflight'ı tek komutta toplandı
+- bu turdaki canlı `python3 scripts/gh_cli_pr_smoke.py --output text`
+  doğrulaması `overall_status: pass` verdi
 - repo tarafındaki `manifest_cli_contract_mismatch` kapatıldı
 - aynı canlı turda önce `claude auth status` yeşil olsa da `claude -p`
   org-level access hatasıyla düştü; kontrollü re-login sonrası helper tam
@@ -93,6 +98,8 @@ automation platform çizgisine taşımak.
 - `setup-token` altında üretilen uzun ömürlü token ise bu turda güvenilir
   kurtarma yolu olarak doğrulanmadı; ayrıca `Invalid bearer token` reddi
   görüldü
+- `gh-cli-pr` lane'inde tam canlı PR açılışı bu slice'ın DIŞINDA kalır;
+  helper yalnız side-effect-safe preflight uygular
 
 **Definition of Done**
 - bundled gerçek-adapter aday seti explicit

--- a/.claude/plans/WP-8.3-GH-CLI-PR-SMOKE-BASELINE.md
+++ b/.claude/plans/WP-8.3-GH-CLI-PR-SMOKE-BASELINE.md
@@ -1,0 +1,97 @@
+# WP-8.3 — `gh-cli-pr` Side-Effect-Safe Smoke Baseline
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#199](https://github.com/Halildeu/ao-kernel/issues/199)
+**Üst WP:** [#199](https://github.com/Halildeu/ao-kernel/issues/199)
+
+## Amaç
+
+`WP-8.1` ile aday seti netleştikten ve `WP-8.2` ile `claude-code-cli`
+lane'i somutlaştıktan sonra ikinci gerçek adapter hattını güvenli bir
+sertifikasyon baseline'ına indirmek. Bu slice `gh-cli-pr` adapter'ını
+production diye ilan etmez; gerçek remote PR açmadan hangi preflight'ın
+gerekli olduğunu yazılı ve çalıştırılabilir hale getirir.
+
+## Bu Slice'ın Sınırı
+
+- odak yalnız `gh-cli-pr`
+- helper side-effect-safe olacak; gerçek remote PR açmayacak
+- bundled manifest contract'i ile operator-safe smoke birbirine karışmayacak
+- tam canlı E2E PR açılışı bu slice'a alınmayacak
+
+## Bugünkü Durum
+
+| Alan | Durum | Not |
+|---|---|---|
+| Bundled manifest | var | `gh pr create --title ... --body-file ...` dar contract'i korunuyor |
+| Operator-safe smoke | **var (ilk cut)** | `python3 scripts/gh_cli_pr_smoke.py` binary/auth/repo/dry-run preflight'ını topluyor |
+| Failure-mode testleri | **var (ilk cut)** | binary missing, auth eksik, repo view fail, dry-run fail, manifest mismatch pinli |
+| Docs/runtime parity | kısmi | helper ve boundary `docs/ADAPTERS.md` + status dosyasında hizalandı |
+| Release gate | yok | helper CI-required değil; operator-managed lane |
+
+## Somutlaştırılan Yüzey
+
+1. **Repo helper**
+   - `scripts/gh_cli_pr_smoke.py`
+   - çıktılar: `text` veya `json`
+   - exit code: tüm zorunlu check'ler `pass` ise `0`, aksi halde `1`
+2. **Kod mantığı**
+   - `ao_kernel/real_adapter_smoke.py`
+   - `gh` binary / version / auth status / manifest contract / repo view /
+     `gh pr create --dry-run` sınıflandırması
+3. **Davranış testleri**
+   - `tests/test_gh_cli_pr_smoke.py`
+   - binary missing
+   - auth eksik
+   - repo view fail
+   - dry-run fail
+   - manifest contract mismatch
+   - clean pass
+4. **Contract pinleri**
+   - `tests/test_adapter_manifest_loader.py`
+   - bundled manifest command + args + stdin contract'i pinli
+
+## Canlı Durum
+
+Bu makinedeki 2026-04-22 canlı kontrolde şu preflight zinciri doğrulandı:
+
+1. `gh auth status --json hosts`
+   - `github.com` host'u için aktif login görünür
+2. `gh repo view --json nameWithOwner,defaultBranchRef,isPrivate,url`
+   - repo `Halildeu/ao-kernel`
+   - varsayılan branch `main`
+3. `gh pr create --repo Halildeu/ao-kernel --head main --base main --title ... --body ... --dry-run`
+   - side effect olmadan başarıyla döndü
+
+Bu kanıt, helper'ın dayandığı güvenli smoke yolunu doğrular; gerçek PR
+açılışı için production-tier sertifikasyon anlamına gelmez.
+
+## Auth ve Güvenlik Duruşu
+
+- varsayılan ve hedeflenen yol: mevcut `gh` oturumu
+- helper gerçek PR açmaz; `--dry-run` kullanır
+- helper repo/binary/auth görünürlüğünü doğrular ama support boundary'yi
+  genişletmez
+
+## İlk Kabul Kriterleri
+
+Bu slice tamamlandı sayılabilmek için en az şu çıktılar görünür olmalı:
+
+1. `gh-cli-pr` için operator-safe smoke komutu ve başarı kriteri yazılı
+2. En az dört failure-mode senaryosu testte pinli
+3. Bundled manifest contract'i ile helper'ın kullandığı güvenli dry-run yolu
+   açıkça ayrılmış
+4. Public support boundary genişletilmeden status ve docs hizalanmış
+
+## Beklenen Sonraki Adımlar
+
+1. helper sonucunu capability matrix'e taşımak (`WP-8.4`)
+2. tam canlı PR açılışının beta mı yoksa deferred mı kalacağını netleştirmek
+3. gerekiyorsa disposable remote hedef üzerinde daha güçlü smoke sözleşmesi
+   tanımlamak
+
+## Deferred
+
+- gerçek remote PR oluşturma smoke'u
+- otomatik CI'da `gh` auth gerektiren canlı lane
+- çoklu repo / çoklu host sertifikasyonu

--- a/ao_kernel/real_adapter_smoke.py
+++ b/ao_kernel/real_adapter_smoke.py
@@ -1,17 +1,15 @@
-"""Operator smoke helpers for the bundled ``claude-code-cli`` adapter.
+"""Operator smoke helpers for bundled real-adapter certification lanes.
 
-This module intentionally targets the operator-managed certification lane
-rather than the deterministic shipped demo surface. The goal is to make
-real-adapter readiness concrete and reproducible:
+This module intentionally targets operator-managed surfaces rather than
+the deterministic shipped demo baseline. Today it covers two adapters:
 
-1. Verify the Claude CLI binary is present.
-2. Verify the CLI can report a version and auth state.
-3. Verify prompt access with a minimal live call.
-4. Verify the bundled adapter manifest still matches the installed CLI
-   contract closely enough to start a smoke invocation.
+1. ``claude-code-cli``:
+   version/auth/prompt/manifest smoke for the bundled Claude CLI path.
+2. ``gh-cli-pr``:
+   binary/auth/repo/dry-run preflight for the typed GitHub PR connector.
 
-The smoke is machine-readable so docs/runbooks can point at a single
-command instead of a prose-only checklist.
+The smoke outputs are machine-readable so docs and runbooks can point at
+one command instead of a prose-only checklist.
 """
 
 from __future__ import annotations
@@ -34,6 +32,9 @@ _MANIFEST_SMOKE_PROMPT = (
     'Your entire response MUST be a single JSON object with exactly this shape: '
     '{"status":"ok","review_findings":{"schema_version":"1","findings":[],"summary":"smoke ok"}}'
 )
+_GH_PR_DRY_RUN_TITLE = "ao-kernel gh-cli-pr smoke probe"
+_GH_PR_DRY_RUN_BODY = "Safe dry-run preflight for gh-cli-pr certification."
+_GH_DRY_RUN_MARKER = "would have created a pull request"
 
 
 @dataclass(frozen=True)
@@ -62,6 +63,21 @@ class ClaudeCodeSmokeReport:
     adapter_id: str
     binary_path: str | None
     api_key_env_present: bool
+    checks: tuple[SmokeCheck, ...]
+    findings: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class GhCliPrSmokeReport:
+    overall_status: Literal["pass", "blocked"]
+    adapter_id: str
+    binary_path: str | None
+    repo_name: str | None
+    default_branch: str | None
+    repo_url: str | None
     checks: tuple[SmokeCheck, ...]
     findings: tuple[str, ...]
 
@@ -192,15 +208,185 @@ def run_claude_code_cli_smoke(
     )
 
 
-def render_text_report(report: ClaudeCodeSmokeReport) -> str:
+def run_gh_cli_pr_smoke(
+    *,
+    timeout_seconds: float = 20.0,
+    runner: Runner | None = None,
+    which: WhichFn = shutil.which,
+    cwd: Path | None = None,
+    repo: str | None = None,
+    base_ref: str | None = None,
+    head_ref: str | None = None,
+    probe_title: str = _GH_PR_DRY_RUN_TITLE,
+    probe_body: str = _GH_PR_DRY_RUN_BODY,
+) -> GhCliPrSmokeReport:
+    """Run side-effect-safe smoke checks for the bundled gh PR adapter."""
+
+    runner = runner or _default_runner
+    manifest = _load_gh_pr_manifest()
+    command = str(manifest.invocation["command"])
+    binary_path = which(command)
+    working_dir = cwd or Path.cwd()
+
+    checks: list[SmokeCheck] = []
+
+    if binary_path is None:
+        checks.append(
+            SmokeCheck(
+                name="binary",
+                status="fail",
+                detail=(
+                    f"bundled manifest command {command!r} PATH uzerinde bulunamadi"
+                ),
+                finding_code="gh_binary_missing",
+                observed={"command": command},
+            )
+        )
+        checks.extend(
+            (
+                SmokeCheck(
+                    name="version",
+                    status="skip",
+                    detail="binary bulunamadigi icin version smoke atlandi",
+                ),
+                SmokeCheck(
+                    name="auth_status",
+                    status="skip",
+                    detail="binary bulunamadigi icin auth status smoke atlandi",
+                ),
+                SmokeCheck(
+                    name="manifest_contract",
+                    status="skip",
+                    detail="binary bulunamadigi icin manifest contract smoke atlandi",
+                ),
+                SmokeCheck(
+                    name="repo_view",
+                    status="skip",
+                    detail="binary bulunamadigi icin repo view smoke atlandi",
+                ),
+                SmokeCheck(
+                    name="pr_dry_run",
+                    status="skip",
+                    detail="binary bulunamadigi icin PR dry-run smoke atlandi",
+                ),
+            )
+        )
+        return _finalize_gh_report(
+            adapter_id=manifest.adapter_id,
+            binary_path=None,
+            repo_name=None,
+            default_branch=None,
+            repo_url=None,
+            checks=checks,
+        )
+
+    version_result = _run_check(
+        runner,
+        (binary_path, "--version"),
+        None,
+        timeout_seconds,
+    )
+    checks.append(_classify_gh_version_check(version_result))
+
+    auth_result = _run_check(
+        runner,
+        (binary_path, "auth", "status", "--json", "hosts"),
+        None,
+        timeout_seconds,
+    )
+    checks.append(_classify_gh_auth_status_check(auth_result))
+    checks.append(_classify_gh_manifest_contract_check(manifest))
+
+    repo_view_argv = [binary_path, "repo", "view"]
+    if repo:
+        repo_view_argv.extend(("--repo", repo))
+    repo_view_argv.extend(
+        ("--json", "nameWithOwner,defaultBranchRef,isPrivate,url")
+    )
+    repo_result = _run_check(
+        runner,
+        tuple(repo_view_argv),
+        working_dir,
+        timeout_seconds,
+    )
+    repo_check, resolved_repo, detected_default_branch, repo_url = (
+        _classify_gh_repo_view_check(repo_result)
+    )
+    checks.append(repo_check)
+
+    resolved_base = base_ref or detected_default_branch
+    resolved_head = head_ref or detected_default_branch
+    if resolved_repo and resolved_base and resolved_head:
+        with tempfile.TemporaryDirectory(prefix="ao-kernel-gh-cli-pr-smoke-") as tmp:
+            temp_root = Path(tmp)
+            body_file = temp_root / "pr-body.md"
+            body_file.write_text(probe_body, encoding="utf-8")
+
+            dry_run_result = _run_check(
+                runner,
+                (
+                    binary_path,
+                    "pr",
+                    "create",
+                    "--repo",
+                    resolved_repo,
+                    "--head",
+                    resolved_head,
+                    "--base",
+                    resolved_base,
+                    "--title",
+                    probe_title,
+                    "--body-file",
+                    str(body_file),
+                    "--dry-run",
+                ),
+                working_dir,
+                timeout_seconds,
+            )
+        checks.append(
+            _classify_gh_pr_dry_run_check(
+                dry_run_result,
+                repo_name=resolved_repo,
+                head_ref=resolved_head,
+                base_ref=resolved_base,
+            )
+        )
+    else:
+        checks.append(
+            SmokeCheck(
+                name="pr_dry_run",
+                status="skip",
+                detail="repo/default-branch cozulmedigi icin PR dry-run smoke atlandi",
+            )
+        )
+
+    return _finalize_gh_report(
+        adapter_id=manifest.adapter_id,
+        binary_path=binary_path,
+        repo_name=resolved_repo,
+        default_branch=detected_default_branch,
+        repo_url=repo_url,
+        checks=checks,
+    )
+
+
+def render_text_report(
+    report: ClaudeCodeSmokeReport | GhCliPrSmokeReport,
+) -> str:
     """Render a concise operator-facing report."""
 
     lines = [
         f"overall_status: {report.overall_status}",
         f"adapter_id: {report.adapter_id}",
         f"binary_path: {report.binary_path or '<missing>'}",
-        "checks:",
     ]
+    if isinstance(report, ClaudeCodeSmokeReport):
+        lines.append(f"api_key_env_present: {str(report.api_key_env_present).lower()}")
+    if isinstance(report, GhCliPrSmokeReport):
+        lines.append(f"repo_name: {report.repo_name or '<unresolved>'}")
+        lines.append(f"default_branch: {report.default_branch or '<unresolved>'}")
+        lines.append(f"repo_url: {report.repo_url or '<unresolved>'}")
+    lines.append("checks:")
     for check in report.checks:
         lines.append(f"- {check.name}: {check.status} - {check.detail}")
         if check.finding_code:
@@ -220,6 +406,12 @@ def _load_claude_manifest() -> AdapterManifest:
     reg = AdapterRegistry()
     reg.load_bundled()
     return reg.get("claude-code-cli")
+
+
+def _load_gh_pr_manifest() -> AdapterManifest:
+    reg = AdapterRegistry()
+    reg.load_bundled()
+    return reg.get("gh-cli-pr")
 
 
 def _default_runner(
@@ -285,6 +477,37 @@ def _classify_version_check(result: CommandResult) -> SmokeCheck:
         status="fail",
         detail="claude --version cagrisi basarisiz",
         finding_code="claude_version_unavailable",
+        argv=result.argv,
+        returncode=result.returncode,
+        observed=_trim_output(result),
+    )
+
+
+def _classify_gh_version_check(result: CommandResult) -> SmokeCheck:
+    if result.timed_out:
+        return SmokeCheck(
+            name="version",
+            status="fail",
+            detail="gh --version cagrisi timeout'a dustu",
+            finding_code="gh_version_timeout",
+            argv=result.argv,
+            returncode=result.returncode,
+            observed=_trim_output(result),
+        )
+    if result.returncode == 0 and result.stdout.strip():
+        first_line = result.stdout.strip().splitlines()[0]
+        return SmokeCheck(
+            name="version",
+            status="pass",
+            detail=f"gh version: {first_line}",
+            argv=result.argv,
+            returncode=result.returncode,
+        )
+    return SmokeCheck(
+        name="version",
+        status="fail",
+        detail="gh --version cagrisi basarisiz",
+        finding_code="gh_version_unavailable",
         argv=result.argv,
         returncode=result.returncode,
         observed=_trim_output(result),
@@ -361,6 +584,264 @@ def _classify_auth_status_check(
             "orgName": payload.get("orgName"),
             "fallback_api_key_env_present": api_key_env_present,
         },
+    )
+
+
+def _classify_gh_auth_status_check(result: CommandResult) -> SmokeCheck:
+    if result.timed_out:
+        return SmokeCheck(
+            name="auth_status",
+            status="fail",
+            detail="gh auth status cagrisi timeout'a dustu",
+            finding_code="gh_auth_status_timeout",
+            argv=result.argv,
+            returncode=result.returncode,
+            observed=_trim_output(result),
+        )
+    if result.returncode != 0:
+        return SmokeCheck(
+            name="auth_status",
+            status="fail",
+            detail="gh auth status cagrisi basarisiz",
+            finding_code="gh_auth_status_failed",
+            argv=result.argv,
+            returncode=result.returncode,
+            observed=_trim_output(result),
+        )
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return SmokeCheck(
+            name="auth_status",
+            status="fail",
+            detail="gh auth status JSON donmedi",
+            finding_code="gh_auth_status_not_json",
+            argv=result.argv,
+            returncode=result.returncode,
+            observed=_trim_output(result),
+        )
+
+    hosts = payload.get("hosts")
+    github_hosts = hosts.get("github.com") if isinstance(hosts, dict) else None
+    active_entry = None
+    if isinstance(github_hosts, list):
+        for entry in github_hosts:
+            if (
+                isinstance(entry, dict)
+                and entry.get("active") is True
+                and entry.get("state") == "success"
+            ):
+                active_entry = entry
+                break
+
+    if active_entry is None:
+        return SmokeCheck(
+            name="auth_status",
+            status="fail",
+            detail="github.com icin aktif gh auth kaydi bulunamadi",
+            finding_code="gh_not_authenticated",
+            argv=result.argv,
+            returncode=result.returncode,
+            observed={
+                "github_hosts_present": "true" if github_hosts is not None else "false",
+            },
+        )
+
+    return SmokeCheck(
+        name="auth_status",
+        status="pass",
+        detail=(
+            f"host='github.com' login={active_entry.get('login')!r} "
+            f"tokenSource={active_entry.get('tokenSource')!r}"
+        ),
+        argv=result.argv,
+        returncode=result.returncode,
+        observed={
+            "host": active_entry.get("host"),
+            "login": active_entry.get("login"),
+            "tokenSource": active_entry.get("tokenSource"),
+            "scopes": active_entry.get("scopes"),
+            "gitProtocol": active_entry.get("gitProtocol"),
+        },
+    )
+
+
+def _classify_gh_manifest_contract_check(manifest: AdapterManifest) -> SmokeCheck:
+    expected_args = (
+        "pr",
+        "create",
+        "--title",
+        "{task_prompt}",
+        "--body-file",
+        "{context_pack_ref}",
+    )
+    actual_args = tuple(str(part) for part in manifest.invocation.get("args", ()))
+    if (
+        manifest.invocation.get("command") == "gh"
+        and actual_args == expected_args
+        and manifest.invocation.get("stdin_mode") == "none"
+    ):
+        return SmokeCheck(
+            name="manifest_contract",
+            status="pass",
+            detail="bundled gh-cli-pr manifest contract smoke gecti",
+            observed={"args": list(actual_args)},
+        )
+    return SmokeCheck(
+        name="manifest_contract",
+        status="fail",
+        detail="bundled gh-cli-pr manifest argv mevcut contract ile uyusmuyor",
+        finding_code="gh_pr_manifest_contract_mismatch",
+        observed={
+            "command": str(manifest.invocation.get("command")),
+            "args": list(actual_args),
+            "stdin_mode": str(manifest.invocation.get("stdin_mode")),
+        },
+    )
+
+
+def _classify_gh_repo_view_check(
+    result: CommandResult,
+) -> tuple[SmokeCheck, str | None, str | None, str | None]:
+    if result.timed_out:
+        return (
+            SmokeCheck(
+                name="repo_view",
+                status="fail",
+                detail="gh repo view cagrisi timeout'a dustu",
+                finding_code="gh_repo_view_timeout",
+                argv=result.argv,
+                returncode=result.returncode,
+                observed=_trim_output(result),
+            ),
+            None,
+            None,
+            None,
+        )
+    if result.returncode != 0:
+        return (
+            SmokeCheck(
+                name="repo_view",
+                status="fail",
+                detail="gh repo view cagrisi basarisiz",
+                finding_code="gh_repo_view_failed",
+                argv=result.argv,
+                returncode=result.returncode,
+                observed=_trim_output(result),
+            ),
+            None,
+            None,
+            None,
+        )
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return (
+            SmokeCheck(
+                name="repo_view",
+                status="fail",
+                detail="gh repo view JSON donmedi",
+                finding_code="gh_repo_view_not_json",
+                argv=result.argv,
+                returncode=result.returncode,
+                observed=_trim_output(result),
+            ),
+            None,
+            None,
+            None,
+        )
+
+    repo_name = payload.get("nameWithOwner")
+    repo_url = payload.get("url")
+    default_branch_ref = payload.get("defaultBranchRef")
+    default_branch = None
+    if isinstance(default_branch_ref, dict):
+        default_branch = default_branch_ref.get("name")
+
+    if not repo_name or not default_branch or not repo_url:
+        return (
+            SmokeCheck(
+                name="repo_view",
+                status="fail",
+                detail="gh repo view gerekli alanlari donmedi",
+                finding_code="gh_repo_view_incomplete",
+                argv=result.argv,
+                returncode=result.returncode,
+                observed={
+                    "nameWithOwner": str(repo_name),
+                    "defaultBranch": str(default_branch),
+                    "url": str(repo_url),
+                },
+            ),
+            None,
+            None,
+            None,
+        )
+
+    return (
+        SmokeCheck(
+            name="repo_view",
+            status="pass",
+            detail=(
+                f"repo={repo_name!r} default_branch={default_branch!r} "
+                f"isPrivate={payload.get('isPrivate')!r}"
+            ),
+            argv=result.argv,
+            returncode=result.returncode,
+            observed={
+                "nameWithOwner": repo_name,
+                "defaultBranch": default_branch,
+                "url": repo_url,
+                "isPrivate": payload.get("isPrivate"),
+            },
+        ),
+        str(repo_name),
+        str(default_branch),
+        str(repo_url),
+    )
+
+
+def _classify_gh_pr_dry_run_check(
+    result: CommandResult,
+    *,
+    repo_name: str,
+    head_ref: str,
+    base_ref: str,
+) -> SmokeCheck:
+    if result.timed_out:
+        return SmokeCheck(
+            name="pr_dry_run",
+            status="fail",
+            detail="gh pr create --dry-run timeout'a dustu",
+            finding_code="gh_pr_dry_run_timeout",
+            argv=result.argv,
+            returncode=result.returncode,
+            observed=_trim_output(result),
+        )
+
+    combined = f"{result.stdout}\n{result.stderr}".lower()
+    if result.returncode == 0 and _GH_DRY_RUN_MARKER in combined:
+        return SmokeCheck(
+            name="pr_dry_run",
+            status="pass",
+            detail=(
+                f"gh pr create --dry-run gecti "
+                f"(repo={repo_name!r}, head={head_ref!r}, base={base_ref!r})"
+            ),
+            argv=result.argv,
+            returncode=result.returncode,
+        )
+
+    return SmokeCheck(
+        name="pr_dry_run",
+        status="fail",
+        detail="gh pr create --dry-run basarisiz",
+        finding_code="gh_pr_dry_run_failed",
+        argv=result.argv,
+        returncode=result.returncode,
+        observed=_trim_output(result),
     )
 
 
@@ -594,6 +1075,37 @@ def _finalize_report(
         adapter_id=adapter_id,
         binary_path=binary_path,
         api_key_env_present=api_key_env_present,
+        checks=tuple(checks),
+        findings=findings,
+    )
+
+
+def _finalize_gh_report(
+    *,
+    adapter_id: str,
+    binary_path: str | None,
+    repo_name: str | None,
+    default_branch: str | None,
+    repo_url: str | None,
+    checks: Sequence[SmokeCheck],
+) -> GhCliPrSmokeReport:
+    findings = tuple(
+        dict.fromkeys(
+            check.finding_code
+            for check in checks
+            if check.finding_code is not None
+        )
+    )
+    overall_status: Literal["pass", "blocked"] = (
+        "pass" if not findings else "blocked"
+    )
+    return GhCliPrSmokeReport(
+        overall_status=overall_status,
+        adapter_id=adapter_id,
+        binary_path=binary_path,
+        repo_name=repo_name,
+        default_branch=default_branch,
+        repo_url=repo_url,
         checks=tuple(checks),
         findings=findings,
     )

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -50,7 +50,7 @@ The `adapter_kind` field is a closed enum that tells ao-kernel how to route invo
 |---|---|---|
 | Bundled `codex-stub` | Shipped baseline | Deterministic demo + CI surface; the default supported adapter path in this repo |
 | `claude-code-cli` walkthroughs and manifests | Operator-managed | Real-adapter evaluation surface; helper-backed preflight lives at `python3 scripts/claude_code_cli_smoke.py`, but this is still not the default support claim |
-| `gh-cli-pr` walkthroughs and manifests | Deferred / contract surface | Typed connector contract exists, but the full end-user E2E PR lane is not the current supported demo |
+| `gh-cli-pr` walkthroughs and manifests | Operator-managed preflight / contract surface | Typed connector contract exists; helper-backed safe preflight lives at `python3 scripts/gh_cli_pr_smoke.py`, but full live PR opening is still not the default supported demo |
 | `custom-cli` / `custom-http` | Escape hatch | Operator-owned integration responsibility; contract-compatible does not mean ao-kernel ships vendor-specific production support |
 
 ### Promotion criteria for new enum values
@@ -307,7 +307,7 @@ The codex stub is an in-process adapter used for CI determinism and demos withou
   "invocation": {
     "transport": "cli",
     "command": "gh",
-    "args": ["pr", "create", "--title", "{task_prompt}", "--body-file", "{context_pack_ref}", "--head", "ao-kernel/run-{run_id}"],
+    "args": ["pr", "create", "--title", "{task_prompt}", "--body-file", "{context_pack_ref}"],
     "env_allowlist_ref": "#/env_allowlist/allowed_keys",
     "cwd_policy": "per_run_worktree",
     "stdin_mode": "none",
@@ -346,6 +346,15 @@ The codex stub is an in-process adapter used for CI determinism and demos withou
 - **Uniform invocation path.** The workflow doesn't have special cases for "open PR via gh" vs "agent opens PR itself". Both go through `adapter_invoked` / `adapter_returned`.
 - **Policy and evidence uniformity.** The same worktree profile and evidence taxonomy apply, including secret handling for `GH_TOKEN`.
 - **Replaceability.** A workspace that uses GitLab can swap `gh-cli-pr` for a hypothetical `glab-cli-mr` adapter without changing the workflow.
+
+### Current certification boundary
+
+- Bundled contract: `gh pr create --title {task_prompt} --body-file {context_pack_ref}`
+- Operator-safe preflight: `python3 scripts/gh_cli_pr_smoke.py`
+- The preflight intentionally adds `--repo`, `--head`, `--base`, and `--dry-run`
+  outside the bundled manifest so operators can verify auth and repo
+  visibility without opening a real remote PR.
+- Full live PR opening remains outside the default shipped support boundary.
 
 ### Why it's NOT a full coding agent
 

--- a/scripts/gh_cli_pr_smoke.py
+++ b/scripts/gh_cli_pr_smoke.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Operator smoke for the bundled ``gh-cli-pr`` adapter."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel.real_adapter_smoke import render_text_report, run_gh_cli_pr_smoke
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="gh_cli_pr_smoke.py",
+        description=(
+            "Run side-effect-safe smoke checks for the bundled gh-cli-pr adapter."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        choices=("text", "json"),
+        default="text",
+        help="Render mode for the smoke report.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=20.0,
+        help="Per-command timeout for live gh CLI probes.",
+    )
+    parser.add_argument(
+        "--repo",
+        help="Optional owner/name repo override for gh repo/pr commands.",
+    )
+    parser.add_argument(
+        "--base",
+        help="Optional base branch override for the dry-run PR probe.",
+    )
+    parser.add_argument(
+        "--head",
+        help="Optional head branch override for the dry-run PR probe.",
+    )
+    args = parser.parse_args()
+
+    report = run_gh_cli_pr_smoke(
+        timeout_seconds=args.timeout_seconds,
+        cwd=_REPO_ROOT,
+        repo=args.repo,
+        base_ref=args.base,
+        head_ref=args.head,
+    )
+    if args.output == "json":
+        print(json.dumps(report.as_dict(), indent=2, sort_keys=True))
+    else:
+        print(render_text_report(report))
+    return 0 if report.overall_status == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_adapter_manifest_loader.py
+++ b/tests/test_adapter_manifest_loader.py
@@ -342,3 +342,24 @@ class TestClaudeCodeCliReviewFindingsV310A1:
             "claude-code-cli",
             ["read_repo", "write_diff", "run_tests", "stream_output", "review_findings"],
         )
+
+
+class TestGhCliPrManifestContractWP83:
+    """WP-8.3 bundled gh-cli-pr manifest contract pin."""
+
+    def test_bundled_manifest_invocation_matches_current_gh_cli_shape(
+        self,
+    ) -> None:
+        reg = AdapterRegistry()
+        reg.load_bundled()
+        manifest = reg.get("gh-cli-pr")
+        assert manifest.invocation["command"] == "gh"
+        assert tuple(manifest.invocation["args"]) == (
+            "pr",
+            "create",
+            "--title",
+            "{task_prompt}",
+            "--body-file",
+            "{context_pack_ref}",
+        )
+        assert manifest.invocation["stdin_mode"] == "none"

--- a/tests/test_gh_cli_pr_smoke.py
+++ b/tests/test_gh_cli_pr_smoke.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import ao_kernel.real_adapter_smoke as smoke
+from ao_kernel.adapters import AdapterRegistry
+from ao_kernel.real_adapter_smoke import CommandResult, run_gh_cli_pr_smoke
+
+
+def _result(
+    argv: tuple[str, ...] | list[str],
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> CommandResult:
+    return CommandResult(
+        argv=tuple(argv),
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _bundled_manifest():
+    reg = AdapterRegistry()
+    reg.load_bundled()
+    return reg.get("gh-cli-pr")
+
+
+def test_binary_missing_blocks_and_skips_remaining_checks() -> None:
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: None,
+        runner=lambda argv, cwd, timeout: _result(argv),
+        cwd=Path("/tmp"),
+    )
+
+    assert report.overall_status == "blocked"
+    assert report.findings == ("gh_binary_missing",)
+    assert [check.status for check in report.checks] == [
+        "fail",
+        "skip",
+        "skip",
+        "skip",
+        "skip",
+        "skip",
+    ]
+
+
+def test_auth_status_requires_active_github_login() -> None:
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        cmd = tuple(argv)
+        if cmd == ("/fake/gh", "--version"):
+            return _result(cmd, stdout="gh version 2.83.2 (2025-12-10)\n")
+        if cmd == ("/fake/gh", "auth", "status", "--json", "hosts"):
+            return _result(cmd, stdout='{"hosts":{"github.com":[]}}')
+        if cmd == (
+            "/fake/gh",
+            "repo",
+            "view",
+            "--json",
+            "nameWithOwner,defaultBranchRef,isPrivate,url",
+        ):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"nameWithOwner":"Halildeu/ao-kernel",'
+                    '"defaultBranchRef":{"name":"main"},'
+                    '"isPrivate":false,'
+                    '"url":"https://github.com/Halildeu/ao-kernel"}'
+                ),
+            )
+        if cmd[:4] == ("/fake/gh", "pr", "create", "--repo"):
+            return _result(
+                cmd,
+                stdout="Would have created a Pull Request with:\n",
+            )
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: "/fake/gh",
+        runner=runner,
+        cwd=Path("/tmp"),
+    )
+
+    assert report.overall_status == "blocked"
+    assert "gh_not_authenticated" in report.findings
+    auth_check = next(check for check in report.checks if check.name == "auth_status")
+    assert auth_check.finding_code == "gh_not_authenticated"
+    assert auth_check.detail == "github.com icin aktif gh auth kaydi bulunamadi"
+
+
+def test_repo_view_failure_skips_dry_run() -> None:
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        cmd = tuple(argv)
+        if cmd == ("/fake/gh", "--version"):
+            return _result(cmd, stdout="gh version 2.83.2 (2025-12-10)\n")
+        if cmd == ("/fake/gh", "auth", "status", "--json", "hosts"):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"hosts":{"github.com":[{"state":"success","active":true,'
+                    '"host":"github.com","login":"Halildeu",'
+                    '"tokenSource":"keyring","scopes":"repo",'
+                    '"gitProtocol":"https"}]}}'
+                ),
+            )
+        if cmd == (
+            "/fake/gh",
+            "repo",
+            "view",
+            "--json",
+            "nameWithOwner,defaultBranchRef,isPrivate,url",
+        ):
+            return _result(cmd, returncode=1, stderr="failed to resolve repo")
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: "/fake/gh",
+        runner=runner,
+        cwd=Path("/tmp"),
+    )
+
+    assert report.overall_status == "blocked"
+    assert "gh_repo_view_failed" in report.findings
+    repo_check = next(check for check in report.checks if check.name == "repo_view")
+    dry_run_check = next(check for check in report.checks if check.name == "pr_dry_run")
+    assert repo_check.finding_code == "gh_repo_view_failed"
+    assert dry_run_check.status == "skip"
+
+
+def test_dry_run_failure_is_reported_explicitly() -> None:
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        cmd = tuple(argv)
+        if cmd == ("/fake/gh", "--version"):
+            return _result(cmd, stdout="gh version 2.83.2 (2025-12-10)\n")
+        if cmd == ("/fake/gh", "auth", "status", "--json", "hosts"):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"hosts":{"github.com":[{"state":"success","active":true,'
+                    '"host":"github.com","login":"Halildeu",'
+                    '"tokenSource":"keyring","scopes":"repo",'
+                    '"gitProtocol":"https"}]}}'
+                ),
+            )
+        if cmd == (
+            "/fake/gh",
+            "repo",
+            "view",
+            "--json",
+            "nameWithOwner,defaultBranchRef,isPrivate,url",
+        ):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"nameWithOwner":"Halildeu/ao-kernel",'
+                    '"defaultBranchRef":{"name":"main"},'
+                    '"isPrivate":false,'
+                    '"url":"https://github.com/Halildeu/ao-kernel"}'
+                ),
+            )
+        if cmd[:4] == ("/fake/gh", "pr", "create", "--repo"):
+            return _result(cmd, returncode=1, stderr="dry-run failed")
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: "/fake/gh",
+        runner=runner,
+        cwd=Path("/tmp"),
+    )
+
+    assert report.overall_status == "blocked"
+    assert "gh_pr_dry_run_failed" in report.findings
+    dry_run_check = next(check for check in report.checks if check.name == "pr_dry_run")
+    assert dry_run_check.finding_code == "gh_pr_dry_run_failed"
+
+
+def test_manifest_contract_mismatch_is_reported() -> None:
+    manifest = replace(
+        _bundled_manifest(),
+        invocation={
+            **_bundled_manifest().invocation,
+            "args": ["pr", "create", "--title", "{task_prompt}"],
+        },
+    )
+
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        cmd = tuple(argv)
+        if cmd == ("/fake/gh", "--version"):
+            return _result(cmd, stdout="gh version 2.83.2 (2025-12-10)\n")
+        if cmd == ("/fake/gh", "auth", "status", "--json", "hosts"):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"hosts":{"github.com":[{"state":"success","active":true,'
+                    '"host":"github.com","login":"Halildeu",'
+                    '"tokenSource":"keyring","scopes":"repo",'
+                    '"gitProtocol":"https"}]}}'
+                ),
+            )
+        if cmd == (
+            "/fake/gh",
+            "repo",
+            "view",
+            "--json",
+            "nameWithOwner,defaultBranchRef,isPrivate,url",
+        ):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"nameWithOwner":"Halildeu/ao-kernel",'
+                    '"defaultBranchRef":{"name":"main"},'
+                    '"isPrivate":false,'
+                    '"url":"https://github.com/Halildeu/ao-kernel"}'
+                ),
+            )
+        if cmd[:4] == ("/fake/gh", "pr", "create", "--repo"):
+            return _result(
+                cmd,
+                stdout="Would have created a Pull Request with:\n",
+            )
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    original = smoke._load_gh_pr_manifest
+    smoke._load_gh_pr_manifest = lambda: manifest
+    try:
+        report = run_gh_cli_pr_smoke(
+            which=lambda command: "/fake/gh",
+            runner=runner,
+            cwd=Path("/tmp"),
+        )
+    finally:
+        smoke._load_gh_pr_manifest = original
+
+    assert report.overall_status == "blocked"
+    assert "gh_pr_manifest_contract_mismatch" in report.findings
+    manifest_check = next(
+        check for check in report.checks if check.name == "manifest_contract"
+    )
+    assert manifest_check.finding_code == "gh_pr_manifest_contract_mismatch"
+
+
+def test_clean_pass_reports_repo_and_dry_run_success() -> None:
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        cmd = tuple(argv)
+        if cmd == ("/fake/gh", "--version"):
+            return _result(cmd, stdout="gh version 2.83.2 (2025-12-10)\n")
+        if cmd == ("/fake/gh", "auth", "status", "--json", "hosts"):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"hosts":{"github.com":[{"state":"success","active":true,'
+                    '"host":"github.com","login":"Halildeu",'
+                    '"tokenSource":"keyring","scopes":"repo",'
+                    '"gitProtocol":"https"}]}}'
+                ),
+            )
+        if cmd == (
+            "/fake/gh",
+            "repo",
+            "view",
+            "--json",
+            "nameWithOwner,defaultBranchRef,isPrivate,url",
+        ):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"nameWithOwner":"Halildeu/ao-kernel",'
+                    '"defaultBranchRef":{"name":"main"},'
+                    '"isPrivate":false,'
+                    '"url":"https://github.com/Halildeu/ao-kernel"}'
+                ),
+            )
+        if cmd[:4] == ("/fake/gh", "pr", "create", "--repo"):
+            return _result(
+                cmd,
+                stdout=(
+                    "Would have created a Pull Request with:\n"
+                    "Title: ao-kernel gh-cli-pr smoke probe\n"
+                ),
+            )
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: "/fake/gh",
+        runner=runner,
+        cwd=Path("/tmp"),
+    )
+
+    assert report.overall_status == "pass"
+    assert report.findings == ()
+    assert report.repo_name == "Halildeu/ao-kernel"
+    assert report.default_branch == "main"
+    dry_run_check = next(check for check in report.checks if check.name == "pr_dry_run")
+    assert dry_run_check.status == "pass"


### PR DESCRIPTION
## Summary
- add a side-effect-safe `gh-cli-pr` smoke helper for binary/auth/repo/dry-run preflight
- pin the bundled `gh-cli-pr` manifest contract and align the adapter/status docs with the new operator-managed lane
- record the WP-8.3 slice in the production hardening status backlog

## Validation
- python3 -m pytest tests/test_claude_code_cli_smoke.py tests/test_gh_cli_pr_smoke.py tests/test_adapter_manifest_loader.py -q
- python3 scripts/gh_cli_pr_smoke.py --output text
- python3 scripts/claude_code_cli_smoke.py --output text

Refs #199