### PR TITLE
[codex] Align WP-8.4 capability matrix docs

### DIFF
--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -69,14 +69,14 @@ automation platform çizgisine taşımak.
 
 **GitHub takip**
 - üst issue: [#199](https://github.com/Halildeu/ao-kernel/issues/199)
-- son merge: `WP-8.2` / PR #214
-- aktif slice: [`WP-8.3-GH-CLI-PR-SMOKE-BASELINE.md`](./WP-8.3-GH-CLI-PR-SMOKE-BASELINE.md)
+- son merge: `WP-8.3` / PR #215
+- aktif slice: [`WP-8.4-CAPABILITY-MATRIX-ALIGNMENT.md`](./WP-8.4-CAPABILITY-MATRIX-ALIGNMENT.md)
 
 **Adım sırası**
 1. `[x]` `WP-8.1` certification baseline + candidate matrix
 2. `[x]` `WP-8.2` `claude-code-cli` smoke + failure-mode baseline
-3. `[~]` `WP-8.3` `gh-cli-pr` side-effect-safe preflight baseline
-4. `[ ]` `WP-8.4` public capability/support matrix hizası
+3. `[x]` `WP-8.3` `gh-cli-pr` side-effect-safe preflight baseline
+4. `[~]` `WP-8.4` public capability/support matrix hizası
 
 **Canlı snapshot**
 - bundled gerçek-adapter aday seti `claude-code-cli` + `gh-cli-pr`
@@ -89,8 +89,8 @@ automation platform çizgisine taşımak.
 - aktif alt slice için `python3 scripts/gh_cli_pr_smoke.py`
   helper'ı eklendi; `gh` binary + auth + repo visibility + safe
   `gh pr create --dry-run` preflight'ı tek komutta toplandı
-- bu turdaki canlı `python3 scripts/gh_cli_pr_smoke.py --output text`
-  doğrulaması `overall_status: pass` verdi
+- `WP-8.3` PR #215 ile merge edildi; canlı `gh_cli_pr_smoke` + tam CI turu
+  yeşil geçti
 - repo tarafındaki `manifest_cli_contract_mismatch` kapatıldı
 - aynı canlı turda önce `claude auth status` yeşil olsa da `claude -p`
   org-level access hatasıyla düştü; kontrollü re-login sonrası helper tam
@@ -98,8 +98,12 @@ automation platform çizgisine taşımak.
 - `setup-token` altında üretilen uzun ömürlü token ise bu turda güvenilir
   kurtarma yolu olarak doğrulanmadı; ayrıca `Invalid bearer token` reddi
   görüldü
-- `gh-cli-pr` lane'inde tam canlı PR açılışı bu slice'ın DIŞINDA kalır;
-  helper yalnız side-effect-safe preflight uygular
+- `claude-code-cli` lane'i bugün **Beta (operator-managed)** olarak
+  hizalanacak: helper-backed preflight ve canlı prompt smoke var, ancak
+  default shipped demo değildir
+- `gh-cli-pr` lane'i bugün **Beta (operator-managed preflight only)** olarak
+  hizalanacak: helper-backed dry-run smoke var, ancak gerçek remote PR açılışı
+  hâlâ deferred kalır
 
 **Definition of Done**
 - bundled gerçek-adapter aday seti explicit

--- a/.claude/plans/WP-8.4-CAPABILITY-MATRIX-ALIGNMENT.md
+++ b/.claude/plans/WP-8.4-CAPABILITY-MATRIX-ALIGNMENT.md
@@ -1,0 +1,47 @@
+# WP-8.4 — Public Capability / Support Matrix Alignment
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#199](https://github.com/Halildeu/ao-kernel/issues/199)
+**Üst WP:** [#199](https://github.com/Halildeu/ao-kernel/issues/199)
+
+## Amaç
+
+`WP-8.2` ve `WP-8.3` ile gerçek adapter smoke yüzeyleri somutlaştıktan sonra,
+bu yüzeylerin public dokümanlarda tek anlamlı tier diline oturmasını
+sağlamak. Bu slice yeni runtime semantics eklemez; support boundary ve
+capability matrisi ifadelerini hizalar.
+
+## Bu Slice'ın Sınırı
+
+- odak `docs/PUBLIC-BETA.md` + `docs/ADAPTERS.md` + status SSOT
+- `claude-code-cli` ve `gh-cli-pr` için tek anlamlı tier dili üretmek
+- `WP-9` runbook / incident readiness kapsamına girmemek
+- yeni operator smoke ya da runtime code eklememek
+
+## Hedef Tier Dili
+
+| Yüzey | Hedef ifade |
+|---|---|
+| Bundled `review_ai_flow` + `codex-stub` | Shipped |
+| `claude-code-cli` helper-backed real-adapter lane | Beta (operator-managed) |
+| `gh-cli-pr` helper-backed dry-run lane | Beta (operator-managed preflight only) |
+| `gh-cli-pr` ile gerçek remote PR açılışı | Deferred |
+
+## Kabul Kriterleri
+
+1. `docs/PUBLIC-BETA.md` ve `docs/ADAPTERS.md` aynı tier kelimelerini kullanır
+2. `claude-code-cli` için helper-backed smoke varlığı beta/operator-managed
+   olarak ifade edilir; shipped baseline sanılmaz
+3. `gh-cli-pr` için dry-run helper ile live PR opening açıkça ayrılır
+4. `PRODUCTION-HARDENING-PROGRAM-STATUS.md` `WP-8.3`'ü kapanmış, `WP-8.4`'ü
+   aktif slice olarak gösterir
+
+## Beklenen Sonraki Adım
+
+`WP-8.4` merge sonrası aktif hat `WP-9` olur:
+
+- incident runbook
+- rollback yolu
+- upgrade notes
+- support boundary
+- known bugs registry

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -49,8 +49,8 @@ The `adapter_kind` field is a closed enum that tells ao-kernel how to route invo
 | Surface | Current status | Meaning |
 |---|---|---|
 | Bundled `codex-stub` | Shipped baseline | Deterministic demo + CI surface; the default supported adapter path in this repo |
-| `claude-code-cli` walkthroughs and manifests | Operator-managed | Real-adapter evaluation surface; helper-backed preflight lives at `python3 scripts/claude_code_cli_smoke.py`, but this is still not the default support claim |
-| `gh-cli-pr` walkthroughs and manifests | Operator-managed preflight / contract surface | Typed connector contract exists; helper-backed safe preflight lives at `python3 scripts/gh_cli_pr_smoke.py`, but full live PR opening is still not the default supported demo |
+| `claude-code-cli` walkthroughs and manifests | Beta (operator-managed) | Helper-backed preflight lives at `python3 scripts/claude_code_cli_smoke.py`; canlı prompt smoke vardır, fakat bu lane default shipped demo değildir |
+| `gh-cli-pr` walkthroughs and manifests | Beta (operator-managed preflight only) | Helper-backed safe preflight lives at `python3 scripts/gh_cli_pr_smoke.py`; gerçek remote PR açılışı ayrı ve deferred yüzeydir |
 | `custom-cli` / `custom-http` | Escape hatch | Operator-owned integration responsibility; contract-compatible does not mean ao-kernel ships vendor-specific production support |
 
 ### Promotion criteria for new enum values
@@ -224,6 +224,14 @@ HTTP adapters must explicitly set `exposure_modes` to include `"http_header"` vi
 - `policy_checked` — a single aggregate pre-invocation policy summary event. In `v4.0.0b1`, the live scope covers secret resolution, sandbox shaping, HTTP-header exposure checks, and adapter CLI command enforcement.
 - `adapter_returned` — after subprocess exit; payload includes status, finish_reason, cost_actual.
 
+### Current support tier
+
+- Current tier: **Beta (operator-managed)**
+- Helper-backed preflight: `python3 scripts/claude_code_cli_smoke.py`
+- Expected operator prerequisite: valid Claude Code session auth
+- This lane is not the default shipped demo; the shipped baseline remains
+  bundled `review_ai_flow` + bundled `codex-stub`
+
 ### Failure modes
 
 - Binary not found → `error.category: "invocation_failed"`.
@@ -347,14 +355,16 @@ The codex stub is an in-process adapter used for CI determinism and demos withou
 - **Policy and evidence uniformity.** The same worktree profile and evidence taxonomy apply, including secret handling for `GH_TOKEN`.
 - **Replaceability.** A workspace that uses GitLab can swap `gh-cli-pr` for a hypothetical `glab-cli-mr` adapter without changing the workflow.
 
-### Current certification boundary
+### Current support tier
 
+- Current tier: **Beta (operator-managed preflight only)**
 - Bundled contract: `gh pr create --title {task_prompt} --body-file {context_pack_ref}`
-- Operator-safe preflight: `python3 scripts/gh_cli_pr_smoke.py`
+- Helper-backed preflight: `python3 scripts/gh_cli_pr_smoke.py`
 - The preflight intentionally adds `--repo`, `--head`, `--base`, and `--dry-run`
   outside the bundled manifest so operators can verify auth and repo
   visibility without opening a real remote PR.
-- Full live PR opening remains outside the default shipped support boundary.
+- Full live PR opening remains **Deferred** and outside the default shipped
+  support boundary.
 
 ### Why it's NOT a full coding agent
 

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -1,6 +1,6 @@
 # Public Beta (v4.0.0b1) — Support Matrix SSOT
 
-> **Sürüm durumu (2026-04-20)**: stable kanal `v3.13.3`, bu branch /
+> **Sürüm durumu (2026-04-22)**: stable kanal `v3.13.3`, bu branch /
 > pre-release paket sürümü `4.0.0b1`. Bu doküman `v4.0.0b1` için canlı
 > destek matrisi ve operator-facing SSOT'tur.
 
@@ -39,10 +39,16 @@ istemek gerekir.
 
 ## Beta
 
+> **Not:** Bu tablodaki yüzeyler shipped baseline değildir. Çalışan smoke ve
+> helper kanıtları vardır, fakat operator-managed kullanım ve ek önkoşullar
+> gerektirirler.
+
 | Yüzey | Durum | Not |
 |---|---|---|
 | Public Beta yüzeyinin tamamı | Beta | Stable kanal hâlâ `3.13.3`; genel kullanım için pre-release install gerekir |
-| Real-adapter benchmark tam modu | Beta | Operator-managed yüzey; deterministik stub lane kadar stabil değil |
+| `claude-code-cli` helper-backed real-adapter lane | Beta (operator-managed) | `python3 scripts/claude_code_cli_smoke.py` ile preflight + canlı prompt smoke doğrulanabilir; varsayılan shipped demo değildir |
+| `gh-cli-pr` helper-backed preflight lane | Beta (operator-managed preflight only) | `python3 scripts/gh_cli_pr_smoke.py` auth/repo visibility + `gh pr create --dry-run` zincirini doğrular; gerçek remote PR açmaz |
+| Real-adapter benchmark tam modu | Beta (operator-managed) | Deterministik stub lane kadar stabil değildir; adapter-altı gerçek tier sınırları yukarıdaki satırlarda tanımlanır |
 
 ## Contract / Inventory Layer
 
@@ -57,7 +63,7 @@ istemek gerekir.
 | Yüzey | Durum | Not |
 |---|---|---|
 | `bug_fix_flow` release closure | Deferred | Public Beta kapsamı dışında |
-| `gh-cli-pr` ile tam E2E PR açılışı | Deferred | Roadmap/spec yüzeyi |
+| `gh-cli-pr` ile tam E2E PR açılışı | Deferred | Mevcut beta yüzey yalnız dry-run preflight'tır; gerçek remote PR açılışı henüz destek vaadi değildir |
 | `docs/roadmap/DEMO-SCRIPT-SPEC.md` içindeki 11 adımlı üç-adapter akış | Deferred | Canlı destek vaadi değildir |
 | Adapter-path `cost_usd` reconcile | Deferred | Ayrı correctness işi |
 
@@ -70,6 +76,8 @@ istemek gerekir.
 
 - Public Beta “hemen çalışır” iddiası yalnızca bundled
   `review_ai_flow` + bundled `codex-stub` yolu için geçerlidir.
+- `claude-code-cli` ve `gh-cli-pr` bugün default demo yüzeyi değildir;
+  yalnız helper-backed operator-managed beta satırları kadar desteklenir.
 - Bundled extension inventory bugün dar runtime-backed yüzeye sahiptir:
   explicit bootstrap-backed smoke `PRJ-HELLO` ile sınırlıdır; kalan
   manifestler doctor truth audit'inde contract-only veya quarantined


### PR DESCRIPTION
## Summary
- mark WP-8.3 complete and switch the active hardening slice to WP-8.4
- add a dedicated WP-8.4 plan doc for public capability/support matrix alignment
- align `docs/PUBLIC-BETA.md` and `docs/ADAPTERS.md` on the exact tier language for `claude-code-cli` and `gh-cli-pr`

## Validation
- docs/status-only slice; no runtime code changes

Refs #199