### PR TITLE
[codex] Add WP-9 ops readiness docs package

### DIFF
--- a/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
+++ b/.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md
@@ -55,82 +55,49 @@ automation platform çizgisine taşımak.
 | `WP-5` Release governance hardening | Faz 3 | Completed on `main` | branch protection / required checks / CODEOWNERS / merge gate sertliği | PR #202 + branch protection snapshot |
 | `WP-6` Worktree/branch safety control loop | Faz 3 | Completed on `main` | stale base / overlap / dirty worktree riskini operasyonel kapatmak | ops komutları + usage proof |
 | `WP-7` Path-scoped write ownership | Faz 3 | Completed on `main` | aynı path alanına iki aktif writer çakışmasın | ownership tests + takeover audit |
-| `WP-8` Real adapter certification | Faz 4 | **Active** ([#199](https://github.com/Halildeu/ao-kernel/issues/199)) | en az 2 gerçek adapter prod-tier smoke ve failure-mode testlerinden geçsin | capability matrix + smoke logs |
-| `WP-9` Ops/runbook/incident readiness | Faz 4 | Planned ([#200](https://github.com/Halildeu/ao-kernel/issues/200)) | rollback / incident / support boundary / known bugs paketi | runbook + drill evidence |
+| `WP-8` Real adapter certification | Faz 4 | Completed on `main` ([#199](https://github.com/Halildeu/ao-kernel/issues/199)) | helper-backed real-adapter smoke/failure-mode baseline + capability matrix hizası | smoke logs + support matrix |
+| `WP-9` Ops/runbook/incident readiness | Faz 4 | **Active** ([#200](https://github.com/Halildeu/ao-kernel/issues/200)) | rollback / incident / support boundary / known bugs paketi | runbook + drill evidence |
 
 ## 5. Şimdi
 
-### `WP-8` — Real Adapter Certification
-
-**Neden şimdi**
-- `WP-7` ile change-safety hattı kapandı. Bundan sonraki ana eksik, gerçek
-  adapter yüzeyinin stub baseline'dan ayrışmış kanıtla sertifiye edilmemiş
-  olması.
-
-**GitHub takip**
-- üst issue: [#199](https://github.com/Halildeu/ao-kernel/issues/199)
-- son merge: `WP-8.3` / PR #215
-- aktif slice: [`WP-8.4-CAPABILITY-MATRIX-ALIGNMENT.md`](./WP-8.4-CAPABILITY-MATRIX-ALIGNMENT.md)
-
-**Adım sırası**
-1. `[x]` `WP-8.1` certification baseline + candidate matrix
-2. `[x]` `WP-8.2` `claude-code-cli` smoke + failure-mode baseline
-3. `[x]` `WP-8.3` `gh-cli-pr` side-effect-safe preflight baseline
-4. `[~]` `WP-8.4` public capability/support matrix hizası
-
-**Canlı snapshot**
-- bundled gerçek-adapter aday seti `claude-code-cli` + `gh-cli-pr`
-  olarak netleşti
-- `codex-stub` sertifikasyon dışı deterministic baseline olarak kalıyor
-- gerçek-adapter CI hâlâ otomatik release gate değildir; mevcut yüzey
-  operator-managed durumdadır
-- aktif alt slice için `python3 scripts/claude_code_cli_smoke.py`
-  helper'ı eklendi; smoke + manifest contract testleri yeşil
-- aktif alt slice için `python3 scripts/gh_cli_pr_smoke.py`
-  helper'ı eklendi; `gh` binary + auth + repo visibility + safe
-  `gh pr create --dry-run` preflight'ı tek komutta toplandı
-- `WP-8.3` PR #215 ile merge edildi; canlı `gh_cli_pr_smoke` + tam CI turu
-  yeşil geçti
-- repo tarafındaki `manifest_cli_contract_mismatch` kapatıldı
-- aynı canlı turda önce `claude auth status` yeşil olsa da `claude -p`
-  org-level access hatasıyla düştü; kontrollü re-login sonrası helper tam
-  `pass` verdi ve doğrudan `claude -p` smoke'u `ok` döndürdü
-- `setup-token` altında üretilen uzun ömürlü token ise bu turda güvenilir
-  kurtarma yolu olarak doğrulanmadı; ayrıca `Invalid bearer token` reddi
-  görüldü
-- `claude-code-cli` lane'i bugün **Beta (operator-managed)** olarak
-  hizalanacak: helper-backed preflight ve canlı prompt smoke var, ancak
-  default shipped demo değildir
-- `gh-cli-pr` lane'i bugün **Beta (operator-managed preflight only)** olarak
-  hizalanacak: helper-backed dry-run smoke var, ancak gerçek remote PR açılışı
-  hâlâ deferred kalır
-
-**Definition of Done**
-- bundled gerçek-adapter aday seti explicit
-- her aday için smoke + failure-mode + evidence gereksinimi yazılı
-- stub baseline ile gerçek adapter yüzeyi net ayrışmış
-- public support boundary yanlış genişletilmemiş
-
-## 6. Sonra
-
 ### `WP-9` — Operations / Runbook / Incident Readiness
 
-**Amaç**
-- ürünün sadece çalışması değil, işletilebilir olması
+**Neden şimdi**
+- `WP-8.4` ile support matrix dili hizalandı. Bundan sonraki ana eksik,
+  operator'ın incident, upgrade, rollback ve support-boundary kararlarını
+  aynı SSOT'tan alabileceği işletim paketidir.
 
-**Minimum kabul**
-- incident runbook
-- rollback yolu
-- upgrade notes
-- support boundary
-- non-empty known bugs registry
+**GitHub takip**
+- üst issue: [#200](https://github.com/Halildeu/ao-kernel/issues/200)
+- son merge: `WP-8.4` / PR #216
+- aktif slice: [`WP-9-OPS-RUNBOOK-INCIDENT-READINESS.md`](./WP-9-OPS-RUNBOOK-INCIDENT-READINESS.md)
+
+**Paket hedefi**
+1. incident runbook
+2. rollback yolu
+3. upgrade notes
+4. support boundary rehberi
+5. non-empty known bugs registry
+
+**Canlı snapshot**
+- shipped baseline ile beta/operator-managed lane ayrımı `PUBLIC-BETA` ve
+  `ADAPTERS` içinde yazılıdır
+- gerçek-adapter helper yüzeyleri (`claude_code_cli_smoke`, `gh_cli_pr_smoke`)
+  kanıtlıdır ama default shipped demo değildir
+- operator için hâlâ tek yerde toplanmış incident/rollback/upgrade paketi ve
+  boş olmayan known-bugs kaydı eksiktir
+
+**Definition of Done**
+- operator bozulduğunda ilk 5 dakikada ne yapacağını bilir
+- rollback yolu yazılı ve doğrulanabilir komutlar içerir
+- support boundary ve known bugs aynı paket içinde görünürdür
+- `PUBLIC-BETA.md` known-bugs bölümü boş değildir
 
 ## 8. Anlık Öncelik
 
 Bugünden itibaren doğru sıra:
 
-1. `WP-8` Real adapter certification
-2. `WP-9` Ops/runbook/incident readiness
+1. `WP-9` Ops/runbook/incident readiness
 
 ## 9. Güncelleme Protokolü
 

--- a/.claude/plans/WP-9-OPS-RUNBOOK-INCIDENT-READINESS.md
+++ b/.claude/plans/WP-9-OPS-RUNBOOK-INCIDENT-READINESS.md
@@ -1,0 +1,43 @@
+# WP-9 — Ops / Runbook / Incident Readiness
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#200](https://github.com/Halildeu/ao-kernel/issues/200)
+**Üst WP:** [#200](https://github.com/Halildeu/ao-kernel/issues/200)
+
+## Amaç
+
+Ürünü yalnız çalışan değil, işletilebilir ve savunulabilir hale getirmek.
+Bu slice runtime semantics değiştirmez; operator-facing operasyon paketini
+çıkarır.
+
+## Bu Slice'ın Sınırı
+
+- incident runbook
+- rollback yolu
+- upgrade notes
+- support boundary anlatısı
+- non-empty known bugs registry
+
+## Çıktı Paketi
+
+1. `docs/OPERATIONS-RUNBOOK.md`
+2. `docs/SUPPORT-BOUNDARY.md`
+3. `docs/UPGRADE-NOTES.md`
+4. `docs/ROLLBACK.md`
+5. `docs/KNOWN-BUGS.md`
+6. `docs/PUBLIC-BETA.md` known-bugs + operations cross-links
+7. `README.md` operations/support docs link yüzeyi
+
+## Kabul Kriterleri
+
+1. Operator shipped baseline ile beta/operator-managed lane'i karıştırmaz
+2. Incident anında ilk 5 dakikada çalıştırılacak komutlar yazılıdır
+3. Package-level rollback ile source-level rollback ayrı anlatılmıştır
+4. `Known Bugs` tablosu boş değildir ve workaround içerir
+5. `PUBLIC-BETA.md`, `README.md` ve status SSOT bu pakete link verir
+
+## Beklenen Sonraki Adım
+
+WP-9 merge sonrası production hardening ana programında yeni aktif hat,
+post-beta correctness backlog veya yeni runtime genişletme işi olur; ops
+hazırlık paketi artık ayrı açık boşluk olarak kalmaz.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ Treat the repo in three layers:
 - **Operator / evaluation only**: benchmark docs, real-adapter runbooks, prompt experiment runbooks, and other opt-in validation paths that are intentionally outside the default deterministic CI/demo lane.
 - **Contract / reference inventory**: bundled JSON defaults, adapter manifests, registry files, and example code such as `examples/hello-llm/`. Their presence in the tree is useful reference material, not blanket proof that every surface is production-ready end to end. The bundled extension inventory is especially narrow at runtime today: `PRJ-HELLO` is the explicit bootstrap-backed smoke path; the rest of the bundled manifests should be treated as contract inventory unless a support doc says otherwise.
 
+### Operational Docs
+
+- [`docs/SUPPORT-BOUNDARY.md`](docs/SUPPORT-BOUNDARY.md)
+- [`docs/OPERATIONS-RUNBOOK.md`](docs/OPERATIONS-RUNBOOK.md)
+- [`docs/UPGRADE-NOTES.md`](docs/UPGRADE-NOTES.md)
+- [`docs/ROLLBACK.md`](docs/ROLLBACK.md)
+- [`docs/KNOWN-BUGS.md`](docs/KNOWN-BUGS.md)
+
 ## Python API
 
 ### ao_kernel.config

--- a/docs/KNOWN-BUGS.md
+++ b/docs/KNOWN-BUGS.md
@@ -1,0 +1,19 @@
+# Known Bugs
+
+This registry tracks bounded, operator-relevant issues that are still open.
+
+`PUBLIC-BETA.md` contains the release-facing summary; this file is the fuller
+operator registry.
+
+## Current entries
+
+| ID | Surface | Symptom | Workaround | Shipped baseline impact |
+|---|---|---|---|---|
+| `KB-001` | `claude-code-cli` beta lane | `claude auth status` may report a healthy login while a real `claude -p` prompt call is still denied | Always trust `python3 scripts/claude_code_cli_smoke.py --output text` over `claude auth status` alone; if blocked, re-login the Claude Code session | None; affects operator-managed lane only |
+| `KB-002` | `claude-code-cli` fallback token route | The long-lived token path derived from `claude setup-token` has shown `Invalid bearer token` failures in live validation | Prefer session auth; do not treat env-token fallback as the primary recovery path | None; affects fallback auth path only |
+
+## Operational rule
+
+If a bug only affects a beta/operator-managed lane while the shipped baseline
+is green, do not silently widen support to cover the broken lane. Update this
+registry and keep the support tier narrow until the issue is resolved.

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -1,0 +1,105 @@
+# Operations Runbook
+
+This document is the operator-facing incident and recovery companion for
+`ao-kernel`. It expands the support boundary in
+[`PUBLIC-BETA.md`](PUBLIC-BETA.md) into a concrete "what do I do now?"
+playbook.
+
+`PUBLIC-BETA.md` remains the normative support matrix. This runbook tells you
+how to verify, triage, and stabilize the currently supported surfaces.
+
+## 1. Incident classes
+
+| Class | Trigger | Severity | Immediate effect |
+|---|---|---|---|
+| Shipped baseline incident | `examples/demo_review.py`, module entrypoints, `ao-kernel doctor`, or packaging smoke fail | Sev 1 | Stop calling the current build "ready" |
+| Beta lane incident | `claude-code-cli` or `gh-cli-pr` helper-backed lanes fail while shipped baseline is healthy | Sev 2 | Keep shipped baseline claim; narrow operator guidance if needed |
+| Contract/doc drift | Docs, support tier wording, or known-bugs inventory drift from runtime reality | Sev 3 | Fix docs/status before widening support |
+
+## 2. First 5 minutes
+
+Run the following from the repo root or from an environment where
+`ao-kernel` is installed:
+
+```bash
+ao-kernel version
+python -m ao_kernel version
+python -m ao_kernel.cli version
+ao-kernel doctor
+python3 examples/demo_review.py --cleanup
+```
+
+If the incident involves an operator-managed real-adapter lane, run the lane's
+smoke next:
+
+```bash
+python3 scripts/claude_code_cli_smoke.py --output text
+python3 scripts/gh_cli_pr_smoke.py --output text
+```
+
+## 3. Decision tree
+
+### 3.1 Shipped baseline fails
+
+Treat the build as not ready when any of these break:
+
+- `ao-kernel version`
+- `python -m ao_kernel version`
+- `python -m ao_kernel.cli version`
+- `ao-kernel doctor`
+- `python3 examples/demo_review.py --cleanup`
+- packaging smoke / required CI gates
+
+Actions:
+
+1. Capture exact command output and current commit SHA.
+2. Record whether the failure is local-only, CI-only, or both.
+3. Check [`ROLLBACK.md`](ROLLBACK.md) if the regression came from a recent
+   merge or release.
+4. Do not widen support claims until the shipped baseline is green again.
+
+### 3.2 Beta/operator-managed lane fails
+
+If shipped baseline stays green but one of these fails:
+
+- `python3 scripts/claude_code_cli_smoke.py --output text`
+- `python3 scripts/gh_cli_pr_smoke.py --output text`
+- operator-run real-adapter benchmark path
+
+Then the shipped baseline claim stays intact, but the operator guidance must
+stay narrow. Actions:
+
+1. Confirm the shipped baseline remains healthy.
+2. Check [`KNOWN-BUGS.md`](KNOWN-BUGS.md) for an existing entry.
+3. If it is new, add it before describing the lane as reliable.
+4. Keep the lane in Beta / operator-managed status until a fix is verified.
+
+## 4. Evidence to collect
+
+For any Sev 1 or Sev 2 incident, collect:
+
+- current commit SHA
+- exact command(s) run
+- stdout/stderr
+- `ao-kernel doctor` output
+- workflow evidence path if a workflow ran:
+  `.ao/evidence/workflows/<run_id>/events.jsonl`
+- adapter evidence path if an adapter lane ran:
+  `.ao/evidence/workflows/<run_id>/adapter-*.jsonl`
+
+## 5. Exit criteria
+
+An incident is considered closed only when:
+
+1. the relevant smoke or support command is green again,
+2. the support boundary is still truthful,
+3. the known-bugs registry is updated if the issue remains open but bounded,
+4. upgrade / rollback guidance does not contradict the current runtime state.
+
+## 6. Related documents
+
+- [`PUBLIC-BETA.md`](PUBLIC-BETA.md) — release support matrix
+- [`SUPPORT-BOUNDARY.md`](SUPPORT-BOUNDARY.md) — narrative support tiers
+- [`UPGRADE-NOTES.md`](UPGRADE-NOTES.md) — upgrade checklist
+- [`ROLLBACK.md`](ROLLBACK.md) — rollback procedures
+- [`KNOWN-BUGS.md`](KNOWN-BUGS.md) — active known-bugs registry

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -22,6 +22,14 @@ pip install --pre ao-kernel
 `pip install ao-kernel` varsayılan olarak stable kanalda kalır; pre-release
 istemek gerekir.
 
+## Operational References
+
+- [`SUPPORT-BOUNDARY.md`](SUPPORT-BOUNDARY.md)
+- [`OPERATIONS-RUNBOOK.md`](OPERATIONS-RUNBOOK.md)
+- [`UPGRADE-NOTES.md`](UPGRADE-NOTES.md)
+- [`ROLLBACK.md`](ROLLBACK.md)
+- [`KNOWN-BUGS.md`](KNOWN-BUGS.md)
+
 ## Shipped (v4.0.0b1)
 
 | Yüzey | Durum | Not |
@@ -69,8 +77,12 @@ istemek gerekir.
 
 ## Known Bugs
 
+> Full operator registry: [`KNOWN-BUGS.md`](KNOWN-BUGS.md)
+
 | Konum | Etki | Workaround | Beta blocker? | Hedef |
 |---|---|---|---|---|
+| `KB-001` / `claude-code-cli` beta lane | `claude auth status` yeşil görünse bile gerçek `claude -p` prompt access bloklu olabilir | `claude auth status` yerine `python3 scripts/claude_code_cli_smoke.py --output text` çıktısını belirleyici kabul et; gerekirse session re-login yap | Yalnız operator-managed lane için evet; shipped baseline için hayır | Open |
+| `KB-002` / `claude-code-cli` token fallback | `claude setup-token` türevi uzun ömürlü token route'u `Invalid bearer token` verebilir | session auth kullan; env-token fallback'i primary recovery olarak görme | Hayır | Open |
 
 ## Kapsam Dışı Notlar
 

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -1,0 +1,60 @@
+# Rollback
+
+Use this document when a recent upgrade, merge, or release leaves the shipped
+baseline or an explicitly supported beta lane in a worse state.
+
+## 1. Package-level rollback
+
+### Return to stable
+
+```bash
+pip install --force-reinstall ao-kernel==3.13.3
+```
+
+### Return to the documented beta pin
+
+```bash
+pip install --force-reinstall ao-kernel==4.0.0b1
+```
+
+After either rollback, verify:
+
+```bash
+ao-kernel version
+python -m ao_kernel version
+python -m ao_kernel.cli version
+ao-kernel doctor
+python3 examples/demo_review.py --cleanup
+```
+
+## 2. Source-repo rollback
+
+If the problem comes from a recent merge on `main`:
+
+1. identify the merge commit or squash commit,
+2. revert it in a new branch,
+3. run the same baseline verification commands,
+4. merge the revert only after the support boundary is truthful again.
+
+Use non-interactive git commands only. Do not reset shared history.
+
+## 3. Release rollback rule
+
+In this repo, merge does not publish a package. Tag-triggered publish is the
+release boundary. That means:
+
+- a merged docs/runtime PR may need a repo revert,
+- a published package may need a package reinstall or follow-up release,
+- both may be needed if the bad state already reached users.
+
+## 4. Beta lane rule
+
+If only an operator-managed beta lane regresses while the shipped baseline
+stays green, prefer narrowing guidance and updating
+[`KNOWN-BUGS.md`](KNOWN-BUGS.md) over rolling back the whole baseline.
+
+## 5. Related documents
+
+- [`UPGRADE-NOTES.md`](UPGRADE-NOTES.md)
+- [`OPERATIONS-RUNBOOK.md`](OPERATIONS-RUNBOOK.md)
+- [`PUBLIC-BETA.md`](PUBLIC-BETA.md)

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -1,0 +1,74 @@
+# Support Boundary
+
+This document is the narrative companion to [`PUBLIC-BETA.md`](PUBLIC-BETA.md).
+When the two disagree, `PUBLIC-BETA.md` wins.
+
+Use this page when you need to answer: "is this surface actually supported,
+operator-only, or just contract inventory?"
+
+## 1. Support layers
+
+| Layer | Included surfaces | Verification |
+|---|---|---|
+| Shipped baseline | module entrypoints, `ao-kernel doctor`, bundled `review_ai_flow`, `examples/demo_review.py`, packaging smoke | entrypoint checks, doctor, demo review smoke, CI |
+| Beta (operator-managed) | `claude-code-cli` helper-backed lane, `gh-cli-pr` helper-backed dry-run lane, real-adapter benchmark full mode | explicit smoke helpers and runbooks |
+| Contract inventory | bundled defaults, manifests, extensions, example inventory | loader/validator and truth audit only |
+| Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a support claim |
+
+## 2. Current line by line boundary
+
+### Shipped baseline
+
+The repo currently supports these as the default claim:
+
+- `ao-kernel version`
+- `python -m ao_kernel version`
+- `python -m ao_kernel.cli version`
+- `ao-kernel doctor`
+- bundled `review_ai_flow` + bundled `codex-stub`
+- `python3 examples/demo_review.py --cleanup`
+
+### Beta (operator-managed)
+
+These are real, testable surfaces, but they are not the default shipped demo:
+
+- `python3 scripts/claude_code_cli_smoke.py --output text`
+- `python3 scripts/gh_cli_pr_smoke.py --output text`
+- real-adapter benchmark full-mode runbooks
+
+### Contract inventory
+
+These may be bundled and schema-valid without being end-to-end supported:
+
+- bundled adapter manifests
+- bundled extensions and registry files
+- `examples/hello-llm/`
+- roadmap/spec documents
+
+## 3. What does NOT automatically widen support
+
+The following do not, by themselves, justify a broader support claim:
+
+- a manifest file existing in `ao_kernel/defaults/`
+- a runbook describing an operator flow
+- a roadmap/spec document
+- a contract loader or truth-audit warning surface
+- a smoke passing only in one operator environment without the support docs
+  being updated
+
+## 4. Operational rule
+
+If a surface is not simultaneously backed by:
+
+1. a real code path,
+2. a behavior check or smoke,
+3. the relevant CI or explicit operator validation path,
+4. the matching support doc wording,
+
+then treat it as not widened.
+
+## 5. Related documents
+
+- [`PUBLIC-BETA.md`](PUBLIC-BETA.md)
+- [`OPERATIONS-RUNBOOK.md`](OPERATIONS-RUNBOOK.md)
+- [`KNOWN-BUGS.md`](KNOWN-BUGS.md)

--- a/docs/UPGRADE-NOTES.md
+++ b/docs/UPGRADE-NOTES.md
@@ -1,0 +1,75 @@
+# Upgrade Notes
+
+This document covers operator-facing upgrade steps for the currently documented
+stable and beta channels.
+
+## 1. Choose the right channel
+
+### Stable channel
+
+```bash
+pip install -U ao-kernel
+```
+
+### Public Beta channel
+
+```bash
+pip install --pre ao-kernel
+# or pin explicitly
+pip install ao-kernel==4.0.0b1
+```
+
+Do not assume `pip install ao-kernel` will pick the beta. It stays on the
+stable channel unless you ask for a pre-release explicitly.
+
+## 2. Pre-upgrade snapshot
+
+Before upgrading, record the current environment state:
+
+```bash
+ao-kernel version
+python -m ao_kernel version
+python -m ao_kernel.cli version
+python -m pip show ao-kernel
+```
+
+## 3. Post-upgrade verification
+
+After upgrading, run the baseline checks:
+
+```bash
+ao-kernel version
+python -m ao_kernel version
+python -m ao_kernel.cli version
+ao-kernel doctor
+python3 examples/demo_review.py --cleanup
+```
+
+If you use operator-managed real-adapter lanes, run the corresponding smoke as
+well:
+
+```bash
+python3 scripts/claude_code_cli_smoke.py --output text
+python3 scripts/gh_cli_pr_smoke.py --output text
+```
+
+## 4. Expected warnings
+
+These do not automatically mean the upgrade failed:
+
+- `ao-kernel doctor` may show a `WARN` for missing optional `llm` extras on a
+  core-only install
+- bundled extension truth inventory may report contract-only or quarantined
+  candidates
+
+Treat those as expected unless the support matrix says otherwise.
+
+## 5. When to stop and roll back
+
+Stop the upgrade and use [`ROLLBACK.md`](ROLLBACK.md) if any shipped-baseline
+check fails:
+
+- entrypoint contract commands
+- `ao-kernel doctor`
+- `python3 examples/demo_review.py --cleanup`
+- required CI or packaging smoke for the target release


### PR DESCRIPTION
## Summary
- add the WP-9 ops/runbook/incident-readiness slice and mark WP-9 active in the program status SSOT
- add operator-facing support boundary, incident runbook, upgrade notes, rollback guide, and a non-empty known-bugs registry
- link the new operational docs from README and PUBLIC-BETA so the support boundary stays discoverable

## Testing
- not run (docs-only change; no runtime behavior change)

Closes #200.
