### PR TITLE
[codex] Correct post-beta active slice

### DIFF
--- a/.claude/plans/PB-1-DEFERRED-CORRECTNESS-PACK-1.md
+++ b/.claude/plans/PB-1-DEFERRED-CORRECTNESS-PACK-1.md
@@ -3,6 +3,7 @@
 **Durum tarihi:** 2026-04-22
 **İlişkili issue:** [#220](https://github.com/Halildeu/ao-kernel/issues/220)
 **Üst tracker:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
+**Durum:** Backfilled complete on `main` (2026-04-22 canlı doğrulama)
 
 ## Amaç
 
@@ -41,3 +42,10 @@ boşluğunu küçük ve merge-edilebilir tek runtime slice altında kapatmak.
 
 Bu slice merge olduktan sonra doğru sıradaki bir sonraki runtime hat
 `PB-2` olacaktır: `bug_fix_flow + codex-stub patch_preview` closure.
+
+## Backfill Kanıtı
+
+- `tests/test_init_cmd.py`
+- `tests/test_internal_roadmap_compiler_coverage.py`
+- `tests/test_internal_roadmap_small_trio_coverage.py`
+- canlı doğrulama: `pytest -q tests/test_init_cmd.py tests/test_internal_roadmap_compiler_coverage.py tests/test_internal_roadmap_small_trio_coverage.py -q`

--- a/.claude/plans/PB-2-BUGFIX-FLOW-PATCH-PREVIEW-CLOSURE.md
+++ b/.claude/plans/PB-2-BUGFIX-FLOW-PATCH-PREVIEW-CLOSURE.md
@@ -1,0 +1,43 @@
+# PB-2 — bug_fix_flow + codex-stub patch_preview Closure
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#222](https://github.com/Halildeu/ao-kernel/issues/222)
+**Üst tracker:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
+
+## Amaç
+
+Deferred bırakılmış `bug_fix_flow` yüzeyi için tek net karar vermek:
+bu yol gerçekten çalışır correctness patch akışına dönüşecek mi, yoksa
+support boundary'den açıkça dışarıda mı kalacak?
+
+## Bu Slice'ın Sınırı
+
+- bundled `bug_fix_flow` workflow tanımı
+- `codex-stub` ile `patch_preview` / patch apply / human gate / devam zinciri
+- ilgili runtime test, smoke ve docs parity kararı
+
+## Kapsam Dışı
+
+- `gh-cli-pr` full remote PR opening
+- genel amaçlı adapter genişletmesi
+- zaman-bağımlı test hygiene taraması
+- `cost_usd` reconcile
+
+## Beklenen Çıktılar
+
+1. canlı repro veya deterministik test kanıtı
+2. gerçek çalışma mümkünse correctness patch'i
+3. mümkün değilse boundary/doküman daraltma kararı
+4. ilgili test ve docs hizası
+
+## Kabul Kriterleri
+
+1. Bu yüzey için tek anlamlı durum kalır: ya supported path ya açık deferred path.
+2. Workflow repro ve docs aynı şeyi söyler.
+3. Human gate / patch_preview / patch apply akışı sessizce fake green üretmez.
+4. Public Beta support boundary yanlış genişlemez.
+
+## Beklenen Sonraki Adım
+
+Bu slice kapandıktan sonra doğru hat `PB-3` olacaktır:
+deterministic test hygiene / time seam audit.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -12,12 +12,12 @@ ayrı ayrı görünür kılmak.
 
 - **Execution status / backlog:** bu dosya
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
-- **Aktif slice planı:** `.claude/plans/PB-1-DEFERRED-CORRECTNESS-PACK-1.md`
+- **Aktif slice planı:** `.claude/plans/PB-2-BUGFIX-FLOW-PATCH-PREVIEW-CLOSURE.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
-- **Aktif issue:** [#220](https://github.com/Halildeu/ao-kernel/issues/220)
+- **Aktif issue:** [#222](https://github.com/Halildeu/ao-kernel/issues/222)
 
 ## 2. Başlangıç Gerçeği
 
@@ -52,8 +52,8 @@ ayrı ayrı görünür kılmak.
 
 | Slice | Durum | Hedef | Zorunlu kanıt |
 |---|---|---|---|
-| `PB-1` Deferred correctness pack 1 | **Active** ([#220](https://github.com/Halildeu/ao-kernel/issues/220)) | `sanitize.py`, `compiler.py`, `init_cmd.py` correctness boşluklarını kapat | targeted tests + minimal doc/deferred update |
-| `PB-2` `bug_fix_flow + codex-stub patch_preview` closure | Planned | deferred bugfix workflow yüzeyini ya gerçekten çalışır hale getirmek ya da boundary'yi kalıcı daraltmak | workflow repro + decision doc + tests |
+| `PB-1` Deferred correctness pack 1 | Completed on `main` ([#220](https://github.com/Halildeu/ao-kernel/issues/220)) | `sanitize.py`, `compiler.py`, `init_cmd.py` correctness boşluklarının zaten kapanmış olduğunu backfill doğrulamak | targeted tests on `main` + status correction |
+| `PB-2` `bug_fix_flow + codex-stub patch_preview` closure | **Active** ([#222](https://github.com/Halildeu/ao-kernel/issues/222)) | deferred bugfix workflow yüzeyini ya gerçekten çalışır hale getirmek ya da boundary'yi kalıcı daraltmak | workflow repro + decision doc + tests |
 | `PB-3` deterministic test hygiene / time seams | Planned | zaman-bağımlı test ve zayıf assertion drift'ini sistematik azaltmak | suite proof + seam inventory |
 | `PB-4` support-surface widening decisions | Planned | `gh-cli-pr` full E2E ve operator lane promotion kararlarını kanıtla vermek | smoke/e2e kanıtı + docs parity |
 | `PB-5` adapter-path cost/evidence completeness | Planned | `cost_usd` reconcile ve evidence completeness boşluklarını kapatmak | tests + evidence parity |
@@ -61,38 +61,39 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### `PB-1` — Deferred Correctness Pack 1
+### `PB-2` — `bug_fix_flow + codex-stub patch_preview` closure
 
 **Neden şimdi**
-- Bunlar küçüktür, user-visible correctness debt'tir ve support boundary'yi
-  widen etmeden kapatılabilir.
-- `bug_fix_flow` closure ve genişletme kararlarından önce düşük-riskli temel
-  doğruluk açıklarının kapanması gerekir.
+- `PB-1` için hedeflenen üç defect zaten `main` üzerinde kapanmış durumda;
+  bu, canlı testlerle doğrulandı.
+- Bundan sonraki en büyük kalan runtime debt, `bug_fix_flow` yüzeyinin ya
+  gerçekten kapanması ya da support boundary'den kalıcı biçimde çıkarılmasıdır.
 
 **Aktif kapsam**
-1. `ao_kernel/_internal/roadmap/sanitize.py:39`
-2. `ao_kernel/_internal/roadmap/compiler.py:139`
-3. `ao_kernel/init_cmd.py:30-33`
+1. bundled `bug_fix_flow` workflow yüzeyi
+2. `codex-stub` ile `patch_preview` / apply / human gate zinciri
+3. docs/test/runtime parity kararı
 
 **Definition of Done**
-- her üç defect için regression test bulunur
-- davranış açıkça pinlenir; silent drift bırakılmaz
-- gerekiyorsa `PUBLIC-BETA` / deferred notları minimal düzeyde güncellenir
-- shipped baseline yanlışlıkla genişlemez
+- bu yüzey ya canlı ve kanıtlı şekilde çalışır hale gelir ya da yanlış destek
+  beklentisi bırakmayacak şekilde boundary daraltılır
+- workflow repro / test / doc üçlüsü aynı şeyi söyler
+- fake demo yüzeyi bırakılmaz
 
 ## 6. Sonra
 
-`PB-1` kapandıktan sonraki doğru sıra:
+`PB-2` kapandıktan sonraki doğru sıra:
 
-1. `PB-2` `bug_fix_flow + codex-stub patch_preview` closure
-2. `PB-3` deterministic test hygiene / time seams
-3. `PB-4` support-surface widening decisions
+1. `PB-3` deterministic test hygiene / time seams
+2. `PB-4` support-surface widening decisions
+3. `PB-5` adapter-path cost/evidence completeness
 
 ## 7. Riskler
 
 | Risk | Etki | Önlem |
 |---|---|---|
 | Küçük correctness fix'i support widening gibi sunmak | Orta | status + docs boundary'yi dar tut |
+| `PB-1` için stale backlog üzerinde çalışmak | Orta | canlı testle doğrula, sonra status'u düzelt |
 | Deferred bugfix closure sırasında yeniden kapsam kayması | Yüksek | `PB-2`yi ayrıca slice'la |
 | Zayıf testlerle fake green oluşması | Yüksek | behavior-first assertions ve smoke kanıtı zorunlu |
 
@@ -100,7 +101,7 @@ ayrı ayrı görünür kılmak.
 
 Bugünden itibaren doğru sıra:
 
-1. `PB-1` Deferred correctness pack 1
+1. `PB-2` `bug_fix_flow + codex-stub patch_preview` closure
 
 ## 9. Güncelleme Protokolü
 


### PR DESCRIPTION
## Summary
- backfill `PB-1` as already complete on `main` after live verification showed its three target defects are already covered by code and tests
- add the `PB-2` active slice plan for `bug_fix_flow + codex-stub patch_preview` closure
- move the post-beta status SSOT from the stale `PB-1` active state to the real next runtime debt

## Testing
- pytest -q tests/test_init_cmd.py tests/test_internal_roadmap_compiler_coverage.py tests/test_internal_roadmap_small_trio_coverage.py -q

Refs #219
Refs #220
Refs #222
