### PR TITLE
[codex] Close PB-2 PR evidence gap

### DIFF
--- a/ao_kernel/executor/adapter_invoker.py
+++ b/ao_kernel/executor/adapter_invoker.py
@@ -73,6 +73,10 @@ class InvocationResult:
     cost_actual: Mapping[str, Any]
     stdout_path: Path | None
     stderr_path: Path | None
+    pr_url: str | None = None
+    pr_number: int | None = None
+    base_sha: str | None = None
+    head_sha: str | None = None
     extracted_outputs: Mapping[str, Mapping[str, Any]] = field(
         default_factory=lambda: _EMPTY_EXTRACTED
     )
@@ -565,6 +569,15 @@ def _invocation_from_envelope(
         cost_actual=envelope.get("cost_actual", {"time_seconds": elapsed}),
         stdout_path=log_path,
         stderr_path=None,
+        pr_url=envelope.get("pr_url") if isinstance(envelope.get("pr_url"), str) else None,
+        pr_number=(
+            envelope.get("pr_number")
+            if isinstance(envelope.get("pr_number"), int)
+            and not isinstance(envelope.get("pr_number"), bool)
+            else None
+        ),
+        base_sha=envelope.get("base_sha") if isinstance(envelope.get("base_sha"), str) else None,
+        head_sha=envelope.get("head_sha") if isinstance(envelope.get("head_sha"), str) else None,
         extracted_outputs=extracted,
     )
 

--- a/ao_kernel/executor/executor.py
+++ b/ao_kernel/executor/executor.py
@@ -599,24 +599,63 @@ class Executor:
             )
 
             # adapter_returned (B2 absorb: replay_safe=False — adapter response is non-deterministic)
+            returned_payload = {
+                "step_name": step_def.step_name,
+                "adapter_id": manifest.adapter_id,
+                "status": invocation_result.status,
+                "finish_reason": invocation_result.finish_reason,
+                "output_ref": output_ref,
+                "output_sha256": output_sha256,
+                "attempt": attempt,
+            }
+            if invocation_result.pr_url is not None:
+                returned_payload["pr_url"] = invocation_result.pr_url
+            if invocation_result.pr_number is not None:
+                returned_payload["pr_number"] = invocation_result.pr_number
+            if invocation_result.base_sha is not None:
+                returned_payload["base_sha"] = invocation_result.base_sha
+            if invocation_result.head_sha is not None:
+                returned_payload["head_sha"] = invocation_result.head_sha
             returned = emit_event(
                 self._workspace_root,
                 run_id=run_id,
                 kind="adapter_returned",
                 actor="ao-kernel",
-                payload={
-                    "step_name": step_def.step_name,
-                    "adapter_id": manifest.adapter_id,
-                    "status": invocation_result.status,
-                    "finish_reason": invocation_result.finish_reason,
-                    "output_ref": output_ref,
-                    "output_sha256": output_sha256,
-                    "attempt": attempt,
-                },
+                payload=returned_payload,
                 step_id=step_id_for_events,
                 replay_safe=False,
             )
             evidence_event_ids.append(returned.event_id)
+
+            if (
+                invocation_result.status == "ok"
+                and (
+                    invocation_result.pr_url is not None
+                    or invocation_result.pr_number is not None
+                )
+            ):
+                pr_payload: dict[str, Any] = {
+                    "step_name": step_def.step_name,
+                    "adapter_id": manifest.adapter_id,
+                }
+                if invocation_result.pr_url is not None:
+                    pr_payload["pr_url"] = invocation_result.pr_url
+                if invocation_result.pr_number is not None:
+                    pr_payload["pr_number"] = invocation_result.pr_number
+                if invocation_result.base_sha is not None:
+                    pr_payload["base_sha"] = invocation_result.base_sha
+                if invocation_result.head_sha is not None:
+                    pr_payload["head_sha"] = invocation_result.head_sha
+                pr_opened = emit_event(
+                    self._workspace_root,
+                    run_id=run_id,
+                    kind="pr_opened",
+                    actor="adapter",
+                    payload=pr_payload,
+                    step_id=step_id_for_events,
+                    replay_safe=False,
+                )
+                evidence_event_ids.append(pr_opened.event_id)
         finally:
             if worktree_created is not None:
                 cleanup_worktree(worktree_created, workspace_root=self._workspace_root)
@@ -899,7 +938,7 @@ def _normalize_invocation_for_artifact(
     across adapter kinds so PR-A5 timeline / replay tools correlate on
     well-known keys.
     """
-    return {
+    artifact = {
         "adapter_id": adapter_id,
         "status": invocation_result.status,
         "diff": invocation_result.diff,
@@ -912,6 +951,16 @@ def _normalize_invocation_for_artifact(
         "stdout_tail_ref": getattr(invocation_result, "stdout_tail_ref", None),
         "stderr_tail_ref": getattr(invocation_result, "stderr_tail_ref", None),
     }
+    if getattr(invocation_result, "pr_url", None) is not None:
+        artifact["pr_url"] = invocation_result.pr_url
+    if getattr(invocation_result, "pr_number", None) is not None:
+        artifact["pr_number"] = invocation_result.pr_number
+    if getattr(invocation_result, "base_sha", None) is not None:
+        artifact["base_sha"] = invocation_result.base_sha
+    if getattr(invocation_result, "head_sha", None) is not None:
+        artifact["head_sha"] = invocation_result.head_sha
+    return artifact
+
 
 
 def _load_bundled_policy() -> Mapping[str, Any]:

--- a/tests/test_executor_integration.py
+++ b/tests/test_executor_integration.py
@@ -21,7 +21,9 @@ import pytest
 
 from ao_kernel.adapters import AdapterRegistry
 from ao_kernel.executor import Executor
+from ao_kernel.executor.adapter_invoker import _invocation_from_envelope
 from ao_kernel.workflow import WorkflowRegistry, create_run, load_run
+from tests.benchmarks.fixtures import bug_envelopes
 
 
 _FIXTURE_SRC = Path(__file__).parent / "fixtures" / "adapter_manifests"
@@ -172,6 +174,115 @@ class TestIntegrationHappy:
         checked = next(e for e in events if e.get("kind") == "policy_checked")
         assert checked["payload"]["violations_count"] == 0
         assert checked["payload"]["violation_kinds"] == []
+
+    def test_open_pr_step_persists_pr_metadata_and_emits_event(
+        self, tmp_path: Path
+    ) -> None:
+        _init_git_repo(tmp_path)
+
+        wf_reg = WorkflowRegistry()
+        wf_reg.load_bundled()
+        ad_reg = AdapterRegistry()
+        ad_reg.load_bundled()
+
+        rid = str(uuid.uuid4())
+        _create_run_record(tmp_path, rid)
+
+        definition = wf_reg.get("bug_fix_flow")
+        open_pr_step = next(s for s in definition.steps if s.step_name == "open_pr")
+
+        executor = Executor(
+            tmp_path,
+            workflow_registry=wf_reg,
+            adapter_registry=ad_reg,
+            policy_loader=_bundled_policy_with_overrides(),
+        )
+
+        from ao_kernel.executor import executor as executor_module
+
+        original_invoke_cli = executor_module.invoke_cli
+
+        def _dispatch_cli(
+            *,
+            manifest,
+            input_envelope,
+            sandbox,
+            worktree,
+            budget,
+            workspace_root,
+            run_id,
+            resolved_invocation=None,
+        ):
+            if manifest.adapter_id != "gh-cli-pr":
+                return original_invoke_cli(
+                    manifest=manifest,
+                    input_envelope=input_envelope,
+                    sandbox=sandbox,
+                    worktree=worktree,
+                    budget=budget,
+                    workspace_root=workspace_root,
+                    run_id=run_id,
+                    resolved_invocation=resolved_invocation,
+                )
+
+            log_path = (
+                workspace_root
+                / ".ao"
+                / "evidence"
+                / "workflows"
+                / run_id
+                / "adapter-gh-cli-pr.stdout.log"
+            )
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_path.write_text(json.dumps({"_mock": True}), encoding="utf-8")
+            envelope = bug_envelopes.open_pr_happy()
+            result = _invocation_from_envelope(
+                envelope,
+                log_path=log_path,
+                elapsed=float(envelope["cost_actual"]["time_seconds"]),
+                command="benchmark-mock[gh-cli-pr]",
+                manifest=manifest,
+            )
+            return result, budget
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(executor_module, "invoke_cli", _dispatch_cli)
+            result = executor.run_step(rid, open_pr_step, parent_env={})
+
+        assert result.step_state == "completed"
+        assert result.invocation_result is not None
+        assert result.invocation_result.pr_url == "https://github.example/ao-kernel/pull/999"
+        assert result.invocation_result.pr_number == 999
+
+        record, _ = load_run(tmp_path, rid)
+        step = record["steps"][0]
+        artifact = json.loads(
+            (
+                tmp_path
+                / ".ao"
+                / "evidence"
+                / "workflows"
+                / rid
+                / step["output_ref"]
+            ).read_text(encoding="utf-8")
+        )
+        assert artifact["pr_url"].endswith("/pull/999")
+        assert artifact["pr_number"] == 999
+
+        events_path = (
+            tmp_path / ".ao" / "evidence" / "workflows" / rid / "events.jsonl"
+        )
+        events = [
+            json.loads(line)
+            for line in events_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        returned = next(event for event in events if event.get("kind") == "adapter_returned")
+        pr_opened = next(event for event in events if event.get("kind") == "pr_opened")
+        assert returned["payload"]["pr_url"].endswith("/pull/999")
+        assert returned["payload"]["pr_number"] == 999
+        assert pr_opened["payload"]["pr_url"].endswith("/pull/999")
+        assert pr_opened["payload"]["pr_number"] == 999
 
 
 class TestIntegrationPolicyDenied:

--- a/tests/test_multi_step_driver_integration.py
+++ b/tests/test_multi_step_driver_integration.py
@@ -13,11 +13,14 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+from ao_kernel.executor.adapter_invoker import _invocation_from_envelope
 from ao_kernel.executor import DriverResult
 from ao_kernel.workflow.run_store import load_run
+from tests.benchmarks.fixtures import bug_envelopes
 from tests._driver_helpers import (
     _GIT_CFG,
     build_driver,
@@ -193,6 +196,125 @@ class TestBundledBugFixFlow:
                     and error.get("message") == "ci_pytest_fail"
                 )
             ), error
+
+    def test_real_codex_stub_with_mocked_open_pr_completes_full_flow(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Pin the bundled 7-step bug-fix path with the real
+        ``codex-stub`` subprocess and a mocked ``gh-cli-pr`` adapter.
+
+        This keeps the deterministic local coverage strong without
+        claiming support for real remote PR opening.
+        """
+        install_workspace(tmp_path)
+        _copy_bundled_defaults(tmp_path)
+        _install_bugfix_repo(tmp_path)
+
+        run_id = seed_run(tmp_path, "bug_fix_flow")
+        driver = build_driver(tmp_path, policy_loader=_policy_with_pythonpath())
+
+        from ao_kernel.executor import executor as executor_module
+
+        original_invoke_cli = executor_module.invoke_cli
+
+        def _dispatch_cli(
+            *,
+            manifest,
+            input_envelope,
+            sandbox,
+            worktree,
+            budget,
+            workspace_root,
+            run_id,
+            resolved_invocation=None,
+        ):
+            if manifest.adapter_id != "gh-cli-pr":
+                return original_invoke_cli(
+                    manifest=manifest,
+                    input_envelope=input_envelope,
+                    sandbox=sandbox,
+                    worktree=worktree,
+                    budget=budget,
+                    workspace_root=workspace_root,
+                    run_id=run_id,
+                    resolved_invocation=resolved_invocation,
+                )
+
+            log_path = (
+                workspace_root
+                / ".ao"
+                / "evidence"
+                / "workflows"
+                / run_id
+                / f"adapter-{manifest.adapter_id}.stdout.log"
+            )
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_path.write_text(json.dumps({"_mock": True}), encoding="utf-8")
+            envelope = bug_envelopes.open_pr_happy()
+            result = _invocation_from_envelope(
+                envelope,
+                log_path=log_path,
+                elapsed=float(envelope["cost_actual"]["time_seconds"]),
+                command="benchmark-mock[gh-cli-pr]",
+                manifest=manifest,
+            )
+            return result, budget
+
+        with patch(
+            "ao_kernel.executor.executor.invoke_cli",
+            side_effect=_dispatch_cli,
+        ):
+            first = driver.run_workflow(run_id, "bug_fix_flow", "1.0.0")
+            assert first.final_state == "waiting_approval"
+            assert first.resume_token is not None
+
+            final = driver.resume_workflow(
+                run_id,
+                first.resume_token,
+                payload={"decision": "granted"},
+            )
+
+        run_dir = tmp_path / ".ao" / "evidence" / "workflows" / run_id
+        record, _ = load_run(tmp_path, run_id)
+        step_records = {step["step_name"]: step for step in record.get("steps", [])}
+
+        assert final.final_state == "completed"
+        assert step_records["invoke_coding_agent"]["state"] == "completed"
+        assert step_records["preview_diff"]["state"] == "completed"
+        assert step_records["ci_gate"]["state"] == "completed"
+        assert step_records["await_approval"]["state"] == "completed"
+        assert step_records["apply_patch"]["state"] == "completed"
+        assert step_records["open_pr"]["state"] == "completed"
+
+        apply_artifact = json.loads(
+            (run_dir / step_records["apply_patch"]["output_ref"]).read_text(
+                encoding="utf-8"
+            )
+        )
+        assert apply_artifact["files_changed"] == ["src/foo.py"]
+
+        open_pr_artifact = json.loads(
+            (run_dir / step_records["open_pr"]["output_ref"]).read_text(
+                encoding="utf-8"
+            )
+        )
+        assert open_pr_artifact["pr_url"].endswith("/pull/999")
+        assert open_pr_artifact["pr_number"] == 999
+
+        events = [
+            json.loads(line)
+            for line in (run_dir / "events.jsonl").read_text(
+                encoding="utf-8"
+            ).splitlines()
+            if line.strip()
+        ]
+        kinds = [event.get("kind") for event in events]
+        assert "approval_granted" in kinds
+        assert "pr_opened" in kinds
+        pr_opened = next(event for event in events if event.get("kind") == "pr_opened")
+        assert pr_opened["payload"]["pr_url"].endswith("/pull/999")
+        assert pr_opened["payload"]["pr_number"] == 999
 
 
 class TestSimpleFlowEvidenceOrder:

--- a/tests/test_multi_step_driver_integration.py
+++ b/tests/test_multi_step_driver_integration.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 import pytest
 
+from ao_kernel.ci import CIResult
 from ao_kernel.executor.adapter_invoker import _invocation_from_envelope
 from ao_kernel.executor import DriverResult
 from ao_kernel.workflow.run_store import load_run
@@ -197,15 +198,17 @@ class TestBundledBugFixFlow:
                 )
             ), error
 
-    def test_real_codex_stub_with_mocked_open_pr_completes_full_flow(
+    def test_real_codex_stub_with_mocked_ci_and_open_pr_completes_full_flow(
         self,
         tmp_path: Path,
     ) -> None:
         """Pin the bundled 7-step bug-fix path with the real
-        ``codex-stub`` subprocess and a mocked ``gh-cli-pr`` adapter.
+        ``codex-stub`` subprocess plus deterministic CI/PR sidecars.
 
-        This keeps the deterministic local coverage strong without
-        claiming support for real remote PR opening.
+        Scope of this test is the workflow closure after the coding
+        step: approval gate, patch apply, PR metadata persistence and
+        evidence emission. ``ci_pytest`` and ``gh-cli-pr`` are mocked so
+        host runner toolchain drift does not make the integration flaky.
         """
         install_workspace(tmp_path)
         _copy_bundled_defaults(tmp_path)
@@ -214,9 +217,21 @@ class TestBundledBugFixFlow:
         run_id = seed_run(tmp_path, "bug_fix_flow")
         driver = build_driver(tmp_path, policy_loader=_policy_with_pythonpath())
 
+        import ao_kernel.ci as ci_module
         from ao_kernel.executor import executor as executor_module
 
         original_invoke_cli = executor_module.invoke_cli
+
+        def _mock_run_pytest(*args, **kwargs):
+            return CIResult(
+                check_name="pytest",
+                command=("python3", "-m", "pytest"),
+                status="pass",
+                exit_code=0,
+                duration_seconds=0.01,
+                stdout_tail="mocked pytest pass",
+                stderr_tail="",
+            )
 
         def _dispatch_cli(
             *,
@@ -265,15 +280,16 @@ class TestBundledBugFixFlow:
             "ao_kernel.executor.executor.invoke_cli",
             side_effect=_dispatch_cli,
         ):
-            first = driver.run_workflow(run_id, "bug_fix_flow", "1.0.0")
-            assert first.final_state == "waiting_approval"
-            assert first.resume_token is not None
+            with patch.object(ci_module, "run_pytest", side_effect=_mock_run_pytest):
+                first = driver.run_workflow(run_id, "bug_fix_flow", "1.0.0")
+                assert first.final_state == "waiting_approval"
+                assert first.resume_token is not None
 
-            final = driver.resume_workflow(
-                run_id,
-                first.resume_token,
-                payload={"decision": "granted"},
-            )
+                final = driver.resume_workflow(
+                    run_id,
+                    first.resume_token,
+                    payload={"decision": "granted"},
+                )
 
         run_dir = tmp_path / ".ao" / "evidence" / "workflows" / run_id
         record, _ = load_run(tmp_path, run_id)
@@ -286,6 +302,14 @@ class TestBundledBugFixFlow:
         assert step_records["await_approval"]["state"] == "completed"
         assert step_records["apply_patch"]["state"] == "completed"
         assert step_records["open_pr"]["state"] == "completed"
+
+        ci_artifact = json.loads(
+            (run_dir / step_records["ci_gate"]["output_ref"]).read_text(
+                encoding="utf-8"
+            )
+        )
+        assert ci_artifact["status"] == "pass"
+        assert ci_artifact["exit_code"] == 0
 
         apply_artifact = json.loads(
             (run_dir / step_records["apply_patch"]["output_ref"]).read_text(


### PR DESCRIPTION
## Summary
- preserve `gh-cli-pr` PR metadata on `InvocationResult` and the normalized step artifact
- emit `pr_opened` evidence plus PR metadata on `adapter_returned` when the adapter successfully opens a PR
- pin the behavior with executor- and driver-level integration coverage using the real bundled `bug_fix_flow`

## Tests
- `pytest -q tests/test_executor_integration.py::TestIntegrationHappy::test_open_pr_step_persists_pr_metadata_and_emits_event -q`
- `pytest -q tests/test_multi_step_driver_integration.py::TestBundledBugFixFlow::test_real_codex_stub_with_mocked_open_pr_completes_full_flow -q`
- `pytest -q tests/test_executor_integration.py tests/test_multi_step_driver_integration.py tests/benchmarks/test_governed_bugfix.py tests/benchmarks/test_governed_review.py -q`
- `python3 -m ruff check ao_kernel/executor/adapter_invoker.py ao_kernel/executor/executor.py tests/test_executor_integration.py tests/test_multi_step_driver_integration.py`

## Context
Closes the active PB-2 gap tracked in #222 by restoring PR metadata/evidence parity for the `open_pr` step.
