### PR TITLE
[codex] Start PB-3 deterministic test hygiene

### DIFF
--- a/.claude/plans/PB-3-DETERMINISTIC-TEST-HYGIENE.md
+++ b/.claude/plans/PB-3-DETERMINISTIC-TEST-HYGIENE.md
@@ -1,0 +1,48 @@
+# PB-3 — deterministic test hygiene / time seams
+
+**Durum tarihi:** 2026-04-22
+**İlişkili issue:** [#226](https://github.com/Halildeu/ao-kernel/issues/226)
+**Üst tracker:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
+**Durum:** In progress
+
+## Amaç
+
+Post-beta correctness hattında fake-green riskini azaltmak: zayıf test
+assertion'larını davranışsal kontrata çekmek, zaman-bağımlı seam'leri görünür
+kılmak ve deterministik olmayan test yüzeylerini küçük tranche'lerle kapatmak.
+
+## Bu Slice'ın Sınırı
+
+- zayıf `result is not None` / benzeri düşük sinyalli assertion alanları
+- time-dependent test seam envanteri
+- uygun yerlerde `now=` veya eşdeğer deterministik seam kullanımı
+
+## Kapsam Dışı
+
+- support boundary widening
+- adapter-path `cost_usd` / evidence completeness closure
+- genel amaçlı production expansion gap map
+- yeni runtime feature ekleme
+
+## İlk Tranche
+
+1. `tests/test_intent_router.py` içindeki zayıf classification assertion'larını
+   davranışsal sonuca çekmek
+2. `tests/test_config.py` workspace root kontratını doğrudan path eşitliği ile
+   pinlemek
+3. `tests/test_context_pack_ref_plumbing.py` adapter envelope override çıktısını
+   tam sözleşme seviyesinde doğrulamak
+
+## Kabul Kriterleri
+
+1. İlk tranche merge edilir ve ilgili testler hedefli pytest ile kanıtlanır.
+2. Status SSOT ve GitHub issue/tracker aktif tranche ile hizalıdır.
+3. `PB-3` halen küçük tranche'lerle yürür; time-seam audit tek PR'da
+   yığılmaz.
+4. Testler artık yalnız “çökmemiş olmayı” değil, beklenen veri sözleşmesini
+   doğrular.
+
+## Beklenen Sonraki Adım
+
+İlk tranche merge olduktan sonra doğru devam, time-dependent seam envanterini
+somut deterministic fix tranche'lerine bölmektir.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -12,12 +12,12 @@ ayrı ayrı görünür kılmak.
 
 - **Execution status / backlog:** bu dosya
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
-- **Aktif slice planı:** `.claude/plans/PB-2-BUGFIX-FLOW-PATCH-PREVIEW-CLOSURE.md`
+- **Aktif slice planı:** `.claude/plans/PB-3-DETERMINISTIC-TEST-HYGIENE.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
-- **Aktif issue:** Henüz açılmadı (`PB-3` issue follow-up)
+- **Aktif issue:** [#226](https://github.com/Halildeu/ao-kernel/issues/226)
 
 ## 2. Başlangıç Gerçeği
 
@@ -25,10 +25,10 @@ ayrı ayrı görünür kılmak.
 - Repo bugün dar ama kanıtlı bir Public Beta / governed runtime yüzeyine sahiptir.
 - Support boundary hâlâ bilerek dardır; `review_ai_flow + codex-stub` shipped
   baseline, gerçek adapter lane'leri ise operator-managed beta durumundadır.
-- Public Beta closeout sonrası hâlâ ayrı correctness işleri vardır:
-  `sanitize.py:39`, `compiler.py:139`, `init_cmd.py:30-33`,
-  `bug_fix_flow + codex-stub patch_preview`, time-dependent test hygiene ve
-  adapter-path cost/evidence completeness.
+- Public Beta closeout sonrası aktif program odağı artık defer edilmiş ilk
+  correctness boşlukları değil; deterministik test hygiene, support-surface
+  widening kararları ve adapter-path cost/evidence completeness gibi kalan
+  post-beta işlerdir.
 - Repo bugün hâlâ genel amaçlı production coding automation platformu değildir;
   bu programın amacı o iddiayı hemen widen etmek değil, önce kalan debt'i
   kontrollü kapatmaktır.
@@ -54,7 +54,7 @@ ayrı ayrı görünür kılmak.
 |---|---|---|---|
 | `PB-1` Deferred correctness pack 1 | Completed on `main` ([#220](https://github.com/Halildeu/ao-kernel/issues/220)) | `sanitize.py`, `compiler.py`, `init_cmd.py` correctness boşluklarının zaten kapanmış olduğunu backfill doğrulamak | targeted tests on `main` + status correction |
 | `PB-2` `bug_fix_flow + codex-stub patch_preview` closure | Completed on `main` ([#222](https://github.com/Halildeu/ao-kernel/issues/222), [#224](https://github.com/Halildeu/ao-kernel/pull/224)) | `open_pr` adımında PR metadata/evidence boşluğunu kapatmak ve deferred bugfix workflow yüzeyini deterministik integration coverage ile doğrulamak | merged runtime fix + integration tests + green CI |
-| `PB-3` deterministic test hygiene / time seams | Planned | zaman-bağımlı test ve zayıf assertion drift'ini sistematik azaltmak | suite proof + seam inventory |
+| `PB-3` deterministic test hygiene / time seams | In progress ([#226](https://github.com/Halildeu/ao-kernel/issues/226)) | zaman-bağımlı test ve zayıf assertion drift'ini sistematik azaltmak | suite proof + seam inventory |
 | `PB-4` support-surface widening decisions | Planned | `gh-cli-pr` full E2E ve operator lane promotion kararlarını kanıtla vermek | smoke/e2e kanıtı + docs parity |
 | `PB-5` adapter-path cost/evidence completeness | Planned | `cost_usd` reconcile ve evidence completeness boşluklarını kapatmak | tests + evidence parity |
 | `PB-6` general-purpose expansion gap map | Planned | narrow beta'dan daha geniş production platform çizgisine geçiş için önkoşulları tabloya dökmek | written gap map + ordered backlog |
@@ -68,6 +68,8 @@ ayrı ayrı görünür kılmak.
   boşluğu kapandı; aktif runtime correctness slice artık bu değil.
 - Bir sonraki yüksek değerli debt, zaman bağımlı test seam'leri ve davranışsal
   olarak zayıf assertion alanlarının sistematik temizlenmesidir.
+- İlk tranche deliberately küçüktür: weak assertion cleanup ile behavior-first
+  test kontratı dar ama kanıtlı şekilde güçlendirilecektir.
 
 **Aktif kapsam**
 1. zaman bağımlı testlerin envanteri

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,8 +30,7 @@ class TestWorkspaceRoot:
 
     def test_finds_ao_dir(self, tmp_workspace: Path):
         result = workspace_root()
-        assert result is not None
-        assert result.name == ".ao"
+        assert result == tmp_workspace
 
     def test_returns_none_library_mode(self, empty_dir: Path):
         result = workspace_root()

--- a/tests/test_context_pack_ref_plumbing.py
+++ b/tests/test_context_pack_ref_plumbing.py
@@ -154,10 +154,11 @@ class TestEnvelopeResolverSuccessPath:
         result = driver._build_adapter_envelope_with_context(
             run_id=run_id, step_def=step_def, record=record,
         )
-        assert result is not None
-        assert result["task_prompt"] == "do the adapter thing"
-        assert result["run_id"] == run_id
-        assert result["context_pack_ref"] == str(context_md_path)
+        assert result == {
+            "task_prompt": "do the adapter thing",
+            "run_id": run_id,
+            "context_pack_ref": str(context_md_path),
+        }
         # Absolute path invariant: adapter subprocess reads from worktree
         # cwd via plain string replacement, so path must resolve regardless.
         assert Path(result["context_pack_ref"]).is_absolute()

--- a/tests/test_intent_router.py
+++ b/tests/test_intent_router.py
@@ -61,8 +61,13 @@ class TestBundledRules:
     def test_bundled_rules_classify_bug_fix(self) -> None:
         router = IntentRouter()
         result = router.classify("Please fix the broken authentication bug")
-        assert result is not None
-        assert result.workflow_id == "bug_fix_flow"
+        assert result == ClassificationResult(
+            workflow_id="bug_fix_flow",
+            workflow_version=None,
+            confidence=0.82,
+            matched_rule_id="bug_fix_keywords",
+            match_type="keyword",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -75,8 +80,13 @@ class TestKeywordMatching:
         rule = _rule(rule_id="r1", keywords=("bug",))
         router = IntentRouter(rules=[rule])
         result = router.classify("We have a bug in production")
-        assert result is not None
-        assert result.matched_rule_id == "r1"
+        assert result == ClassificationResult(
+            workflow_id="demo_flow",
+            workflow_version=None,
+            confidence=0.8,
+            matched_rule_id="r1",
+            match_type="keyword",
+        )
 
     def test_substring_does_not_match(self) -> None:
         rule = _rule(rule_id="r1", keywords=("bug",))
@@ -89,24 +99,39 @@ class TestKeywordMatching:
         rule = _rule(rule_id="r1", keywords=("BUG",))
         router = IntentRouter(rules=[rule])
         result = router.classify("tiny bug today")
-        assert result is not None
-        assert result.matched_rule_id == "r1"
+        assert result == ClassificationResult(
+            workflow_id="demo_flow",
+            workflow_version=None,
+            confidence=0.8,
+            matched_rule_id="r1",
+            match_type="keyword",
+        )
 
     def test_keyword_with_dash_boundary(self) -> None:
         """Dashed keyword matches the dashed token exactly."""
         rule = _rule(rule_id="r1", keywords=("bug-fix",))
         router = IntentRouter(rules=[rule])
         result = router.classify("we filed a bug-fix yesterday")
-        assert result is not None
-        assert result.match_type == "keyword"
+        assert result == ClassificationResult(
+            workflow_id="demo_flow",
+            workflow_version=None,
+            confidence=0.8,
+            matched_rule_id="r1",
+            match_type="keyword",
+        )
 
     def test_keyword_with_underscore_is_part_of_word(self) -> None:
         """Underscore is `\\w`, so 'bug' does match 'bug_fix' token."""
         rule = _rule(rule_id="r1", keywords=("bug_fix",))
         router = IntentRouter(rules=[rule])
         result = router.classify("tag: bug_fix pending")
-        assert result is not None
-        assert result.matched_rule_id == "r1"
+        assert result == ClassificationResult(
+            workflow_id="demo_flow",
+            workflow_version=None,
+            confidence=0.8,
+            matched_rule_id="r1",
+            match_type="keyword",
+        )
 
 
 class TestRegexMatching:
@@ -119,8 +144,13 @@ class TestRegexMatching:
         )
         router = IntentRouter(rules=[rule])
         result = router.classify("Fix: resolve crash in worker")
-        assert result is not None
-        assert result.match_type == "regex"
+        assert result == ClassificationResult(
+            workflow_id="demo_flow",
+            workflow_version=None,
+            confidence=0.8,
+            matched_rule_id="r1",
+            match_type="regex",
+        )
 
     def test_regex_miss_returns_none(self) -> None:
         pattern = re.compile(r"^fix:", re.IGNORECASE)
@@ -143,7 +173,13 @@ class TestCombinedMatching:
         )
         router = IntentRouter(rules=[rule])
         # Both conditions met.
-        assert router.classify("Fix: urgent crash in worker") is not None
+        assert router.classify("Fix: urgent crash in worker") == ClassificationResult(
+            workflow_id="demo_flow",
+            workflow_version=None,
+            confidence=0.8,
+            matched_rule_id="r1",
+            match_type="combined",
+        )
         # Keyword only — no regex match.
         assert router.classify("urgent change needed") is None
         # Regex only — no keyword match.
@@ -167,9 +203,13 @@ class TestPriority:
         )
         router = IntentRouter(rules=[low, high])
         result = router.classify("please fix the crash")
-        assert result is not None
-        assert result.matched_rule_id == "high"
-        assert result.workflow_id == "other_flow"
+        assert result == ClassificationResult(
+            workflow_id="other_flow",
+            workflow_version=None,
+            confidence=0.9,
+            matched_rule_id="high",
+            match_type="keyword",
+        )
 
     def test_duplicate_priority_match_raises(self) -> None:
         r1 = _rule(rule_id="a", keywords=("fix",), priority=5)
@@ -210,10 +250,13 @@ class TestFallback:
             default_workflow_id="fallback_flow",
         )
         result = router.classify("unrelated text")
-        assert result is not None
-        assert result.workflow_id == "fallback_flow"
-        assert result.matched_rule_id == "__default__"
-        assert result.match_type == "default"
+        assert result == ClassificationResult(
+            workflow_id="fallback_flow",
+            workflow_version=None,
+            confidence=0.0,
+            matched_rule_id="__default__",
+            match_type="default",
+        )
 
     def test_llm_fallback_raises_classification_error_when_llm_missing(self) -> None:
         """PR-A6: llm_fallback now tries to call LLM; without [llm]


### PR DESCRIPTION
## Summary
- add the living PB-3 slice plan and point the post-beta status SSOT at issue #226
- strengthen the first weak-assertion tranche in intent router, config, and context-pack plumbing tests
- update the GitHub tracker so PB-3 is the active post-beta slice

## Testing
- python3 -m pytest tests/test_intent_router.py tests/test_config.py tests/test_context_pack_ref_plumbing.py -q

Refs #226
Refs #219
