### PR TITLE
[codex] Add PB-3 coordination status time seam

### DIFF
--- a/.claude/plans/PB-3-DETERMINISTIC-TEST-HYGIENE.md
+++ b/.claude/plans/PB-3-DETERMINISTIC-TEST-HYGIENE.md
@@ -46,3 +46,11 @@ kılmak ve deterministik olmayan test yüzeylerini küçük tranche'lerle kapatm
 
 İlk tranche merge olduktan sonra doğru devam, time-dependent seam envanterini
 somut deterministic fix tranche'lerine bölmektir.
+
+## İkinci Tranche
+
+1. `ao_kernel.coordination.status.build_coordination_status(...)` için opsiyonel
+   `now` seam'i eklemek
+2. `tests/test_coordination_status.py` içindeki canlı saat kullanımını sabit
+   zamana çekmek
+3. snapshot `generated_at` alanını da deterministic sözleşme olarak pinlemek

--- a/ao_kernel/coordination/status.py
+++ b/ao_kernel/coordination/status.py
@@ -65,15 +65,24 @@ def _claim_state(
     )
 
 
-def build_coordination_status(workspace_root: Path | str) -> dict[str, Any]:
+def build_coordination_status(
+    workspace_root: Path | str,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
     """Build a machine-readable coordination snapshot.
 
     The snapshot is derived from the claim SSOT under ``claims.lock``. Dormant
     coordination returns a successful IDLE payload rather than raising: status
     visibility is allowed to say "nothing is active" without forcing an opt-in.
+    ``now`` exists so tests can pin time-sensitive claim-state transitions
+    without relying on wall-clock drift.
     """
     project_root = _project_root(workspace_root)
-    generated_at = datetime.now(timezone.utc).isoformat()
+    resolved_now = now or datetime.now(timezone.utc)
+    if resolved_now.tzinfo is None:
+        resolved_now = resolved_now.replace(tzinfo=timezone.utc)
+    generated_at = resolved_now.isoformat()
     policy = load_coordination_policy(project_root)
 
     if not policy.enabled:
@@ -112,7 +121,6 @@ def build_coordination_status(workspace_root: Path | str) -> dict[str, Any]:
     with file_lock(_claims_lock_path(project_root)):
         registry._ensure_index_consistent()
         index = registry._load_index()
-        now = datetime.now(timezone.utc)
         for agent_id, resource_ids in sorted(index.agents.items()):
             for resource_id in resource_ids:
                 claim = registry._load_claim_if_exists(resource_id)
@@ -123,7 +131,7 @@ def build_coordination_status(workspace_root: Path | str) -> dict[str, Any]:
                     claim.heartbeat_at,
                     expiry_seconds=policy.expiry_seconds,
                     takeover_grace_period_seconds=policy.takeover_grace_period_seconds,
-                    now=now,
+                    now=resolved_now,
                 )
                 claims.append(
                     {

--- a/tests/test_coordination_status.py
+++ b/tests/test_coordination_status.py
@@ -15,6 +15,8 @@ from ao_kernel.coordination.status import (
     render_coordination_status,
 )
 
+FIXED_NOW = datetime(2026, 4, 22, 12, 0, 0, tzinfo=timezone.utc)
+
 
 def _enabled_policy(**overrides: object) -> dict[str, object]:
     base: dict[str, object] = {
@@ -48,11 +50,12 @@ def _validate_snapshot(snapshot: dict) -> None:
 
 class TestCoordinationStatus:
     def test_disabled_policy_returns_idle_snapshot(self, tmp_path: Path) -> None:
-        snapshot = build_coordination_status(tmp_path)
+        snapshot = build_coordination_status(tmp_path, now=FIXED_NOW)
 
         _validate_snapshot(snapshot)
         assert snapshot["status"] == "IDLE"
         assert snapshot["coordination_enabled"] is False
+        assert snapshot["generated_at"] == FIXED_NOW.isoformat()
         assert snapshot["claims"] == []
         assert snapshot["summary"]["total_active"] == 0
         assert snapshot["summary"]["total_reported"] == 0
@@ -62,11 +65,12 @@ class TestCoordinationStatus:
     ) -> None:
         _write_workspace_policy(tmp_path, _enabled_policy())
 
-        snapshot = build_coordination_status(tmp_path)
+        snapshot = build_coordination_status(tmp_path, now=FIXED_NOW)
 
         _validate_snapshot(snapshot)
         assert snapshot["status"] == "IDLE"
         assert snapshot["coordination_enabled"] is True
+        assert snapshot["generated_at"] == FIXED_NOW.isoformat()
         assert snapshot["summary"]["coordination_enabled"] is True
 
     def test_path_area_claims_surface_resource_kind_and_label(
@@ -81,7 +85,7 @@ class TestCoordinationStatus:
             paths=["pkg/a.py", "tests/test_demo.py"],
         )
 
-        snapshot = build_coordination_status(tmp_path)
+        snapshot = build_coordination_status(tmp_path, now=FIXED_NOW)
 
         _validate_snapshot(snapshot)
         assert snapshot["status"] == "OK"
@@ -109,11 +113,10 @@ class TestCoordinationStatus:
         ready_doc = json.loads(
             claim_path(tmp_path, ready_claim.resource_id).read_text(encoding="utf-8")
         )
-        now = datetime.now(timezone.utc)
-        grace_doc["heartbeat_at"] = (now - timedelta(seconds=12)).isoformat()
-        grace_doc["expires_at"] = (now - timedelta(seconds=2)).isoformat()
-        ready_doc["heartbeat_at"] = (now - timedelta(seconds=20)).isoformat()
-        ready_doc["expires_at"] = (now - timedelta(seconds=10)).isoformat()
+        grace_doc["heartbeat_at"] = (FIXED_NOW - timedelta(seconds=12)).isoformat()
+        grace_doc["expires_at"] = (FIXED_NOW - timedelta(seconds=2)).isoformat()
+        ready_doc["heartbeat_at"] = (FIXED_NOW - timedelta(seconds=20)).isoformat()
+        ready_doc["expires_at"] = (FIXED_NOW - timedelta(seconds=10)).isoformat()
         from ao_kernel.coordination.claim import claim_revision
 
         grace_doc["revision"] = claim_revision(grace_doc)
@@ -127,7 +130,7 @@ class TestCoordinationStatus:
             encoding="utf-8",
         )
 
-        snapshot = build_coordination_status(tmp_path)
+        snapshot = build_coordination_status(tmp_path, now=FIXED_NOW)
 
         _validate_snapshot(snapshot)
         by_id = {item["work_item_id"]: item for item in snapshot["claims"]}
@@ -143,7 +146,9 @@ class TestCoordinationStatus:
         registry = ClaimRegistry(tmp_path)
         registry.acquire_claim("worktree-a", "agent-alpha")
 
-        rendered = render_coordination_status(build_coordination_status(tmp_path))
+        rendered = render_coordination_status(
+            build_coordination_status(tmp_path, now=FIXED_NOW)
+        )
 
         assert "== coordination status ==" in rendered
         assert "owner=agent-alpha" in rendered


### PR DESCRIPTION
## Summary
- add a narrow `now` seam to `build_coordination_status(...)` so claim-state snapshots can be tested deterministically
- move coordination status tests to a fixed timestamp and pin `generated_at` as part of the snapshot contract
- update the living PB-3 slice plan with the second tranche scope

## Testing
- python3 -m pytest tests/test_coordination_status.py tests/test_coordination_cli.py -q

Refs #226
Refs #219
