### PR TITLE
[codex] Harden PB-3 context store time seams

### DIFF
--- a/.claude/plans/PB-3-DETERMINISTIC-TEST-HYGIENE.md
+++ b/.claude/plans/PB-3-DETERMINISTIC-TEST-HYGIENE.md
@@ -54,3 +54,12 @@ somut deterministic fix tranche'lerine bölmektir.
 2. `tests/test_coordination_status.py` içindeki canlı saat kullanımını sabit
    zamana çekmek
 3. snapshot `generated_at` alanını da deterministic sözleşme olarak pinlemek
+
+## Üçüncü Tranche
+
+1. `ao_kernel._internal.session.context_store` içinde dağınık `datetime.now(...)`
+   çağrılarını mevcut `_now_iso8601()` seam'i ile hizalamak
+2. `tests/test_context_store_internal.py` içinde `new_context` ve
+   `renew_context` için exact timestamp sözleşmesini pinlemek
+3. daha geniş `context_store_coverage` alanını sonraki küçük tranche'lere
+   bırakmak

--- a/ao_kernel/_internal/session/context_store.py
+++ b/ao_kernel/_internal/session/context_store.py
@@ -196,8 +196,10 @@ def new_context(
     if not isinstance(ttl_seconds, int) or ttl_seconds < 60 or ttl_seconds > 604800:
         raise SessionContextError("INVALID_ARGS", "ttl_seconds must be in [60, 604800]")
 
-    now = datetime.now(timezone.utc)
-    created_at = now.isoformat().replace("+00:00", "Z")
+    created_at = _now_iso8601()
+    now = _parse_iso8601(created_at)
+    if now is None:
+        raise SessionContextError("INVALID_TIME", "failed to resolve current time")
     expires_at = (now + timedelta(seconds=int(ttl_seconds))).isoformat().replace("+00:00", "Z")
 
     ctx: dict[str, Any] = {
@@ -481,8 +483,10 @@ def renew_context(context: dict[str, Any], ttl_seconds: int) -> dict[str, Any]:
     if not isinstance(ttl_seconds, int) or ttl_seconds < 60 or ttl_seconds > 604800:
         raise SessionContextError("INVALID_ARGS", "ttl_seconds must be in [60, 604800]")
 
-    now = datetime.now(timezone.utc)
-    now_iso = now.isoformat().replace("+00:00", "Z")
+    now_iso = _now_iso8601()
+    now = _parse_iso8601(now_iso)
+    if now is None:
+        raise SessionContextError("INVALID_TIME", "failed to resolve current time")
     expires_at = (now + timedelta(seconds=int(ttl_seconds))).isoformat().replace("+00:00", "Z")
 
     context = prune_expired_decisions(context, now_iso)

--- a/tests/test_context_store_internal.py
+++ b/tests/test_context_store_internal.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+import ao_kernel._internal.session.context_store as context_store_module
 
 from ao_kernel._internal.session.context_store import (
     SessionContextError,
@@ -20,13 +21,28 @@ from ao_kernel._internal.session.context_store import (
     upsert_decision,
 )
 
+FIXED_CONTEXT_NOW = "2026-04-22T12:00:00Z"
+FIXED_RENEW_NOW = "2026-04-22T12:30:00Z"
+
 
 class TestNewContext:
-    def test_creates_valid_context(self, tmp_path: Path):
+    def test_creates_valid_context(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr(
+            context_store_module,
+            "_now_iso8601",
+            lambda: FIXED_CONTEXT_NOW,
+        )
         ctx = new_context("sess-001", str(tmp_path), 3600)
         assert ctx["session_id"] == "sess-001"
         assert ctx["version"] == "v1"
         assert ctx["ttl_seconds"] == 3600
+        assert ctx["created_at"] == FIXED_CONTEXT_NOW
+        assert ctx["updated_at"] == FIXED_CONTEXT_NOW
+        assert ctx["expires_at"] == "2026-04-22T13:00:00Z"
         assert ctx["ephemeral_decisions"] == []
         assert len(ctx["hashes"]["session_context_sha256"]) == 64
 
@@ -163,12 +179,27 @@ class TestSaveLoadRoundtrip:
 
 
 class TestRenewContext:
-    def test_renew_extends_ttl(self, tmp_path: Path):
+    def test_renew_extends_ttl(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr(
+            context_store_module,
+            "_now_iso8601",
+            lambda: FIXED_CONTEXT_NOW,
+        )
         ctx = new_context("renew", str(tmp_path), 600)
-        old_expires = ctx["expires_at"]
+        assert ctx["expires_at"] == "2026-04-22T12:10:00Z"
+        monkeypatch.setattr(
+            context_store_module,
+            "_now_iso8601",
+            lambda: FIXED_RENEW_NOW,
+        )
         ctx = renew_context(ctx, 7200)
         assert ctx["ttl_seconds"] == 7200
-        assert ctx["expires_at"] > old_expires
+        assert ctx["updated_at"] == FIXED_RENEW_NOW
+        assert ctx["expires_at"] == "2026-04-22T14:30:00Z"
 
     def test_renew_invalid_ttl_raises(self, tmp_path: Path):
         ctx = new_context("renew-bad", str(tmp_path), 3600)


### PR DESCRIPTION
## Summary
- align `new_context` and `renew_context` with the existing `_now_iso8601()` seam instead of using ad hoc wall-clock reads
- pin exact timestamp contracts for `new_context` and `renew_context` in internal tests
- extend the living PB-3 plan with the third tranche scope

## Testing
- python3 -m pytest tests/test_context_store_internal.py tests/test_context_store_coverage.py -q

Refs #226
Refs #219
