### PR TITLE
[codex] record PB-4 gh-cli-pr decision note

### DIFF
--- a/.claude/plans/PB-4-SUPPORT-SURFACE-WIDENING-DECISIONS.md
+++ b/.claude/plans/PB-4-SUPPORT-SURFACE-WIDENING-DECISIONS.md
@@ -201,6 +201,69 @@ Bugünkü tutarlılık hükmü:
    ve rollback koşullarını yazılı kontrol listesine çevirmek
 3. koşullar eksikse yüzeyi bilinçli olarak deferred bırakmak
 
+## Üçüncü Tranche — `gh-cli-pr` Karar Notu
+
+**Karar tarihi:** 2026-04-22
+
+İncelenen yüzeyler:
+
+1. `docs/PUBLIC-BETA.md`
+2. `docs/ADAPTERS.md`
+3. `docs/SUPPORT-BOUNDARY.md`
+4. `docs/ROLLBACK.md`
+5. `scripts/gh_cli_pr_smoke.py`
+6. `ao_kernel.real_adapter_smoke.run_gh_cli_pr_smoke(...)`
+7. ilk tranche canlı smoke kanıtı:
+   `python3 scripts/gh_cli_pr_smoke.py --output text`
+
+Karar:
+
+1. `gh-cli-pr` helper-backed lane bugün için **Beta (operator-managed
+   preflight only)** olarak kalır.
+2. Bunun nedeni helper smoke'un gerçek remote PR açmaması ve bunu özellikle
+   yapmamasıdır:
+   - helper `gh pr create --dry-run` kullanır
+   - helper bundled manifest dışından `--repo`, `--head`, `--base`, `--dry-run`
+     ekler
+   - doğruladığı şey auth, repo visibility ve CLI contract'tır; gerçek remote
+     side effect değildir
+3. `gh-cli-pr` tam E2E remote PR açılışı bugün için **Deferred** kalır.
+4. Bu deferred kararının nedeni yalnız smoke eksikliği değil; güvenli operator
+   prosedür eksikliğidir:
+   - disposable sandbox clone kullanımı ayrı belgelenmiş support runbook'u
+     seviyesinde pinli değildir
+   - `docs/ROLLBACK.md` paket ve source-repo rollback'ini anlatır, fakat yanlış
+     açılmış remote PR'ı kapatma / temizleme / repo-side cleanup akışını
+     tanımlamaz
+   - bu yüzden yanlış bir live smoke, uzak GitHub durumunda yan etki
+     bırakabilir
+
+Bugünkü tutarlılık hükmü:
+
+1. `PUBLIC-BETA.md` satırı doğru: helper-backed lane preflight-only'dir,
+   gerçek remote PR açmaz.
+2. `ADAPTERS.md` satırı doğru: current tier `Beta (operator-managed preflight
+   only)` ve tam live PR açılışı ayrı deferred yüzeydir.
+3. `SUPPORT-BOUNDARY.md` satırı doğru: helper-backed dry-run lane beta,
+   live `gh-cli-pr` PR opening deferred kabul edilir.
+4. `ROLLBACK.md` bugünkü shipped baseline için yeterlidir, fakat remote PR
+   cleanup runbook'u olmadığı için full-E2E promotion için tek başına yeterli
+   değildir.
+
+Üçüncü tranche sonucu:
+
+1. `gh-cli-pr` için yazılı karar artık nettir:
+   - dry-run helper smoke = beta preflight kanıtı
+   - gerçek remote PR açılışı = deferred
+2. Full-E2E promotion önkoşulları da nettir:
+   - disposable sandbox clone prosedürü
+   - remote PR cleanup / close / recovery runbook'u
+   - bu akışın canlı operator kanıtı
+3. Bu tranche sonunda zorunlu docs düzeltmesi çıkmadı; mevcut boundary anlatısı
+   bugünkü kanıtla tutarlı kaldı.
+4. `PB-4` teknik olarak closeout-ready duruma gelmiştir; ayrı closeout/issue
+   kapanış turu ile tamamlanabilir.
+
 ## Kabul Kriterleri
 
 1. Her aday yüzey için karar durumu açıktır:
@@ -239,6 +302,6 @@ python3 examples/demo_review.py --cleanup
 
 ## Beklenen Sonraki Adım
 
-Üçüncü tranche ile `gh-cli-pr` preflight-only boundary ve deferred full-E2E
-remote PR açılışı için disposable sandbox / rollback önkoşullarını karar
-notuna çevirmektir.
+`PB-4` closeout değerlendirmesi yapıp issue/status yüzeyinde tamamlandı
+işaretlemek; ardından `PB-5` adapter-path cost/evidence completeness hattına
+geçmektir.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -94,8 +94,12 @@ ayrı ayrı görünür kılmak.
   `claude-code-cli` lane'i smoke pass verse de Beta/operator-managed kalır;
   belirleyici sağlık sinyali helper smoke'tur, `claude auth status` tek başına
   yeterli değildir, env-token fallback support widening gerekçesi sayılmaz
-- sıradaki alt adım: `gh-cli-pr` preflight-only boundary ile deferred full-E2E
-  remote PR açılışı için karar notunu yazmak
+- üçüncü tranche kararı da netleşti:
+  `gh-cli-pr` helper smoke yalnız dry-run preflight kanıtı üretir; gerçek
+  remote PR açılışı disposable sandbox + remote cleanup/rollback runbook'u
+  olmadan widening adayı değildir ve deferred kalır
+- `PB-4` closeout-ready duruma geldi; sıradaki alt adım closeout değerlendirmesi
+  ve issue/status kapanış turudur
 
 ## 6. Sonra
 


### PR DESCRIPTION
## Özet
- PB-4 üçüncü tranche için `gh-cli-pr` boundary karar notunu ekle
- preflight-only helper lane ile deferred full-E2E remote PR açılışı arasındaki çizgiyi yazılı hale getir
- post-beta status SSOT'unu PB-4 closeout-ready durumuna ilerlet

## Karar
- `gh-cli-pr` helper smoke yalnız dry-run preflight kanıtı üretir
- gerçek remote PR açılışı disposable sandbox + remote cleanup/rollback runbook'u olmadan widening adayı değildir
- bu yüzden helper lane `Beta (operator-managed preflight only)` kalır
- tam live remote PR açılışı `Deferred` kalır

## Not
- zorunlu docs daraltması çıkmadı; mevcut support boundary anlatısı bugünkü kanıtla tutarlı
- sonraki aktif adım: PB-4 closeout / issue kapanış turu