### PR TITLE
docs: start PB-6 expansion gap map

### DIFF
--- a/.claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md
+++ b/.claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md
@@ -1,0 +1,200 @@
+# PB-6 — general-purpose expansion gap map
+
+**Durum tarihi:** 2026-04-23
+**İlişkili issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
+**Üst tracker:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
+**Durum:** In progress
+
+## Amaç
+
+`ao-kernel` bugün dar ama kanıtlı bir Public Beta support surface'e sahiptir.
+`PB-6`'nın amacı bu support boundary'yi hemen widen etmek değildir; dar
+baseline ile genel amaçlı production coding automation platform iddiası
+arasındaki gerçek boşlukları kanıt bazlı haritalamaktır.
+
+Bu slice şu soruya cevap vermelidir:
+
+> "Bugünkü repo, hangi somut eksikler nedeniyle hâlâ general-purpose
+> production-grade platform değildir ve bu eksikler hangi sırayla kapanmalıdır?"
+
+## Başlangıç Gerçeği
+
+Bugünkü measured baseline:
+
+1. `docs/PUBLIC-BETA.md` ve `docs/SUPPORT-BOUNDARY.md` narrow shipped baseline
+   tanımlar:
+   - module entrypoint'ler
+   - `ao-kernel doctor`
+   - bundled `review_ai_flow` + bundled `codex-stub`
+   - `examples/demo_review.py`
+   - packaging smoke
+2. Real-adapter lane'ler bugün helper-backed ve operator-managed durumdadır.
+3. Bundled extension / adapter / registry inventory'si runtime-backed support
+   claim ile aynı şey değildir.
+4. General-purpose platform iddiası için yalnız adapter binary varlığı veya tek
+   makinede geçen smoke yeterli değildir.
+
+## Canlı Baseline Kanıtı
+
+**Audit tarihi:** 2026-04-23
+
+Çalıştırılan komutlar:
+
+```bash
+python3 -m ao_kernel doctor
+python3 scripts/claude_code_cli_smoke.py --output json
+python3 scripts/gh_cli_pr_smoke.py --output json
+```
+
+Özet:
+
+1. `python3 -m ao_kernel doctor`
+   - `8 OK, 1 WARN, 0 FAIL`
+   - `runtime_backed=1`
+   - `contract_only=0`
+   - `quarantined=18`
+   - `remap_candidate_refs=69`
+   - `missing_runtime_refs=161`
+   - tek runtime-backed bundled extension: `PRJ-HELLO`
+2. `python3 scripts/claude_code_cli_smoke.py --output json`
+   - `overall_status="pass"`
+   - binary / auth / prompt_access / manifest_invocation check'leri geçti
+3. `python3 scripts/gh_cli_pr_smoke.py --output json`
+   - `overall_status="pass"`
+   - binary / auth / manifest_contract / repo_view / `gh pr create --dry-run`
+     check'leri geçti
+
+Hüküm:
+
+1. Operator helper lane'ler bugün canlı smoke verebiliyor.
+2. Buna rağmen repo hâlâ general-purpose production platform değildir; çünkü
+   runtime-backed support yüzeyi çok dardır ve inventory'nin büyük kısmı
+   quarantined durumdadır.
+
+## Bu Slice'ın Sınırı
+
+- general-purpose readiness için gap sınıflandırması
+- support widening önkoşullarının yazılı hale gelmesi
+- bundled inventory, real-adapter workflow ve write-side orchestration
+  boşluklarının tek tabloda görünür kılınması
+- ordered tranche backlog üretmek
+
+## Kapsam Dışı
+
+- doğrudan support boundary widening
+- `PB-6` içinde gerçek adapter lane promotion'ı tek PR'da gerçekleştirmek
+- deferred `bug_fix_flow` benzeri eski correctness işlerini yeniden açmak
+- yalnız doc güzelleştirme yapmak ama ölçülebilir gap tanımlamamak
+
+## Gap Haritası
+
+| Gap bucket | Bugünkü kanıt | Açık boşluk | Production-grade için gereken |
+|---|---|---|---|
+| Extension/runtime truth gap | `doctor` yalnız `PRJ-HELLO`yu runtime-backed görüyor; `quarantined=18` | Bundled inventory'nin çoğu runtime-backed değil, remap/missing ref debt yüksek | extension bazlı promote / quarantine / retire kararı + ölçülebilir truth target |
+| Real-adapter workflow graduation gap | `claude-code-cli` helper smoke yeşil | helper smoke workflow-driven support kanıtı değildir | end-to-end workflow smoke, failure-mode matrisi, support docs promotion kararı |
+| Write-side / PR orchestration gap | `gh-cli-pr` dry-run smoke yeşil | gerçek remote PR opening hâlâ deferred; disposable sandbox/rollback contract dar | side-effectful PR lane için bounded E2E kanıt ve rollback güvencesi |
+| Support boundary vs contract inventory gap | docs boundary dürüst, ama inventory çok geniş | operator bir manifest gördüğünde onu destekli yüzey sanabilir | contract inventory ile supported surface arasında daha sert sınıflandırma ve mapping |
+| Ops / incident / rollback widening gap | narrow baseline runbook mevcut | widened surface'ler için incident class, rollback, auth expiry, secret hygiene operasyonu eksik | operator lane bazlı runbook + known-bug + rollback + exit criteria paketleri |
+
+## İlk Verdict
+
+`PB-6` için en kritik açık bugün feature eksikliği değil, **bundled inventory ile
+gerçek runtime-backed surface arasındaki açıklığın büyüklüğüdür**.
+
+Bu nedenle doğru ilk tranche:
+
+1. extension/runtime truth gap'i sayısal ve extension-bazlı bir tabloya indirmek
+2. ardından yalnız gerçekten canlı smoke taşıyan adapter/workflow lane'ler için
+   graduation kriterlerini yazmak
+3. en son write-side ve ops widening kararlarına geçmek
+
+## Önerilen Tranche Sırası
+
+### `PB-6.1` Extension truth rationalization
+
+Amaç:
+
+1. Bundled extension inventory'yi `runtime_backed / contract_only / quarantined`
+   yanında eylem odaklı sınıflara indirmek:
+   - promote candidate
+   - quarantine-keep
+   - remap-needed
+   - retire/dead-reference
+2. `doctor` WARN yüzeyini yalnız sayım değil, karar girdisi haline getirmek
+
+DoD:
+
+1. bundled extension bazlı karar tablosu
+2. hangi extension'ların PB-6 içinde promotion adayı bile olmadığı yazılı
+3. quarantine azaltma veya explicit quarantine kabulü için sayısal hedef
+
+### `PB-6.2` Real-adapter workflow graduation criteria
+
+Amaç:
+
+1. `claude-code-cli` helper smoke ile gerçek workflow-backed support claim
+   arasındaki farkı kapatmak için gereken kanıt setini yazmak
+2. benchmark full-mode, helper smoke, workflow smoke ve shipped demo
+   yüzeylerini karıştırmamak
+
+DoD:
+
+1. `claude-code-cli` için promotion checklist
+2. failure-mode matrisi
+3. support-tier promotion için minimum smoke/test/doc şartları
+
+### `PB-6.3` Write-side / PR lane graduation criteria
+
+Amaç:
+
+1. `gh-cli-pr` dry-run preflight'tan gerçek remote PR opening'e geçişin
+   önkoşullarını netleştirmek
+2. disposable sandbox, rollback ve side-effect boundary'sini yazmak
+
+DoD:
+
+1. safe preflight ile live write lane arasındaki sınır net
+2. remote PR opening için rollback ve evidence koşulları yazılı
+
+### `PB-6.4` Support mapping hardening
+
+Amaç:
+
+1. contract inventory'deki yüzeylerin support-tier mapping'ini daha sert hale
+   getirmek
+2. doctor/report/docs aynı sınıfları konuşsun
+
+DoD:
+
+1. inventory-to-support mapping tablosu
+2. dead-reference veya aspirational manifest confusion riski düşürülmüş
+
+### `PB-6.5` Ops readiness for widened lanes
+
+Amaç:
+
+1. widened lane'ler için incident / rollback / known-bug / auth-expiry
+   işletme paketini tanımlamak
+
+DoD:
+
+1. widened lane operator runbook exit criteria
+2. support widening sonrası incident handling boşluğu kalmıyor
+
+## Başarı Kriterleri
+
+1. `PB-6` sonunda "general-purpose readiness" lafı soyut kalmaz; her gap somut
+   kanıta bağlanır.
+2. Her bundled yüzey için "neden bugün supported değil?" sorusuna kısa yazılı
+   cevap vardır.
+3. Sonraki runtime slice'lar rastgele değil, ordered tranche backlog'tan çıkar.
+4. Support widening kararı helper smoke veya manifest varlığına indirgenmez.
+
+## Beklenen Sonraki Adım
+
+`PB-6` için ilk uygulanabilir slice `PB-6.1` olacaktır:
+
+1. doctor truth inventory'yi extension bazlı karar tablosuna çevirmek
+2. quarantine/remap/missing-runtime ref debt'ini en yüksek sinyalli kümelerle
+   sınıflandırmak
+3. bu sınıflandırmadan sonra ancak gerçek promotion adaylarını ayırmak

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -1,6 +1,6 @@
 # Post-Beta Correctness and Expansion Status
 
-**Durum tarihi:** 2026-04-22
+**Durum tarihi:** 2026-04-23
 **Amaç:** Public Beta closeout sonrasında kalan correctness debt'ini
 fail-closed disiplinle kapatmak, support-surface widening kararlarını kanıtla
 yönetmek ve genel amaçlı production çizgisine geçiş için gerçek gap'leri
@@ -12,12 +12,12 @@ ayrı ayrı görünür kılmak.
 
 - **Execution status / backlog:** bu dosya
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
-- **Aktif slice planı:** `—` (`PB-5` closeout tamamlandı; sıradaki plan açılışı `PB-6` için)
+- **Aktif slice planı:** `.claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
-- **Aktif issue:** `—` (`PB-6` issue açılışı sıradaki iş)
+- **Aktif issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
 
 ## 2. Başlangıç Gerçeği
 
@@ -26,9 +26,8 @@ ayrı ayrı görünür kılmak.
 - Support boundary hâlâ bilerek dardır; `review_ai_flow + codex-stub` shipped
   baseline, gerçek adapter lane'leri ise operator-managed beta durumundadır.
 - Public Beta closeout sonrası aktif program odağı artık defer edilmiş ilk
-  correctness boşlukları değil; support-surface widening closeout'u bitmiş,
-  aktif odak adapter-path cost/evidence completeness ve onun arkasındaki daha
-  geniş expansion gap'lerdir.
+  correctness boşlukları değil; support-surface widening ve PB-5 closeout'u
+  tamamlandı, bugünkü aktif odak daha geniş expansion gap'lerin sıralanmasıdır.
 - Repo bugün hâlâ genel amaçlı production coding automation platformu değildir;
   bu programın amacı o iddiayı hemen widen etmek değil, önce kalan debt'i
   kontrollü kapatmaktır.
@@ -57,42 +56,46 @@ ayrı ayrı görünür kılmak.
 | `PB-3` deterministic test hygiene / time seams | Completed on `main` ([#226](https://github.com/Halildeu/ao-kernel/issues/226), [#227](https://github.com/Halildeu/ao-kernel/pull/227), [#228](https://github.com/Halildeu/ao-kernel/pull/228), [#229](https://github.com/Halildeu/ao-kernel/pull/229), [#230](https://github.com/Halildeu/ao-kernel/pull/230), [#231](https://github.com/Halildeu/ao-kernel/pull/231)) | zaman-bağımlı test ve zayıf assertion drift'ini sistematik azaltmak | targeted suite proof + residual seam inventory |
 | `PB-4` support-surface widening decisions | Completed on `main` ([#232](https://github.com/Halildeu/ao-kernel/issues/232), [#237](https://github.com/Halildeu/ao-kernel/pull/237)) | `gh-cli-pr` full E2E ve operator lane promotion kararlarını kanıtla vermek | canlı smoke + karar notu + docs parity |
 | `PB-5` adapter-path cost/evidence completeness | Completed ([#238](https://github.com/Halildeu/ao-kernel/issues/238)) | `cost_usd` reconcile ve evidence completeness yüzeyinde ayrı runtime gap olup olmadığını karara bağlamak; sonuç: docs parity closeout yeterli, ayrı tranche 3 gerekmedi | truth audit + targeted tests + docs parity closeout |
-| `PB-6` general-purpose expansion gap map | Planned | narrow beta'dan daha geniş production platform çizgisine geçiş için önkoşulları tabloya dökmek | written gap map + ordered backlog |
+| `PB-6` general-purpose expansion gap map | In progress ([#243](https://github.com/Halildeu/ao-kernel/issues/243)) | narrow beta'dan daha geniş production platform çizgisine geçiş için hangi yüzeylerin neden henüz promoted olmadığını canlı kanıtla sınıflandırmak | written gap map + ordered tranche backlog + canlı baseline |
 
 ## 5. Şimdi
 
-### `PB-5` — closeout kararı
+### `PB-6` — general-purpose expansion gap map
 
-`PB-5` bu turda kapanmıştır. Docs parity patch sonrasında yeniden yapılan
-runtime/test/evidence audit'i şu hükme varmıştır:
+`PB-6` aktif hat olarak açıldı. Bu slice'ın işi support boundary'yi hemen
+widen etmek değil; narrow Public Beta yüzeyi ile general-purpose production
+iddiası arasındaki somut boşlukları canlı kanıtla sınıflandırmaktır.
 
-1. `post_adapter_reconcile` runtime hook'u, executor wiring'i ve scorecard
-   consumer zinciri `main` üzerinde gerçektir.
-2. Kalan asıl problem runtime yokluğu değil, support-boundary ile
-   benchmark/operator dilinin scope ayrımıydı; tranche 2 bunu tek anlamlı hale
-   getirmiştir.
-3. Bu nedenle ayrı bir `PB-5 tranche 3` runtime/evidence fix hattı
-   açılmamıştır.
+Canlı baseline:
 
-Closeout kanıtı:
+1. `python3 -m ao_kernel doctor`
+   - `8 OK, 1 WARN, 0 FAIL`
+   - `runtime_backed=1`, `quarantined=18`, `missing_runtime_refs=161`
+2. `python3 scripts/claude_code_cli_smoke.py --output json`
+   - `overall_status="pass"`
+3. `python3 scripts/gh_cli_pr_smoke.py --output json`
+   - `overall_status="pass"`
 
-- `python3 -m pytest tests/test_post_adapter_reconcile.py -q` → `17 passed`
-- `python3 -m pytest tests/test_cost_marker_idempotency.py -q` → `12 passed`
-- `python3 -m pytest tests/test_scorecard_render.py -q` → `10 passed`
-- `python3 -m pytest tests/benchmarks/test_full_mode_smoke.py -q -m full_mode --benchmark-mode=full`
-  → `1 skipped, 5 deselected`
+İlk hüküm:
 
-Residual not:
+1. helper-backed beta lane'ler bugün canlı smoke veriyor
+2. buna rağmen runtime-backed surface hâlâ çok dar
+3. en kritik ilk gap, bundled inventory ile gerçek runtime-backed support
+   yüzeyi arasındaki açıklıktır
 
-- `tests/benchmarks/test_governed_review.py::TestCostReconcile::test_cost_usd_not_drained_in_fast_mode`
-  için `ADV-001` kalite advisory'si sürüyor; bu, ayrı runtime/evidence gap'i
-  değil test-hijyen backlog'udur.
+Sıradaki doğru alt adım:
+
+1. `PB-6.1` extension truth rationalization
+2. doctor truth inventory'yi extension bazlı karar tablosuna çevirmek
+3. promotion adayı / quarantine / retire kümelerini ayırmak
 
 ## 6. Sonra
 
-`PB-5` kapandığı için sıradaki doğru sıra:
+`PB-6` açıldıktan sonraki doğru sıra:
 
-1. `PB-6` general-purpose expansion gap map
+1. `PB-6.1` extension truth rationalization
+2. `PB-6.2` real-adapter workflow graduation criteria
+3. `PB-6.3` write-side / PR lane graduation criteria
 
 ## 7. Riskler
 
@@ -102,12 +105,13 @@ Residual not:
 | `PB-1` için stale backlog üzerinde çalışmak | Orta | canlı testle doğrula, sonra status'u düzelt |
 | Deterministic test hygiene işinde scope creep | Yüksek | `PB-3`ü seam inventory + küçük tranche fix'ler olarak dilimle |
 | Zayıf testlerle fake green oluşması | Yüksek | behavior-first assertions ve smoke kanıtı zorunlu |
+| Inventory genişliği nedeniyle yanlış promotion yapmak | Yüksek | extension bazlı karar tablosu olmadan support widening yapma |
 
 ## 8. Anlık Öncelik
 
 Bugünden itibaren doğru sıra:
 
-1. `PB-6` general-purpose expansion gap map
+1. `PB-6.1` extension truth rationalization
 
 ## 9. Güncelleme Protokolü
 


### PR DESCRIPTION
## Summary
- add the living PB-6 plan for general-purpose expansion gaps
- move the post-beta status SSOT to PB-6 as the active slice
- anchor PB-6 on live baseline evidence from doctor and helper-backed beta lane smokes

## Live baseline
- python3 -m ao_kernel doctor
- python3 scripts/claude_code_cli_smoke.py --output json
- python3 scripts/gh_cli_pr_smoke.py --output json

## Scope
- start PB-6 as a written gap map and ordered tranche backlog
- do not widen support boundary in this PR
- keep issue #243 open for follow-up tranche work

Refs #243