### PR TITLE
docs: confirm PB-6.1a retire/archive candidates

### DIFF
--- a/.claude/plans/PB-6.1-EXTENSION-TRUTH-RATIONALIZATION.md
+++ b/.claude/plans/PB-6.1-EXTENSION-TRUTH-RATIONALIZATION.md
@@ -92,7 +92,7 @@ gerekçesi ayrıca ispat edilmelidir.
 | promote candidate | 3 | `PRJ-CONTEXT-ORCHESTRATION`, `PRJ-KERNEL-API`, `PRJ-RELEASE-AUTOMATION` |
 | remap-needed | 7 | `PRJ-AIRUNNER`, `PRJ-DEPLOY`, `PRJ-GITHUB-OPS`, `PRJ-PLANNER`, `PRJ-PM-SUITE`, `PRJ-UX-NORTH-STAR`, `PRJ-WORK-INTAKE` |
 | quarantine-keep | 4 | `PRJ-ENFORCEMENT-PACK`, `PRJ-M0-MAINTAINABILITY`, `PRJ-OBSERVABILITY-OTEL`, `PRJ-ZANZIBAR-OPENFGA` |
-| retire/dead-reference candidate | 4 | `PRJ-EXECUTORPORT`, `PRJ-MEMORYPORT`, `PRJ-SEARCH`, `PRJ-UI-COCKPIT-LITE` |
+| confirmed retire/archive candidate | 4 | `PRJ-EXECUTORPORT`, `PRJ-MEMORYPORT`, `PRJ-SEARCH`, `PRJ-UI-COCKPIT-LITE` |
 
 ## Extension Bazlı Karar Tablosu
 
@@ -131,7 +131,7 @@ gerekçesi ayrıca ispat edilmelidir.
 | `PRJ-OBSERVABILITY-OTEL` | `missing=12`, `remap=3`, no entrypoint/ui | observability önemli ama bundled extension olarak canlı runtime iz düşümü zayıf | quarantine'de kalsın; önce concrete handler/ops planı gerekir |
 | `PRJ-ZANZIBAR-OPENFGA` | `missing=5`, `remap=1`, entrypoint yok | mimari/roadmap izi var fakat aktif runtime surface yok | quarantine'de kalsın; security/domain owner olmadan widen edilmesin |
 
-### Retire / dead-reference candidate
+### Confirmed retire / archive candidate
 
 | Extension | Sinyal | Karar gerekçesi | Sonraki karar |
 |---|---|---|---|
@@ -139,6 +139,30 @@ gerekçesi ayrıca ispat edilmelidir.
 | `PRJ-MEMORYPORT` | `entrypoints=0`, `ui=0`, `missing=9`, eski `src/orchestrator/memory/*` port refs | legacy bridge gibi davranıyor; runtime promotion gerekçesi yok | archive veya retire değerlendirmesi |
 | `PRJ-SEARCH` | `missing=9`, `remap=0`, `extensions/PRJ-SEARCH/*` ve `PRJ-UI-COCKPIT-LITE/keyword_search.py` gibi absent dosyalara bağlı | kendi canlı runtime'ı yok; başka stale UI yüzeyine bağımlı | retire adayı; ancak explicit owner çıkarsa yeniden açılır |
 | `PRJ-UI-COCKPIT-LITE` | `missing=29`, `remap=0`, büyük absent UI/server/test ağacı | en yüksek stale yük; bundled inventory'de en zayıf canlılık sinyali | archive/dead-reference doğrulama turu açılmalı |
+
+## `PB-6.1a` Confirmatory Pass
+
+`PB-6.1a` bu slice altında hedefli olarak çalıştırıldı:
+
+- plan: `.claude/plans/PB-6.1a-RETIRE-DEAD-REFERENCE-CONFIRMATION.md`
+- issue: [#247](https://github.com/Halildeu/ao-kernel/issues/247)
+
+Teyit sonucu:
+
+1. `PRJ-EXECUTORPORT`
+2. `PRJ-MEMORYPORT`
+3. `PRJ-SEARCH`
+4. `PRJ-UI-COCKPIT-LITE`
+
+bu tur sonunda **confirmed retire/archive candidate** olarak kaldı.
+
+Ortak kanıt:
+
+1. dördünün de `docs_ref` hedefi bugünkü repoda yok
+2. explicit runtime handler yok
+3. ref setleri ağırlıkla absent `extensions/*` veya eski `src/orchestrator/*`
+   katmanına bakıyor
+4. downgrade gerektirecek canlı runtime eşdeğeri bulunmadı
 
 ## İlk Hüküm
 
@@ -152,12 +176,9 @@ gerekçesi ayrıca ispat edilmelidir.
 
 ## Önerilen Sonraki Sıra
 
-1. `PB-6.1a` retire/dead-reference adayları için confirmatory pass
-   - özellikle `PRJ-EXECUTORPORT`, `PRJ-MEMORYPORT`, `PRJ-SEARCH`,
-     `PRJ-UI-COCKPIT-LITE`
-2. `PB-6.1b` promote candidate shortlist kararı
+1. `PB-6.1b` promote candidate shortlist kararı
    - `PRJ-CONTEXT-ORCHESTRATION`
    - `PRJ-KERNEL-API`
    - `PRJ-RELEASE-AUTOMATION`
-3. Bu shortlist'ten sonra ancak `PB-6.2`/`PB-6.3` widening slice'ları
+2. Bu shortlist'ten sonra ancak `PB-6.2`/`PB-6.3` widening slice'ları
    güvenli sıraya konabilir

--- a/.claude/plans/PB-6.1a-RETIRE-DEAD-REFERENCE-CONFIRMATION.md
+++ b/.claude/plans/PB-6.1a-RETIRE-DEAD-REFERENCE-CONFIRMATION.md
@@ -1,0 +1,90 @@
+# PB-6.1a — retire/dead-reference confirmatory pass
+
+**Durum tarihi:** 2026-04-23
+**İlişkili issue:** [#247](https://github.com/Halildeu/ao-kernel/issues/247)
+**Üst slice:** [#245](https://github.com/Halildeu/ao-kernel/issues/245)
+**Durum:** In progress
+
+## Amaç
+
+`PB-6.1` içinde retire/dead-reference adayı olarak işaretlenen dört extension'ın
+bu hükmü gerçekten hak edip etmediğini dosya seviyesinde teyit etmek.
+
+Bu slice şu soruya cevap verir:
+
+> "Bu dört extension için bundled inventory'de kalmayı savunacak canlı runtime
+> karşılığı var mı, yoksa archive/retire kararı artık yazılı olarak
+> savunulabilir mi?"
+
+## Hedefler
+
+1. `PRJ-EXECUTORPORT`
+2. `PRJ-MEMORYPORT`
+3. `PRJ-SEARCH`
+4. `PRJ-UI-COCKPIT-LITE`
+
+## Canlı Kanıt Paketi
+
+**Audit tarihi:** 2026-04-23
+
+Kullanılan komutlar:
+
+```bash
+python3 -m ao_kernel doctor
+python3 - <<'PY'
+from ao_kernel.extensions.loader import ExtensionRegistry
+...
+PY
+rg -n "PRJ-(EXECUTORPORT|MEMORYPORT|SEARCH|UI-COCKPIT-LITE)|..."
+```
+
+Ortak bulgular:
+
+1. Dördü de `truth=quarantined` ve `runtime_handler_registered=False`.
+2. Dördünün `docs_ref` hedefi olan `docs/OPERATIONS/EXTENSIONS.md` bugünkü
+   repoda mevcut değildir.
+3. Default handler registry bugün yalnız `PRJ-HELLO` içerir; bu dört yüzey için
+   explicit handler yoktur.
+4. Dört surface de ağırlıklı olarak eski `extensions/*` veya `src/orchestrator/*`
+   yollarına bakmaktadır.
+
+## Confirmatory Findings
+
+| Extension | Canlı sinyal | Hüküm | Gerekçe |
+|---|---|---|---|
+| `PRJ-EXECUTORPORT` | `entrypoints=0`, `ui=0`, `missing=9`, missing refs eski `src/orchestrator/executor_*` ve absent `extensions/PRJ-EXECUTORPORT/tests/*` yoluna gidiyor | Confirmed retire/archive candidate | köprü manifesti kalmış; bugünkü repo içinde ne ops yüzeyi ne runtime handler ne de yaşayan docs/test karşılığı var |
+| `PRJ-MEMORYPORT` | `entrypoints=0`, `ui=0`, `missing=9`, missing refs eski `src/orchestrator/memory/*` port katmanına gidiyor | Confirmed retire/archive candidate | legacy memory bridge kabuğu dışında canlı karşılık görünmüyor; bundled defaults'ta kalması support confusion üretiyor |
+| `PRJ-SEARCH` | `ops=['search-check']`, ama runtime code/test/readme absent; `extensions/PRJ-SEARCH/*` ve `PRJ-UI-COCKPIT-LITE/keyword_search.py` yok | Confirmed retire/archive candidate | isim olarak canlı görünse de manifestin dayandığı repo yüzeyi yok; başka stale UI yüzeyine bağımlı |
+| `PRJ-UI-COCKPIT-LITE` | `cockpit_lite` UI/ops iddiası var, fakat README/server ve 24+ test yolu absent; `missing=29` | Confirmed retire/archive candidate | en ağır stale yük burada; manifested UI surface bugünkü repo gerçeğinde taşınmıyor |
+
+## Neden Downgrade Etmedik
+
+Bu dört extension için "quarantine-keep" veya "remap-needed"e dönüş
+gerekçesi çıkmadı çünkü:
+
+1. missing refs'in çoğu taşınmış ama bulunabilir dosyalara değil, doğrudan
+   bugünkü ağaçta karşılığı olmayan eski repo segmentlerine bakıyor
+2. explicit runtime handler yok
+3. support doc anchor'ları bile yok
+4. en az ikisinde (`PRJ-EXECUTORPORT`, `PRJ-MEMORYPORT`) entrypoint/UI yüzeyi
+   tamamen boş
+
+## Karar
+
+`PB-6.1a` hükmü:
+
+1. Dört hedef de **confirmed retire/archive candidate** olarak kalır.
+2. Bunlar için near-term runtime promotion veya support widening hattı
+   açılmamalıdır.
+3. Sonraki mantıklı hareket ya:
+   - bundled defaults / registry içinde görünürlüklerini azaltacak archive planı,
+     ya da
+   - explicit owner çıkana kadar açıkça archived-candidate statüsü vermektir.
+
+## Beklenen Sonraki Adım
+
+`PB-6.1a` sonrasındaki doğru sıra:
+
+1. `PB-6.1b` promote candidate shortlist
+2. `PRJ-CONTEXT-ORCHESTRATION`, `PRJ-KERNEL-API`, `PRJ-RELEASE-AUTOMATION`
+   arasından ilk gerçek runtime promotion adayını seçmek

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -12,12 +12,12 @@ ayrı ayrı görünür kılmak.
 
 - **Execution status / backlog:** bu dosya
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
-- **Aktif slice planı:** `.claude/plans/PB-6.1-EXTENSION-TRUTH-RATIONALIZATION.md`
+- **Aktif slice planı:** `.claude/plans/PB-6.1a-RETIRE-DEAD-REFERENCE-CONFIRMATION.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
-- **Aktif issue:** [#245](https://github.com/Halildeu/ao-kernel/issues/245)
+- **Aktif issue:** [#247](https://github.com/Halildeu/ao-kernel/issues/247)
 
 ## 2. Başlangıç Gerçeği
 
@@ -60,11 +60,11 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### `PB-6.1` — extension truth rationalization
+### `PB-6.1a` — retire/dead-reference confirmatory pass
 
-`PB-6` içinde aktif alt hat artık `PB-6.1`'dir. Bu slice'ın işi, bundled
-extension inventory'yi tek parça "quarantined" kümesi gibi görmek yerine
-extension-bazlı karar tablosuna çevirmektir.
+`PB-6` içinde aktif alt hat artık `PB-6.1a`'dır. Bu slice'ın işi, `PB-6.1`
+karar tablosundaki dört retire/dead-reference adayının bu hükmü gerçekten
+hak edip etmediğini teyit etmektir.
 
 Canlı baseline:
 
@@ -76,30 +76,36 @@ Canlı baseline:
 3. `python3 scripts/gh_cli_pr_smoke.py --output json`
    - `overall_status="pass"`
 
-`PB-6.1` kararı:
+`PB-6.1a` hükmü:
 
-1. `PRJ-HELLO` dışındaki 18 extension aynı tedaviyle ele alınmayacak
-2. bucket ayrımı yazılı hale geldi:
-   - `promote candidate`
-   - `remap-needed`
-   - `quarantine-keep`
-   - `retire/dead-reference candidate`
-3. support widening bundan sonra bu karar tablosu olmadan ilerlemeyecek
+1. `PRJ-EXECUTORPORT`
+2. `PRJ-MEMORYPORT`
+3. `PRJ-SEARCH`
+4. `PRJ-UI-COCKPIT-LITE`
+
+hepsi confirmatory pass sonunda **confirmed retire/archive candidate** olarak
+kaldı.
+
+Teyit gerekçesi:
+
+1. dördünün de `docs_ref` hedefi bugünkü repoda yok
+2. explicit runtime handler yok
+3. missing ref kümeleri ağırlıkla absent `extensions/*` veya eski
+   `src/orchestrator/*` yollarına gidiyor
+4. downgrade gerektirecek canlı runtime eşdeğeri bulunmadı
 
 Sıradaki doğru alt adım:
 
-1. `PB-6.1a` retire/dead-reference adayları için confirmatory pass
-2. `PB-6.1b` promote candidate shortlist seçimi
-3. sonra ancak widening slice sırasını netleştirmek
+1. `PB-6.1b` promote candidate shortlist seçimi
+2. sonra widening slice sırasını netleştirmek
 
 ## 6. Sonra
 
 `PB-6` açıldıktan sonraki doğru sıra:
 
-1. `PB-6.1a` retire/dead-reference confirmatory pass
-2. `PB-6.1b` promote candidate shortlist
-3. `PB-6.2` real-adapter workflow graduation criteria
-4. `PB-6.3` write-side / PR lane graduation criteria
+1. `PB-6.1b` promote candidate shortlist
+2. `PB-6.2` real-adapter workflow graduation criteria
+3. `PB-6.3` write-side / PR lane graduation criteria
 
 ## 7. Riskler
 
@@ -115,7 +121,7 @@ Sıradaki doğru alt adım:
 
 Bugünden itibaren doğru sıra:
 
-1. `PB-6.1a` retire/dead-reference confirmatory pass
+1. `PB-6.1b` promote candidate shortlist
 
 ## 9. Güncelleme Protokolü
 


### PR DESCRIPTION
## Summary
- add the living PB-6.1a confirmatory pass note for retire/dead-reference candidates
- keep PB-6.1 in sync by upgrading the four target extensions to confirmed retire/archive candidates
- move the post-beta status SSOT to PB-6.1a and advance the next step to PB-6.1b

## Targets confirmed
- PRJ-EXECUTORPORT
- PRJ-MEMORYPORT
- PRJ-SEARCH
- PRJ-UI-COCKPIT-LITE

## Live evidence used
- python3 -m ao_kernel doctor
- ExtensionRegistry truth dump for the four targets
- repo-wide rg for missing docs/runtime/test counterparts

## Scope
- no support widening
- no runtime handler changes
- no bundled extension removals yet; this PR only confirms the candidates and records the decision

Refs #247
Refs #245