### PR TITLE
[codex] close PB-6.1b promote shortlist

### DIFF
--- a/.claude/plans/PB-6.1-EXTENSION-TRUTH-RATIONALIZATION.md
+++ b/.claude/plans/PB-6.1-EXTENSION-TRUTH-RATIONALIZATION.md
@@ -164,6 +164,50 @@ Ortak kanıt:
    katmanına bakıyor
 4. downgrade gerektirecek canlı runtime eşdeğeri bulunmadı
 
+Closeout:
+
+1. PR: [#248](https://github.com/Halildeu/ao-kernel/pull/248)
+2. issue: [#247](https://github.com/Halildeu/ao-kernel/issues/247)
+3. sonuç: dört aday da confirm edildi, `PB-6.1a` kapanabilir
+
+## `PB-6.1b` Promote Shortlist
+
+`PB-6.1b` bu slice içinde bir sonraki aktif karar turudur:
+
+- plan: `.claude/plans/PB-6.1b-PROMOTE-CANDIDATE-SHORTLIST.md`
+- issue: [#249](https://github.com/Halildeu/ao-kernel/issues/249)
+
+Bu turun amacı, üç `promote candidate` arasından widening sırasını yazılı hale
+getirmektir:
+
+1. `PRJ-CONTEXT-ORCHESTRATION`
+2. `PRJ-KERNEL-API`
+3. `PRJ-RELEASE-AUTOMATION`
+
+Bu turda beklenen çıktı:
+
+1. ranked shortlist: `first / second / hold`
+2. her aday için kısa ama savunulabilir gerekçe
+3. shortlist sonucunun `PB-6.2` ve `PB-6.3` sırasını nasıl etkilediği
+
+Closeout kararı:
+
+| Sıra | Extension | Karar |
+|---|---|---|
+| `first` | `PRJ-KERNEL-API` | `promote-now candidate` |
+| `second` | `PRJ-CONTEXT-ORCHESTRATION` | `later candidate` |
+| `hold` | `PRJ-RELEASE-AUTOMATION` | `not-now` |
+
+Gerekçe:
+
+1. `PRJ-KERNEL-API`, yaşayan `ao_kernel/_internal/prj_kernel_api/*` runtime
+   kodu ve mevcut `kernel_api_actions` dispatch modeli nedeniyle en düşük
+   blast-radius promotion hattıdır.
+2. `PRJ-CONTEXT-ORCHESTRATION`, canlı context koduna sahip olsa da ops/UI
+   yüzeyi daha geniştir ve önce owner/remap boundary ister.
+3. `PRJ-RELEASE-AUTOMATION`, repo governance yönüyle hizalıdır fakat dedicated
+   runtime module bugünkü repoda yoktur; bu yüzden hold kalır.
+
 ## İlk Hüküm
 
 1. General-purpose readiness'i bugün en çok yavaşlatan şey "çok extension var"

--- a/.claude/plans/PB-6.1b-PROMOTE-CANDIDATE-SHORTLIST.md
+++ b/.claude/plans/PB-6.1b-PROMOTE-CANDIDATE-SHORTLIST.md
@@ -1,0 +1,197 @@
+# PB-6.1b — promote candidate shortlist
+
+**Durum tarihi:** 2026-04-23
+**İlişkili issue:** [#249](https://github.com/Halildeu/ao-kernel/issues/249)
+**Üst slice:** [#245](https://github.com/Halildeu/ao-kernel/issues/245)
+**Program:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
+**Durum:** Closeout drafted
+
+## Amaç
+
+`PB-6.1b`'nin işi, `PB-6.1` karar tablosundaki üç `promote candidate`
+extension arasından widening sırasını belirsizlik bırakmadan seçmektir.
+
+Bu slice şu soruya cevap verir:
+
+> "Hangi aday ilk runtime widening hattını hak ediyor, hangisi ikinci sırada
+> beklemeli ve hangisi bugün `not now` olarak tutulmalı?"
+
+Bu slice **promotion uygulamaz**; yalnız shortlist ve sıra kararı üretir.
+
+## Aday Kümesi
+
+1. `PRJ-CONTEXT-ORCHESTRATION`
+2. `PRJ-KERNEL-API`
+3. `PRJ-RELEASE-AUTOMATION`
+
+## Girdi Kanıtları
+
+1. `.claude/plans/PB-6.1-EXTENSION-TRUTH-RATIONALIZATION.md`
+   - extension-bazlı karar tablosu
+   - bucket ayrımı
+   - aday başına sinyal kümeleri
+2. `.claude/plans/PB-6.1a-RETIRE-DEAD-REFERENCE-CONFIRMATION.md`
+   - retire/archive tarafının netleşmiş olması
+3. canlı baseline
+   - `python3 -m ao_kernel doctor`
+   - `python3 scripts/claude_code_cli_smoke.py --output json`
+   - `python3 scripts/gh_cli_pr_smoke.py --output json`
+
+## İlk Canlı Sinyal
+
+İlk repo taraması sonunda üç aday için başlangıç resmi şöyledir:
+
+| Aday | Canlı sinyal | İlk okuma |
+|---|---|---|
+| `PRJ-CONTEXT-ORCHESTRATION` | `truth=quarantined`, `runtime_handler_registered=false`, `remap=5`, `missing=4`, güçlü ops/UI yüzeyi var; yaşayan iz daha çok `ao_kernel/context/*` + default policy/schema katmanında | stratejik olarak güçlü ama blast radius geniş; bounded widening için önce gerçek runtime owner çizgisi netleşmeli |
+| `PRJ-KERNEL-API` | `truth=quarantined`, `runtime_handler_registered=false`, `remap=3`, `missing=5`; repo içinde yaşayan `ao_kernel/_internal/prj_kernel_api/*` kodu ve yoğun test izi var | ilk bakışta en somut promotion adayı; canlı kod en yakın burada görünüyor |
+| `PRJ-RELEASE-AUTOMATION` | `truth=quarantined`, `runtime_handler_registered=false`, `remap=4`, `missing=6`; policy/schema ve ops yüzeyi var ama manifestte işaret edilen `src/prj_release_automation/release_engine.py` repo içinde yok | repo yönüyle hizalı ama immediate runtime promotion adayı olmaktan çok governance/ops contract adayı gibi duruyor |
+
+Bu tablo **nihai shortlist değildir**; yalnız ilk kanıt turunun working
+hypothesis'ini yazar.
+
+## Sıkı Karşılaştırma Kanıtı
+
+### Ortak gerçek
+
+Canlı doğrulama:
+
+```bash
+python3 -m ao_kernel doctor
+```
+
+Sonuç:
+
+1. `8 OK, 1 WARN, 0 FAIL`
+2. `runtime_backed=1`
+3. `quarantined=18`
+4. tek runtime-backed bundled extension hâlâ `PRJ-HELLO`
+
+Handler kontratı:
+
+1. `ao_kernel/extensions/bootstrap.py` otomatik discovery yapmıyor.
+2. Bundled runtime promotion için explicit handler kaydı gerekiyor.
+3. `_DEFAULT_HANDLERS` bugün yalnız `PRJ-HELLO` içeriyor.
+4. İlk aktif dispatch yüzeyi `kernel_api_actions`; `ops` yüzeyleri için aynı
+   derecede dar ve hazır handler kontratı yok.
+
+Bu nedenle "manifestte entrypoint var" tek başına promotion kanıtı değildir.
+Promotion adayı, explicit handler + bounded smoke + docs boundary kurmaya en
+yakın yüzey olmalıdır.
+
+### Aday karşılaştırması
+
+| Aday | Runtime yakınlığı | Handler/smoke kurulabilirliği | Blast radius | Hüküm |
+|---|---|---|---|---|
+| `PRJ-KERNEL-API` | En güçlü. Repo içinde `ao_kernel/_internal/prj_kernel_api/*` altında 15 Python modülü ve public `ao_kernel.llm`/client kullanım izi var. | En düşük riskli. Mevcut dispatch modeli zaten `kernel_api_actions` için tasarlanmış; manifestteki 5 action bounded handler smoke'a çevrilebilir. | Düşük/orta. İlk promotion yalnız action registration + read-only smoke ile sınırlandırılabilir. | **first / promote-now candidate** |
+| `PRJ-CONTEXT-ORCHESTRATION` | Güçlü ama dağınık. `ao_kernel/context/*` altında yaşayan kod ve çok sayıda test var; fakat manifestteki ops/UI entrypoint'ler doğrudan hazır dispatch yüzeyine bağlanmıyor. | Orta/yüksek riskli. Önce `ops` handler kontratı veya context-specific action mapping netleşmeli. | Yüksek. Context yüzeyi session, memory, retrieval ve orchestration katmanlarına yayılıyor. | **second / later candidate** |
+| `PRJ-RELEASE-AUTOMATION` | Zayıf. Policy/schema var, fakat manifestte işaret edilen `src/prj_release_automation/release_engine.py` bugünkü repoda yok. | Zayıf. Runtime module ve handler owner önce kurulmadan smoke anlamlı olmaz. | Orta. Repo governance yönüyle hizalı ama extension promotion bugünkü runtime gerçeğini aşırı genişletir. | **hold / not-now** |
+
+### Ek sayısal sinyal
+
+İlk tarama sayımları:
+
+1. `PRJ-KERNEL-API`
+   - `ao_kernel/_internal/prj_kernel_api`: 15 Python modülü
+   - ilgili test izi: 22 test dosyası
+   - manifest: `kernel_api_actions=5`, `ops=0`
+2. `PRJ-CONTEXT-ORCHESTRATION`
+   - `ao_kernel/context`: 18 Python modülü
+   - ilgili test izi: 55 test dosyası
+   - manifest: `ops=9`, `ops_single_gate=2`, `ui_surfaces=2`
+3. `PRJ-RELEASE-AUTOMATION`
+   - dedicated runtime module: yok
+   - manifest: `ops=6`, `ui_surfaces=2`
+   - canlı iz: default policy/schema ve repo governance süreci; extension
+     runtime kodu değil
+
+## Karar Soruları
+
+### `PRJ-CONTEXT-ORCHESTRATION`
+
+1. Bugünkü repoda gerçekten owner atanabilecek yaşayan runtime yüzeyi var mı?
+2. Mevcut debt daha çok remap/policy/test ref temizliği mi, yoksa handler
+   eksikliği mi?
+3. Bu aday önce seçilirse `PB-6.2` ve `PB-6.3` için blast radius kabul
+   edilebilir mi?
+
+### `PRJ-KERNEL-API`
+
+1. `ao_kernel/_internal/prj_kernel_api/*` kodu bounded bir promotion hattı için
+   yeterli çekirdeği sağlıyor mu?
+2. Minimal handler registration + action smoke paketi diğer adaylardan daha mı
+   düşük riskli?
+3. Operator-facing support boundary en temiz burada mı kurulabilir?
+
+### `PRJ-RELEASE-AUTOMATION`
+
+1. Repo yönüyle hizası güçlü olsa da extension promotion için runtime yüzey
+   gerçekten mevcut mu?
+2. Bu aday widening yerine governance/docs karakteri ağır basan bir yüzey mi?
+3. Promotion seçilirse rollback ve operator prerequisites net biçimde
+   taşınabilir mi?
+
+## Karar Ekseni
+
+Her aday şu eksenlerde kıyaslanacak:
+
+1. **Runtime yakınlığı:** yaşayan kod, handler'a yakınlık, invocation yüzeyi
+2. **Owner sinyali:** repo yönü, sorumluluk sınırı, operator anlamlılığı
+3. **Kanıt kurulabilirliği:** bounded smoke/test/docs boundary kurulabilir mi?
+4. **Blast radius:** yanlış sırada seçildiğinde geri dönüş maliyeti
+5. **Bağımlılık yükü:** `PB-6.2` ve `PB-6.3` sırasını ne kadar zorlar?
+
+## Beklenen Çıktı
+
+1. `first / second / hold` formatında ranked shortlist
+2. Her aday için kısa ama savunulabilir `promote-now / later / not-now`
+   gerekçesi
+3. Shortlist sonucunun `PB-6.2` ve `PB-6.3` sırasını nasıl etkilediği
+4. Status SSOT ve issue yüzeyinin bu kararla hizalanması
+
+## Kapsam Dışı
+
+1. Runtime handler implementasyonu
+2. Support boundary widening
+3. Adapter certification veya yeni smoke ekleme
+4. `retire/archive` kararını yeniden açma
+
+## Kabul Kriteri
+
+1. Üç adayın hiçbiri "genel his" ile değil, repo içi kanıtla sıralanmış olacak.
+2. Çıktı sonunda widening için tek bir "ilk aday" açıkça seçilmiş olacak.
+3. `PB-6.2` ve `PB-6.3` için hangi adayın hangi sırayı tetiklediği yazılı
+   hale gelecek.
+4. Yaşayan status dosyası bu slice'ı aktif iş olarak gösterecek.
+
+## Closeout Kararı
+
+### Ranked shortlist
+
+| Sıra | Aday | Karar | Gerekçe |
+|---|---|---|---|
+| `first` | `PRJ-KERNEL-API` | `promote-now candidate` | yaşayan internal runtime kodu, mevcut `kernel_api_actions` dispatch modeli ve bounded action smoke kurulabilirliği diğer adaylardan daha güçlü |
+| `second` | `PRJ-CONTEXT-ORCHESTRATION` | `later candidate` | canlı context kodu güçlü fakat manifest ops/UI yüzeyi geniş; önce handler/owner sınırı ve remap planı netleşmeli |
+| `hold` | `PRJ-RELEASE-AUTOMATION` | `not-now` | repo governance yönüyle hizalı ama dedicated runtime module yok; promotion bugün gerçek runtime yüzeyini olduğundan büyük gösterir |
+
+### Sonraki hat etkisi
+
+`PB-6.1b` sonucu provisional `PB-6.2`/`PB-6.3` sırasını daraltır:
+
+1. Sıradaki runtime widening hattı `PRJ-KERNEL-API` olmalıdır.
+2. İlk implementasyon slice'ı support claim'i genişletmemeli; yalnız
+   `PRJ-KERNEL-API` için promotion criteria, handler boundary ve smoke
+   tasarımını yazmalıdır.
+3. `PRJ-CONTEXT-ORCHESTRATION`, `PRJ-KERNEL-API` hattı kapandıktan sonra ayrı
+   remap/owner slice'ına girmelidir.
+4. `PRJ-RELEASE-AUTOMATION`, dedicated runtime module veya explicit owner
+   çıkana kadar hold kalmalıdır.
+
+### DoD durumu
+
+1. Üç aday repo içi kanıtla sıralandı.
+2. İlk widening adayı açıkça `PRJ-KERNEL-API` seçildi.
+3. İkinci aday `PRJ-CONTEXT-ORCHESTRATION`, hold adayı
+   `PRJ-RELEASE-AUTOMATION` olarak kaydedildi.
+4. Bu closeout runtime behavior değiştirmez; yalnız sıradaki expansion hattını
+   seçer.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -12,12 +12,12 @@ ayrı ayrı görünür kılmak.
 
 - **Execution status / backlog:** bu dosya
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
-- **Aktif slice planı:** `.claude/plans/PB-6.1a-RETIRE-DEAD-REFERENCE-CONFIRMATION.md`
+- **Aktif slice planı:** `.claude/plans/PB-6.1b-PROMOTE-CANDIDATE-SHORTLIST.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
-- **Aktif issue:** [#247](https://github.com/Halildeu/ao-kernel/issues/247)
+- **Aktif issue:** [#249](https://github.com/Halildeu/ao-kernel/issues/249)
 
 ## 2. Başlangıç Gerçeği
 
@@ -60,11 +60,11 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### `PB-6.1a` — retire/dead-reference confirmatory pass
+### `PB-6.1b` — promote candidate shortlist closeout
 
-`PB-6` içinde aktif alt hat artık `PB-6.1a`'dır. Bu slice'ın işi, `PB-6.1`
-karar tablosundaki dört retire/dead-reference adayının bu hükmü gerçekten
-hak edip etmediğini teyit etmektir.
+`PB-6` içinde aktif alt hat `PB-6.1b`'dir. Bu slice'ın işi, `PB-6.1` karar
+tablosundaki üç `promote candidate` arasından widening sırasını net biçimde
+seçmekti; closeout kararı bu branch üzerinde yazıldı.
 
 Canlı baseline:
 
@@ -76,7 +76,7 @@ Canlı baseline:
 3. `python3 scripts/gh_cli_pr_smoke.py --output json`
    - `overall_status="pass"`
 
-`PB-6.1a` hükmü:
+`PB-6.1a` closeout'u bu slice için artık giriş kanıtıdır:
 
 1. `PRJ-EXECUTORPORT`
 2. `PRJ-MEMORYPORT`
@@ -86,26 +86,44 @@ Canlı baseline:
 hepsi confirmatory pass sonunda **confirmed retire/archive candidate** olarak
 kaldı.
 
-Teyit gerekçesi:
+`PB-6.1b` karar sonucu:
 
-1. dördünün de `docs_ref` hedefi bugünkü repoda yok
-2. explicit runtime handler yok
-3. missing ref kümeleri ağırlıkla absent `extensions/*` veya eski
-   `src/orchestrator/*` yollarına gidiyor
-4. downgrade gerektirecek canlı runtime eşdeğeri bulunmadı
+1. `first`: `PRJ-KERNEL-API`
+2. `second`: `PRJ-CONTEXT-ORCHESTRATION`
+3. `hold`: `PRJ-RELEASE-AUTOMATION`
 
-Sıradaki doğru alt adım:
+Kısa gerekçe:
 
-1. `PB-6.1b` promote candidate shortlist seçimi
-2. sonra widening slice sırasını netleştirmek
+1. `PRJ-KERNEL-API`, `ao_kernel/_internal/prj_kernel_api/*` runtime kodu ve
+   mevcut `kernel_api_actions` dispatch modeli nedeniyle en düşük blast-radius
+   promotion hattıdır.
+2. `PRJ-CONTEXT-ORCHESTRATION`, güçlü context koduna rağmen daha geniş ops/UI
+   yüzeyi ve owner/remap kararı gerektirir.
+3. `PRJ-RELEASE-AUTOMATION`, dedicated runtime module eksik olduğu için hold
+   kalır.
+
+Beklenen çıktı:
+
+1. `PB-6.1b` PR'ı review/merge hattına girecek.
+2. Merge sonrası aktif hat `PB-6.2` olarak `PRJ-KERNEL-API` promotion
+   criteria ve handler/smoke boundary planına dönecek.
+3. `PRJ-CONTEXT-ORCHESTRATION` ikinci promotion adayı olarak ayrı slice'a
+   kalacak.
+4. `PRJ-RELEASE-AUTOMATION`, runtime module/owner çıkana kadar hold kalacak.
 
 ## 6. Sonra
 
 `PB-6` açıldıktan sonraki doğru sıra:
 
-1. `PB-6.1b` promote candidate shortlist
-2. `PB-6.2` real-adapter workflow graduation criteria
-3. `PB-6.3` write-side / PR lane graduation criteria
+1. `PB-6.2` `PRJ-KERNEL-API` promotion criteria + handler/smoke boundary
+2. `PB-6.3` `PRJ-CONTEXT-ORCHESTRATION` remap/owner decision
+3. `PB-6.4` real-adapter/write-side graduation criteria yeniden sıralama
+
+Not:
+
+1. Önceki provisional `PB-6.2`/`PB-6.3` isimleri `PB-6.1b` sonucu ile
+   daraltıldı; support widening gerçek extension promotion sırasına göre
+   ilerleyecek.
 
 ## 7. Riskler
 


### PR DESCRIPTION
## Summary

Closes the `PB-6.1b` promote-candidate shortlist decision and records the next expansion sequence.

## What changed

- Adds `.claude/plans/PB-6.1b-PROMOTE-CANDIDATE-SHORTLIST.md` as the dedicated closeout note for the three promote candidates.
- Updates the PB-6.1 rationalization plan with the ranked shortlist decision.
- Updates the post-beta expansion status SSOT so the next active lane is driven by the shortlist outcome.

## Decision

- `first`: `PRJ-KERNEL-API` as the promote-now candidate.
- `second`: `PRJ-CONTEXT-ORCHESTRATION` as the later candidate.
- `hold`: `PRJ-RELEASE-AUTOMATION` until a dedicated runtime module or explicit owner exists.

## Validation

- `git diff --check`
- `python3 -m ao_kernel doctor` -> `8 OK, 1 WARN, 0 FAIL` with the expected extension truth warning.

## Runtime impact

Docs/status only. No runtime behavior changes.
