### PR TITLE
[codex] promote PRJ-KERNEL-API minimum actions

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -75,11 +75,12 @@ ayrı ayrı görünür kılmak.
 `PB-6.2b` support boundary'yi ancak handler, manifest, tests, smoke, doctor
 truth metric ve docs parity aynı PR'da kapanırsa genişletebilir.
 
-Canlı baseline:
+`PB-6.2b` hedef runtime baseline:
 
 1. `python3 -m ao_kernel doctor`
    - `8 OK, 1 WARN, 0 FAIL`
-   - `runtime_backed=1`, `quarantined=18`, `missing_runtime_refs=161`
+   - `runtime_backed=2`, `quarantined=17`
+   - `runtime_backed_ids=PRJ-HELLO, PRJ-KERNEL-API`
 2. `python3 scripts/claude_code_cli_smoke.py --output json`
    - `overall_status="pass"`
 3. `python3 scripts/gh_cli_pr_smoke.py --output json`

--- a/ao_kernel/defaults/extensions/PRJ-KERNEL-API/extension.manifest.v1.json
+++ b/ao_kernel/defaults/extensions/PRJ-KERNEL-API/extension.manifest.v1.json
@@ -1,38 +1,31 @@
 {
   "ai_context_refs": [
-    "AGENTS.md",
-    "docs/OPERATIONS/EXTENSIONS.md",
-    "docs/OPERATIONS/SSOT-MAP.md",
-    "policies/policy_kernel_api_guardrails.v1.json",
-    "schemas/kernel-api-request.schema.v1.json",
-    "schemas/kernel-api-response.schema.v1.json",
-    "src/prj_kernel_api/adapter.py"
+    "extensions/handlers/prj_kernel_api.py",
+    "_internal/prj_kernel_api/llm_router.py",
+    "defaults/policies/policy_kernel_api_guardrails.v1.json",
+    "defaults/schemas/kernel-api-request.schema.v1.json",
+    "defaults/schemas/kernel-api-response.schema.v1.json"
   ],
   "compat": {
     "core_max": "",
     "core_min": "0.0.0",
     "notes": []
   },
-  "docs_ref": "docs/OPERATIONS/EXTENSIONS.md#ext-PRJ-KERNEL-API",
+  "docs_ref": "",
   "entrypoints": {
     "cockpit_sections": [],
     "kernel_api_actions": [
-      "doc_nav_check",
-      "project_status",
-      "roadmap_finish",
-      "roadmap_follow",
-      "system_status"
+      "system_status",
+      "doc_nav_check"
     ],
     "ops": [],
     "ops_single_gate": []
   },
-  "tests_entrypoints": [
-    "extensions/PRJ-KERNEL-API/tests/contract_test.py"
-  ],
+  "tests_entrypoints": [],
   "tests_policy": {
     "network_allowed": false,
     "notes": [
-      "contract_test_only"
+      "bounded_handler_tests_only"
     ]
   },
   "extension_id": "PRJ-KERNEL-API",
@@ -43,30 +36,33 @@
       "validate_schemas"
     ]
   },
+  "guardrails": {
+    "offline": true,
+    "network_default": false
+  },
   "layer_contract": {
     "notes": [],
     "read_roots_allowlist": [
-      "roadmaps/PROJECTS/PRJ-KERNEL-API/"
+      "defaults/policies/",
+      "defaults/schemas/",
+      "_internal/prj_kernel_api/"
     ],
-    "write_roots_allowlist": [
-      ".cache/",
-      "incubator/",
-      "external_allowlist/"
-    ]
+    "write_roots_allowlist": []
   },
-  "notes": [],
+  "notes": [
+    "Minimum runtime-backed tranche only: system_status and doc_nav_check.",
+    "project_status, roadmap_follow, and roadmap_finish remain deferred."
+  ],
   "origin": "CORE",
   "outputs": {
-    "workspace_reports": [
-      ".cache/reports/kernel_api_audit.v1.jsonl"
-    ]
+    "workspace_reports": []
   },
   "owner": "CORE",
   "policies": [],
   "policy_files": [
-    "policies/policy_kernel_api_guardrails.v1.json"
+    "defaults/policies/policy_kernel_api_guardrails.v1.json"
   ],
-  "semver": "0.1.0",
+  "semver": "0.2.0",
   "ui_surfaces": [],
   "version": "v1",
   "enabled": true

--- a/ao_kernel/extensions/bootstrap.py
+++ b/ao_kernel/extensions/bootstrap.py
@@ -82,6 +82,7 @@ def _manifest_activatable(
 # whole point of D7 preservation.
 _DEFAULT_HANDLERS: list[tuple[str, str]] = [
     ("PRJ-HELLO", "ao_kernel.extensions.handlers.prj_hello"),
+    ("PRJ-KERNEL-API", "ao_kernel.extensions.handlers.prj_kernel_api"),
 ]
 
 

--- a/ao_kernel/extensions/handlers/prj_kernel_api.py
+++ b/ao_kernel/extensions/handlers/prj_kernel_api.py
@@ -1,0 +1,111 @@
+"""Minimum runtime-backed handlers for PRJ-KERNEL-API.
+
+This module intentionally promotes only the bounded, read-only tranche:
+``system_status`` and ``doc_nav_check``. Wider project/roadmap actions stay
+deferred until their workspace and write-side contracts are explicit.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import ao_kernel
+
+from ao_kernel.extensions.loader import ExtensionRegistry
+
+EXTENSION_ID = "PRJ-KERNEL-API"
+SUPPORTED_ACTIONS = ("system_status", "doc_nav_check")
+DEFERRED_ACTIONS = ("project_status", "roadmap_follow", "roadmap_finish")
+
+
+def _truth_payload() -> dict[str, Any]:
+    registry = ExtensionRegistry()
+    registry.load_from_defaults()
+    summary = registry.truth_summary()
+    return {
+        "total_extensions": summary.total_extensions,
+        "runtime_backed": summary.runtime_backed,
+        "contract_only": summary.contract_only,
+        "quarantined": summary.quarantined,
+        "remap_candidate_refs": summary.remap_candidate_refs,
+        "missing_runtime_refs": summary.missing_runtime_refs,
+        "runtime_backed_ids": list(summary.runtime_backed_ids),
+        "quarantined_ids": list(summary.quarantined_ids),
+    }
+
+
+def _extension_payload() -> dict[str, Any]:
+    registry = ExtensionRegistry()
+    registry.load_from_defaults()
+    manifest = registry.get(EXTENSION_ID)
+    if manifest is None:
+        return {
+            "extension_id": EXTENSION_ID,
+            "present": False,
+            "truth_tier": "missing",
+            "runtime_handler_registered": False,
+            "missing_runtime_refs": [],
+            "remap_candidate_refs": [],
+            "kernel_api_actions": [],
+        }
+    return {
+        "extension_id": manifest.extension_id,
+        "present": True,
+        "truth_tier": manifest.truth_tier,
+        "runtime_handler_registered": manifest.runtime_handler_registered,
+        "missing_runtime_refs": list(manifest.missing_runtime_refs),
+        "remap_candidate_refs": list(manifest.remap_candidate_refs),
+        "kernel_api_actions": list(manifest.entrypoints.get("kernel_api_actions", [])),
+    }
+
+
+def _envelope(action: str, result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "action": action,
+        "extension_id": EXTENSION_ID,
+        "result": result,
+    }
+
+
+def system_status(params: dict[str, Any]) -> dict[str, Any]:
+    """Return a read-only runtime truth snapshot for the installed package."""
+    return _envelope(
+        "system_status",
+        {
+            "version": ao_kernel.__version__,
+            "supported_actions": list(SUPPORTED_ACTIONS),
+            "deferred_actions": list(DEFERRED_ACTIONS),
+            "extension_truth": _truth_payload(),
+            "params_echo": {
+                key: params[key]
+                for key in sorted(params)
+                if key in {"detail", "request_id"}
+            },
+        },
+    )
+
+
+def doc_nav_check(params: dict[str, Any]) -> dict[str, Any]:
+    """Return the package-local manifest/ref truth used by doctor audit."""
+    return _envelope(
+        "doc_nav_check",
+        {
+            "extension": _extension_payload(),
+            "supported_actions": list(SUPPORTED_ACTIONS),
+            "deferred_actions": list(DEFERRED_ACTIONS),
+            "network_required": False,
+            "workspace_write": False,
+            "params_echo": {
+                key: params[key]
+                for key in sorted(params)
+                if key in {"detail", "request_id"}
+            },
+        },
+    )
+
+
+def register(registry: Any) -> None:
+    """Register the bounded PRJ-KERNEL-API action tranche."""
+    registry.register("system_status", system_status, extension_id=EXTENSION_ID)
+    registry.register("doc_nav_check", doc_nav_check, extension_id=EXTENSION_ID)

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -39,7 +39,8 @@ istemek gerekir.
 | `python -m ao_kernel.cli version` | Shipped | CLI module kontratı |
 | Bundled `review_ai_flow` + bundled `codex-stub` | Shipped | Desteklenen demo workflow |
 | `examples/demo_review.py` | Shipped | Disposable workspace + canlı smoke `completed`; komut, `ao-kernel` kurulu bir Python environment'ı içinde çalıştırılmalıdır |
-| `ao-kernel doctor` | Shipped | Workspace health check + bundled extension truth audit; may emit WARN while contract-only / quarantined inventory remains |
+| `ao-kernel doctor` | Shipped | Workspace health check + bundled extension truth audit; may emit WARN while quarantined inventory remains |
+| `PRJ-KERNEL-API` minimum runtime-backed actions | Shipped | Only `system_status` and `doc_nav_check`; both are explicit bootstrap handlers, offline, read-only, and behavior-tested |
 | CI coverage gate 85% | Shipped | `pyproject.toml` ile hizalı (`test.yml --fail-under=85`) |
 | Adapter CLI command enforcement | Shipped | `policy_checked` / `policy_denied` artık resolved command ihlallerini de içerir; canonical sıra `step_started -> policy_checked -> adapter_invoked` korunur |
 | `{python_executable}` localized exception | Shipped | Yalnız manifest `command` alanı explicit `{python_executable}` kullandığında, yalnız resolved `sys.executable` realpath'i için geçerli; sandbox allowlist'ini mutate etmez |
@@ -74,6 +75,7 @@ istemek gerekir.
 | `gh-cli-pr` ile tam E2E PR açılışı | Deferred | Mevcut beta yüzey yalnız dry-run preflight'tır; gerçek remote PR açılışı henüz destek vaadi değildir |
 | `docs/roadmap/DEMO-SCRIPT-SPEC.md` içindeki 11 adımlı üç-adapter akış | Deferred | Canlı destek vaadi değildir |
 | Adapter-path `cost_usd` reconcile | Deferred | Public support claim olarak hâlâ deferred; benchmark/internal runtime hook varlığı bunu tek başına shipped veya beta support yüzeyine yükseltmez |
+| `PRJ-KERNEL-API` `project_status`, `roadmap_follow`, `roadmap_finish` actions | Deferred | Manifest ve runtime handler yüzeyi ilk tranche'ta bilerek iki read-only action'a daraltıldı; workspace/write-side contract netleşmeden desteklenmez |
 
 ## Known Bugs
 
@@ -91,9 +93,9 @@ istemek gerekir.
 - `claude-code-cli` ve `gh-cli-pr` bugün default demo yüzeyi değildir;
   yalnız helper-backed operator-managed beta satırları kadar desteklenir.
 - Bundled extension inventory bugün dar runtime-backed yüzeye sahiptir:
-  explicit bootstrap-backed smoke `PRJ-HELLO` ile sınırlıdır; kalan
-  manifestler doctor truth audit'inde contract-only veya quarantined
-  olarak görülebilir.
+  explicit bootstrap-backed smoke `PRJ-HELLO` ve `PRJ-KERNEL-API` için
+  yalnız `system_status` / `doc_nav_check` action'ları. Kalan manifestler
+  doctor truth audit'inde quarantined olarak görülebilir.
 - Bu doküman, ao-kernel'in genel amaçlı bir production coding automation
   platformu olduğunu iddia etmez; destek vaadi dar ve açıkça tablolanmış
   yüzeyler içindir.

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -10,7 +10,7 @@ operator-only, or just contract inventory?"
 
 | Layer | Included surfaces | Verification |
 |---|---|---|
-| Shipped baseline | module entrypoints, `ao-kernel doctor`, bundled `review_ai_flow`, `examples/demo_review.py`, packaging smoke | entrypoint checks, doctor, demo review smoke, CI |
+| Shipped baseline | module entrypoints, `ao-kernel doctor`, bundled `review_ai_flow`, `examples/demo_review.py`, packaging smoke, `PRJ-KERNEL-API` `system_status` / `doc_nav_check` actions | entrypoint checks, doctor, demo review smoke, behavior tests, CI |
 | Beta (operator-managed) | `claude-code-cli` helper-backed lane, `gh-cli-pr` helper-backed dry-run lane, real-adapter benchmark full mode | explicit smoke helpers and runbooks |
 | Contract inventory | bundled defaults, manifests, extensions, example inventory | loader/validator and truth audit only |
 | Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary |
@@ -27,6 +27,8 @@ The repo currently supports these as the default claim:
 - `ao-kernel doctor`
 - bundled `review_ai_flow` + bundled `codex-stub`
 - `python3 examples/demo_review.py --cleanup`
+- `PRJ-KERNEL-API` runtime-backed action: `system_status`
+- `PRJ-KERNEL-API` runtime-backed action: `doc_nav_check`
 
 ### Beta (operator-managed)
 
@@ -44,6 +46,13 @@ These may be bundled and schema-valid without being end-to-end supported:
 - bundled extensions and registry files
 - `examples/hello-llm/`
 - roadmap/spec documents
+
+For `PRJ-KERNEL-API`, these actions remain outside the shipped support
+boundary even though the extension has a minimum runtime-backed tranche:
+
+- `project_status`
+- `roadmap_follow`
+- `roadmap_finish`
 
 ## 3. What does NOT automatically widen support
 

--- a/tests/test_extension_dispatch.py
+++ b/tests/test_extension_dispatch.py
@@ -91,6 +91,62 @@ class TestBootstrapHelloExtension:
         assert "hello_world" in ext.entrypoints.get("kernel_api_actions", [])
 
 
+class TestBootstrapKernelApiExtension:
+    def test_kernel_api_default_handler_id_is_explicit(self):
+        from ao_kernel.extensions.bootstrap import default_handler_extension_ids
+
+        assert "PRJ-KERNEL-API" in default_handler_extension_ids()
+
+    def test_kernel_api_minimum_actions_registered_by_default(self):
+        client = AoKernelClient()
+
+        for action in ("system_status", "doc_nav_check"):
+            record = client.action_registry.resolve(action)
+            assert record is not None
+            assert record.extension_id == "PRJ-KERNEL-API"
+
+        for action in ("project_status", "roadmap_follow", "roadmap_finish"):
+            assert client.action_registry.resolve(action) is None
+
+    def test_kernel_api_system_status_payload_is_bounded(self):
+        client = AoKernelClient()
+
+        out = client.call_action("system_status", {"detail": True, "ignored": "x"})
+
+        assert out["ok"] is True
+        assert out["action"] == "system_status"
+        assert out["extension_id"] == "PRJ-KERNEL-API"
+        result = out["result"]
+        assert result["supported_actions"] == ["system_status", "doc_nav_check"]
+        assert result["deferred_actions"] == [
+            "project_status",
+            "roadmap_follow",
+            "roadmap_finish",
+        ]
+        assert result["params_echo"] == {"detail": True}
+        truth = result["extension_truth"]
+        assert truth["runtime_backed"] == 2
+        assert "PRJ-KERNEL-API" in truth["runtime_backed_ids"]
+
+    def test_kernel_api_doc_nav_check_reports_clean_runtime_refs(self):
+        client = AoKernelClient()
+
+        out = client.call_action("doc_nav_check")
+
+        assert out["ok"] is True
+        assert out["action"] == "doc_nav_check"
+        result = out["result"]
+        assert result["network_required"] is False
+        assert result["workspace_write"] is False
+        ext = result["extension"]
+        assert ext["extension_id"] == "PRJ-KERNEL-API"
+        assert ext["truth_tier"] == "runtime_backed"
+        assert ext["runtime_handler_registered"] is True
+        assert ext["kernel_api_actions"] == ["system_status", "doc_nav_check"]
+        assert ext["missing_runtime_refs"] == []
+        assert ext["remap_candidate_refs"] == []
+
+
 class TestBootstrapSkipsBlocked:
     def test_bootstrap_skips_disabled_manifest(self, tmp_path, monkeypatch):
         """Disabled manifests are not wired into the action registry."""
@@ -147,8 +203,10 @@ class TestBootstrapSkipsBlocked:
         from ao_kernel.extensions.bootstrap import register_default_handlers
         actions = ActionRegistry()
         registered = register_default_handlers(actions, extensions=None)
-        assert registered == 1
+        assert registered == 2
         assert actions.resolve("hello_world") is not None
+        assert actions.resolve("system_status") is not None
+        assert actions.resolve("doc_nav_check") is not None
 
 
 class TestFailureIsolation:

--- a/tests/test_extension_loader.py
+++ b/tests/test_extension_loader.py
@@ -61,10 +61,39 @@ class TestBundledDefaults:
         reg.load_from_defaults()
         summary = reg.truth_summary()
         assert summary.total_extensions >= 1
-        assert summary.runtime_backed >= 1
+        assert summary.runtime_backed >= 2
         assert "PRJ-HELLO" in summary.runtime_backed_ids
+        assert "PRJ-KERNEL-API" in summary.runtime_backed_ids
         assert summary.quarantined >= 1
         assert summary.missing_runtime_refs >= 1
+
+    def test_kernel_api_manifest_is_minimum_runtime_backed(self):
+        reg = ExtensionRegistry()
+        reg.load_from_defaults()
+        ext = reg.get("PRJ-KERNEL-API")
+        assert ext is not None
+        assert ext.truth_tier == "runtime_backed"
+        assert ext.runtime_handler_registered is True
+        assert ext.remap_candidate_refs == ()
+        assert ext.missing_runtime_refs == ()
+        assert ext.entrypoints.get("kernel_api_actions") == [
+            "system_status",
+            "doc_nav_check",
+        ]
+        assert ext.guardrails == {"offline": True, "network_default": False}
+        assert ext.policy_files == (
+            "defaults/policies/policy_kernel_api_guardrails.v1.json",
+        )
+        for action in ("project_status", "roadmap_follow", "roadmap_finish"):
+            assert action not in ext.entrypoints.get("kernel_api_actions", [])
+
+    def test_truth_summary_pins_kernel_api_promotion_metrics(self):
+        reg = ExtensionRegistry()
+        reg.load_from_defaults()
+        summary = reg.truth_summary()
+        assert summary.runtime_backed == 2
+        assert summary.quarantined == 17
+        assert summary.runtime_backed_ids == ("PRJ-HELLO", "PRJ-KERNEL-API")
 
     def test_list_enabled_filters_disabled_and_blocked(self):
         reg = ExtensionRegistry()


### PR DESCRIPTION
## Summary\n- add explicit PRJ-KERNEL-API runtime handler for the bounded read-only tranche\n- register only system_status and doc_nav_check; keep project_status, roadmap_follow, and roadmap_finish deferred\n- clean PRJ-KERNEL-API manifest refs so doctor truth promotes it to runtime_backed\n- update support docs/status and add behavior-first tests for handler ownership, payload, deferred actions, and doctor truth metrics\n\n## Validation\n- ruff check ao_kernel/extensions/bootstrap.py ao_kernel/extensions/handlers/prj_kernel_api.py tests/test_extension_dispatch.py tests/test_extension_loader.py\n- pytest tests/test_extension_dispatch.py tests/test_extension_loader.py tests/test_doctor_cmd.py -q\n- pytest tests/ --ignore=tests/benchmarks -q\n- mypy ao_kernel\n- python3 -m ao_kernel doctor\n- python3 scripts/packaging_smoke.py\n- fresh-venv wheel install + system_status/doc_nav_check action smoke\n\n## Notes\n- Full local ruff check . still reports pre-existing E402 findings in scripts/claude_code_cli_smoke.py and scripts/gh_cli_pr_smoke.py; this PR leaves that unrelated cleanup out of PB-6.2b scope.\n\nCloses #253.\nParent: #243.