### PR TITLE
[codex] decide context orchestration boundary

### DIFF
--- a/.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md
+++ b/.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md
@@ -1,0 +1,104 @@
+# PB-6.3 Context Orchestration Decision
+
+**Date:** 2026-04-23
+**Issue:** [#256](https://github.com/Halildeu/ao-kernel/issues/256)
+**Parent:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
+**Scope:** decision and owner-boundary record only; no runtime support widening
+
+## Decision
+
+`PRJ-CONTEXT-ORCHESTRATION` remains a later candidate, but it is not ready for
+runtime-backed promotion in this slice.
+
+Current classification:
+
+| Axis | Decision | Reason |
+|---|---|---|
+| Promotion class | `remap-needed` | Live `ao_kernel.context` code exists, but the manifest still points at legacy ops/UI/spec surfaces. |
+| Support boundary | keep quarantined | No explicit bundled handler exists and current entrypoints are not registered dispatch actions. |
+| Runtime owner | `ao_kernel.context` package for primitives; no extension handler owner yet | The code owner is real, but the extension activation boundary is missing. |
+| Next action | manifest/contract cleanup before implementation | Do not widen support until refs, action set, handler contract, tests, and docs line up. |
+
+## Evidence Snapshot
+
+Live inspection of the bundled manifest via `ExtensionRegistry.load_from_defaults()`
+shows:
+
+| Field | Value |
+|---|---|
+| `truth_tier` | `quarantined` |
+| `runtime_handler_registered` | `False` |
+| `remap_candidate_refs` | 5 |
+| `missing_runtime_refs` | 4 |
+| `ops` entrypoints | 9 |
+| `ops_single_gate` entrypoints | 2 |
+| `ui_surfaces` | 2 |
+| `kernel_api_actions` | 0 |
+
+Current ref audit:
+
+| Ref | Current status | Decision |
+|---|---|---|
+| `policies/policy_context_orchestration.v1.json` | remap candidate | Map to `defaults/policies/policy_context_orchestration.v1.json`. |
+| `schemas/context-pack-router-result.schema.v1.json` | remap candidate | Map to `defaults/schemas/context-pack-router-result.schema.v1.json`. |
+| `schemas/context-pack.schema.v1.json` | remap candidate | Map to `defaults/schemas/context-pack.schema.v1.json`. |
+| `schemas/policy-context-orchestration.schema.v1.json` | remap candidate | Map to `defaults/schemas/policy-context-orchestration.schema.v1.json`. |
+| `schemas/session-context.schema.json` | remap candidate | Map to `defaults/schemas/session-context.schema.json` only if the file exists in the distribution; otherwise remove or replace. |
+| `AGENTS.md` | missing | Do not keep as a bundled package ref unless the file is packaged. |
+| `docs/OPERATIONS/EXTENSIONS.md` | missing | Replace with current public support docs or remove until an extension operations page exists. |
+| `docs/OPERATIONS/SSOT-MAP.md` | missing | Replace with the current status SSOT or remove until packaged docs exist. |
+| `extensions/PRJ-CONTEXT-ORCHESTRATION/tests/contract_test.py` | missing | Replace with real `tests/test_context_*.py` coverage only after a handler contract exists. |
+
+## Owner Boundary
+
+The live runtime primitives are under `ao_kernel.context`. They cover profile
+routing, context compilation, session lifecycle, canonical memory, semantic
+retrieval, and vector-store resolution. That is a broad surface; promoting the
+extension as-is would overstate what is actually callable through the extension
+dispatch layer.
+
+Future runtime-backed promotion must introduce an explicit handler module:
+
+```text
+ao_kernel/extensions/handlers/prj_context_orchestration.py
+```
+
+The handler must be intentionally narrower than the current manifest. It should
+start with read-only, offline, behavior-testable actions and must not expose
+workspace write paths, session mutation, memory mutation, semantic retrieval
+network dependencies, or UI cockpit surfaces in the first tranche.
+
+Acceptable first-tranche action shape:
+
+| Candidate action | Runtime source | Allowed in first tranche? | Reason |
+|---|---|---|---|
+| `context_profiles_list` | `ao_kernel.context.profile_router.PROFILES` | Yes | Pure read-only metadata; no workspace required. |
+| `context_profile_detect` | `ao_kernel.context.profile_router.detect_profile` | Yes | Pure deterministic function over supplied messages. |
+| `context_compile_preview` | `ao_kernel.context.context_compiler.compile_context` | Maybe later | Only safe if semantic search is forced off and inputs are caller-supplied. |
+| `session_status` / `session_set` / `session_sync` | session lifecycle and workspace state | No | Workspace/state boundary needs a separate write/read contract. |
+| `context_pack_build` / `context_reconcile` / `context_drift` | report-producing ops/spec surfaces | No | These are not active extension dispatch handlers today. |
+| `cockpit_sections.context_orchestration` | UI surface | No | No shipped cockpit runtime is attached to this extension. |
+
+## Required Contract Before Promotion
+
+Before `PRJ-CONTEXT-ORCHESTRATION` can move from quarantined/contract cleanup to
+runtime-backed, a separate implementation contract must define:
+
+1. The exact `kernel_api_actions` action names.
+2. The handler module and registration in `ao_kernel/extensions/bootstrap.py`.
+3. Behavior-first tests for action registration and action payloads.
+4. A package-installed smoke or doctor proof that the extension remains truthful.
+5. Manifest ref cleanup from legacy top-level `policies/` and `schemas/` refs to
+   package-local `defaults/...` refs, or explicit removal of non-packaged refs.
+6. Public docs that say only those read-only actions are supported.
+
+## Closeout
+
+`PB-6.3` closes as a decision slice:
+
+1. No runtime behavior changes.
+2. No support boundary widening.
+3. `PRJ-CONTEXT-ORCHESTRATION` remains non-shipped until the next implementation
+   contract slice remaps refs and narrows action scope.
+4. The next active slice should be a manifest/contract cleanup for the same
+   extension, not another promotion candidate.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -13,6 +13,7 @@ ayrı ayrı görünür kılmak.
 - **Execution status / backlog:** bu dosya
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-6.2-KERNEL-API-PROMOTION-CONTRACT.md`
+- **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
@@ -101,23 +102,28 @@ Güncel runtime baseline:
 3. Support widening yine code path + behavior tests + smoke/doctor evidence +
    docs parity birlikte mevcut olmadan yapılmayacak.
 
-`PB-6.3` karar soruları:
+`PB-6.3` karar sonucu:
 
-1. `PRJ-CONTEXT-ORCHESTRATION` promote candidate mı, remap-needed mı,
-   quarantine-keep mi, yoksa retire candidate mı?
-2. Yaşayan runtime karşılığı varsa explicit handler/owner boundary hangi
-   modül ve action setiyle sınırlandırılmalı?
-3. Missing/remap refs hangi yaşayan package-local ref'lere bağlanabilir?
-4. Minimum runtime-backed tranche varsa hangi action'lar side-effect-free ve
-   behavior-testable?
+1. `PRJ-CONTEXT-ORCHESTRATION` `remap-needed` later candidate olarak kalır.
+2. Bu slice runtime behavior değiştirmez ve support boundary genişletmez.
+3. Extension bugün `truth_tier=quarantined`,
+   `runtime_handler_registered=False`, `remap_candidate_refs=5`,
+   `missing_runtime_refs=4` durumundadır.
+4. Canlı runtime owner sinyali `ao_kernel.context` paketidir; fakat extension
+   handler owner henüz yoktur.
+5. Gelecek runtime promotion ancak
+   `ao_kernel/extensions/handlers/prj_context_orchestration.py` gibi explicit
+   bir handler, dar `kernel_api_actions`, behavior-first tests ve docs parity
+   ile yapılabilir.
 
 Beklenen çıktı:
 
-1. `PRJ-CONTEXT-ORCHESTRATION` için written decision table çıkacak.
-2. Eğer promote edilecekse ayrı implementation contract açılacak.
-3. Eğer promote edilmeyecekse quarantine/retire gerekçesi status ve issue
-   yüzeyinde kapanacak.
-4. `PRJ-RELEASE-AUTOMATION`, `PB-6.3` kapanana kadar başlamayacak.
+1. Written decision table:
+   `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`.
+2. Manifest ref cleanup ve handler/action contract ayrı follow-up slice'a
+   ayrılacak.
+3. `PRJ-RELEASE-AUTOMATION`, context orchestration contract cleanup kararı
+   yazılmadan başlamayacak.
 
 ## 6. Sonra
 
@@ -127,14 +133,17 @@ Beklenen çıktı:
    - completed on `main` via [#255](https://github.com/Halildeu/ao-kernel/pull/255)
 2. `PB-6.3` `PRJ-CONTEXT-ORCHESTRATION` remap/owner decision
    - active via [#256](https://github.com/Halildeu/ao-kernel/issues/256)
-3. `PB-6.4` real-adapter/write-side graduation criteria yeniden sıralama
+   - decision: `remap-needed`, keep non-shipped until contract cleanup
+3. `PB-6.3b` `PRJ-CONTEXT-ORCHESTRATION` manifest/contract cleanup
+   - next slice after `PB-6.3` merge
+4. `PB-6.4` real-adapter/write-side graduation criteria yeniden sıralama
 
 Not:
 
 1. `PB-6.2` planning slice'ı support boundary'yi değiştirmedi; yalnız
    implementation PR için contract çıkardı.
 2. `PB-6.2b` support boundary'yi yalnız iki read-only action için genişletti.
-3. `PB-6.3` merge olmadan başka extension promotion hattı başlamayacak.
+3. `PB-6.3b` merge olmadan başka extension promotion hattı başlamayacak.
 
 ## 7. Riskler
 
@@ -151,6 +160,7 @@ Not:
 Bugünden itibaren doğru sıra:
 
 1. `PB-6.3` `PRJ-CONTEXT-ORCHESTRATION` remap/owner decision
+2. `PB-6.3b` `PRJ-CONTEXT-ORCHESTRATION` manifest/contract cleanup
 
 ## 9. Güncelleme Protokolü
 


### PR DESCRIPTION
## Summary
- records the PB-6.3 decision for `PRJ-CONTEXT-ORCHESTRATION`
- keeps the extension non-shipped/quarantined for now: `remap-needed`, no runtime support widening
- updates the living post-beta status SSOT so the next active slice is manifest/contract cleanup before any promotion work

## Decision
`PRJ-CONTEXT-ORCHESTRATION` has live `ao_kernel.context` primitives, but no explicit extension handler and a manifest that still points at legacy ops/UI/spec refs. The correct boundary is a later, narrow handler contract under `ao_kernel/extensions/handlers/prj_context_orchestration.py`, starting only with read-only offline actions.

## Validation
- `git diff --check`
- `python3 -m ao_kernel doctor` -> `8 OK, 1 WARN, 0 FAIL`, `runtime_backed=2`, `quarantined=17`

Closes #256.
