### PR TITLE
[codex] pb-6.3b: clean PRJ-CONTEXT-ORCHESTRATION manifest contract

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -88,8 +88,10 @@ Güncel runtime baseline:
 
 1. `python3 -m ao_kernel doctor`
    - `8 OK, 1 WARN, 0 FAIL`
-   - `runtime_backed=2`, `quarantined=17`
+   - `runtime_backed=2`, `contract_only=1`, `quarantined=16`
+   - `remap_candidate_refs=61`, `missing_runtime_refs=152`
    - `runtime_backed_ids=PRJ-HELLO, PRJ-KERNEL-API`
+   - `contract_only_ids=PRJ-CONTEXT-ORCHESTRATION`
 2. `python3 scripts/claude_code_cli_smoke.py --output json`
    - `overall_status="pass"`
 3. `python3 scripts/gh_cli_pr_smoke.py --output json`
@@ -107,7 +109,8 @@ Güncel runtime baseline:
 
 1. `PRJ-CONTEXT-ORCHESTRATION` `remap-needed` later candidate olarak kalır.
 2. Bu slice runtime behavior değiştirmez ve support boundary genişletmez.
-3. Extension bugün `truth_tier=quarantined`,
+3. `PB-6.3` karar anındaki snapshot'ta extension
+   `truth_tier=quarantined`,
    `runtime_handler_registered=False`, `remap_candidate_refs=5`,
    `missing_runtime_refs=4` durumundadır.
 4. Canlı runtime owner sinyali `ao_kernel.context` paketidir; fakat extension
@@ -116,6 +119,8 @@ Güncel runtime baseline:
    `ao_kernel/extensions/handlers/prj_context_orchestration.py` gibi explicit
    bir handler, dar `kernel_api_actions`, behavior-first tests ve docs parity
    ile yapılabilir.
+6. `PB-6.3b` manifest cleanup ile extension truth
+   `contract_only` katmanına çekilir; runtime handler hâlâ register edilmez.
 
 Beklenen çıktı:
 

--- a/ao_kernel/defaults/extensions/PRJ-CONTEXT-ORCHESTRATION/extension.manifest.v1.json
+++ b/ao_kernel/defaults/extensions/PRJ-CONTEXT-ORCHESTRATION/extension.manifest.v1.json
@@ -1,49 +1,32 @@
 {
   "ai_context_refs": [
-    "AGENTS.md",
-    "docs/OPERATIONS/EXTENSIONS.md",
-    "docs/OPERATIONS/SSOT-MAP.md",
-    "policies/policy_context_orchestration.v1.json",
-    "schemas/context-pack-router-result.schema.v1.json",
-    "schemas/context-pack.schema.v1.json",
-    "schemas/policy-context-orchestration.schema.v1.json",
-    "schemas/session-context.schema.json"
+    "context/profile_router.py",
+    "context/context_compiler.py",
+    "defaults/policies/policy_context_orchestration.v1.json",
+    "defaults/policies/policy_context_profile_registry.v1.json",
+    "defaults/schemas/context-pack-router-result.schema.v1.json",
+    "defaults/schemas/context-pack.schema.v1.json",
+    "defaults/schemas/policy-context-orchestration.schema.v1.json",
+    "defaults/schemas/session-context.schema.json"
   ],
   "compat": {
     "core_max": "",
     "core_min": "0.0.0",
     "notes": []
   },
-  "docs_ref": "docs/OPERATIONS/EXTENSIONS.md#ext-PRJ-CONTEXT-ORCHESTRATION",
+  "docs_ref": "",
   "enabled": true,
   "entrypoints": {
-    "cockpit_sections": [
-      "context_orchestration"
-    ],
+    "cockpit_sections": [],
     "kernel_api_actions": [],
-    "ops": [
-      "context-drift",
-      "context-health",
-      "context-pack-build",
-      "context-pack-route",
-      "context-reconcile",
-      "session-link-parent",
-      "session-set",
-      "session-status",
-      "session-sync"
-    ],
-    "ops_single_gate": [
-      "context-health-check",
-      "context-router-check"
-    ]
+    "ops": [],
+    "ops_single_gate": []
   },
-  "tests_entrypoints": [
-    "extensions/PRJ-CONTEXT-ORCHESTRATION/tests/contract_test.py"
-  ],
+  "tests_entrypoints": [],
   "tests_policy": {
     "network_allowed": false,
     "notes": [
-      "contract_test_only"
+      "contract_only_no_runtime_handler"
     ]
   },
   "extension_id": "PRJ-CONTEXT-ORCHESTRATION",
@@ -61,18 +44,14 @@
   },
   "layer_contract": {
     "notes": [
-      "skeleton_plus_ops_mapping"
+      "contract_cleanup_no_runtime_handler"
     ],
     "read_roots_allowlist": [
-      "extensions/PRJ-CONTEXT-ORCHESTRATION/",
-      "policies/",
-      "schemas/"
+      "context/",
+      "defaults/policies/",
+      "defaults/schemas/"
     ],
-    "write_roots_allowlist": [
-      ".cache/",
-      "incubator/",
-      "external_allowlist/"
-    ]
+    "write_roots_allowlist": []
   },
   "notes": [
     "ai_ile_yazilim_gelistirirken_baglam_yonetimi",
@@ -80,25 +59,24 @@
   ],
   "origin": "CORE",
   "outputs": {
-    "workspace_reports": [
-      ".cache/reports/context_orchestration_status.v1.json",
-      ".cache/reports/request_intake_to_exec_trace.v1.json",
-      ".cache/reports/context_drift_report.v1.json",
-      ".cache/reports/context_reconciliation_report.v1.json",
-      ".cache/reports/portfolio_context_health.v1.json"
-    ]
+    "workspace_reports": []
   },
   "owner": "CORE",
   "policies": [
-    "policies/policy_context_orchestration.v1.json"
+    "defaults/policies/policy_context_orchestration.v1.json"
   ],
   "policy_files": [
-    "policies/policy_context_orchestration.v1.json"
+    "defaults/policies/policy_context_orchestration.v1.json"
   ],
-  "semver": "0.2.0",
-  "ui_surfaces": [
-    "system-status",
-    "portfolio-status"
-  ],
+  "semver": "0.3.0",
+  "ui_surfaces": [],
+  "future_handler_contract": {
+    "module": "ao_kernel/extensions/handlers/prj_context_orchestration.py",
+    "kernel_api_actions": [
+      "context_profiles_list",
+      "context_profile_detect"
+    ],
+    "status": "not_registered"
+  },
   "version": "v1"
 }

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -94,8 +94,10 @@ istemek gerekir.
   yalnız helper-backed operator-managed beta satırları kadar desteklenir.
 - Bundled extension inventory bugün dar runtime-backed yüzeye sahiptir:
   explicit bootstrap-backed smoke `PRJ-HELLO` ve `PRJ-KERNEL-API` için
-  yalnız `system_status` / `doc_nav_check` action'ları. Kalan manifestler
-  doctor truth audit'inde quarantined olarak görülebilir.
+  yalnız `system_status` / `doc_nav_check` action'ları.
+  `PRJ-CONTEXT-ORCHESTRATION` bugün contract-only katmandadır
+  (manifest/contract cleanup sonrası, runtime handler hâlâ yoktur);
+  kalan manifestler doctor truth audit'inde quarantined olarak görülebilir.
 - Bu doküman, ao-kernel'in genel amaçlı bir production coding automation
   platformu olduğunu iddia etmez; destek vaadi dar ve açıkça tablolanmış
   yüzeyler içindir.

--- a/tests/test_extension_loader.py
+++ b/tests/test_extension_loader.py
@@ -62,6 +62,7 @@ class TestBundledDefaults:
         summary = reg.truth_summary()
         assert summary.total_extensions >= 1
         assert summary.runtime_backed >= 2
+        assert summary.contract_only >= 1
         assert "PRJ-HELLO" in summary.runtime_backed_ids
         assert "PRJ-KERNEL-API" in summary.runtime_backed_ids
         assert summary.quarantined >= 1
@@ -92,8 +93,30 @@ class TestBundledDefaults:
         reg.load_from_defaults()
         summary = reg.truth_summary()
         assert summary.runtime_backed == 2
-        assert summary.quarantined == 17
+        assert summary.contract_only == 1
+        assert summary.quarantined == 16
         assert summary.runtime_backed_ids == ("PRJ-HELLO", "PRJ-KERNEL-API")
+        assert summary.contract_only_ids == ("PRJ-CONTEXT-ORCHESTRATION",)
+
+    def test_context_orchestration_manifest_is_contract_only_with_clean_refs(self):
+        reg = ExtensionRegistry()
+        reg.load_from_defaults()
+        ext = reg.get("PRJ-CONTEXT-ORCHESTRATION")
+        assert ext is not None
+        assert ext.truth_tier == "contract_only"
+        assert ext.runtime_handler_registered is False
+        assert ext.remap_candidate_refs == ()
+        assert ext.missing_runtime_refs == ()
+        assert ext.docs_ref == ""
+        assert ext.tests_entrypoints == ()
+        assert ext.policy_files == (
+            "defaults/policies/policy_context_orchestration.v1.json",
+        )
+        assert ext.entrypoints.get("ops", []) == []
+        assert ext.entrypoints.get("ops_single_gate", []) == []
+        assert ext.entrypoints.get("cockpit_sections", []) == []
+        assert ext.ui_surfaces == []
+        assert ext.layer_contract.get("write_roots_allowlist") == []
 
     def test_list_enabled_filters_disabled_and_blocked(self):
         reg = ExtensionRegistry()


### PR DESCRIPTION
Summary:\n- PRJ-CONTEXT-ORCHESTRATION manifest contract-only truth surface\n- missing/remap-heavy refs removed, package-local refs kept\n- extension loader tests and PB status/docs parity updated\n\nScope guard:\n- no runtime handler registration\n- no support-surface widening\n- no orchestration action activation\n\nValidation:\n- pytest tests/test_extension_loader.py tests/test_extension_dispatch.py tests/test_doctor_cmd.py -q\n- ruff check tests/test_extension_loader.py\n- python3 -m ao_kernel doctor\n- python3 scripts/packaging_smoke.py\n\nRefs #259