### PR TITLE
[codex] docs/tests: PB-6.4a support mapping hardening

### DIFF
--- a/.claude/plans/PB-6.4a-SUPPORT-MAPPING-HARDENING.md
+++ b/.claude/plans/PB-6.4a-SUPPORT-MAPPING-HARDENING.md
@@ -1,0 +1,35 @@
+# PB-6.4a — Support Mapping Hardening
+
+**Status:** Active  
+**Date:** 2026-04-23  
+**Parent:** `PB-6.4`  
+**Issue:** [#265](https://github.com/Halildeu/ao-kernel/issues/265)
+
+## Amaç
+
+`doctor` truth sınıfları (`runtime_backed`, `contract_only`, `quarantined`)
+ile support boundary doküman dilini tek anlamlı hale getirmek.
+
+## Kapsam
+
+1. `docs/SUPPORT-BOUNDARY.md` mapping tablosu
+2. `docs/PUBLIC-BETA.md` truth-tier yorum kuralı
+3. `tests/test_doctor_cmd.py` structured report truth payload parity assert'leri
+4. status SSOT'ta aktif slice/issue hizası
+
+## Kapsam Dışı
+
+1. runtime handler/policy davranışı değiştirmek
+2. support widening implementation açmak
+3. write-side lane promotion yapmak
+
+## DoD
+
+1. truth tier -> support yorumu iki dokümanda da aynı
+2. `doctor` structured report testi `contract_only` ve id-count parity'yi pinler
+3. aktif issue + status dosyası aynı slice'ı gösterir
+
+## Kanıt
+
+1. `pytest tests/test_doctor_cmd.py tests/test_extension_loader.py -q`
+2. `python3 -m ao_kernel doctor`

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -19,7 +19,7 @@ ayrı ayrı görünür kılmak.
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
-- **Aktif issue:** [#263](https://github.com/Halildeu/ao-kernel/issues/263)
+- **Aktif issue:** [#265](https://github.com/Halildeu/ao-kernel/issues/265)
 
 ## 2. Başlangıç Gerçeği
 
@@ -76,6 +76,15 @@ bir sonraki implementation hattına taşımaktır.
    `.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md`
 3. Hedef: first/second/hold tranche sırasını yazılı kapıya çevirmek ve
    ilk implementasyon hattını `PB-6.4a` olarak tekillemek.
+
+`PB-6.4a` active implementation slice:
+
+1. Issue: [#265](https://github.com/Halildeu/ao-kernel/issues/265)
+2. Hedef: support mapping hardening (`truth tier` -> support language parity)
+3. Kapsam: `docs/PUBLIC-BETA.md`, `docs/SUPPORT-BOUNDARY.md`,
+   `tests/test_doctor_cmd.py`, status SSOT hizası
+4. Slice plan:
+   `.claude/plans/PB-6.4a-SUPPORT-MAPPING-HARDENING.md`
 
 `PB-6.2` contract slice'ı tamamlandı:
 
@@ -158,6 +167,7 @@ Güncel runtime baseline:
    - issue: [#263](https://github.com/Halildeu/ao-kernel/issues/263)
    - contract:
      `.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md`
+   - active implementation tranche: `PB-6.4a` ([#265](https://github.com/Halildeu/ao-kernel/issues/265))
 
 Not:
 

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -67,6 +67,19 @@ istemek gerekir.
 | Bundled `defaults/registry`, `defaults/extensions`, `defaults/operations`, `defaults/adapters` içeriği | Contract inventory | Ağaçta görünmesi destek vaadi değildir; ancak ilgili doküman/test/Public Beta matrisi o yüzeyi ayrıca işaretliyorsa destekli sayılır |
 | `examples/hello-llm/` | Example-only | SDK kullanım örneğidir; Public Beta destek vaadinin parçası değildir |
 
+### Truth-tier yorum kuralı
+
+`ao-kernel doctor` truth sınıfları support boundary ile aşağıdaki kuralla
+eşlenir:
+
+| Truth tier | Support yorumu |
+|---|---|
+| `runtime_backed` | Runtime owner vardır; yine de shipped/beta claim için behavior test + smoke + docs parity birlikte gerekir |
+| `contract_only` | Contract katmanı vardır, runtime register yoktur; support claim değildir |
+| `quarantined` | Açık runtime gap vardır; support dışı/deferred sınıfında kalır |
+
+Bu kuralın amacı, inventory görünürlüğünü support widening ile karıştırmamaktır.
+
 ## Deferred
 
 | Yüzey | Durum | Not |

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -15,6 +15,19 @@ operator-only, or just contract inventory?"
 | Contract inventory | bundled defaults, manifests, extensions, example inventory | loader/validator and truth audit only |
 | Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary |
 
+### 1.1 Truth inventory to support mapping
+
+`ao-kernel doctor` içindeki extension truth sınıfları support kararı için tek
+başına yeterli değildir. Bu sınıfların support yorumu aşağıdaki gibi sabittir:
+
+| Doctor truth tier | Support anlamı | Promotion kuralı |
+|---|---|---|
+| `runtime_backed` | Runtime handler + entrypoint bağlantısı vardır | Shipped/Beta claim için ek olarak behavior test + smoke + docs parity gerekir |
+| `contract_only` | Manifest/contract katmanı vardır, runtime handler register değildir | Tek başına support claim üretmez; implementation tranche gerektirir |
+| `quarantined` | Runtime owner/refs/entrypoint tarafında açık gap vardır | Support dışı kalır; yalnız karar/debt izleme yüzeyi olarak ele alınır |
+
+Bu tablo, `docs/PUBLIC-BETA.md` ve status SSOT ile aynı anlamda okunur.
+
 ## 2. Current line by line boundary
 
 ### Shipped baseline

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -28,6 +28,12 @@ class TestDoctorReport:
 
         extension_truth = report["extension_truth"]
         assert extension_truth["total_extensions"] >= 1
-        assert extension_truth["runtime_backed"] >= 1
+        assert extension_truth["runtime_backed"] >= 2
+        assert extension_truth["contract_only"] >= 1
         assert extension_truth["quarantined"] >= 1
         assert "PRJ-HELLO" in extension_truth["runtime_backed_ids"]
+        assert "PRJ-KERNEL-API" in extension_truth["runtime_backed_ids"]
+        assert "PRJ-CONTEXT-ORCHESTRATION" in extension_truth["contract_only_ids"]
+        assert len(extension_truth["runtime_backed_ids"]) == extension_truth["runtime_backed"]
+        assert len(extension_truth["contract_only_ids"]) == extension_truth["contract_only"]
+        assert len(extension_truth["quarantined_ids"]) == extension_truth["quarantined"]


### PR DESCRIPTION
Summary:
- add explicit truth-tier to support-language mapping in support docs
- start PB-6.4a slice plan and align status SSOT active issue to #265
- harden doctor structured report test with contract_only and id-count parity assertions

Scope guard:
- no runtime behavior change
- no support widening implementation
- docs + tests only

Validation:
- pytest tests/test_doctor_cmd.py tests/test_extension_loader.py -q
- ruff check tests/test_doctor_cmd.py
- python3 -m ao_kernel doctor

Refs #265
Refs #263