### PR TITLE
[codex] plans: PB-6.4b claude-code-cli readiness decision slice

### DIFF
--- a/.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md
+++ b/.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md
@@ -116,10 +116,16 @@ Bu beş kapıdan biri eksikse lane widening yapılmaz.
 
 1. first/second/hold lane sırası
 2. her lane için açık DoD/hold koşulu
-3. bir sonraki implementasyon hattının tekil seçimi (`PB-6.4a`)
+3. aktif implementasyon hattının tekil seçimi (`PB-6.4b`)
 
 ## 8) Sıradaki Adım
 
-Bu karar contract'ı merge olduktan sonra ilk implementasyon hattı:
+Güncel yürütüm sırası:
 
-1. `PB-6.4a` support mapping hardening (docs/truth parity slice)
+1. `PB-6.4a` support mapping hardening tamamlandı
+   - issue: [#265](https://github.com/Halildeu/ao-kernel/issues/265)
+   - PR: [#266](https://github.com/Halildeu/ao-kernel/pull/266)
+2. aktif hat: `PB-6.4b` `claude-code-cli` lane promotion readiness karar dilimi
+   - issue: [#267](https://github.com/Halildeu/ao-kernel/issues/267)
+   - plan:
+     `.claude/plans/PB-6.4b-CLAUDE-CODE-CLI-PROMOTION-READINESS.md`

--- a/.claude/plans/PB-6.4b-CLAUDE-CODE-CLI-PROMOTION-READINESS.md
+++ b/.claude/plans/PB-6.4b-CLAUDE-CODE-CLI-PROMOTION-READINESS.md
@@ -1,0 +1,90 @@
+# PB-6.4b — Claude Code CLI Lane Promotion Readiness (Decision Slice)
+
+**Status:** Active (decision)  
+**Date:** 2026-04-23  
+**Parent:** `PB-6.4`  
+**Parent issue:** [#263](https://github.com/Halildeu/ao-kernel/issues/263)  
+**Active issue:** [#267](https://github.com/Halildeu/ao-kernel/issues/267)
+
+## Amaç
+
+`claude-code-cli` lane'i için "operator-managed beta" seviyesinden
+promotion-candidate değerlendirmesine geçip geçemeyeceğini, yalnız kanıt ve
+risk kapılarıyla karar altına almak.
+
+## Kapsam
+
+1. Lane-specific promotion checklist (minimum kanıt seti)
+2. Failure-mode matrisi ve recovery kararları
+3. Known bugs (`KB-001`, `KB-002`) etkisinin decision logic'e bağlanması
+4. Karar çıktısı: `stay_beta` veya `promotion_candidate`
+
+## Kapsam Dışı
+
+1. Runtime widening implementation açmak
+2. `PUBLIC-BETA` support tier satırını bu slice içinde doğrudan yükseltmek
+3. Adapter invocation/policy davranışı değiştirmek
+
+## Canlı Baseline Kanıtı (Bu tur)
+
+Komut:
+
+`python3 scripts/claude_code_cli_smoke.py --output json`
+
+Gözlem (2026-04-23):
+
+1. `overall_status = pass`
+2. `version`, `auth_status`, `prompt_access`, `manifest_invocation` adımları
+   geçti
+3. `api_key_env_present = false` (session auth lane aktif)
+
+Not:
+
+Bu başarı tek başına promotion kararı üretmez; known-bug etkisi ve tekrar
+edilebilirlik kapıları ayrıca aranır.
+
+## Promotion Readiness Checklist (Draft)
+
+Her madde için durum `pass/fail/inconclusive` olarak işaretlenecek:
+
+1. **Binary + auth baseline**
+   - `claude --version` geçmeli
+   - `claude auth status` geçmeli
+2. **Canlı prompt erişimi**
+   - `claude -p` smoke geçmeli
+3. **Manifest invocation**
+   - bundled manifest ile smoke invocation geçmeli
+4. **Known-bug etkisi**
+   - `KB-001`/`KB-002` için güncel durum + workaround doğrulaması yazılı olmalı
+5. **Support parity**
+   - `PUBLIC-BETA`, `SUPPORT-BOUNDARY`, `KNOWN-BUGS` aynı tier dilini konuşmalı
+6. **Repeatability gate**
+   - en az 2 bağımsız çalıştırmada smoke başarısı veya deterministik fail
+     pattern'i kanıtlanmalı
+
+## Failure-Mode Matrisi (Draft)
+
+| Failure mode | Etki | Karar |
+|---|---|---|
+| `auth_status` pass ama `prompt_access` fail (`KB-001` sınıfı) | Yanlış güven | `stay_beta`; known-bug güncellemesi zorunlu |
+| Fallback token route `Invalid bearer token` (`KB-002`) | Recovery zayıf | `stay_beta`; session-auth zorunlu notu korunur |
+| Manifest invocation fail, prompt smoke pass | Lane kısmi | `stay_beta`; adapter contract/parsing incelemesi açılır |
+| Tüm smoke adımları tekrar edilebilir şekilde pass | Risk düşer | Promotion-candidate değerlendirmesi açılabilir (otomatik promotion değil) |
+
+## Karar Çıkışı Şablonu
+
+Bu slice kapanışında yalnız bir karar üretilecek:
+
+1. `stay_beta`:
+   - gerekçe: hangi gate(ler) eksik
+   - sonraki adım: dar fix tranche veya ek evidence turu
+2. `promotion_candidate`:
+   - gerekçe: tüm gate'ler nasıl karşılandı
+   - sonraki adım: support widening implementation için ayrı dar tranche
+
+## DoD
+
+1. Checklist + failure-mode matrisi finalize edilmiş
+2. Bu tur canlı smoke çıktısı decision girdisi olarak yazılmış
+3. `KB-001`/`KB-002` etkisi karar metninde açık
+4. Tekil karar çıktısı ve bir sonraki adım net

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -19,7 +19,7 @@ ayrı ayrı görünür kılmak.
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
-- **Aktif issue:** [#265](https://github.com/Halildeu/ao-kernel/issues/265)
+- **Aktif issue:** [#267](https://github.com/Halildeu/ao-kernel/issues/267)
 
 ## 2. Başlangıç Gerçeği
 
@@ -75,16 +75,23 @@ bir sonraki implementation hattına taşımaktır.
 2. Decision/ordering contract:
    `.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md`
 3. Hedef: first/second/hold tranche sırasını yazılı kapıya çevirmek ve
-   ilk implementasyon hattını `PB-6.4a` olarak tekillemek.
+   yalnız aktif tranche'ı net tutmak.
 
-`PB-6.4a` active implementation slice:
+`PB-6.4a` implementation slice'ı tamamlandı:
 
 1. Issue: [#265](https://github.com/Halildeu/ao-kernel/issues/265)
-2. Hedef: support mapping hardening (`truth tier` -> support language parity)
-3. Kapsam: `docs/PUBLIC-BETA.md`, `docs/SUPPORT-BOUNDARY.md`,
-   `tests/test_doctor_cmd.py`, status SSOT hizası
-4. Slice plan:
-   `.claude/plans/PB-6.4a-SUPPORT-MAPPING-HARDENING.md`
+2. PR: [#266](https://github.com/Halildeu/ao-kernel/pull/266)
+3. Merge commit: `b934fb65003dd0b3713fac982a066e8c252a92b8`
+4. Sonuç: support mapping parity (`PUBLIC-BETA` + `SUPPORT-BOUNDARY`) ve
+   `tests/test_doctor_cmd.py` doğrulamaları hizalandı.
+
+`PB-6.4b` active decision slice:
+
+1. Issue: [#267](https://github.com/Halildeu/ao-kernel/issues/267)
+2. Hedef: `claude-code-cli` lane'i için promotion readiness kararını
+   checklist + failure-mode matrisi ile yazılı kapıya çevirmek
+3. Slice plan:
+   `.claude/plans/PB-6.4b-CLAUDE-CODE-CLI-PROMOTION-READINESS.md`
 
 `PB-6.2` contract slice'ı tamamlandı:
 
@@ -167,7 +174,8 @@ Güncel runtime baseline:
    - issue: [#263](https://github.com/Halildeu/ao-kernel/issues/263)
    - contract:
      `.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md`
-   - active implementation tranche: `PB-6.4a` ([#265](https://github.com/Halildeu/ao-kernel/issues/265))
+   - first tranche complete: `PB-6.4a` ([#265](https://github.com/Halildeu/ao-kernel/issues/265), [#266](https://github.com/Halildeu/ao-kernel/pull/266))
+   - active implementation tranche: `PB-6.4b` ([#267](https://github.com/Halildeu/ao-kernel/issues/267))
 
 Not:
 
@@ -190,7 +198,7 @@ Not:
 
 Bugünden itibaren doğru sıra:
 
-1. `PB-6.4` real-adapter/write-side graduation criteria yeniden sıralama
+1. `PB-6.4b` `claude-code-cli` lane promotion readiness karar dilimi
 
 ## 9. Güncelleme Protokolü
 


### PR DESCRIPTION
## Summary\n- add PB-6.4b decision-slice plan for claude-code-cli lane promotion readiness\n- update post-beta status SSOT: PB-6.4a completed, PB-6.4b active\n- update PB-6.4 ordering contract next-active slice to PB-6.4b\n\n## Issue hygiene\n- closes #265\n- references #263 and #267\n\n## Validation\n- python3 scripts/claude_code_cli_smoke.py --output json\n  - overall_status=pass\n  - version/auth_status/prompt_access/manifest_invocation: pass