### PR TITLE
[codex] plans: PB-6.4b decision closeout and PB-6.4 fold

### DIFF
--- a/.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md
+++ b/.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md
@@ -1,6 +1,6 @@
 # PB-6.4 — Real-adapter / Write-side Graduation Order Contract
 
-**Status:** In progress (decision/ordering slice)  
+**Status:** Completed (decision/ordering slice)  
 **Date:** 2026-04-23  
 **Parent tracker:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)  
 **Active issue:** [#263](https://github.com/Halildeu/ao-kernel/issues/263)
@@ -118,6 +118,12 @@ Bu beş kapıdan biri eksikse lane widening yapılmaz.
 2. her lane için açık DoD/hold koşulu
 3. aktif implementasyon hattının tekil seçimi (`PB-6.4b`)
 
+Kapanış doğrulaması (2026-04-23):
+
+1. `PB-6.4a` tamamlandı (`#266`)
+2. `PB-6.4b` tamamlandı (`#268`) ve karar `promotion_candidate`
+3. hold lane sınırları (`PB-6.4c`, `PB-6.4d`) korunarak yazılı bırakıldı
+
 ## 8) Sıradaki Adım
 
 Güncel yürütüm sırası:
@@ -125,7 +131,11 @@ Güncel yürütüm sırası:
 1. `PB-6.4a` support mapping hardening tamamlandı
    - issue: [#265](https://github.com/Halildeu/ao-kernel/issues/265)
    - PR: [#266](https://github.com/Halildeu/ao-kernel/pull/266)
-2. aktif hat: `PB-6.4b` `claude-code-cli` lane promotion readiness karar dilimi
+2. `PB-6.4b` `claude-code-cli` lane promotion readiness karar dilimi tamamlandı
    - issue: [#267](https://github.com/Halildeu/ao-kernel/issues/267)
    - plan:
      `.claude/plans/PB-6.4b-CLAUDE-CODE-CLI-PROMOTION-READINESS.md`
+3. sonraki aktif hat:
+   - `PB-6` umbrella (`#243`) altında hold lane precondition/backlog yönetimi
+   - `PB-6.4c` ve `PB-6.4d` ayrı widening implementation'a çevrilmeden önce
+     karar ve kanıt kapıları korunur

--- a/.claude/plans/PB-6.4b-CLAUDE-CODE-CLI-PROMOTION-READINESS.md
+++ b/.claude/plans/PB-6.4b-CLAUDE-CODE-CLI-PROMOTION-READINESS.md
@@ -1,6 +1,6 @@
 # PB-6.4b — Claude Code CLI Lane Promotion Readiness (Decision Slice)
 
-**Status:** Active (decision)  
+**Status:** Completed (decision: `promotion_candidate`)  
 **Date:** 2026-04-23  
 **Parent:** `PB-6.4`  
 **Parent issue:** [#263](https://github.com/Halildeu/ao-kernel/issues/263)  
@@ -25,7 +25,7 @@ risk kapılarıyla karar altına almak.
 2. `PUBLIC-BETA` support tier satırını bu slice içinde doğrudan yükseltmek
 3. Adapter invocation/policy davranışı değiştirmek
 
-## Canlı Baseline Kanıtı (Bu tur)
+## Canlı Baseline Kanıtı
 
 Komut:
 
@@ -37,15 +37,17 @@ Gözlem (2026-04-23):
 2. `version`, `auth_status`, `prompt_access`, `manifest_invocation` adımları
    geçti
 3. `api_key_env_present = false` (session auth lane aktif)
+4. Aynı gün içinde birden fazla bağımsız smoke koşusu `pass` döndürdü
+   (repeatability gate için yeterli kanıt)
 
 Not:
 
 Bu başarı tek başına promotion kararı üretmez; known-bug etkisi ve tekrar
 edilebilirlik kapıları ayrıca aranır.
 
-## Promotion Readiness Checklist (Draft)
+## Promotion Readiness Checklist (Final)
 
-Her madde için durum `pass/fail/inconclusive` olarak işaretlenecek:
+Her madde `pass/fail/inconclusive` ile değerlendirildi:
 
 1. **Binary + auth baseline**
    - `claude --version` geçmeli
@@ -62,7 +64,16 @@ Her madde için durum `pass/fail/inconclusive` olarak işaretlenecek:
    - en az 2 bağımsız çalıştırmada smoke başarısı veya deterministik fail
      pattern'i kanıtlanmalı
 
-## Failure-Mode Matrisi (Draft)
+| Gate | Durum | Not |
+|---|---|---|
+| Binary + auth baseline | `pass` | `claude --version` ve `claude auth status` başarılı |
+| Canlı prompt erişimi | `pass` | `claude -p` smoke başarılı |
+| Manifest invocation | `pass` | bundled manifest invocation smoke başarılı |
+| Known-bug etkisi | `pass` (bounded) | `KB-001` / `KB-002` açık, fakat workaround ve destek sınırı dokümanlarıyla yönetiliyor |
+| Support parity | `pass` | `PUBLIC-BETA`, `SUPPORT-BOUNDARY`, `KNOWN-BUGS` aynı tier dilini konuşuyor |
+| Repeatability gate | `pass` | 2026-04-23 içinde birden fazla bağımsız koşuda `overall_status=pass` |
+
+## Failure-Mode Matrisi (Final)
 
 | Failure mode | Etki | Karar |
 |---|---|---|
@@ -71,16 +82,23 @@ Her madde için durum `pass/fail/inconclusive` olarak işaretlenecek:
 | Manifest invocation fail, prompt smoke pass | Lane kısmi | `stay_beta`; adapter contract/parsing incelemesi açılır |
 | Tüm smoke adımları tekrar edilebilir şekilde pass | Risk düşer | Promotion-candidate değerlendirmesi açılabilir (otomatik promotion değil) |
 
-## Karar Çıkışı Şablonu
+## Karar Çıkışı
 
-Bu slice kapanışında yalnız bir karar üretilecek:
+Bu slice kapanış kararı:
 
-1. `stay_beta`:
-   - gerekçe: hangi gate(ler) eksik
-   - sonraki adım: dar fix tranche veya ek evidence turu
-2. `promotion_candidate`:
-   - gerekçe: tüm gate'ler nasıl karşılandı
-   - sonraki adım: support widening implementation için ayrı dar tranche
+1. Karar: `promotion_candidate`
+2. Gerekçe:
+   - checklist kapıları bu turda karşılandı
+   - smoke kanıtı tekrar edilebilir şekilde geçti
+   - known-bug etkisi bounded ve operator-managed lane sınırında yönetilebilir
+3. Sınır:
+   - bu karar support tier'i otomatik yükseltmez
+   - lane, ayrı widening implementation/karar dilimi açılana kadar
+     `Beta (operator-managed)` kalır
+4. Sonraki adım:
+   - `PB-6.4` umbrella closeout (issue `#263`)
+   - `PB-6.4c` ve `PB-6.4d` hold koşulları korunarak `PB-6` altında deferred
+     backlog olarak kalır
 
 ## DoD
 

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -19,7 +19,7 @@ ayrı ayrı görünür kılmak.
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
-- **Aktif issue:** [#267](https://github.com/Halildeu/ao-kernel/issues/267)
+- **Aktif issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
 
 ## 2. Başlangıç Gerçeği
 
@@ -64,7 +64,7 @@ ayrı ayrı görünür kılmak.
 
 ### `PB-6.4` — real-adapter/write-side graduation criteria yeniden sıralama
 
-`PB-6` içinde aktif alt hat artık `PB-6.4`'dür. Bu slice'ın işi,
+`PB-6` içinde `PB-6.4` sıralama/karar alt hattı tamamlandı. Bu slice'ın işi,
 genel amaçlı platform widening'i için real-adapter/write-side promotion
 kriterlerini risk sırasına göre yeniden düzenlemek ve yalnız kanıtlı adayları
 bir sonraki implementation hattına taşımaktır.
@@ -85,12 +85,16 @@ bir sonraki implementation hattına taşımaktır.
 4. Sonuç: support mapping parity (`PUBLIC-BETA` + `SUPPORT-BOUNDARY`) ve
    `tests/test_doctor_cmd.py` doğrulamaları hizalandı.
 
-`PB-6.4b` active decision slice:
+`PB-6.4b` decision slice'ı tamamlandı:
 
 1. Issue: [#267](https://github.com/Halildeu/ao-kernel/issues/267)
-2. Hedef: `claude-code-cli` lane'i için promotion readiness kararını
-   checklist + failure-mode matrisi ile yazılı kapıya çevirmek
-3. Slice plan:
+2. PR: [#268](https://github.com/Halildeu/ao-kernel/pull/268)
+3. Karar: `promotion_candidate` (otomatik support widening yok)
+4. Gerekçe: checklist kapıları geçildi, smoke tekrar edilebilir, known-bug
+   etkisi operator-managed lane sınırında bounded kaldı.
+5. Sınır: lane support tier'i ayrı widening slice açılana kadar
+   `Beta (operator-managed)` olarak kalır.
+6. Slice plan:
    `.claude/plans/PB-6.4b-CLAUDE-CODE-CLI-PROMOTION-READINESS.md`
 
 `PB-6.2` contract slice'ı tamamlandı:
@@ -170,19 +174,21 @@ Güncel runtime baseline:
    - completed on `main` via [#261](https://github.com/Halildeu/ao-kernel/pull/261)
    - outcome: `truth_tier=contract_only`, no runtime handler registration
 4. `PB-6.4` real-adapter/write-side graduation criteria yeniden sıralama
-   - active
+   - completed (ordering + second decision tranche)
    - issue: [#263](https://github.com/Halildeu/ao-kernel/issues/263)
    - contract:
      `.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md`
    - first tranche complete: `PB-6.4a` ([#265](https://github.com/Halildeu/ao-kernel/issues/265), [#266](https://github.com/Halildeu/ao-kernel/pull/266))
-   - active implementation tranche: `PB-6.4b` ([#267](https://github.com/Halildeu/ao-kernel/issues/267))
+   - second tranche complete: `PB-6.4b` ([#267](https://github.com/Halildeu/ao-kernel/issues/267), [#268](https://github.com/Halildeu/ao-kernel/pull/268))
+   - hold backlog: `PB-6.4c` (gh-cli-pr live write lane), `PB-6.4d` (kernel-api write-side widening)
 
 Not:
 
 1. `PB-6.2` planning slice'ı support boundary'yi değiştirmedi; yalnız
    implementation PR için contract çıkardı.
 2. `PB-6.2b` support boundary'yi yalnız iki read-only action için genişletti.
-3. `PB-6.4` karar notu çıkmadan yeni support widening implementation açılmayacak.
+3. `PB-6.4` karar notu tamamlandı; `PB-6.4c`/`PB-6.4d` için ayrı dar karar
+   dilimi açılmadan support widening implementation açılmayacak.
 
 ## 7. Riskler
 
@@ -198,7 +204,9 @@ Not:
 
 Bugünden itibaren doğru sıra:
 
-1. `PB-6.4b` `claude-code-cli` lane promotion readiness karar dilimi
+1. `PB-6` umbrella altında hold backlog yönetimi:
+   - `PB-6.4c` ve `PB-6.4d` için precondition/exit kriterleri
+   - support widening implementation açmadan önce dar karar dilimi
 
 ## 9. Güncelleme Protokolü
 


### PR DESCRIPTION
## Summary
- finalize PB-6.4b decision slice with explicit checklist evaluation and single verdict
- record decision as promotion_candidate without widening support tier
- fold PB-6.4 status into completed state and move active focus back to PB-6 umbrella hold backlog

## Why
- PB-6.4a and PB-6.4b are complete; the repo needed a single written decision and consistent SSOT wording
- keep scope discipline: decision closeout only, no runtime behavior change

## Validation
- python3 -m ao_kernel doctor
- python3 scripts/claude_code_cli_smoke.py --output json
- python3 scripts/gh_cli_pr_smoke.py --output json

Closes #267
Closes #263