### PR TITLE
[codex] plans: start PB-6.4c hold-lane decision and queue PB-6.4d

### DIFF
--- a/.claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md
+++ b/.claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md
@@ -218,6 +218,8 @@ Canlı yürütme sırası bundan sonra aşağıdaki SSOT'tan takip edilir:
 Özet:
 
 1. `PB-6.1a`, `PB-6.1b`, `PB-6.2`, `PB-6.2b`, `PB-6.3`, `PB-6.3b` tamamlandı.
-2. Aktif alt hat `PB-6.4` (issue: [#263](https://github.com/Halildeu/ao-kernel/issues/263)).
-3. `PB-6.4` için karar/ordering contract:
+2. `PB-6.4` karar/ordering slice tamamlandı (issue: [#263](https://github.com/Halildeu/ao-kernel/issues/263)).
+3. Aktif alt hat `PB-6.4c` (issue: [#271](https://github.com/Halildeu/ao-kernel/issues/271));
+   queued alt hat `PB-6.4d` (issue: [#270](https://github.com/Halildeu/ao-kernel/issues/270)).
+4. `PB-6.4` için karar/ordering contract:
    `.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md`

--- a/.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md
+++ b/.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md
@@ -3,7 +3,8 @@
 **Status:** Completed (decision/ordering slice)  
 **Date:** 2026-04-23  
 **Parent tracker:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)  
-**Active issue:** [#263](https://github.com/Halildeu/ao-kernel/issues/263)
+**Decision issue (closed):** [#263](https://github.com/Halildeu/ao-kernel/issues/263)  
+**Follow-up active issue:** [#271](https://github.com/Halildeu/ao-kernel/issues/271)
 
 ## 1) Problem
 
@@ -135,7 +136,11 @@ Güncel yürütüm sırası:
    - issue: [#267](https://github.com/Halildeu/ao-kernel/issues/267)
    - plan:
      `.claude/plans/PB-6.4b-CLAUDE-CODE-CLI-PROMOTION-READINESS.md`
-3. sonraki aktif hat:
-   - `PB-6` umbrella (`#243`) altında hold lane precondition/backlog yönetimi
-   - `PB-6.4c` ve `PB-6.4d` ayrı widening implementation'a çevrilmeden önce
-     karar ve kanıt kapıları korunur
+3. aktif follow-up hat:
+   - `PB-6.4c` (`#271`) `gh-cli-pr` live write lane precondition kararı
+   - plan:
+     `.claude/plans/PB-6.4c-GH-CLI-PR-LIVE-WRITE-GRADUATION.md`
+4. queued follow-up hat:
+   - `PB-6.4d` (`#270`) kernel-api write-side widening preconditions
+   - plan:
+     `.claude/plans/PB-6.4d-KERNEL-API-WRITE-SIDE-WIDENING-PRECONDITIONS.md`

--- a/.claude/plans/PB-6.4c-GH-CLI-PR-LIVE-WRITE-GRADUATION.md
+++ b/.claude/plans/PB-6.4c-GH-CLI-PR-LIVE-WRITE-GRADUATION.md
@@ -1,0 +1,69 @@
+# PB-6.4c — gh-cli-pr Live Write Lane Graduation Preconditions
+
+**Status:** Active (decision)  
+**Date:** 2026-04-23  
+**Parent:** `PB-6` / `PB-6.4`  
+**Parent issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)  
+**Active issue:** [#271](https://github.com/Halildeu/ao-kernel/issues/271)
+
+## Amaç
+
+`gh-cli-pr` lane için mevcut `preflight-only` desteği ile gerçek
+`live write` (remote PR opening) desteği arasındaki kapıları yazılı, test
+edilebilir ve denetlenebilir bir karar dilimine indirmek.
+
+## Kapsam
+
+1. `preflight-only` ve `live write` lane sınırının kesin tanımı
+2. disposable sandbox ve side-effect boundary sözleşmesi
+3. rollback + evidence completeness kapıları
+4. operator prerequisite ve failure-mode karar matrisi
+5. tekil karar çıktısı: `stay_preflight` veya `promotion_candidate_live_write`
+
+## Kapsam Dışı
+
+1. bu slice içinde runtime widening implementation yapmak
+2. gerçek remote PR opening support tier'ını doğrudan yükseltmek
+3. workflow/adapter kodu veya policy semantics değiştirmek
+
+## Canlı Başlangıç Baseline
+
+2026-04-23 itibarıyla:
+
+1. `python3 scripts/gh_cli_pr_smoke.py --output json` -> `overall_status=pass`
+2. smoke yüzeyi `gh pr create --dry-run` ile sınırlıdır
+3. canlı remote write side-effect kanıtı henüz support boundary içinde değildir
+
+Bu baseline, `live write` promotion kararı için tek başına yeterli değildir.
+
+## Graduation Gate'leri (Draft)
+
+1. lane boundary gate:
+   - preflight ile live write arasındaki sınır davranışsal olarak pinlenmiş mi?
+2. sandbox gate:
+   - disposable workspace ve cleanup/teardown sözleşmesi açık mı?
+3. side-effect gate:
+   - yanlış repo/branch/base senaryolarında fail-closed davranış var mı?
+4. rollback gate:
+   - başarısız write akışı sonrası geri dönüş adımları deterministik mi?
+5. evidence gate:
+   - PR metadata, event timeline ve karar izleri eksiksiz toplanıyor mu?
+6. docs parity gate:
+   - `PUBLIC-BETA`, `SUPPORT-BOUNDARY`, `OPERATIONS-RUNBOOK` aynı şeyi söylüyor mu?
+
+## Failure-Mode Matrisi (Draft)
+
+| Failure mode | Etki | Karar |
+|---|---|---|
+| preflight geçer, live write senaryosu kanıtsız | yanlış güven | `stay_preflight` |
+| yanlış repo/branch'e write riski | yüksek side-effect | `stay_preflight`; guard contract zorunlu |
+| rollback adımları eksik | operasyonel risk | `stay_preflight` |
+| evidence eksikliği (`pr_opened`/metadata boşluğu) | audit zayıf | `stay_preflight` |
+| tüm gate'ler karşılanır ve tekrar edilebilir | risk düşer | `promotion_candidate_live_write` değerlendirmesi açılabilir |
+
+## DoD
+
+1. gate checklist ve failure-mode matrisi finalize edilmiş
+2. preflight/live boundary testlenebilir sözleşme halinde yazılmış
+3. tek karar çıktısı ve sonraki dar adım net
+4. status SSOT ve issue yüzeyi aynı kararı taşıyor

--- a/.claude/plans/PB-6.4d-KERNEL-API-WRITE-SIDE-WIDENING-PRECONDITIONS.md
+++ b/.claude/plans/PB-6.4d-KERNEL-API-WRITE-SIDE-WIDENING-PRECONDITIONS.md
@@ -1,0 +1,52 @@
+# PB-6.4d — Kernel API Write-side Widening Preconditions
+
+**Status:** Queued (hold decision)  
+**Date:** 2026-04-23  
+**Parent:** `PB-6` / `PB-6.4`  
+**Parent issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)  
+**Queue issue:** [#270](https://github.com/Halildeu/ao-kernel/issues/270)
+
+## Amaç
+
+`PRJ-KERNEL-API` write-side action widening için gerekli governance, test ve
+support-boundary kapılarını implementation'dan önce yazılı karar dilimi olarak
+sabitlemek.
+
+## Kapsam
+
+1. write-side governance/policy contract önkoşulları
+2. action-level behavior test ve negative path coverage gereksinimleri
+3. support-boundary update gate'leri
+4. hold-to-implementation geçiş kriterleri
+
+## Kapsam Dışı
+
+1. bu slice içinde write-side action widening implementation yapmak
+2. support tier yükseltmesini doğrudan uygulamak
+3. read-only `system_status` / `doc_nav_check` kapsamını değiştirmek
+
+## Başlangıç Durumu
+
+1. `PRJ-KERNEL-API` bugün yalnız read-only iki action ile support boundary'de
+   yer alır: `system_status`, `doc_nav_check`
+2. `project_status`, `roadmap_follow`, `roadmap_finish` write-side widening
+   adayları defer/hold durumundadır
+
+## Hold Kapıları (Draft)
+
+1. governance gate:
+   - action-level policy contract fail-closed tanımlı mı?
+2. behavior gate:
+   - positive + negative + denial path testleri mevcut mu?
+3. safety gate:
+   - overwrite/conflict/idempotency davranışı açık mı?
+4. docs parity gate:
+   - support boundary ve runbook dilinde widening sınırı net mi?
+5. rollback gate:
+   - write-side başarısızlıklarında geri alma/sınırlandırma adımları belirli mi?
+
+## DoD
+
+1. write-side widening için action bazlı gate tablosu finalize edilmiş
+2. defer veya implementation kararı tekilleştirilmiş
+3. sonraki slice (implementation açılacaksa) kapsamı dar ve ölçülebilir

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -19,7 +19,8 @@ ayrı ayrı görünür kılmak.
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
-- **Aktif issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
+- **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
+- **Aktif issue:** [#271](https://github.com/Halildeu/ao-kernel/issues/271)
 
 ## 2. Başlangıç Gerçeği
 
@@ -96,6 +97,22 @@ bir sonraki implementation hattına taşımaktır.
    `Beta (operator-managed)` olarak kalır.
 6. Slice plan:
    `.claude/plans/PB-6.4b-CLAUDE-CODE-CLI-PROMOTION-READINESS.md`
+
+`PB-6.4c` active decision slice:
+
+1. Issue: [#271](https://github.com/Halildeu/ao-kernel/issues/271)
+2. Hedef: `gh-cli-pr` için `preflight-only` ile `live write` lane sınırını
+   gate tabanlı karar dilimine çevirmek
+3. Slice plan:
+   `.claude/plans/PB-6.4c-GH-CLI-PR-LIVE-WRITE-GRADUATION.md`
+
+`PB-6.4d` queued hold slice:
+
+1. Issue: [#270](https://github.com/Halildeu/ao-kernel/issues/270)
+2. Hedef: `PRJ-KERNEL-API` write-side widening önkoşullarını action bazlı
+   gate tablosuna indirmek
+3. Slice plan:
+   `.claude/plans/PB-6.4d-KERNEL-API-WRITE-SIDE-WIDENING-PRECONDITIONS.md`
 
 `PB-6.2` contract slice'ı tamamlandı:
 
@@ -180,15 +197,16 @@ Güncel runtime baseline:
      `.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md`
    - first tranche complete: `PB-6.4a` ([#265](https://github.com/Halildeu/ao-kernel/issues/265), [#266](https://github.com/Halildeu/ao-kernel/pull/266))
    - second tranche complete: `PB-6.4b` ([#267](https://github.com/Halildeu/ao-kernel/issues/267), [#268](https://github.com/Halildeu/ao-kernel/pull/268))
-   - hold backlog: `PB-6.4c` (gh-cli-pr live write lane), `PB-6.4d` (kernel-api write-side widening)
+   - active hold-management tranche: `PB-6.4c` ([#271](https://github.com/Halildeu/ao-kernel/issues/271))
+   - queued hold tranche: `PB-6.4d` ([#270](https://github.com/Halildeu/ao-kernel/issues/270))
 
 Not:
 
 1. `PB-6.2` planning slice'ı support boundary'yi değiştirmedi; yalnız
    implementation PR için contract çıkardı.
 2. `PB-6.2b` support boundary'yi yalnız iki read-only action için genişletti.
-3. `PB-6.4` karar notu tamamlandı; `PB-6.4c`/`PB-6.4d` için ayrı dar karar
-   dilimi açılmadan support widening implementation açılmayacak.
+3. `PB-6.4` karar notu tamamlandı; `PB-6.4c` aktif karar dilimi ve `PB-6.4d`
+   queued hold dilimi kapanmadan support widening implementation açılmayacak.
 
 ## 7. Riskler
 
@@ -204,9 +222,11 @@ Not:
 
 Bugünden itibaren doğru sıra:
 
-1. `PB-6` umbrella altında hold backlog yönetimi:
-   - `PB-6.4c` ve `PB-6.4d` için precondition/exit kriterleri
-   - support widening implementation açmadan önce dar karar dilimi
+1. `PB-6.4c` active decision slice (`#271`)
+   - `gh-cli-pr` preflight vs live write boundary
+   - disposable sandbox + rollback + evidence completeness kapıları
+2. `PB-6.4d` queued hold slice (`#270`)
+   - kernel-api write-side widening preconditions
 
 ## 9. Güncelleme Protokolü
 


### PR DESCRIPTION
## Summary
- add PB-6.4c active decision plan for gh-cli-pr live write lane graduation preconditions
- add PB-6.4d queued decision plan for kernel-api write-side widening preconditions
- update PB-6 status SSOT and PB-6.4 contract to issue-based hold backlog sequencing
- refresh PB-6 gap-map active note to reflect PB-6.4 complete and PB-6.4c/PB-6.4d handoff

## Issue alignment
- refs #243
- refs #271
- refs #270

## Validation
- python3 -m ao_kernel doctor