### PR TITLE
[codex] plans: close PB-6.4c decision with stay_preflight

### DIFF
--- a/.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md
+++ b/.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md
@@ -4,7 +4,7 @@
 **Date:** 2026-04-23  
 **Parent tracker:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)  
 **Decision issue (closed):** [#263](https://github.com/Halildeu/ao-kernel/issues/263)  
-**Follow-up active issue:** [#271](https://github.com/Halildeu/ao-kernel/issues/271)
+**Follow-up active issue:** [#270](https://github.com/Halildeu/ao-kernel/issues/270)
 
 ## 1) Problem
 
@@ -137,10 +137,10 @@ Güncel yürütüm sırası:
    - plan:
      `.claude/plans/PB-6.4b-CLAUDE-CODE-CLI-PROMOTION-READINESS.md`
 3. aktif follow-up hat:
-   - `PB-6.4c` (`#271`) `gh-cli-pr` live write lane precondition kararı
+   - `PB-6.4c` (`#271`) karar dilimi tamamlandı: `stay_preflight`
    - plan:
      `.claude/plans/PB-6.4c-GH-CLI-PR-LIVE-WRITE-GRADUATION.md`
-4. queued follow-up hat:
+4. aktif follow-up hat:
    - `PB-6.4d` (`#270`) kernel-api write-side widening preconditions
    - plan:
      `.claude/plans/PB-6.4d-KERNEL-API-WRITE-SIDE-WIDENING-PRECONDITIONS.md`

--- a/.claude/plans/PB-6.4c-GH-CLI-PR-LIVE-WRITE-GRADUATION.md
+++ b/.claude/plans/PB-6.4c-GH-CLI-PR-LIVE-WRITE-GRADUATION.md
@@ -1,6 +1,6 @@
 # PB-6.4c — gh-cli-pr Live Write Lane Graduation Preconditions
 
-**Status:** Active (decision)  
+**Status:** Completed (decision: `stay_preflight`)  
 **Date:** 2026-04-23  
 **Parent:** `PB-6` / `PB-6.4`  
 **Parent issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)  
@@ -26,17 +26,19 @@ edilebilir ve denetlenebilir bir karar dilimine indirmek.
 2. gerçek remote PR opening support tier'ını doğrudan yükseltmek
 3. workflow/adapter kodu veya policy semantics değiştirmek
 
-## Canlı Başlangıç Baseline
+## Canlı Baseline Kanıtı
 
-2026-04-23 itibarıyla:
+Gözlem (2026-04-23):
 
 1. `python3 scripts/gh_cli_pr_smoke.py --output json` -> `overall_status=pass`
 2. smoke yüzeyi `gh pr create --dry-run` ile sınırlıdır
 3. canlı remote write side-effect kanıtı henüz support boundary içinde değildir
+4. auth/repo visibility ve manifest contract adımları geçmektedir; fakat bu
+   kanıt write-side side-effect güvenliğini doğrulamaz
 
 Bu baseline, `live write` promotion kararı için tek başına yeterli değildir.
 
-## Graduation Gate'leri (Draft)
+## Graduation Gate'leri (Final)
 
 1. lane boundary gate:
    - preflight ile live write arasındaki sınır davranışsal olarak pinlenmiş mi?
@@ -51,7 +53,16 @@ Bu baseline, `live write` promotion kararı için tek başına yeterli değildir
 6. docs parity gate:
    - `PUBLIC-BETA`, `SUPPORT-BOUNDARY`, `OPERATIONS-RUNBOOK` aynı şeyi söylüyor mu?
 
-## Failure-Mode Matrisi (Draft)
+| Gate | Durum | Not |
+|---|---|---|
+| Lane boundary gate | `pass` (bounded) | preflight-only sınırı ve live-write dışı boundary yazılı |
+| Sandbox gate | `fail` | disposable sandbox + cleanup contract canlı write için henüz kanıtlı değil |
+| Side-effect gate | `fail` | yanlış repo/branch/base write riskleri için runtime guard kanıtı yok |
+| Rollback gate | `fail` | live write failure sonrası geri dönüş zinciri testli değil |
+| Evidence gate | `inconclusive` | preflight evidence var; live write event/evidence completeness yok |
+| Docs parity gate | `pass` | dokümanlar lane'i beta/preflight sınırında tutuyor |
+
+## Failure-Mode Matrisi (Final)
 
 | Failure mode | Etki | Karar |
 |---|---|---|
@@ -60,6 +71,24 @@ Bu baseline, `live write` promotion kararı için tek başına yeterli değildir
 | rollback adımları eksik | operasyonel risk | `stay_preflight` |
 | evidence eksikliği (`pr_opened`/metadata boşluğu) | audit zayıf | `stay_preflight` |
 | tüm gate'ler karşılanır ve tekrar edilebilir | risk düşer | `promotion_candidate_live_write` değerlendirmesi açılabilir |
+
+## Karar Çıkışı
+
+Bu slice kapanış kararı:
+
+1. Karar: `stay_preflight`
+2. Gerekçe:
+   - canlı smoke yalnız `preflight-only` yüzeyini doğruluyor
+   - live write lane için side-effect/rollback/sandbox kapıları karşılanmadı
+   - audit/evidence zinciri live write seviyesinde henüz kanıtlı değil
+3. Sınır:
+   - `gh-cli-pr` lane support tier'i `Beta (operator-managed preflight only)`
+     olarak kalır
+   - gerçek remote PR opening support boundary'ye alınmaz
+4. Sonraki adım:
+   - `PB-6.4d` queued hold slice'ı aktif sıraya alınır
+   - live write widening ancak ayrı implementation + governance paketinden
+     sonra yeniden değerlendirilir
 
 ## DoD
 

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -20,7 +20,7 @@ ayrı ayrı görünür kılmak.
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
-- **Aktif issue:** [#271](https://github.com/Halildeu/ao-kernel/issues/271)
+- **Aktif issue:** [#270](https://github.com/Halildeu/ao-kernel/issues/270)
 
 ## 2. Başlangıç Gerçeği
 
@@ -98,15 +98,16 @@ bir sonraki implementation hattına taşımaktır.
 6. Slice plan:
    `.claude/plans/PB-6.4b-CLAUDE-CODE-CLI-PROMOTION-READINESS.md`
 
-`PB-6.4c` active decision slice:
+`PB-6.4c` decision slice'ı tamamlandı:
 
 1. Issue: [#271](https://github.com/Halildeu/ao-kernel/issues/271)
-2. Hedef: `gh-cli-pr` için `preflight-only` ile `live write` lane sınırını
-   gate tabanlı karar dilimine çevirmek
-3. Slice plan:
+2. Karar: `stay_preflight`
+3. Gerekçe: live write lane için sandbox/side-effect/rollback/evidence
+   kapıları henüz karşılanmadı; preflight-only support sınırı korunuyor
+4. Slice plan:
    `.claude/plans/PB-6.4c-GH-CLI-PR-LIVE-WRITE-GRADUATION.md`
 
-`PB-6.4d` queued hold slice:
+`PB-6.4d` active hold-decision slice:
 
 1. Issue: [#270](https://github.com/Halildeu/ao-kernel/issues/270)
 2. Hedef: `PRJ-KERNEL-API` write-side widening önkoşullarını action bazlı
@@ -197,16 +198,18 @@ Güncel runtime baseline:
      `.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md`
    - first tranche complete: `PB-6.4a` ([#265](https://github.com/Halildeu/ao-kernel/issues/265), [#266](https://github.com/Halildeu/ao-kernel/pull/266))
    - second tranche complete: `PB-6.4b` ([#267](https://github.com/Halildeu/ao-kernel/issues/267), [#268](https://github.com/Halildeu/ao-kernel/pull/268))
-   - active hold-management tranche: `PB-6.4c` ([#271](https://github.com/Halildeu/ao-kernel/issues/271))
-   - queued hold tranche: `PB-6.4d` ([#270](https://github.com/Halildeu/ao-kernel/issues/270))
+   - third tranche complete: `PB-6.4c` decision closeout (`stay_preflight`, [#271](https://github.com/Halildeu/ao-kernel/issues/271))
+   - active hold tranche: `PB-6.4d` ([#270](https://github.com/Halildeu/ao-kernel/issues/270))
 
 Not:
 
 1. `PB-6.2` planning slice'ı support boundary'yi değiştirmedi; yalnız
    implementation PR için contract çıkardı.
 2. `PB-6.2b` support boundary'yi yalnız iki read-only action için genişletti.
-3. `PB-6.4` karar notu tamamlandı; `PB-6.4c` aktif karar dilimi ve `PB-6.4d`
-   queued hold dilimi kapanmadan support widening implementation açılmayacak.
+3. `PB-6.4c` kararı `stay_preflight` olarak kapanmıştır; live write widening
+   support boundary dışında kalır.
+4. `PB-6.4d` karar dilimi kapanmadan kernel-api write-side widening
+   implementation açılmayacak.
 
 ## 7. Riskler
 
@@ -222,11 +225,9 @@ Not:
 
 Bugünden itibaren doğru sıra:
 
-1. `PB-6.4c` active decision slice (`#271`)
-   - `gh-cli-pr` preflight vs live write boundary
-   - disposable sandbox + rollback + evidence completeness kapıları
-2. `PB-6.4d` queued hold slice (`#270`)
+1. `PB-6.4d` active hold-decision slice (`#270`)
    - kernel-api write-side widening preconditions
+   - governance/policy + behavior test + rollback gate tabanı
 
 ## 9. Güncelleme Protokolü
 


### PR DESCRIPTION
## Summary
- finalize PB-6.4c decision slice with explicit gate outcomes
- set decision to stay_preflight for gh-cli-pr live write lane
- move active status focus to PB-6.4d hold-decision slice

## Why
- current evidence proves preflight lane only (dry-run and contract checks)
- live write side-effect, rollback, and evidence completeness gates are not met

## Validation
- python3 scripts/gh_cli_pr_smoke.py --output json

Closes #271
Refs #243
Refs #270