### PR TITLE
[codex] plans: finalize PB-6.4d kernel-api write-side decision

### DIFF
--- a/.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md
+++ b/.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md
@@ -4,7 +4,7 @@
 **Date:** 2026-04-23  
 **Parent tracker:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)  
 **Decision issue (closed):** [#263](https://github.com/Halildeu/ao-kernel/issues/263)  
-**Follow-up active issue:** [#270](https://github.com/Halildeu/ao-kernel/issues/270)
+**Follow-up active issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
 
 ## 1) Problem
 
@@ -123,7 +123,10 @@ Kapanış doğrulaması (2026-04-23):
 
 1. `PB-6.4a` tamamlandı (`#266`)
 2. `PB-6.4b` tamamlandı (`#268`) ve karar `promotion_candidate`
-3. hold lane sınırları (`PB-6.4c`, `PB-6.4d`) korunarak yazılı bırakıldı
+3. `PB-6.4c` tamamlandı (`#273`) ve karar `stay_preflight`
+4. `PB-6.4d` tamamlandı (`#270` closeout) ve karar `stay_deferred`
+5. hold lane sınırları yazılı kararlarla korundu; write-side widening
+   implementation açılmadı
 
 ## 8) Sıradaki Adım
 
@@ -140,7 +143,12 @@ Güncel yürütüm sırası:
    - `PB-6.4c` (`#271`) karar dilimi tamamlandı: `stay_preflight`
    - plan:
      `.claude/plans/PB-6.4c-GH-CLI-PR-LIVE-WRITE-GRADUATION.md`
-4. aktif follow-up hat:
+4. follow-up hat:
    - `PB-6.4d` (`#270`) kernel-api write-side widening preconditions
+   - karar: `stay_deferred` (closeout)
    - plan:
      `.claude/plans/PB-6.4d-KERNEL-API-WRITE-SIDE-WIDENING-PRECONDITIONS.md`
+5. sonraki aktif hat:
+   - `PB-6` umbrella üzerinde widening implementation adayının
+     (yeni tranche) dar kapsamla seçilmesi
+   - issue: [#243](https://github.com/Halildeu/ao-kernel/issues/243)

--- a/.claude/plans/PB-6.4d-KERNEL-API-WRITE-SIDE-WIDENING-PRECONDITIONS.md
+++ b/.claude/plans/PB-6.4d-KERNEL-API-WRITE-SIDE-WIDENING-PRECONDITIONS.md
@@ -1,6 +1,6 @@
 # PB-6.4d — Kernel API Write-side Widening Preconditions
 
-**Status:** Queued (hold decision)  
+**Status:** Completed (decision: `stay_deferred`)  
 **Date:** 2026-04-23  
 **Parent:** `PB-6` / `PB-6.4`  
 **Parent issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)  
@@ -32,21 +32,56 @@ sabitlemek.
 2. `project_status`, `roadmap_follow`, `roadmap_finish` write-side widening
    adayları defer/hold durumundadır
 
-## Hold Kapıları (Draft)
+## Hold Kapıları (Final)
 
-1. governance gate:
-   - action-level policy contract fail-closed tanımlı mı?
-2. behavior gate:
-   - positive + negative + denial path testleri mevcut mu?
-3. safety gate:
-   - overwrite/conflict/idempotency davranışı açık mı?
-4. docs parity gate:
-   - support boundary ve runbook dilinde widening sınırı net mi?
-5. rollback gate:
-   - write-side başarısızlıklarında geri alma/sınırlandırma adımları belirli mi?
+| Gate | Sonuç | Kanıt | Değerlendirme |
+|---|---|---|---|
+| Governance gate | FAIL | `ao_kernel/extensions/handlers/prj_kernel_api.py` yalnız `system_status` ve `doc_nav_check` register ediyor; write-side aday action'lar runtime'a bağlı değil | Write-side widening için action-level fail-closed policy contract henüz yok |
+| Behavior gate | FAIL | `pytest -q tests/test_extension_dispatch.py::TestBootstrapKernelApiExtension::test_kernel_api_minimum_actions_registered_by_default` (pass) ile write-side action'ların register edilmediği pinli | Write-side positive/negative/deny behavior test matrisi yok |
+| Safety gate | FAIL | `project_status`, `roadmap_follow`, `roadmap_finish` için overwrite/conflict/idempotency sözleşmesi ve testleri yok | Write-side safety semantics tanımsız |
+| Docs parity gate | PASS | `docs/PUBLIC-BETA.md` ve `docs/SUPPORT-BOUNDARY.md` write-side action'ları açıkça `Deferred` sınırında tutuyor | Operator-facing boundary doğru ve dürüst |
+| Rollback gate | FAIL | Write-side action lane'i açılmadığı için rollback/runbook adımları tanımlı değil | Promotion için rollback/containment yolu önceden yazılmalı |
 
-## DoD
+## Evidence Snapshot
 
-1. write-side widening için action bazlı gate tablosu finalize edilmiş
-2. defer veya implementation kararı tekilleştirilmiş
-3. sonraki slice (implementation açılacaksa) kapsamı dar ve ölçülebilir
+1. Runtime registry çözümleme:
+   - `project_status -> missing`
+   - `roadmap_follow -> missing`
+   - `roadmap_finish -> missing`
+   - `system_status -> registered`
+   - `doc_nav_check -> registered`
+2. Targeted tests:
+   - `pytest -q tests/test_extension_dispatch.py::TestBootstrapKernelApiExtension::test_kernel_api_minimum_actions_registered_by_default` -> pass
+   - `pytest -q tests/test_extension_loader.py::TestBundledDefaults::test_kernel_api_manifest_is_minimum_runtime_backed` -> pass
+3. Boundary docs:
+   - `docs/PUBLIC-BETA.md`: write-side kernel-api actions `Deferred`
+   - `docs/SUPPORT-BOUNDARY.md`: support boundary read-only iki action ile sınırlı
+
+## Karar
+
+`PRJ-KERNEL-API` write-side widening bu tranche'ta açılmıyor.  
+**Final verdict:** `stay_deferred`.
+
+Gerekçe:
+
+1. Runtime + behavior + safety + rollback kapıları write-side için henüz yok.
+2. Docs parity kapısı tek başına widening için yeterli değil.
+3. Mevcut dar read-only support boundary (`system_status`, `doc_nav_check`)
+   korunarak fake support widening riski engelleniyor.
+
+## Sonraki Slice Önkoşulları (Implementation Açmadan Önce)
+
+1. Action-level write contract:
+   - her action için input/output schema, write root sınırı, fail-closed policy
+2. Behavior-first test matrisi:
+   - positive + negative + deny + idempotency + conflict path testleri
+3. Safety/rollback:
+   - kısmi write başarısızlığı için rollback/compensation adımları ve runbook
+4. Support parity:
+   - docs + status + tests + smoke zinciri birlikte güncellenmeden boundary widen edilmez
+
+## DoD (Karar Slice)
+
+1. write-side widening gate tablosu finalize edildi
+2. karar tekilleşti: `stay_deferred`
+3. implementation açılış önkoşulları dar, ölçülebilir ve yazılı bırakıldı

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -20,7 +20,7 @@ ayrı ayrı görünür kılmak.
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
-- **Aktif issue:** [#270](https://github.com/Halildeu/ao-kernel/issues/270)
+- **Aktif issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
 
 ## 2. Başlangıç Gerçeği
 
@@ -107,12 +107,13 @@ bir sonraki implementation hattına taşımaktır.
 4. Slice plan:
    `.claude/plans/PB-6.4c-GH-CLI-PR-LIVE-WRITE-GRADUATION.md`
 
-`PB-6.4d` active hold-decision slice:
+`PB-6.4d` decision slice'ı tamamlandı:
 
 1. Issue: [#270](https://github.com/Halildeu/ao-kernel/issues/270)
-2. Hedef: `PRJ-KERNEL-API` write-side widening önkoşullarını action bazlı
-   gate tablosuna indirmek
-3. Slice plan:
+2. Karar: `stay_deferred`
+3. Gerekçe: governance + behavior + safety + rollback kapıları write-side
+   widening için karşılanmadı; docs parity tek başına widening açmadı
+4. Slice plan:
    `.claude/plans/PB-6.4d-KERNEL-API-WRITE-SIDE-WIDENING-PRECONDITIONS.md`
 
 `PB-6.2` contract slice'ı tamamlandı:
@@ -199,7 +200,7 @@ Güncel runtime baseline:
    - first tranche complete: `PB-6.4a` ([#265](https://github.com/Halildeu/ao-kernel/issues/265), [#266](https://github.com/Halildeu/ao-kernel/pull/266))
    - second tranche complete: `PB-6.4b` ([#267](https://github.com/Halildeu/ao-kernel/issues/267), [#268](https://github.com/Halildeu/ao-kernel/pull/268))
    - third tranche complete: `PB-6.4c` decision closeout (`stay_preflight`, [#271](https://github.com/Halildeu/ao-kernel/issues/271))
-   - active hold tranche: `PB-6.4d` ([#270](https://github.com/Halildeu/ao-kernel/issues/270))
+   - fourth tranche complete: `PB-6.4d` decision closeout (`stay_deferred`, [#270](https://github.com/Halildeu/ao-kernel/issues/270))
 
 Not:
 
@@ -208,8 +209,9 @@ Not:
 2. `PB-6.2b` support boundary'yi yalnız iki read-only action için genişletti.
 3. `PB-6.4c` kararı `stay_preflight` olarak kapanmıştır; live write widening
    support boundary dışında kalır.
-4. `PB-6.4d` karar dilimi kapanmadan kernel-api write-side widening
-   implementation açılmayacak.
+4. `PB-6.4d` kararı `stay_deferred` olarak kapanmıştır; kernel-api write-side
+   widening için ayrı implementation tranche'i yalnız yazılı önkoşullar
+   karşılandığında açılabilir.
 
 ## 7. Riskler
 
@@ -225,9 +227,9 @@ Not:
 
 Bugünden itibaren doğru sıra:
 
-1. `PB-6.4d` active hold-decision slice (`#270`)
-   - kernel-api write-side widening preconditions
-   - governance/policy + behavior test + rollback gate tabanı
+1. `PB-6` umbrella closeout ve sonraki widening tranche seçimi (`#243`)
+   - `PB-6.4a/b/c/d` kararlarını tek backlog sırasına indir
+   - bir sonraki aktif slice'ı tek issue + tek DoD ile aç
 
 ## 9. Güncelleme Protokolü
 


### PR DESCRIPTION
## Summary
- finalize PB-6.4d as a completed decision slice with verdict stay_deferred
- add final gate table and evidence snapshot for kernel-api write-side widening preconditions
- align PB-6.4 ordering contract and post-beta status SSOT to mark PB-6.4d complete and move active issue back to #243

## Validation
- pytest -q tests/test_extension_dispatch.py::TestBootstrapKernelApiExtension::test_kernel_api_minimum_actions_registered_by_default
- pytest -q tests/test_extension_loader.py::TestBundledDefaults::test_kernel_api_manifest_is_minimum_runtime_backed
- python3 inline runtime registry probe (project_status/roadmap_follow/roadmap_finish missing, system_status/doc_nav_check registered)

Closes #270
Refs #243