### PR TITLE
[codex] plans: kickoff PB-6.5 ops readiness gates

### DIFF
--- a/.claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md
+++ b/.claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md
@@ -219,7 +219,11 @@ Canlı yürütme sırası bundan sonra aşağıdaki SSOT'tan takip edilir:
 
 1. `PB-6.1a`, `PB-6.1b`, `PB-6.2`, `PB-6.2b`, `PB-6.3`, `PB-6.3b` tamamlandı.
 2. `PB-6.4` karar/ordering slice tamamlandı (issue: [#263](https://github.com/Halildeu/ao-kernel/issues/263)).
-3. Aktif alt hat `PB-6.4c` (issue: [#271](https://github.com/Halildeu/ao-kernel/issues/271));
-   queued alt hat `PB-6.4d` (issue: [#270](https://github.com/Halildeu/ao-kernel/issues/270)).
-4. `PB-6.4` için karar/ordering contract:
+3. `PB-6.4c` ve `PB-6.4d` karar dilimleri tamamlandı:
+   - `PB-6.4c`: `stay_preflight` ([#271](https://github.com/Halildeu/ao-kernel/issues/271))
+   - `PB-6.4d`: `stay_deferred` ([#270](https://github.com/Halildeu/ao-kernel/issues/270))
+4. `PB-6.4` karar/ordering contract:
    `.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md`
+5. Yeni aktif alt hat `PB-6.5`:
+   - issue: [#275](https://github.com/Halildeu/ao-kernel/issues/275)
+   - plan: `.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md`

--- a/.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md
+++ b/.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md
@@ -149,6 +149,7 @@ Güncel yürütüm sırası:
    - plan:
      `.claude/plans/PB-6.4d-KERNEL-API-WRITE-SIDE-WIDENING-PRECONDITIONS.md`
 5. sonraki aktif hat:
-   - `PB-6` umbrella üzerinde widening implementation adayının
-     (yeni tranche) dar kapsamla seçilmesi
-   - issue: [#243](https://github.com/Halildeu/ao-kernel/issues/243)
+   - `PB-6.5` ops readiness gates slice'ı başlatıldı
+   - issue: [#275](https://github.com/Halildeu/ao-kernel/issues/275)
+   - plan:
+     `.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md`

--- a/.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md
+++ b/.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md
@@ -1,0 +1,75 @@
+# PB-6.5 — Ops Readiness Gates for Widened Lanes
+
+**Status:** Active  
+**Date:** 2026-04-23  
+**Parent:** `PB-6`  
+**Parent issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)  
+**Active issue:** [#275](https://github.com/Halildeu/ao-kernel/issues/275)
+
+## Amaç
+
+Widening adayları (operator-managed lane veya ileride write-side lane) için
+support tier kararı öncesinde zorunlu operasyon kapılarını netleştirmek:
+
+1. incident class + severity + owner sınırı
+2. rollback/containment önkoşulları
+3. known-bug registry ve support boundary parity
+4. lane bazlı operator prerequisite/exit criteria
+
+## Kapsam
+
+1. `claude-code-cli` lane için ops readiness gate tablosu
+2. `gh-cli-pr` preflight lane için ops readiness gate tablosu
+3. deferred write-side lane'ler için (`gh-cli-pr` live write, `PRJ-KERNEL-API`
+   write-side actions) açılış önkoşulu checklist'i
+4. runbook/docs parity kontrol listesi (`PUBLIC-BETA`, `SUPPORT-BOUNDARY`,
+   `OPERATIONS-RUNBOOK`, `KNOWN-BUGS`, `ROLLBACK`)
+
+## Kapsam Dışı
+
+1. runtime widening implementation
+2. support tier promotion'ı doğrudan açmak
+3. yeni adapter/handler geliştirmek
+
+## Başlangıç Gerçeği
+
+1. `PB-6.4c` kararı `stay_preflight`: `gh-cli-pr` live write lane açılmadı.
+2. `PB-6.4d` kararı `stay_deferred`: kernel-api write-side widening açılmadı.
+3. Operator-managed lane'ler (claude-code-cli / gh-cli-pr preflight) canlı
+   smoke ile doğrulanabiliyor; fakat widening kararı için ops gates henüz tek
+   tabloda toplanmış değil.
+
+## Ops Gate Matrisi (PB-6.5 Çıktısı)
+
+Her lane için aşağıdaki kapılar birlikte değerlendirilir:
+
+1. Incident gate:
+   - class/severity/owner açık mı?
+2. Rollback gate:
+   - lane bozulduğunda containment/rollback adımı tanımlı mı?
+3. Known-bug gate:
+   - açık riskler registry'de ve support boundary notlarında görünüyor mu?
+4. Prerequisite gate:
+   - operator'ın lane'i çalıştırmadan önce sağlaması gereken koşullar açık mı?
+5. Evidence gate:
+   - smoke/test/CI kanıtı reproducible ve lane-level raporlanabilir mi?
+6. Docs parity gate:
+   - docs yüzeyleri aynı support sınırını konuşuyor mu?
+
+## DoD
+
+1. lane bazlı ops readiness gate tablosu finalize edildi
+2. her lane için verdict tekilleşti:
+   - `stay_beta_operator_managed` veya
+   - `promotion_candidate_with_ops_gates` veya
+   - `stay_deferred`
+3. widening implementation açılacaksa bir sonraki slice tek issue + tek DoD ile
+   tanımlandı
+4. status SSOT ve umbrella issue güncellendi
+
+## İlk Yürütüm Sırası
+
+1. `docs/OPERATIONS-RUNBOOK.md`, `docs/KNOWN-BUGS.md`, `docs/ROLLBACK.md`,
+   `docs/PUBLIC-BETA.md`, `docs/SUPPORT-BOUNDARY.md` parity taraması
+2. lane bazlı readiness checklist'in mevcut kanıtla doldurulması
+3. açık ops gap'ler için dar kapsamlı follow-up slice önerisi

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -14,13 +14,13 @@ ayrı ayrı görünür kılmak.
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-6.2-KERNEL-API-PROMOTION-CONTRACT.md`
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
-- **Aktif decision/ordering contract:** `.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md`
+- **Aktif decision/ordering contract:** `.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
-- **Aktif issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
+- **Aktif issue:** [#275](https://github.com/Halildeu/ao-kernel/issues/275)
 
 ## 2. Başlangıç Gerçeği
 
@@ -116,6 +116,14 @@ bir sonraki implementation hattına taşımaktır.
 4. Slice plan:
    `.claude/plans/PB-6.4d-KERNEL-API-WRITE-SIDE-WIDENING-PRECONDITIONS.md`
 
+`PB-6.5` kickoff:
+
+1. Issue: [#275](https://github.com/Halildeu/ao-kernel/issues/275)
+2. Hedef: widened lane adayları için ops-readiness kapılarını tek tabloda
+   finalize etmek (incident + rollback + prerequisite + known-bug + parity)
+3. Slice plan:
+   `.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md`
+
 `PB-6.2` contract slice'ı tamamlandı:
 
 1. Issue: [#251](https://github.com/Halildeu/ao-kernel/issues/251)
@@ -201,6 +209,10 @@ Güncel runtime baseline:
    - second tranche complete: `PB-6.4b` ([#267](https://github.com/Halildeu/ao-kernel/issues/267), [#268](https://github.com/Halildeu/ao-kernel/pull/268))
    - third tranche complete: `PB-6.4c` decision closeout (`stay_preflight`, [#271](https://github.com/Halildeu/ao-kernel/issues/271))
    - fourth tranche complete: `PB-6.4d` decision closeout (`stay_deferred`, [#270](https://github.com/Halildeu/ao-kernel/issues/270))
+5. `PB-6.5` ops readiness gates
+   - active planning slice (issue: [#275](https://github.com/Halildeu/ao-kernel/issues/275))
+   - plan:
+     `.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md`
 
 Not:
 
@@ -227,9 +239,9 @@ Not:
 
 Bugünden itibaren doğru sıra:
 
-1. `PB-6` umbrella closeout ve sonraki widening tranche seçimi (`#243`)
-   - `PB-6.4a/b/c/d` kararlarını tek backlog sırasına indir
-   - bir sonraki aktif slice'ı tek issue + tek DoD ile aç
+1. `PB-6.5` active ops-readiness slice (`#275`)
+   - lane bazlı ops gate tablosunu finalize et
+   - widening implementation öncesi tekil karar/verdict setini çıkar
 
 ## 9. Güncelleme Protokolü
 


### PR DESCRIPTION
## Summary
- create PB-6.5 active plan for ops-readiness gates on widened lanes
- move status SSOT active contract/issue pointers to PB-6.5 (#275)
- align PB-6 gap map and PB-6.4 ordering contract with the new active slice

## Scope
- planning/status/docs alignment only
- no runtime widening implementation

## Validation
- docs/plans parity review in repo

Refs #243
Refs #275