### PR TITLE
[codex] PB-6.5 closeout ve PB-6.6 kickoff hizası

### DIFF
--- a/.claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md
+++ b/.claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md
@@ -224,6 +224,9 @@ Canlı yürütme sırası bundan sonra aşağıdaki SSOT'tan takip edilir:
    - `PB-6.4d`: `stay_deferred` ([#270](https://github.com/Halildeu/ao-kernel/issues/270))
 4. `PB-6.4` karar/ordering contract:
    `.claude/plans/PB-6.4-REAL-ADAPTER-WRITE-SIDE-GRADUATION-ORDER-CONTRACT.md`
-5. Yeni aktif alt hat `PB-6.5`:
+5. `PB-6.5` decision closeout tamamlandı:
    - issue: [#275](https://github.com/Halildeu/ao-kernel/issues/275)
    - plan: `.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md`
+6. Yeni aktif alt hat `PB-6.6`:
+   - issue: [#277](https://github.com/Halildeu/ao-kernel/issues/277)
+   - plan: `.claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md`

--- a/.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md
+++ b/.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md
@@ -1,10 +1,11 @@
 # PB-6.5 — Ops Readiness Gates for Widened Lanes
 
-**Status:** Active  
+**Status:** Completed (decision closeout)  
 **Date:** 2026-04-23  
 **Parent:** `PB-6`  
 **Parent issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)  
-**Active issue:** [#275](https://github.com/Halildeu/ao-kernel/issues/275)
+**Decision issue:** [#275](https://github.com/Halildeu/ao-kernel/issues/275)  
+**Next active issue:** [#277](https://github.com/Halildeu/ao-kernel/issues/277)
 
 ## Amaç
 
@@ -39,7 +40,33 @@ support tier kararı öncesinde zorunlu operasyon kapılarını netleştirmek:
    smoke ile doğrulanabiliyor; fakat widening kararı için ops gates henüz tek
    tabloda toplanmış değil.
 
-## Ops Gate Matrisi (PB-6.5 Çıktısı)
+## Canlı Kanıt Turu (2026-04-23)
+
+Komutlar:
+
+```bash
+python3 -m ao_kernel doctor
+python3 scripts/claude_code_cli_smoke.py --output json
+python3 scripts/gh_cli_pr_smoke.py --output json
+python3 - <<'PY'
+from ao_kernel.client import AoKernelClient
+c=AoKernelClient()
+for name in ["project_status","roadmap_follow","roadmap_finish","system_status","doc_nav_check"]:
+    rec=c.action_registry.resolve(name)
+    print(f"{name}={'registered' if rec else 'missing'}")
+PY
+```
+
+Özet:
+
+1. `doctor`: `8 OK, 1 WARN, 0 FAIL` (`runtime_backed=2`, `contract_only=1`,
+   `quarantined=16`)
+2. `claude_code_cli_smoke`: `overall_status="pass"`
+3. `gh_cli_pr_smoke`: `overall_status="pass"` (`pr_dry_run` dahil)
+4. kernel-api write-side action'lar runtime'da `missing`:
+   `project_status`, `roadmap_follow`, `roadmap_finish`
+
+## Ops Gate Matrisi (Final)
 
 Her lane için aşağıdaki kapılar birlikte değerlendirilir:
 
@@ -56,15 +83,54 @@ Her lane için aşağıdaki kapılar birlikte değerlendirilir:
 6. Docs parity gate:
    - docs yüzeyleri aynı support sınırını konuşuyor mu?
 
+| Lane | Incident | Rollback | Known-bug | Prerequisite | Evidence | Docs parity | Verdict |
+|---|---|---|---|---|---|---|---|
+| `claude-code-cli` helper lane | PASS | PASS | PASS (bounded) | PASS | PASS | PASS | `promotion_candidate_with_ops_gates` |
+| `gh-cli-pr` preflight lane | PASS | PASS | PASS | PASS | PASS | PASS | `stay_beta_operator_managed` |
+| `gh-cli-pr` live write lane | FAIL | FAIL | INCONCLUSIVE | FAIL | FAIL | PASS | `stay_deferred` |
+| `PRJ-KERNEL-API` write-side actions | FAIL | FAIL | INCONCLUSIVE | FAIL | FAIL | PASS | `stay_deferred` |
+
+Notlar:
+
+1. `claude-code-cli` lane için açık KB'ler (`KB-001`, `KB-002`) support
+   sınırını bozmayacak şekilde operator-managed lane içinde bounded kaldı.
+2. `gh-cli-pr` için canlı lane kanıtı yalnız preflight (`--dry-run`) seviyesinde
+   olduğu için live write widening açılmadı.
+3. kernel-api write-side action'lar runtime registry'de yok; bu yüzden
+   write-side widening ops gates bu slice'ta geçmedi.
+
+## PB-6.5 Karar Çıkışı
+
+1. `claude-code-cli` lane:
+   `promotion_candidate_with_ops_gates` (otomatik support widening yok)
+2. `gh-cli-pr` preflight lane:
+   `stay_beta_operator_managed` (preflight-only boundary korunur)
+3. `gh-cli-pr` live write lane:
+   `stay_deferred`
+4. `PRJ-KERNEL-API` write-side actions:
+   `stay_deferred`
+
+## PB-6.5 DoD Doğrulaması
+
+1. lane bazlı ops-readiness gate tablosu finalize edildi
+2. her lane için tekil verdict üretildi
+3. sonraki aktif implementation/decision slice issue + plan ile açıldı:
+   `PB-6.6` / [#277](https://github.com/Halildeu/ao-kernel/issues/277)
+4. status SSOT ve umbrella issue hizası bu closeout ile güncellenecek
+
+## Sonraki Aktif Hat
+
+`PB-6.6` — claude-code-cli lane ops-gated promotion closeout:
+
+1. issue: [#277](https://github.com/Halildeu/ao-kernel/issues/277)
+2. plan:
+   `.claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md`
+
 ## DoD
 
 1. lane bazlı ops readiness gate tablosu finalize edildi
-2. her lane için verdict tekilleşti:
-   - `stay_beta_operator_managed` veya
-   - `promotion_candidate_with_ops_gates` veya
-   - `stay_deferred`
-3. widening implementation açılacaksa bir sonraki slice tek issue + tek DoD ile
-   tanımlandı
+2. her lane için verdict tekilleşti
+3. bir sonraki aktif slice tek issue + tek DoD ile açıldı
 4. status SSOT ve umbrella issue güncellendi
 
 ## İlk Yürütüm Sırası

--- a/.claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md
+++ b/.claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md
@@ -1,0 +1,60 @@
+# PB-6.6 — Claude Code CLI Lane Ops-Gated Promotion Closeout
+
+**Status:** Active  
+**Date:** 2026-04-23  
+**Parent:** `PB-6`  
+**Parent issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)  
+**Active issue:** [#277](https://github.com/Halildeu/ao-kernel/issues/277)
+
+## Amaç
+
+`PB-6.5` sonucunda `promotion_candidate_with_ops_gates` çıkan
+`claude-code-cli` lane'i için tekil support-tier closeout kararını üretmek.
+
+Bu slice runtime davranışını değiştirmez; support-tier kararını ve operator
+işletim kapılarını finalize eder.
+
+## Kapsam
+
+1. `claude-code-cli` lane için ops-gated promotion checklist finalizasyonu
+2. decision sonucu:
+   - `stay_beta_operator_managed` veya
+   - `promoted_with_ops_gates`
+3. `PUBLIC-BETA`, `SUPPORT-BOUNDARY`, `OPERATIONS-RUNBOOK`, `KNOWN-BUGS`,
+   `ROLLBACK` yüzeylerinde karar uyumunu sağlamak
+4. `PB-6` umbrella üzerinde sonraki aktif hattı netleştirmek
+
+## Kapsam Dışı
+
+1. adapter/runtime/policy behavior değişikliği
+2. `gh-cli-pr` live write widening
+3. `PRJ-KERNEL-API` write-side widening
+
+## Giriş Kanıtı
+
+`PB-6.5` closeout çıktısı:
+
+1. `claude-code-cli` lane verdict:
+   `promotion_candidate_with_ops_gates`
+2. known-bug etkisi:
+   `KB-001`, `KB-002` bounded, workaround yazılı
+3. live smoke:
+   `python3 scripts/claude_code_cli_smoke.py --output json` -> pass
+
+## Gate Seti
+
+1. Evidence repeatability gate:
+   - bağımsız smoke koşularında lane kararlı mı?
+2. Known-bug containment gate:
+   - açık bug'lar operator için yönetilebilir ve yanlış destek iddiası üretmiyor mu?
+3. Ops runbook gate:
+   - incident/rollback akışı lane özelinde uygulanabilir mi?
+4. Docs parity gate:
+   - support tier dili tüm SSOT yüzeylerinde tek anlamlı mı?
+
+## DoD
+
+1. `claude-code-cli` lane için tek support-tier verdict üretildi
+2. kararın gerekçesi gate bazında yazılı
+3. docs/status/issue yüzeyleri aynı kararı taşıyor
+4. `PB-6` umbrella'da bir sonraki aktif hat tek issue ile bırakıldı

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -14,13 +14,13 @@ ayrı ayrı görünür kılmak.
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-6.2-KERNEL-API-PROMOTION-CONTRACT.md`
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
-- **Aktif decision/ordering contract:** `.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md`
+- **Aktif decision/ordering contract:** `.claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
-- **Aktif issue:** [#275](https://github.com/Halildeu/ao-kernel/issues/275)
+- **Aktif issue:** [#277](https://github.com/Halildeu/ao-kernel/issues/277)
 
 ## 2. Başlangıç Gerçeği
 
@@ -116,13 +116,24 @@ bir sonraki implementation hattına taşımaktır.
 4. Slice plan:
    `.claude/plans/PB-6.4d-KERNEL-API-WRITE-SIDE-WIDENING-PRECONDITIONS.md`
 
-`PB-6.5` kickoff:
+`PB-6.5` decision closeout tamamlandı:
 
 1. Issue: [#275](https://github.com/Halildeu/ao-kernel/issues/275)
-2. Hedef: widened lane adayları için ops-readiness kapılarını tek tabloda
-   finalize etmek (incident + rollback + prerequisite + known-bug + parity)
+2. Karar özeti:
+   - `claude-code-cli`: `promotion_candidate_with_ops_gates`
+   - `gh-cli-pr` preflight: `stay_beta_operator_managed`
+   - `gh-cli-pr` live write: `stay_deferred`
+   - `PRJ-KERNEL-API` write-side: `stay_deferred`
 3. Slice plan:
    `.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md`
+
+`PB-6.6` kickoff:
+
+1. Issue: [#277](https://github.com/Halildeu/ao-kernel/issues/277)
+2. Hedef: `claude-code-cli` lane için ops-gated support-tier closeout kararını
+   tekilleştirmek
+3. Slice plan:
+   `.claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md`
 
 `PB-6.2` contract slice'ı tamamlandı:
 
@@ -210,9 +221,13 @@ Güncel runtime baseline:
    - third tranche complete: `PB-6.4c` decision closeout (`stay_preflight`, [#271](https://github.com/Halildeu/ao-kernel/issues/271))
    - fourth tranche complete: `PB-6.4d` decision closeout (`stay_deferred`, [#270](https://github.com/Halildeu/ao-kernel/issues/270))
 5. `PB-6.5` ops readiness gates
-   - active planning slice (issue: [#275](https://github.com/Halildeu/ao-kernel/issues/275))
+   - completed decision closeout (issue: [#275](https://github.com/Halildeu/ao-kernel/issues/275))
    - plan:
      `.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md`
+6. `PB-6.6` claude-code-cli lane ops-gated promotion closeout
+   - active decision slice (issue: [#277](https://github.com/Halildeu/ao-kernel/issues/277))
+   - plan:
+     `.claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md`
 
 Not:
 
@@ -239,9 +254,9 @@ Not:
 
 Bugünden itibaren doğru sıra:
 
-1. `PB-6.5` active ops-readiness slice (`#275`)
-   - lane bazlı ops gate tablosunu finalize et
-   - widening implementation öncesi tekil karar/verdict setini çıkar
+1. `PB-6.6` active ops-gated promotion closeout (`#277`)
+   - `claude-code-cli` lane için support-tier verdict tekilleştir
+   - kararın docs/status/issue yüzeylerinde tek anlamlı kalmasını sağla
 
 ## 9. Güncelleme Protokolü
 


### PR DESCRIPTION
## Özet\n- PB-6.5 ops-readiness slice'ını completed decision closeout olarak finalize eder\n- PB-6.6 (claude-code-cli lane ops-gated promotion closeout) için yeni plan dosyası ekler\n- program status ve PB-6 gap-map yüzeylerinde aktif hattı #277'ye çeker\n\n## Değişen dosyalar\n- .claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md\n- .claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md\n- .claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md\n- .claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md\n\n## Kanıt\n- python3 -m ao_kernel doctor\n- python3 scripts/claude_code_cli_smoke.py --output json\n- python3 scripts/gh_cli_pr_smoke.py --output json\n\nCloses #275\nRefs #277\nRefs #243