### PR TITLE
[codex] PB-6.6 closeout: claude-code-cli beta verdict

### DIFF
--- a/.claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md
+++ b/.claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md
@@ -227,6 +227,8 @@ Canlı yürütme sırası bundan sonra aşağıdaki SSOT'tan takip edilir:
 5. `PB-6.5` decision closeout tamamlandı:
    - issue: [#275](https://github.com/Halildeu/ao-kernel/issues/275)
    - plan: `.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md`
-6. Yeni aktif alt hat `PB-6.6`:
+6. `PB-6.6` decision closeout tamamlandı:
    - issue: [#277](https://github.com/Halildeu/ao-kernel/issues/277)
    - plan: `.claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md`
+7. Sonraki aktif adım:
+   - `PB-6` umbrella (`#243`) altında bir sonraki dar tranche issue/plan açılışı

--- a/.claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md
+++ b/.claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md
@@ -1,10 +1,11 @@
 # PB-6.6 — Claude Code CLI Lane Ops-Gated Promotion Closeout
 
-**Status:** Active  
+**Status:** Completed (decision closeout)  
 **Date:** 2026-04-23  
 **Parent:** `PB-6`  
 **Parent issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)  
-**Active issue:** [#277](https://github.com/Halildeu/ao-kernel/issues/277)
+**Decision issue:** [#277](https://github.com/Halildeu/ao-kernel/issues/277)  
+**Next active issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
 
 ## Amaç
 
@@ -41,6 +42,21 @@ işletim kapılarını finalize eder.
 3. live smoke:
    `python3 scripts/claude_code_cli_smoke.py --output json` -> pass
 
+## Canlı Kanıt Turu (2026-04-23)
+
+Komut:
+
+```bash
+python3 scripts/claude_code_cli_smoke.py --output json
+```
+
+Özet:
+
+1. `overall_status="pass"`
+2. `version`, `auth_status`, `prompt_access`, `manifest_invocation` alt
+   kontrolleri geçiyor
+3. lane teknik olarak canlı ve tekrar edilebilir smoke üretiyor
+
 ## Gate Seti
 
 1. Evidence repeatability gate:
@@ -52,9 +68,40 @@ işletim kapılarını finalize eder.
 4. Docs parity gate:
    - support tier dili tüm SSOT yüzeylerinde tek anlamlı mı?
 
+## Gate Değerlendirmesi (Final)
+
+| Gate | Durum | Kanıt | Yorum |
+|---|---|---|---|
+| Evidence repeatability | PASS | `scripts/claude_code_cli_smoke.py --output json` | Lane tekrar eden smoke ile doğrulanıyor |
+| Known-bug containment | PASS (bounded) | `KB-001`, `KB-002` | Etki operator-managed sınır içinde yönetilebilir; shipped baseline etkisi yok |
+| Ops runbook | PASS | `docs/OPERATIONS-RUNBOOK.md`, `docs/ROLLBACK.md` | Incident/rollback akışı lane için yazılı ve uygulanabilir |
+| Docs parity | PASS | `PUBLIC-BETA`, `SUPPORT-BOUNDARY`, `KNOWN-BUGS` | Lane tier anlatımı tek anlamlı ve çelişkisiz |
+
+## PB-6.6 Karar Çıkışı
+
+**Final verdict:** `stay_beta_operator_managed`
+
+Gerekçe:
+
+1. `promotion_candidate_with_ops_gates` sinyali korunuyor, fakat lane bugün hâlâ
+   operator çevresine bağımlı canlı auth/prompt precondition'ları taşıyor.
+2. `KB-001` ve `KB-002` bounded olsa da support tier'i widen edecek kadar
+   evrensel/çevre-bağımsız dayanıklılık kanıtı üretilmiş değil.
+3. Bu nedenle lane support sınırı `Beta (operator-managed)` olarak kalır;
+   shipped baseline'a yükseltilmez.
+
+## Docs/Status Parity Sonucu
+
+1. `docs/PUBLIC-BETA.md`: `claude-code-cli` satırı `Beta (operator-managed)`
+2. `docs/SUPPORT-BOUNDARY.md`: Beta layer aynı sınırı taşıyor
+3. `docs/OPERATIONS-RUNBOOK.md`, `docs/KNOWN-BUGS.md`, `docs/ROLLBACK.md`:
+   incident/known-bug/rollback anlatımı bu verdict ile uyumlu
+4. program status SSOT (`POST-BETA-...STATUS.md`) aktif issue/hat bilgisini
+   `#243` umbrella seviyesine çeker
+
 ## DoD
 
 1. `claude-code-cli` lane için tek support-tier verdict üretildi
 2. kararın gerekçesi gate bazında yazılı
 3. docs/status/issue yüzeyleri aynı kararı taşıyor
-4. `PB-6` umbrella'da bir sonraki aktif hat tek issue ile bırakıldı
+4. `PB-6` umbrella'da bir sonraki aktif hat tek issue ile bırakıldı (`#243`)

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -14,13 +14,13 @@ ayrı ayrı görünür kılmak.
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-6.2-KERNEL-API-PROMOTION-CONTRACT.md`
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
-- **Aktif decision/ordering contract:** `.claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md`
+- **Aktif decision/ordering contract:** `.claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
-- **Aktif issue:** [#277](https://github.com/Halildeu/ao-kernel/issues/277)
+- **Aktif issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
 
 ## 2. Başlangıç Gerçeği
 
@@ -127,12 +127,15 @@ bir sonraki implementation hattına taşımaktır.
 3. Slice plan:
    `.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md`
 
-`PB-6.6` kickoff:
+`PB-6.6` decision closeout tamamlandı:
 
 1. Issue: [#277](https://github.com/Halildeu/ao-kernel/issues/277)
-2. Hedef: `claude-code-cli` lane için ops-gated support-tier closeout kararını
-   tekilleştirmek
-3. Slice plan:
+2. Final verdict: `stay_beta_operator_managed`
+3. Gerekçe özeti:
+   - smoke repeatability var, fakat lane hâlâ operator-env bağımlı
+   - `KB-001` ve `KB-002` bounded/open olarak kalıyor
+   - support tier widening yerine narrow beta sınırı korunuyor
+4. Slice plan:
    `.claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md`
 
 `PB-6.2` contract slice'ı tamamlandı:
@@ -225,7 +228,7 @@ Güncel runtime baseline:
    - plan:
      `.claude/plans/PB-6.5-OPS-READINESS-FOR-WIDENED-LANES.md`
 6. `PB-6.6` claude-code-cli lane ops-gated promotion closeout
-   - active decision slice (issue: [#277](https://github.com/Halildeu/ao-kernel/issues/277))
+   - completed decision closeout (issue: [#277](https://github.com/Halildeu/ao-kernel/issues/277))
    - plan:
      `.claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md`
 
@@ -254,9 +257,9 @@ Not:
 
 Bugünden itibaren doğru sıra:
 
-1. `PB-6.6` active ops-gated promotion closeout (`#277`)
-   - `claude-code-cli` lane için support-tier verdict tekilleştir
-   - kararın docs/status/issue yüzeylerinde tek anlamlı kalmasını sağla
+1. `PB-6` umbrella (`#243`) altında bir sonraki dar tranche'i seç
+   - inventory truth gap ve support widening sırasını yeniden doğrula
+   - tek issue + tek plan + tek DoD disipliniyle yeni alt slice aç
 
 ## 9. Güncelleme Protokolü
 

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -55,7 +55,7 @@ istemek gerekir.
 | Yüzey | Durum | Not |
 |---|---|---|
 | Public Beta yüzeyinin tamamı | Beta | Stable kanal hâlâ `3.13.3`; genel kullanım için pre-release install gerekir |
-| `claude-code-cli` helper-backed real-adapter lane | Beta (operator-managed) | `python3 scripts/claude_code_cli_smoke.py` ile preflight + canlı prompt smoke doğrulanabilir; varsayılan shipped demo değildir |
+| `claude-code-cli` helper-backed real-adapter lane | Beta (operator-managed) | `python3 scripts/claude_code_cli_smoke.py` ile preflight + canlı prompt smoke doğrulanabilir; varsayılan shipped demo değildir. `PB-6.6` closeout verdict'i: `stay_beta_operator_managed` |
 | `gh-cli-pr` helper-backed preflight lane | Beta (operator-managed preflight only) | `python3 scripts/gh_cli_pr_smoke.py` auth/repo visibility + `gh pr create --dry-run` zincirini doğrular; gerçek remote PR açmaz |
 | Real-adapter benchmark tam modu | Beta (operator-managed) | Deterministik stub lane kadar stabil değildir; adapter-altı gerçek tier sınırları yukarıdaki satırlarda tanımlanır |
 

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -51,6 +51,9 @@ These are real, testable surfaces, but they are not the default shipped demo:
 - `python3 scripts/gh_cli_pr_smoke.py --output text`
 - real-adapter benchmark full-mode runbooks
 
+`PB-6.6` closeout kararıyla `claude-code-cli` lane support-tier'i
+`stay_beta_operator_managed` olarak korunur; lane shipped baseline'a yükselmez.
+
 ### Contract inventory
 
 These may be bundled and schema-valid without being end-to-end supported:


### PR DESCRIPTION
## Ozet
- PB-6.6 planini decision closeout olarak finalize eder
- final verdict: stay_beta_operator_managed
- status/gap-map ve support dokumanlarini bu kararla hizalar

## Dosyalar
- .claude/plans/PB-6.6-CLAUDE-CODE-CLI-OPS-GATED-PROMOTION-CLOSEOUT.md
- .claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
- .claude/plans/PB-6-GENERAL-PURPOSE-EXPANSION-GAP-MAP.md
- docs/PUBLIC-BETA.md
- docs/SUPPORT-BOUNDARY.md

## Canli Kanit
- python3 -m ao_kernel doctor
- python3 scripts/claude_code_cli_smoke.py --output text

Closes #277
Refs #243
Refs #219