### PR TITLE
PB-7.1: gh-cli-pr live-write readiness guards

### DIFF
--- a/.claude/plans/PB-7.1-GH-CLI-PR-LIVE-WRITE-READINESS.md
+++ b/.claude/plans/PB-7.1-GH-CLI-PR-LIVE-WRITE-READINESS.md
@@ -1,0 +1,77 @@
+# PB-7.1 — gh-cli-pr Live-Write Readiness Guards
+
+**Status:** Active  
+**Date:** 2026-04-23  
+**Parent milestone:** Post-Beta Correctness and Expansion  
+**Tracker:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)  
+**Active issue:** [#281](https://github.com/Halildeu/ao-kernel/issues/281)
+
+## Amaç
+
+`PB-6.4c` kararında `stay_preflight` kalan `gh-cli-pr` lane'i için,
+preflight-only sınırı bozulmadan live-write readiness kontratını dar ve
+fail-closed bir uygulama dilimine çevirmek.
+
+Bu slice **support boundary widening** yapmak için değil, widening öncesi
+eksik kapıları yazılı/testli hale getirmek için açılır.
+
+## Kapsam
+
+1. `scripts/gh_cli_pr_smoke.py` preflight default davranışı korunacak.
+2. Live-write probe yalnız explicit opt-in modla çalışacak.
+3. Live-write modda disposable workspace/branch guard'ları zorunlu olacak.
+4. Başarılı live-write probe için rollback (`gh pr close`) zinciri koşulacak.
+5. Probe çıktısı live-write metadata ve rollback sonucunu kanıt olarak taşıyacak.
+6. Docs/status yüzeyi lane'in hâlâ `deferred/beta` sınırında olduğunu açık
+   yazacak.
+
+## Kapsam Dışı
+
+1. `gh-cli-pr` lane support tier'ını bu slice ile yükseltmek.
+2. `bug_fix_flow` support boundary widening.
+3. `PRJ-KERNEL-API` write-side action widening.
+4. Runtime policy semantiğini (`executor` / `policy_enforcer`) değiştirmek.
+
+## Gate'ler ve DoD
+
+### Gate-1: Preflight parity
+
+- Varsayılan komut (`--mode preflight`) mevcut davranışı aynen korur.
+- `tests/test_gh_cli_pr_smoke.py` preflight regresyonu yakalar.
+
+### Gate-2: Opt-in safety
+
+- Live-write mode explicit flag olmadan fail-closed kalır.
+- Disposable guard'lar (repo/head/base) sağlanmadan write denemesi yapılmaz.
+
+### Gate-3: Rollback + evidence
+
+- Create başarılıysa close adımı koşar (veya explicit keep-open ile atlanır).
+- Report payload'ı create/close durumunu ayrı check'lerde taşır.
+
+### Gate-4: Docs parity
+
+- `PUBLIC-BETA`/`SUPPORT-BOUNDARY` live-write lane'i promoted göstermeyecek.
+- Bu slice çıktısı "readiness guard implemented" olarak kayıt altına alınacak.
+
+## Test Paketi
+
+Minimum zorunlu testler:
+
+1. `tests/test_gh_cli_pr_smoke.py` (new live-write unit matrix)
+2. `tests/test_cli_entrypoints.py` (no regression smoke)
+3. `pytest -q tests/test_gh_cli_pr_smoke.py`
+
+İsteğe bağlı canlı doğrulama (operator-managed):
+
+```bash
+python3 scripts/gh_cli_pr_smoke.py --output json
+python3 scripts/gh_cli_pr_smoke.py --mode live-write --help
+```
+
+## Çıkış Kriteri
+
+1. Kod + test + docs/status aynı gerçeği söyler.
+2. Varsayılan preflight yolu backward-compatible kalır.
+3. Live-write readiness guard'ları testli ve fail-closed olur.
+4. Slice kapanışında issue + PR + test kanıtı status dosyasına işlenir.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -14,13 +14,13 @@ ayrı ayrı görünür kılmak.
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-6.2-KERNEL-API-PROMOTION-CONTRACT.md`
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
-- **Aktif decision/ordering contract:** Yok (program closeout tamamlandı)
+- **Aktif decision/ordering contract:** `.claude/plans/PB-7.1-GH-CLI-PR-LIVE-WRITE-READINESS.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
-- **Aktif issue:** Yok (closeout sonrası yeni tranche açılmadı)
+- **Aktif issue:** [#281](https://github.com/Halildeu/ao-kernel/issues/281) (`PB-7.1`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -255,10 +255,12 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Program closeout tamamlandı.
+`PB-7.1` aktif.
 
-1. Aktif runtime slice yok.
-2. Yeni iş açılacaksa doğrudan `#243` umbrella altında yeni dar tranche issue + plan + DoD ile başlat.
+1. Aktif runtime slice: `PB-7.1` (`gh-cli-pr` live-write readiness guards)
+2. Scope: preflight default'u bozmadan opt-in live-write guard/rollback/evidence
+   kontratı eklemek.
+3. `PB-7.1` kapanmadan yeni runtime widening slice açılmaz.
 
 ## 9. Program Closeout (Final)
 
@@ -281,3 +283,14 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
 - issue / PR / kanıt referansı
 - yeni risk veya deferred notu
 - sıradaki tek aktif hat
+
+## 11. PB-7 Kickoff
+
+`PB-6` closeout sonrası bir sonraki dar implementation hattı bugün
+`PB-7.1` olarak açıldı:
+
+1. Issue: [#281](https://github.com/Halildeu/ao-kernel/issues/281)
+2. Plan: `.claude/plans/PB-7.1-GH-CLI-PR-LIVE-WRITE-READINESS.md`
+3. Hedef: `gh-cli-pr` lane'inde live-write promotion için eksik kalan
+   sandbox/side-effect/rollback/evidence kapılarını
+   **support boundary widening yapmadan** kod/test seviyesinde somutlamak.

--- a/ao_kernel/real_adapter_smoke.py
+++ b/ao_kernel/real_adapter_smoke.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -35,6 +36,12 @@ _MANIFEST_SMOKE_PROMPT = (
 _GH_PR_DRY_RUN_TITLE = "ao-kernel gh-cli-pr smoke probe"
 _GH_PR_DRY_RUN_BODY = "Safe dry-run preflight for gh-cli-pr certification."
 _GH_DRY_RUN_MARKER = "would have created a pull request"
+_GH_LIVE_WRITE_ROLLBACK_COMMENT = (
+    "ao-kernel gh-cli-pr live-write smoke rollback"
+)
+_GITHUB_PR_URL_RE = re.compile(
+    r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+"
+)
 
 
 @dataclass(frozen=True)
@@ -217,12 +224,24 @@ def run_gh_cli_pr_smoke(
     repo: str | None = None,
     base_ref: str | None = None,
     head_ref: str | None = None,
+    mode: Literal["preflight", "live_write"] = "preflight",
+    allow_live_write: bool = False,
+    keep_live_write_pr_open: bool = False,
+    require_disposable_repo_keyword: str | None = "sandbox",
     probe_title: str = _GH_PR_DRY_RUN_TITLE,
     probe_body: str = _GH_PR_DRY_RUN_BODY,
 ) -> GhCliPrSmokeReport:
-    """Run side-effect-safe smoke checks for the bundled gh PR adapter."""
+    """Run smoke checks for the bundled gh PR adapter.
+
+    ``mode='preflight'`` is side-effect-safe and runs `gh pr create --dry-run`.
+    ``mode='live_write'`` is explicit opt-in and executes a bounded create/close
+    chain for disposable environments.
+    """
 
     runner = runner or _default_runner
+    if mode not in ("preflight", "live_write"):
+        raise ValueError("mode must be 'preflight' or 'live_write'")
+
     manifest = _load_gh_pr_manifest()
     command = str(manifest.invocation["command"])
     binary_path = which(command)
@@ -264,13 +283,31 @@ def run_gh_cli_pr_smoke(
                     status="skip",
                     detail="binary bulunamadigi icin repo view smoke atlandi",
                 ),
+            )
+        )
+        if mode == "preflight":
+            checks.append(
                 SmokeCheck(
                     name="pr_dry_run",
                     status="skip",
                     detail="binary bulunamadigi icin PR dry-run smoke atlandi",
-                ),
+                )
             )
-        )
+        else:
+            checks.extend(
+                (
+                    SmokeCheck(
+                        name="pr_live_write",
+                        status="skip",
+                        detail="binary bulunamadigi icin live-write smoke atlandi",
+                    ),
+                    SmokeCheck(
+                        name="pr_live_write_rollback",
+                        status="skip",
+                        detail="binary bulunamadigi icin rollback smoke atlandi",
+                    ),
+                )
+            )
         return _finalize_gh_report(
             adapter_id=manifest.adapter_id,
             binary_path=None,
@@ -316,49 +353,290 @@ def run_gh_cli_pr_smoke(
 
     resolved_base = base_ref or detected_default_branch
     resolved_head = head_ref or detected_default_branch
-    if resolved_repo and resolved_base and resolved_head:
-        with tempfile.TemporaryDirectory(prefix="ao-kernel-gh-cli-pr-smoke-") as tmp:
-            temp_root = Path(tmp)
-            body_file = temp_root / "pr-body.md"
-            body_file.write_text(probe_body, encoding="utf-8")
+    if mode == "preflight":
+        if resolved_repo and resolved_base and resolved_head:
+            with tempfile.TemporaryDirectory(prefix="ao-kernel-gh-cli-pr-smoke-") as tmp:
+                temp_root = Path(tmp)
+                body_file = temp_root / "pr-body.md"
+                body_file.write_text(probe_body, encoding="utf-8")
 
-            dry_run_result = _run_check(
-                runner,
-                (
-                    binary_path,
-                    "pr",
-                    "create",
-                    "--repo",
-                    resolved_repo,
-                    "--head",
-                    resolved_head,
-                    "--base",
-                    resolved_base,
-                    "--title",
-                    probe_title,
-                    "--body-file",
-                    str(body_file),
-                    "--dry-run",
-                ),
-                working_dir,
-                timeout_seconds,
+                dry_run_result = _run_check(
+                    runner,
+                    (
+                        binary_path,
+                        "pr",
+                        "create",
+                        "--repo",
+                        resolved_repo,
+                        "--head",
+                        resolved_head,
+                        "--base",
+                        resolved_base,
+                        "--title",
+                        probe_title,
+                        "--body-file",
+                        str(body_file),
+                        "--dry-run",
+                    ),
+                    working_dir,
+                    timeout_seconds,
+                )
+            checks.append(
+                _classify_gh_pr_dry_run_check(
+                    dry_run_result,
+                    repo_name=resolved_repo,
+                    head_ref=resolved_head,
+                    base_ref=resolved_base,
+                )
             )
-        checks.append(
-            _classify_gh_pr_dry_run_check(
-                dry_run_result,
-                repo_name=resolved_repo,
-                head_ref=resolved_head,
-                base_ref=resolved_base,
+        else:
+            checks.append(
+                SmokeCheck(
+                    name="pr_dry_run",
+                    status="skip",
+                    detail=(
+                        "repo/default-branch cozulmedigi icin PR dry-run smoke atlandi"
+                    ),
+                )
             )
+        return _finalize_gh_report(
+            adapter_id=manifest.adapter_id,
+            binary_path=binary_path,
+            repo_name=resolved_repo,
+            default_branch=detected_default_branch,
+            repo_url=repo_url,
+            checks=checks,
         )
-    else:
+
+    if not allow_live_write:
         checks.append(
             SmokeCheck(
-                name="pr_dry_run",
-                status="skip",
-                detail="repo/default-branch cozulmedigi icin PR dry-run smoke atlandi",
+                name="pr_live_write",
+                status="fail",
+                detail=(
+                    "live-write smoke icin --allow-live-write explicit opt-in gereklidir"
+                ),
+                finding_code="gh_pr_live_write_opt_in_required",
+                observed={"mode": mode},
             )
         )
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write_rollback",
+                status="skip",
+                detail="live-write adimi acilmadigi icin rollback smoke atlandi",
+            )
+        )
+        return _finalize_gh_report(
+            adapter_id=manifest.adapter_id,
+            binary_path=binary_path,
+            repo_name=resolved_repo,
+            default_branch=detected_default_branch,
+            repo_url=repo_url,
+            checks=checks,
+        )
+
+    if not resolved_repo or not resolved_base or not resolved_head:
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write",
+                status="skip",
+                detail="repo/default-branch cozulmedigi icin live-write smoke atlandi",
+            )
+        )
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write_rollback",
+                status="skip",
+                detail="live-write adimi kosulmadigi icin rollback smoke atlandi",
+            )
+        )
+        return _finalize_gh_report(
+            adapter_id=manifest.adapter_id,
+            binary_path=binary_path,
+            repo_name=resolved_repo,
+            default_branch=detected_default_branch,
+            repo_url=repo_url,
+            checks=checks,
+        )
+
+    if not head_ref:
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write",
+                status="fail",
+                detail=(
+                    "live-write smoke icin explicit --head verilmelidir "
+                    "(default branch fallback kabul edilmez)"
+                ),
+                finding_code="gh_pr_live_write_head_ref_required",
+                observed={"resolved_base": resolved_base, "resolved_head": resolved_head},
+            )
+        )
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write_rollback",
+                status="skip",
+                detail="live-write adimi baslamadigi icin rollback smoke atlandi",
+            )
+        )
+        return _finalize_gh_report(
+            adapter_id=manifest.adapter_id,
+            binary_path=binary_path,
+            repo_name=resolved_repo,
+            default_branch=detected_default_branch,
+            repo_url=repo_url,
+            checks=checks,
+        )
+
+    if resolved_head == resolved_base:
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write",
+                status="fail",
+                detail="live-write smoke icin --head ve --base farkli olmalidir",
+                finding_code="gh_pr_live_write_same_head_base",
+                observed={"resolved_base": resolved_base, "resolved_head": resolved_head},
+            )
+        )
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write_rollback",
+                status="skip",
+                detail="live-write adimi baslamadigi icin rollback smoke atlandi",
+            )
+        )
+        return _finalize_gh_report(
+            adapter_id=manifest.adapter_id,
+            binary_path=binary_path,
+            repo_name=resolved_repo,
+            default_branch=detected_default_branch,
+            repo_url=repo_url,
+            checks=checks,
+        )
+
+    if require_disposable_repo_keyword:
+        required_keyword = require_disposable_repo_keyword.strip().lower()
+        if required_keyword and required_keyword not in resolved_repo.lower():
+            checks.append(
+                SmokeCheck(
+                    name="pr_live_write",
+                    status="fail",
+                    detail=(
+                        "live-write smoke disposable repo guard'ina takildi "
+                        f"(keyword={required_keyword!r})"
+                    ),
+                    finding_code="gh_pr_live_write_repo_not_disposable",
+                    observed={"repo_name": resolved_repo, "required_keyword": required_keyword},
+                )
+            )
+            checks.append(
+                SmokeCheck(
+                    name="pr_live_write_rollback",
+                    status="skip",
+                    detail="live-write adimi baslamadigi icin rollback smoke atlandi",
+                )
+            )
+            return _finalize_gh_report(
+                adapter_id=manifest.adapter_id,
+                binary_path=binary_path,
+                repo_name=resolved_repo,
+                default_branch=detected_default_branch,
+                repo_url=repo_url,
+                checks=checks,
+            )
+
+    with tempfile.TemporaryDirectory(prefix="ao-kernel-gh-cli-pr-live-smoke-") as tmp:
+        temp_root = Path(tmp)
+        body_file = temp_root / "pr-body.md"
+        body_file.write_text(probe_body, encoding="utf-8")
+
+        live_create_result = _run_check(
+            runner,
+            (
+                binary_path,
+                "pr",
+                "create",
+                "--repo",
+                resolved_repo,
+                "--head",
+                resolved_head,
+                "--base",
+                resolved_base,
+                "--title",
+                probe_title,
+                "--body-file",
+                str(body_file),
+                "--draft",
+            ),
+            working_dir,
+            timeout_seconds,
+        )
+    live_write_check, created_pr_url = _classify_gh_pr_live_write_check(
+        live_create_result,
+        repo_name=resolved_repo,
+        head_ref=resolved_head,
+        base_ref=resolved_base,
+    )
+    checks.append(live_write_check)
+
+    if live_write_check.status != "pass" or created_pr_url is None:
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write_rollback",
+                status="skip",
+                detail="live-write create basarisiz oldugu icin rollback smoke atlandi",
+            )
+        )
+        return _finalize_gh_report(
+            adapter_id=manifest.adapter_id,
+            binary_path=binary_path,
+            repo_name=resolved_repo,
+            default_branch=detected_default_branch,
+            repo_url=repo_url,
+            checks=checks,
+        )
+
+    if keep_live_write_pr_open:
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write_rollback",
+                status="skip",
+                detail="--keep-live-write-pr-open nedeniyle rollback skip edildi",
+                observed={"pr_url": created_pr_url},
+            )
+        )
+        return _finalize_gh_report(
+            adapter_id=manifest.adapter_id,
+            binary_path=binary_path,
+            repo_name=resolved_repo,
+            default_branch=detected_default_branch,
+            repo_url=repo_url,
+            checks=checks,
+        )
+
+    rollback_result = _run_check(
+        runner,
+        (
+            binary_path,
+            "pr",
+            "close",
+            created_pr_url,
+            "--repo",
+            resolved_repo,
+            "--comment",
+            _GH_LIVE_WRITE_ROLLBACK_COMMENT,
+        ),
+        working_dir,
+        timeout_seconds,
+    )
+    checks.append(
+        _classify_gh_pr_live_write_rollback_check(
+            rollback_result,
+            pr_url=created_pr_url,
+            repo_name=resolved_repo,
+        )
+    )
 
     return _finalize_gh_report(
         adapter_id=manifest.adapter_id,
@@ -843,6 +1121,116 @@ def _classify_gh_pr_dry_run_check(
         returncode=result.returncode,
         observed=_trim_output(result),
     )
+
+
+def _classify_gh_pr_live_write_check(
+    result: CommandResult,
+    *,
+    repo_name: str,
+    head_ref: str,
+    base_ref: str,
+) -> tuple[SmokeCheck, str | None]:
+    if result.timed_out:
+        return (
+            SmokeCheck(
+                name="pr_live_write",
+                status="fail",
+                detail="gh pr create --draft timeout'a dustu",
+                finding_code="gh_pr_live_write_timeout",
+                argv=result.argv,
+                returncode=result.returncode,
+                observed=_trim_output(result),
+            ),
+            None,
+        )
+
+    if result.returncode != 0:
+        return (
+            SmokeCheck(
+                name="pr_live_write",
+                status="fail",
+                detail="gh pr create --draft basarisiz",
+                finding_code="gh_pr_live_write_failed",
+                argv=result.argv,
+                returncode=result.returncode,
+                observed=_trim_output(result),
+            ),
+            None,
+        )
+
+    pr_url = _extract_github_pr_url(result.stdout, result.stderr)
+    if pr_url is None:
+        return (
+            SmokeCheck(
+                name="pr_live_write",
+                status="fail",
+                detail="gh pr create --draft cikisinda PR URL cozulmedi",
+                finding_code="gh_pr_live_write_url_missing",
+                argv=result.argv,
+                returncode=result.returncode,
+                observed=_trim_output(result),
+            ),
+            None,
+        )
+
+    return (
+        SmokeCheck(
+            name="pr_live_write",
+            status="pass",
+            detail=(
+                "gh pr create --draft gecti "
+                f"(repo={repo_name!r}, head={head_ref!r}, base={base_ref!r})"
+            ),
+            argv=result.argv,
+            returncode=result.returncode,
+            observed={"pr_url": pr_url},
+        ),
+        pr_url,
+    )
+
+
+def _classify_gh_pr_live_write_rollback_check(
+    result: CommandResult,
+    *,
+    pr_url: str,
+    repo_name: str,
+) -> SmokeCheck:
+    if result.timed_out:
+        return SmokeCheck(
+            name="pr_live_write_rollback",
+            status="fail",
+            detail="gh pr close rollback timeout'a dustu",
+            finding_code="gh_pr_live_write_rollback_timeout",
+            argv=result.argv,
+            returncode=result.returncode,
+            observed=_trim_output(result),
+        )
+    if result.returncode == 0:
+        return SmokeCheck(
+            name="pr_live_write_rollback",
+            status="pass",
+            detail=f"gh pr close rollback gecti (repo={repo_name!r})",
+            argv=result.argv,
+            returncode=result.returncode,
+            observed={"pr_url": pr_url},
+        )
+    return SmokeCheck(
+        name="pr_live_write_rollback",
+        status="fail",
+        detail="gh pr close rollback basarisiz",
+        finding_code="gh_pr_live_write_rollback_failed",
+        argv=result.argv,
+        returncode=result.returncode,
+        observed={"pr_url": pr_url, **_trim_output(result)},
+    )
+
+
+def _extract_github_pr_url(stdout: str, stderr: str) -> str | None:
+    text = f"{stdout}\n{stderr}"
+    match = _GITHUB_PR_URL_RE.search(text)
+    if match is None:
+        return None
+    return match.group(0)
 
 
 def _classify_prompt_access_check(result: CommandResult) -> SmokeCheck:

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -50,7 +50,7 @@ The `adapter_kind` field is a closed enum that tells ao-kernel how to route invo
 |---|---|---|
 | Bundled `codex-stub` | Shipped baseline | Deterministic demo + CI surface; the default supported adapter path in this repo |
 | `claude-code-cli` walkthroughs and manifests | Beta (operator-managed) | Helper-backed preflight lives at `python3 scripts/claude_code_cli_smoke.py`; canlı prompt smoke vardır, fakat bu lane default shipped demo değildir |
-| `gh-cli-pr` walkthroughs and manifests | Beta (operator-managed preflight only) | Helper-backed safe preflight lives at `python3 scripts/gh_cli_pr_smoke.py`; gerçek remote PR açılışı ayrı ve deferred yüzeydir |
+| `gh-cli-pr` walkthroughs and manifests | Beta (operator-managed preflight + live-write readiness probe) | Default helper yolu preflight (`python3 scripts/gh_cli_pr_smoke.py`), live-write probe ise explicit opt-in (`--mode live-write --allow-live-write`) + disposable guard ister; gerçek remote PR açılışı hâlâ deferred support yüzeyidir |
 | `custom-cli` / `custom-http` | Escape hatch | Operator-owned integration responsibility; contract-compatible does not mean ao-kernel ships vendor-specific production support |
 
 ### Promotion criteria for new enum values

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -35,6 +35,8 @@ smoke next:
 ```bash
 python3 scripts/claude_code_cli_smoke.py --output text
 python3 scripts/gh_cli_pr_smoke.py --output text
+# Optional readiness probe (live-write, explicit opt-in + disposable guard):
+# python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch>
 ```
 
 ## 3. Decision tree
@@ -64,6 +66,7 @@ If shipped baseline stays green but one of these fails:
 
 - `python3 scripts/claude_code_cli_smoke.py --output text`
 - `python3 scripts/gh_cli_pr_smoke.py --output text`
+- optional live-write readiness probe (`gh_cli_pr_smoke.py --mode live-write --allow-live-write ...`)
 - operator-run real-adapter benchmark path
 
 Then the shipped baseline claim stays intact, but the operator guidance must

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -56,7 +56,7 @@ istemek gerekir.
 |---|---|---|
 | Public Beta yüzeyinin tamamı | Beta | Stable kanal hâlâ `3.13.3`; genel kullanım için pre-release install gerekir |
 | `claude-code-cli` helper-backed real-adapter lane | Beta (operator-managed) | `python3 scripts/claude_code_cli_smoke.py` ile preflight + canlı prompt smoke doğrulanabilir; varsayılan shipped demo değildir. `PB-6.6` closeout verdict'i: `stay_beta_operator_managed` |
-| `gh-cli-pr` helper-backed preflight lane | Beta (operator-managed preflight only) | `python3 scripts/gh_cli_pr_smoke.py` auth/repo visibility + `gh pr create --dry-run` zincirini doğrular; gerçek remote PR açmaz |
+| `gh-cli-pr` helper-backed preflight lane | Beta (operator-managed preflight + live-write readiness probe) | Varsayılan `python3 scripts/gh_cli_pr_smoke.py` preflight yoludur (`--dry-run`). `--mode live-write --allow-live-write` readiness probe'u explicit opt-in + disposable guard ister; support widening değildir |
 | Real-adapter benchmark tam modu | Beta (operator-managed) | Deterministik stub lane kadar stabil değildir; adapter-altı gerçek tier sınırları yukarıdaki satırlarda tanımlanır |
 
 ## Contract / Inventory Layer
@@ -85,7 +85,7 @@ Bu kuralın amacı, inventory görünürlüğünü support widening ile karışt
 | Yüzey | Durum | Not |
 |---|---|---|
 | `bug_fix_flow` release closure | Deferred | Public Beta kapsamı dışında |
-| `gh-cli-pr` ile tam E2E PR açılışı | Deferred | Mevcut beta yüzey yalnız dry-run preflight'tır; gerçek remote PR açılışı henüz destek vaadi değildir |
+| `gh-cli-pr` ile tam E2E PR açılışı | Deferred | Readiness probe varlığına rağmen gerçek remote PR açılışı henüz destek vaadi değildir; live-write lane yalnız operator-managed/deferred boundary içinde değerlendirilir |
 | `docs/roadmap/DEMO-SCRIPT-SPEC.md` içindeki 11 adımlı üç-adapter akış | Deferred | Canlı destek vaadi değildir |
 | Adapter-path `cost_usd` reconcile | Deferred | Public support claim olarak hâlâ deferred; benchmark/internal runtime hook varlığı bunu tek başına shipped veya beta support yüzeyine yükseltmez |
 | `PRJ-KERNEL-API` `project_status`, `roadmap_follow`, `roadmap_finish` actions | Deferred | Manifest ve runtime handler yüzeyi ilk tranche'ta bilerek iki read-only action'a daraltıldı; workspace/write-side contract netleşmeden desteklenmez |

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -11,7 +11,7 @@ operator-only, or just contract inventory?"
 | Layer | Included surfaces | Verification |
 |---|---|---|
 | Shipped baseline | module entrypoints, `ao-kernel doctor`, bundled `review_ai_flow`, `examples/demo_review.py`, packaging smoke, `PRJ-KERNEL-API` `system_status` / `doc_nav_check` actions | entrypoint checks, doctor, demo review smoke, behavior tests, CI |
-| Beta (operator-managed) | `claude-code-cli` helper-backed lane, `gh-cli-pr` helper-backed dry-run lane, real-adapter benchmark full mode | explicit smoke helpers and runbooks |
+| Beta (operator-managed) | `claude-code-cli` helper-backed lane, `gh-cli-pr` helper-backed preflight + live-write readiness probe lane, real-adapter benchmark full mode | explicit smoke helpers and runbooks |
 | Contract inventory | bundled defaults, manifests, extensions, example inventory | loader/validator and truth audit only |
 | Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary |
 
@@ -49,10 +49,15 @@ These are real, testable surfaces, but they are not the default shipped demo:
 
 - `python3 scripts/claude_code_cli_smoke.py --output text`
 - `python3 scripts/gh_cli_pr_smoke.py --output text`
+- `python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch>`
 - real-adapter benchmark full-mode runbooks
 
 `PB-6.6` closeout kararıyla `claude-code-cli` lane support-tier'i
 `stay_beta_operator_managed` olarak korunur; lane shipped baseline'a yükselmez.
+
+`gh-cli-pr` live-write probe, `PB-7.1` ile readiness amaçlı opt-in guard
+katmanı kazanır. Bu probe'un varlığı tek başına live remote PR opening support
+tier'ını widen etmez; public boundary satırı deferred kalır.
 
 ### Contract inventory
 

--- a/docs/UPGRADE-NOTES.md
+++ b/docs/UPGRADE-NOTES.md
@@ -51,6 +51,8 @@ well:
 ```bash
 python3 scripts/claude_code_cli_smoke.py --output text
 python3 scripts/gh_cli_pr_smoke.py --output text
+# Optional readiness probe (live-write, explicit opt-in + disposable guard):
+# python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch>
 ```
 
 ## 4. Expected warnings

--- a/scripts/gh_cli_pr_smoke.py
+++ b/scripts/gh_cli_pr_smoke.py
@@ -19,7 +19,8 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         prog="gh_cli_pr_smoke.py",
         description=(
-            "Run side-effect-safe smoke checks for the bundled gh-cli-pr adapter."
+            "Run gh-cli-pr adapter smoke checks (preflight default; "
+            "live-write explicit opt-in)."
         ),
     )
     parser.add_argument(
@@ -44,7 +45,34 @@ def main() -> int:
     )
     parser.add_argument(
         "--head",
-        help="Optional head branch override for the dry-run PR probe.",
+        help="Optional head branch override for the PR probe.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("preflight", "live-write"),
+        default="preflight",
+        help=(
+            "Probe mode. preflight runs side-effect-safe dry-run; "
+            "live-write runs create+rollback chain with explicit opt-in."
+        ),
+    )
+    parser.add_argument(
+        "--allow-live-write",
+        action="store_true",
+        help="Required guard flag for --mode live-write.",
+    )
+    parser.add_argument(
+        "--keep-live-write-pr-open",
+        action="store_true",
+        help="Skip rollback close step after live-write create success.",
+    )
+    parser.add_argument(
+        "--require-disposable-keyword",
+        default="sandbox",
+        help=(
+            "Disposable repo guard keyword for live-write mode "
+            "(empty string disables the guard)."
+        ),
     )
     args = parser.parse_args()
 
@@ -54,6 +82,10 @@ def main() -> int:
         repo=args.repo,
         base_ref=args.base,
         head_ref=args.head,
+        mode=args.mode.replace("-", "_"),
+        allow_live_write=args.allow_live_write,
+        keep_live_write_pr_open=args.keep_live_write_pr_open,
+        require_disposable_repo_keyword=args.require_disposable_keyword or None,
     )
     if args.output == "json":
         print(json.dumps(report.as_dict(), indent=2, sort_keys=True))

--- a/tests/test_gh_cli_pr_smoke.py
+++ b/tests/test_gh_cli_pr_smoke.py
@@ -315,3 +315,203 @@ def test_clean_pass_reports_repo_and_dry_run_success() -> None:
     assert report.default_branch == "main"
     dry_run_check = next(check for check in report.checks if check.name == "pr_dry_run")
     assert dry_run_check.status == "pass"
+
+
+def test_live_write_requires_explicit_opt_in() -> None:
+    create_called = False
+
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        nonlocal create_called
+        cmd = tuple(argv)
+        if cmd == ("/fake/gh", "--version"):
+            return _result(cmd, stdout="gh version 2.83.2 (2025-12-10)\n")
+        if cmd == ("/fake/gh", "auth", "status", "--json", "hosts"):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"hosts":{"github.com":[{"state":"success","active":true,'
+                    '"host":"github.com","login":"Halildeu",'
+                    '"tokenSource":"keyring","scopes":"repo",'
+                    '"gitProtocol":"https"}]}}'
+                ),
+            )
+        if cmd == (
+            "/fake/gh",
+            "repo",
+            "view",
+            "--json",
+            "nameWithOwner,defaultBranchRef,isPrivate,url",
+        ):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"nameWithOwner":"Halildeu/ao-kernel",'
+                    '"defaultBranchRef":{"name":"main"},'
+                    '"isPrivate":false,'
+                    '"url":"https://github.com/Halildeu/ao-kernel"}'
+                ),
+            )
+        if cmd[:4] == ("/fake/gh", "pr", "create", "--repo"):
+            create_called = True
+            raise AssertionError("live-write create should not run without opt-in")
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: "/fake/gh",
+        runner=runner,
+        cwd=Path("/tmp"),
+        mode="live_write",
+        allow_live_write=False,
+        head_ref="feature/smoke",
+        base_ref="main",
+        require_disposable_repo_keyword="ao-kernel",
+    )
+
+    assert report.overall_status == "blocked"
+    assert "gh_pr_live_write_opt_in_required" in report.findings
+    assert create_called is False
+
+
+def test_live_write_passes_with_create_and_rollback() -> None:
+    create_called = False
+    close_called = False
+
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        nonlocal create_called, close_called
+        cmd = tuple(argv)
+        if cmd == ("/fake/gh", "--version"):
+            return _result(cmd, stdout="gh version 2.83.2 (2025-12-10)\n")
+        if cmd == ("/fake/gh", "auth", "status", "--json", "hosts"):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"hosts":{"github.com":[{"state":"success","active":true,'
+                    '"host":"github.com","login":"Halildeu",'
+                    '"tokenSource":"keyring","scopes":"repo",'
+                    '"gitProtocol":"https"}]}}'
+                ),
+            )
+        if cmd == (
+            "/fake/gh",
+            "repo",
+            "view",
+            "--json",
+            "nameWithOwner,defaultBranchRef,isPrivate,url",
+        ):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"nameWithOwner":"Halildeu/ao-kernel",'
+                    '"defaultBranchRef":{"name":"main"},'
+                    '"isPrivate":false,'
+                    '"url":"https://github.com/Halildeu/ao-kernel"}'
+                ),
+            )
+        if cmd[:4] == ("/fake/gh", "pr", "create", "--repo"):
+            create_called = True
+            assert "--draft" in cmd
+            return _result(
+                cmd,
+                stdout=(
+                    "https://github.com/Halildeu/ao-kernel/pull/123\n"
+                    "Creating draft pull request...\n"
+                ),
+            )
+        if cmd[:4] == (
+            "/fake/gh",
+            "pr",
+            "close",
+            "https://github.com/Halildeu/ao-kernel/pull/123",
+        ):
+            close_called = True
+            return _result(cmd, stdout="Closed pull request #123\n")
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: "/fake/gh",
+        runner=runner,
+        cwd=Path("/tmp"),
+        mode="live_write",
+        allow_live_write=True,
+        head_ref="feature/smoke",
+        base_ref="main",
+        require_disposable_repo_keyword="ao-kernel",
+    )
+
+    assert report.overall_status == "pass"
+    assert report.findings == ()
+    live_check = next(check for check in report.checks if check.name == "pr_live_write")
+    rollback_check = next(
+        check for check in report.checks if check.name == "pr_live_write_rollback"
+    )
+    assert live_check.status == "pass"
+    assert rollback_check.status == "pass"
+    assert create_called is True
+    assert close_called is True
+
+
+def test_live_write_disposable_repo_guard_blocks_write() -> None:
+    create_called = False
+
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        nonlocal create_called
+        cmd = tuple(argv)
+        if cmd == ("/fake/gh", "--version"):
+            return _result(cmd, stdout="gh version 2.83.2 (2025-12-10)\n")
+        if cmd == ("/fake/gh", "auth", "status", "--json", "hosts"):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"hosts":{"github.com":[{"state":"success","active":true,'
+                    '"host":"github.com","login":"Halildeu",'
+                    '"tokenSource":"keyring","scopes":"repo",'
+                    '"gitProtocol":"https"}]}}'
+                ),
+            )
+        if cmd == (
+            "/fake/gh",
+            "repo",
+            "view",
+            "--json",
+            "nameWithOwner,defaultBranchRef,isPrivate,url",
+        ):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"nameWithOwner":"Halildeu/ao-kernel",'
+                    '"defaultBranchRef":{"name":"main"},'
+                    '"isPrivate":false,'
+                    '"url":"https://github.com/Halildeu/ao-kernel"}'
+                ),
+            )
+        if cmd[:4] == ("/fake/gh", "pr", "create", "--repo"):
+            create_called = True
+            raise AssertionError("disposable guard failsa create calismamali")
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: "/fake/gh",
+        runner=runner,
+        cwd=Path("/tmp"),
+        mode="live_write",
+        allow_live_write=True,
+        head_ref="feature/smoke",
+        base_ref="main",
+        require_disposable_repo_keyword="sandbox",
+    )
+
+    assert report.overall_status == "blocked"
+    assert "gh_pr_live_write_repo_not_disposable" in report.findings
+    assert create_called is False


### PR DESCRIPTION
## Summary
- activate PB-7.1 as active slice in post-beta status SSOT and add a dedicated plan document
- extend `run_gh_cli_pr_smoke` with explicit `live_write` mode, fail-closed opt-in guard, disposable-repo guard, and create->rollback checks
- expose live-write options in `scripts/gh_cli_pr_smoke.py` while keeping preflight as default
- add unit coverage for live-write opt-in, success+rollback, and disposable guard blocks
- align support docs to describe live-write as readiness probe (not support widening)

## Validation
- `pytest -q tests/test_gh_cli_pr_smoke.py`
- `pytest -q tests/test_cli_entrypoints.py`
- `python3 -m py_compile ao_kernel/real_adapter_smoke.py scripts/gh_cli_pr_smoke.py tests/test_gh_cli_pr_smoke.py`
- `python3 scripts/gh_cli_pr_smoke.py --output text`
- `python3 scripts/gh_cli_pr_smoke.py --mode live-write --output text` (expected blocked without `--allow-live-write`)

## Tracking
- closes #281