### PR TITLE
PB-7.2: bug_fix_flow support-boundary decision

### DIFF
--- a/.claude/plans/PB-7.2-BUGFIX-FLOW-SUPPORT-GRADUATION.md
+++ b/.claude/plans/PB-7.2-BUGFIX-FLOW-SUPPORT-GRADUATION.md
@@ -1,0 +1,74 @@
+# PB-7.2 — bug_fix_flow Support-Boundary Graduation Decision
+
+**Status:** Completed (decision: `stay_deferred`)  
+**Date:** 2026-04-23  
+**Tracker:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)  
+**Active issue:** [#283](https://github.com/Halildeu/ao-kernel/issues/283)
+
+## Amaç
+
+`bug_fix_flow` yüzeyinin Public Beta support boundary içinde
+genişletilip genişletilmeyeceğini canlı kanıtla karara bağlamak.
+
+Bu slice runtime davranışı genişletmez; önce karar kapısını tekilleştirir.
+
+## Kapsam
+
+1. `bug_fix_flow` workflow/runtime kanıtı
+2. benchmark/integration doğrulama çıktıları
+3. `PUBLIC-BETA` ve `SUPPORT-BOUNDARY` parity metni
+4. status SSOT güncellemesi
+
+## Kapsam Dışı
+
+1. `bug_fix_flow` lane'ini shipped/beta support'e yükseltecek runtime guard
+   implementationı
+2. `gh-cli-pr` full live remote PR opening widening
+3. `PRJ-KERNEL-API` write-side widening
+
+## Canlı Kanıt Özeti
+
+Çalıştırılan komutlar:
+
+```bash
+pytest -q tests/test_executor_integration.py -k "open_pr_step_persists_pr_metadata"
+pytest -q tests/benchmarks
+python3 scripts/gh_cli_pr_smoke.py --output json
+python3 scripts/gh_cli_pr_smoke.py --mode live-write --output json
+```
+
+Özet:
+
+1. `bug_fix_flow` `open_pr` step metadata/evidence yolu integration testte yeşil.
+2. Benchmark paketi yeşil (`15 passed, 1 skipped`), fakat bu lane mock harness
+   üzerinden koşar.
+3. `gh-cli-pr` preflight smoke yeşil.
+4. `gh-cli-pr` live-write path explicit opt-in olmadan fail-closed (`blocked`).
+5. Workflow-level `open_pr` adımı hâlâ gerçek `gh pr create` side-effect
+   yoludur; support widening için disposable/rollback guardları workflow runtime
+   düzeyinde henüz zorunlu kontrata bağlanmış değildir.
+
+## Karar
+
+**Final verdict:** `stay_deferred`.
+
+Gerekçe:
+
+1. Mevcut kanıt `bug_fix_flow` correctness ve artifact zincirini doğruluyor,
+   fakat support widening için gereken side-effect safety kapısı henüz workflow
+   runtime seviyesinde enforce edilmiş değil.
+2. `PB-7.1` ile gelen live-write readiness guard'ları smoke düzeyinde mevcut;
+   bu guard'lar tek başına `bug_fix_flow` support tier'ını genişletmeye
+   yetmez.
+3. Bu nedenle `bug_fix_flow release closure` satırı Public Beta deferred
+   boundary'de kalır.
+
+## Sonraki Doğru Hat
+
+`PB-7.3` — `PRJ-KERNEL-API` write-side widening preconditions karar dilimi.
+
+## DoD
+
+1. karar tekilleşti: `stay_deferred`
+2. status dosyası aktif issue/aktif slice gerçeğiyle güncellendi
+3. public support dokümanları kararla aynı dili konuşuyor

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -14,13 +14,13 @@ ayrı ayrı görünür kılmak.
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-6.2-KERNEL-API-PROMOTION-CONTRACT.md`
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
-- **Aktif decision/ordering contract:** `.claude/plans/PB-7.1-GH-CLI-PR-LIVE-WRITE-READINESS.md`
+- **Aktif decision/ordering contract:** `.claude/plans/PB-7.2-BUGFIX-FLOW-SUPPORT-GRADUATION.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
-- **Aktif issue:** [#281](https://github.com/Halildeu/ao-kernel/issues/281) (`PB-7.1`)
+- **Aktif issue:** [#283](https://github.com/Halildeu/ao-kernel/issues/283) (`PB-7.2`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -255,12 +255,11 @@ Not:
 
 ## 8. Anlık Öncelik
 
-`PB-7.1` aktif.
+`PB-7.2` tamamlandı.
 
-1. Aktif runtime slice: `PB-7.1` (`gh-cli-pr` live-write readiness guards)
-2. Scope: preflight default'u bozmadan opt-in live-write guard/rollback/evidence
-   kontratı eklemek.
-3. `PB-7.1` kapanmadan yeni runtime widening slice açılmaz.
+1. Son kapanan slice: `PB-7.2` (`bug_fix_flow` support-boundary graduation decision)
+2. Karar: `stay_deferred` (support widening açılmadı)
+3. Sonraki aktif hat: `PB-7.3` (`PRJ-KERNEL-API` write-side widening preconditions)
 
 ## 9. Program Closeout (Final)
 
@@ -294,3 +293,21 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
 3. Hedef: `gh-cli-pr` lane'inde live-write promotion için eksik kalan
    sandbox/side-effect/rollback/evidence kapılarını
    **support boundary widening yapmadan** kod/test seviyesinde somutlamak.
+
+`PB-7.1` closeout:
+
+1. Issue: [#281](https://github.com/Halildeu/ao-kernel/issues/281)
+2. PR: [#282](https://github.com/Halildeu/ao-kernel/pull/282)
+3. Merge commit: `431e0d9`
+4. Sonuç: `gh-cli-pr` lane'i için preflight default korunarak live-write
+   readiness guard/rollback check katmanı eklendi; support widening açılmadı.
+
+`PB-7.2` closeout:
+
+1. Issue: [#283](https://github.com/Halildeu/ao-kernel/issues/283)
+2. Plan: `.claude/plans/PB-7.2-BUGFIX-FLOW-SUPPORT-GRADUATION.md`
+3. Karar: `stay_deferred`
+4. Gerekçe özeti: `bug_fix_flow` correctness/evidence zinciri doğrulansa da
+   write-side support widening için workflow-level side-effect safety kapıları
+   henüz promoted kontrat seviyesinde değil.
+5. Sonraki hat: `PB-7.3` (`PRJ-KERNEL-API` write-side widening preconditions)

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -84,7 +84,7 @@ Bu kuralın amacı, inventory görünürlüğünü support widening ile karışt
 
 | Yüzey | Durum | Not |
 |---|---|---|
-| `bug_fix_flow` release closure | Deferred | Public Beta kapsamı dışında |
+| `bug_fix_flow` release closure | Deferred | Deterministik correctness/evidence coverage mevcut olsa da write-side support widening kararı `PB-7.2` ile `stay_deferred`; live remote PR yan-etki kapıları promoted değil |
 | `gh-cli-pr` ile tam E2E PR açılışı | Deferred | Readiness probe varlığına rağmen gerçek remote PR açılışı henüz destek vaadi değildir; live-write lane yalnız operator-managed/deferred boundary içinde değerlendirilir |
 | `docs/roadmap/DEMO-SCRIPT-SPEC.md` içindeki 11 adımlı üç-adapter akış | Deferred | Canlı destek vaadi değildir |
 | Adapter-path `cost_usd` reconcile | Deferred | Public support claim olarak hâlâ deferred; benchmark/internal runtime hook varlığı bunu tek başına shipped veya beta support yüzeyine yükseltmez |

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -13,7 +13,7 @@ operator-only, or just contract inventory?"
 | Shipped baseline | module entrypoints, `ao-kernel doctor`, bundled `review_ai_flow`, `examples/demo_review.py`, packaging smoke, `PRJ-KERNEL-API` `system_status` / `doc_nav_check` actions | entrypoint checks, doctor, demo review smoke, behavior tests, CI |
 | Beta (operator-managed) | `claude-code-cli` helper-backed lane, `gh-cli-pr` helper-backed preflight + live-write readiness probe lane, real-adapter benchmark full mode | explicit smoke helpers and runbooks |
 | Contract inventory | bundled defaults, manifests, extensions, example inventory | loader/validator and truth audit only |
-| Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary |
+| Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary (`PB-7.2` verdict for bug_fix_flow: `stay_deferred`) |
 
 ### 1.1 Truth inventory to support mapping
 


### PR DESCRIPTION
## Summary
- add PB-7.2 decision record for `bug_fix_flow` support-boundary graduation
- update post-beta status SSOT: PB-7.1 closeout + PB-7.2 closeout + next active hat PB-7.3
- align `PUBLIC-BETA.md` and `SUPPORT-BOUNDARY.md` wording with PB-7.2 verdict (`stay_deferred`)

## Validation evidence
- `pytest -q tests/test_executor_integration.py -k "open_pr_step_persists_pr_metadata"`
- `pytest -q tests/benchmarks`
- `python3 scripts/gh_cli_pr_smoke.py --output json`
- `python3 scripts/gh_cli_pr_smoke.py --mode live-write --output json` (expected blocked without explicit opt-in)

## Decision
`bug_fix_flow` correctness/evidence coverage confirmed, but write-side support widening gates remain unmet at workflow-runtime promotion level, so verdict is `stay_deferred`.

closes #283