### PR TITLE
PB-7.3: decide PRJ-KERNEL-API write-side support boundary

### DIFF
--- a/.claude/plans/PB-7.3-KERNEL-API-WRITE-SIDE-WIDENING-DECISION.md
+++ b/.claude/plans/PB-7.3-KERNEL-API-WRITE-SIDE-WIDENING-DECISION.md
@@ -1,0 +1,83 @@
+# PB-7.3 — PRJ-KERNEL-API Write-side Widening Decision
+
+**Status:** Completed (decision: `stay_deferred`)  
+**Date:** 2026-04-23  
+**Tracker:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)  
+**Active issue:** [#285](https://github.com/Halildeu/ao-kernel/issues/285)
+
+## Amaç
+
+`PRJ-KERNEL-API` write-side action widening
+(`project_status`, `roadmap_follow`, `roadmap_finish`) için support-boundary
+kararını güncel runtime/test kanıtıyla tekilleştirmek.
+
+Bu slice runtime davranışı genişletmez; widening öncesi kapıların durumunu
+kanıtla değerlendirir.
+
+## Kapsam
+
+1. runtime registry / entrypoint owner doğrulaması
+2. kernel-api manifest ve bootstrap tranche doğrulaması
+3. write-side action precondition gate değerlendirmesi
+4. `PUBLIC-BETA` + `SUPPORT-BOUNDARY` parity güncellemesi
+
+## Kapsam Dışı
+
+1. write-side action implementation widening
+2. support tier yükseltmesini bu slice içinde açmak
+3. `system_status` / `doc_nav_check` read-only tranche kapsamını değiştirmek
+
+## Canlı Kanıt Özeti
+
+Çalıştırılan komutlar:
+
+```bash
+pytest -q tests/test_extension_dispatch.py::TestBootstrapKernelApiExtension::test_kernel_api_minimum_actions_registered_by_default
+pytest -q tests/test_extension_dispatch.py::TestBootstrapKernelApiExtension::test_kernel_api_system_status_payload_is_bounded tests/test_extension_dispatch.py::TestBootstrapKernelApiExtension::test_kernel_api_doc_nav_check_reports_clean_runtime_refs
+pytest -q tests/test_extension_loader.py::TestBundledDefaults::test_kernel_api_manifest_is_minimum_runtime_backed
+python3 -m ao_kernel doctor
+python3 - <<'PY'
+from ao_kernel.extensions.loader import ExtensionRegistry
+r = ExtensionRegistry(); r.load_from_defaults()
+for action in ['project_status','roadmap_follow','roadmap_finish','system_status','doc_nav_check']:
+    owners = [m.extension_id for m in r.find_by_entrypoint(action)]
+    print(action, owners)
+PY
+```
+
+Özet:
+
+1. kernel-api bootstrap testleri yeşil; runtime-backed yüzey yalnız
+   `system_status` ve `doc_nav_check`.
+2. `project_status`, `roadmap_follow`, `roadmap_finish` için owner bulunmuyor;
+   runtime entrypoint registry bu action'ları hâlâ açmıyor.
+3. `ao-kernel doctor` çıktısı geniş inventory uyarılarına rağmen
+   shipped minimum tranche'i doğruluyor (`runtime_backed_ids` içinde
+   `PRJ-KERNEL-API` var).
+4. Write-side widening için governance/behavior/safety/rollback kapıları
+   promoted support kontratı seviyesinde hâlâ tamamlanmış değil.
+
+## Karar
+
+**Final verdict:** `stay_deferred`.
+
+Gerekçe:
+
+1. Runtime manifest + handler yüzeyi bilerek minimum read-only tranche ile
+   sınırlandırılmış durumda.
+2. Write-side action'lar registry'de açılmadığı için support widening için
+   gerekli behavior/safety/rollback kanıt zinciri oluşmuyor.
+3. Docs parity korunarak fake widening riski engelleniyor.
+
+## Sonraki Durum
+
+1. Aktif widening implementation slice açılmadı.
+2. Support boundary dar read-only tranche'ta korunuyor.
+3. Yeni widening hattı yalnız explicit runtime implementation + behavior-first
+   test + rollback/runbook paketi ile açılabilir.
+
+## DoD
+
+1. karar tekilleşti: `stay_deferred`
+2. status SSOT aktif slice gerçeğiyle güncellendi
+3. Public support dokümanları kararla aynı dili konuşuyor

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -14,13 +14,13 @@ ayrı ayrı görünür kılmak.
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-6.2-KERNEL-API-PROMOTION-CONTRACT.md`
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
-- **Aktif decision/ordering contract:** `.claude/plans/PB-7.2-BUGFIX-FLOW-SUPPORT-GRADUATION.md`
+- **Aktif decision/ordering contract:** `.claude/plans/PB-7.3-KERNEL-API-WRITE-SIDE-WIDENING-DECISION.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
-- **Aktif issue:** [#283](https://github.com/Halildeu/ao-kernel/issues/283) (`PB-7.2`)
+- **Aktif issue:** [#285](https://github.com/Halildeu/ao-kernel/issues/285) (`PB-7.3`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -255,11 +255,11 @@ Not:
 
 ## 8. Anlık Öncelik
 
-`PB-7.2` tamamlandı.
+`PB-7.3` tamamlandı.
 
-1. Son kapanan slice: `PB-7.2` (`bug_fix_flow` support-boundary graduation decision)
-2. Karar: `stay_deferred` (support widening açılmadı)
-3. Sonraki aktif hat: `PB-7.3` (`PRJ-KERNEL-API` write-side widening preconditions)
+1. Son kapanan slice: `PB-7.3` (`PRJ-KERNEL-API` write-side widening decision)
+2. Karar: `stay_deferred` (write-side support widening açılmadı)
+3. Sonraki aktif hat: yok (yeni widening implementation slice'ı açılmadı)
 
 ## 9. Program Closeout (Final)
 
@@ -311,3 +311,14 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
    write-side support widening için workflow-level side-effect safety kapıları
    henüz promoted kontrat seviyesinde değil.
 5. Sonraki hat: `PB-7.3` (`PRJ-KERNEL-API` write-side widening preconditions)
+
+`PB-7.3` closeout:
+
+1. Issue: [#285](https://github.com/Halildeu/ao-kernel/issues/285)
+2. Plan: `.claude/plans/PB-7.3-KERNEL-API-WRITE-SIDE-WIDENING-DECISION.md`
+3. Karar: `stay_deferred`
+4. Gerekçe özeti: write-side action'lar runtime registry'de açılmadı
+   (`project_status`, `roadmap_follow`, `roadmap_finish` owner yok); behavior +
+   safety + rollback kapıları widening için hâlâ tamamlanmadı.
+5. Sonraki hat: yok (explicit widening implementation tranche açılmadan
+   support boundary dar kalır)

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -88,7 +88,7 @@ Bu kuralın amacı, inventory görünürlüğünü support widening ile karışt
 | `gh-cli-pr` ile tam E2E PR açılışı | Deferred | Readiness probe varlığına rağmen gerçek remote PR açılışı henüz destek vaadi değildir; live-write lane yalnız operator-managed/deferred boundary içinde değerlendirilir |
 | `docs/roadmap/DEMO-SCRIPT-SPEC.md` içindeki 11 adımlı üç-adapter akış | Deferred | Canlı destek vaadi değildir |
 | Adapter-path `cost_usd` reconcile | Deferred | Public support claim olarak hâlâ deferred; benchmark/internal runtime hook varlığı bunu tek başına shipped veya beta support yüzeyine yükseltmez |
-| `PRJ-KERNEL-API` `project_status`, `roadmap_follow`, `roadmap_finish` actions | Deferred | Manifest ve runtime handler yüzeyi ilk tranche'ta bilerek iki read-only action'a daraltıldı; workspace/write-side contract netleşmeden desteklenmez |
+| `PRJ-KERNEL-API` `project_status`, `roadmap_follow`, `roadmap_finish` actions | Deferred | `PB-7.3` kararı `stay_deferred`: runtime owner/entrypoint kaydı bu action'lar için hâlâ yok; behavior/safety/rollback kapıları tamamlanmadan support widening açılmaz |
 
 ## Known Bugs
 

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -13,7 +13,7 @@ operator-only, or just contract inventory?"
 | Shipped baseline | module entrypoints, `ao-kernel doctor`, bundled `review_ai_flow`, `examples/demo_review.py`, packaging smoke, `PRJ-KERNEL-API` `system_status` / `doc_nav_check` actions | entrypoint checks, doctor, demo review smoke, behavior tests, CI |
 | Beta (operator-managed) | `claude-code-cli` helper-backed lane, `gh-cli-pr` helper-backed preflight + live-write readiness probe lane, real-adapter benchmark full mode | explicit smoke helpers and runbooks |
 | Contract inventory | bundled defaults, manifests, extensions, example inventory | loader/validator and truth audit only |
-| Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary (`PB-7.2` verdict for bug_fix_flow: `stay_deferred`) |
+| Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, `PRJ-KERNEL-API` write-side actions, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary (`PB-7.2` verdict for bug_fix_flow: `stay_deferred`, `PB-7.3` verdict for kernel-api write-side: `stay_deferred`) |
 
 ### 1.1 Truth inventory to support mapping
 
@@ -74,6 +74,10 @@ boundary even though the extension has a minimum runtime-backed tranche:
 - `project_status`
 - `roadmap_follow`
 - `roadmap_finish`
+
+`PB-7.3` kararına göre bu write-side action'lar için widening açılmadı; runtime
+owner/entrypoint yokluğu ile behavior/safety/rollback kapıları tamamlanana
+kadar deferred sınır korunur.
 
 ## 3. What does NOT automatically widen support
 


### PR DESCRIPTION
## Summary
- add PB-7.3 decision record for `PRJ-KERNEL-API` write-side widening
- update post-beta status SSOT to mark PB-7.3 as completed with `stay_deferred`
- align support docs so kernel-api write-side actions are explicitly deferred with PB-7.3 verdict

## Why
`project_status`, `roadmap_follow`, `roadmap_finish` still have no runtime entrypoint owner and do not meet behavior/safety/rollback gates for support widening.

## Validation
- `pytest -q tests/test_extension_dispatch.py::TestBootstrapKernelApiExtension::test_kernel_api_minimum_actions_registered_by_default tests/test_extension_dispatch.py::TestBootstrapKernelApiExtension::test_kernel_api_system_status_payload_is_bounded tests/test_extension_dispatch.py::TestBootstrapKernelApiExtension::test_kernel_api_doc_nav_check_reports_clean_runtime_refs`
- `pytest -q tests/test_extension_loader.py::TestBundledDefaults::test_kernel_api_manifest_is_minimum_runtime_backed`
- `python3 -m ao_kernel doctor`
- runtime owner probe via `ExtensionRegistry.find_by_entrypoint(...)`

Closes #285
