### PR TITLE
docs: close post-beta status active-slice drift

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -14,13 +14,14 @@ ayrı ayrı görünür kılmak.
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-6.2-KERNEL-API-PROMOTION-CONTRACT.md`
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
-- **Aktif decision/ordering contract:** `.claude/plans/PB-7.3-KERNEL-API-WRITE-SIDE-WIDENING-DECISION.md`
+- **Aktif decision/ordering contract:** yok (`PB-7.3` kapanış kararı:
+  `.claude/plans/PB-7.3-KERNEL-API-WRITE-SIDE-WIDENING-DECISION.md`)
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
-- **Aktif issue:** [#285](https://github.com/Halildeu/ao-kernel/issues/285) (`PB-7.3`)
+- **Aktif issue:** yok (open slice bulunmuyor)
 
 ## 2. Başlangıç Gerçeği
 


### PR DESCRIPTION
## Summary
- remove stale "active issue" reference after PB-7.3 closeout
- mark active decision contract as none (PB-7.3 is recorded as closeout artifact)

## Why
Status SSOT should not point to closed issue #285 as active.

## Validation
- doc-only status parity update
