### PR TITLE
[codex] PB-8.1: harden gh-cli-pr live-write smoke contract

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -263,6 +263,20 @@ Not:
 2. Bugünkü aktif slice: `PB-8.1` (`gh-cli-pr` live-write productionization)
 3. Sonraki sıra (planlı): `PB-8.2` -> `PB-8.3` -> `PB-8.4`
 
+`PB-8.1` implementation deltas (active branch snapshot):
+
+1. `gh-cli-pr` live-write lane artık fail-closed precondition seti uygular:
+   explicit `--allow-live-write`, explicit `--head`, explicit `--base`,
+   disposable keyword guard.
+2. Live-write execution zinciri create -> verify (`gh pr view`) -> rollback
+   (`gh pr close`) sırasıyla zorunlu evidence check'lerine bağlandı.
+3. `--keep-live-write-pr-open` yolu side-effect riski olarak işaretlenir ve
+   raporu `blocked` döndürür (`gh_pr_live_write_keep_open_requested`).
+4. Test matrisi create/verify/rollback fail-path davranışlarını behavior-first
+   assertion'larla pinler (`tests/test_gh_cli_pr_smoke.py`).
+5. Support boundary dokümanlarında lane açıklaması bu davranışla hizalanır
+   (`docs/PUBLIC-BETA.md`, `docs/SUPPORT-BOUNDARY.md`, `docs/ADAPTERS.md`).
+
 ## 9. PB-7 Closeout Snapshot
 
 **Kapanış tarihi:** 2026-04-23

--- a/ao_kernel/real_adapter_smoke.py
+++ b/ao_kernel/real_adapter_smoke.py
@@ -39,6 +39,9 @@ _GH_DRY_RUN_MARKER = "would have created a pull request"
 _GH_LIVE_WRITE_ROLLBACK_COMMENT = (
     "ao-kernel gh-cli-pr live-write smoke rollback"
 )
+_GH_LIVE_WRITE_VERIFY_JSON_FIELDS = (
+    "state,isDraft,url,number,headRefName,baseRefName"
+)
 _GITHUB_PR_URL_RE = re.compile(
     r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+"
 )
@@ -302,6 +305,11 @@ def run_gh_cli_pr_smoke(
                         detail="binary bulunamadigi icin live-write smoke atlandi",
                     ),
                     SmokeCheck(
+                        name="pr_live_write_verify",
+                        status="skip",
+                        detail="binary bulunamadigi icin live-write verify smoke atlandi",
+                    ),
+                    SmokeCheck(
                         name="pr_live_write_rollback",
                         status="skip",
                         detail="binary bulunamadigi icin rollback smoke atlandi",
@@ -422,6 +430,13 @@ def run_gh_cli_pr_smoke(
         )
         checks.append(
             SmokeCheck(
+                name="pr_live_write_verify",
+                status="skip",
+                detail="live-write adimi acilmadigi icin verify smoke atlandi",
+            )
+        )
+        checks.append(
+            SmokeCheck(
                 name="pr_live_write_rollback",
                 status="skip",
                 detail="live-write adimi acilmadigi icin rollback smoke atlandi",
@@ -436,19 +451,66 @@ def run_gh_cli_pr_smoke(
             checks=checks,
         )
 
-    if not resolved_repo or not resolved_base or not resolved_head:
+    if not resolved_repo:
         checks.append(
             SmokeCheck(
                 name="pr_live_write",
+                status="fail",
+                detail="live-write smoke icin repo context cozulmelidir",
+                finding_code="gh_pr_live_write_repo_context_required",
+            )
+        )
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write_verify",
                 status="skip",
-                detail="repo/default-branch cozulmedigi icin live-write smoke atlandi",
+                detail="live-write adimi baslamadigi icin verify smoke atlandi",
             )
         )
         checks.append(
             SmokeCheck(
                 name="pr_live_write_rollback",
                 status="skip",
-                detail="live-write adimi kosulmadigi icin rollback smoke atlandi",
+                detail="live-write adimi baslamadigi icin rollback smoke atlandi",
+            )
+        )
+        return _finalize_gh_report(
+            adapter_id=manifest.adapter_id,
+            binary_path=binary_path,
+            repo_name=resolved_repo,
+            default_branch=detected_default_branch,
+            repo_url=repo_url,
+            checks=checks,
+        )
+
+    if not base_ref:
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write",
+                status="fail",
+                detail=(
+                    "live-write smoke icin explicit --base verilmelidir "
+                    "(default branch fallback kabul edilmez)"
+                ),
+                finding_code="gh_pr_live_write_base_ref_required",
+                observed={
+                    "resolved_base": resolved_base,
+                    "resolved_head": resolved_head,
+                },
+            )
+        )
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write_verify",
+                status="skip",
+                detail="live-write adimi baslamadigi icin verify smoke atlandi",
+            )
+        )
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write_rollback",
+                status="skip",
+                detail="live-write adimi baslamadigi icin rollback smoke atlandi",
             )
         )
         return _finalize_gh_report(
@@ -470,7 +532,17 @@ def run_gh_cli_pr_smoke(
                     "(default branch fallback kabul edilmez)"
                 ),
                 finding_code="gh_pr_live_write_head_ref_required",
-                observed={"resolved_base": resolved_base, "resolved_head": resolved_head},
+                observed={
+                    "resolved_base": resolved_base,
+                    "resolved_head": resolved_head,
+                },
+            )
+        )
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write_verify",
+                status="skip",
+                detail="live-write adimi baslamadigi icin verify smoke atlandi",
             )
         )
         checks.append(
@@ -496,7 +568,17 @@ def run_gh_cli_pr_smoke(
                 status="fail",
                 detail="live-write smoke icin --head ve --base farkli olmalidir",
                 finding_code="gh_pr_live_write_same_head_base",
-                observed={"resolved_base": resolved_base, "resolved_head": resolved_head},
+                observed={
+                    "resolved_base": resolved_base,
+                    "resolved_head": resolved_head,
+                },
+            )
+        )
+        checks.append(
+            SmokeCheck(
+                name="pr_live_write_verify",
+                status="skip",
+                detail="live-write adimi baslamadigi icin verify smoke atlandi",
             )
         )
         checks.append(
@@ -527,7 +609,17 @@ def run_gh_cli_pr_smoke(
                         f"(keyword={required_keyword!r})"
                     ),
                     finding_code="gh_pr_live_write_repo_not_disposable",
-                    observed={"repo_name": resolved_repo, "required_keyword": required_keyword},
+                    observed={
+                        "repo_name": resolved_repo,
+                        "required_keyword": required_keyword,
+                    },
+                )
+            )
+            checks.append(
+                SmokeCheck(
+                    name="pr_live_write_verify",
+                    status="skip",
+                    detail="live-write adimi baslamadigi icin verify smoke atlandi",
                 )
             )
             checks.append(
@@ -583,6 +675,13 @@ def run_gh_cli_pr_smoke(
     if live_write_check.status != "pass" or created_pr_url is None:
         checks.append(
             SmokeCheck(
+                name="pr_live_write_verify",
+                status="skip",
+                detail="live-write create basarisiz oldugu icin verify smoke atlandi",
+            )
+        )
+        checks.append(
+            SmokeCheck(
                 name="pr_live_write_rollback",
                 status="skip",
                 detail="live-write create basarisiz oldugu icin rollback smoke atlandi",
@@ -597,13 +696,45 @@ def run_gh_cli_pr_smoke(
             checks=checks,
         )
 
+    verify_result = _run_check(
+        runner,
+        (
+            binary_path,
+            "pr",
+            "view",
+            created_pr_url,
+            "--repo",
+            resolved_repo,
+            "--json",
+            _GH_LIVE_WRITE_VERIFY_JSON_FIELDS,
+        ),
+        working_dir,
+        timeout_seconds,
+    )
+    checks.append(
+        _classify_gh_pr_live_write_verify_check(
+            verify_result,
+            pr_url=created_pr_url,
+            repo_name=resolved_repo,
+            head_ref=resolved_head,
+            base_ref=resolved_base,
+        )
+    )
+
     if keep_live_write_pr_open:
         checks.append(
             SmokeCheck(
                 name="pr_live_write_rollback",
-                status="skip",
-                detail="--keep-live-write-pr-open nedeniyle rollback skip edildi",
-                observed={"pr_url": created_pr_url},
+                status="fail",
+                detail=(
+                    "--keep-live-write-pr-open nedeniyle rollback devre disi kaldigi "
+                    "icin lane riskli kabul edildi"
+                ),
+                finding_code="gh_pr_live_write_keep_open_requested",
+                observed={
+                    "pr_url": created_pr_url,
+                    "risk": "rollback_not_executed",
+                },
             )
         )
         return _finalize_gh_report(
@@ -1186,6 +1317,109 @@ def _classify_gh_pr_live_write_check(
             observed={"pr_url": pr_url},
         ),
         pr_url,
+    )
+
+
+def _classify_gh_pr_live_write_verify_check(
+    result: CommandResult,
+    *,
+    pr_url: str,
+    repo_name: str,
+    head_ref: str,
+    base_ref: str,
+) -> SmokeCheck:
+    if result.timed_out:
+        return SmokeCheck(
+            name="pr_live_write_verify",
+            status="fail",
+            detail="gh pr view verify cagrisi timeout'a dustu",
+            finding_code="gh_pr_live_write_verify_timeout",
+            argv=result.argv,
+            returncode=result.returncode,
+            observed={"pr_url": pr_url, **_trim_output(result)},
+        )
+    if result.returncode != 0:
+        return SmokeCheck(
+            name="pr_live_write_verify",
+            status="fail",
+            detail="gh pr view verify cagrisi basarisiz",
+            finding_code="gh_pr_live_write_verify_failed",
+            argv=result.argv,
+            returncode=result.returncode,
+            observed={"pr_url": pr_url, **_trim_output(result)},
+        )
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return SmokeCheck(
+            name="pr_live_write_verify",
+            status="fail",
+            detail="gh pr view verify JSON donmedi",
+            finding_code="gh_pr_live_write_verify_not_json",
+            argv=result.argv,
+            returncode=result.returncode,
+            observed={"pr_url": pr_url, **_trim_output(result)},
+        )
+
+    observed_url = payload.get("url")
+    observed_state = str(payload.get("state"))
+    observed_is_draft = payload.get("isDraft")
+    observed_head = payload.get("headRefName")
+    observed_base = payload.get("baseRefName")
+    observed_number = payload.get("number")
+    verify_ok = (
+        isinstance(observed_number, int)
+        and observed_url == pr_url
+        and observed_state.upper() == "OPEN"
+        and observed_is_draft is True
+        and observed_head == head_ref
+        and observed_base == base_ref
+    )
+    if verify_ok:
+        return SmokeCheck(
+            name="pr_live_write_verify",
+            status="pass",
+            detail=(
+                "gh pr view verify gecti "
+                f"(repo={repo_name!r}, pr={pr_url!r}, number={observed_number})"
+            ),
+            argv=result.argv,
+            returncode=result.returncode,
+            observed={
+                "pr_url": observed_url,
+                "number": observed_number,
+                "state": observed_state,
+                "is_draft": observed_is_draft,
+                "head_ref": observed_head,
+                "base_ref": observed_base,
+            },
+        )
+
+    return SmokeCheck(
+        name="pr_live_write_verify",
+        status="fail",
+        detail="gh pr view verify sonucu beklenen state/head/base ile uyusmuyor",
+        finding_code="gh_pr_live_write_verify_mismatch",
+        argv=result.argv,
+        returncode=result.returncode,
+        observed={
+            "expected": {
+                "pr_url": pr_url,
+                "state": "OPEN",
+                "is_draft": True,
+                "head_ref": head_ref,
+                "base_ref": base_ref,
+            },
+            "actual": {
+                "pr_url": observed_url,
+                "number": observed_number,
+                "state": observed_state,
+                "is_draft": observed_is_draft,
+                "head_ref": observed_head,
+                "base_ref": observed_base,
+            },
+        },
     )
 
 

--- a/ao_kernel/real_adapter_smoke.py
+++ b/ao_kernel/real_adapter_smoke.py
@@ -561,7 +561,10 @@ def run_gh_cli_pr_smoke(
             checks=checks,
         )
 
-    if resolved_head == resolved_base:
+    resolved_base_ref = base_ref
+    resolved_head_ref = head_ref
+
+    if resolved_head_ref == resolved_base_ref:
         checks.append(
             SmokeCheck(
                 name="pr_live_write",
@@ -569,8 +572,8 @@ def run_gh_cli_pr_smoke(
                 detail="live-write smoke icin --head ve --base farkli olmalidir",
                 finding_code="gh_pr_live_write_same_head_base",
                 observed={
-                    "resolved_base": resolved_base,
-                    "resolved_head": resolved_head,
+                    "resolved_base": resolved_base_ref,
+                    "resolved_head": resolved_head_ref,
                 },
             )
         )
@@ -652,9 +655,9 @@ def run_gh_cli_pr_smoke(
                 "--repo",
                 resolved_repo,
                 "--head",
-                resolved_head,
+                resolved_head_ref,
                 "--base",
-                resolved_base,
+                resolved_base_ref,
                 "--title",
                 probe_title,
                 "--body-file",
@@ -667,8 +670,8 @@ def run_gh_cli_pr_smoke(
     live_write_check, created_pr_url = _classify_gh_pr_live_write_check(
         live_create_result,
         repo_name=resolved_repo,
-        head_ref=resolved_head,
-        base_ref=resolved_base,
+        head_ref=resolved_head_ref,
+        base_ref=resolved_base_ref,
     )
     checks.append(live_write_check)
 
@@ -716,8 +719,8 @@ def run_gh_cli_pr_smoke(
             verify_result,
             pr_url=created_pr_url,
             repo_name=resolved_repo,
-            head_ref=resolved_head,
-            base_ref=resolved_base,
+            head_ref=resolved_head_ref,
+            base_ref=resolved_base_ref,
         )
     )
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -50,7 +50,7 @@ The `adapter_kind` field is a closed enum that tells ao-kernel how to route invo
 |---|---|---|
 | Bundled `codex-stub` | Shipped baseline | Deterministic demo + CI surface; the default supported adapter path in this repo |
 | `claude-code-cli` walkthroughs and manifests | Beta (operator-managed) | Helper-backed preflight lives at `python3 scripts/claude_code_cli_smoke.py`; canlı prompt smoke vardır, fakat bu lane default shipped demo değildir |
-| `gh-cli-pr` walkthroughs and manifests | Beta (operator-managed preflight + live-write readiness probe) | Default helper yolu preflight (`python3 scripts/gh_cli_pr_smoke.py`), live-write probe ise explicit opt-in (`--mode live-write --allow-live-write`) + disposable guard ister; gerçek remote PR açılışı hâlâ deferred support yüzeyidir |
+| `gh-cli-pr` walkthroughs and manifests | Beta (operator-managed preflight + live-write readiness probe) | Default helper yolu preflight (`python3 scripts/gh_cli_pr_smoke.py`), live-write probe ise explicit opt-in (`--mode live-write --allow-live-write --head <branch> --base <branch>`) + disposable guard + create->verify->rollback zinciri ister. `--keep-live-write-pr-open` lane'i riskli sayar ve `blocked` döner; gerçek remote PR açılışı hâlâ deferred support yüzeyidir |
 | `custom-cli` / `custom-http` | Escape hatch | Operator-owned integration responsibility; contract-compatible does not mean ao-kernel ships vendor-specific production support |
 
 ### Promotion criteria for new enum values

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -56,7 +56,7 @@ istemek gerekir.
 |---|---|---|
 | Public Beta yüzeyinin tamamı | Beta | Stable kanal hâlâ `3.13.3`; genel kullanım için pre-release install gerekir |
 | `claude-code-cli` helper-backed real-adapter lane | Beta (operator-managed) | `python3 scripts/claude_code_cli_smoke.py` ile preflight + canlı prompt smoke doğrulanabilir; varsayılan shipped demo değildir. `PB-6.6` closeout verdict'i: `stay_beta_operator_managed` |
-| `gh-cli-pr` helper-backed preflight lane | Beta (operator-managed preflight + live-write readiness probe) | Varsayılan `python3 scripts/gh_cli_pr_smoke.py` preflight yoludur (`--dry-run`). `--mode live-write --allow-live-write` readiness probe'u explicit opt-in + disposable guard ister; support widening değildir |
+| `gh-cli-pr` helper-backed preflight lane | Beta (operator-managed preflight + live-write readiness probe) | Varsayılan `python3 scripts/gh_cli_pr_smoke.py` preflight yoludur (`--dry-run`). Live-write probe (`--mode live-write --allow-live-write --head <branch> --base <branch>`) explicit opt-in + disposable guard + create->verify->rollback zinciri ister; `--keep-live-write-pr-open` lane'i riskli sayar ve `blocked` döner. Support widening değildir |
 | Real-adapter benchmark tam modu | Beta (operator-managed) | Deterministik stub lane kadar stabil değildir; adapter-altı gerçek tier sınırları yukarıdaki satırlarda tanımlanır |
 
 ## Contract / Inventory Layer
@@ -85,7 +85,7 @@ Bu kuralın amacı, inventory görünürlüğünü support widening ile karışt
 | Yüzey | Durum | Not |
 |---|---|---|
 | `bug_fix_flow` release closure | Deferred | Deterministik correctness/evidence coverage mevcut olsa da write-side support widening kararı `PB-7.2` ile `stay_deferred`; live remote PR yan-etki kapıları promoted değil |
-| `gh-cli-pr` ile tam E2E PR açılışı | Deferred | Readiness probe varlığına rağmen gerçek remote PR açılışı henüz destek vaadi değildir; live-write lane yalnız operator-managed/deferred boundary içinde değerlendirilir |
+| `gh-cli-pr` ile tam E2E PR açılışı | Deferred | Live-write probe create->verify->rollback guard'larıyla güçlense de gerçek remote PR açılışı hâlâ destek vaadi değildir; lane operator-managed/deferred boundary içinde değerlendirilir |
 | `docs/roadmap/DEMO-SCRIPT-SPEC.md` içindeki 11 adımlı üç-adapter akış | Deferred | Canlı destek vaadi değildir |
 | Adapter-path `cost_usd` reconcile | Deferred | Public support claim olarak hâlâ deferred; benchmark/internal runtime hook varlığı bunu tek başına shipped veya beta support yüzeyine yükseltmez |
 | `PRJ-KERNEL-API` `project_status`, `roadmap_follow`, `roadmap_finish` actions | Deferred | `PB-7.3` kararı `stay_deferred`: runtime owner/entrypoint kaydı bu action'lar için hâlâ yok; behavior/safety/rollback kapıları tamamlanmadan support widening açılmaz |

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -55,9 +55,11 @@ These are real, testable surfaces, but they are not the default shipped demo:
 `PB-6.6` closeout kararıyla `claude-code-cli` lane support-tier'i
 `stay_beta_operator_managed` olarak korunur; lane shipped baseline'a yükselmez.
 
-`gh-cli-pr` live-write probe, `PB-7.1` ile readiness amaçlı opt-in guard
-katmanı kazanır. Bu probe'un varlığı tek başına live remote PR opening support
-tier'ını widen etmez; public boundary satırı deferred kalır.
+`gh-cli-pr` live-write probe, `PB-8.1` ile explicit precondition (opt-in,
+disposable repo, explicit `--head` + `--base`) ve create -> verify -> rollback
+zincirine taşınmıştır. `--keep-live-write-pr-open` seçeneği lane'i riskli kabul
+eder ve rapor `blocked` döner. Bu probe'un varlığı tek başına live remote PR
+opening support tier'ını widen etmez; public boundary satırı deferred kalır.
 
 ### Contract inventory
 

--- a/scripts/gh_cli_pr_smoke.py
+++ b/scripts/gh_cli_pr_smoke.py
@@ -41,11 +41,17 @@ def main() -> int:
     )
     parser.add_argument(
         "--base",
-        help="Optional base branch override for the dry-run PR probe.",
+        help=(
+            "Base branch override. live-write mode'da explicit --base zorunludur; "
+            "preflight modunda default branch fallback kullanilir."
+        ),
     )
     parser.add_argument(
         "--head",
-        help="Optional head branch override for the PR probe.",
+        help=(
+            "Head branch override. live-write mode'da explicit --head zorunludur; "
+            "preflight modunda default branch fallback kullanilir."
+        ),
     )
     parser.add_argument(
         "--mode",
@@ -64,7 +70,10 @@ def main() -> int:
     parser.add_argument(
         "--keep-live-write-pr-open",
         action="store_true",
-        help="Skip rollback close step after live-write create success.",
+        help=(
+            "Create edilen PR'i acik birak. Bu secenek lane'i riskli sayar ve "
+            "rapor blocked doner."
+        ),
     )
     parser.add_argument(
         "--require-disposable-keyword",

--- a/tests/test_gh_cli_pr_smoke.py
+++ b/tests/test_gh_cli_pr_smoke.py
@@ -29,6 +29,38 @@ def _bundled_manifest():
     return reg.get("gh-cli-pr")
 
 
+def _base_gh_runner_result(cmd: tuple[str, ...]) -> CommandResult | None:
+    if cmd == ("/fake/gh", "--version"):
+        return _result(cmd, stdout="gh version 2.83.2 (2025-12-10)\n")
+    if cmd == ("/fake/gh", "auth", "status", "--json", "hosts"):
+        return _result(
+            cmd,
+            stdout=(
+                '{"hosts":{"github.com":[{"state":"success","active":true,'
+                '"host":"github.com","login":"Halildeu",'
+                '"tokenSource":"keyring","scopes":"repo",'
+                '"gitProtocol":"https"}]}}'
+            ),
+        )
+    if cmd == (
+        "/fake/gh",
+        "repo",
+        "view",
+        "--json",
+        "nameWithOwner,defaultBranchRef,isPrivate,url",
+    ):
+        return _result(
+            cmd,
+            stdout=(
+                '{"nameWithOwner":"Halildeu/ao-kernel",'
+                '"defaultBranchRef":{"name":"main"},'
+                '"isPrivate":false,'
+                '"url":"https://github.com/Halildeu/ao-kernel"}'
+            ),
+        )
+    return None
+
+
 def test_binary_missing_blocks_and_skips_remaining_checks() -> None:
     report = run_gh_cli_pr_smoke(
         which=lambda command: None,
@@ -378,6 +410,7 @@ def test_live_write_requires_explicit_opt_in() -> None:
 
 def test_live_write_passes_with_create_and_rollback() -> None:
     create_called = False
+    verify_called = False
     close_called = False
 
     def runner(
@@ -385,7 +418,7 @@ def test_live_write_passes_with_create_and_rollback() -> None:
         cwd: Path | None,
         timeout: float | None,
     ) -> CommandResult:
-        nonlocal create_called, close_called
+        nonlocal create_called, verify_called, close_called
         cmd = tuple(argv)
         if cmd == ("/fake/gh", "--version"):
             return _result(cmd, stdout="gh version 2.83.2 (2025-12-10)\n")
@@ -428,6 +461,23 @@ def test_live_write_passes_with_create_and_rollback() -> None:
         if cmd[:4] == (
             "/fake/gh",
             "pr",
+            "view",
+            "https://github.com/Halildeu/ao-kernel/pull/123",
+        ):
+            verify_called = True
+            return _result(
+                cmd,
+                stdout=(
+                    '{"state":"OPEN","isDraft":true,'
+                    '"url":"https://github.com/Halildeu/ao-kernel/pull/123",'
+                    '"number":123,'
+                    '"headRefName":"feature/smoke",'
+                    '"baseRefName":"main"}'
+                ),
+            )
+        if cmd[:4] == (
+            "/fake/gh",
+            "pr",
             "close",
             "https://github.com/Halildeu/ao-kernel/pull/123",
         ):
@@ -449,12 +499,17 @@ def test_live_write_passes_with_create_and_rollback() -> None:
     assert report.overall_status == "pass"
     assert report.findings == ()
     live_check = next(check for check in report.checks if check.name == "pr_live_write")
+    verify_check = next(
+        check for check in report.checks if check.name == "pr_live_write_verify"
+    )
     rollback_check = next(
         check for check in report.checks if check.name == "pr_live_write_rollback"
     )
     assert live_check.status == "pass"
+    assert verify_check.status == "pass"
     assert rollback_check.status == "pass"
     assert create_called is True
+    assert verify_called is True
     assert close_called is True
 
 
@@ -515,3 +570,288 @@ def test_live_write_disposable_repo_guard_blocks_write() -> None:
     assert report.overall_status == "blocked"
     assert "gh_pr_live_write_repo_not_disposable" in report.findings
     assert create_called is False
+
+
+def test_live_write_requires_explicit_base_ref() -> None:
+    create_called = False
+
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        nonlocal create_called
+        cmd = tuple(argv)
+        baseline = _base_gh_runner_result(cmd)
+        if baseline is not None:
+            return baseline
+        if cmd[:4] == ("/fake/gh", "pr", "create", "--repo"):
+            create_called = True
+            raise AssertionError("base yokken live-write create calismamali")
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: "/fake/gh",
+        runner=runner,
+        cwd=Path("/tmp"),
+        mode="live_write",
+        allow_live_write=True,
+        head_ref="feature/smoke",
+        base_ref=None,
+        require_disposable_repo_keyword="ao-kernel",
+    )
+
+    assert report.overall_status == "blocked"
+    assert "gh_pr_live_write_base_ref_required" in report.findings
+    create_check = next(check for check in report.checks if check.name == "pr_live_write")
+    verify_check = next(
+        check for check in report.checks if check.name == "pr_live_write_verify"
+    )
+    rollback_check = next(
+        check for check in report.checks if check.name == "pr_live_write_rollback"
+    )
+    assert create_check.status == "fail"
+    assert verify_check.status == "skip"
+    assert rollback_check.status == "skip"
+    assert create_called is False
+
+
+def test_live_write_create_failure_skips_verify_and_rollback() -> None:
+    verify_called = False
+    close_called = False
+
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        nonlocal verify_called, close_called
+        cmd = tuple(argv)
+        baseline = _base_gh_runner_result(cmd)
+        if baseline is not None:
+            return baseline
+        if cmd[:4] == ("/fake/gh", "pr", "create", "--repo"):
+            return _result(cmd, returncode=1, stderr="create failed")
+        if cmd[:4] == ("/fake/gh", "pr", "view", "https://github.com"):
+            verify_called = True
+            raise AssertionError("create fail oldugunda verify calismamali")
+        if cmd[:4] == ("/fake/gh", "pr", "close", "https://github.com"):
+            close_called = True
+            raise AssertionError("create fail oldugunda rollback calismamali")
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: "/fake/gh",
+        runner=runner,
+        cwd=Path("/tmp"),
+        mode="live_write",
+        allow_live_write=True,
+        head_ref="feature/smoke",
+        base_ref="main",
+        require_disposable_repo_keyword="ao-kernel",
+    )
+
+    assert report.overall_status == "blocked"
+    assert "gh_pr_live_write_failed" in report.findings
+    verify_check = next(
+        check for check in report.checks if check.name == "pr_live_write_verify"
+    )
+    rollback_check = next(
+        check for check in report.checks if check.name == "pr_live_write_rollback"
+    )
+    assert verify_check.status == "skip"
+    assert rollback_check.status == "skip"
+    assert verify_called is False
+    assert close_called is False
+
+
+def test_live_write_verify_failure_is_fail_closed_and_still_rolls_back() -> None:
+    close_called = False
+
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        nonlocal close_called
+        cmd = tuple(argv)
+        baseline = _base_gh_runner_result(cmd)
+        if baseline is not None:
+            return baseline
+        if cmd[:4] == ("/fake/gh", "pr", "create", "--repo"):
+            return _result(
+                cmd,
+                stdout=(
+                    "https://github.com/Halildeu/ao-kernel/pull/456\n"
+                    "Creating draft pull request...\n"
+                ),
+            )
+        if cmd[:4] == (
+            "/fake/gh",
+            "pr",
+            "view",
+            "https://github.com/Halildeu/ao-kernel/pull/456",
+        ):
+            return _result(cmd, returncode=1, stderr="verify failed")
+        if cmd[:4] == (
+            "/fake/gh",
+            "pr",
+            "close",
+            "https://github.com/Halildeu/ao-kernel/pull/456",
+        ):
+            close_called = True
+            return _result(cmd, stdout="Closed pull request #456\n")
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: "/fake/gh",
+        runner=runner,
+        cwd=Path("/tmp"),
+        mode="live_write",
+        allow_live_write=True,
+        head_ref="feature/smoke",
+        base_ref="main",
+        require_disposable_repo_keyword="ao-kernel",
+    )
+
+    assert report.overall_status == "blocked"
+    assert "gh_pr_live_write_verify_failed" in report.findings
+    verify_check = next(
+        check for check in report.checks if check.name == "pr_live_write_verify"
+    )
+    rollback_check = next(
+        check for check in report.checks if check.name == "pr_live_write_rollback"
+    )
+    assert verify_check.status == "fail"
+    assert rollback_check.status == "pass"
+    assert close_called is True
+
+
+def test_live_write_keep_open_is_marked_as_blocking_risk() -> None:
+    close_called = False
+
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        nonlocal close_called
+        cmd = tuple(argv)
+        baseline = _base_gh_runner_result(cmd)
+        if baseline is not None:
+            return baseline
+        if cmd[:4] == ("/fake/gh", "pr", "create", "--repo"):
+            return _result(
+                cmd,
+                stdout=(
+                    "https://github.com/Halildeu/ao-kernel/pull/777\n"
+                    "Creating draft pull request...\n"
+                ),
+            )
+        if cmd[:4] == (
+            "/fake/gh",
+            "pr",
+            "view",
+            "https://github.com/Halildeu/ao-kernel/pull/777",
+        ):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"state":"OPEN","isDraft":true,'
+                    '"url":"https://github.com/Halildeu/ao-kernel/pull/777",'
+                    '"number":777,'
+                    '"headRefName":"feature/smoke",'
+                    '"baseRefName":"main"}'
+                ),
+            )
+        if cmd[:4] == (
+            "/fake/gh",
+            "pr",
+            "close",
+            "https://github.com/Halildeu/ao-kernel/pull/777",
+        ):
+            close_called = True
+            raise AssertionError("keep-open seceneginde rollback calismamali")
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: "/fake/gh",
+        runner=runner,
+        cwd=Path("/tmp"),
+        mode="live_write",
+        allow_live_write=True,
+        keep_live_write_pr_open=True,
+        head_ref="feature/smoke",
+        base_ref="main",
+        require_disposable_repo_keyword="ao-kernel",
+    )
+
+    assert report.overall_status == "blocked"
+    assert "gh_pr_live_write_keep_open_requested" in report.findings
+    rollback_check = next(
+        check for check in report.checks if check.name == "pr_live_write_rollback"
+    )
+    assert rollback_check.status == "fail"
+    assert close_called is False
+
+
+def test_live_write_rollback_failure_blocks_lane() -> None:
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        cmd = tuple(argv)
+        baseline = _base_gh_runner_result(cmd)
+        if baseline is not None:
+            return baseline
+        if cmd[:4] == ("/fake/gh", "pr", "create", "--repo"):
+            return _result(
+                cmd,
+                stdout=(
+                    "https://github.com/Halildeu/ao-kernel/pull/999\n"
+                    "Creating draft pull request...\n"
+                ),
+            )
+        if cmd[:4] == (
+            "/fake/gh",
+            "pr",
+            "view",
+            "https://github.com/Halildeu/ao-kernel/pull/999",
+        ):
+            return _result(
+                cmd,
+                stdout=(
+                    '{"state":"OPEN","isDraft":true,'
+                    '"url":"https://github.com/Halildeu/ao-kernel/pull/999",'
+                    '"number":999,'
+                    '"headRefName":"feature/smoke",'
+                    '"baseRefName":"main"}'
+                ),
+            )
+        if cmd[:4] == (
+            "/fake/gh",
+            "pr",
+            "close",
+            "https://github.com/Halildeu/ao-kernel/pull/999",
+        ):
+            return _result(cmd, returncode=1, stderr="close failed")
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: "/fake/gh",
+        runner=runner,
+        cwd=Path("/tmp"),
+        mode="live_write",
+        allow_live_write=True,
+        head_ref="feature/smoke",
+        base_ref="main",
+        require_disposable_repo_keyword="ao-kernel",
+    )
+
+    assert report.overall_status == "blocked"
+    assert "gh_pr_live_write_rollback_failed" in report.findings
+    rollback_check = next(
+        check for check in report.checks if check.name == "pr_live_write_rollback"
+    )
+    assert rollback_check.status == "fail"


### PR DESCRIPTION
## Summary
- harden `gh-cli-pr` live-write smoke preconditions as fail-closed checks with machine-readable reason codes
- enforce create -> verify (`gh pr view`) -> rollback (`gh pr close`) chain in `run_gh_cli_pr_smoke`
- treat `--keep-live-write-pr-open` as explicit blocking risk (`gh_pr_live_write_keep_open_requested`)
- expand behavior-first unit matrix for create/verify/rollback fail paths
- align support boundary/status docs with the new live-write probe contract

## Files
- `ao_kernel/real_adapter_smoke.py`
- `tests/test_gh_cli_pr_smoke.py`
- `scripts/gh_cli_pr_smoke.py`
- `docs/SUPPORT-BOUNDARY.md`
- `docs/PUBLIC-BETA.md`
- `docs/ADAPTERS.md`
- `.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md`

## Validation
- `pytest -q tests/test_gh_cli_pr_smoke.py`
- `python3 scripts/gh_cli_pr_smoke.py --output json`
- `python3 scripts/gh_cli_pr_smoke.py --mode live-write --output json` (expected blocked without explicit opt-in)
- `python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head main --base main --require-disposable-keyword ao-kernel --output json` (expected blocked: `gh_pr_live_write_same_head_base`)

Refs #289
