### PR TITLE
[codex] PB-8.2 kernel-api write-side runtime implementation

### DIFF
--- a/.claude/plans/PB-8.2-KERNEL-API-WRITE-SIDE-RUNTIME-IMPLEMENTATION.md
+++ b/.claude/plans/PB-8.2-KERNEL-API-WRITE-SIDE-RUNTIME-IMPLEMENTATION.md
@@ -1,0 +1,50 @@
+# PB-8.2 — PRJ-KERNEL-API Write-side Runtime Implementation
+
+**Status:** Active  
+**Date:** 2026-04-23  
+**Parent tracker:** [#288](https://github.com/Halildeu/ao-kernel/issues/288)  
+**Active issue:** [#290](https://github.com/Halildeu/ao-kernel/issues/290)
+
+## Amaç
+
+`PRJ-KERNEL-API` içindeki write-side action'ları
+`project_status`, `roadmap_follow`, `roadmap_finish`
+runtime owner + behavior-first safety contract ile üretim çizgisine yaklaştırmak.
+
+Bu slice, support boundary widening'i otomatik açmaz; önce runtime/test/docs
+parity kapılarını kapatır.
+
+## Kapsam
+
+1. Runtime action registration:
+   - `project_status`
+   - `roadmap_follow`
+   - `roadmap_finish`
+2. Action-level safety contract:
+   - `workspace_root` zorunlu
+   - varsayılan `dry_run=true`
+   - gerçek yazma için explicit `confirm_write` token
+3. Behavior-first test matrisi:
+   - positive
+   - deny (`workspace_root`, `confirm_write`)
+   - idempotency
+   - conflict
+   - partial failure rollback
+4. Docs/runtime parity:
+   - `PUBLIC-BETA`
+   - `SUPPORT-BOUNDARY`
+   - `OPERATIONS-RUNBOOK`
+   - status SSOT
+
+## Kapsam Dışı
+
+1. `bug_fix_flow` widening
+2. `gh-cli-pr` full remote live-write widening
+3. `PB-8.4` final support-boundary closeout
+
+## DoD
+
+1. Üç write-side action runtime registry'de `PRJ-KERNEL-API` owner ile kayıtlı.
+2. Dispatch/loader testleri yeni action setini pinliyor.
+3. Conflict/idempotency/deny/rollback negatif path testleri yeşil.
+4. Docs ve status yüzeyi write-side lane'i doğru support tier ile anlatıyor.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -15,14 +15,14 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-6.2-KERNEL-API-PROMOTION-CONTRACT.md`
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md`
-- **Aktif decision/ordering contract:** `.claude/plans/PB-8.1-GH-CLI-PR-LIVE-WRITE-PRODUCTIONIZATION.md`
+- **Aktif decision/ordering contract:** `.claude/plans/PB-8.2-KERNEL-API-WRITE-SIDE-RUNTIME-IMPLEMENTATION.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
 - **PB-8 tracker issue:** [#288](https://github.com/Halildeu/ao-kernel/issues/288)
-- **Aktif issue:** [#289](https://github.com/Halildeu/ao-kernel/issues/289) (`PB-8.1`)
+- **Aktif issue:** [#290](https://github.com/Halildeu/ao-kernel/issues/290) (`PB-8.2`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -259,23 +259,16 @@ Not:
 
 `PB-8` kickoff aktif.
 
-1. Son kapanan slice: `PB-7.3` (`PRJ-KERNEL-API` write-side widening decision)
-2. Bugünkü aktif slice: `PB-8.1` (`gh-cli-pr` live-write productionization)
-3. Sonraki sıra (planlı): `PB-8.2` -> `PB-8.3` -> `PB-8.4`
+1. Son kapanan slice: `PB-8.1` (`gh-cli-pr` live-write productionization)
+2. Bugünkü aktif slice: `PB-8.2` (`PRJ-KERNEL-API` write-side runtime implementation)
+3. Sonraki sıra (planlı): `PB-8.3` -> `PB-8.4`
 
-`PB-8.1` implementation deltas (active branch snapshot):
+`PB-8.2` implementation odakları:
 
-1. `gh-cli-pr` live-write lane artık fail-closed precondition seti uygular:
-   explicit `--allow-live-write`, explicit `--head`, explicit `--base`,
-   disposable keyword guard.
-2. Live-write execution zinciri create -> verify (`gh pr view`) -> rollback
-   (`gh pr close`) sırasıyla zorunlu evidence check'lerine bağlandı.
-3. `--keep-live-write-pr-open` yolu side-effect riski olarak işaretlenir ve
-   raporu `blocked` döndürür (`gh_pr_live_write_keep_open_requested`).
-4. Test matrisi create/verify/rollback fail-path davranışlarını behavior-first
-   assertion'larla pinler (`tests/test_gh_cli_pr_smoke.py`).
-5. Support boundary dokümanlarında lane açıklaması bu davranışla hizalanır
-   (`docs/PUBLIC-BETA.md`, `docs/SUPPORT-BOUNDARY.md`, `docs/ADAPTERS.md`).
+1. `project_status`, `roadmap_follow`, `roadmap_finish` runtime owner/registration
+2. write-side action contract: `workspace_root`, `dry_run`, `confirm_write`
+3. deny/idempotency/conflict/partial-failure rollback test matrisi
+4. docs + status parity güncellemesi
 
 ## 9. PB-7 Closeout Snapshot
 
@@ -345,9 +338,8 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
 
 1. Program roadmap: `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md`
 2. Tracker issue: [#288](https://github.com/Halildeu/ao-kernel/issues/288)
-3. Aktif tranche: `PB-8.1` ([#289](https://github.com/Halildeu/ao-kernel/issues/289))
+3. Aktif tranche: `PB-8.2` ([#290](https://github.com/Halildeu/ao-kernel/issues/290))
 4. Sıradaki tranche'lar:
-   - `PB-8.2` ([#290](https://github.com/Halildeu/ao-kernel/issues/290))
    - `PB-8.3` ([#291](https://github.com/Halildeu/ao-kernel/issues/291))
    - `PB-8.4` ([#292](https://github.com/Halildeu/ao-kernel/issues/292))
 5. Program kuralı: tek aktif runtime tranche + zorunlu kanıt paketi.

--- a/ao_kernel/defaults/extensions/PRJ-KERNEL-API/extension.manifest.v1.json
+++ b/ao_kernel/defaults/extensions/PRJ-KERNEL-API/extension.manifest.v1.json
@@ -16,7 +16,10 @@
     "cockpit_sections": [],
     "kernel_api_actions": [
       "system_status",
-      "doc_nav_check"
+      "doc_nav_check",
+      "project_status",
+      "roadmap_follow",
+      "roadmap_finish"
     ],
     "ops": [],
     "ops_single_gate": []
@@ -47,11 +50,14 @@
       "defaults/schemas/",
       "_internal/prj_kernel_api/"
     ],
-    "write_roots_allowlist": []
+    "write_roots_allowlist": [
+      ".ao/reports/",
+      ".ao/state/"
+    ]
   },
   "notes": [
-    "Minimum runtime-backed tranche only: system_status and doc_nav_check.",
-    "project_status, roadmap_follow, and roadmap_finish remain deferred."
+    "system_status and doc_nav_check stay read-only runtime actions.",
+    "project_status, roadmap_follow, and roadmap_finish are write-side runtime-backed actions with explicit dry-run and confirm-write contract."
   ],
   "origin": "CORE",
   "outputs": {
@@ -62,7 +68,7 @@
   "policy_files": [
     "defaults/policies/policy_kernel_api_guardrails.v1.json"
   ],
-  "semver": "0.2.0",
+  "semver": "0.3.0",
   "ui_surfaces": [],
   "version": "v1",
   "enabled": true

--- a/ao_kernel/extensions/handlers/prj_kernel_api.py
+++ b/ao_kernel/extensions/handlers/prj_kernel_api.py
@@ -141,7 +141,7 @@ def _default_roadmap_state() -> dict[str, Any]:
         "active_roadmap_id": None,
         "status": "idle",
         "last_step_id": None,
-        "updated_at": _now_iso(),
+        "updated_at": None,
         "finished_at": None,
         "history": [],
     }

--- a/ao_kernel/extensions/handlers/prj_kernel_api.py
+++ b/ao_kernel/extensions/handlers/prj_kernel_api.py
@@ -1,21 +1,223 @@
-"""Minimum runtime-backed handlers for PRJ-KERNEL-API.
+"""Runtime-backed handlers for PRJ-KERNEL-API.
 
-This module intentionally promotes only the bounded, read-only tranche:
-``system_status`` and ``doc_nav_check``. Wider project/roadmap actions stay
-deferred until their workspace and write-side contracts are explicit.
+Read-only actions stay available:
+``system_status`` and ``doc_nav_check``.
+
+Write-side actions are now runtime-backed with an explicit safety contract:
+``project_status``, ``roadmap_follow``, and ``roadmap_finish``.
 """
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 import ao_kernel
 
+from ao_kernel._internal.shared.utils import write_bytes_atomic, write_json_atomic
 from ao_kernel.extensions.loader import ExtensionRegistry
 
 EXTENSION_ID = "PRJ-KERNEL-API"
-SUPPORTED_ACTIONS = ("system_status", "doc_nav_check")
-DEFERRED_ACTIONS = ("project_status", "roadmap_follow", "roadmap_finish")
+READ_ONLY_ACTIONS = ("system_status", "doc_nav_check")
+WRITE_ACTIONS = ("project_status", "roadmap_follow", "roadmap_finish")
+SUPPORTED_ACTIONS = READ_ONLY_ACTIONS + WRITE_ACTIONS
+
+REQUIRED_WRITE_CONFIRMATION = "I_UNDERSTAND_SIDE_EFFECTS"
+ROADMAP_STATE_REL_PATH = ".ao/state/kernel_api_roadmap_state.v1.json"
+PROJECT_STATUS_REL_PATH = ".ao/reports/project_status.v1.json"
+WRITE_AUDIT_REL_PATH = ".ao/reports/kernel_api_write_audit.v1.jsonl"
+ALLOWED_WRITE_PREFIXES = (".ao/state/", ".ao/reports/")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _write_contract() -> dict[str, Any]:
+    return {
+        "dry_run_default": True,
+        "require_workspace_root": True,
+        "require_confirm_for_write": True,
+        "confirm_token": REQUIRED_WRITE_CONFIRMATION,
+        "allowed_write_prefixes": list(ALLOWED_WRITE_PREFIXES),
+        "rollback_on_partial_failure": True,
+    }
+
+
+def _load_json_dict(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(parsed, dict):
+        raise ValueError(f"Expected JSON object at {path}")
+    return parsed
+
+
+def _canonical_json(data: dict[str, Any]) -> str:
+    return json.dumps(data, ensure_ascii=False, sort_keys=True)
+
+
+def _project_status_signature(data: dict[str, Any]) -> str:
+    normalized = dict(data)
+    normalized.pop("generated_at", None)
+    normalized.pop("request_id", None)
+    return _canonical_json(normalized)
+
+
+def _safe_relative(workspace_root: Path, target: Path) -> str:
+    try:
+        rel = target.resolve().relative_to(workspace_root.resolve())
+    except ValueError as exc:
+        raise ValueError(f"Path escapes workspace_root: {target}") from exc
+    rel_norm = rel.as_posix()
+    if not any(
+        rel_norm == prefix.rstrip("/") or rel_norm.startswith(prefix)
+        for prefix in ALLOWED_WRITE_PREFIXES
+    ):
+        raise ValueError(f"Path outside write allowlist: {rel_norm}")
+    return rel_norm
+
+
+def _resolve_workspace_root(action: str, params: dict[str, Any]) -> tuple[Path | None, dict[str, Any] | None]:
+    raw = params.get("workspace_root")
+    if not isinstance(raw, str) or not raw.strip():
+        return (
+            None,
+            _error_envelope(
+                action,
+                error_code="WORKSPACE_ROOT_REQUIRED",
+                message="workspace_root is required for write-side actions",
+                status="BLOCKED",
+            ),
+        )
+    root = Path(raw).expanduser().resolve()
+    if not root.is_dir():
+        return (
+            None,
+            _error_envelope(
+                action,
+                error_code="WORKSPACE_ROOT_INVALID",
+                message=f"workspace_root is not a directory: {root}",
+                status="BLOCKED",
+            ),
+        )
+    return root, None
+
+
+def _resolve_write_mode(action: str, params: dict[str, Any]) -> tuple[bool | None, dict[str, Any] | None]:
+    dry_run = params.get("dry_run", True)
+    if not isinstance(dry_run, bool):
+        return (
+            None,
+            _error_envelope(
+                action,
+                error_code="INVALID_DRY_RUN",
+                message="dry_run must be boolean",
+                status="BLOCKED",
+            ),
+        )
+    if not dry_run:
+        confirm = params.get("confirm_write")
+        if confirm != REQUIRED_WRITE_CONFIRMATION:
+            return (
+                None,
+                _error_envelope(
+                    action,
+                    error_code="WRITE_CONFIRM_REQUIRED",
+                    message=(
+                        "set confirm_write to the required token before write-side execution"
+                    ),
+                    status="BLOCKED",
+                ),
+            )
+    return dry_run, None
+
+
+def _default_roadmap_state() -> dict[str, Any]:
+    return {
+        "version": "v1",
+        "active_roadmap_id": None,
+        "status": "idle",
+        "last_step_id": None,
+        "updated_at": _now_iso(),
+        "finished_at": None,
+        "history": [],
+    }
+
+
+def _load_roadmap_state(state_path: Path) -> dict[str, Any]:
+    current = _load_json_dict(state_path)
+    if current is None:
+        return _default_roadmap_state()
+    merged = _default_roadmap_state()
+    merged.update(current)
+    history = merged.get("history")
+    if not isinstance(history, list):
+        merged["history"] = []
+    return merged
+
+
+def _append_history(
+    state: dict[str, Any],
+    *,
+    event: str,
+    roadmap_id: str,
+    step_id: str | None = None,
+) -> None:
+    history = state.get("history")
+    if not isinstance(history, list):
+        history = []
+    entry: dict[str, Any] = {
+        "event": event,
+        "roadmap_id": roadmap_id,
+        "timestamp": _now_iso(),
+    }
+    if step_id:
+        entry["step_id"] = step_id
+    history.append(entry)
+    state["history"] = history[-100:]
+
+
+def _append_jsonl(path: Path, entry: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(entry, ensure_ascii=False, sort_keys=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(payload + "\n")
+
+
+def _write_with_audit_and_rollback(
+    *,
+    workspace_root: Path,
+    target_path: Path,
+    payload: dict[str, Any],
+    audit_path: Path,
+    audit_entry: dict[str, Any],
+    force_fail_after_primary_write: bool,
+) -> tuple[bool, str | None]:
+    _safe_relative(workspace_root, target_path)
+    _safe_relative(workspace_root, audit_path)
+
+    existed = target_path.exists()
+    previous = target_path.read_bytes() if existed else b""
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    write_json_atomic(target_path, payload)
+
+    try:
+        if force_fail_after_primary_write:
+            raise RuntimeError("forced failure after primary write")
+        _append_jsonl(audit_path, audit_entry)
+        return True, None
+    except Exception as exc:  # noqa: BLE001
+        try:
+            if existed:
+                write_bytes_atomic(target_path, previous)
+            elif target_path.exists():
+                target_path.unlink()
+        except Exception as rollback_exc:  # noqa: BLE001
+            return False, f"{exc}; rollback_failed={rollback_exc}"
+        return False, str(exc)
 
 
 def _truth_payload() -> dict[str, Any]:
@@ -62,20 +264,41 @@ def _extension_payload() -> dict[str, Any]:
 def _envelope(action: str, result: dict[str, Any]) -> dict[str, Any]:
     return {
         "ok": True,
+        "status": "OK",
         "action": action,
         "extension_id": EXTENSION_ID,
         "result": result,
     }
 
 
+def _error_envelope(
+    action: str,
+    *,
+    error_code: str,
+    message: str,
+    status: str = "FAIL",
+    result: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "status": status,
+        "action": action,
+        "extension_id": EXTENSION_ID,
+        "error": {"code": error_code, "message": message},
+        "result": result or {},
+    }
+
+
 def system_status(params: dict[str, Any]) -> dict[str, Any]:
-    """Return a read-only runtime truth snapshot for the installed package."""
+    """Return runtime truth snapshot for the installed package."""
     return _envelope(
         "system_status",
         {
             "version": ao_kernel.__version__,
             "supported_actions": list(SUPPORTED_ACTIONS),
-            "deferred_actions": list(DEFERRED_ACTIONS),
+            "read_only_actions": list(READ_ONLY_ACTIONS),
+            "write_actions": list(WRITE_ACTIONS),
+            "write_side_contract": _write_contract(),
             "extension_truth": _truth_payload(),
             "params_echo": {
                 key: params[key]
@@ -93,7 +316,9 @@ def doc_nav_check(params: dict[str, Any]) -> dict[str, Any]:
         {
             "extension": _extension_payload(),
             "supported_actions": list(SUPPORTED_ACTIONS),
-            "deferred_actions": list(DEFERRED_ACTIONS),
+            "read_only_actions": list(READ_ONLY_ACTIONS),
+            "write_actions": list(WRITE_ACTIONS),
+            "write_side_contract": _write_contract(),
             "network_required": False,
             "workspace_write": False,
             "params_echo": {
@@ -105,7 +330,456 @@ def doc_nav_check(params: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def project_status(params: dict[str, Any]) -> dict[str, Any]:
+    action = "project_status"
+    workspace_root, ws_error = _resolve_workspace_root(action, params)
+    if ws_error is not None or workspace_root is None:
+        return ws_error or _error_envelope(
+            action,
+            error_code="WORKSPACE_ROOT_REQUIRED",
+            message="workspace_root is required",
+            status="BLOCKED",
+        )
+
+    dry_run, mode_error = _resolve_write_mode(action, params)
+    if mode_error is not None or dry_run is None:
+        return mode_error or _error_envelope(
+            action,
+            error_code="INVALID_DRY_RUN",
+            message="dry_run parsing failed",
+            status="BLOCKED",
+        )
+
+    report_path = workspace_root / PROJECT_STATUS_REL_PATH
+    state_path = workspace_root / ROADMAP_STATE_REL_PATH
+    audit_path = workspace_root / WRITE_AUDIT_REL_PATH
+
+    try:
+        rel_report = _safe_relative(workspace_root, report_path)
+        rel_audit = _safe_relative(workspace_root, audit_path)
+    except ValueError as exc:
+        return _error_envelope(
+            action,
+            error_code="WRITE_PATH_VIOLATION",
+            message=str(exc),
+            status="BLOCKED",
+        )
+
+    try:
+        roadmap_state = _load_roadmap_state(state_path)
+    except Exception as exc:  # noqa: BLE001
+        return _error_envelope(
+            action,
+            error_code="ROADMAP_STATE_INVALID",
+            message=str(exc),
+        )
+
+    report_payload: dict[str, Any] = {
+        "version": "v1",
+        "generated_at": _now_iso(),
+        "extension_id": EXTENSION_ID,
+        "workspace_root": str(workspace_root),
+        "truth": _truth_payload(),
+        "roadmap_state": roadmap_state,
+        "request_id": params.get("request_id"),
+    }
+
+    try:
+        current = _load_json_dict(report_path)
+    except Exception as exc:  # noqa: BLE001
+        return _error_envelope(
+            action,
+            error_code="PROJECT_STATUS_INVALID",
+            message=str(exc),
+        )
+    idempotent = (
+        current is not None
+        and _project_status_signature(current) == _project_status_signature(report_payload)
+    )
+
+    if dry_run:
+        return _envelope(
+            action,
+            {
+                "dry_run": True,
+                "write_applied": False,
+                "idempotent": idempotent,
+                "workspace_root": str(workspace_root),
+                "report_path": rel_report,
+                "audit_path": rel_audit,
+                "roadmap_state_status": roadmap_state.get("status"),
+            },
+        )
+
+    if idempotent:
+        return _envelope(
+            action,
+            {
+                "dry_run": False,
+                "write_applied": False,
+                "idempotent": True,
+                "workspace_root": str(workspace_root),
+                "report_path": rel_report,
+                "audit_path": rel_audit,
+            },
+        )
+
+    force_fail = bool(params.get("_force_fail_after_primary_write", False))
+    ok, write_err = _write_with_audit_and_rollback(
+        workspace_root=workspace_root,
+        target_path=report_path,
+        payload=report_payload,
+        audit_path=audit_path,
+        audit_entry={
+            "version": "v1",
+            "timestamp": _now_iso(),
+            "action": action,
+            "workspace_root": str(workspace_root),
+            "report_path": rel_report,
+            "idempotent": False,
+        },
+        force_fail_after_primary_write=force_fail,
+    )
+    if not ok:
+        return _error_envelope(
+            action,
+            error_code="WRITE_PARTIAL_FAILURE_ROLLBACK",
+            message=str(write_err),
+            result={
+                "dry_run": False,
+                "write_applied": False,
+                "rollback_applied": True,
+                "report_path": rel_report,
+            },
+        )
+
+    return _envelope(
+        action,
+        {
+            "dry_run": False,
+            "write_applied": True,
+            "idempotent": False,
+            "workspace_root": str(workspace_root),
+            "report_path": rel_report,
+            "audit_path": rel_audit,
+        },
+    )
+
+
+def roadmap_follow(params: dict[str, Any]) -> dict[str, Any]:
+    action = "roadmap_follow"
+    workspace_root, ws_error = _resolve_workspace_root(action, params)
+    if ws_error is not None or workspace_root is None:
+        return ws_error or _error_envelope(
+            action,
+            error_code="WORKSPACE_ROOT_REQUIRED",
+            message="workspace_root is required",
+            status="BLOCKED",
+        )
+
+    dry_run, mode_error = _resolve_write_mode(action, params)
+    if mode_error is not None or dry_run is None:
+        return mode_error or _error_envelope(
+            action,
+            error_code="INVALID_DRY_RUN",
+            message="dry_run parsing failed",
+            status="BLOCKED",
+        )
+
+    roadmap_id = params.get("roadmap_id")
+    if not isinstance(roadmap_id, str) or not roadmap_id.strip():
+        return _error_envelope(
+            action,
+            error_code="ROADMAP_ID_REQUIRED",
+            message="roadmap_id must be a non-empty string",
+            status="BLOCKED",
+        )
+    roadmap_id = roadmap_id.strip()
+
+    step_id_raw = params.get("step_id", "")
+    step_id = step_id_raw.strip() if isinstance(step_id_raw, str) else ""
+    allow_takeover = bool(params.get("allow_takeover", False))
+
+    state_path = workspace_root / ROADMAP_STATE_REL_PATH
+    audit_path = workspace_root / WRITE_AUDIT_REL_PATH
+    try:
+        rel_state = _safe_relative(workspace_root, state_path)
+        rel_audit = _safe_relative(workspace_root, audit_path)
+        current_state = _load_roadmap_state(state_path)
+    except Exception as exc:  # noqa: BLE001
+        return _error_envelope(
+            action,
+            error_code="ROADMAP_STATE_INVALID",
+            message=str(exc),
+        )
+
+    active_roadmap = current_state.get("active_roadmap_id")
+    current_status = current_state.get("status")
+    if (
+        isinstance(active_roadmap, str)
+        and active_roadmap
+        and active_roadmap != roadmap_id
+        and current_status == "following"
+        and not allow_takeover
+    ):
+        return _error_envelope(
+            action,
+            error_code="ROADMAP_CONFLICT",
+            message=f"active roadmap is {active_roadmap}; set allow_takeover=true to switch",
+            status="BLOCKED",
+            result={"active_roadmap_id": active_roadmap},
+        )
+
+    idempotent = (
+        current_status == "following"
+        and active_roadmap == roadmap_id
+        and current_state.get("last_step_id") == (step_id or None)
+    )
+
+    if dry_run:
+        return _envelope(
+            action,
+            {
+                "dry_run": True,
+                "write_applied": False,
+                "idempotent": idempotent,
+                "state_path": rel_state,
+                "audit_path": rel_audit,
+                "roadmap_id": roadmap_id,
+                "step_id": step_id or None,
+                "allow_takeover": allow_takeover,
+            },
+        )
+
+    if idempotent:
+        return _envelope(
+            action,
+            {
+                "dry_run": False,
+                "write_applied": False,
+                "idempotent": True,
+                "state_path": rel_state,
+                "audit_path": rel_audit,
+                "roadmap_id": roadmap_id,
+                "step_id": step_id or None,
+            },
+        )
+
+    new_state = dict(current_state)
+    new_state["version"] = "v1"
+    new_state["active_roadmap_id"] = roadmap_id
+    new_state["status"] = "following"
+    new_state["last_step_id"] = step_id or None
+    new_state["updated_at"] = _now_iso()
+    new_state["finished_at"] = None
+    _append_history(new_state, event=action, roadmap_id=roadmap_id, step_id=step_id or None)
+
+    force_fail = bool(params.get("_force_fail_after_primary_write", False))
+    ok, write_err = _write_with_audit_and_rollback(
+        workspace_root=workspace_root,
+        target_path=state_path,
+        payload=new_state,
+        audit_path=audit_path,
+        audit_entry={
+            "version": "v1",
+            "timestamp": _now_iso(),
+            "action": action,
+            "roadmap_id": roadmap_id,
+            "step_id": step_id or None,
+            "state_path": rel_state,
+        },
+        force_fail_after_primary_write=force_fail,
+    )
+    if not ok:
+        return _error_envelope(
+            action,
+            error_code="WRITE_PARTIAL_FAILURE_ROLLBACK",
+            message=str(write_err),
+            result={
+                "dry_run": False,
+                "write_applied": False,
+                "rollback_applied": True,
+                "state_path": rel_state,
+            },
+        )
+
+    return _envelope(
+        action,
+        {
+            "dry_run": False,
+            "write_applied": True,
+            "idempotent": False,
+            "state_path": rel_state,
+            "audit_path": rel_audit,
+            "roadmap_id": roadmap_id,
+            "step_id": step_id or None,
+            "status": "following",
+        },
+    )
+
+
+def roadmap_finish(params: dict[str, Any]) -> dict[str, Any]:
+    action = "roadmap_finish"
+    workspace_root, ws_error = _resolve_workspace_root(action, params)
+    if ws_error is not None or workspace_root is None:
+        return ws_error or _error_envelope(
+            action,
+            error_code="WORKSPACE_ROOT_REQUIRED",
+            message="workspace_root is required",
+            status="BLOCKED",
+        )
+
+    dry_run, mode_error = _resolve_write_mode(action, params)
+    if mode_error is not None or dry_run is None:
+        return mode_error or _error_envelope(
+            action,
+            error_code="INVALID_DRY_RUN",
+            message="dry_run parsing failed",
+            status="BLOCKED",
+        )
+
+    roadmap_id = params.get("roadmap_id")
+    if not isinstance(roadmap_id, str) or not roadmap_id.strip():
+        return _error_envelope(
+            action,
+            error_code="ROADMAP_ID_REQUIRED",
+            message="roadmap_id must be a non-empty string",
+            status="BLOCKED",
+        )
+    roadmap_id = roadmap_id.strip()
+
+    step_id_raw = params.get("step_id", "")
+    step_id = step_id_raw.strip() if isinstance(step_id_raw, str) else ""
+    allow_takeover = bool(params.get("allow_takeover", False))
+
+    state_path = workspace_root / ROADMAP_STATE_REL_PATH
+    audit_path = workspace_root / WRITE_AUDIT_REL_PATH
+    try:
+        rel_state = _safe_relative(workspace_root, state_path)
+        rel_audit = _safe_relative(workspace_root, audit_path)
+        current_state = _load_roadmap_state(state_path)
+    except Exception as exc:  # noqa: BLE001
+        return _error_envelope(
+            action,
+            error_code="ROADMAP_STATE_INVALID",
+            message=str(exc),
+        )
+
+    active_roadmap = current_state.get("active_roadmap_id")
+    current_status = current_state.get("status")
+
+    if current_status == "finished" and active_roadmap == roadmap_id:
+        idempotent = True
+    else:
+        idempotent = False
+        if (
+            isinstance(active_roadmap, str)
+            and active_roadmap
+            and active_roadmap != roadmap_id
+            and current_status == "following"
+            and not allow_takeover
+        ):
+            return _error_envelope(
+                action,
+                error_code="ROADMAP_CONFLICT",
+                message=f"active roadmap is {active_roadmap}; set allow_takeover=true to finish another roadmap",
+                status="BLOCKED",
+                result={"active_roadmap_id": active_roadmap},
+            )
+        if not active_roadmap and current_status != "finished":
+            return _error_envelope(
+                action,
+                error_code="ROADMAP_NOT_FOLLOWING",
+                message="no active roadmap to finish; run roadmap_follow first",
+                status="BLOCKED",
+            )
+
+    if dry_run:
+        return _envelope(
+            action,
+            {
+                "dry_run": True,
+                "write_applied": False,
+                "idempotent": idempotent,
+                "state_path": rel_state,
+                "audit_path": rel_audit,
+                "roadmap_id": roadmap_id,
+                "step_id": step_id or None,
+            },
+        )
+
+    if idempotent:
+        return _envelope(
+            action,
+            {
+                "dry_run": False,
+                "write_applied": False,
+                "idempotent": True,
+                "state_path": rel_state,
+                "audit_path": rel_audit,
+                "roadmap_id": roadmap_id,
+                "step_id": step_id or None,
+                "status": "finished",
+            },
+        )
+
+    new_state = dict(current_state)
+    new_state["version"] = "v1"
+    new_state["active_roadmap_id"] = roadmap_id
+    new_state["status"] = "finished"
+    new_state["last_step_id"] = step_id or current_state.get("last_step_id")
+    new_state["updated_at"] = _now_iso()
+    new_state["finished_at"] = _now_iso()
+    _append_history(new_state, event=action, roadmap_id=roadmap_id, step_id=step_id or None)
+
+    force_fail = bool(params.get("_force_fail_after_primary_write", False))
+    ok, write_err = _write_with_audit_and_rollback(
+        workspace_root=workspace_root,
+        target_path=state_path,
+        payload=new_state,
+        audit_path=audit_path,
+        audit_entry={
+            "version": "v1",
+            "timestamp": _now_iso(),
+            "action": action,
+            "roadmap_id": roadmap_id,
+            "step_id": step_id or None,
+            "state_path": rel_state,
+        },
+        force_fail_after_primary_write=force_fail,
+    )
+    if not ok:
+        return _error_envelope(
+            action,
+            error_code="WRITE_PARTIAL_FAILURE_ROLLBACK",
+            message=str(write_err),
+            result={
+                "dry_run": False,
+                "write_applied": False,
+                "rollback_applied": True,
+                "state_path": rel_state,
+            },
+        )
+
+    return _envelope(
+        action,
+        {
+            "dry_run": False,
+            "write_applied": True,
+            "idempotent": False,
+            "state_path": rel_state,
+            "audit_path": rel_audit,
+            "roadmap_id": roadmap_id,
+            "step_id": step_id or None,
+            "status": "finished",
+        },
+    )
+
+
 def register(registry: Any) -> None:
-    """Register the bounded PRJ-KERNEL-API action tranche."""
+    """Register PRJ-KERNEL-API action tranche."""
     registry.register("system_status", system_status, extension_id=EXTENSION_ID)
     registry.register("doc_nav_check", doc_nav_check, extension_id=EXTENSION_ID)
+    registry.register("project_status", project_status, extension_id=EXTENSION_ID)
+    registry.register("roadmap_follow", roadmap_follow, extension_id=EXTENSION_ID)
+    registry.register("roadmap_finish", roadmap_finish, extension_id=EXTENSION_ID)

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -39,6 +39,21 @@ python3 scripts/gh_cli_pr_smoke.py --output text
 # python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch>
 ```
 
+`PRJ-KERNEL-API` write-side lane için ek doğrulama:
+
+```bash
+python3 - <<'PY'
+from ao_kernel.client import AoKernelClient
+import tempfile
+from pathlib import Path
+ws = Path(tempfile.mkdtemp(prefix="kernel-api-write-smoke-"))
+client = AoKernelClient()
+print(client.call_action("project_status", {"workspace_root": str(ws), "dry_run": True})["status"])
+print(client.call_action("roadmap_follow", {"workspace_root": str(ws), "roadmap_id": "SMOKE", "step_id": "s1", "dry_run": False, "confirm_write": "I_UNDERSTAND_SIDE_EFFECTS"})["status"])
+print(client.call_action("roadmap_finish", {"workspace_root": str(ws), "roadmap_id": "SMOKE", "step_id": "s2", "dry_run": False, "confirm_write": "I_UNDERSTAND_SIDE_EFFECTS"})["status"])
+PY
+```
+
 ## 3. Decision tree
 
 ### 3.1 Shipped baseline fails
@@ -67,6 +82,7 @@ If shipped baseline stays green but one of these fails:
 - `python3 scripts/claude_code_cli_smoke.py --output text`
 - `python3 scripts/gh_cli_pr_smoke.py --output text`
 - optional live-write readiness probe (`gh_cli_pr_smoke.py --mode live-write --allow-live-write ...`)
+- `PRJ-KERNEL-API` write-side action lane (`project_status`, `roadmap_follow`, `roadmap_finish`)
 - operator-run real-adapter benchmark path
 
 Then the shipped baseline claim stays intact, but the operator guidance must

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -40,7 +40,7 @@ istemek gerekir.
 | Bundled `review_ai_flow` + bundled `codex-stub` | Shipped | Desteklenen demo workflow |
 | `examples/demo_review.py` | Shipped | Disposable workspace + canlı smoke `completed`; komut, `ao-kernel` kurulu bir Python environment'ı içinde çalıştırılmalıdır |
 | `ao-kernel doctor` | Shipped | Workspace health check + bundled extension truth audit; may emit WARN while quarantined inventory remains |
-| `PRJ-KERNEL-API` minimum runtime-backed actions | Shipped | Only `system_status` and `doc_nav_check`; both are explicit bootstrap handlers, offline, read-only, and behavior-tested |
+| `PRJ-KERNEL-API` read-only runtime-backed actions | Shipped | `system_status` and `doc_nav_check`; explicit bootstrap handlers, offline, read-only, behavior-tested |
 | CI coverage gate 85% | Shipped | `pyproject.toml` ile hizalı (`test.yml --fail-under=85`) |
 | Adapter CLI command enforcement | Shipped | `policy_checked` / `policy_denied` artık resolved command ihlallerini de içerir; canonical sıra `step_started -> policy_checked -> adapter_invoked` korunur |
 | `{python_executable}` localized exception | Shipped | Yalnız manifest `command` alanı explicit `{python_executable}` kullandığında, yalnız resolved `sys.executable` realpath'i için geçerli; sandbox allowlist'ini mutate etmez |
@@ -57,6 +57,7 @@ istemek gerekir.
 | Public Beta yüzeyinin tamamı | Beta | Stable kanal hâlâ `3.13.3`; genel kullanım için pre-release install gerekir |
 | `claude-code-cli` helper-backed real-adapter lane | Beta (operator-managed) | `python3 scripts/claude_code_cli_smoke.py` ile preflight + canlı prompt smoke doğrulanabilir; varsayılan shipped demo değildir. `PB-6.6` closeout verdict'i: `stay_beta_operator_managed` |
 | `gh-cli-pr` helper-backed preflight lane | Beta (operator-managed preflight + live-write readiness probe) | Varsayılan `python3 scripts/gh_cli_pr_smoke.py` preflight yoludur (`--dry-run`). Live-write probe (`--mode live-write --allow-live-write --head <branch> --base <branch>`) explicit opt-in + disposable guard + create->verify->rollback zinciri ister; `--keep-live-write-pr-open` lane'i riskli sayar ve `blocked` döner. Support widening değildir |
+| `PRJ-KERNEL-API` write-side actions | Beta (operator-managed write contract) | `project_status`, `roadmap_follow`, `roadmap_finish` runtime-backed. `workspace_root` zorunlu, varsayılan `dry_run=true`, gerçek yazma için `confirm_write=I_UNDERSTAND_SIDE_EFFECTS` gerekir; conflict/idempotency/rollback davranışı behavior testlerle pinlidir |
 | Real-adapter benchmark tam modu | Beta (operator-managed) | Deterministik stub lane kadar stabil değildir; adapter-altı gerçek tier sınırları yukarıdaki satırlarda tanımlanır |
 
 ## Contract / Inventory Layer
@@ -88,7 +89,6 @@ Bu kuralın amacı, inventory görünürlüğünü support widening ile karışt
 | `gh-cli-pr` ile tam E2E PR açılışı | Deferred | Live-write probe create->verify->rollback guard'larıyla güçlense de gerçek remote PR açılışı hâlâ destek vaadi değildir; lane operator-managed/deferred boundary içinde değerlendirilir |
 | `docs/roadmap/DEMO-SCRIPT-SPEC.md` içindeki 11 adımlı üç-adapter akış | Deferred | Canlı destek vaadi değildir |
 | Adapter-path `cost_usd` reconcile | Deferred | Public support claim olarak hâlâ deferred; benchmark/internal runtime hook varlığı bunu tek başına shipped veya beta support yüzeyine yükseltmez |
-| `PRJ-KERNEL-API` `project_status`, `roadmap_follow`, `roadmap_finish` actions | Deferred | `PB-7.3` kararı `stay_deferred`: runtime owner/entrypoint kaydı bu action'lar için hâlâ yok; behavior/safety/rollback kapıları tamamlanmadan support widening açılmaz |
 
 ## Known Bugs
 
@@ -105,9 +105,10 @@ Bu kuralın amacı, inventory görünürlüğünü support widening ile karışt
   `review_ai_flow` + bundled `codex-stub` yolu için geçerlidir.
 - `claude-code-cli` ve `gh-cli-pr` bugün default demo yüzeyi değildir;
   yalnız helper-backed operator-managed beta satırları kadar desteklenir.
-- Bundled extension inventory bugün dar runtime-backed yüzeye sahiptir:
-  explicit bootstrap-backed smoke `PRJ-HELLO` ve `PRJ-KERNEL-API` için
-  yalnız `system_status` / `doc_nav_check` action'ları.
+- Bundled extension inventory runtime-backed olsa da support-tier ayrımı korunur:
+  `PRJ-KERNEL-API` içinde `system_status` / `doc_nav_check` shipped read-only
+  satırındadır; `project_status` / `roadmap_follow` / `roadmap_finish` ise
+  explicit write contract ile Beta (operator-managed) satırındadır.
   `PRJ-CONTEXT-ORCHESTRATION` bugün contract-only katmandadır
   (manifest/contract cleanup sonrası, runtime handler hâlâ yoktur);
   kalan manifestler doctor truth audit'inde quarantined olarak görülebilir.

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -11,9 +11,9 @@ operator-only, or just contract inventory?"
 | Layer | Included surfaces | Verification |
 |---|---|---|
 | Shipped baseline | module entrypoints, `ao-kernel doctor`, bundled `review_ai_flow`, `examples/demo_review.py`, packaging smoke, `PRJ-KERNEL-API` `system_status` / `doc_nav_check` actions | entrypoint checks, doctor, demo review smoke, behavior tests, CI |
-| Beta (operator-managed) | `claude-code-cli` helper-backed lane, `gh-cli-pr` helper-backed preflight + live-write readiness probe lane, real-adapter benchmark full mode | explicit smoke helpers and runbooks |
+| Beta (operator-managed) | `claude-code-cli` helper-backed lane, `gh-cli-pr` helper-backed preflight + live-write readiness probe lane, `PRJ-KERNEL-API` write-side actions (`project_status`, `roadmap_follow`, `roadmap_finish`) with explicit write contract, real-adapter benchmark full mode | explicit smoke helpers and runbooks |
 | Contract inventory | bundled defaults, manifests, extensions, example inventory | loader/validator and truth audit only |
-| Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, `PRJ-KERNEL-API` write-side actions, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary (`PB-7.2` verdict for bug_fix_flow: `stay_deferred`, `PB-7.3` verdict for kernel-api write-side: `stay_deferred`) |
+| Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary (`PB-7.2` verdict for bug_fix_flow: `stay_deferred`) |
 
 ### 1.1 Truth inventory to support mapping
 
@@ -50,6 +50,7 @@ These are real, testable surfaces, but they are not the default shipped demo:
 - `python3 scripts/claude_code_cli_smoke.py --output text`
 - `python3 scripts/gh_cli_pr_smoke.py --output text`
 - `python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch>`
+- `PRJ-KERNEL-API` write-side actions (`project_status`, `roadmap_follow`, `roadmap_finish`) with explicit `workspace_root`, default `dry_run=true`, and `confirm_write=I_UNDERSTAND_SIDE_EFFECTS` for real writes
 - real-adapter benchmark full-mode runbooks
 
 `PB-6.6` closeout kararıyla `claude-code-cli` lane support-tier'i
@@ -70,16 +71,8 @@ These may be bundled and schema-valid without being end-to-end supported:
 - `examples/hello-llm/`
 - roadmap/spec documents
 
-For `PRJ-KERNEL-API`, these actions remain outside the shipped support
-boundary even though the extension has a minimum runtime-backed tranche:
-
-- `project_status`
-- `roadmap_follow`
-- `roadmap_finish`
-
-`PB-7.3` kararına göre bu write-side action'lar için widening açılmadı; runtime
-owner/entrypoint yokluğu ile behavior/safety/rollback kapıları tamamlanana
-kadar deferred sınır korunur.
+`PRJ-KERNEL-API` write-side actions runtime-backed olsa da shipped baseline
+değildir; support tier yalnız Beta (operator-managed) satırı kadar genişler.
 
 ## 3. What does NOT automatically widen support
 

--- a/tests/test_extension_dispatch.py
+++ b/tests/test_extension_dispatch.py
@@ -10,6 +10,8 @@ Covers:
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from ao_kernel.client import AoKernelClient
@@ -97,16 +99,19 @@ class TestBootstrapKernelApiExtension:
 
         assert "PRJ-KERNEL-API" in default_handler_extension_ids()
 
-    def test_kernel_api_minimum_actions_registered_by_default(self):
+    def test_kernel_api_actions_registered_by_default(self):
         client = AoKernelClient()
 
-        for action in ("system_status", "doc_nav_check"):
+        for action in (
+            "system_status",
+            "doc_nav_check",
+            "project_status",
+            "roadmap_follow",
+            "roadmap_finish",
+        ):
             record = client.action_registry.resolve(action)
             assert record is not None
             assert record.extension_id == "PRJ-KERNEL-API"
-
-        for action in ("project_status", "roadmap_follow", "roadmap_finish"):
-            assert client.action_registry.resolve(action) is None
 
     def test_kernel_api_system_status_payload_is_bounded(self):
         client = AoKernelClient()
@@ -117,12 +122,22 @@ class TestBootstrapKernelApiExtension:
         assert out["action"] == "system_status"
         assert out["extension_id"] == "PRJ-KERNEL-API"
         result = out["result"]
-        assert result["supported_actions"] == ["system_status", "doc_nav_check"]
-        assert result["deferred_actions"] == [
+        assert result["supported_actions"] == [
+            "system_status",
+            "doc_nav_check",
             "project_status",
             "roadmap_follow",
             "roadmap_finish",
         ]
+        assert result["read_only_actions"] == ["system_status", "doc_nav_check"]
+        assert result["write_actions"] == [
+            "project_status",
+            "roadmap_follow",
+            "roadmap_finish",
+        ]
+        contract = result["write_side_contract"]
+        assert contract["dry_run_default"] is True
+        assert contract["require_confirm_for_write"] is True
         assert result["params_echo"] == {"detail": True}
         truth = result["extension_truth"]
         assert truth["runtime_backed"] == 2
@@ -142,9 +157,163 @@ class TestBootstrapKernelApiExtension:
         assert ext["extension_id"] == "PRJ-KERNEL-API"
         assert ext["truth_tier"] == "runtime_backed"
         assert ext["runtime_handler_registered"] is True
-        assert ext["kernel_api_actions"] == ["system_status", "doc_nav_check"]
+        assert ext["kernel_api_actions"] == [
+            "system_status",
+            "doc_nav_check",
+            "project_status",
+            "roadmap_follow",
+            "roadmap_finish",
+        ]
         assert ext["missing_runtime_refs"] == []
         assert ext["remap_candidate_refs"] == []
+        assert result["write_side_contract"]["dry_run_default"] is True
+
+    def test_project_status_requires_workspace_root(self):
+        client = AoKernelClient()
+        out = client.call_action("project_status", {})
+
+        assert out["ok"] is False
+        assert out["status"] == "BLOCKED"
+        assert out["error"]["code"] == "WORKSPACE_ROOT_REQUIRED"
+
+    def test_project_status_dry_run_default_no_side_effect(self, tmp_path):
+        client = AoKernelClient()
+
+        out = client.call_action(
+            "project_status",
+            {"workspace_root": str(tmp_path)},
+        )
+
+        assert out["ok"] is True
+        result = out["result"]
+        assert result["dry_run"] is True
+        assert result["write_applied"] is False
+        report_path = tmp_path / result["report_path"]
+        assert not report_path.exists()
+
+    def test_project_status_write_requires_confirm_token(self, tmp_path):
+        client = AoKernelClient()
+        out = client.call_action(
+            "project_status",
+            {
+                "workspace_root": str(tmp_path),
+                "dry_run": False,
+            },
+        )
+
+        assert out["ok"] is False
+        assert out["status"] == "BLOCKED"
+        assert out["error"]["code"] == "WRITE_CONFIRM_REQUIRED"
+
+    def test_project_status_idempotent_write_contract(self, tmp_path):
+        client = AoKernelClient()
+        params = {
+            "workspace_root": str(tmp_path),
+            "dry_run": False,
+            "confirm_write": "I_UNDERSTAND_SIDE_EFFECTS",
+            "request_id": "req-1",
+        }
+
+        first = client.call_action("project_status", params)
+        second = client.call_action("project_status", params)
+
+        assert first["ok"] is True
+        assert first["result"]["write_applied"] is True
+        assert first["result"]["idempotent"] is False
+        assert second["ok"] is True
+        assert second["result"]["write_applied"] is False
+        assert second["result"]["idempotent"] is True
+
+    def test_roadmap_follow_conflict_and_takeover(self, tmp_path):
+        client = AoKernelClient()
+        base_params = {
+            "workspace_root": str(tmp_path),
+            "dry_run": False,
+            "confirm_write": "I_UNDERSTAND_SIDE_EFFECTS",
+        }
+
+        first = client.call_action(
+            "roadmap_follow",
+            {**base_params, "roadmap_id": "A", "step_id": "s1"},
+        )
+        conflict = client.call_action(
+            "roadmap_follow",
+            {**base_params, "roadmap_id": "B", "step_id": "s1"},
+        )
+        takeover = client.call_action(
+            "roadmap_follow",
+            {
+                **base_params,
+                "roadmap_id": "B",
+                "step_id": "s1",
+                "allow_takeover": True,
+            },
+        )
+
+        assert first["ok"] is True
+        assert conflict["ok"] is False
+        assert conflict["status"] == "BLOCKED"
+        assert conflict["error"]["code"] == "ROADMAP_CONFLICT"
+        assert takeover["ok"] is True
+        assert takeover["result"]["status"] == "following"
+
+    def test_roadmap_finish_requires_follow_then_becomes_idempotent(self, tmp_path):
+        client = AoKernelClient()
+        base_params = {
+            "workspace_root": str(tmp_path),
+            "dry_run": False,
+            "confirm_write": "I_UNDERSTAND_SIDE_EFFECTS",
+            "roadmap_id": "R1",
+            "step_id": "s2",
+        }
+
+        not_following = client.call_action("roadmap_finish", base_params)
+        follow = client.call_action("roadmap_follow", base_params)
+        finish = client.call_action("roadmap_finish", base_params)
+        finish_again = client.call_action("roadmap_finish", base_params)
+
+        assert not_following["ok"] is False
+        assert not_following["status"] == "BLOCKED"
+        assert not_following["error"]["code"] == "ROADMAP_NOT_FOLLOWING"
+        assert follow["ok"] is True
+        assert finish["ok"] is True
+        assert finish["result"]["idempotent"] is False
+        assert finish["result"]["status"] == "finished"
+        assert finish_again["ok"] is True
+        assert finish_again["result"]["idempotent"] is True
+
+    def test_write_partial_failure_restores_previous_state(self, tmp_path, monkeypatch):
+        from ao_kernel.extensions.handlers import prj_kernel_api
+
+        client = AoKernelClient()
+        base_params = {
+            "workspace_root": str(tmp_path),
+            "dry_run": False,
+            "confirm_write": "I_UNDERSTAND_SIDE_EFFECTS",
+            "roadmap_id": "ROLLBACK-1",
+            "step_id": "s1",
+        }
+        first = client.call_action("roadmap_follow", base_params)
+        assert first["ok"] is True
+
+        state_path = tmp_path / ".ao" / "state" / "kernel_api_roadmap_state.v1.json"
+        before = state_path.read_text(encoding="utf-8")
+
+        def _boom(path, entry):  # noqa: ARG001
+            raise RuntimeError("forced-audit-failure")
+
+        monkeypatch.setattr(prj_kernel_api, "_append_jsonl", _boom)
+        failed = client.call_action(
+            "roadmap_follow",
+            {**base_params, "step_id": "s2"},
+        )
+
+        assert failed["ok"] is False
+        assert failed["error"]["code"] == "WRITE_PARTIAL_FAILURE_ROLLBACK"
+        after = state_path.read_text(encoding="utf-8")
+        assert after == before
+        restored = json.loads(after)
+        assert restored["last_step_id"] == "s1"
 
 
 class TestBootstrapSkipsBlocked:

--- a/tests/test_extension_loader.py
+++ b/tests/test_extension_loader.py
@@ -68,7 +68,7 @@ class TestBundledDefaults:
         assert summary.quarantined >= 1
         assert summary.missing_runtime_refs >= 1
 
-    def test_kernel_api_manifest_is_minimum_runtime_backed(self):
+    def test_kernel_api_manifest_is_runtime_backed_with_write_contract(self):
         reg = ExtensionRegistry()
         reg.load_from_defaults()
         ext = reg.get("PRJ-KERNEL-API")
@@ -80,13 +80,18 @@ class TestBundledDefaults:
         assert ext.entrypoints.get("kernel_api_actions") == [
             "system_status",
             "doc_nav_check",
+            "project_status",
+            "roadmap_follow",
+            "roadmap_finish",
         ]
         assert ext.guardrails == {"offline": True, "network_default": False}
         assert ext.policy_files == (
             "defaults/policies/policy_kernel_api_guardrails.v1.json",
         )
-        for action in ("project_status", "roadmap_follow", "roadmap_finish"):
-            assert action not in ext.entrypoints.get("kernel_api_actions", [])
+        assert ext.layer_contract.get("write_roots_allowlist") == [
+            ".ao/reports/",
+            ".ao/state/",
+        ]
 
     def test_truth_summary_pins_kernel_api_promotion_metrics(self):
         reg = ExtensionRegistry()


### PR DESCRIPTION
## Summary
- implement runtime-backed PRJ-KERNEL-API write-side actions: project_status, roadmap_follow, roadmap_finish
- add explicit write-side safety contract (workspace_root, default dry_run=true, confirm token for real writes, rollback on partial failure)
- update kernel-api manifest entrypoints + write root contract and align support/docs/status parity for PB-8.2 active tranche
- upgrade behavior-first tests for deny/idempotency/conflict/rollback paths

## Validation
- python3 -m pytest -q tests/test_extension_dispatch.py tests/test_extension_loader.py
- python3 -m pytest -q tests/test_extension_dispatch.py tests/test_extension_loader.py tests/test_doctor_cmd.py
- python3 -m pytest -q tests/test_cli_entrypoints.py
- manual smoke: project_status dry-run, roadmap_follow write, roadmap_finish write

Closes #290