### PR TITLE
[codex] PB-8.3 open_pr failure metadata evidence closure

### DIFF
--- a/ao_kernel/executor/multi_step_driver.py
+++ b/ao_kernel/executor/multi_step_driver.py
@@ -579,11 +579,41 @@ class MultiStepDriver:
             raise
 
         if exec_result.step_state != "completed":
+            invocation_result = getattr(exec_result, "invocation_result", None)
+            adapter_status = getattr(
+                invocation_result, "status", exec_result.step_state
+            )
+            error_payload: Mapping[str, Any] = {}
+            if invocation_result is not None:
+                raw_error = getattr(invocation_result, "error", None)
+                if isinstance(raw_error, Mapping):
+                    error_payload = raw_error
+
+            category = "other"
+            if adapter_status == "failed":
+                category = "invocation_failed"
+            elif adapter_status == "partial":
+                category = "timeout"
+
+            raw_category = error_payload.get("category")
+            if isinstance(raw_category, str) and raw_category.strip():
+                category = _legal_error_category(raw_category.strip())
+
+            code = "ADAPTER_FAILED"
+            raw_code = error_payload.get("code")
+            if isinstance(raw_code, str) and raw_code.strip():
+                code = raw_code.strip()
+
+            detail = f"adapter_status={adapter_status}"
+            raw_message = error_payload.get("message")
+            if isinstance(raw_message, str) and raw_message.strip():
+                detail = raw_message.strip()
+
             raise _StepFailed(
-                reason=f"adapter_status={exec_result.step_state}",
+                reason=f"adapter_status={adapter_status}: {detail}",
                 attempt=attempt,
-                category="other",
-                code="ADAPTER_FAILED",
+                category=category,
+                code=code,
             )
 
         # PR-B6 v4 §2.2 absorb: driver-owned per-capability artifact
@@ -1381,13 +1411,17 @@ class MultiStepDriver:
         on_failure = step_def.on_failure
         self._emit(run_id, "step_failed",
             {"step_name": step_def.step_name, "reason": failure.reason,
-             "attempt": failure.attempt, "code": failure.code},
+             "attempt": failure.attempt, "code": failure.code,
+             "category": _legal_error_category(failure.category)},
             step_id=self._step_id_for_attempt(step_def.step_name, failure.attempt))
 
         # CAS: append terminal failed attempt step_record
         record = self._append_failed_attempt_record(
             run_id, record, step_def,
-            attempt=failure.attempt, reason=failure.reason,
+            attempt=failure.attempt,
+            reason=failure.reason,
+            category=failure.category,
+            code=failure.code,
         )
 
         if on_failure == "transition_to_failed":
@@ -1591,9 +1625,13 @@ class MultiStepDriver:
         *,
         attempt: int,
         reason: str,
+        category: str = "other",
+        code: str = "",
     ) -> dict[str, Any]:
         step_id = self._step_id_for_attempt(step_def.step_name, attempt)
         now = _now_iso()
+        normalized_category = _legal_error_category(category)
+        normalized_code = code or "STEP_FAILED"
 
         def _mutator(cur: dict[str, Any]) -> dict[str, Any]:
             steps = list(cur.get("steps", []))
@@ -1605,8 +1643,11 @@ class MultiStepDriver:
                         **sr,
                         "state": "failed",
                         "completed_at": now,
-                        "error": {"category": "other", "code": "STEP_FAILED",
-                                  "message": reason},
+                        "error": {
+                            "category": normalized_category,
+                            "code": normalized_code,
+                            "message": reason,
+                        },
                     }
                     cur["steps"] = steps
                     return cur
@@ -1619,8 +1660,11 @@ class MultiStepDriver:
                 "started_at": now,
                 "completed_at": now,
                 "attempt": attempt,
-                "error": {"category": "other", "code": "STEP_FAILED",
-                          "message": reason},
+                "error": {
+                    "category": normalized_category,
+                    "code": normalized_code,
+                    "message": reason,
+                },
             }
             if step_def.adapter_id:
                 entry["adapter_id"] = step_def.adapter_id

--- a/tests/test_multi_step_driver_integration.py
+++ b/tests/test_multi_step_driver_integration.py
@@ -340,6 +340,134 @@ class TestBundledBugFixFlow:
         assert pr_opened["payload"]["pr_url"].endswith("/pull/999")
         assert pr_opened["payload"]["pr_number"] == 999
 
+    def test_open_pr_failure_preserves_adapter_error_metadata(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Open-PR failure path should keep adapter error code/category
+        on both evidence stream and persisted step record.
+        """
+        install_workspace(tmp_path)
+        _copy_bundled_defaults(tmp_path)
+        _install_bugfix_repo(tmp_path)
+
+        run_id = seed_run(tmp_path, "bug_fix_flow")
+        driver = build_driver(tmp_path, policy_loader=_policy_with_pythonpath())
+
+        import ao_kernel.ci as ci_module
+        from ao_kernel.executor import executor as executor_module
+
+        original_invoke_cli = executor_module.invoke_cli
+
+        def _mock_run_pytest(*args, **kwargs):
+            return CIResult(
+                check_name="pytest",
+                command=("python3", "-m", "pytest"),
+                status="pass",
+                exit_code=0,
+                duration_seconds=0.01,
+                stdout_tail="mocked pytest pass",
+                stderr_tail="",
+            )
+
+        def _dispatch_cli(
+            *,
+            manifest,
+            input_envelope,
+            sandbox,
+            worktree,
+            budget,
+            workspace_root,
+            run_id,
+            resolved_invocation=None,
+        ):
+            if manifest.adapter_id != "gh-cli-pr":
+                return original_invoke_cli(
+                    manifest=manifest,
+                    input_envelope=input_envelope,
+                    sandbox=sandbox,
+                    worktree=worktree,
+                    budget=budget,
+                    workspace_root=workspace_root,
+                    run_id=run_id,
+                    resolved_invocation=resolved_invocation,
+                )
+
+            log_path = (
+                workspace_root
+                / ".ao"
+                / "evidence"
+                / "workflows"
+                / run_id
+                / f"adapter-{manifest.adapter_id}.stdout.log"
+            )
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_path.write_text(json.dumps({"_mock": True}), encoding="utf-8")
+            envelope = {
+                "status": "failed",
+                "error": {
+                    "code": "PR_CREATE_FAILED",
+                    "category": "invocation_failed",
+                    "message": "mocked gh pr create failed",
+                },
+                "cost_actual": {"time_seconds": 0.4},
+            }
+            result = _invocation_from_envelope(
+                envelope,
+                log_path=log_path,
+                elapsed=float(envelope["cost_actual"]["time_seconds"]),
+                command="benchmark-mock[gh-cli-pr]",
+                manifest=manifest,
+            )
+            return result, budget
+
+        with patch(
+            "ao_kernel.executor.executor.invoke_cli",
+            side_effect=_dispatch_cli,
+        ):
+            with patch.object(ci_module, "run_pytest", side_effect=_mock_run_pytest):
+                first = driver.run_workflow(run_id, "bug_fix_flow", "1.0.0")
+                assert first.final_state == "waiting_approval"
+                assert first.resume_token is not None
+                final = driver.resume_workflow(
+                    run_id,
+                    first.resume_token,
+                    payload={"decision": "granted"},
+                )
+
+        assert final.final_state == "failed"
+        record, _ = load_run(tmp_path, run_id)
+        run_error = record.get("error") or {}
+        assert run_error.get("category") == "invocation_failed"
+        assert run_error.get("code") == "PR_CREATE_FAILED"
+
+        step_records = {
+            step["step_name"]: step for step in record.get("steps", [])
+        }
+        assert step_records["open_pr"]["state"] == "failed"
+        step_error = step_records["open_pr"].get("error") or {}
+        assert step_error.get("category") == "invocation_failed"
+        assert step_error.get("code") == "PR_CREATE_FAILED"
+
+        events = [
+            json.loads(line)
+            for line in (
+                tmp_path / ".ao" / "evidence" / "workflows" / run_id / "events.jsonl"
+            ).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        kinds = [event.get("kind") for event in events]
+        assert "pr_opened" not in kinds
+        open_pr_failed = [
+            event for event in events
+            if event.get("kind") == "step_failed"
+            and event.get("payload", {}).get("step_name") == "open_pr"
+        ]
+        assert open_pr_failed, kinds
+        payload = open_pr_failed[-1]["payload"]
+        assert payload.get("category") == "invocation_failed"
+        assert payload.get("code") == "PR_CREATE_FAILED"
+
 
 class TestSimpleFlowEvidenceOrder:
     """Verify the canonical event order (workflow_started → step_* →


### PR DESCRIPTION
## Summary
- `bug_fix_flow` adapter-path failurelarda generic `ADAPTER_FAILED` kaybını kapatır
- `open_pr` failed envelope içindeki `error.code/category/message` bilgisini driver-level failure zincirine taşır
- `step_failed` evidence payload'ına `category` ekleyerek audit/debug alanını tamamlar

## Runtime changes
- `ao_kernel/executor/multi_step_driver.py`
  - adapter step non-completed path'ında `invocation_result.error` metadata'sını okur
  - `_StepFailed` artık status + adapter error'a göre doğru `category/code/reason` üretir
  - `_handle_step_failure` event payload'ı `category` taşır
  - `_append_failed_attempt_record` generic `STEP_FAILED` yerine çağrıdan gelen `category/code` değerlerini persist eder

## Tests
- `tests/test_multi_step_driver_integration.py`
  - yeni test: `test_open_pr_failure_preserves_adapter_error_metadata`
  - open_pr failed senaryosunda run error + step error + `step_failed` event payload code/category parity'sini pinler

## Commands run
- `python3 -m pytest -q tests/test_multi_step_driver_integration.py -k "open_pr_failure_preserves_adapter_error_metadata or mocked_ci_and_open_pr_completes_full_flow"`
- `python3 -m pytest -q tests/test_multi_step_driver.py tests/test_multi_step_driver_integration.py`

## Linked issues
- Refs #291
