### PR TITLE
[codex] PB-8.3: enforce open_pr live-write guard

### DIFF
--- a/.claude/plans/PB-8.3-BUG-FIX-FLOW-RELEASE-CLOSURE-PROMOTION.md
+++ b/.claude/plans/PB-8.3-BUG-FIX-FLOW-RELEASE-CLOSURE-PROMOTION.md
@@ -148,3 +148,14 @@ Başlangıç gap notları:
 3. Release-closure kararı için docs/status parity güncellemesi yalnız karar
    çıktıktan sonra yapılacak; bu dilimde false-promotion önlemek için
    `stay_deferred` seçeneği açık tutulur.
+
+T2 progress update (2026-04-23):
+
+1. [#297](https://github.com/Halildeu/ao-kernel/pull/297) merge edildi:
+   `open_pr` failure metadata artık generic fallback altında kaybolmuyor.
+2. Bu dilimde bir sonraki closure adımı olarak workflow-level live-write guard
+   açıldı: `gh-cli-pr` `open_pr` side effect'i yalnız
+   `AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1` explicit opt-in ile çalışır.
+3. Guard davranışı, başarı/failure zinciri ve benchmark full-flow yolu
+   behavior-first testlerle pinlenecek; ardından T3 karar/parity turuna
+   geçilecek.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -281,6 +281,15 @@ Not:
    `promote` veya `stay_deferred`
 4. `PUBLIC-BETA` + `SUPPORT-BOUNDARY` + status parity güncellemesi
 
+`PB-8.3` T2 progress (kapanan dilimler):
+
+1. [#297](https://github.com/Halildeu/ao-kernel/pull/297) (`f09d9fa`) merge:
+   `open_pr` failure path'inde adapter error metadata (`code/category/message`)
+   run error + step error + `step_failed` payload seviyesinde korunuyor.
+2. Bu branchte aktif dilim: `open_pr` için explicit live-write guard
+   (`AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1`) + behavior-first test pinleri.
+   Hedef: workflow-level side-effect safety gap'ini dar kapsamda kapatmak.
+
 ## 9. PB-7 Closeout Snapshot
 
 **Kapanış tarihi:** 2026-04-23

--- a/ao_kernel/executor/multi_step_driver.py
+++ b/ao_kernel/executor/multi_step_driver.py
@@ -86,6 +86,7 @@ __all__ = [
 
 
 _DIFF_PATH = re.compile(r"^(?:\+\+\+|---) [ab]/(.+)$", re.MULTILINE)
+_OPEN_PR_LIVE_WRITE_GUARD_ENV = "AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE"
 
 
 @dataclass(frozen=True)
@@ -478,6 +479,8 @@ class MultiStepDriver:
             AdapterOutputParseError,
         )
 
+        self._enforce_open_pr_live_write_guard(step_def, attempt=attempt)
+
         # PR-C1a: resolve context_pack_ref from prior context_compile step's
         # artifact; None → Executor default envelope (backwards-compat).
         envelope_override = self._build_adapter_envelope_with_context(
@@ -659,6 +662,37 @@ class MultiStepDriver:
         # Refresh record so completion update sees the latest CAS state
         refreshed, _ = load_run(self._workspace_root, run_id)
         return dict(refreshed), exec_result, capability_output_refs
+
+    def _enforce_open_pr_live_write_guard(
+        self,
+        step_def: StepDefinition,
+        *,
+        attempt: int,
+    ) -> None:
+        """Fail-closed guard for workflow-level ``open_pr`` side effects.
+
+        `bug_fix_flow` release-closure lane keeps PR creation behind an explicit
+        operator opt-in flag so accidental workflow runs cannot trigger remote
+        write operations by default.
+        """
+        if step_def.actor != "adapter":
+            return
+        if step_def.adapter_id != "gh-cli-pr":
+            return
+
+        guard_value = os.environ.get(_OPEN_PR_LIVE_WRITE_GUARD_ENV, "")
+        if guard_value.strip() == "1":
+            return
+
+        raise _StepFailed(
+            reason=(
+                "gh-cli-pr live-write guard blocked: set "
+                f"{_OPEN_PR_LIVE_WRITE_GUARD_ENV}=1"
+            ),
+            attempt=attempt,
+            category="policy_denied",
+            code="LIVE_WRITE_NOT_ALLOWED",
+        )
 
     def _build_adapter_envelope_with_context(
         self,

--- a/tests/benchmarks/test_governed_bugfix.py
+++ b/tests/benchmarks/test_governed_bugfix.py
@@ -34,6 +34,7 @@ from tests.benchmarks.mock_transport import (
 _WORKFLOW_ID = "governed_bugfix_bench"
 _WORKFLOW_VERSION = "1.0.0"
 _SCENARIO_ID = "governed_bugfix"
+_OPEN_PR_GUARD_ENV = "AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE"
 
 
 def _run_dir(workspace_root: Path, run_id: str) -> Path:
@@ -244,6 +245,7 @@ class TestFullBundledBugFixFlow:
         workspace_root: Path,
         seeded_run,
         benchmark_driver,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """PR-C1b.1 (C2.1 unblock): Full 7-step bundled bug_fix_flow
         with default benchmark_driver (now sees bundled policy via
@@ -263,6 +265,7 @@ class TestFullBundledBugFixFlow:
             ),
             ("full_bundled_bugfix", "gh-cli-pr", 1): bug_envelopes.open_pr_happy(),
         }
+        monkeypatch.setenv(_OPEN_PR_GUARD_ENV, "1")
 
         with mock_adapter_transport(
             canned,

--- a/tests/test_multi_step_driver_integration.py
+++ b/tests/test_multi_step_driver_integration.py
@@ -32,6 +32,7 @@ from tests._driver_helpers import (
 )
 
 _BUNDLED_ROOT = Path(__file__).resolve().parent.parent / "ao_kernel" / "defaults"
+_OPEN_PR_GUARD_ENV = "AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE"
 
 
 def _copy_bundled_defaults(root: Path) -> None:
@@ -276,20 +277,23 @@ class TestBundledBugFixFlow:
             )
             return result, budget
 
-        with patch(
-            "ao_kernel.executor.executor.invoke_cli",
-            side_effect=_dispatch_cli,
-        ):
-            with patch.object(ci_module, "run_pytest", side_effect=_mock_run_pytest):
-                first = driver.run_workflow(run_id, "bug_fix_flow", "1.0.0")
-                assert first.final_state == "waiting_approval"
-                assert first.resume_token is not None
+        with patch.dict(os.environ, {_OPEN_PR_GUARD_ENV: "1"}, clear=False):
+            with patch(
+                "ao_kernel.executor.executor.invoke_cli",
+                side_effect=_dispatch_cli,
+            ):
+                with patch.object(
+                    ci_module, "run_pytest", side_effect=_mock_run_pytest
+                ):
+                    first = driver.run_workflow(run_id, "bug_fix_flow", "1.0.0")
+                    assert first.final_state == "waiting_approval"
+                    assert first.resume_token is not None
 
-                final = driver.resume_workflow(
-                    run_id,
-                    first.resume_token,
-                    payload={"decision": "granted"},
-                )
+                    final = driver.resume_workflow(
+                        run_id,
+                        first.resume_token,
+                        payload={"decision": "granted"},
+                    )
 
         run_dir = tmp_path / ".ao" / "evidence" / "workflows" / run_id
         record, _ = load_run(tmp_path, run_id)
@@ -421,19 +425,22 @@ class TestBundledBugFixFlow:
             )
             return result, budget
 
-        with patch(
-            "ao_kernel.executor.executor.invoke_cli",
-            side_effect=_dispatch_cli,
-        ):
-            with patch.object(ci_module, "run_pytest", side_effect=_mock_run_pytest):
-                first = driver.run_workflow(run_id, "bug_fix_flow", "1.0.0")
-                assert first.final_state == "waiting_approval"
-                assert first.resume_token is not None
-                final = driver.resume_workflow(
-                    run_id,
-                    first.resume_token,
-                    payload={"decision": "granted"},
-                )
+        with patch.dict(os.environ, {_OPEN_PR_GUARD_ENV: "1"}, clear=False):
+            with patch(
+                "ao_kernel.executor.executor.invoke_cli",
+                side_effect=_dispatch_cli,
+            ):
+                with patch.object(
+                    ci_module, "run_pytest", side_effect=_mock_run_pytest
+                ):
+                    first = driver.run_workflow(run_id, "bug_fix_flow", "1.0.0")
+                    assert first.final_state == "waiting_approval"
+                    assert first.resume_token is not None
+                    final = driver.resume_workflow(
+                        run_id,
+                        first.resume_token,
+                        payload={"decision": "granted"},
+                    )
 
         assert final.final_state == "failed"
         record, _ = load_run(tmp_path, run_id)
@@ -467,6 +474,138 @@ class TestBundledBugFixFlow:
         payload = open_pr_failed[-1]["payload"]
         assert payload.get("category") == "invocation_failed"
         assert payload.get("code") == "PR_CREATE_FAILED"
+
+    def test_open_pr_requires_explicit_live_write_guard(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """`bug_fix_flow` open_pr side effects stay behind explicit opt-in.
+
+        Guard yoksa workflow open_pr adiminda fail etmeli ve gh-cli-pr adapter
+        subprocess'i hic invoke edilmemeli.
+        """
+        install_workspace(tmp_path)
+        _copy_bundled_defaults(tmp_path)
+        _install_bugfix_repo(tmp_path)
+
+        run_id = seed_run(tmp_path, "bug_fix_flow")
+        driver = build_driver(tmp_path, policy_loader=_policy_with_pythonpath())
+
+        import ao_kernel.ci as ci_module
+        from ao_kernel.executor import executor as executor_module
+
+        original_invoke_cli = executor_module.invoke_cli
+        gh_open_pr_calls = 0
+
+        def _mock_run_pytest(*args, **kwargs):
+            return CIResult(
+                check_name="pytest",
+                command=("python3", "-m", "pytest"),
+                status="pass",
+                exit_code=0,
+                duration_seconds=0.01,
+                stdout_tail="mocked pytest pass",
+                stderr_tail="",
+            )
+
+        def _dispatch_cli(
+            *,
+            manifest,
+            input_envelope,
+            sandbox,
+            worktree,
+            budget,
+            workspace_root,
+            run_id,
+            resolved_invocation=None,
+        ):
+            nonlocal gh_open_pr_calls
+            if manifest.adapter_id != "gh-cli-pr":
+                return original_invoke_cli(
+                    manifest=manifest,
+                    input_envelope=input_envelope,
+                    sandbox=sandbox,
+                    worktree=worktree,
+                    budget=budget,
+                    workspace_root=workspace_root,
+                    run_id=run_id,
+                    resolved_invocation=resolved_invocation,
+                )
+
+            gh_open_pr_calls += 1
+            log_path = (
+                workspace_root
+                / ".ao"
+                / "evidence"
+                / "workflows"
+                / run_id
+                / f"adapter-{manifest.adapter_id}.stdout.log"
+            )
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_path.write_text(json.dumps({"_mock": True}), encoding="utf-8")
+            envelope = bug_envelopes.open_pr_happy()
+            result = _invocation_from_envelope(
+                envelope,
+                log_path=log_path,
+                elapsed=float(envelope["cost_actual"]["time_seconds"]),
+                command="benchmark-mock[gh-cli-pr]",
+                manifest=manifest,
+            )
+            return result, budget
+
+        with patch(
+            "ao_kernel.executor.executor.invoke_cli",
+            side_effect=_dispatch_cli,
+        ):
+            with patch.object(ci_module, "run_pytest", side_effect=_mock_run_pytest):
+                first = driver.run_workflow(run_id, "bug_fix_flow", "1.0.0")
+                assert first.final_state == "waiting_approval"
+                assert first.resume_token is not None
+                final = driver.resume_workflow(
+                    run_id,
+                    first.resume_token,
+                    payload={"decision": "granted"},
+                )
+
+        assert final.final_state == "failed"
+        assert gh_open_pr_calls == 0
+
+        record, _ = load_run(tmp_path, run_id)
+        run_error = record.get("error") or {}
+        assert run_error.get("category") == "policy_denied"
+        assert run_error.get("code") == "LIVE_WRITE_NOT_ALLOWED"
+
+        step_records = {
+            step["step_name"]: step for step in record.get("steps", [])
+        }
+        assert step_records["open_pr"]["state"] == "failed"
+        step_error = step_records["open_pr"].get("error") or {}
+        assert step_error.get("category") == "policy_denied"
+        assert step_error.get("code") == "LIVE_WRITE_NOT_ALLOWED"
+
+        events = [
+            json.loads(line)
+            for line in (
+                tmp_path / ".ao" / "evidence" / "workflows" / run_id / "events.jsonl"
+            ).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        kinds = [event.get("kind") for event in events]
+        assert "pr_opened" not in kinds
+        assert not any(
+            event.get("kind") == "adapter_invoked"
+            and event.get("payload", {}).get("step_name") == "open_pr"
+            for event in events
+        )
+        open_pr_failed = [
+            event for event in events
+            if event.get("kind") == "step_failed"
+            and event.get("payload", {}).get("step_name") == "open_pr"
+        ]
+        assert open_pr_failed, kinds
+        payload = open_pr_failed[-1]["payload"]
+        assert payload.get("category") == "policy_denied"
+        assert payload.get("code") == "LIVE_WRITE_NOT_ALLOWED"
 
 
 class TestSimpleFlowEvidenceOrder:


### PR DESCRIPTION
## Summary
- enforce a workflow-level guard for bug_fix_flow open_pr side effects: AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1 is now required
- keep the guard fail-closed (policy_denied / LIVE_WRITE_NOT_ALLOWED) so gh-cli-pr is not invoked accidentally
- add behavior-first integration coverage for guard deny path and align benchmark full-flow test with explicit opt-in
- update PB-8.3 plan/status docs with T2 progress notes

## Tests
- python3 -m pytest -q tests/test_multi_step_driver.py tests/test_multi_step_driver_integration.py
- python3 -m pytest -q tests/benchmarks/test_governed_bugfix.py tests/benchmarks/test_governed_review.py
- python3 -m ruff check ao_kernel/executor/multi_step_driver.py tests/test_multi_step_driver_integration.py tests/benchmarks/test_governed_bugfix.py

Refs: #291