### PR TITLE
[codex] PB-8.3: closeout decision parity

### DIFF
--- a/.claude/plans/PB-8.3-BUG-FIX-FLOW-RELEASE-CLOSURE-PROMOTION.md
+++ b/.claude/plans/PB-8.3-BUG-FIX-FLOW-RELEASE-CLOSURE-PROMOTION.md
@@ -159,3 +159,17 @@ T2 progress update (2026-04-23):
 3. Guard davranışı, başarı/failure zinciri ve benchmark full-flow yolu
    behavior-first testlerle pinlenecek; ardından T3 karar/parity turuna
    geçilecek.
+
+T3 closeout update (2026-04-23):
+
+1. [#298](https://github.com/Halildeu/ao-kernel/pull/298) merge edildi:
+   workflow-level `open_pr` guard runtime'a alındı ve integration/benchmark
+   testleri yeni explicit opt-in kontratına hizalandı.
+2. Final decision: `stay_deferred`.
+   - `bug_fix_flow` lane'inde side-effect risk azaltımı ve evidence parity
+     kapanmış olsa da disposable/live rollback zinciri workflow runtime support
+     contract'ında promoted seviyeye çıkmadı.
+3. Decision parity:
+   - `docs/PUBLIC-BETA.md` + `docs/SUPPORT-BOUNDARY.md` deferred satırları
+     `PB-8.3` verdict'i ile hizalandı.
+4. Sonraki aktif hat: `PB-8.4` support widening closeout.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -259,9 +259,9 @@ Not:
 
 `PB-8` kickoff aktif.
 
-1. Son kapanan slice: `PB-8.2` (`PRJ-KERNEL-API` write-side runtime implementation)
-2. Bugünkü aktif slice: `PB-8.3` (`bug_fix_flow` release closure promotion)
-3. Sonraki sıra (planlı): `PB-8.4`
+1. Son kapanan slice: `PB-8.3` (`bug_fix_flow` release closure promotion)
+2. Bugünkü aktif slice: `PB-8.4` (`support widening closeout`)
+3. Sonraki sıra (planlı): `PB-9`
 
 `PB-8.2` completion kaydı:
 
@@ -271,24 +271,26 @@ Not:
 4. Sonuç: `PRJ-KERNEL-API` write-side action'lar runtime-backed hale geldi ve
    behavior-first test matrisi + docs parity merge edildi.
 
-`PB-8.3` implementation odakları:
+`PB-8.3` completion kaydı:
 
-1. `bug_fix_flow` lane'inde side-effect safety/rollback kontratını workflow
-   düzeyinde enforce etmek
-2. `open_pr` path evidence completeness + retry/approval/apply zinciri
-   davranışını negatif senaryolarla pinlemek
-3. release-closure sonucu için kanıta dayalı tek karar üretmek:
-   `promote` veya `stay_deferred`
-4. `PUBLIC-BETA` + `SUPPORT-BOUNDARY` + status parity güncellemesi
+1. Issue: [#291](https://github.com/Halildeu/ao-kernel/issues/291)
+2. PR'ler:
+   - [#297](https://github.com/Halildeu/ao-kernel/pull/297) (`f09d9fa`)
+   - [#298](https://github.com/Halildeu/ao-kernel/pull/298) (`99f9ed3`)
+3. Sonuç:
+   - `open_pr` failure metadata parity (run + step + event) güçlendirildi
+   - `bug_fix_flow` `open_pr` adımı workflow-level explicit live-write guard
+     (`AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1`) arkasına alındı
+4. Karar: `stay_deferred`
+   - gerekçe: guard + evidence iyileştirmelerine rağmen disposable/live rollback
+     zinciri workflow runtime contract'ında promoted support kapısı değildir.
 
-`PB-8.3` T2 progress (kapanan dilimler):
+`PB-8.4` implementation odakları:
 
-1. [#297](https://github.com/Halildeu/ao-kernel/pull/297) (`f09d9fa`) merge:
-   `open_pr` failure path'inde adapter error metadata (`code/category/message`)
-   run error + step error + `step_failed` payload seviyesinde korunuyor.
-2. Bu branchte aktif dilim: `open_pr` için explicit live-write guard
-   (`AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1`) + behavior-first test pinleri.
-   Hedef: workflow-level side-effect safety gap'ini dar kapsamda kapatmak.
+1. `PB-8.1`..`PB-8.3` kararlarını support docs yüzeyinde tek anlamlı closeout'a
+   indirmek
+2. `PUBLIC-BETA` + `SUPPORT-BOUNDARY` + status parity drift'ini kapatmak
+3. `PB-8` tracker closeout kararını issue/docs kanıtlarıyla netleştirmek
 
 ## 9. PB-7 Closeout Snapshot
 

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -85,7 +85,7 @@ Bu kuralın amacı, inventory görünürlüğünü support widening ile karışt
 
 | Yüzey | Durum | Not |
 |---|---|---|
-| `bug_fix_flow` release closure | Deferred | Deterministik correctness/evidence coverage mevcut olsa da write-side support widening kararı `PB-7.2` ile `stay_deferred`; live remote PR yan-etki kapıları promoted değil |
+| `bug_fix_flow` release closure | Deferred | `PB-8.3` closeout kararı: `stay_deferred`. Workflow-level `open_pr` adımı explicit opt-in guard (`AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1`) arkasına alındı ve failure metadata/evidence parity güçlendirildi; buna rağmen disposable/live rollback zinciri workflow runtime contract'ında promoted support kapısı değil |
 | `gh-cli-pr` ile tam E2E PR açılışı | Deferred | Live-write probe create->verify->rollback guard'larıyla güçlense de gerçek remote PR açılışı hâlâ destek vaadi değildir; lane operator-managed/deferred boundary içinde değerlendirilir |
 | `docs/roadmap/DEMO-SCRIPT-SPEC.md` içindeki 11 adımlı üç-adapter akış | Deferred | Canlı destek vaadi değildir |
 | Adapter-path `cost_usd` reconcile | Deferred | Public support claim olarak hâlâ deferred; benchmark/internal runtime hook varlığı bunu tek başına shipped veya beta support yüzeyine yükseltmez |

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -13,7 +13,7 @@ operator-only, or just contract inventory?"
 | Shipped baseline | module entrypoints, `ao-kernel doctor`, bundled `review_ai_flow`, `examples/demo_review.py`, packaging smoke, `PRJ-KERNEL-API` `system_status` / `doc_nav_check` actions | entrypoint checks, doctor, demo review smoke, behavior tests, CI |
 | Beta (operator-managed) | `claude-code-cli` helper-backed lane, `gh-cli-pr` helper-backed preflight + live-write readiness probe lane, `PRJ-KERNEL-API` write-side actions (`project_status`, `roadmap_follow`, `roadmap_finish`) with explicit write contract, real-adapter benchmark full mode | explicit smoke helpers and runbooks |
 | Contract inventory | bundled defaults, manifests, extensions, example inventory | loader/validator and truth audit only |
-| Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary (`PB-7.2` verdict for bug_fix_flow: `stay_deferred`) |
+| Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary (`PB-8.3` verdict for bug_fix_flow: `stay_deferred`) |
 
 ### 1.1 Truth inventory to support mapping
 
@@ -61,6 +61,11 @@ disposable repo, explicit `--head` + `--base`) ve create -> verify -> rollback
 zincirine taşınmıştır. `--keep-live-write-pr-open` seçeneği lane'i riskli kabul
 eder ve rapor `blocked` döner. Bu probe'un varlığı tek başına live remote PR
 opening support tier'ını widen etmez; public boundary satırı deferred kalır.
+
+`PB-8.3` ile `bug_fix_flow` içindeki `open_pr` adımı ayrıca workflow-level
+explicit opt-in guard (`AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1`) arkasına
+alınmıştır. Bu guard accidental side-effect riskini düşürür, fakat tek başına
+support boundary widening kararı üretmez; lane deferred kalır.
 
 ### Contract inventory
 


### PR DESCRIPTION
## Summary
- record PB-8.3 final decision as stay_deferred in plan/status SSOT surfaces
- update PUBLIC-BETA and SUPPORT-BOUNDARY to reflect PB-8.3 verdict and open_pr explicit guard context
- hand off active line from PB-8.3 to PB-8.4 in status docs

## Scope
- docs/status parity only (no runtime change)

Refs: #291