### PR TITLE
[codex] PB-8.4: runbook/release-gate parity tranche-1

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -12,17 +12,17 @@ ayrı ayrı görünür kılmak.
 
 - **Execution status / backlog:** bu dosya
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
-- **Son tamamlanan implementation contract:** `.claude/plans/PB-8.2-KERNEL-API-WRITE-SIDE-RUNTIME-IMPLEMENTATION.md`
+- **Son tamamlanan implementation contract:** `.claude/plans/PB-8.3-BUG-FIX-FLOW-RELEASE-CLOSURE-PROMOTION.md`
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md`
-- **Aktif decision/ordering contract:** `.claude/plans/PB-8.3-BUG-FIX-FLOW-RELEASE-CLOSURE-PROMOTION.md`
+- **Aktif decision/ordering contract:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md` (`PB-8.4` closeout lane)
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
 - **PB-8 tracker issue:** [#288](https://github.com/Halildeu/ao-kernel/issues/288)
-- **Aktif issue:** [#291](https://github.com/Halildeu/ao-kernel/issues/291) (`PB-8.3`)
+- **Aktif issue:** [#292](https://github.com/Halildeu/ao-kernel/issues/292) (`PB-8.4`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -31,8 +31,8 @@ ayrı ayrı görünür kılmak.
 - Support boundary hâlâ bilerek dardır; `review_ai_flow + codex-stub` shipped
   baseline, gerçek adapter lane'leri ise operator-managed beta durumundadır.
 - Public Beta closeout sonrası aktif program odağı artık defer edilmiş ilk
-  correctness boşlukları değil; support-surface widening ve PB-5 closeout'u
-  tamamlandı, bugünkü aktif odak daha geniş expansion gap'lerin sıralanmasıdır.
+  correctness boşlukları değil; `PB-8.4` içinde support docs/runbook/release-gate
+  parity closeout'unu tek anlamlı hale getirmektir.
 - Repo bugün hâlâ genel amaçlı production coding automation platformu değildir;
   bu programın amacı o iddiayı hemen widen etmek değil, önce kalan debt'i
   kontrollü kapatmaktır.
@@ -360,7 +360,7 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
 
 1. Program roadmap: `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md`
 2. Tracker issue: [#288](https://github.com/Halildeu/ao-kernel/issues/288)
-3. Aktif tranche: `PB-8.3` ([#291](https://github.com/Halildeu/ao-kernel/issues/291))
+3. Aktif tranche: `PB-8.4` ([#292](https://github.com/Halildeu/ao-kernel/issues/292))
 4. Sıradaki tranche'lar:
-   - `PB-8.4` ([#292](https://github.com/Halildeu/ao-kernel/issues/292))
+   - `PB-9` (plan açılışında issue atanacak)
 5. Program kuralı: tek aktif runtime tranche + zorunlu kanıt paketi.

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -39,6 +39,11 @@ python3 scripts/gh_cli_pr_smoke.py --output text
 # python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch>
 ```
 
+`bug_fix_flow` içinde workflow-level `open_pr` side effect'i varsayılan
+fail-closed guard ile gelir. `AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1` olmadan
+`open_pr` adımında `LIVE_WRITE_NOT_ALLOWED` görmek beklenen davranıştır ve tek
+başına incident sayılmaz.
+
 `PRJ-KERNEL-API` write-side lane için ek doğrulama:
 
 ```bash

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -8,8 +8,11 @@ baseline or an explicitly supported beta lane in a worse state.
 ### Return to stable
 
 ```bash
-pip install --force-reinstall ao-kernel==3.13.3
+pip install --force-reinstall ao-kernel
 ```
+
+`ao-kernel` stable channel pin'i dokümana sabit yazılmaz; bu komut pre-release
+flag olmadan en güncel stable hattı geri yükler.
 
 ### Return to the documented beta pin
 

--- a/docs/UPGRADE-NOTES.md
+++ b/docs/UPGRADE-NOTES.md
@@ -55,6 +55,10 @@ python3 scripts/gh_cli_pr_smoke.py --output text
 # python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch>
 ```
 
+`bug_fix_flow` workflow path'inde `open_pr` adımı varsayılan fail-closed
+guard arkasındadır. Gerçek live-write denemesi yalnız disposable ortamda,
+explicit `AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1` ile yapılmalıdır.
+
 ## 4. Expected warnings
 
 These do not automatically mean the upgrade failed:
@@ -63,6 +67,8 @@ These do not automatically mean the upgrade failed:
   core-only install
 - bundled extension truth inventory may report contract-only or quarantined
   candidates
+- guard env tanımlı değilken `bug_fix_flow` `open_pr` adımının
+  `LIVE_WRITE_NOT_ALLOWED` ile fail etmesi (beklenen güvenlik davranışı)
 
 Treat those as expected unless the support matrix says otherwise.
 


### PR DESCRIPTION
## Summary
- update POST-BETA status SSOT pointers to PB-8.4 active issue/contract context
- remove stable-channel version hardcode from ROLLBACK and keep stable recovery rule drift-safe
- add explicit bug_fix_flow open_pr guard expectations to OPERATIONS-RUNBOOK and UPGRADE-NOTES

## Scope
- docs/status parity only
- no runtime behavior change

## Validation
- python3 -m pytest -q tests/test_doctor_cmd.py

Refs: #292