### PR TITLE
[codex] PB-9 kickoff: roadmap + active tranche

### DIFF
--- a/.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md
+++ b/.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md
@@ -1,8 +1,8 @@
 # PB-8 — General-Purpose Productionization Roadmap
 
-**Status:** Active  
+**Status:** Completed  
 **Date:** 2026-04-23  
-**Tracker:** [#288](https://github.com/Halildeu/ao-kernel/issues/288)  
+**Tracker:** [#288](https://github.com/Halildeu/ao-kernel/issues/288) (closed)  
 **Execution mode:** Kapsam disiplini, tek aktif runtime tranche
 
 ## Amaç
@@ -115,3 +115,16 @@ Toplam hedef: 4-6 hafta (dış bağımlılık ve auth/sandbox stabilitesine bağ
    açıkça işlenir.
 3. `POST-BETA-CORRECTNESS-EXPANSION-STATUS.md` aktif slice'ı kapatır.
 4. Tracker [#288](https://github.com/Halildeu/ao-kernel/issues/288) kapanır.
+
+## Closeout Snapshot (2026-04-23)
+
+1. Tüm tranche'lar tamamlandı:
+   - `PB-8.1` [#289](https://github.com/Halildeu/ao-kernel/issues/289)
+   - `PB-8.2` [#290](https://github.com/Halildeu/ao-kernel/issues/290)
+   - `PB-8.3` [#291](https://github.com/Halildeu/ao-kernel/issues/291)
+   - `PB-8.4` [#292](https://github.com/Halildeu/ao-kernel/issues/292)
+2. `PB-8.3` karar çıktısı `stay_deferred` olarak korunmuştur.
+3. `PB-8.4` docs/runbook/release-gate parity closeout'u
+   [#300](https://github.com/Halildeu/ao-kernel/pull/300) +
+   [#301](https://github.com/Halildeu/ao-kernel/pull/301) ile tamamlanmıştır.
+4. Sonraki aktif hat `PB-9` tracker'ına taşınmıştır.

--- a/.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md
+++ b/.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md
@@ -1,0 +1,102 @@
+# PB-9 — Production Claim Readiness Gates
+
+**Status:** Active  
+**Date:** 2026-04-23  
+**Tracker:** [#302](https://github.com/Halildeu/ao-kernel/issues/302)  
+**Execution mode:** Kapsam disiplini, tek aktif runtime tranche
+
+## Amaç
+
+`ao-kernel` için mevcut dar ama kanıtlı Public Beta yüzeyinden,
+genel amaçlı production iddiasına geçiş kararını ölçülebilir kapılarla
+yönetmek.
+
+Bu programın amacı tek adımda support boundary widening yapmak değildir.
+Amaç, widening kararını kişi güveninden çıkarıp kanıt kontratına bağlamaktır.
+
+## Başlangıç Gerçeği
+
+1. `PB-8` kapanmıştır; tracker [#288](https://github.com/Halildeu/ao-kernel/issues/288)
+   closed durumdadır.
+2. Shipped baseline çalışır ve CI zinciri (`test + coverage + packaging-smoke`)
+   zorunludur.
+3. `claude-code-cli` ve `gh-cli-pr` lane'leri beta/operator-managed sınırdadır.
+4. Deferred sınır korunur:
+   - `bug_fix_flow` release closure (`stay_deferred`)
+   - live `gh-cli-pr` remote PR opening support claim'i
+   - adapter-path `cost_usd` reconcile support claim'i
+5. Known bugs (`KB-001`, `KB-002`) açıktır ve support widening kararını etkiler.
+
+## Gate Modeli (Non-Negotiable)
+
+Production-claim seviyesinde herhangi bir widening kararı ancak aşağıdaki
+kapılar birlikte geçerse verilir:
+
+1. **G1 — Truth parity:** docs/runtime/test/CI aynı support boundary'yi söyler.
+2. **G2 — Prerequisite determinism:** operator prerequisite seti açık ve
+   tekrarlanabilir; smoke çıktıları docs ile çelişmez.
+3. **G3 — Behavior + evidence completeness:** write/live lane'lerde failure-mode
+   ve evidence zinciri pinlenmiştir.
+4. **G4 — Rollback/incident readiness:** side-effect lane için geri dönüş yolu
+   çalışır ve runbook'ta karar akışı nettir.
+5. **G5 — Governance enforcement:** release/merge kapıları GitHub + CI tarafında
+   bypass edilmeden uygulanır.
+6. **G6 — Decision record:** widening veya `stay_*` kararı yazılı ve test/smoke
+   kanıtına bağlıdır.
+
+## Tranche Sırası
+
+### `PB-9.1` — Operator prerequisite contract parity (Active)
+
+- Issue: [#303](https://github.com/Halildeu/ao-kernel/issues/303)
+- Hedef: `claude-code-cli` ve `gh-cli-pr` lane'lerinde prerequisite dilini
+  `PUBLIC-BETA`, `SUPPORT-BOUNDARY`, `OPERATIONS-RUNBOOK` ve smoke helper
+  çıktılarıyla tek anlamlı yapmak.
+- Ana çıktı: operatör aynı prereq bilgisini tüm SSOT yüzeylerde aynı şekilde görür.
+
+### `PB-9.2` — Truth inventory debt ratchet (Planned)
+
+- Issue: `pending`
+- Hedef: doctor truth inventory (`runtime_backed/contract_only/quarantined`)
+  üzerinden promotion sırası için ölçülebilir karar tablosu çıkarmak.
+- Ana çıktı: widening adayları için objektif ve tekrar üretilebilir ranking.
+
+### `PB-9.3` — Write/live lane evidence rehearsal (Planned)
+
+- Issue: `pending`
+- Hedef: write/live lane'lerde create->verify->rollback zincirini
+  behavior-first kanıtla güçlendirmek.
+- Ana çıktı: live side-effect risklerinin incident/rollback açısından
+  operatörce savunulabilir olması.
+
+### `PB-9.4` — Production claim decision closeout (Planned)
+
+- Issue: `pending`
+- Hedef: `promote` veya `stay_beta_operator_managed` kararını
+  tek bir kapanış notuna bağlamak.
+- Ana çıktı: support boundary satırları kararla birlikte güncellenir,
+  tracker kapanış kriteri netleşir.
+
+## Başarı Kriterleri
+
+1. **BC-1** `PB-9.1` sonrası prerequisite anlatısı tek anlamlıdır.
+2. **BC-2** `PB-9.2` sonrası widening aday sırası ölçülebilir hale gelir.
+3. **BC-3** `PB-9.3` sonrası write/live lane kanıt paketi incident-ready olur.
+4. **BC-4** `PB-9.4` sonrası support boundary kararı yazılı, testli ve izlenebilirdir.
+5. **BC-5** production-claim kararı kişisel yargı değil gate kanıtı ile verilir.
+
+## Risk Register
+
+| Risk | Etki | Önlem |
+|---|---|---|
+| Docs parity kapanmadan widening baskısı | Yüksek | `PB-9.1` bitmeden runtime widening açma |
+| Smoke green ama prerequisite drift | Orta | helper output + docs cross-check zorunlu |
+| Side-effect lane'lerde eksik rollback prova | Yüksek | `PB-9.3`te rehearsal kanıtı şart |
+| Scope creep | Yüksek | tranche dışı değişiklikleri blokla |
+| Karar kaydı eksikliği | Orta | `PB-9.4`te zorunlu closeout notu |
+
+## Program Kapanış Koşulu
+
+1. `PB-9.1`..`PB-9.4` için karar kayıtları tamamlanır.
+2. `POST-BETA-CORRECTNESS-EXPANSION-STATUS.md` aktif hatı kapatır.
+3. Tracker [#302](https://github.com/Halildeu/ao-kernel/issues/302) kapanır.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -12,17 +12,18 @@ ayrı ayrı görünür kılmak.
 
 - **Execution status / backlog:** bu dosya
 - **Tarihsel closeout snapshot:** `.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`
-- **Son tamamlanan implementation contract:** `.claude/plans/PB-8.3-BUG-FIX-FLOW-RELEASE-CLOSURE-PROMOTION.md`
+- **Son tamamlanan implementation contract:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md` (`PB-8` closeout)
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
-- **Program roadmap:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md`
-- **Aktif decision/ordering contract:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md` (`PB-8` closeout tamam; `PB-9` kickoff pending)
+- **Program roadmap:** `.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md`
+- **Aktif decision/ordering contract:** `.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md` (`PB-9.1` active)
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
-- **PB-8 tracker issue:** [#288](https://github.com/Halildeu/ao-kernel/issues/288)
-- **Aktif issue:** yok (`PB-8` closeout sonrası `PB-9` kickoff issue'su açılacak)
+- **PB-8 tracker issue:** [#288](https://github.com/Halildeu/ao-kernel/issues/288) (`closed`)
+- **PB-9 tracker issue:** [#302](https://github.com/Halildeu/ao-kernel/issues/302)
+- **Aktif issue:** [#303](https://github.com/Halildeu/ao-kernel/issues/303) (`PB-9.1`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -31,7 +32,8 @@ ayrı ayrı görünür kılmak.
 - Support boundary hâlâ bilerek dardır; `review_ai_flow + codex-stub` shipped
   baseline, gerçek adapter lane'leri ise operator-managed beta durumundadır.
 - Public Beta closeout sonrası `PB-8.4` docs/runbook/release-gate parity
-  tranche'i tamamlandı; bir sonraki aktif hat `PB-9` kickoff planlamasıdır.
+  tranche'i tamamlandı ve `PB-8` tracker kapandı; aktif hat artık `PB-9.1`
+  prerequisite contract parity dilimidir.
 - Repo bugün hâlâ genel amaçlı production coding automation platformu değildir;
   bu programın amacı o iddiayı hemen widen etmek değil, önce kalan debt'i
   kontrollü kapatmaktır.
@@ -61,6 +63,8 @@ ayrı ayrı görünür kılmak.
 | `PB-4` support-surface widening decisions | Completed on `main` ([#232](https://github.com/Halildeu/ao-kernel/issues/232), [#237](https://github.com/Halildeu/ao-kernel/pull/237)) | `gh-cli-pr` full E2E ve operator lane promotion kararlarını kanıtla vermek | canlı smoke + karar notu + docs parity |
 | `PB-5` adapter-path cost/evidence completeness | Completed ([#238](https://github.com/Halildeu/ao-kernel/issues/238)) | `cost_usd` reconcile ve evidence completeness yüzeyinde ayrı runtime gap olup olmadığını karara bağlamak; sonuç: docs parity closeout yeterli, ayrı tranche 3 gerekmedi | truth audit + targeted tests + docs parity closeout |
 | `PB-6` general-purpose expansion gap map | Completed on `main` ([#243](https://github.com/Halildeu/ao-kernel/issues/243), [#279](https://github.com/Halildeu/ao-kernel/pull/279)) | narrow beta'dan daha geniş production platform çizgisine geçiş için hangi yüzeylerin neden henüz promoted olmadığını canlı kanıtla sınıflandırmak | written gap map + ordered tranche backlog + PB-6.6 final verdict closeout |
+| `PB-8` general-purpose productionization roadmap | Completed on `main` ([#288](https://github.com/Halildeu/ao-kernel/issues/288), [#300](https://github.com/Halildeu/ao-kernel/pull/300), [#301](https://github.com/Halildeu/ao-kernel/pull/301)) | widening kararlarını tranche bazında kapatmak ve support closeout parity'yi tamamlamak | tracker closeout + docs/runbook/release-gate parity |
+| `PB-9` production claim readiness gates | Active ([#302](https://github.com/Halildeu/ao-kernel/issues/302), active tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | active roadmap + tranche issue + status parity |
 
 ## 5. Şimdi
 
@@ -256,11 +260,11 @@ Not:
 
 ## 8. Anlık Öncelik
 
-`PB-8` programı kapanış aşamasına geçti.
+`PB-9` kickoff aktif.
 
 1. Son kapanan slice: `PB-8.4` (`support widening closeout`)
-2. Bugünkü aktif iş: `PB-8` tracker closeout ve `PB-9` kickoff hazırlığı
-3. Sonraki sıra (planlı): `PB-9` issue + ordering contract
+2. Bugünkü aktif iş: `PB-9.1` prerequisite contract parity
+3. Sonraki sıra (planlı): `PB-9.2` truth inventory debt ratchet
 
 `PB-8.2` completion kaydı:
 
@@ -301,7 +305,7 @@ Not:
    - `ROLLBACK` stable rollback satırı drift-safe hale getirildi
    - `OPERATIONS-RUNBOOK` + `UPGRADE-NOTES` üzerinde `bug_fix_flow open_pr`
      fail-closed guard beklentisi explicit yazıldı
-5. Karar: `PB-8` support closeout tranche'i tamamlandı, tracker closeout adımına geçildi
+5. Karar: `PB-8` support closeout tranche'i tamamlandı
 
 ## 9. PB-7 Closeout Snapshot
 
@@ -370,12 +374,24 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
 `PB-7` closeout sonrası açılan `PB-8` widening programındaki tranche'lar tamamlandı.
 
 1. Program roadmap: `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md`
-2. Tracker issue: [#288](https://github.com/Halildeu/ao-kernel/issues/288) (`closeout pending`)
+2. Tracker issue: [#288](https://github.com/Halildeu/ao-kernel/issues/288) (`closed`)
 3. Kapanan tranche'lar:
    - `PB-8.1` ([#289](https://github.com/Halildeu/ao-kernel/issues/289))
    - `PB-8.2` ([#290](https://github.com/Halildeu/ao-kernel/issues/290))
    - `PB-8.3` ([#291](https://github.com/Halildeu/ao-kernel/issues/291))
    - `PB-8.4` ([#292](https://github.com/Halildeu/ao-kernel/issues/292))
 4. Sonraki hat:
-   - `PB-9` (yeni issue + aktif ordering contract ataması ile açılacak)
+   - `PB-9` ([#302](https://github.com/Halildeu/ao-kernel/issues/302))
+5. Program kuralı korunur: tek aktif runtime tranche + zorunlu kanıt paketi.
+
+## 13. PB-9 Kickoff
+
+`PB-8` closeout sonrası yeni aktif widening/decision hattı `PB-9` olarak açıldı.
+
+1. Program roadmap:
+   `.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md`
+2. Tracker issue: [#302](https://github.com/Halildeu/ao-kernel/issues/302)
+3. Aktif tranche: `PB-9.1`
+   ([#303](https://github.com/Halildeu/ao-kernel/issues/303))
+4. Sonraki tranche (planlı): `PB-9.2` (`truth inventory debt ratchet`)
 5. Program kuralı korunur: tek aktif runtime tranche + zorunlu kanıt paketi.


### PR DESCRIPTION
## Summary
- add PB-9 roadmap contract for production-claim readiness gates
- switch post-beta status SSOT active contract to PB-9 and active issue to #303
- mark PB-8 roadmap as completed and append closeout snapshot

## Validation
- python3 -m pytest -q tests/test_doctor_cmd.py

Refs: #302 #303
