### PR TITLE
feat: add PB-9.2 truth inventory debt ratchet

### DIFF
--- a/.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md
+++ b/.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md
@@ -58,6 +58,7 @@ kapılar birlikte geçerse verilir:
 ### `PB-9.2` — Truth inventory debt ratchet (Active)
 
 - Issue: [#306](https://github.com/Halildeu/ao-kernel/issues/306)
+- Karar notu: `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - Hedef: doctor truth inventory (`runtime_backed/contract_only/quarantined`)
   üzerinden promotion sırası için ölçülebilir karar tablosu çıkarmak.
 - Ana çıktı: widening adayları için objektif ve tekrar üretilebilir ranking.

--- a/.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md
+++ b/.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md
@@ -1,0 +1,124 @@
+# PB-9.2 — Truth Inventory Debt Ratchet
+
+**Durum:** Active (`PB-9.2`)  
+**Issue:** [#306](https://github.com/Halildeu/ao-kernel/issues/306)  
+**Tracker:** [#302](https://github.com/Halildeu/ao-kernel/issues/302)  
+**Amaç:** `ao-kernel doctor` truth çıktısını support widening kararından
+ayırarak, extension debt sırasını ölçülebilir ve tekrar üretilebilir kurala
+bağlamak.
+
+## 1) Kapsam Kuralı
+
+Bu belge support boundary widening kararı vermez. Yalnız şu soruyu yanıtlar:
+
+1. bundled extension inventory içindeki debt hangi sırayla ele alınmalı?
+2. hangi extension bugün `promotion_candidate` olamaz?
+
+Support claim kararı için tek otorite yine:
+
+1. `docs/PUBLIC-BETA.md`
+2. `docs/SUPPORT-BOUNDARY.md`
+
+## 2) Veri Kaynağı (Deterministik)
+
+Ratchet girdisi yalnız aşağıdaki komutlardan üretilir:
+
+```bash
+python3 -m ao_kernel doctor
+python3 scripts/truth_inventory_ratchet.py --output json
+```
+
+Snapshot (2026-04-23):
+
+- `total_extensions=19`
+- `runtime_backed=2`
+- `contract_only=1`
+- `quarantined=16`
+- `remap_candidate_refs=61`
+- `missing_runtime_refs=152`
+
+## 3) Karar Sınıfları (Ratchet Kuralları)
+
+Bu tranche'ta sıralama şu deterministic kuralla yapılır:
+
+1. `maintain_runtime_backed`
+   - `truth_tier=runtime_backed`
+2. `promotion_candidate`
+   - `truth_tier=contract_only`
+   - `missing_runtime_refs=0`
+   - `remap_candidate_refs=0`
+3. `remap_priority`
+   - `truth_tier=quarantined`
+   - `missing_runtime_refs<=8`
+   - `remap_candidate_refs>=1`
+4. `quarantine_keep`
+   - `truth_tier=quarantined`
+   - `missing_runtime_refs>=9`
+   - `(entrypoint_count>0 OR ui_surfaces_count>0)`
+5. `retire_candidate`
+   - `truth_tier=quarantined`
+   - `missing_runtime_refs>=9`
+   - `entrypoint_count=0`
+   - `ui_surfaces_count=0`
+
+`remap_priority` sınıfı kendi içinde şu skorla sıralanır:
+
+```text
+priority_score = (entrypoint_count * 2) + (ui_surfaces_count * 3)
+                 - missing_runtime_refs - remap_candidate_refs
+```
+
+Skor yalnız debt işlem sırasını etkiler; support tier etkisi yoktur.
+
+## 4) Current Decision Table (2026-04-23)
+
+| Extension | truth_tier | ep | ui | remap | missing | Ratchet sınıfı |
+|---|---|---:|---:|---:|---:|---|
+| `PRJ-HELLO` | runtime_backed | 1 | 0 | 0 | 0 | `maintain_runtime_backed` |
+| `PRJ-KERNEL-API` | runtime_backed | 5 | 0 | 0 | 0 | `maintain_runtime_backed` |
+| `PRJ-CONTEXT-ORCHESTRATION` | contract_only | 0 | 0 | 0 | 0 | `promotion_candidate` |
+| `PRJ-AIRUNNER` | quarantined | 2 | 0 | 9 | 7 | `remap_priority` |
+| `PRJ-DEPLOY` | quarantined | 4 | 2 | 8 | 7 | `remap_priority` |
+| `PRJ-GITHUB-OPS` | quarantined | 7 | 2 | 6 | 8 | `remap_priority` |
+| `PRJ-M0-MAINTAINABILITY` | quarantined | 3 | 0 | 1 | 7 | `remap_priority` |
+| `PRJ-PLANNER` | quarantined | 5 | 0 | 4 | 7 | `remap_priority` |
+| `PRJ-RELEASE-AUTOMATION` | quarantined | 8 | 2 | 4 | 6 | `remap_priority` |
+| `PRJ-UX-NORTH-STAR` | quarantined | 1 | 0 | 5 | 7 | `remap_priority` |
+| `PRJ-WORK-INTAKE` | quarantined | 9 | 0 | 5 | 8 | `remap_priority` |
+| `PRJ-PM-SUITE` | quarantined | 1 | 2 | 8 | 9 | `quarantine_keep` |
+| `PRJ-SEARCH` | quarantined | 5 | 0 | 0 | 9 | `quarantine_keep` |
+| `PRJ-UI-COCKPIT-LITE` | quarantined | 5 | 1 | 0 | 29 | `quarantine_keep` |
+| `PRJ-ENFORCEMENT-PACK` | quarantined | 4 | 0 | 3 | 13 | `quarantine_keep` |
+| `PRJ-OBSERVABILITY-OTEL` | quarantined | 0 | 0 | 3 | 12 | `retire_candidate` |
+| `PRJ-ZANZIBAR-OPENFGA` | quarantined | 0 | 0 | 1 | 5 | `remap_priority` |
+| `PRJ-EXECUTORPORT` | quarantined | 0 | 0 | 2 | 9 | `retire_candidate` |
+| `PRJ-MEMORYPORT` | quarantined | 0 | 0 | 2 | 9 | `retire_candidate` |
+
+## 5) Ordered Queue (PB-9.2 Çıkışı)
+
+Ratchet sonucu açık işlem sırası:
+
+1. `promotion_candidate`: `PRJ-CONTEXT-ORCHESTRATION`
+2. `remap_priority` (score sırasına göre):
+   - `PRJ-RELEASE-AUTOMATION`
+   - `PRJ-GITHUB-OPS`
+   - `PRJ-WORK-INTAKE`
+   - `PRJ-DEPLOY`
+   - `PRJ-PLANNER`
+   - `PRJ-M0-MAINTAINABILITY`
+   - `PRJ-ZANZIBAR-OPENFGA`
+   - `PRJ-UX-NORTH-STAR`
+   - `PRJ-AIRUNNER`
+3. `quarantine_keep`: `PRJ-ENFORCEMENT-PACK`, `PRJ-PM-SUITE`, `PRJ-SEARCH`,
+   `PRJ-UI-COCKPIT-LITE`
+4. `retire_candidate`: `PRJ-EXECUTORPORT`, `PRJ-MEMORYPORT`,
+   `PRJ-OBSERVABILITY-OTEL`
+
+## 6) Karar Notu
+
+`PB-9.2` sonunda:
+
+1. truth-tier -> debt-action eşlemesi yazılı ve deterministic hale geldi.
+2. support boundary ile çelişen "inventory = support" yorumu engellendi.
+3. widening kararı halen `PB-9.3` ve `PB-9.4` kapıları üzerinden verilecek;
+   bu belge yalnız backlog sırasını kilitler.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -16,6 +16,7 @@ ayrı ayrı görünür kılmak.
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md`
 - **Aktif decision/ordering contract:** `.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md` (`PB-9.2` active)
+- **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)

--- a/ao_kernel/extension_truth_ratchet.py
+++ b/ao_kernel/extension_truth_ratchet.py
@@ -1,0 +1,182 @@
+"""PB-9.2 helper: deterministic truth inventory debt ratchet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from ao_kernel.extensions.loader import (
+    TRUTH_TIER_CONTRACT_ONLY,
+    TRUTH_TIER_QUARANTINED,
+    TRUTH_TIER_RUNTIME_BACKED,
+    ExtensionManifest,
+    ExtensionRegistry,
+)
+
+
+@dataclass(frozen=True)
+class RatchetRow:
+    extension_id: str
+    truth_tier: str
+    entrypoint_count: int
+    ui_surfaces_count: int
+    remap_candidate_refs: int
+    missing_runtime_refs: int
+    runtime_handler_registered: bool
+    bucket: str
+    priority_score: int | None
+
+
+def entrypoint_count(manifest: ExtensionManifest) -> int:
+    return sum(len(values) for values in manifest.entrypoints.values())
+
+
+def classify_bucket(manifest: ExtensionManifest) -> str:
+    missing = len(manifest.missing_runtime_refs)
+    remap = len(manifest.remap_candidate_refs)
+    entrypoints = entrypoint_count(manifest)
+    ui = len(manifest.ui_surfaces)
+    tier = manifest.truth_tier
+
+    if tier == TRUTH_TIER_RUNTIME_BACKED:
+        return "maintain_runtime_backed"
+    if tier == TRUTH_TIER_CONTRACT_ONLY and missing == 0 and remap == 0:
+        return "promotion_candidate"
+    if tier == TRUTH_TIER_QUARANTINED and missing >= 9 and entrypoints == 0 and ui == 0:
+        return "retire_candidate"
+    if tier == TRUTH_TIER_QUARANTINED and missing <= 8 and remap >= 1:
+        return "remap_priority"
+    return "quarantine_keep"
+
+
+def compute_priority_score(manifest: ExtensionManifest, bucket: str) -> int | None:
+    if bucket != "remap_priority":
+        return None
+    entrypoints = entrypoint_count(manifest)
+    ui = len(manifest.ui_surfaces)
+    missing = len(manifest.missing_runtime_refs)
+    remap = len(manifest.remap_candidate_refs)
+    return (entrypoints * 2) + (ui * 3) - missing - remap
+
+
+def build_report() -> dict[str, Any]:
+    registry = ExtensionRegistry()
+    registry.load_from_defaults()
+    summary = registry.truth_summary()
+
+    rows: list[RatchetRow] = []
+    for manifest in registry.list_all():
+        bucket = classify_bucket(manifest)
+        rows.append(
+            RatchetRow(
+                extension_id=manifest.extension_id,
+                truth_tier=manifest.truth_tier,
+                entrypoint_count=entrypoint_count(manifest),
+                ui_surfaces_count=len(manifest.ui_surfaces),
+                remap_candidate_refs=len(manifest.remap_candidate_refs),
+                missing_runtime_refs=len(manifest.missing_runtime_refs),
+                runtime_handler_registered=manifest.runtime_handler_registered,
+                bucket=bucket,
+                priority_score=compute_priority_score(manifest, bucket),
+            )
+        )
+
+    bucket_counts: dict[str, int] = {}
+    for row in rows:
+        bucket_counts[row.bucket] = bucket_counts.get(row.bucket, 0) + 1
+
+    remap_queue = sorted(
+        (row for row in rows if row.bucket == "remap_priority"),
+        key=lambda row: (-(row.priority_score or -10_000), row.extension_id),
+    )
+
+    ordered_queue = {
+        "promotion_candidate": [
+            row.extension_id for row in rows if row.bucket == "promotion_candidate"
+        ],
+        "remap_priority": [row.extension_id for row in remap_queue],
+        "quarantine_keep": sorted(
+            row.extension_id for row in rows if row.bucket == "quarantine_keep"
+        ),
+        "retire_candidate": sorted(
+            row.extension_id for row in rows if row.bucket == "retire_candidate"
+        ),
+    }
+
+    return {
+        "summary": {
+            "total_extensions": summary.total_extensions,
+            "runtime_backed": summary.runtime_backed,
+            "contract_only": summary.contract_only,
+            "quarantined": summary.quarantined,
+            "remap_candidate_refs": summary.remap_candidate_refs,
+            "missing_runtime_refs": summary.missing_runtime_refs,
+        },
+        "bucket_counts": bucket_counts,
+        "ordered_queue": ordered_queue,
+        "rows": [
+            {
+                "extension_id": row.extension_id,
+                "truth_tier": row.truth_tier,
+                "entrypoint_count": row.entrypoint_count,
+                "ui_surfaces_count": row.ui_surfaces_count,
+                "remap_candidate_refs": row.remap_candidate_refs,
+                "missing_runtime_refs": row.missing_runtime_refs,
+                "runtime_handler_registered": row.runtime_handler_registered,
+                "bucket": row.bucket,
+                "priority_score": row.priority_score,
+            }
+            for row in rows
+        ],
+    }
+
+
+def render_text(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    bucket_counts = report["bucket_counts"]
+    queue = report["ordered_queue"]
+    lines: list[str] = []
+    lines.append("truth_inventory_ratchet")
+    lines.append(
+        "summary:"
+        f" total={summary['total_extensions']}"
+        f" runtime_backed={summary['runtime_backed']}"
+        f" contract_only={summary['contract_only']}"
+        f" quarantined={summary['quarantined']}"
+        f" remap_candidate_refs={summary['remap_candidate_refs']}"
+        f" missing_runtime_refs={summary['missing_runtime_refs']}"
+    )
+    lines.append(
+        "buckets:"
+        f" maintain_runtime_backed={bucket_counts.get('maintain_runtime_backed', 0)}"
+        f" promotion_candidate={bucket_counts.get('promotion_candidate', 0)}"
+        f" remap_priority={bucket_counts.get('remap_priority', 0)}"
+        f" quarantine_keep={bucket_counts.get('quarantine_keep', 0)}"
+        f" retire_candidate={bucket_counts.get('retire_candidate', 0)}"
+    )
+    lines.append("queue.promotion_candidate: " + ", ".join(queue["promotion_candidate"]))
+    lines.append("queue.remap_priority: " + ", ".join(queue["remap_priority"]))
+    lines.append("queue.quarantine_keep: " + ", ".join(queue["quarantine_keep"]))
+    lines.append("queue.retire_candidate: " + ", ".join(queue["retire_candidate"]))
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Emit PB-9.2 truth inventory debt ratchet report.",
+    )
+    parser.add_argument(
+        "--output",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text).",
+    )
+    args = parser.parse_args(argv)
+    report = build_report()
+    if args.output == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    return 0

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -80,6 +80,10 @@ eşlenir:
 | `quarantined` | Açık runtime gap vardır; support dışı/deferred sınıfında kalır |
 
 Bu kuralın amacı, inventory görünürlüğünü support widening ile karıştırmamaktır.
+`PB-9.2` kapsamında debt işlem sırası ve truth-tier tabanlı karar ratchet'i
+`.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md` içinde tutulur.
+Bu ratchet support tier'ı tek başına widen etmez.
+Canlı snapshot üretimi için: `python3 scripts/truth_inventory_ratchet.py --output json`.
 
 ## Deferred
 

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -27,6 +27,12 @@ başına yeterli değildir. Bu sınıfların support yorumu aşağıdaki gibi sa
 | `quarantined` | Runtime owner/refs/entrypoint tarafında açık gap vardır | Support dışı kalır; yalnız karar/debt izleme yüzeyi olarak ele alınır |
 
 Bu tablo, `docs/PUBLIC-BETA.md` ve status SSOT ile aynı anlamda okunur.
+`PB-9.2` debt sıralama kuralları için tek karar kaynağı:
+`.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`.
+Bu ratchet tablosu support widening kararı vermez; yalnız debt işlem sırasını
+deterministik hale getirir.
+Canlı ratchet raporu `python3 scripts/truth_inventory_ratchet.py --output json`
+ile tekrar üretilebilir.
 
 ## 2. Current line by line boundary
 

--- a/scripts/truth_inventory_ratchet.py
+++ b/scripts/truth_inventory_ratchet.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""CLI wrapper for PB-9.2 truth inventory debt ratchet report."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel.extension_truth_ratchet import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_extension_truth_ratchet.py
+++ b/tests/test_extension_truth_ratchet.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from ao_kernel.extension_truth_ratchet import build_report, render_text
+
+
+def _row(report: dict[str, object], extension_id: str) -> dict[str, object]:
+    rows = report["rows"]
+    assert isinstance(rows, list)
+    for candidate in rows:
+        assert isinstance(candidate, dict)
+        if candidate.get("extension_id") == extension_id:
+            return candidate
+    raise AssertionError(f"extension row not found: {extension_id}")
+
+
+def test_build_report_has_expected_buckets_and_queue() -> None:
+    report = build_report()
+    summary = report["summary"]
+    assert summary["total_extensions"] >= 1
+    assert summary["runtime_backed"] >= 2
+    assert summary["contract_only"] >= 1
+    assert summary["quarantined"] >= 1
+
+    queue = report["ordered_queue"]
+    assert "PRJ-CONTEXT-ORCHESTRATION" in queue["promotion_candidate"]
+    assert "PRJ-RELEASE-AUTOMATION" in queue["remap_priority"]
+    assert "PRJ-EXECUTORPORT" in queue["retire_candidate"]
+
+
+def test_known_extension_classifications_are_stable() -> None:
+    report = build_report()
+
+    context_orch = _row(report, "PRJ-CONTEXT-ORCHESTRATION")
+    assert context_orch["bucket"] == "promotion_candidate"
+    assert context_orch["priority_score"] is None
+
+    executorport = _row(report, "PRJ-EXECUTORPORT")
+    assert executorport["bucket"] == "retire_candidate"
+    assert executorport["priority_score"] is None
+
+    cockpit = _row(report, "PRJ-UI-COCKPIT-LITE")
+    assert cockpit["bucket"] == "quarantine_keep"
+    assert cockpit["priority_score"] is None
+
+
+def test_render_text_contains_key_sections() -> None:
+    rendered = render_text(build_report())
+    assert "truth_inventory_ratchet" in rendered
+    assert "queue.promotion_candidate:" in rendered
+    assert "queue.remap_priority:" in rendered
+    assert "queue.retire_candidate:" in rendered
+
+
+def test_script_wrapper_executes_from_repo_root() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "scripts/truth_inventory_ratchet.py", "--output", "json"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "summary" in payload
+    assert "ordered_queue" in payload


### PR DESCRIPTION
## Özet
- PB-9.2 için doctor truth inventory tabanlı deterministic ratchet karar notunu ekler
- `ao_kernel.extension_truth_ratchet` + `scripts/truth_inventory_ratchet.py` ile tekrar üretilebilir queue raporu sağlar
- support docs (`PUBLIC-BETA`, `SUPPORT-BOUNDARY`) ile ratchet karar kaynağını hizalar
- roadmap/status SSOT içinde PB-9.2 karar notu referansını görünür yapar

## Doğrulama
- python3 -m pytest -q tests/test_extension_truth_ratchet.py tests/test_doctor_cmd.py
- python3 -m ruff check ao_kernel/extension_truth_ratchet.py scripts/truth_inventory_ratchet.py tests/test_extension_truth_ratchet.py
- python3 scripts/truth_inventory_ratchet.py --output text

## Bağlantılar
- Parent tracker: #302
- Active tranche: #306
