### PR TITLE
PB-9.4: production claim decision closeout

### DIFF
--- a/.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md
+++ b/.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md
@@ -1,6 +1,6 @@
 # PB-9 — Production Claim Readiness Gates
 
-**Status:** Active  
+**Status:** Completed  
 **Date:** 2026-04-23  
 **Tracker:** [#302](https://github.com/Halildeu/ao-kernel/issues/302)  
 **Execution mode:** Kapsam disiplini, tek aktif runtime tranche
@@ -74,13 +74,15 @@ kapılar birlikte geçerse verilir:
 - Ana çıktı: live side-effect risklerinin incident/rollback açısından
   operatörce savunulabilir olması.
 
-### `PB-9.4` — Production claim decision closeout (Active)
+### `PB-9.4` — Production claim decision closeout (Completed)
 
-- Issue: [#312](https://github.com/Halildeu/ao-kernel/issues/312)
+- Issue: [#312](https://github.com/Halildeu/ao-kernel/issues/312) (`closed`)
+- Karar notu: `.claude/plans/PB-9.4-PRODUCTION-CLAIM-DECISION-CLOSEOUT.md`
 - Hedef: `promote` veya `stay_beta_operator_managed` kararını
   tek bir kapanış notuna bağlamak.
 - Ana çıktı: support boundary satırları kararla birlikte güncellenir,
   tracker kapanış kriteri netleşir.
+- Çıktı kararı: `stay_beta_operator_managed`
 
 ## Başarı Kriterleri
 
@@ -102,6 +104,6 @@ kapılar birlikte geçerse verilir:
 
 ## Program Kapanış Koşulu
 
-1. `PB-9.1`..`PB-9.4` için karar kayıtları tamamlanır.
-2. `POST-BETA-CORRECTNESS-EXPANSION-STATUS.md` aktif hatı kapatır.
-3. Tracker [#302](https://github.com/Halildeu/ao-kernel/issues/302) kapanır.
+1. `PB-9.1`..`PB-9.4` için karar kayıtları tamamlandı.
+2. `POST-BETA-CORRECTNESS-EXPANSION-STATUS.md` aktif hatı kapattı.
+3. Tracker [#302](https://github.com/Halildeu/ao-kernel/issues/302) kapandı.

--- a/.claude/plans/PB-9.4-PRODUCTION-CLAIM-DECISION-CLOSEOUT.md
+++ b/.claude/plans/PB-9.4-PRODUCTION-CLAIM-DECISION-CLOSEOUT.md
@@ -1,0 +1,78 @@
+# PB-9.4 — Production Claim Decision Closeout
+
+**Durum:** Completed (`PB-9.4`)  
+**Issue:** [#312](https://github.com/Halildeu/ao-kernel/issues/312)  
+**Tracker:** [#302](https://github.com/Halildeu/ao-kernel/issues/302)  
+**Karar tarihi:** 2026-04-23
+
+## 1) Karar
+
+`ao-kernel` icin production claim karari:
+
+1. `stay_beta_operator_managed`
+
+Bu karar platformun "hic calismiyor" oldugu anlamina gelmez. Karar,
+destek sinirinin kontrollu ve kanita dayali sekilde dar tutulmasi anlamina
+gelir.
+
+## 2) Karar Giris Kaniti (Canli)
+
+Bu dilimde tekrar uretilen paket:
+
+```bash
+python3 scripts/kernel_api_write_smoke.py --output json
+python3 scripts/gh_cli_pr_smoke.py --output json
+python3 scripts/claude_code_cli_smoke.py --output json
+python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head main --base main --output json
+python3 -m pytest -q tests/test_kernel_api_write_smoke.py tests/test_gh_cli_pr_smoke.py tests/test_executor_policy_rollout_v311_p2.py
+python3 scripts/packaging_smoke.py
+```
+
+Gozlem:
+
+1. `kernel_api_write_smoke`: `overall_status=pass` ve write contract check seti
+   tamami `pass`.
+2. `gh_cli_pr_smoke` preflight: `overall_status=pass`.
+3. `claude_code_cli_smoke`: `overall_status=pass`.
+4. `gh_cli_pr_smoke` live-write denemesi (`--head main --base main`):
+   fail-closed `blocked` (`gh_pr_live_write_same_head_base`), yani explicit
+   guard davranisi aktif.
+5. Targeted behavior test paketi: `28 passed`.
+6. Packaging smoke: wheel-install yolunda entrypoint + `demo_review` tamam
+   (`final state: completed`).
+
+## 3) Gate Degerlendirmesi
+
+| Gate | Sonuc | Not |
+|---|---|---|
+| G1 Truth parity | pass | `PUBLIC-BETA`, `SUPPORT-BOUNDARY`, `OPERATIONS-RUNBOOK` ayni tier sinirini tasiyor |
+| G2 Prerequisite determinism | pass | operator smoke komutlari tekrar uretilir ve rapor formati deterministik |
+| G3 Behavior + evidence completeness | pass (beta scope) | write-side contract + policy rollout testleri + lane smoke kaniti var |
+| G4 Rollback/incident readiness | bounded pass | side-effect lane karar akisi runbook'ta net; live-write genel destek degil, explicit guard altinda |
+| G5 Governance enforcement | pass | required CI zinciri + packaging smoke PR turunda gecerli |
+| G6 Decision record | pass | bu closeout notu + roadmap/status parity + issue/tracker senkronu |
+
+## 4) Neden `promote` degil?
+
+1. `gh-cli-pr` remote live PR opening hala support boundary'de deferred.
+2. `bug_fix_flow` release closure hala deferred.
+3. Public support claim'i deterministic shipped baseline + operator-managed beta
+   lane'ler disina genisletmek icin ek widening karari/implementationi yok.
+4. Extension envanterinin buyuk kismi halen quarantine/contract-only; bu durum
+   tek basina blocker degil ama "general-purpose production" iddiasi icin
+   yeterli promotion sinyali degil.
+
+## 5) Boundary Sonucu
+
+1. Shipped baseline iddiasi korunur.
+2. `claude-code-cli`, `gh-cli-pr`, `PRJ-KERNEL-API` write-side lane'leri
+   `Beta (operator-managed)` tier'inda kalir.
+3. Deferred satirlari aynen korunur; bu dilimde widening yoktur.
+
+## 6) Closeout
+
+1. `PB-9.1..PB-9.4` karar kayitlari tamamlandi.
+2. `PB-9` tracker kapanisina izin veren karar kaydi olustu.
+3. Sonraki adim, yeni backlog/program acilacaksa ayri tracker ile acilmalidir;
+   `PB-9` icinde yeni widening dilimi acilmaz.
+

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -15,17 +15,18 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md` (`PB-8` closeout)
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md`
-- **Aktif decision/ordering contract:** `.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md` (`PB-9.4` active)
+- **Aktif decision/ordering contract:** `none` (`PB-9` closeout tamamlandı)
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
+- **PB-9.4 karar notu:** `.claude/plans/PB-9.4-PRODUCTION-CLAIM-DECISION-CLOSEOUT.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
 - **GitHub tracker issue:** [#219](https://github.com/Halildeu/ao-kernel/issues/219)
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
 - **PB-8 tracker issue:** [#288](https://github.com/Halildeu/ao-kernel/issues/288) (`closed`)
-- **PB-9 tracker issue:** [#302](https://github.com/Halildeu/ao-kernel/issues/302)
-- **Aktif issue:** [#312](https://github.com/Halildeu/ao-kernel/issues/312) (`PB-9.4`)
+- **PB-9 tracker issue:** [#302](https://github.com/Halildeu/ao-kernel/issues/302) (`closed`)
+- **Aktif issue:** `none`
 
 ## 2. Başlangıç Gerçeği
 
@@ -35,9 +36,8 @@ ayrı ayrı görünür kılmak.
   baseline, gerçek adapter lane'leri ise operator-managed beta durumundadır.
 - Public Beta closeout sonrası `PB-8.4` docs/runbook/release-gate parity
   tranche'i tamamlandı ve `PB-8` tracker kapandı; `PB-9.1` prerequisite parity,
-  `PB-9.2` truth inventory debt ratchet ve `PB-9.3` write/live evidence
-  rehearsal dilimleri kapanmıştır. Aktif hat artık `PB-9.4` production claim
-  decision closeout'tur.
+  `PB-9.2` truth inventory debt ratchet, `PB-9.3` write/live evidence rehearsal
+  ve `PB-9.4` production claim decision closeout dilimleri kapanmıştır.
 - Repo bugün hâlâ genel amaçlı production coding automation platformu değildir;
   bu programın amacı o iddiayı hemen widen etmek değil, önce kalan debt'i
   kontrollü kapatmaktır.
@@ -68,7 +68,7 @@ ayrı ayrı görünür kılmak.
 | `PB-5` adapter-path cost/evidence completeness | Completed ([#238](https://github.com/Halildeu/ao-kernel/issues/238)) | `cost_usd` reconcile ve evidence completeness yüzeyinde ayrı runtime gap olup olmadığını karara bağlamak; sonuç: docs parity closeout yeterli, ayrı tranche 3 gerekmedi | truth audit + targeted tests + docs parity closeout |
 | `PB-6` general-purpose expansion gap map | Completed on `main` ([#243](https://github.com/Halildeu/ao-kernel/issues/243), [#279](https://github.com/Halildeu/ao-kernel/pull/279)) | narrow beta'dan daha geniş production platform çizgisine geçiş için hangi yüzeylerin neden henüz promoted olmadığını canlı kanıtla sınıflandırmak | written gap map + ordered tranche backlog + PB-6.6 final verdict closeout |
 | `PB-8` general-purpose productionization roadmap | Completed on `main` ([#288](https://github.com/Halildeu/ao-kernel/issues/288), [#300](https://github.com/Halildeu/ao-kernel/pull/300), [#301](https://github.com/Halildeu/ao-kernel/pull/301)) | widening kararlarını tranche bazında kapatmak ve support closeout parity'yi tamamlamak | tracker closeout + docs/runbook/release-gate parity |
-| `PB-9` production claim readiness gates | Active ([#302](https://github.com/Halildeu/ao-kernel/issues/302), closed tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303), closed tranche [#306](https://github.com/Halildeu/ao-kernel/issues/306), closed tranche [#309](https://github.com/Halildeu/ao-kernel/issues/309), active tranche [#312](https://github.com/Halildeu/ao-kernel/issues/312)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | active roadmap + tranche issue + status parity |
+| `PB-9` production claim readiness gates | Completed on `main` ([#302](https://github.com/Halildeu/ao-kernel/issues/302), closed tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303), closed tranche [#306](https://github.com/Halildeu/ao-kernel/issues/306), closed tranche [#309](https://github.com/Halildeu/ao-kernel/issues/309), closed tranche [#312](https://github.com/Halildeu/ao-kernel/issues/312)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | roadmap + decision records + tracker closeout |
 
 ## 5. Şimdi
 
@@ -264,11 +264,11 @@ Not:
 
 ## 8. Anlık Öncelik
 
-`PB-9` yürütmesi aktif.
+`PB-9` yürütmesi kapandı.
 
-1. Son kapanan slice: `PB-9.3` write/live lane evidence rehearsal
-2. Bugünkü aktif iş: `PB-9.4` production claim decision closeout
-3. Sonraki sıra (planlı): `PB-9` tracker closeout
+1. Son kapanan slice: `PB-9.4` production claim decision closeout
+2. Bugünkü aktif iş: `none` (`PB-9` closeout tamamlandı)
+3. Sonraki sıra (planlı): yeni backlog/program kickoff (ayrı tracker)
 
 `PB-8.2` completion kaydı:
 
@@ -394,7 +394,7 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
 
 1. Program roadmap:
    `.claude/plans/PB-9-PRODUCTION-CLAIM-READINESS-GATES.md`
-2. Tracker issue: [#302](https://github.com/Halildeu/ao-kernel/issues/302)
+2. Tracker issue: [#302](https://github.com/Halildeu/ao-kernel/issues/302) (`closed`)
 3. `PB-9.1` completion:
    - issue: [#303](https://github.com/Halildeu/ao-kernel/issues/303) (`closed`)
    - PR: [#305](https://github.com/Halildeu/ao-kernel/pull/305)
@@ -417,6 +417,14 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
      (`scripts/kernel_api_write_smoke.py` + `scripts/gh_cli_pr_smoke.py`)
      ve karar notu (`.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`)
      `main`e alındı.
-6. Aktif tranche: `PB-9.4`
-   ([#312](https://github.com/Halildeu/ao-kernel/issues/312))
-7. Program kuralı korunur: tek aktif runtime tranche + zorunlu kanıt paketi.
+6. `PB-9.4` completion:
+   - issue: [#312](https://github.com/Halildeu/ao-kernel/issues/312) (`closed`)
+   - PR: `PB-9.4 closeout patch` (bu commit)
+   - merge commit: `pending (merge anında işlenecek)`
+   - sonuç: production claim closeout kararı
+     `stay_beta_operator_managed` olarak yazılı karar notuna bağlandı
+     (`.claude/plans/PB-9.4-PRODUCTION-CLAIM-DECISION-CLOSEOUT.md`).
+7. Program kapanış notu:
+   - `PB-9.1..PB-9.4` tamamlandı
+   - active tranche yok
+   - yeni widening/program hattı ayrı tracker ile açılacak

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -109,6 +109,8 @@ Canlı snapshot üretimi için: `python3 scripts/truth_inventory_ratchet.py --ou
   `review_ai_flow` + bundled `codex-stub` yolu için geçerlidir.
 - `claude-code-cli` ve `gh-cli-pr` bugün default demo yüzeyi değildir;
   yalnız helper-backed operator-managed beta satırları kadar desteklenir.
+- `PB-9.4` closeout kararı `stay_beta_operator_managed` olarak sabitlenmiştir;
+  bu release çizgisinde support widening yapılmaz.
 - Bundled extension inventory runtime-backed olsa da support-tier ayrımı korunur:
   `PRJ-KERNEL-API` içinde `system_status` / `doc_nav_check` shipped read-only
   satırındadır; `project_status` / `roadmap_follow` / `roadmap_finish` ise

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -84,6 +84,9 @@ zincirine taşınmıştır. `--keep-live-write-pr-open` seçeneği lane'i riskli
 eder ve rapor `blocked` döner. Bu probe'un varlığı tek başına live remote PR
 opening support tier'ını widen etmez; public boundary satırı deferred kalır.
 
+`PB-9.4` closeout kararı `stay_beta_operator_managed` olduğu için bu satırların
+support tier'i widening almadan korunur.
+
 `PB-8.3` ile `bug_fix_flow` içindeki `open_pr` adımı ayrıca workflow-level
 explicit opt-in guard (`AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1`) arkasına
 alınmıştır. Bu guard accidental side-effect riskini düşürür, fakat tek başına


### PR DESCRIPTION
## Summary
- add PB-9.4 decision record with live evidence and final verdict: stay_beta_operator_managed
- mark PB-9.4 completed in roadmap and mark PB-9 program closeout conditions as completed
- sync post-beta status SSOT to closed PB-9 state (no active PB-9 tranche)
- align PUBLIC-BETA and SUPPORT-BOUNDARY wording with PB-9.4 closeout verdict

## Validation
- python3 -m pytest -q tests/test_kernel_api_write_smoke.py tests/test_gh_cli_pr_smoke.py tests/test_executor_policy_rollout_v311_p2.py
- python3 scripts/kernel_api_write_smoke.py --output text
- python3 scripts/gh_cli_pr_smoke.py --output json
- python3 scripts/claude_code_cli_smoke.py --output json
- python3 scripts/packaging_smoke.py

Refs #312
Refs #302