### PR TITLE
docs(plan): switch GP-1 active tranche to #318

### DIFF
--- a/.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md
+++ b/.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md
@@ -36,16 +36,19 @@ Amaç, widening'i yalnız kanıt zinciri tamamlandığında açmaktır.
 
 ## Tranche Sırası
 
-### `GP-1.1` — Widening authority map and entry gates (Active)
+### `GP-1.1` — Widening authority map and entry gates (Completed)
 
 - Issue: [#315](https://github.com/Halildeu/ao-kernel/issues/315)
 - Hedef: hangi yüzey hangi gate seti olmadan promote edilemez, bunu
   authoritative tabloya bağlamak.
 - Ana çıktı: tek anlamlı entry-gate kontratı + tranche sıralaması.
+- Kapanış kanıtı:
+  - PR: [#317](https://github.com/Halildeu/ao-kernel/pull/317)
+  - Merge commit: `9c4ca53`
 
-### `GP-1.2` — `gh-cli-pr` live-write disposable contract (Planned)
+### `GP-1.2` — `gh-cli-pr` live-write disposable contract (Active)
 
-- Issue: `pending`
+- Issue: [#318](https://github.com/Halildeu/ao-kernel/issues/318)
 - Hedef: disposable sandbox + create->verify->rollback zincirini production-grade
   karar seviyesinde doğrulamak.
 - Ana çıktı: `promote_candidate` veya `stay_preflight` kararı.
@@ -89,4 +92,3 @@ Amaç, widening'i yalnız kanıt zinciri tamamlandığında açmaktır.
 1. `GP-1.1..GP-1.5` için karar kayıtları tamamlanır.
 2. `POST-BETA-CORRECTNESS-EXPANSION-STATUS.md` aktif hattı kapatır.
 3. Tracker [#316](https://github.com/Halildeu/ao-kernel/issues/316) kapanır.
-

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -15,7 +15,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md` (`PB-8` closeout)
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md`
-- **Aktif decision/ordering contract:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md` (`GP-1.1` active)
+- **Aktif decision/ordering contract:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md` (`GP-1.2` active)
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
 - **PB-9.4 karar notu:** `.claude/plans/PB-9.4-PRODUCTION-CLAIM-DECISION-CLOSEOUT.md`
@@ -28,7 +28,7 @@ ayrı ayrı görünür kılmak.
 - **PB-8 tracker issue:** [#288](https://github.com/Halildeu/ao-kernel/issues/288) (`closed`)
 - **PB-9 tracker issue:** [#302](https://github.com/Halildeu/ao-kernel/issues/302) (`closed`)
 - **GP-1 tracker issue:** [#316](https://github.com/Halildeu/ao-kernel/issues/316)
-- **Aktif issue:** [#315](https://github.com/Halildeu/ao-kernel/issues/315) (`GP-1.1`)
+- **Aktif issue:** [#318](https://github.com/Halildeu/ao-kernel/issues/318) (`GP-1.2`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -40,7 +40,8 @@ ayrı ayrı görünür kılmak.
   tranche'i tamamlandı ve `PB-8` tracker kapandı; `PB-9.1` prerequisite parity,
   `PB-9.2` truth inventory debt ratchet, `PB-9.3` write/live evidence rehearsal
   ve `PB-9.4` production claim decision closeout dilimleri kapanmıştır.
-- `GP-1` tracker açıldı; aktif hat `GP-1.1` authority map + entry gates dilimidir.
+- `GP-1` tracker açıldı; `GP-1.1` kapanmış, aktif hat `GP-1.2`
+  live-write disposable contract dilimidir.
 - Repo bugün hâlâ genel amaçlı production coding automation platformu değildir;
   bu programın amacı o iddiayı hemen widen etmek değil, önce kalan debt'i
   kontrollü kapatmaktır.
@@ -72,7 +73,7 @@ ayrı ayrı görünür kılmak.
 | `PB-6` general-purpose expansion gap map | Completed on `main` ([#243](https://github.com/Halildeu/ao-kernel/issues/243), [#279](https://github.com/Halildeu/ao-kernel/pull/279)) | narrow beta'dan daha geniş production platform çizgisine geçiş için hangi yüzeylerin neden henüz promoted olmadığını canlı kanıtla sınıflandırmak | written gap map + ordered tranche backlog + PB-6.6 final verdict closeout |
 | `PB-8` general-purpose productionization roadmap | Completed on `main` ([#288](https://github.com/Halildeu/ao-kernel/issues/288), [#300](https://github.com/Halildeu/ao-kernel/pull/300), [#301](https://github.com/Halildeu/ao-kernel/pull/301)) | widening kararlarını tranche bazında kapatmak ve support closeout parity'yi tamamlamak | tracker closeout + docs/runbook/release-gate parity |
 | `PB-9` production claim readiness gates | Completed on `main` ([#302](https://github.com/Halildeu/ao-kernel/issues/302), closed tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303), closed tranche [#306](https://github.com/Halildeu/ao-kernel/issues/306), closed tranche [#309](https://github.com/Halildeu/ao-kernel/issues/309), closed tranche [#312](https://github.com/Halildeu/ao-kernel/issues/312)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | roadmap + decision records + tracker closeout |
-| `GP-1` general-purpose production widening | Active ([#316](https://github.com/Halildeu/ao-kernel/issues/316), active tranche [#315](https://github.com/Halildeu/ao-kernel/issues/315)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde yürütmek | roadmap + active tranche issue + status parity |
+| `GP-1` general-purpose production widening | Active ([#316](https://github.com/Halildeu/ao-kernel/issues/316), active tranche [#318](https://github.com/Halildeu/ao-kernel/issues/318)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde yürütmek | roadmap + active tranche issue + status parity |
 
 ## 5. Şimdi
 
@@ -270,9 +271,9 @@ Not:
 
 `GP-1` yürütmesi aktif.
 
-1. Son kapanan slice: `PB-9.4` production claim decision closeout
-2. Bugünkü aktif iş: `GP-1.1` widening authority map + entry gates
-3. Sonraki sıra (planlı): `GP-1.2` live-write disposable contract değerlendirmesi
+1. Son kapanan slice: `GP-1.1` widening authority map + entry gates
+2. Bugünkü aktif iş: `GP-1.2` `gh-cli-pr` live-write disposable contract
+3. Sonraki sıra (planlı): `GP-1.3` `bug_fix_flow` release-closure re-evaluation
 
 `PB-8.2` completion kaydı:
 
@@ -441,10 +442,14 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
    `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md`
 2. Tracker issue: [#316](https://github.com/Halildeu/ao-kernel/issues/316) (`open`)
 3. Aktif tranche issue:
-   - [#315](https://github.com/Halildeu/ao-kernel/issues/315) (`GP-1.1`, `open`)
+   - [#318](https://github.com/Halildeu/ao-kernel/issues/318) (`GP-1.2`, `open`)
 4. `GP-1.1` kapsamı:
    - widening authority map and entry gates
    - support widening kararları için non-negotiable gate setini sabitlemek
-5. Sonraki planlı sıra:
-   - `GP-1.2` `gh-cli-pr` live-write disposable contract
+5. `GP-1.1` completion:
+   - issue: [#315](https://github.com/Halildeu/ao-kernel/issues/315) (`closed`)
+   - PR: [#317](https://github.com/Halildeu/ao-kernel/pull/317)
+   - merge commit: `9c4ca53`
+6. Sonraki planlı sıra:
    - `GP-1.3` `bug_fix_flow` release-closure re-evaluation
+   - `GP-1.4` extension promotion tranche


### PR DESCRIPTION
## Summary
- mark GP-1.1 as completed in the GP-1 roadmap with PR/merge evidence
- activate GP-1.2 in roadmap and bind it to issue #318
- update post-beta status SSOT to show GP-1.2 as active issue/tranche

## Context
- Tracker: #316
- Closed tranche: #315
- Active tranche: #318

## Validation
- docs/plan only changes
- pre-commit hook passed