### PR TITLE
feat(smoke): persist gh-cli-pr smoke report artifact

### DIFF
--- a/ao_kernel/real_adapter_smoke.py
+++ b/ao_kernel/real_adapter_smoke.py
@@ -814,6 +814,19 @@ def render_text_report(
     return "\n".join(lines)
 
 
+def write_smoke_report_json(
+    report: ClaudeCodeSmokeReport | GhCliPrSmokeReport,
+    output_path: Path | str,
+) -> Path:
+    """Persist a smoke report as canonical JSON and return absolute path."""
+
+    target_path = Path(output_path).expanduser()
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(report.as_dict(), indent=2, sort_keys=True) + "\n"
+    target_path.write_text(payload, encoding="utf-8")
+    return target_path.resolve()
+
+
 def _load_claude_manifest() -> AdapterManifest:
     reg = AdapterRegistry()
     reg.load_bundled()

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -38,6 +38,8 @@ python3 scripts/gh_cli_pr_smoke.py --output text
 python3 scripts/kernel_api_write_smoke.py --output text
 # Optional readiness probe (live-write, explicit opt-in + disposable guard):
 # python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch>
+# Optional: persist canonical JSON evidence artifact
+# python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch> --output json --report-path /tmp/gh-cli-pr-live-write.report.json
 ```
 
 Prerequisite contract (operator-managed lanes):
@@ -53,6 +55,23 @@ Prerequisite contract (operator-managed lanes):
    taşımıyorsa probe bilerek `blocked` döner.
 5. `--keep-live-write-pr-open` lane'i riskli kabul ettirir; bu sonucu support
    widening sinyali olarak yorumlama.
+
+Deterministic command/evidence pack (`GP-1.2` live-write rehearsal):
+
+```bash
+ARTIFACT_ROOT=/tmp/ao-kernel-gh-cli-pr-live-write
+mkdir -p "$ARTIFACT_ROOT"
+python3 scripts/gh_cli_pr_smoke.py \
+  --mode live-write \
+  --allow-live-write \
+  --head <feature-branch> \
+  --base <target-branch> \
+  --output json \
+  --report-path "$ARTIFACT_ROOT/gh-cli-pr-live-write.report.json"
+```
+
+Bu komut paketi support widening kararı için canonical evidence girdisidir;
+`report_path` dosyası issue/PR karar notuna doğrudan bağlanır.
 
 `bug_fix_flow` içinde workflow-level `open_pr` side effect'i varsayılan
 fail-closed guard ile gelir. `AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1` olmadan
@@ -118,6 +137,8 @@ For any Sev 1 or Sev 2 incident, collect:
   `.ao/evidence/workflows/<run_id>/events.jsonl`
 - adapter evidence path if an adapter lane ran:
   `.ao/evidence/workflows/<run_id>/adapter-*.jsonl`
+- helper smoke report artifact path (opsiyonel ama önerilen):
+  `--report-path` ile üretilen `gh-cli-pr-live-write.report.json`
 
 ## 5. Exit criteria
 

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -56,6 +56,7 @@ These are real, testable surfaces, but they are not the default shipped demo:
 - `python3 scripts/claude_code_cli_smoke.py --output text`
 - `python3 scripts/gh_cli_pr_smoke.py --output text`
 - `python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch>`
+- `python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch> --output json --report-path <artifact.json>`
 - `python3 scripts/kernel_api_write_smoke.py --output text`
 - `PRJ-KERNEL-API` write-side actions (`project_status`, `roadmap_follow`, `roadmap_finish`) with explicit `workspace_root`, default `dry_run=true`, and `confirm_write=I_UNDERSTAND_SIDE_EFFECTS` for real writes
 - real-adapter benchmark full-mode runbooks

--- a/scripts/gh_cli_pr_smoke.py
+++ b/scripts/gh_cli_pr_smoke.py
@@ -13,6 +13,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from ao_kernel.real_adapter_smoke import render_text_report, run_gh_cli_pr_smoke
+from ao_kernel.real_adapter_smoke import write_smoke_report_json
 
 
 def main() -> int:
@@ -28,6 +29,13 @@ def main() -> int:
         choices=("text", "json"),
         default="text",
         help="Render mode for the smoke report.",
+    )
+    parser.add_argument(
+        "--report-path",
+        help=(
+            "Optional JSON artifact output path. When provided, "
+            "the canonical smoke report is written to this file."
+        ),
     )
     parser.add_argument(
         "--timeout-seconds",
@@ -96,10 +104,15 @@ def main() -> int:
         keep_live_write_pr_open=args.keep_live_write_pr_open,
         require_disposable_repo_keyword=args.require_disposable_keyword or None,
     )
+    persisted_report_path: Path | None = None
+    if args.report_path:
+        persisted_report_path = write_smoke_report_json(report, args.report_path)
     if args.output == "json":
         print(json.dumps(report.as_dict(), indent=2, sort_keys=True))
     else:
         print(render_text_report(report))
+        if persisted_report_path is not None:
+            print(f"report_path: {persisted_report_path}")
     return 0 if report.overall_status == "pass" else 1
 
 

--- a/tests/test_gh_cli_pr_smoke.py
+++ b/tests/test_gh_cli_pr_smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 from pathlib import Path
 
@@ -855,3 +856,41 @@ def test_live_write_rollback_failure_blocks_lane() -> None:
         check for check in report.checks if check.name == "pr_live_write_rollback"
     )
     assert rollback_check.status == "fail"
+
+
+def test_write_smoke_report_json_persists_canonical_payload(
+    tmp_path: Path,
+) -> None:
+    def runner(
+        argv: tuple[str, ...] | list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        cmd = tuple(argv)
+        baseline = _base_gh_runner_result(cmd)
+        if baseline is not None:
+            return baseline
+        if cmd[:4] == ("/fake/gh", "pr", "create", "--repo"):
+            return _result(
+                cmd,
+                stdout=(
+                    "Would have created a Pull Request with:\n"
+                    "Title: ao-kernel gh-cli-pr smoke probe\n"
+                ),
+            )
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_gh_cli_pr_smoke(
+        which=lambda command: "/fake/gh",
+        runner=runner,
+        cwd=tmp_path,
+    )
+    output_path = tmp_path / "artifacts" / "gh-cli-pr-smoke.report.json"
+    resolved = smoke.write_smoke_report_json(report, output_path)
+
+    assert resolved == output_path.resolve()
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["overall_status"] == "pass"
+    assert payload["adapter_id"] == "gh-cli-pr"
+    assert payload["repo_name"] == "Halildeu/ao-kernel"
+    assert payload["checks"][-1]["name"] == "pr_dry_run"


### PR DESCRIPTION
## Summary
- add write_smoke_report_json helper to persist canonical real-adapter smoke reports
- extend scripts/gh_cli_pr_smoke.py with --report-path so live-write rehearsals can emit deterministic JSON evidence artifacts
- update operator docs with the GP-1.2 deterministic command/evidence pack and report artifact expectation
- add unit coverage for report artifact persistence in tests/test_gh_cli_pr_smoke.py

## Context
- Active tranche: #318 (GP-1.2)
- Tracker: #316

## Validation
- python3 -m pytest -q tests/test_gh_cli_pr_smoke.py
- python3 scripts/gh_cli_pr_smoke.py --help
