### PR TITLE
docs(plan): close GP-1.3 and activate GP-1.4

### DIFF
--- a/.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md
+++ b/.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md
@@ -56,15 +56,18 @@ Amaç, widening'i yalnız kanıt zinciri tamamlandığında açmaktır.
   - `.claude/plans/GP-1.2-GH-CLI-PR-LIVE-WRITE-DISPOSABLE-DECISION.md`
 - Karar: `stay_preflight`
 
-### `GP-1.3` — `bug_fix_flow` release-closure re-evaluation (Active)
+### `GP-1.3` — `bug_fix_flow` release-closure re-evaluation (Completed)
 
 - Issue: [#322](https://github.com/Halildeu/ao-kernel/issues/322)
 - Hedef: `bug_fix_flow` deferred sınırını yeniden değerlendirmek.
 - Ana çıktı: support boundary satırı için promote/stay kararı.
+- Karar notu:
+  - `.claude/plans/GP-1.3-BUG-FIX-FLOW-RELEASE-CLOSURE-DECISION.md`
+- Karar: `stay_deferred`
 
-### `GP-1.4` — Extension promotion tranche (`PRJ-CONTEXT-ORCHESTRATION`) (Planned)
+### `GP-1.4` — Extension promotion tranche (`PRJ-CONTEXT-ORCHESTRATION`) (Active)
 
-- Issue: `pending`
+- Issue: [#324](https://github.com/Halildeu/ao-kernel/issues/324)
 - Hedef: contract-only extension için runtime ownership / handler readiness kanıtı.
 - Ana çıktı: `promotion_candidate` veya `stay_contract_only`.
 

--- a/.claude/plans/GP-1.3-BUG-FIX-FLOW-RELEASE-CLOSURE-DECISION.md
+++ b/.claude/plans/GP-1.3-BUG-FIX-FLOW-RELEASE-CLOSURE-DECISION.md
@@ -1,0 +1,57 @@
+# GP-1.3 — bug_fix_flow Release-Closure Re-Evaluation Decision
+
+**Status:** Completed  
+**Date:** 2026-04-23  
+**Tracker:** [#316](https://github.com/Halildeu/ao-kernel/issues/316)  
+**Issue:** [#322](https://github.com/Halildeu/ao-kernel/issues/322)
+
+## 1. Karar
+
+`bug_fix_flow` release-closure widening kararı bu tranche'te
+**`stay_deferred`** olarak teyit edilmiştir.
+
+## 2. Neden
+
+1. `open_pr` adımı workflow seviyesinde explicit guard
+   (`AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1`) arkasındadır ve bu safety iyileştirmesi
+   tek başına support widening üretmez.
+2. Lane için behavior/evidence zinciri canlıdır, ancak support boundary'de
+   promised bir default live side-effect contract açılmamıştır.
+3. `PB-8.3` closeout kararı (`stay_deferred`) bugün güncel runtime/test/smoke
+   kanıtlarıyla yeniden doğrulanmış ve tersine çevrilmesini gerektirecek yeni
+   bir sinyal bulunmamıştır.
+
+## 3. Canlı Kanıtlar
+
+Çalıştırılan komutlar:
+
+```bash
+python3 -m pytest -q tests/test_multi_step_driver_integration.py -k "open_pr_requires_explicit_live_write_guard or open_pr_failure_preserves_adapter_error_metadata or real_codex_stub_with_mocked_ci_and_open_pr_completes_full_flow"
+python3 -m pytest -q tests/test_executor_integration.py -k "open_pr_step_persists_pr_metadata_and_emits_event"
+python3 -m pytest -q tests/benchmarks/test_governed_bugfix.py tests/benchmarks/test_governed_review.py
+python3 scripts/gh_cli_pr_smoke.py --mode preflight --output json --report-path /tmp/gp13-gh-preflight.report.json
+```
+
+Özet sonuç:
+
+1. `multi_step_driver` hedef testleri: `3 passed`
+2. `executor` `open_pr` metadata/evidence testi: `1 passed`
+3. `governed_bugfix + governed_review` benchmark seti: `10 passed`
+4. `gh-cli-pr` preflight smoke: `overall_status=pass`
+
+Not:
+
+`tests/benchmarks/test_governed_bugfix.py` tek başına çağrıldığında scorecard
+primary-scenario kontrolü nedeniyle finalize aşamasında fail eder; canonical
+komut seti `governed_review` ile birlikte çalıştırılmalıdır.
+
+## 4. Parity Etkisi
+
+1. `docs/PUBLIC-BETA.md` deferred satırı `GP-1.3` teyidi ile hizalıdır.
+2. `docs/SUPPORT-BOUNDARY.md` deferred anlatımı `GP-1.3` teyidi ile hizalıdır.
+3. Status/roadmap aktif hat `GP-1.4`e devredilir.
+
+## 5. Sonraki Hat
+
+Bir sonraki aktif tranche: `GP-1.4` extension promotion tranche
+(`PRJ-CONTEXT-ORCHESTRATION`) — issue [#324](https://github.com/Halildeu/ao-kernel/issues/324).

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -15,11 +15,12 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md` (`PB-8` closeout)
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md`
-- **Aktif decision/ordering contract:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md` (`GP-1.3` active)
+- **Aktif decision/ordering contract:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md` (`GP-1.4` active)
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
 - **PB-9.4 karar notu:** `.claude/plans/PB-9.4-PRODUCTION-CLAIM-DECISION-CLOSEOUT.md`
 - **GP-1.2 karar notu:** `.claude/plans/GP-1.2-GH-CLI-PR-LIVE-WRITE-DISPOSABLE-DECISION.md`
+- **GP-1.3 karar notu:** `.claude/plans/GP-1.3-BUG-FIX-FLOW-RELEASE-CLOSURE-DECISION.md`
 - **GP-1 roadmap:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
@@ -29,7 +30,7 @@ ayrı ayrı görünür kılmak.
 - **PB-8 tracker issue:** [#288](https://github.com/Halildeu/ao-kernel/issues/288) (`closed`)
 - **PB-9 tracker issue:** [#302](https://github.com/Halildeu/ao-kernel/issues/302) (`closed`)
 - **GP-1 tracker issue:** [#316](https://github.com/Halildeu/ao-kernel/issues/316)
-- **Aktif issue:** [#322](https://github.com/Halildeu/ao-kernel/issues/322) (`GP-1.3`)
+- **Aktif issue:** [#324](https://github.com/Halildeu/ao-kernel/issues/324) (`GP-1.4`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -41,8 +42,9 @@ ayrı ayrı görünür kılmak.
   tranche'i tamamlandı ve `PB-8` tracker kapandı; `PB-9.1` prerequisite parity,
   `PB-9.2` truth inventory debt ratchet, `PB-9.3` write/live evidence rehearsal
   ve `PB-9.4` production claim decision closeout dilimleri kapanmıştır.
-- `GP-1` tracker açıldı; `GP-1.2` canlı karar kanıtı ile kapanmış, aktif hat
-  `GP-1.3` bug_fix_flow release-closure re-evaluation dilimidir.
+- `GP-1` tracker açıldı; `GP-1.2` canlı karar kanıtı ile kapanmış,
+  `GP-1.3` `stay_deferred` kararıyla tamamlanmış ve aktif hat `GP-1.4`
+  extension promotion dilimine devredilmiştir.
 - Repo bugün hâlâ genel amaçlı production coding automation platformu değildir;
   bu programın amacı o iddiayı hemen widen etmek değil, önce kalan debt'i
   kontrollü kapatmaktır.
@@ -74,7 +76,7 @@ ayrı ayrı görünür kılmak.
 | `PB-6` general-purpose expansion gap map | Completed on `main` ([#243](https://github.com/Halildeu/ao-kernel/issues/243), [#279](https://github.com/Halildeu/ao-kernel/pull/279)) | narrow beta'dan daha geniş production platform çizgisine geçiş için hangi yüzeylerin neden henüz promoted olmadığını canlı kanıtla sınıflandırmak | written gap map + ordered tranche backlog + PB-6.6 final verdict closeout |
 | `PB-8` general-purpose productionization roadmap | Completed on `main` ([#288](https://github.com/Halildeu/ao-kernel/issues/288), [#300](https://github.com/Halildeu/ao-kernel/pull/300), [#301](https://github.com/Halildeu/ao-kernel/pull/301)) | widening kararlarını tranche bazında kapatmak ve support closeout parity'yi tamamlamak | tracker closeout + docs/runbook/release-gate parity |
 | `PB-9` production claim readiness gates | Completed on `main` ([#302](https://github.com/Halildeu/ao-kernel/issues/302), closed tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303), closed tranche [#306](https://github.com/Halildeu/ao-kernel/issues/306), closed tranche [#309](https://github.com/Halildeu/ao-kernel/issues/309), closed tranche [#312](https://github.com/Halildeu/ao-kernel/issues/312)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | roadmap + decision records + tracker closeout |
-| `GP-1` general-purpose production widening | Active ([#316](https://github.com/Halildeu/ao-kernel/issues/316), active tranche [#322](https://github.com/Halildeu/ao-kernel/issues/322)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde yürütmek | roadmap + active tranche issue + status parity |
+| `GP-1` general-purpose production widening | Active ([#316](https://github.com/Halildeu/ao-kernel/issues/316), active tranche [#324](https://github.com/Halildeu/ao-kernel/issues/324)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde yürütmek | roadmap + active tranche issue + status parity |
 
 ## 5. Şimdi
 
@@ -272,9 +274,9 @@ Not:
 
 `GP-1` yürütmesi aktif.
 
-1. Son kapanan slice: `GP-1.2` `gh-cli-pr` live-write disposable contract
-2. Bugünkü aktif iş: `GP-1.3` `bug_fix_flow` release-closure re-evaluation
-3. Sonraki sıra (planlı): `GP-1.4` extension promotion tranche
+1. Son kapanan slice: `GP-1.3` `bug_fix_flow` release-closure re-evaluation
+2. Bugünkü aktif iş: `GP-1.4` extension promotion tranche
+3. Sonraki sıra (planlı): `GP-1.5` program closeout decision
 
 `PB-8.2` completion kaydı:
 
@@ -443,7 +445,7 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
    `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md`
 2. Tracker issue: [#316](https://github.com/Halildeu/ao-kernel/issues/316) (`open`)
 3. Aktif tranche issue:
-   - [#322](https://github.com/Halildeu/ao-kernel/issues/322) (`GP-1.3`, `open`)
+   - [#324](https://github.com/Halildeu/ao-kernel/issues/324) (`GP-1.4`, `open`)
 4. `GP-1.1` kapsamı:
    - widening authority map and entry gates
    - support widening kararları için non-negotiable gate setini sabitlemek
@@ -457,6 +459,14 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
    - canlı PR kanıtı: [#321](https://github.com/Halildeu/ao-kernel/pull/321) (`draft`, sonra `CLOSED`)
    - karar notu: `.claude/plans/GP-1.2-GH-CLI-PR-LIVE-WRITE-DISPOSABLE-DECISION.md`
    - verdict: `stay_preflight`
-7. Sonraki planlı sıra:
+7. `GP-1.3` completion:
+   - issue: [#322](https://github.com/Halildeu/ao-kernel/issues/322) (`open`, closeout bu tranche merge sonrası)
+   - canlı kanıt: `multi_step_driver` guard/evidence testleri (`3 passed`),
+     executor `open_pr` metadata testi (`1 passed`), benchmark çifti
+     (`bugfix+review`, `10 passed`), `gh-cli-pr` preflight smoke
+     (`/tmp/gp13-gh-preflight.report.json`, `overall_status=pass`)
+   - karar notu: `.claude/plans/GP-1.3-BUG-FIX-FLOW-RELEASE-CLOSURE-DECISION.md`
+   - verdict: `stay_deferred`
+8. Sonraki planlı sıra:
    - `GP-1.4` extension promotion tranche
    - `GP-1.5` program closeout decision

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -89,7 +89,7 @@ Canlı snapshot üretimi için: `python3 scripts/truth_inventory_ratchet.py --ou
 
 | Yüzey | Durum | Not |
 |---|---|---|
-| `bug_fix_flow` release closure | Deferred | `PB-8.3` closeout kararı: `stay_deferred`. Workflow-level `open_pr` adımı explicit opt-in guard (`AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1`) arkasına alındı ve failure metadata/evidence parity güçlendirildi; buna rağmen disposable/live rollback zinciri workflow runtime contract'ında promoted support kapısı değil |
+| `bug_fix_flow` release closure | Deferred | `PB-8.3` closeout kararı (`stay_deferred`) `GP-1.3` re-evaluation ile yeniden doğrulandı. Workflow-level `open_pr` adımı explicit opt-in guard (`AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1`) arkasına alındı ve failure metadata/evidence parity güçlendirildi; buna rağmen disposable/live rollback zinciri workflow runtime contract'ında promoted support kapısı değil |
 | `gh-cli-pr` ile tam E2E PR açılışı | Deferred | Live-write probe create->verify->rollback guard'larıyla güçlense de gerçek remote PR açılışı hâlâ destek vaadi değildir; lane operator-managed/deferred boundary içinde değerlendirilir |
 | `docs/roadmap/DEMO-SCRIPT-SPEC.md` içindeki 11 adımlı üç-adapter akış | Deferred | Canlı destek vaadi değildir |
 | Adapter-path `cost_usd` reconcile | Deferred | Public support claim olarak hâlâ deferred; benchmark/internal runtime hook varlığı bunu tek başına shipped veya beta support yüzeyine yükseltmez |

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -13,7 +13,7 @@ operator-only, or just contract inventory?"
 | Shipped baseline | module entrypoints, `ao-kernel doctor`, bundled `review_ai_flow`, `examples/demo_review.py`, packaging smoke, `PRJ-KERNEL-API` `system_status` / `doc_nav_check` actions | entrypoint checks, doctor, demo review smoke, behavior tests, CI |
 | Beta (operator-managed) | `claude-code-cli` helper-backed lane, `gh-cli-pr` helper-backed preflight + live-write readiness probe lane, `PRJ-KERNEL-API` write-side actions (`project_status`, `roadmap_follow`, `roadmap_finish`) with explicit write contract, real-adapter benchmark full mode | explicit smoke helpers and runbooks |
 | Contract inventory | bundled defaults, manifests, extensions, example inventory | loader/validator and truth audit only |
-| Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary (`PB-8.3` verdict for bug_fix_flow: `stay_deferred`) |
+| Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary (`PB-8.3` verdict `stay_deferred`, `GP-1.3` revalidation ile teyitli) |
 
 ### 1.1 Truth inventory to support mapping
 
@@ -90,8 +90,9 @@ support tier'i widening almadan korunur.
 
 `PB-8.3` ile `bug_fix_flow` içindeki `open_pr` adımı ayrıca workflow-level
 explicit opt-in guard (`AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1`) arkasına
-alınmıştır. Bu guard accidental side-effect riskini düşürür, fakat tek başına
-support boundary widening kararı üretmez; lane deferred kalır.
+alınmıştır. `GP-1.3` re-evaluation, bu durumun kararını değiştirmemiştir.
+Guard accidental side-effect riskini düşürür, fakat tek başına support boundary
+widening kararı üretmez; lane deferred kalır.
 
 ### Contract inventory
 


### PR DESCRIPTION
## Özet
- `GP-1.3` karar notunu ekler: `bug_fix_flow` release-closure verdict `stay_deferred`
- GP-1 roadmap ve status SSOT yüzeyini `GP-1.3 completed -> GP-1.4 active (#324)` şeklinde hizalar
- `PUBLIC-BETA` ve `SUPPORT-BOUNDARY` deferred satırlarını `GP-1.3` revalidation notuyla günceller

## Karar
- `bug_fix_flow` lane için support boundary widening açılmadı (`stay_deferred`)
- Guard/evidence iyileştirmeleri teyitli, ancak promoted live side-effect support contract'ı hâlâ yok

## Kanıt komutları
- `python3 -m pytest -q tests/test_multi_step_driver_integration.py -k "open_pr_requires_explicit_live_write_guard or open_pr_failure_preserves_adapter_error_metadata or real_codex_stub_with_mocked_ci_and_open_pr_completes_full_flow"`
- `python3 -m pytest -q tests/test_executor_integration.py -k "open_pr_step_persists_pr_metadata_and_emits_event"`
- `python3 -m pytest -q tests/benchmarks/test_governed_bugfix.py tests/benchmarks/test_governed_review.py`
- `python3 scripts/gh_cli_pr_smoke.py --mode preflight --output json --report-path /tmp/gp13-gh-preflight.report.json`

## İlişkili issue'lar
- Closes #322
- Activates #324
