### PR TITLE
docs(plan): close GP-1.4 and activate GP-1.5

### DIFF
--- a/.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md
+++ b/.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md
@@ -65,15 +65,18 @@ Amaç, widening'i yalnız kanıt zinciri tamamlandığında açmaktır.
   - `.claude/plans/GP-1.3-BUG-FIX-FLOW-RELEASE-CLOSURE-DECISION.md`
 - Karar: `stay_deferred`
 
-### `GP-1.4` — Extension promotion tranche (`PRJ-CONTEXT-ORCHESTRATION`) (Active)
+### `GP-1.4` — Extension promotion tranche (`PRJ-CONTEXT-ORCHESTRATION`) (Completed)
 
 - Issue: [#324](https://github.com/Halildeu/ao-kernel/issues/324)
 - Hedef: contract-only extension için runtime ownership / handler readiness kanıtı.
 - Ana çıktı: `promotion_candidate` veya `stay_contract_only`.
+- Karar notu:
+  - `.claude/plans/GP-1.4-CONTEXT-ORCHESTRATION-PROMOTION-DECISION.md`
+- Karar: `stay_contract_only`
 
-### `GP-1.5` — Program closeout decision (Planned)
+### `GP-1.5` — Program closeout decision (Active)
 
-- Issue: `pending`
+- Issue: [#326](https://github.com/Halildeu/ao-kernel/issues/326)
 - Hedef: program sonunda widening etkisini tek closeout notunda sabitlemek.
 - Ana çıktı: updated support boundary + tracker closeout.
 

--- a/.claude/plans/GP-1.4-CONTEXT-ORCHESTRATION-PROMOTION-DECISION.md
+++ b/.claude/plans/GP-1.4-CONTEXT-ORCHESTRATION-PROMOTION-DECISION.md
@@ -1,0 +1,61 @@
+# GP-1.4 — PRJ-CONTEXT-ORCHESTRATION Promotion Decision
+
+**Status:** Completed  
+**Date:** 2026-04-23  
+**Tracker:** [#316](https://github.com/Halildeu/ao-kernel/issues/316)  
+**Issue:** [#324](https://github.com/Halildeu/ao-kernel/issues/324)
+
+## 1. Karar
+
+`PRJ-CONTEXT-ORCHESTRATION` için support widening kararı bu tranche'te
+**`stay_contract_only`** olarak sabitlenmiştir.
+
+## 2. Teknik Gerekçe
+
+1. Manifest refs temizdir (`remap_candidate_refs=0`, `missing_runtime_refs=0`)
+   ve truth tier `contract_only` olarak doğrulanır.
+2. Runtime owner/handler hâlâ yoktur:
+   - `ao_kernel/extensions/bootstrap.py` içinde default handler listesinde
+     `PRJ-CONTEXT-ORCHESTRATION` yoktur.
+   - manifestteki `future_handler_contract.module`
+     (`ao_kernel/extensions/handlers/prj_context_orchestration.py`) repo içinde
+     mevcut değildir.
+3. Bu nedenle extension, promotion backlog'ında `promotion_candidate` olarak
+   kalabilir; ancak support boundary genişlemesi için gereken runtime-backed
+   koşulu karşılanmamıştır.
+
+## 3. Canlı Kanıtlar
+
+Çalıştırılan komutlar:
+
+```bash
+python3 -m pytest -q tests/test_extension_loader.py -k "context_orchestration_manifest_is_contract_only_with_clean_refs or truth_summary_pins_kernel_api_promotion_metrics"
+python3 -m pytest -q tests/test_extension_truth_ratchet.py
+python3 -m pytest -q tests/test_doctor_cmd.py
+python3 scripts/truth_inventory_ratchet.py --output json
+python3 -m ao_kernel doctor
+```
+
+Özet sonuç:
+
+1. Extension loader odak testleri: `2 passed`
+2. Truth ratchet test paketi: `4 passed`
+3. Doctor report testi: `1 passed`
+4. Ratchet çıktısı: `promotion_candidate=["PRJ-CONTEXT-ORCHESTRATION"]`
+5. Doctor canlı çıktısı:
+   - `runtime_backed=2`
+   - `contract_only=1`
+   - `quarantined=16`
+
+## 4. Parity Etkisi
+
+1. `docs/PUBLIC-BETA.md` içindeki `PRJ-CONTEXT-ORCHESTRATION` satırı
+   `stay_contract_only` kararıyla hizalanır.
+2. `docs/SUPPORT-BOUNDARY.md` contract inventory anlatımına `GP-1.4`
+   karar notu referansı eklenir.
+3. Program aktif hattı `GP-1.5`e devredilir.
+
+## 5. Sonraki Hat
+
+Bir sonraki aktif tranche: `GP-1.5` program closeout decision —
+issue [#326](https://github.com/Halildeu/ao-kernel/issues/326).

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -15,12 +15,13 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md` (`PB-8` closeout)
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md`
-- **Aktif decision/ordering contract:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md` (`GP-1.4` active)
+- **Aktif decision/ordering contract:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md` (`GP-1.5` active)
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
 - **PB-9.4 karar notu:** `.claude/plans/PB-9.4-PRODUCTION-CLAIM-DECISION-CLOSEOUT.md`
 - **GP-1.2 karar notu:** `.claude/plans/GP-1.2-GH-CLI-PR-LIVE-WRITE-DISPOSABLE-DECISION.md`
 - **GP-1.3 karar notu:** `.claude/plans/GP-1.3-BUG-FIX-FLOW-RELEASE-CLOSURE-DECISION.md`
+- **GP-1.4 karar notu:** `.claude/plans/GP-1.4-CONTEXT-ORCHESTRATION-PROMOTION-DECISION.md`
 - **GP-1 roadmap:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
@@ -30,7 +31,7 @@ ayrı ayrı görünür kılmak.
 - **PB-8 tracker issue:** [#288](https://github.com/Halildeu/ao-kernel/issues/288) (`closed`)
 - **PB-9 tracker issue:** [#302](https://github.com/Halildeu/ao-kernel/issues/302) (`closed`)
 - **GP-1 tracker issue:** [#316](https://github.com/Halildeu/ao-kernel/issues/316)
-- **Aktif issue:** [#324](https://github.com/Halildeu/ao-kernel/issues/324) (`GP-1.4`)
+- **Aktif issue:** [#326](https://github.com/Halildeu/ao-kernel/issues/326) (`GP-1.5`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -43,8 +44,9 @@ ayrı ayrı görünür kılmak.
   `PB-9.2` truth inventory debt ratchet, `PB-9.3` write/live evidence rehearsal
   ve `PB-9.4` production claim decision closeout dilimleri kapanmıştır.
 - `GP-1` tracker açıldı; `GP-1.2` canlı karar kanıtı ile kapanmış,
-  `GP-1.3` `stay_deferred` kararıyla tamamlanmış ve aktif hat `GP-1.4`
-  extension promotion dilimine devredilmiştir.
+  `GP-1.3` `stay_deferred` kararıyla tamamlanmış, `GP-1.4`
+  `stay_contract_only` kararıyla kapanmış ve aktif hat `GP-1.5`
+  program closeout dilimine devredilmiştir.
 - Repo bugün hâlâ genel amaçlı production coding automation platformu değildir;
   bu programın amacı o iddiayı hemen widen etmek değil, önce kalan debt'i
   kontrollü kapatmaktır.
@@ -76,7 +78,7 @@ ayrı ayrı görünür kılmak.
 | `PB-6` general-purpose expansion gap map | Completed on `main` ([#243](https://github.com/Halildeu/ao-kernel/issues/243), [#279](https://github.com/Halildeu/ao-kernel/pull/279)) | narrow beta'dan daha geniş production platform çizgisine geçiş için hangi yüzeylerin neden henüz promoted olmadığını canlı kanıtla sınıflandırmak | written gap map + ordered tranche backlog + PB-6.6 final verdict closeout |
 | `PB-8` general-purpose productionization roadmap | Completed on `main` ([#288](https://github.com/Halildeu/ao-kernel/issues/288), [#300](https://github.com/Halildeu/ao-kernel/pull/300), [#301](https://github.com/Halildeu/ao-kernel/pull/301)) | widening kararlarını tranche bazında kapatmak ve support closeout parity'yi tamamlamak | tracker closeout + docs/runbook/release-gate parity |
 | `PB-9` production claim readiness gates | Completed on `main` ([#302](https://github.com/Halildeu/ao-kernel/issues/302), closed tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303), closed tranche [#306](https://github.com/Halildeu/ao-kernel/issues/306), closed tranche [#309](https://github.com/Halildeu/ao-kernel/issues/309), closed tranche [#312](https://github.com/Halildeu/ao-kernel/issues/312)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | roadmap + decision records + tracker closeout |
-| `GP-1` general-purpose production widening | Active ([#316](https://github.com/Halildeu/ao-kernel/issues/316), active tranche [#324](https://github.com/Halildeu/ao-kernel/issues/324)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde yürütmek | roadmap + active tranche issue + status parity |
+| `GP-1` general-purpose production widening | Active ([#316](https://github.com/Halildeu/ao-kernel/issues/316), active tranche [#326](https://github.com/Halildeu/ao-kernel/issues/326)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde yürütmek | roadmap + active tranche issue + status parity |
 
 ## 5. Şimdi
 
@@ -274,9 +276,9 @@ Not:
 
 `GP-1` yürütmesi aktif.
 
-1. Son kapanan slice: `GP-1.3` `bug_fix_flow` release-closure re-evaluation
-2. Bugünkü aktif iş: `GP-1.4` extension promotion tranche
-3. Sonraki sıra (planlı): `GP-1.5` program closeout decision
+1. Son kapanan slice: `GP-1.4` extension promotion tranche
+2. Bugünkü aktif iş: `GP-1.5` program closeout decision
+3. Sonraki sıra (planlı): GP-1 tracker closeout (`#316`)
 
 `PB-8.2` completion kaydı:
 
@@ -445,7 +447,7 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
    `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md`
 2. Tracker issue: [#316](https://github.com/Halildeu/ao-kernel/issues/316) (`open`)
 3. Aktif tranche issue:
-   - [#324](https://github.com/Halildeu/ao-kernel/issues/324) (`GP-1.4`, `open`)
+   - [#326](https://github.com/Halildeu/ao-kernel/issues/326) (`GP-1.5`, `open`)
 4. `GP-1.1` kapsamı:
    - widening authority map and entry gates
    - support widening kararları için non-negotiable gate setini sabitlemek
@@ -460,13 +462,21 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
    - karar notu: `.claude/plans/GP-1.2-GH-CLI-PR-LIVE-WRITE-DISPOSABLE-DECISION.md`
    - verdict: `stay_preflight`
 7. `GP-1.3` completion:
-   - issue: [#322](https://github.com/Halildeu/ao-kernel/issues/322) (`open`, closeout bu tranche merge sonrası)
+   - issue: [#322](https://github.com/Halildeu/ao-kernel/issues/322) (`closed`)
    - canlı kanıt: `multi_step_driver` guard/evidence testleri (`3 passed`),
      executor `open_pr` metadata testi (`1 passed`), benchmark çifti
      (`bugfix+review`, `10 passed`), `gh-cli-pr` preflight smoke
      (`/tmp/gp13-gh-preflight.report.json`, `overall_status=pass`)
    - karar notu: `.claude/plans/GP-1.3-BUG-FIX-FLOW-RELEASE-CLOSURE-DECISION.md`
    - verdict: `stay_deferred`
-8. Sonraki planlı sıra:
-   - `GP-1.4` extension promotion tranche
+8. `GP-1.4` completion:
+   - issue: [#324](https://github.com/Halildeu/ao-kernel/issues/324) (`open`, closeout bu tranche merge sonrası)
+   - canlı kanıt: extension loader (`2 passed`), truth ratchet (`4 passed`),
+     doctor report testi (`1 passed`), `truth_inventory_ratchet`
+     (`promotion_candidate=["PRJ-CONTEXT-ORCHESTRATION"]`) ve canlı doctor
+     (`runtime_backed=2`, `contract_only=1`, `quarantined=16`)
+   - karar notu: `.claude/plans/GP-1.4-CONTEXT-ORCHESTRATION-PROMOTION-DECISION.md`
+   - verdict: `stay_contract_only`
+9. Sonraki planlı sıra:
    - `GP-1.5` program closeout decision
+   - GP-1 tracker closeout (`#316`)

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -117,6 +117,7 @@ Canlı snapshot üretimi için: `python3 scripts/truth_inventory_ratchet.py --ou
   explicit write contract ile Beta (operator-managed) satırındadır.
   `PRJ-CONTEXT-ORCHESTRATION` bugün contract-only katmandadır
   (manifest/contract cleanup sonrası, runtime handler hâlâ yoktur);
+  `GP-1.4` kararı da bu sınırı değiştirmemiştir (`stay_contract_only`).
   kalan manifestler doctor truth audit'inde quarantined olarak görülebilir.
 - Bu doküman, ao-kernel'in genel amaçlı bir production coding automation
   platformu olduğunu iddia etmez; destek vaadi dar ve açıkça tablolanmış

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -105,6 +105,8 @@ These may be bundled and schema-valid without being end-to-end supported:
 
 `PRJ-KERNEL-API` write-side actions runtime-backed olsa da shipped baseline
 değildir; support tier yalnız Beta (operator-managed) satırı kadar genişler.
+`PRJ-CONTEXT-ORCHESTRATION` için `GP-1.4` kararı `stay_contract_only` olduğu
+için bu extension contract inventory katmanında kalır; support widening yoktur.
 
 ## 3. What does NOT automatically widen support
 


### PR DESCRIPTION
## Özet
- `GP-1.4` karar notunu ekler ve `PRJ-CONTEXT-ORCHESTRATION` için verdict'i `stay_contract_only` olarak sabitler
- GP-1 roadmap/status SSOT'u `GP-1.4 completed -> GP-1.5 active (#326)` hizasına çeker
- `PUBLIC-BETA` ve `SUPPORT-BOUNDARY` üzerinde context-orchestration satırlarını GP-1.4 kararıyla parity yapar

## Karar
- Support widening açılmadı (`stay_contract_only`)
- Extension clean contract refs ile `promotion_candidate` backlog'ında kalır, ancak runtime owner/handler yokluğu nedeniyle contract inventory katmanında kalmaya devam eder

## Kanıt komutları
- `python3 -m pytest -q tests/test_extension_loader.py -k "context_orchestration_manifest_is_contract_only_with_clean_refs or truth_summary_pins_kernel_api_promotion_metrics"`
- `python3 -m pytest -q tests/test_extension_truth_ratchet.py`
- `python3 -m pytest -q tests/test_doctor_cmd.py`
- `python3 scripts/truth_inventory_ratchet.py --output json`
- `python3 -m ao_kernel doctor`

## İlişkili issue'lar
- Closes #324
- Activates #326
