### PR TITLE
docs(plan): close GP-1 program with final decision record

### DIFF
--- a/.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md
+++ b/.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md
@@ -1,6 +1,6 @@
 # GP-1 — General-Purpose Production Widening Program
 
-**Status:** Active  
+**Status:** Completed  
 **Date:** 2026-04-23  
 **Tracker:** [#316](https://github.com/Halildeu/ao-kernel/issues/316)  
 **Execution mode:** Kapsam disiplini, tek aktif runtime tranche
@@ -74,11 +74,14 @@ Amaç, widening'i yalnız kanıt zinciri tamamlandığında açmaktır.
   - `.claude/plans/GP-1.4-CONTEXT-ORCHESTRATION-PROMOTION-DECISION.md`
 - Karar: `stay_contract_only`
 
-### `GP-1.5` — Program closeout decision (Active)
+### `GP-1.5` — Program closeout decision (Completed)
 
 - Issue: [#326](https://github.com/Halildeu/ao-kernel/issues/326)
 - Hedef: program sonunda widening etkisini tek closeout notunda sabitlemek.
 - Ana çıktı: updated support boundary + tracker closeout.
+- Karar notu:
+  - `.claude/plans/GP-1.5-PROGRAM-CLOSEOUT-DECISION.md`
+- Karar: program closed (`stay_beta_operator_managed`)
 
 ## Başarı Kriterleri
 
@@ -98,6 +101,6 @@ Amaç, widening'i yalnız kanıt zinciri tamamlandığında açmaktır.
 
 ## Program Kapanış Koşulu
 
-1. `GP-1.1..GP-1.5` için karar kayıtları tamamlanır.
-2. `POST-BETA-CORRECTNESS-EXPANSION-STATUS.md` aktif hattı kapatır.
-3. Tracker [#316](https://github.com/Halildeu/ao-kernel/issues/316) kapanır.
+1. `GP-1.1..GP-1.5` için karar kayıtları tamamlandı.
+2. `POST-BETA-CORRECTNESS-EXPANSION-STATUS.md` aktif hattı kapattı.
+3. Tracker [#316](https://github.com/Halildeu/ao-kernel/issues/316) bu tranche ile kapatılır.

--- a/.claude/plans/GP-1.5-PROGRAM-CLOSEOUT-DECISION.md
+++ b/.claude/plans/GP-1.5-PROGRAM-CLOSEOUT-DECISION.md
@@ -1,0 +1,62 @@
+# GP-1.5 — Program Closeout Decision
+
+**Status:** Completed  
+**Date:** 2026-04-23  
+**Tracker:** [#316](https://github.com/Halildeu/ao-kernel/issues/316)  
+**Issue:** [#326](https://github.com/Halildeu/ao-kernel/issues/326)
+
+## 1. Karar
+
+`GP-1` general-purpose production widening programı bu tranche sonunda
+**kapanmıştır**.
+
+Final verdict:
+
+1. public support boundary genişlememiştir,
+2. program sonucu `stay_beta_operator_managed` çizgisini korur,
+3. `GP-1` tracker close edilir.
+
+## 2. Dilim Bazlı Sonuç Matrisi
+
+| Dilim | Karar | Etki |
+|---|---|---|
+| `GP-1.1` authority map | completed | widening kapıları authoritative hale getirildi |
+| `GP-1.2` `gh-cli-pr` live-write disposable contract | `stay_preflight` | live-write promote edilmedi; preflight boundary korundu |
+| `GP-1.3` `bug_fix_flow` re-evaluation | `stay_deferred` | workflow-level guard/evidence iyileşti, support widening açılmadı |
+| `GP-1.4` context orchestration promotion | `stay_contract_only` | extension candidate kaldı, runtime-backed support açılmadı |
+| `GP-1.5` program closeout | completed | tracker kapanışı + status parity finalize |
+
+## 3. Kapanış Kanıtları
+
+Program closeout sırasında tekrar doğrulanan komutlar:
+
+```bash
+python3 -m ao_kernel doctor
+python3 scripts/truth_inventory_ratchet.py --output json
+```
+
+Özet:
+
+1. `doctor`: `8 OK, 1 WARN, 0 FAIL`
+2. extension truth: `runtime_backed=2`, `contract_only=1`, `quarantined=16`
+3. ratchet queue: `promotion_candidate=["PRJ-CONTEXT-ORCHESTRATION"]`
+
+Bu sinyal, GP-1 sonunda support widening yerine controlled backlog
+yaklaşımını doğrular.
+
+## 4. Parity Sonucu
+
+1. roadmap + status + support docs aynı boundary mesajını verir:
+   - shipped baseline dar
+   - operator-managed beta lane'leri kontrollü
+   - deferred/contract-only satırları explicit
+2. `PRJ-CONTEXT-ORCHESTRATION` hâlâ contract inventory katmanındadır.
+3. `bug_fix_flow` release closure hâlâ deferred satırındadır.
+
+## 5. Kapanış Hükmü
+
+`GP-1` program kapanış koşulları sağlandı:
+
+1. `GP-1.1..GP-1.5` karar kayıtları tamamlandı.
+2. status dosyasında aktif hat kapatıldı.
+3. tracker [#316](https://github.com/Halildeu/ao-kernel/issues/316) close edilir.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -15,13 +15,14 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md` (`PB-8` closeout)
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md`
-- **Aktif decision/ordering contract:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md` (`GP-1.5` active)
+- **Aktif decision/ordering contract:** `none` (`GP-1 closed`)
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
 - **PB-9.4 karar notu:** `.claude/plans/PB-9.4-PRODUCTION-CLAIM-DECISION-CLOSEOUT.md`
 - **GP-1.2 karar notu:** `.claude/plans/GP-1.2-GH-CLI-PR-LIVE-WRITE-DISPOSABLE-DECISION.md`
 - **GP-1.3 karar notu:** `.claude/plans/GP-1.3-BUG-FIX-FLOW-RELEASE-CLOSURE-DECISION.md`
 - **GP-1.4 karar notu:** `.claude/plans/GP-1.4-CONTEXT-ORCHESTRATION-PROMOTION-DECISION.md`
+- **GP-1.5 karar notu:** `.claude/plans/GP-1.5-PROGRAM-CLOSEOUT-DECISION.md`
 - **GP-1 roadmap:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
@@ -30,8 +31,8 @@ ayrı ayrı görünür kılmak.
 - **PB-6 umbrella issue:** [#243](https://github.com/Halildeu/ao-kernel/issues/243)
 - **PB-8 tracker issue:** [#288](https://github.com/Halildeu/ao-kernel/issues/288) (`closed`)
 - **PB-9 tracker issue:** [#302](https://github.com/Halildeu/ao-kernel/issues/302) (`closed`)
-- **GP-1 tracker issue:** [#316](https://github.com/Halildeu/ao-kernel/issues/316)
-- **Aktif issue:** [#326](https://github.com/Halildeu/ao-kernel/issues/326) (`GP-1.5`)
+- **GP-1 tracker issue:** [#316](https://github.com/Halildeu/ao-kernel/issues/316) (`closed`)
+- **Aktif issue:** `none` (`GP-1 closeout tamamlandı`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -43,10 +44,8 @@ ayrı ayrı görünür kılmak.
   tranche'i tamamlandı ve `PB-8` tracker kapandı; `PB-9.1` prerequisite parity,
   `PB-9.2` truth inventory debt ratchet, `PB-9.3` write/live evidence rehearsal
   ve `PB-9.4` production claim decision closeout dilimleri kapanmıştır.
-- `GP-1` tracker açıldı; `GP-1.2` canlı karar kanıtı ile kapanmış,
-  `GP-1.3` `stay_deferred` kararıyla tamamlanmış, `GP-1.4`
-  `stay_contract_only` kararıyla kapanmış ve aktif hat `GP-1.5`
-  program closeout dilimine devredilmiştir.
+- `GP-1` tracker kapanmıştır; `GP-1.1..GP-1.5` kararları tamamlanmış ve
+  support boundary `stay_beta_operator_managed` çizgisinde korunmuştur.
 - Repo bugün hâlâ genel amaçlı production coding automation platformu değildir;
   bu programın amacı o iddiayı hemen widen etmek değil, önce kalan debt'i
   kontrollü kapatmaktır.
@@ -78,7 +77,7 @@ ayrı ayrı görünür kılmak.
 | `PB-6` general-purpose expansion gap map | Completed on `main` ([#243](https://github.com/Halildeu/ao-kernel/issues/243), [#279](https://github.com/Halildeu/ao-kernel/pull/279)) | narrow beta'dan daha geniş production platform çizgisine geçiş için hangi yüzeylerin neden henüz promoted olmadığını canlı kanıtla sınıflandırmak | written gap map + ordered tranche backlog + PB-6.6 final verdict closeout |
 | `PB-8` general-purpose productionization roadmap | Completed on `main` ([#288](https://github.com/Halildeu/ao-kernel/issues/288), [#300](https://github.com/Halildeu/ao-kernel/pull/300), [#301](https://github.com/Halildeu/ao-kernel/pull/301)) | widening kararlarını tranche bazında kapatmak ve support closeout parity'yi tamamlamak | tracker closeout + docs/runbook/release-gate parity |
 | `PB-9` production claim readiness gates | Completed on `main` ([#302](https://github.com/Halildeu/ao-kernel/issues/302), closed tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303), closed tranche [#306](https://github.com/Halildeu/ao-kernel/issues/306), closed tranche [#309](https://github.com/Halildeu/ao-kernel/issues/309), closed tranche [#312](https://github.com/Halildeu/ao-kernel/issues/312)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | roadmap + decision records + tracker closeout |
-| `GP-1` general-purpose production widening | Active ([#316](https://github.com/Halildeu/ao-kernel/issues/316), active tranche [#326](https://github.com/Halildeu/ao-kernel/issues/326)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde yürütmek | roadmap + active tranche issue + status parity |
+| `GP-1` general-purpose production widening | Completed on `main` ([#316](https://github.com/Halildeu/ao-kernel/issues/316), [#327](https://github.com/Halildeu/ao-kernel/pull/327), [#326](https://github.com/Halildeu/ao-kernel/issues/326)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde tamamlamak | GP-1.1..GP-1.5 decision records + closeout parity |
 
 ## 5. Şimdi
 
@@ -274,11 +273,11 @@ Not:
 
 ## 8. Anlık Öncelik
 
-`GP-1` yürütmesi aktif.
+Aktif runtime/program slice yok.
 
-1. Son kapanan slice: `GP-1.4` extension promotion tranche
-2. Bugünkü aktif iş: `GP-1.5` program closeout decision
-3. Sonraki sıra (planlı): GP-1 tracker closeout (`#316`)
+1. Son kapanan slice: `GP-1.5` program closeout decision
+2. `GP-1` programı tamamlandı (`#316` closed)
+3. Sonraki sıra: yeni program/tranche açılmadan önce backlog reprioritization
 
 `PB-8.2` completion kaydı:
 
@@ -439,44 +438,34 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
    - active tranche yok
    - yeni widening/program hattı ayrı tracker ile açılacak
 
-## 14. GP-1 Kickoff
+## 14. GP-1 Closeout Snapshot
 
-`PB-9` closeout sonrası yeni aktif widening hattı `GP-1` olarak açıldı.
+`GP-1` programı kapanmıştır.
 
 1. Program roadmap:
    `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md`
-2. Tracker issue: [#316](https://github.com/Halildeu/ao-kernel/issues/316) (`open`)
-3. Aktif tranche issue:
-   - [#326](https://github.com/Halildeu/ao-kernel/issues/326) (`GP-1.5`, `open`)
-4. `GP-1.1` kapsamı:
-   - widening authority map and entry gates
-   - support widening kararları için non-negotiable gate setini sabitlemek
-5. `GP-1.1` completion:
+2. Tracker issue: [#316](https://github.com/Halildeu/ao-kernel/issues/316) (`closed`)
+3. `GP-1.1` completion:
    - issue: [#315](https://github.com/Halildeu/ao-kernel/issues/315) (`closed`)
    - PR: [#317](https://github.com/Halildeu/ao-kernel/pull/317)
-   - merge commit: `9c4ca53`
-6. `GP-1.2` completion:
+   - verdict: authority gate map completed
+4. `GP-1.2` completion:
    - issue: [#318](https://github.com/Halildeu/ao-kernel/issues/318) (`closed`)
-   - canlı kanıt: preflight (`/tmp/gp12-gh-preflight.report.json`), fail-closed guard (`/tmp/gp12-gh-livewrite-guard.report.json`), controlled live-write chain (`/tmp/gp12-gh-livewrite-pass.report.json`)
-   - canlı PR kanıtı: [#321](https://github.com/Halildeu/ao-kernel/pull/321) (`draft`, sonra `CLOSED`)
    - karar notu: `.claude/plans/GP-1.2-GH-CLI-PR-LIVE-WRITE-DISPOSABLE-DECISION.md`
    - verdict: `stay_preflight`
-7. `GP-1.3` completion:
+5. `GP-1.3` completion:
    - issue: [#322](https://github.com/Halildeu/ao-kernel/issues/322) (`closed`)
-   - canlı kanıt: `multi_step_driver` guard/evidence testleri (`3 passed`),
-     executor `open_pr` metadata testi (`1 passed`), benchmark çifti
-     (`bugfix+review`, `10 passed`), `gh-cli-pr` preflight smoke
-     (`/tmp/gp13-gh-preflight.report.json`, `overall_status=pass`)
    - karar notu: `.claude/plans/GP-1.3-BUG-FIX-FLOW-RELEASE-CLOSURE-DECISION.md`
    - verdict: `stay_deferred`
-8. `GP-1.4` completion:
-   - issue: [#324](https://github.com/Halildeu/ao-kernel/issues/324) (`open`, closeout bu tranche merge sonrası)
-   - canlı kanıt: extension loader (`2 passed`), truth ratchet (`4 passed`),
-     doctor report testi (`1 passed`), `truth_inventory_ratchet`
-     (`promotion_candidate=["PRJ-CONTEXT-ORCHESTRATION"]`) ve canlı doctor
-     (`runtime_backed=2`, `contract_only=1`, `quarantined=16`)
+6. `GP-1.4` completion:
+   - issue: [#324](https://github.com/Halildeu/ao-kernel/issues/324) (`closed`)
    - karar notu: `.claude/plans/GP-1.4-CONTEXT-ORCHESTRATION-PROMOTION-DECISION.md`
    - verdict: `stay_contract_only`
-9. Sonraki planlı sıra:
-   - `GP-1.5` program closeout decision
-   - GP-1 tracker closeout (`#316`)
+7. `GP-1.5` completion:
+   - issue: [#326](https://github.com/Halildeu/ao-kernel/issues/326) (`closed`)
+   - karar notu: `.claude/plans/GP-1.5-PROGRAM-CLOSEOUT-DECISION.md`
+   - verdict: program closed (`stay_beta_operator_managed`)
+8. Closeout sonucu:
+   - aktif tranche yok
+   - support boundary genişletilmedi
+   - yeni widening hattı için ayrı tracker açılmadan program tekrar açılmaz

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -118,6 +118,8 @@ Canlı snapshot üretimi için: `python3 scripts/truth_inventory_ratchet.py --ou
   `PRJ-CONTEXT-ORCHESTRATION` bugün contract-only katmandadır
   (manifest/contract cleanup sonrası, runtime handler hâlâ yoktur);
   `GP-1.4` kararı da bu sınırı değiştirmemiştir (`stay_contract_only`).
+- `GP-1.5` program closeout kararı support boundary'yi widen etmemiştir;
+  genel hüküm `stay_beta_operator_managed` çizgisinin korunmasıdır.
   kalan manifestler doctor truth audit'inde quarantined olarak görülebilir.
 - Bu doküman, ao-kernel'in genel amaçlı bir production coding automation
   platformu olduğunu iddia etmez; destek vaadi dar ve açıkça tablolanmış

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -107,6 +107,8 @@ These may be bundled and schema-valid without being end-to-end supported:
 değildir; support tier yalnız Beta (operator-managed) satırı kadar genişler.
 `PRJ-CONTEXT-ORCHESTRATION` için `GP-1.4` kararı `stay_contract_only` olduğu
 için bu extension contract inventory katmanında kalır; support widening yoktur.
+`GP-1.5` program closeout kararı da boundary'yi widen etmemiştir; genel çizgi
+`stay_beta_operator_managed` olarak korunur.
 
 ## 3. What does NOT automatically widen support
 


### PR DESCRIPTION
## Özet
- `GP-1.5` karar notunu ekler ve GP-1 program closeout hükmünü yazılı hale getirir
- GP-1 roadmap/status yüzeylerini `Completed` durumuna çeker
- `PUBLIC-BETA` ve `SUPPORT-BOUNDARY` üzerinde GP-1.5 parity notlarını ekler (boundary widening yok)

## Final karar
- Program verdict: `stay_beta_operator_managed`
- GP-1 kapsamı (`GP-1.1..GP-1.5`) kapanmıştır
- Yeni widening hattı için ayrı tracker açılmadan program yeniden aktif edilmez

## Kanıtlar
- `python3 -m ao_kernel doctor`
- `python3 scripts/truth_inventory_ratchet.py --output json`
- `python3 -m pytest -q tests/test_doctor_cmd.py tests/test_extension_truth_ratchet.py`

## İlişkili issue'lar
Closes #326
Closes #316
