### PR TITLE
[codex] docs(plan): GP-2.1 deferred lane evidence-delta ordering

### DIFF
--- a/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
+++ b/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
@@ -30,9 +30,12 @@ giriş kapılarını netleştirmektir.
 
 ### `GP-2.1` — Deferred lane evidence-delta map (Active)
 
+- Issue: [#331](https://github.com/Halildeu/ao-kernel/issues/331)
 - Hedef: her deferred satır için mevcut kanıt, kalan kanıt boşluğu, risk seviyesi
   ve promotion önkoşulunu tek tabloda toplamak.
 - Çıktı: `Now / Next / Later` sırası + ilk uygulanabilir tranche önerisi.
+- Decision record:
+  `.claude/plans/GP-2.1-DEFERRED-LANE-EVIDENCE-DELTA-MAP.md`
 - DoD:
   1. Deferred lane tablosu tek anlamlı hale gelir.
   2. İlk aktif runtime tranche açıkça seçilir.
@@ -42,6 +45,7 @@ giriş kapılarını netleştirmektir.
 
 - Hedef: `GP-2.1` çıktısındaki ilk lane'i dar kapsamlı bir implementation dilimi
   olarak başlatmak.
+- Current candidate lane (from `GP-2.1`): adapter-path `cost_usd` reconcile completeness.
 - Kural: yalnız bir lane açılır; diğer deferred satırlar status dosyasında
   `deferred` olarak kalır.
 

--- a/.claude/plans/GP-2.1-DEFERRED-LANE-EVIDENCE-DELTA-MAP.md
+++ b/.claude/plans/GP-2.1-DEFERRED-LANE-EVIDENCE-DELTA-MAP.md
@@ -1,0 +1,42 @@
+# GP-2.1 — Deferred Lane Evidence-Delta Map
+
+**Status:** Active  
+**Date:** 2026-04-23  
+**Tracker:** [#331](https://github.com/Halildeu/ao-kernel/issues/331)  
+**Parent program:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
+
+## Amaç
+
+`PUBLIC-BETA` içinde deferred kalan lane'leri kanıt boşluğu bazında sıralamak
+ve ilk dar runtime slice'ı tek anlamlı seçmek.
+
+## Authoritative Inputs
+
+1. `docs/PUBLIC-BETA.md` (Deferred + Known Bugs satırları)
+2. `docs/SUPPORT-BOUNDARY.md` (support tier ve deferred sınırı)
+3. `docs/KNOWN-BUGS.md` (operator lane kırıkları)
+4. `python3 scripts/truth_inventory_ratchet.py --output json` (truth/debt queue)
+
+## Deferred Lane Evidence-Delta Tablosu
+
+| Lane | Mevcut kanıt | Eksik kanıt (delta) | Risk | Promotion önkoşulu | Sıra |
+|---|---|---|---|---|---|
+| Adapter-path `cost_usd` reconcile | `PB-5` closeout ile docs parity + internal hook varlığı doğrulandı | transport/adaptör katmanında deterministic maliyet reconcile davranışını pinleyen integration test + evidence assertion paketi yok | Orta | side-effect üretmeyen maliyet kanıtı + behavior test + docs parity | **Now** |
+| `gh-cli-pr` tam E2E remote PR açılışı | preflight + live-write probe + rollback guard mevcut; operator runbook'lar var | disposable sandbox dışı ortamda güvenli create->verify->rollback zincirini üretim şartlarında tekrar eden kanıt yok | Yüksek | disposable repo policy + rollback drill + incident runbook rehearsal | **Next** |
+| `bug_fix_flow` release closure | workflow-level guard (`AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1`) ve metadata/evidence parity güçlendirildi | gerçek adapter lane ile E2E release closure güvence kanıtı, `gh-cli-pr` live write güvenilirliğiyle bağlı | Yüksek | `gh-cli-pr` E2E lane olgunluğu + bug_fix_flow integration kanıtı | **Later** |
+| `DEMO-SCRIPT-SPEC` üç-adapter akışın canlı support'e alınması | dosya roadmap/spec olarak işaretli, compatibility stub korunuyor | production support boundary için runtime-backed adapter zinciri ve operasyonel runbook yok | Düşük/Orta | spec'i canlı claim'e çevirecek ayrı ürünleşme kararı | **Later (spec-only)** |
+
+## Ordering Kararı
+
+1. **Now:** `Adapter-path cost_usd reconcile` lane'i için dar runtime/evidence completeness slice aç.
+2. **Next:** `gh-cli-pr` full E2E live remote PR opening lane'i disposable guard ve rollback kanıtıyla tekrar değerlendir.
+3. **Later:** `bug_fix_flow` release closure ve `DEMO-SCRIPT-SPEC` widening kararları, yukarıdaki lane sonuçlarına bağlı yürütülür.
+
+## First Runtime Slice Adayı
+
+- **Aday:** `GP-2.2` altında `cost_usd` reconcile completeness tranche'i
+- **Sınır:** support boundary widening yok; amaç yalnız runtime/evidence parity gap'i kapatmak
+- **Başarı ölçütü:**
+  1. deterministic reconcile testleri
+  2. evidence payload içinde `cost_usd` uyum kanıtı
+  3. PUBLIC-BETA deferred satır notunun güncellenebilir hale gelmesi

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -15,7 +15,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md` (`PB-8` closeout)
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
-- **Aktif decision/ordering contract:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md` (`GP-2.1 active`)
+- **Aktif decision/ordering contract:** `.claude/plans/GP-2.1-DEFERRED-LANE-EVIDENCE-DELTA-MAP.md` (`GP-2.1 active`)
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
 - **PB-9.4 karar notu:** `.claude/plans/PB-9.4-PRODUCTION-CLAIM-DECISION-CLOSEOUT.md`
@@ -25,6 +25,7 @@ ayrı ayrı görünür kılmak.
 - **GP-1.5 karar notu:** `.claude/plans/GP-1.5-PROGRAM-CLOSEOUT-DECISION.md`
 - **GP-1 roadmap:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md`
 - **GP-2 roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
+- **GP-2.1 karar notu:** `.claude/plans/GP-2.1-DEFERRED-LANE-EVIDENCE-DELTA-MAP.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
@@ -34,7 +35,8 @@ ayrı ayrı görünür kılmak.
 - **PB-9 tracker issue:** [#302](https://github.com/Halildeu/ao-kernel/issues/302) (`closed`)
 - **GP-1 tracker issue:** [#316](https://github.com/Halildeu/ao-kernel/issues/316) (`closed`)
 - **GP-2 tracker issue:** [#329](https://github.com/Halildeu/ao-kernel/issues/329) (`open`)
-- **Aktif issue:** [#329](https://github.com/Halildeu/ao-kernel/issues/329) (`GP-2.1 active`)
+- **GP-2.1 issue:** [#331](https://github.com/Halildeu/ao-kernel/issues/331) (`open`)
+- **Aktif issue:** [#331](https://github.com/Halildeu/ao-kernel/issues/331) (`GP-2.1 active`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -489,3 +491,18 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
 5. Sınır:
    - bu kickoff dilimi runtime widening implementasyonu içermez
    - support boundary kararı yalnız yazılı kanıt/karar notu ile güncellenir
+
+## 16. GP-2.1 Active Snapshot
+
+`GP-2` kickoff sonrası aktif ordering tranche `GP-2.1`e indirildi.
+
+1. Issue: [#331](https://github.com/Halildeu/ao-kernel/issues/331) (`open`)
+2. Active contract:
+   `.claude/plans/GP-2.1-DEFERRED-LANE-EVIDENCE-DELTA-MAP.md`
+3. Ordering verdict:
+   - `Now`: adapter-path `cost_usd` reconcile completeness
+   - `Next`: `gh-cli-pr` full E2E live remote PR opening
+   - `Later`: `bug_fix_flow` release closure + `DEMO-SCRIPT-SPEC` widening
+4. Next implementation start condition:
+   - `GP-2.2` için tek issue/branch açılacak
+   - ilk runtime slice yalnız `cost_usd` evidence parity kapsamıyla sınırlı kalacak


### PR DESCRIPTION
## Summary
- add `GP-2.1` decision record with deferred lane evidence-delta map
- define `Now / Next / Later` ordering and first runtime slice candidate (`cost_usd` reconcile completeness)
- update `GP-2` roadmap and status SSOT active issue/contract pointers to `#331`

Closes #331

## Validation
- `python3 scripts/truth_inventory_ratchet.py --output json`
