### PR TITLE
[codex] docs(plan): kick off GP-2.2 cost reconcile tranche

### DIFF
--- a/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
+++ b/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
@@ -28,7 +28,7 @@ giriş kapılarını netleştirmektir.
 
 ## Tranche Sırası
 
-### `GP-2.1` — Deferred lane evidence-delta map (Active)
+### `GP-2.1` — Deferred lane evidence-delta map (Completed)
 
 - Issue: [#331](https://github.com/Halildeu/ao-kernel/issues/331)
 - Hedef: her deferred satır için mevcut kanıt, kalan kanıt boşluğu, risk seviyesi
@@ -40,11 +40,14 @@ giriş kapılarını netleştirmektir.
   1. Deferred lane tablosu tek anlamlı hale gelir.
   2. İlk aktif runtime tranche açıkça seçilir.
   3. Seçilen tranche için tek issue + tek contract referansı üretilir.
+- Kapanış: [#331](https://github.com/Halildeu/ao-kernel/issues/331) closed, PR [#332](https://github.com/Halildeu/ao-kernel/pull/332)
 
-### `GP-2.2` — First runtime slice kickoff (Pending)
+### `GP-2.2` — First runtime slice kickoff (Active)
 
-- Hedef: `GP-2.1` çıktısındaki ilk lane'i dar kapsamlı bir implementation dilimi
-  olarak başlatmak.
+- Issue: [#333](https://github.com/Halildeu/ao-kernel/issues/333)
+- Contract:
+  `.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md`
+- Hedef: `GP-2.1` çıktısındaki ilk lane'i dar kapsamlı bir implementation dilimi olarak başlatmak.
 - Current candidate lane (from `GP-2.1`): adapter-path `cost_usd` reconcile completeness.
 - Kural: yalnız bir lane açılır; diğer deferred satırlar status dosyasında
   `deferred` olarak kalır.

--- a/.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md
+++ b/.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md
@@ -1,0 +1,64 @@
+# GP-2.2 — Adapter-Path `cost_usd` Reconcile Completeness
+
+**Status:** Active  
+**Date:** 2026-04-23  
+**Tracker:** [#333](https://github.com/Halildeu/ao-kernel/issues/333)  
+**Parent:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
+
+## Amaç
+
+`GP-2.1` ordering kararındaki `Now` lane'i dar kapsamda uygulamak:
+adapter-path `cost_usd` reconcile davranışını deterministic test + evidence
+assertion seviyesinde kapatmak.
+
+Bu tranche support widening kararı üretmez; yalnız completeness gap'ini kapatır.
+
+## Başlangıç Bulgusu
+
+1. `PUBLIC-BETA` içinde adapter-path `cost_usd` reconcile satırı deferred.
+2. Runtime'da `post_adapter_reconcile` hook'u mevcut (`executor` ve benchmark lane).
+3. Gap: lane'in support-tier kararına temel olacak davranışsal/evidence
+   assertion seti henüz tek contract altında kapanmış değil.
+
+## Dar Kapsam (Implementation Slices)
+
+### `GP-2.2a` — Runtime/evidence truth capture (Active)
+
+- Hedef: reconcile akışında hangi alanların canonical assert edilmesi gerektiğini
+  çalışma kodundan çıkarmak.
+- Hedef dosya alanı:
+  - `ao_kernel/executor/executor.py`
+  - `ao_kernel/cost/middleware.py`
+  - `tests/test_post_adapter_reconcile.py`
+  - `tests/benchmarks/*` (özellikle cost-source/reconcile assertion katmanı)
+- Çıktı: kapsamı sınırlı assertion matrisi (`required` vs `nice-to-have`)
+
+### `GP-2.2b` — Deterministic assertion upgrade (Pending)
+
+- Hedef: `cost_usd` reconcile davranışı için doğrudan kırmızı/yeşil davranış
+  testi eklemek veya mevcut testleri güçlendirmek.
+- DoD:
+  1. en az bir negatif (reconcile yok/bozuk) yol testte yakalanır
+  2. en az bir pozitif yol evidence/cost alanlarını açık assert eder
+
+### `GP-2.2c` — Minimum runtime patch (Conditional)
+
+- Hedef: yalnız testlerle kapanmayan gerçek runtime gap varsa minimal kod düzeltmesi.
+- Kural: adapter-path dışına yayılma yok; scope creep blok.
+
+### `GP-2.2d` — Docs/status parity closeout (Pending)
+
+- Hedef: `PUBLIC-BETA` ve status satırlarında tranche sonucu gerçek davranışla hizalı.
+- Kural: support tier promotion iddiası yok; karar notu düzeyinde netlik.
+
+## Zorunlu Kanıt Komutları
+
+1. `python3 -m pytest -q tests/test_post_adapter_reconcile.py`
+2. `python3 -m pytest -q tests/benchmarks/test_governed_review.py tests/benchmarks/test_governed_bugfix.py`
+3. `python3 scripts/truth_inventory_ratchet.py --output json`
+
+## Çıkış Kriteri
+
+1. Reconcile completeness için behavior-first assertion paketi yeşil.
+2. Runtime patch gerekiyorsa minimal ve lane-scope içinde.
+3. Status SSOT + docs parity güncel.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -15,7 +15,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md` (`PB-8` closeout)
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
-- **Aktif decision/ordering contract:** `.claude/plans/GP-2.1-DEFERRED-LANE-EVIDENCE-DELTA-MAP.md` (`GP-2.1 active`)
+- **Aktif decision/ordering contract:** `.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md` (`GP-2.2 active`)
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
 - **PB-9.4 karar notu:** `.claude/plans/PB-9.4-PRODUCTION-CLAIM-DECISION-CLOSEOUT.md`
@@ -26,6 +26,7 @@ ayrı ayrı görünür kılmak.
 - **GP-1 roadmap:** `.claude/plans/GP-1-GENERAL-PURPOSE-PRODUCTION-WIDENING-ROADMAP.md`
 - **GP-2 roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
 - **GP-2.1 karar notu:** `.claude/plans/GP-2.1-DEFERRED-LANE-EVIDENCE-DELTA-MAP.md`
+- **GP-2.2 contract:** `.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md`
 - **Public Beta support boundary:** `docs/PUBLIC-BETA.md`
 - **Known bugs registry:** `docs/KNOWN-BUGS.md`
 - **GitHub milestone:** [Post-Beta Correctness and Expansion](https://github.com/Halildeu/ao-kernel/milestone/2)
@@ -35,8 +36,9 @@ ayrı ayrı görünür kılmak.
 - **PB-9 tracker issue:** [#302](https://github.com/Halildeu/ao-kernel/issues/302) (`closed`)
 - **GP-1 tracker issue:** [#316](https://github.com/Halildeu/ao-kernel/issues/316) (`closed`)
 - **GP-2 tracker issue:** [#329](https://github.com/Halildeu/ao-kernel/issues/329) (`open`)
-- **GP-2.1 issue:** [#331](https://github.com/Halildeu/ao-kernel/issues/331) (`open`)
-- **Aktif issue:** [#331](https://github.com/Halildeu/ao-kernel/issues/331) (`GP-2.1 active`)
+- **GP-2.1 issue:** [#331](https://github.com/Halildeu/ao-kernel/issues/331) (`closed`)
+- **GP-2.2 issue:** [#333](https://github.com/Halildeu/ao-kernel/issues/333) (`open`)
+- **Aktif issue:** [#333](https://github.com/Halildeu/ao-kernel/issues/333) (`GP-2.2 active`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -506,3 +508,17 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
 4. Next implementation start condition:
    - `GP-2.2` için tek issue/branch açılacak
    - ilk runtime slice yalnız `cost_usd` evidence parity kapsamıyla sınırlı kalacak
+
+## 17. GP-2.2 Kickoff Snapshot
+
+`GP-2.1` ordering closeout sonrası aktif runtime tranche `GP-2.2` olarak açıldı.
+
+1. Issue: [#333](https://github.com/Halildeu/ao-kernel/issues/333) (`open`)
+2. Active contract:
+   `.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md`
+3. Scope:
+   - adapter-path `cost_usd` reconcile completeness gap'ini dar kapsamda kapatmak
+   - behavior-first test/evidence assertion setini güçlendirmek
+4. Sınır:
+   - support boundary widening kararı bu tranche'ta verilmeyecek
+   - `gh-cli-pr` full E2E ve `bug_fix_flow` closure lane'leri `deferred` kalacak


### PR DESCRIPTION
## Summary
- add `GP-2.2` runtime tranche contract for adapter-path `cost_usd` reconcile completeness
- mark `GP-2.1` completed in `GP-2` roadmap and activate `GP-2.2`
- switch status SSOT active issue/contract pointers to `#333` / `GP-2.2` and append kickoff snapshot

## Context
- parent tracker: #329
- active tranche issue: #333
- GP-2.1 closeout PR: #332

## Validation
- `python3 scripts/truth_inventory_ratchet.py --output json`
