### PR TITLE
[codex] GP-2.2b deterministic reconcile assertion upgrade

### DIFF
--- a/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
+++ b/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
@@ -51,6 +51,9 @@ giriş kapılarını netleştirmektir.
 - Current candidate lane (from `GP-2.1`): adapter-path `cost_usd` reconcile completeness.
 - Kural: yalnız bir lane açılır; diğer deferred satırlar status dosyasında
   `deferred` olarak kalır.
+- İlerleme:
+  1. `GP-2.2a` truth-capture closure merged via PR [#335](https://github.com/Halildeu/ao-kernel/pull/335)
+  2. `GP-2.2b` deterministic assertion upgrade active on issue [#336](https://github.com/Halildeu/ao-kernel/issues/336)
 
 ## Gate Modeli
 

--- a/.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md
+++ b/.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md
@@ -22,7 +22,7 @@ Bu tranche support widening kararı üretmez; yalnız completeness gap'ini kapat
 
 ## Dar Kapsam (Implementation Slices)
 
-### `GP-2.2a` — Runtime/evidence truth capture (Active)
+### `GP-2.2a` — Runtime/evidence truth capture (Completed)
 
 - Hedef: reconcile akışında hangi alanların canonical assert edilmesi gerektiğini
   çalışma kodundan çıkarmak.
@@ -45,10 +45,17 @@ Bu tranche support widening kararı üretmez; yalnız completeness gap'ini kapat
 | Executor ordering | reconcile terminal eventten önce çağrılır; reconcile hatası step-level failure olarak yüzeye çıkar | `ao_kernel/executor/executor.py` (post-adapter reconcile bloğu) |
 | Benchmark evidence | full-mode lane en az bir `llm_spend_recorded(source=adapter_path)` eventini doğrular | `tests/benchmarks/assertions.py::assert_spend_recorded_event` |
 
-### `GP-2.2b` — Deterministic assertion upgrade (Pending)
+Kapanış: PR [#335](https://github.com/Halildeu/ao-kernel/pull/335)
+
+### `GP-2.2b` — Deterministic assertion upgrade (In Progress)
 
 - Hedef: `cost_usd` reconcile davranışı için doğrudan kırmızı/yeşil davranış
   testi eklemek veya mevcut testleri güçlendirmek.
+- Issue: [#336](https://github.com/Halildeu/ao-kernel/issues/336)
+- Mevcut ilerleme:
+  1. Fast-mode negatif guard: `adapter_path` spend event'inin yokluğu benchmark testinde pinlendi.
+  2. Full-mode pozitif guard: `llm_spend_recorded` payload alanları (`run_id`, `step_id`, `attempt`, `cost_usd`) açık assert edildi.
+  3. `post_adapter_reconcile` contract testleri payload alanları için daha sıkı hale getirildi.
 - DoD:
   1. en az bir negatif (reconcile yok/bozuk) yol testte yakalanır
   2. en az bir pozitif yol evidence/cost alanlarını açık assert eder

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -38,7 +38,8 @@ ayrı ayrı görünür kılmak.
 - **GP-2 tracker issue:** [#329](https://github.com/Halildeu/ao-kernel/issues/329) (`open`)
 - **GP-2.1 issue:** [#331](https://github.com/Halildeu/ao-kernel/issues/331) (`closed`)
 - **GP-2.2 issue:** [#333](https://github.com/Halildeu/ao-kernel/issues/333) (`open`)
-- **Aktif issue:** [#333](https://github.com/Halildeu/ao-kernel/issues/333) (`GP-2.2 active`)
+- **GP-2.2b issue:** [#336](https://github.com/Halildeu/ao-kernel/issues/336) (`open`)
+- **Aktif issue:** [#336](https://github.com/Halildeu/ao-kernel/issues/336) (`GP-2.2b deterministic assertion upgrade`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -84,7 +85,7 @@ ayrı ayrı görünür kılmak.
 | `PB-8` general-purpose productionization roadmap | Completed on `main` ([#288](https://github.com/Halildeu/ao-kernel/issues/288), [#300](https://github.com/Halildeu/ao-kernel/pull/300), [#301](https://github.com/Halildeu/ao-kernel/pull/301)) | widening kararlarını tranche bazında kapatmak ve support closeout parity'yi tamamlamak | tracker closeout + docs/runbook/release-gate parity |
 | `PB-9` production claim readiness gates | Completed on `main` ([#302](https://github.com/Halildeu/ao-kernel/issues/302), closed tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303), closed tranche [#306](https://github.com/Halildeu/ao-kernel/issues/306), closed tranche [#309](https://github.com/Halildeu/ao-kernel/issues/309), closed tranche [#312](https://github.com/Halildeu/ao-kernel/issues/312)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | roadmap + decision records + tracker closeout |
 | `GP-1` general-purpose production widening | Completed on `main` ([#316](https://github.com/Halildeu/ao-kernel/issues/316), [#327](https://github.com/Halildeu/ao-kernel/pull/327), [#326](https://github.com/Halildeu/ao-kernel/issues/326)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde tamamlamak | GP-1.1..GP-1.5 decision records + closeout parity |
-| `GP-2` deferred support-lane backlog reprioritization | Active ([#329](https://github.com/Halildeu/ao-kernel/issues/329)) | `GP-1` sonrası deferred lane'leri tek anlamlı sıraya indirip ilk aktif runtime tranche'i seçmek | deferred lane evidence-delta map + `Now/Next/Later` kararı + yeni aktif tranche kickoff |
+| `GP-2` deferred support-lane backlog reprioritization | Active ([#329](https://github.com/Halildeu/ao-kernel/issues/329), current slice [#336](https://github.com/Halildeu/ao-kernel/issues/336)) | `GP-1` sonrası deferred lane'leri tek anlamlı sıraya indirip ilk aktif runtime tranche'i seçmek | deferred lane evidence-delta map + `Now/Next/Later` kararı + yeni aktif tranche kickoff |
 
 ## 5. Şimdi
 

--- a/tests/benchmarks/assertions.py
+++ b/tests/benchmarks/assertions.py
@@ -244,12 +244,35 @@ def assert_spend_recorded_event(
     )
 
 
+def assert_no_spend_recorded_event(
+    run_dir: Path,
+    *,
+    source: str = "adapter_path",
+) -> None:
+    """Assert no ``llm_spend_recorded`` event exists for ``source``.
+
+    Used by fast-mode benchmark contracts where adapter-path reconcile
+    is intentionally inactive and spend evidence must remain absent.
+    """
+    events = _iter_events(run_dir)
+    for event in events:
+        if event.get("kind") != "llm_spend_recorded":
+            continue
+        payload = event.get("payload") or {}
+        if isinstance(payload, Mapping) and payload.get("source") == source:
+            raise AssertionError(
+                f"unexpected llm_spend_recorded event with source={source!r} "
+                f"in {run_dir / 'events.jsonl'!s}"
+            )
+
+
 __all__ = [
     "assert_adapter_ok",
     "assert_budget_axis_seeded",
     "assert_budget_unchanged",
     "assert_capability_artifact",
     "assert_cost_consumed",
+    "assert_no_spend_recorded_event",
     "assert_review_score",
     "assert_spend_recorded_event",
     "assert_workflow_completed",

--- a/tests/benchmarks/test_full_mode_smoke.py
+++ b/tests/benchmarks/test_full_mode_smoke.py
@@ -287,6 +287,12 @@ class TestFullModeAdapterPathReconcile:
         # `cost_source="real_adapter"`.
         event = assert_spend_recorded_event(run_dir, source="adapter_path")
         assert event.get("kind") == "llm_spend_recorded"
+        payload = event.get("payload") or {}
+        assert payload.get("source") == "adapter_path"
+        assert payload.get("run_id") == run_id
+        assert isinstance(payload.get("step_id"), str) and payload["step_id"]
+        assert isinstance(payload.get("attempt"), int) and payload["attempt"] >= 1
+        assert float(payload.get("cost_usd", 0.0)) > 0.0
 
         # Publish the scorecard primary sidecar (full-mode expected
         # set = {governed_review} per mode-gated session-finish).

--- a/tests/benchmarks/test_governed_review.py
+++ b/tests/benchmarks/test_governed_review.py
@@ -19,6 +19,7 @@ from ao_kernel.workflow.run_store import load_run
 from tests.benchmarks.assertions import (
     assert_adapter_ok,
     assert_capability_artifact,
+    assert_no_spend_recorded_event,
     assert_review_score,
     assert_workflow_completed,
     assert_workflow_failed,
@@ -203,8 +204,11 @@ class TestCostReconcile:
             )
 
         record, _ = load_run(workspace_root, run_id)
+        run_dir = _run_dir(workspace_root, run_id)
+        assert (run_dir / "events.jsonl").is_file()
         # Fast-mode contract post-F2: axis seeded but not drained.
         assert_budget_unchanged(record, axis="cost_usd")
+        assert_no_spend_recorded_event(run_dir, source="adapter_path")
 
 
 class TestMissingPayload:

--- a/tests/test_post_adapter_reconcile.py
+++ b/tests/test_post_adapter_reconcile.py
@@ -189,6 +189,12 @@ class TestHappyPath:
         payload = spend_events[0]["payload"]
         assert payload["source"] == "adapter_path"
         assert payload["run_id"] == run_id
+        assert payload["step_id"] == "s1"
+        assert payload["attempt"] == 1
+        assert payload["provider_id"] == "codex"
+        assert payload["model"] == "stub"
+        assert payload["tokens_input"] == 100
+        assert payload["tokens_output"] == 50
         assert payload["cost_usd"] == pytest.approx(0.05)
 
 
@@ -225,8 +231,14 @@ class TestUsageMissing:
         ]
         assert len(usage_missing_events) == 1
         assert len(spend_events) == 0
-        assert usage_missing_events[0]["payload"]["source"] == "adapter_path"
-        assert set(usage_missing_events[0]["payload"]["missing_fields"]) == {
+        payload = usage_missing_events[0]["payload"]
+        assert payload["source"] == "adapter_path"
+        assert payload["run_id"] == run_id
+        assert payload["step_id"] == "s1"
+        assert payload["attempt"] == 1
+        assert payload["provider_id"] == "codex"
+        assert payload["model"] == "stub"
+        assert set(payload["missing_fields"]) == {
             "tokens_input", "tokens_output",
         }
 


### PR DESCRIPTION
## Summary
- adds a fast-mode negative guard to assert no llm_spend_recorded(source=adapter_path) evidence is emitted
- strengthens full-mode smoke assertions for llm_spend_recorded payload (run_id, step_id, attempt, cost_usd)
- tightens adapter-path reconcile contract tests with explicit payload-field assertions
- updates GP-2.2 contract, GP-2 roadmap, and status SSOT with active GP-2.2b progress on #336

## Scope
- test/assertion + status/docs parity only
- no runtime semantics change

## Validation
- python3 -m pytest -q tests/test_post_adapter_reconcile.py
- python3 -m pytest -q tests/benchmarks/test_governed_review.py tests/benchmarks/test_governed_bugfix.py
- python3 -m pytest -q tests/benchmarks/test_governed_review.py tests/benchmarks/test_governed_bugfix.py tests/benchmarks/test_full_mode_smoke.py
- python3 scripts/truth_inventory_ratchet.py --output json

Closes #336
