### PR TITLE
[codex] add production stable live roadmap

### DIFF
--- a/.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md
+++ b/.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md
@@ -47,11 +47,13 @@ Bu tranche support widening kararı üretmez; yalnız completeness gap'ini kapat
 
 Kapanış: PR [#335](https://github.com/Halildeu/ao-kernel/pull/335)
 
-### `GP-2.2b` — Deterministic assertion upgrade (In Progress)
+### `GP-2.2b` — Deterministic assertion upgrade (Completed)
 
 - Hedef: `cost_usd` reconcile davranışı için doğrudan kırmızı/yeşil davranış
   testi eklemek veya mevcut testleri güçlendirmek.
 - Issue: [#336](https://github.com/Halildeu/ao-kernel/issues/336)
+- PR: [#337](https://github.com/Halildeu/ao-kernel/pull/337)
+- Sonuç: issue kapandı; deterministic assertion paketi `main` üzerinde.
 - Mevcut ilerleme:
   1. Fast-mode negatif guard: `adapter_path` spend event'inin yokluğu benchmark testinde pinlendi.
   2. Full-mode pozitif guard: `llm_spend_recorded` payload alanları (`run_id`, `step_id`, `attempt`, `cost_usd`) açık assert edildi.
@@ -60,12 +62,14 @@ Kapanış: PR [#335](https://github.com/Halildeu/ao-kernel/pull/335)
   1. en az bir negatif (reconcile yok/bozuk) yol testte yakalanır
   2. en az bir pozitif yol evidence/cost alanlarını açık assert eder
 
-### `GP-2.2c` — Minimum runtime patch (Conditional)
+### `GP-2.2c` — Minimum runtime patch (Conditional / currently no-op)
 
 - Hedef: yalnız testlerle kapanmayan gerçek runtime gap varsa minimal kod düzeltmesi.
 - Kural: adapter-path dışına yayılma yok; scope creep blok.
+- Mevcut karar: `GP-2.2b` sonrası ayrı runtime patch gap'i henüz
+  kanıtlanmadı; `GP-2.2d` closeout sırasında tekrar kontrol edilir.
 
-### `GP-2.2d` — Docs/status parity closeout (Pending)
+### `GP-2.2d` — Docs/status parity closeout (Active)
 
 - Hedef: `PUBLIC-BETA` ve status satırlarında tranche sonucu gerçek davranışla hizalı.
 - Kural: support tier promotion iddiası yok; karar notu düzeyinde netlik.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -1,6 +1,6 @@
 # Post-Beta Correctness and Expansion Status
 
-**Durum tarihi:** 2026-04-23
+**Durum tarihi:** 2026-04-24
 **Amaç:** Public Beta closeout sonrasında kalan correctness debt'ini
 fail-closed disiplinle kapatmak, support-surface widening kararlarını kanıtla
 yönetmek ve genel amaçlı production çizgisine geçiş için gerçek gap'leri
@@ -15,6 +15,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md` (`PB-8` closeout)
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
+- **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Aktif decision/ordering contract:** `.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md` (`GP-2.2 active`)
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
@@ -38,8 +39,8 @@ ayrı ayrı görünür kılmak.
 - **GP-2 tracker issue:** [#329](https://github.com/Halildeu/ao-kernel/issues/329) (`open`)
 - **GP-2.1 issue:** [#331](https://github.com/Halildeu/ao-kernel/issues/331) (`closed`)
 - **GP-2.2 issue:** [#333](https://github.com/Halildeu/ao-kernel/issues/333) (`open`)
-- **GP-2.2b issue:** [#336](https://github.com/Halildeu/ao-kernel/issues/336) (`open`)
-- **Aktif issue:** [#336](https://github.com/Halildeu/ao-kernel/issues/336) (`GP-2.2b deterministic assertion upgrade`)
+- **GP-2.2b issue:** [#336](https://github.com/Halildeu/ao-kernel/issues/336) (`closed`)
+- **Aktif issue:** [#333](https://github.com/Halildeu/ao-kernel/issues/333) (`GP-2.2 docs/status parity closeout`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -85,9 +86,31 @@ ayrı ayrı görünür kılmak.
 | `PB-8` general-purpose productionization roadmap | Completed on `main` ([#288](https://github.com/Halildeu/ao-kernel/issues/288), [#300](https://github.com/Halildeu/ao-kernel/pull/300), [#301](https://github.com/Halildeu/ao-kernel/pull/301)) | widening kararlarını tranche bazında kapatmak ve support closeout parity'yi tamamlamak | tracker closeout + docs/runbook/release-gate parity |
 | `PB-9` production claim readiness gates | Completed on `main` ([#302](https://github.com/Halildeu/ao-kernel/issues/302), closed tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303), closed tranche [#306](https://github.com/Halildeu/ao-kernel/issues/306), closed tranche [#309](https://github.com/Halildeu/ao-kernel/issues/309), closed tranche [#312](https://github.com/Halildeu/ao-kernel/issues/312)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | roadmap + decision records + tracker closeout |
 | `GP-1` general-purpose production widening | Completed on `main` ([#316](https://github.com/Halildeu/ao-kernel/issues/316), [#327](https://github.com/Halildeu/ao-kernel/pull/327), [#326](https://github.com/Halildeu/ao-kernel/issues/326)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde tamamlamak | GP-1.1..GP-1.5 decision records + closeout parity |
-| `GP-2` deferred support-lane backlog reprioritization | Active ([#329](https://github.com/Halildeu/ao-kernel/issues/329), current slice [#336](https://github.com/Halildeu/ao-kernel/issues/336)) | `GP-1` sonrası deferred lane'leri tek anlamlı sıraya indirip ilk aktif runtime tranche'i seçmek | deferred lane evidence-delta map + `Now/Next/Later` kararı + yeni aktif tranche kickoff |
+| `GP-2` deferred support-lane backlog reprioritization | Active ([#329](https://github.com/Halildeu/ao-kernel/issues/329), current slice [#333](https://github.com/Halildeu/ao-kernel/issues/333)) | `GP-1` sonrası deferred lane'leri tek anlamlı sıraya indirip ilk aktif runtime tranche'i seçmek | deferred lane evidence-delta map + `Now/Next/Later` kararı + GP-2.2 closeout |
 
 ## 5. Şimdi
+
+### `GP-2.2d` — adapter-path `cost_usd` reconcile docs/status parity closeout
+
+Aktif iş artık `GP-2.2d` closeout'tur. `GP-2.2b` deterministic assertion
+upgrade issue'su [#336](https://github.com/Halildeu/ao-kernel/issues/336)
+kapanmış, PR [#337](https://github.com/Halildeu/ao-kernel/pull/337) merge
+edilmiştir. `GP-2.2c` için ayrı runtime patch gap'i henüz kanıtlanmadığı için
+closeout kararı bu slice'ta yazılı hale getirilecektir.
+
+Bu slice'ın sınırı:
+
+1. `PUBLIC-BETA` stable kanal sürüm dilini hard-code etmeden doğru anlatır.
+2. `GP-2.2` contract dosyası `GP-2.2b completed`, `GP-2.2d active`
+   durumunu gösterir.
+3. `POST-BETA-CORRECTNESS-EXPANSION-STATUS` aktif issue olarak [#333](https://github.com/Halildeu/ao-kernel/issues/333)
+   satırına döner.
+4. Support widening yapılmaz; adapter-path `cost_usd` reconcile public support
+   claim olarak deferred kalır.
+5. `ST-0` production-stable roadmap kapısı için status/docs drift kapanır.
+
+Tarihi PB/GP kayıtları aşağıda korunur; güncel yürütme kararı yukarıdaki
+`GP-2.2d` bloğudur.
 
 ### `PB-6.4` — real-adapter/write-side graduation criteria yeniden sıralama
 
@@ -281,11 +304,14 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Aktif runtime/program slice yok.
+Aktif slice: `GP-2.2d` docs/status parity closeout.
 
-1. Son kapanan slice: `GP-1.5` program closeout decision
-2. `GP-1` programı tamamlandı (`#316` closed)
-3. Sonraki sıra: yeni program/tranche açılmadan önce backlog reprioritization
+1. Tracker: [#333](https://github.com/Halildeu/ao-kernel/issues/333) (`open`)
+2. Son kapanan alt slice: [#336](https://github.com/Halildeu/ao-kernel/issues/336) (`GP-2.2b`, `closed`)
+3. Production-stable kapısı: `ST-0` (`.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`)
+4. Sonraki karar: `GP-2.2c` runtime patch gerekmediği yazılı kapanırsa
+   `GP-2.2d` closeout tamamlanır; ardından `ST-1` pre-release gate
+   (`4.0.0b2` varsayımı) planlanır.
 
 `PB-8.2` completion kaydı:
 

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -1,0 +1,295 @@
+# Production Stable Live Roadmap
+
+**Durum tarihi:** 2026-04-24
+**Rol:** Public Beta / post-beta correctness hattindan production stable live
+release'e gecis icin takip edilebilir program kontrati.
+**Kapsam mottosu:** once gercegi kilitle, sonra support'u genislet.
+
+## 1. Hedef
+
+Bu roadmap'in hedefi `ao-kernel` icin "canli stable production" kararini
+kanita baglamaktir. Stable release, sadece surum numarasi degildir; asagidaki
+bes seyin ayni anda dogru oldugu release'tir:
+
+1. `pip install ao-kernel` ile gelen stable paket gercek desteklenen yuzeyi
+   kurar.
+2. Runtime, docs, tests, CI ve runbook ayni support boundary'yi anlatir.
+3. Wheel-installed smoke repo kokune, editable install'a veya host PATH
+   tesaduflerine dayanmaz.
+4. Shipped iddialar negative/positive behavior testleriyle kanitlidir.
+5. Operator, hata aninda rollback/incident/known-bug yolunu bilir.
+
+## 2. Stable Claim Seviyeleri
+
+Iki farkli hedef birbirine karistirilmeyecek:
+
+| Seviye | Anlam | Stable icin durum |
+|---|---|---|
+| Stable runtime release | Dar support boundary ile guvenilir, paketlenmis, isletilebilir cekirdek | `4.0.0` icin hedeflenebilir |
+| General-purpose production coding automation platform | Gercek adapter'lar, live-write E2E, multi-agent safety ve operator runbook'lariyla genis platform | Ancak sertifikasyon kapilari kapandiktan sonra iddia edilir |
+
+`4.0.0` stable release dar ama dogru bir production runtime olabilir. "Genel
+amacli production coding automation platform" iddiasi, gercek adapter
+sertifikasyonu ve live-write rollback kanitlari kapanmadan kullanilmayacak.
+
+## 3. Mevcut Baseline
+
+- `main` temiz ve `origin/main` ile senkron.
+- Paket metadata su anda `4.0.0b1` gosteriyor.
+- Public tag `v4.0.0-beta.1` mevcut; `main` bu tag'den ileride.
+- Public Beta support boundary dar: `review_ai_flow + codex-stub`,
+  entrypoint'ler, doctor, policy command enforcement ve wheel smoke kanitli
+  cekirdek shipped yuzeydir.
+- `claude-code-cli`, `gh-cli-pr` ve write/live hatlari operator-managed beta
+  veya karar bekleyen yuzeylerdir.
+- Post-beta programda GP-2 hattinda deferred support lane'leri kanitla
+  kapatiliyor.
+
+## 4. Immediate Drift Kayitlari
+
+Stable roadmap baslamadan once su drift'ler kapatilacak veya karar notuna
+baglanacak:
+
+1. `docs/PUBLIC-BETA.md` stable kanal orneginde stale surum yazimi varsa
+   hard-code yerine kural yazacak.
+2. `.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md` icinde GP-2.2b
+   issue/status satirlari merge sonrasi gercekle hizalanacak.
+3. Adapter-path `cost_usd` reconcile icin "runtime fix gerekir mi, yoksa
+   evidence/test/docs closeout yeterli mi" karari GP-2.2d'de kapanacak.
+4. `v4.0.0-beta.1` tag'i main'in gerisinde kaldigi icin bir sonraki public
+   beta/stable release eski tag uzerinden degil current `main` uzerinden
+   cikacak.
+
+## 5. Release Stratejisi
+
+Stable'a dogrudan ziplanmayacak. Varsayilan yol:
+
+1. `4.0.0b2` veya release-candidate niteliginde yeni pre-release cik.
+2. Fresh install / wheel / docs / smoke / runbook kanitlarini bu pre-release
+   uzerinde topla.
+3. Support boundary genisletilecekse sadece kanitli yuzeyleri genislet.
+4. Blocker kalmazsa `4.0.0` stable tag ve PyPI publish yap.
+
+Eger `4.0.0b2` sirasinda shipped yuzeyi degistiren runtime bug bulunursa,
+stable yerine yeni beta devam eder. Stable release, takvim karari degil gate
+kararidir.
+
+## 6. Work Packages
+
+### ST-0 — Beta Sync ve Status Truth Closeout
+
+**Amac:** Current `main` ile public beta/live dokumanlari arasindaki drift'i
+kapatmak.
+
+**Kapsam:**
+
+- GP-2.2 status/issue satirlarini merge sonrasi gercege cek.
+- `docs/PUBLIC-BETA.md`, `docs/SUPPORT-BOUNDARY.md`,
+  `docs/KNOWN-BUGS.md` ve status dosyalarinda stable/beta/deferred dilini
+  hizala.
+- Stable kanal surumunu hard-code etmek yerine install kuralini yaz.
+
+**DoD:**
+
+- Support matrix'te stale issue/surum/status yok.
+- GP-2.2d closeout karari yazili.
+- Public Beta dokumani current `main` gercegini anlatiyor.
+
+### ST-1 — Releasable Pre-Release Gate (`4.0.0b2`)
+
+**Amac:** Current `main`'i eski `v4.0.0-beta.1` tag'inden ayrilmis yeni bir
+kanitli pre-release'e cevirmek.
+
+**Kapsam:**
+
+- Version bump gerekiyorsa `4.0.0b2`.
+- Changelog/release note: `v4.0.0-beta.1` sonrasi kapanan governance,
+  support-boundary, evidence ve adapter kararlarini ozetle.
+- CI + packaging smoke + publish workflow dry-run/publish gate.
+
+**DoD:**
+
+- Fresh venv, repo disi cwd, wheel install smoke geciyor.
+- `ao-kernel version`, `python -m ao_kernel version`,
+  `python -m ao_kernel.cli version` ayni pre-release surumunu veriyor.
+- `python3 examples/demo_review.py --cleanup` installed package yuzeyiyle
+  `completed` oluyor.
+- PyPI pre-release verify tamam.
+
+### ST-2 — Stable Support Boundary Freeze
+
+**Amac:** `4.0.0` stable'in neyi destekledigini release oncesi dondurmek.
+
+**Kapsam:**
+
+- Shipped / Beta / Deferred / Known Bugs matrisi final review.
+- Her shipped satir icin kod yolu + test/smoke + docs kaniti.
+- Her beta/deferred satir icin neden stable scope disinda kaldigi.
+
+**DoD:**
+
+- Stable release notes "genel amacli her seyi yapar" iddiasi tasimiyor.
+- Known bug listesinde shipped baseline'i bozan blocker yok.
+- Beta operator-managed yuzeyler stable iddianin icine sizmiyor.
+
+### ST-3 — Real Adapter Certification Decision
+
+**Amac:** Gercek adapter yuzeylerinin stable scope'a girip girmeyecegini
+kanıtla karara baglamak.
+
+**Adaylar:**
+
+- `claude-code-cli`: PATH binary + operator auth/prerequisite lane.
+- `gh-cli-pr`: PATH binary + GitHub CLI auth/preflight/live-write lane.
+- `codex-stub`: repo-native deterministic stub, production adapter degil.
+
+**DoD:**
+
+- Her adapter icin capability tier: `stub`, `preflight`, `operator-managed
+  beta`, `production-certified`.
+- Production-certified denilen adapter icin timeout/cancel/retry,
+  idempotency, secret handling, evidence completeness ve failure-mode smoke
+  mevcut.
+- Production-certified adapter yoksa stable claim dar runtime olarak kalir.
+
+### ST-4 — Live Write ve Rollback Rehearsal
+
+**Amac:** Canli yazma yapacak yuzeyler icin geri alma ve kanit kontratini
+gercekte denemek.
+
+**Kapsam:**
+
+- Disposable sandbox repo veya controlled test target.
+- Live-write create/verify/rollback akisi.
+- Idempotent cleanup.
+- Evidence JSONL ve operator runbook kaydi.
+
+**DoD:**
+
+- Live-write iddiasi olan her yuzey icin rollback kaniti var.
+- Rollback yoksa yuzey stable write scope'a alinmaz.
+
+### ST-5 — Deferred Correctness Closure
+
+**Amac:** Stable shipped yuzeyi etkileyen correctness borcunu kapatmak veya
+bilerek stable disina almak.
+
+**Kapsam adaylari:**
+
+- `bug_fix_flow` release closure.
+- `gh-cli-pr` full E2E remote PR opening.
+- Roadmap/spec demo yuzeyinin live support'a alinip alinmayacagi.
+- Adapter-path `cost_usd` reconcile son karari.
+
+**DoD:**
+
+- Her item `ship`, `beta`, `deferred` veya `retire` olarak tek kategoriye
+  duser.
+- Iki kategoriye birden yazilan yuzey kalmaz.
+
+### ST-6 — Operations Readiness
+
+**Amac:** Stable release'i isletilebilir hale getirmek.
+
+**Kapsam:**
+
+- Incident runbook.
+- Rollback/upgrade notes.
+- Support boundary.
+- Known bugs registry.
+- Required checks ve branch protection uyumu.
+
+**DoD:**
+
+- Operator "kurulum bozuldu", "adapter auth bozuk", "policy deny beklenmiyor",
+  "publish hatali" durumlarinda hangi komutu kosacagini biliyor.
+- Publish sonrasi verify komutlari yazili.
+- Emergency rollback ve yanked release karari yazili.
+
+### ST-7 — Stable Release Candidate
+
+**Amac:** `4.0.0` stable icin final aday cikarmak.
+
+**Kapsam:**
+
+- Version `4.0.0`.
+- Changelog final.
+- Docs'ta beta/pre-release install dilini stable release diline ayir.
+- Full CI, packaging smoke, installed demo, doctor, adapter smokes.
+
+**DoD:**
+
+- `pip install ao-kernel==4.0.0` icin publish-oncesi wheel smoke ayni
+  kontrati geciyor.
+- `--pre` gerektiren kurulum stable docs'ta stable yol gibi anlatilmiyor.
+- Release blocker listesi bos.
+
+### ST-8 — Stable Publish ve Post-Publish Verification
+
+**Amac:** Stable'i canliya almak ve public install gercegini dogrulamak.
+
+**Kapsam:**
+
+- Tag: `v4.0.0`.
+- Publish workflow success.
+- PyPI HTTP/JSON verify.
+- Fresh venv public install verify.
+- Post-release issue/status closeout.
+
+**DoD:**
+
+- `pip install ao-kernel` stable kanaldan `4.0.0` kuruyor.
+- Fresh venv smoke public paketle geciyor.
+- GitHub release, CHANGELOG, docs ve status ayni sonucu anlatiyor.
+
+## 7. Stable Release Blocker Listesi
+
+Asagidaki durumlardan biri varsa stable publish yapilmaz:
+
+- Docs/runtime/test/CI ayni support boundary'yi anlatmiyor.
+- Wheel-installed smoke repo kokune veya editable install'a bagimli.
+- Shipped yuzeyde bilinen blocker known bug var.
+- Policy/security enforcement icin negative test yok.
+- Adapter production claim'i sadece manifest veya docs'a dayaniyor.
+- Live-write yuzeyi rollback rehearsali olmadan stable scope'a alinmis.
+- `docs/PUBLIC-BETA.md` veya `docs/SUPPORT-BOUNDARY.md` stale surum/status
+  bilgisi tasiyor.
+- `main` ile release branch/tag arasinda aciklanmamis fark var.
+
+## 8. Zorunlu Kanit Paketi
+
+Stable kararindan once en az su komutlar gecmis olacak:
+
+```bash
+python3 -m pytest -q tests/ --ignore=tests/benchmarks --cov
+python3 -m pytest -q tests/benchmarks/test_governed_review.py tests/benchmarks/test_governed_bugfix.py
+python3 scripts/packaging_smoke.py
+python3 scripts/truth_inventory_ratchet.py --output json
+python3 examples/demo_review.py --cleanup
+python3 -m ao_kernel doctor
+```
+
+Release branch uzerinde ek olarak fresh temp venv + wheel install smoke
+zorunludur. Public publish sonrasinda ayni kontrat PyPI paketinden tekrar
+dogrulanir.
+
+## 9. Yurutme Kurali
+
+- Ayni anda en fazla bir `ST-*` implementation slice acik olur.
+- Her slice icin issue veya status entry acilir.
+- Her PR su paketle kapanir: kod/doc degisikligi, test/smoke kaniti,
+  changelog etkisi, kalan deferred maddeler.
+- Support boundary genisletme PR'i, onu kanitlayan runtime/test PR'ina
+  baglanmadan merge edilmez.
+- Stable release karari tek kisi kanaatiyle degil, bu dosyadaki blocker ve DoD
+  listesinin kapanmasiyla verilir.
+
+## 10. Hemen Siradaki Is
+
+1. `ST-0` baslat: GP-2.2 closeout ve status/docs drift temizligi.
+2. `ST-1` hazirla: current `main` icin yeni pre-release gate karari
+   (`4.0.0b2` varsayilan).
+3. `ST-2` ile stable support boundary freeze yap.
+4. Sonra stable scope kararina gore `ST-3` ve `ST-4` gerekli mi, yoksa dar
+   runtime stable release'e gecilebilir mi karar ver.
+

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -1,8 +1,10 @@
 # Public Beta (v4.0.0b1) — Support Matrix SSOT
 
-> **Sürüm durumu (2026-04-22)**: stable kanal `v3.13.3`, bu branch /
-> pre-release paket sürümü `4.0.0b1`. Bu doküman `v4.0.0b1` için canlı
-> destek matrisi ve operator-facing SSOT'tur.
+> **Sürüm durumu (2026-04-24)**: stable kanal `pip install ao-kernel`
+> komutuyla, Public Beta ise explicit pre-release pin veya `--pre` ile
+> kurulur. Bu doküman `v4.0.0b1` için canlı destek matrisi ve
+> operator-facing SSOT'tur; stable kanalın exact sürüm numarası release
+> anında PyPI'dan doğrulanır, burada hard-code edilmez.
 
 ## Kurulum
 
@@ -54,7 +56,7 @@ istemek gerekir.
 
 | Yüzey | Durum | Not |
 |---|---|---|
-| Public Beta yüzeyinin tamamı | Beta | Stable kanal hâlâ `3.13.3`; genel kullanım için pre-release install gerekir |
+| Public Beta yüzeyinin tamamı | Beta | Stable kanal pre-release kurmaz; genel kullanım için explicit pre-release install gerekir |
 | `claude-code-cli` helper-backed real-adapter lane | Beta (operator-managed) | `python3 scripts/claude_code_cli_smoke.py --output text` sonucu `overall_status: pass` olmalıdır. Bu smoke içinde hem `auth_status` hem `prompt_access` check'i geçmelidir; yalnız `claude auth status` yeşili yeterli kabul edilmez. Varsayılan shipped demo değildir. `PB-6.6` closeout verdict'i: `stay_beta_operator_managed` |
 | `gh-cli-pr` helper-backed preflight lane | Beta (operator-managed preflight + live-write readiness probe) | Varsayılan `python3 scripts/gh_cli_pr_smoke.py --output text` preflight yoludur ve side-effect-safe `gh pr create --dry-run` zincirini çalıştırır. Live-write probe (`--mode live-write --allow-live-write --head <branch> --base <branch>`) explicit opt-in + create->verify->rollback ister. Varsayılan disposable guard keyword `sandbox`'dır; repo adında bu keyword yoksa lane `blocked` döner (`gh_pr_live_write_repo_not_disposable`). `--keep-live-write-pr-open` lane'i riskli sayar ve `blocked` döner. Support widening değildir |
 | `PRJ-KERNEL-API` write-side actions | Beta (operator-managed write contract) | `project_status`, `roadmap_follow`, `roadmap_finish` runtime-backed. `workspace_root` zorunlu, varsayılan `dry_run=true`, gerçek yazma için `confirm_write=I_UNDERSTAND_SIDE_EFFECTS` gerekir; conflict/idempotency/audit davranışı behavior testlerle pinlidir. Operator smoke: `python3 scripts/kernel_api_write_smoke.py --output text` |


### PR DESCRIPTION
## Summary
- add a Production Stable Live Roadmap as the ST-* gate contract for stable release readiness
- link the new roadmap from the post-beta execution status SSOT
- align GP-2.2 status/docs drift: #336 closed, #333 active, no hard-coded stable channel version in PUBLIC-BETA

## Validation
- git diff --check
- python3 -m pytest -q tests/test_post_adapter_reconcile.py
- python3 -m pytest -q tests/benchmarks/test_governed_review.py tests/benchmarks/test_governed_bugfix.py
- python3 scripts/truth_inventory_ratchet.py --output json

Refs #333
Refs #329