### PR TITLE
[codex] prepare 4.0.0b2 pre-release

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -94,7 +94,7 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### `ST-1` — releasable pre-release gate (`4.0.0b2` varsayımı)
+### `ST-1` — releasable pre-release gate (`4.0.0b2` release PR)
 
 Aktif iş artık production-stable roadmap'teki `ST-1` kapısına hazırlıktır.
 Issue [#340](https://github.com/Halildeu/ao-kernel/issues/340) açıldı ve
@@ -118,6 +118,16 @@ Son GP-2.2 kararı:
 Bu slice'ın işi release publish değildir; release PR'ı başlamadan önce exact
 dosya listesi, karar soruları, local/CI/publish kanıt komutları ve blocker
 listesi yazılı hale getirilir.
+
+Contract PR [#341](https://github.com/Halildeu/ao-kernel/pull/341) ile
+tamamlandı. Aktif alt adım artık `4.0.0b2` release PR'ıdır:
+
+1. `pyproject.toml` ve `ao_kernel/__init__.py` version surfaces
+   `4.0.0b2`ye çekilir.
+2. `CHANGELOG.md`, `docs/PUBLIC-BETA.md`, `docs/UPGRADE-NOTES.md` ve
+   `docs/ROLLBACK.md` beta pinleri hizalanır.
+3. Local validation + full CI + packaging-smoke geçmeden tag/publish yoktur.
+4. Merge sonrası tag hedefi `v4.0.0-beta.2`dir.
 
 Tarihi PB/GP kayıtları aşağıda korunur; güncel yürütme kararı yukarıdaki
 `ST-1` bloğudur.
@@ -320,7 +330,7 @@ Aktif slice: `ST-1` pre-release gate hazırlığı.
    closeout ([#333](https://github.com/Halildeu/ao-kernel/issues/333))
 2. Production-stable roadmap: `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 3. Aktif contract: `.claude/plans/ST-1-RELEASABLE-PRE-RELEASE-GATE.md`
-4. Sonraki iş: `4.0.0b2` release PR'ını contract'a göre aç.
+4. Sonraki iş: `4.0.0b2` release PR'ını contract'a göre merge et.
 5. Stable release'e doğrudan geçilmez; önce fresh wheel/PyPI pre-release
    kanıtı toplanır.
 

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -35,7 +35,8 @@ sertifikasyonu ve live-write rollback kanitlari kapanmadan kullanilmayacak.
 ## 3. Mevcut Baseline
 
 - `main` temiz ve `origin/main` ile senkron.
-- Paket metadata su anda `4.0.0b1` gosteriyor.
+- `ST-1` release PR package metadata hedefi `4.0.0b2`; onceki public
+  pre-release package metadata `4.0.0b1` idi.
 - Public tag `v4.0.0-beta.1` mevcut; `main` bu tag'den ileride.
 - Public Beta support boundary dar: `review_ai_flow + codex-stub`,
   entrypoint'ler, doctor, policy command enforcement ve wheel smoke kanitli
@@ -100,7 +101,7 @@ kapatmak.
 
 ### ST-1 — Releasable Pre-Release Gate (`4.0.0b2`)
 
-**Durum:** Active via [#340](https://github.com/Halildeu/ao-kernel/issues/340)
+**Durum:** Release PR active via [#340](https://github.com/Halildeu/ao-kernel/issues/340)
 and `.claude/plans/ST-1-RELEASABLE-PRE-RELEASE-GATE.md`.
 
 **Amac:** Current `main`'i eski `v4.0.0-beta.1` tag'inden ayrilmis yeni bir

--- a/.claude/plans/ST-1-RELEASABLE-PRE-RELEASE-GATE.md
+++ b/.claude/plans/ST-1-RELEASABLE-PRE-RELEASE-GATE.md
@@ -1,6 +1,6 @@
 # ST-1 — Releasable Pre-Release Gate (`4.0.0b2`)
 
-**Durum:** Active
+**Durum:** Release PR active
 **Issue:** [#340](https://github.com/Halildeu/ao-kernel/issues/340)
 **Umbrella:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
 **Hedef pre-release:** package version `4.0.0b2`, git tag
@@ -14,10 +14,10 @@ amacı bu ilerlemeyi yeni bir kanitli pre-release gate'e cevirmektir. Bu gate
 stable'a dogrudan gecis degil; stable oncesi fresh wheel, CI, docs ve PyPI
 pre-release gercegini tekrar kanitlama adimidir.
 
-## 2. Current Baseline
+## 2. Contract-Start Baseline
 
 - `main` `origin/main` ile senkron baslamali.
-- Current package metadata `4.0.0b1` gosteriyor:
+- Contract-start package metadata `4.0.0b1` gosteriyordu:
   - `pyproject.toml`
   - `ao_kernel/__init__.py`
 - Son public pre-release tag'i `v4.0.0-beta.1`.
@@ -29,6 +29,9 @@ pre-release gercegini tekrar kanitlama adimidir.
   - shipped baseline dar
   - real adapter lane'leri operator-managed beta
   - adapter-path `cost_usd` reconcile public support claim olarak deferred
+
+Release PR hedefi bu metadata'yi `4.0.0b2`ye tasimaktir. Stable `4.0.0`
+claim'i bu slice'ta yoktur.
 
 ## 3. Kapsam
 
@@ -49,6 +52,7 @@ Bu ayrim bilerek yapilir: release PR'i baslamadan once gate net olmalidir.
 | `pyproject.toml` | Package version `4.0.0b1 -> 4.0.0b2` olacak mi? |
 | `ao_kernel/__init__.py` | `__version__` package version ile birebir ayni mi? |
 | `CHANGELOG.md` | `[4.0.0b2] - <date>` entry'si beta.1 sonrasi kapanan PR/gate'leri dogru ozetliyor mu? |
+| `tests/test_pr_a6_features.py` | Version bump contract testleri yeni package version'i bekliyor mu? |
 | `docs/PUBLIC-BETA.md` | Public Beta pin `4.0.0b2` olarak guncellendi mi; support boundary genislemedi mi? |
 | `docs/UPGRADE-NOTES.md` | Explicit beta install pin `4.0.0b2` oldu mu? |
 | `docs/ROLLBACK.md` | Documented beta rollback pin `4.0.0b2` oldu mu; stable rollback komutu hard-code stable version yazmiyor mu? |
@@ -86,9 +90,14 @@ python3 -m pytest -q tests/ --ignore=tests/benchmarks --cov
 python3 -m pytest -q tests/benchmarks/test_governed_review.py tests/benchmarks/test_governed_bugfix.py
 python3 scripts/packaging_smoke.py
 python3 scripts/truth_inventory_ratchet.py --output json
-python3 examples/demo_review.py --cleanup
 python3 -m ao_kernel doctor
 ```
+
+`examples/demo_review.py` dogrulamasi wheel-installed Python ile yapilmalidir;
+`scripts/packaging_smoke.py` bunu fresh venv icinde otomatik kosar. Source
+checkout'tan plain `python3 examples/demo_review.py --cleanup` komutu gate
+degildir, cunku adapter subprocess sandbox'i host `PYTHONPATH`'ini tasimaz ve
+ambient install durumuna bagli hale gelir.
 
 Version-specific local checks:
 
@@ -191,4 +200,3 @@ Release PR veya tag publish su durumlarda durur:
    olarak gosterir.
 6. Issue [#340](https://github.com/Halildeu/ao-kernel/issues/340) closeout
    comment ile kapatilir.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [4.0.0b2] - 2026-04-24
+
+### Changed — Post-beta closeout + stable-release gate preparation
+
+`v4.0.0b2` refreshes the Public Beta pre-release line from current `main`
+after the post-beta correctness and productionization program work. It does
+not widen the public support boundary to a general-purpose production coding
+automation platform; it packages the current governed runtime baseline with
+clearer release gates and closeout records.
+
+- Added the production stable live roadmap and ST-1 pre-release gate contract:
+  - `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
+  - `.claude/plans/ST-1-RELEASABLE-PRE-RELEASE-GATE.md`
+- Closed the GP-2.2 adapter-path `cost_usd` reconcile completeness tranche:
+  - deterministic assertions now pin the fast-mode negative path and
+    full-mode `llm_spend_recorded(source="adapter_path")` payload fields
+  - no additional runtime patch was required
+  - adapter-path `cost_usd` reconcile remains deferred as a public support
+    claim
+- Public Beta docs no longer hard-code the exact stable channel version; they
+  document the install rule instead.
+- Support boundary remains intentionally narrow:
+  - shipped baseline: module/CLI entrypoints, doctor, `review_ai_flow` +
+    `codex-stub`, `examples/demo_review.py`, policy command enforcement,
+    packaging smoke, and documented read-only kernel API actions
+  - operator-managed beta: `claude-code-cli`, `gh-cli-pr` preflight/live-write
+    readiness probe, kernel API write-side actions, and real-adapter benchmark
+    full mode
+  - deferred: `bug_fix_flow` release closure, full remote PR opening,
+    roadmap/spec demo widening, and adapter-path `cost_usd` as a public
+    support claim
+- Version bump `4.0.0b1 -> 4.0.0b2` (git tag target:
+  `v4.0.0-beta.2`).
+
+### Migration note
+
+- `pip install ao-kernel` still stays on the stable channel until a
+  pre-release is requested explicitly.
+- Public Beta users should pin `ao-kernel==4.0.0b2` or use
+  `pip install --pre ao-kernel`.
+- No stable `4.0.0` claim is made by this release.
+
 ## [4.0.0b1] - 2026-04-20
 
 ### Changed — Runtime command enforcement + packaging smoke gate

--- a/ao_kernel/__init__.py
+++ b/ao_kernel/__init__.py
@@ -1,6 +1,6 @@
 """ao-kernel — Governed AI orchestration runtime."""
 
-__version__ = "4.0.0b1"
+__version__ = "4.0.0b2"
 
 from ao_kernel.client import AoKernelClient
 from ao_kernel.config import load_default, load_with_override, workspace_root

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -1,8 +1,8 @@
-# Public Beta (v4.0.0b1) — Support Matrix SSOT
+# Public Beta (v4.0.0b2) — Support Matrix SSOT
 
 > **Sürüm durumu (2026-04-24)**: stable kanal `pip install ao-kernel`
 > komutuyla, Public Beta ise explicit pre-release pin veya `--pre` ile
-> kurulur. Bu doküman `v4.0.0b1` için canlı destek matrisi ve
+> kurulur. Bu doküman `v4.0.0b2` için canlı destek matrisi ve
 > operator-facing SSOT'tur; stable kanalın exact sürüm numarası release
 > anında PyPI'dan doğrulanır, burada hard-code edilmez.
 
@@ -17,7 +17,7 @@ pip install ao-kernel
 ### Public Beta pre-release
 
 ```bash
-pip install ao-kernel==4.0.0b1
+pip install ao-kernel==4.0.0b2
 pip install --pre ao-kernel
 ```
 
@@ -32,7 +32,7 @@ istemek gerekir.
 - [`ROLLBACK.md`](ROLLBACK.md)
 - [`KNOWN-BUGS.md`](KNOWN-BUGS.md)
 
-## Shipped (v4.0.0b1)
+## Shipped (v4.0.0b2)
 
 | Yüzey | Durum | Not |
 |---|---|---|

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -17,7 +17,7 @@ flag olmadan en güncel stable hattı geri yükler.
 ### Return to the documented beta pin
 
 ```bash
-pip install --force-reinstall ao-kernel==4.0.0b1
+pip install --force-reinstall ao-kernel==4.0.0b2
 ```
 
 After either rollback, verify:

--- a/docs/UPGRADE-NOTES.md
+++ b/docs/UPGRADE-NOTES.md
@@ -16,7 +16,7 @@ pip install -U ao-kernel
 ```bash
 pip install --pre ao-kernel
 # or pin explicitly
-pip install ao-kernel==4.0.0b1
+pip install ao-kernel==4.0.0b2
 ```
 
 Do not assume `pip install ao-kernel` will pick the beta. It stays on the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ao-kernel"
-version = "4.0.0b1"
+version = "4.0.0b2"
 description = "Governed AI orchestration runtime — policy-driven, fail-closed, evidence-trail"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_pr_a6_features.py
+++ b/tests/test_pr_a6_features.py
@@ -93,10 +93,10 @@ class TestLlmFallback:
 
 
 class TestVersionBump:
-    def test_version_is_4_0_0b1(self) -> None:
+    def test_version_is_4_0_0b2(self) -> None:
         import ao_kernel
 
-        assert ao_kernel.__version__ == "4.0.0b1"
+        assert ao_kernel.__version__ == "4.0.0b2"
 
     def test_pyproject_version_matches(self) -> None:
         import tomllib
@@ -106,7 +106,7 @@ class TestVersionBump:
             pyproject = Path(__file__).parent.parent / "pyproject.toml"
         with open(pyproject, "rb") as f:
             data = tomllib.load(f)
-        assert data["project"]["version"] == "4.0.0b1"
+        assert data["project"]["version"] == "4.0.0b2"
 
 
 class TestMetaExtras:


### PR DESCRIPTION
## Summary

Prepares the next Public Beta pre-release package, `4.0.0b2`, from the current production-stable roadmap gate.

This PR intentionally does not widen the stable support boundary. It updates package metadata, beta install/rollback docs, release status docs, changelog notes, and stale version contract tests so the `v4.0.0-beta.2` tag can publish a coherent pre-release.

Refs #340
Refs #329

## Validation

- `git diff --check`
- `python3 -m pytest -q tests/test_pr_a6_features.py`
- `python3 -m pytest -q tests/ --ignore=tests/benchmarks --cov`
- `python3 -m pytest -q tests/benchmarks/test_governed_review.py tests/benchmarks/test_governed_bugfix.py`
- `python3 scripts/truth_inventory_ratchet.py --output json`
- `python3 scripts/packaging_smoke.py`
- `python3 -m ao_kernel doctor`

## Release note

After merge, the intended tag is `v4.0.0-beta.2`. Publish remains tag-triggered through `publish.yml`; merge alone does not publish PyPI.
