### PR TITLE
[codex] define ST-2 support boundary freeze

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -17,7 +17,7 @@ ayrı ayrı görünür kılmak.
 - **Program roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-1-RELEASABLE-PRE-RELEASE-GATE.md` (`ST-1 completed`)
-- **Aktif decision/ordering contract:** `ST-2` issue/contract açılacak
+- **Aktif decision/ordering contract:** `.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md` (`ST-2 active`)
 - **GP-2.2 closeout contract:** `.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md`
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
@@ -43,7 +43,8 @@ ayrı ayrı görünür kılmak.
 - **GP-2.2 issue:** [#333](https://github.com/Halildeu/ao-kernel/issues/333) (`closed`)
 - **GP-2.2b issue:** [#336](https://github.com/Halildeu/ao-kernel/issues/336) (`closed`)
 - **ST-1 issue:** [#340](https://github.com/Halildeu/ao-kernel/issues/340) (`closed after closeout`)
-- **Aktif issue:** `ST-2` için açılacak
+- **ST-2 issue:** [#344](https://github.com/Halildeu/ao-kernel/issues/344) (`open`)
+- **Aktif issue:** [#344](https://github.com/Halildeu/ao-kernel/issues/344) (`ST-2 stable support boundary freeze`)
 
 ## 2. Başlangıç Gerçeği
 
@@ -92,6 +93,7 @@ ayrı ayrı görünür kılmak.
 | `GP-2` deferred support-lane backlog reprioritization | Active ([#329](https://github.com/Halildeu/ao-kernel/issues/329), latest slice [#333](https://github.com/Halildeu/ao-kernel/issues/333) closed) | `GP-1` sonrası deferred lane'leri tek anlamlı sıraya indirip ilk aktif runtime tranche'i seçmek | deferred lane evidence-delta map + `Now/Next/Later` kararı + GP-2.2 closeout |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
+| `ST-2` stable support boundary freeze | Active ([#344](https://github.com/Halildeu/ao-kernel/issues/344)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
 
 ## 5. Şimdi
 
@@ -132,8 +134,33 @@ ile merge edildi ve tag/publish doğrulaması tamamlandı:
    installed-package `examples/demo_review.py --cleanup` smoke geçti.
 
 Tarihi PB/GP kayıtları aşağıda korunur; güncel yürütme kararı yukarıdaki
-`ST-1` closeout bloğudur. Sonraki aday aktif hat `ST-2` stable support
-boundary freeze'dir; yeni issue açılmadan stable scope genişletilmeyecek.
+`ST-1` closeout bloğudur. Aktif hat artık `ST-2` stable support boundary
+freeze'dir; issue [#344](https://github.com/Halildeu/ao-kernel/issues/344)
+ve contract
+`.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md` üzerinden yürür.
+Stable scope, bu gate tamamlanmadan genişletilmeyecek.
+
+### `ST-2` — stable support boundary freeze active
+
+`ST-2` amacı `4.0.0` stable öncesinde support boundary'yi dondurmaktır. Bu
+runtime widening işi değildir. İlk PR yalnız contract/status bağlantısını
+kurar; sonraki freeze PR'i `docs/PUBLIC-BETA.md`,
+`docs/SUPPORT-BOUNDARY.md`, `docs/KNOWN-BUGS.md`, `docs/UPGRADE-NOTES.md`,
+`docs/ROLLBACK.md` ve gerekirse `CHANGELOG.md` üzerinde docs parity +
+stable-blocker kararını kapatır.
+
+Mevcut varsayılan karar:
+
+1. Shipped candidate dar kalır: entrypoint'ler, `doctor`,
+   `review_ai_flow + codex-stub`, `examples/demo_review.py`,
+   `PRJ-KERNEL-API` read-only actions, policy command enforcement ve release
+   gate'leri.
+2. `claude-code-cli`, `gh-cli-pr`, `PRJ-KERNEL-API` write-side actions ve
+   real-adapter benchmark tam modu operator-managed beta kalır.
+3. `bug_fix_flow` release closure, full remote PR opening, roadmap/spec demo
+   ve adapter-path `cost_usd` public support claim deferred kalır.
+4. Known bug registry shipped baseline blocker taşımıyorsa stable blocker yok
+   olarak yazılır; shipped baseline etkilenirse ST-2 durur.
 
 ### `PB-6.4` — real-adapter/write-side graduation criteria yeniden sıralama
 
@@ -327,16 +354,16 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Aktif slice: `ST-1` pre-release gate closeout tamamlandı; sıradaki aday hat
-`ST-2` stable support boundary freeze.
+Aktif slice: `ST-2` stable support boundary freeze.
 
 1. Son kapanan slice: `GP-2.2` adapter-path `cost_usd` reconcile completeness
    closeout ([#333](https://github.com/Halildeu/ao-kernel/issues/333))
 2. Production-stable roadmap: `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 3. Completed contract: `.claude/plans/ST-1-RELEASABLE-PRE-RELEASE-GATE.md`
-4. Sonraki iş: `ST-2` için issue/contract açıp stable support boundary
-   freeze kararını yazılı hale getir.
-5. Stable release'e doğrudan geçilmez; önce ST-2 boundary freeze ve sonraki
+4. Aktif contract: `.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md`
+5. Sonraki iş: ST-2 freeze PR'i ile support docs parity ve stable blocker
+   kararını kapat.
+6. Stable release'e doğrudan geçilmez; önce ST-2 boundary freeze ve sonraki
    stable gates kapanır.
 
 `PB-8.2` completion kaydı:

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -127,6 +127,9 @@ kanitli pre-release'e cevirmek.
 
 ### ST-2 — Stable Support Boundary Freeze
 
+**Durum:** Active via [#344](https://github.com/Halildeu/ao-kernel/issues/344)
+and `.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md`.
+
 **Amac:** `4.0.0` stable'in neyi destekledigini release oncesi dondurmek.
 
 **Kapsam:**

--- a/.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md
+++ b/.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md
@@ -1,0 +1,158 @@
+# ST-2 — Stable Support Boundary Freeze
+
+**Durum:** Active
+**Issue:** [#344](https://github.com/Halildeu/ao-kernel/issues/344)
+**Umbrella:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
+**Precondition:** `ST-1` tamamlandi; `v4.0.0-beta.2` published ve PyPI
+exact pin `ao-kernel==4.0.0b2` fresh venv ile dogrulandi.
+**Stable publish degil:** bu slice `4.0.0` tag veya PyPI publish yapmaz.
+
+## 1. Amac
+
+`4.0.0` stable oncesinde support boundary'yi dondurmak. Bu is, yeni runtime
+feature eklemek degil; stable adayinda hangi yuzeylerin `shipped`, hangilerinin
+`beta/operator-managed`, hangilerinin `deferred`, hangilerinin `known bug`
+olarak kalacagini tek anlamli hale getirmek icindir.
+
+Stable release ciktigi zaman kullanilacak dil:
+
+- "dar ama kanitli governed runtime baseline"
+- "genel amacli production coding automation platformu" degil
+- "real adapter production-certified" degil, ancak ST-3 ayri olarak bunu
+  kanitlarsa karar degisebilir
+
+## 2. Authoritative Inputs
+
+ST-2 kararinda asagidaki yuzeyler birlikte okunur:
+
+| Kaynak | Rol |
+|---|---|
+| `docs/PUBLIC-BETA.md` | current support matrix SSOT |
+| `docs/SUPPORT-BOUNDARY.md` | support boundary anlatimi |
+| `docs/KNOWN-BUGS.md` | operator-relevant known bug registry |
+| `docs/UPGRADE-NOTES.md` | kurulum/yukseltme dogrulama yolu |
+| `docs/ROLLBACK.md` | rollback dogrulama yolu |
+| `CHANGELOG.md` | release-facing claim dili |
+| `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md` | stable gate sirasi |
+| `scripts/packaging_smoke.py` | wheel-installed shipped smoke |
+| `scripts/truth_inventory_ratchet.py` | extension truth inventory snapshot |
+
+`docs/PUBLIC-BETA.md` ile diger dokumanlar ayrisirsa
+`docs/PUBLIC-BETA.md` kazanir; ST-2'nin isi bu ayrismayi ortadan kaldirmaktir.
+
+## 3. Stable Shipped Candidate Matrix
+
+Bu tablo, stable candidate'a girebilecek dar shipped yuzeyi temsil eder. Her
+satir ST-2 sirasinda tekrar dogrulanir; kanit eksikse satir stable shipped
+claim'inden cikar veya ST-2 blocker olarak isaretlenir.
+
+| Yuzey | Kod/kontrat kaynagi | Test/smoke kaniti | Stable karari |
+|---|---|---|---|
+| CLI/module version entrypoint'leri | `ao_kernel/cli.py`, `ao_kernel/__main__.py` | `tests/test_cli_entrypoints.py`, `scripts/packaging_smoke.py` | Shipped candidate |
+| `ao-kernel doctor` | `ao_kernel/doctor_cmd.py` | `tests/test_doctor_cmd.py`, `tests/test_cli.py`, `tests/test_client.py`, `python3 -m ao_kernel doctor` | Shipped candidate; WARN truth inventory blocker degil |
+| `review_ai_flow` + `codex-stub` | `ao_kernel/defaults/workflows/review_ai_flow.v1.json`, `ao_kernel/defaults/adapters/codex-stub.manifest.v1.json`, `ao_kernel/fixtures/codex_stub.py` | `examples/demo_review.py`, `tests/benchmarks/test_governed_review.py`, `scripts/packaging_smoke.py` | Shipped candidate |
+| `examples/demo_review.py` | `examples/demo_review.py` | wheel-installed run inside `scripts/packaging_smoke.py` and PyPI post-publish verify | Shipped candidate only when run with installed package Python |
+| `PRJ-KERNEL-API` read-only actions | `ao_kernel/extensions/handlers/prj_kernel_api.py` | `tests/test_extension_dispatch.py` | Shipped candidate for `system_status` and `doc_nav_check` only |
+| Adapter CLI command enforcement | `ao_kernel/executor/executor.py`, `ao_kernel/executor/policy_enforcer.py`, `ao_kernel/executor/adapter_invoker.py` | `tests/test_executor_policy_rollout_v311_p2.py`, `tests/test_executor_policy_enforcer.py`, `tests/test_executor_adapter_invoker.py`, `tests/test_executor_integration.py` | Shipped candidate |
+| Release gate / packaging trust | `.github/workflows/test.yml`, `.github/workflows/publish.yml`, `scripts/packaging_smoke.py` | CI `packaging-smoke`, PyPI `v4.0.0-beta.2` publish verify | Shipped release gate, not runtime feature |
+| Coverage gate | `pyproject.toml`, `.github/workflows/test.yml` | CI coverage `--fail-under=85` | Shipped quality gate, not runtime feature |
+
+## 4. Stable-Dışı Tutulacak Yüzeyler
+
+Bu tablo ST-2 boyunca varsayilan karar tablosudur. Promote etmek isteyen PR,
+bu tabloyu ancak yeni kanitla degistirebilir.
+
+| Yuzey | Mevcut tier | Neden stable shipped degil |
+|---|---|---|
+| `claude-code-cli` helper-backed lane | Beta, operator-managed | PATH binary + operator auth + prompt access prerequisite gerektirir; production-certified adapter failure-mode matrisi henuz stable gate degil |
+| `gh-cli-pr` preflight/live-write readiness probe | Beta, operator-managed / deferred live opening | Live-write disposable sandbox + rollback kaniti olmadan remote PR opening shipped claim olamaz |
+| `PRJ-KERNEL-API` write-side actions | Beta, operator-managed write contract | Gercek yazma explicit `confirm_write=I_UNDERSTAND_SIDE_EFFECTS` ister; stable shipped read-only yuzeyden ayridir |
+| Real-adapter benchmark tam modu | Beta, operator-managed | Deterministik CI baseline degil; ortam/auth/prerequisite bagimli |
+| `bug_fix_flow` release closure | Deferred | `open_pr` side-effect guard'i var ama workflow-level promoted support ve rollback zinciri yok |
+| `docs/roadmap/DEMO-SCRIPT-SPEC.md` 11 adimli akis | Deferred/spec-only | Canli demo kontrati degil |
+| Adapter-path `cost_usd` reconcile public claim | Deferred | Internal benchmark/runtime hook varligi public support claim icin yeterli degil |
+| Bundled extension inventory geneli | Contract inventory | Manifest/loader/truth audit varligi end-to-end support claim uretmez |
+
+## 5. Known Bug Gate
+
+Stable support boundary icin known bug karari:
+
+| ID | Surface | Stable blocker? | ST-2 karari |
+|---|---|---|---|
+| `KB-001` | `claude-code-cli` beta lane prompt access | Hayir, shipped baseline disi | Known bug registry'de kalir |
+| `KB-002` | `claude-code-cli` token fallback | Hayir, shipped baseline disi | Known bug registry'de kalir |
+
+ST-2 sirasinda shipped baseline'i bozan yeni bug bulunursa:
+
+1. `docs/KNOWN-BUGS.md` icine eklenir.
+2. Stable release blocker olarak isaretlenir.
+3. `ST-2` tamamlanmaz; fix veya stable scope daraltma karari gerekir.
+
+## 6. Exact File List
+
+ST-2 contract PR'i:
+
+| Dosya | Karar sorusu |
+|---|---|
+| `.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md` | Gate, matrix, risk ve DoD yazili mi? |
+| `.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md` | Aktif issue/contract `ST-2`ye gecti mi? |
+| `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md` | ST-2 active olarak gorunuyor mu? |
+
+ST-2 implementation/freeze PR'i:
+
+| Dosya | Karar sorusu |
+|---|---|
+| `docs/PUBLIC-BETA.md` | Stable candidate support matrix tek anlamli mi? |
+| `docs/SUPPORT-BOUNDARY.md` | Narrative boundary matrix ile ayni mi? |
+| `docs/KNOWN-BUGS.md` | Shipped baseline blocker yoksa acikca yaziyor mu? |
+| `docs/UPGRADE-NOTES.md` | Stable/beta dogrulama komutlari support boundary ile ayni mi? |
+| `docs/ROLLBACK.md` | Stable ve beta rollback yolu support boundary ile ayni mi? |
+| `CHANGELOG.md` | `Unreleased` stable-boundary freeze notu gerekiyorsa eklendi mi? |
+
+## 7. Validation Plan
+
+Contract PR minimum:
+
+```bash
+git diff --check
+```
+
+Freeze PR minimum:
+
+```bash
+git diff --check
+python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py tests/test_cli.py tests/test_client.py
+python3 -m pytest -q tests/test_extension_dispatch.py
+python3 -m pytest -q tests/test_executor_policy_enforcer.py tests/test_executor_adapter_invoker.py tests/test_executor_policy_rollout_v311_p2.py tests/test_executor_integration.py
+python3 -m pytest -q tests/benchmarks/test_governed_review.py
+python3 scripts/packaging_smoke.py
+python3 scripts/truth_inventory_ratchet.py --output json
+python3 -m ao_kernel doctor
+```
+
+Full CI must pass before merge. Stable release still requires later ST gates.
+
+## 8. Risks
+
+| Risk | Etki | Mitigation |
+|---|---|---|
+| Support widening by wording | Stable kullaniciya fazla vaat verir | PUBLIC-BETA SSOT + shipped evidence matrix |
+| Fake shipped claim | Test/smoke olmayan yuzey stable'a girer | Her shipped satir kod + test/smoke + docs baglantisi ister |
+| Real adapter overclaim | Operator-auth lane production-certified gibi gorunur | `operator-managed beta` dili korunur; ST-3 ayri gate |
+| Live-write overclaim | Remote side-effect shipped gibi gorunur | ST-4 olmadan live-write stable'a girmez |
+| Known bug under-reporting | Stable blocker sakli kalir | Known bug gate shipped baseline'a etkisini zorunlu sorar |
+
+## 9. Exit Criteria
+
+`ST-2` completed sayilmasi icin:
+
+1. Contract PR merge edilir.
+2. Freeze PR merge edilir.
+3. `docs/PUBLIC-BETA.md`, `docs/SUPPORT-BOUNDARY.md`, `docs/KNOWN-BUGS.md`,
+   `docs/UPGRADE-NOTES.md`, `docs/ROLLBACK.md` ayni support boundary'yi
+   anlatir.
+4. Her shipped candidate satiri kod/test/smoke/docs kanitina baglanir.
+5. Stable blocker known bug yoktur veya stable scope daraltma karari yazilir.
+6. ST-3 ve ST-4'un gerekli olup olmadigi acik karar olarak cikar.
+7. Issue [#344](https://github.com/Halildeu/ao-kernel/issues/344) closeout
+   comment ile kapatilir.


### PR DESCRIPTION
## Summary

Starts ST-2: stable support boundary freeze.

This is a contract/status PR only. It creates the ST-2 gate document, links issue #344, and moves the live program status from ST-1 closeout to ST-2 active. No runtime behavior or support widening is included.

Refs #344
Refs #329

## Validation

- `git diff --check`

## Next

The next PR is the ST-2 freeze implementation: verify docs parity across `PUBLIC-BETA`, `SUPPORT-BOUNDARY`, `KNOWN-BUGS`, `UPGRADE-NOTES`, `ROLLBACK`, and decide whether ST-3/ST-4 are required before stable `4.0.0`.
