### PR TITLE
[codex] freeze ST-2 support boundary

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -354,16 +354,18 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Aktif slice: `ST-2` stable support boundary freeze.
+Aktif slice: `ST-2` stable support boundary freeze implementation.
 
 1. Son kapanan slice: `GP-2.2` adapter-path `cost_usd` reconcile completeness
    closeout ([#333](https://github.com/Halildeu/ao-kernel/issues/333))
 2. Production-stable roadmap: `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 3. Completed contract: `.claude/plans/ST-1-RELEASABLE-PRE-RELEASE-GATE.md`
 4. Aktif contract: `.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md`
-5. Sonraki iş: ST-2 freeze PR'i ile support docs parity ve stable blocker
+5. Aktif iş: ST-2 freeze PR'i ile support docs parity ve stable blocker
    kararını kapat.
-6. Stable release'e doğrudan geçilmez; önce ST-2 boundary freeze ve sonraki
+6. Freeze PR kararı: dar stable runtime için ST-3/ST-4 blocker değildir;
+   real-adapter/live-write promotion istenirse ayrı gate gerekir.
+7. Stable release'e doğrudan geçilmez; önce ST-2 boundary freeze ve sonraki
    stable gates kapanır.
 
 `PB-8.2` completion kaydı:

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -127,8 +127,9 @@ kanitli pre-release'e cevirmek.
 
 ### ST-2 — Stable Support Boundary Freeze
 
-**Durum:** Active via [#344](https://github.com/Halildeu/ao-kernel/issues/344)
-and `.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md`.
+**Durum:** Freeze PR active via
+[#344](https://github.com/Halildeu/ao-kernel/issues/344) and
+`.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md`.
 
 **Amac:** `4.0.0` stable'in neyi destekledigini release oncesi dondurmek.
 

--- a/.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md
+++ b/.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md
@@ -1,6 +1,6 @@
 # ST-2 — Stable Support Boundary Freeze
 
-**Durum:** Active
+**Durum:** Freeze PR active
 **Issue:** [#344](https://github.com/Halildeu/ao-kernel/issues/344)
 **Umbrella:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
 **Precondition:** `ST-1` tamamlandi; `v4.0.0-beta.2` published ve PyPI
@@ -87,6 +87,23 @@ ST-2 sirasinda shipped baseline'i bozan yeni bug bulunursa:
 1. `docs/KNOWN-BUGS.md` icine eklenir.
 2. Stable release blocker olarak isaretlenir.
 3. `ST-2` tamamlanmaz; fix veya stable scope daraltma karari gerekir.
+
+## 5.1 Freeze Decision
+
+Freeze PR karari:
+
+1. Stable candidate support set, `docs/PUBLIC-BETA.md` icindeki `Shipped`
+   tablosuyla sinirli kalir.
+2. Current known bugs shipped baseline'i bloklamaz; ikisi de
+   `claude-code-cli` operator-managed beta lane'leriyle sinirlidir.
+3. `ST-3` real-adapter certification dar stable runtime release icin blocker
+   degildir, cunku real adapter lane'leri stable shipped claim'e alinmiyor.
+4. `ST-4` live-write rollback rehearsal dar stable runtime release icin blocker
+   degildir, cunku live-write / remote side-effect yuzeyleri stable shipped
+   claim'e alinmiyor.
+5. Gelecekte `claude-code-cli`, `gh-cli-pr`, kernel API write-side actions,
+   real-adapter benchmark tam modu veya `bug_fix_flow` release closure stable'a
+   promote edilmek istenirse ST-3/ST-4 tarzi yeni kanit gate'i zorunlu olur.
 
 ## 6. Exact File List
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — Stable support boundary freeze
+
+- Added the ST-2 stable support boundary freeze decision:
+  - stable candidate support remains the narrow shipped baseline only
+  - operator-managed beta lanes are not promoted into stable support
+  - deferred lanes remain deferred unless later ST gates provide new evidence
+  - current known bugs do not block the shipped baseline
+- Clarified upgrade and rollback docs so stable checks do not fall back to
+  beta/operator-managed lanes.
+
 ## [4.0.0b2] - 2026-04-24
 
 ### Changed — Post-beta closeout + stable-release gate preparation

--- a/docs/KNOWN-BUGS.md
+++ b/docs/KNOWN-BUGS.md
@@ -7,6 +7,12 @@ operator registry.
 
 ## Current entries
 
+Stable shipped baseline blocker status: **none currently known**.
+
+The open entries below affect operator-managed beta lanes only. They do not
+block a narrow stable runtime release unless a future ST gate promotes those
+lanes into stable shipped support.
+
 | ID | Surface | Symptom | Workaround | Shipped baseline impact |
 |---|---|---|---|---|
 | `KB-001` | `claude-code-cli` beta lane | `claude auth status` may report a healthy login while a real `claude -p` prompt call is still denied | Always trust `python3 scripts/claude_code_cli_smoke.py --output text` over `claude auth status` alone; if blocked, re-login the Claude Code session | None; affects operator-managed lane only |

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -32,6 +32,25 @@ istemek gerekir.
 - [`ROLLBACK.md`](ROLLBACK.md)
 - [`KNOWN-BUGS.md`](KNOWN-BUGS.md)
 
+## Stable Candidate Freeze (ST-2)
+
+`ST-2` freezes the support boundary for a possible future `4.0.0` stable
+release. The stable candidate support set is exactly the `Shipped` table below
+unless a later ST gate changes this document with new evidence.
+
+Stable candidate rules:
+
+1. `Beta`, `Deferred`, `Contract inventory`, and `Example-only` rows are not
+   stable shipped support claims.
+2. `claude-code-cli`, `gh-cli-pr`, `PRJ-KERNEL-API` write-side actions, and
+   real-adapter benchmark full mode remain operator-managed beta.
+3. `bug_fix_flow` release closure, full remote PR opening, roadmap/spec demo
+   widening, and adapter-path `cost_usd` public support remain deferred.
+4. There is currently no known bug that blocks the shipped baseline; current
+   known bugs affect operator-managed beta lanes only.
+5. This boundary still does not claim ao-kernel is a general-purpose
+   production coding automation platform.
+
 ## Shipped (v4.0.0b2)
 
 | Yüzey | Durum | Not |

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -56,7 +56,19 @@ If only an operator-managed beta lane regresses while the shipped baseline
 stays green, prefer narrowing guidance and updating
 [`KNOWN-BUGS.md`](KNOWN-BUGS.md) over rolling back the whole baseline.
 
-## 5. Related documents
+## 5. Stable boundary rule
+
+Rollback does not widen support. If a stable shipped baseline check fails,
+either rollback to the last known-good package or ship a corrective release.
+Do not substitute an operator-managed beta lane as the stable path.
+
+For the current stable candidate boundary:
+
+- shipped baseline regressions are release blockers,
+- beta/operator-managed regressions stay in [`KNOWN-BUGS.md`](KNOWN-BUGS.md),
+- live-write or real-adapter promotion requires separate ST gate evidence.
+
+## 6. Related documents
 
 - [`UPGRADE-NOTES.md`](UPGRADE-NOTES.md)
 - [`OPERATIONS-RUNBOOK.md`](OPERATIONS-RUNBOOK.md)

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -15,7 +15,26 @@ operator-only, or just contract inventory?"
 | Contract inventory | bundled defaults, manifests, extensions, example inventory | loader/validator and truth audit only |
 | Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary (`PB-8.3` verdict `stay_deferred`, `GP-1.3` revalidation ile teyitli) |
 
-### 1.1 Truth inventory to support mapping
+### 1.1 ST-2 stable candidate freeze
+
+For the possible future `4.0.0` stable release, the stable support candidate is
+the `Shipped baseline` layer only. This freeze deliberately excludes:
+
+- operator-managed beta lanes,
+- live-write / remote side-effect flows,
+- contract inventory without behavior evidence,
+- roadmap/spec-only walkthroughs,
+- deferred support claims.
+
+`ST-3` real-adapter certification and `ST-4` live-write rollback rehearsal are
+not blockers for a narrow stable runtime release as long as stable docs do not
+claim those surfaces. They become blockers only if a future PR tries to promote
+real adapters or live-write behavior into stable shipped support.
+
+There is currently no known bug that blocks the shipped baseline. The known
+bugs in [`KNOWN-BUGS.md`](KNOWN-BUGS.md) affect operator-managed beta lanes.
+
+### 1.2 Truth inventory to support mapping
 
 `ao-kernel doctor` içindeki extension truth sınıfları support kararı için tek
 başına yeterli değildir. Bu sınıfların support yorumu aşağıdaki gibi sabittir:

--- a/docs/UPGRADE-NOTES.md
+++ b/docs/UPGRADE-NOTES.md
@@ -22,6 +22,23 @@ pip install ao-kernel==4.0.0b2
 Do not assume `pip install ao-kernel` will pick the beta. It stays on the
 stable channel unless you ask for a pre-release explicitly.
 
+## 1.1 Stable support boundary
+
+The stable candidate support boundary is intentionally narrow. Treat the
+`Shipped` table in [`PUBLIC-BETA.md`](PUBLIC-BETA.md) and the `Shipped
+baseline` layer in [`SUPPORT-BOUNDARY.md`](SUPPORT-BOUNDARY.md) as the supported
+runtime claim.
+
+Do not treat the following as stable shipped support unless a later release
+explicitly promotes them:
+
+- `claude-code-cli` real-adapter lane,
+- `gh-cli-pr` preflight or live-write lane,
+- `PRJ-KERNEL-API` write-side actions,
+- real-adapter benchmark full mode,
+- `bug_fix_flow` release closure,
+- full remote PR opening.
+
 ## 2. Pre-upgrade snapshot
 
 Before upgrading, record the current environment state:
@@ -44,6 +61,11 @@ python -m ao_kernel.cli version
 ao-kernel doctor
 python3 examples/demo_review.py --cleanup
 ```
+
+`examples/demo_review.py` must be executed with a Python environment that has
+the intended `ao-kernel` package installed. The release gate version of this
+check is `scripts/packaging_smoke.py`, which installs the wheel into a fresh
+venv before running the demo.
 
 If you use operator-managed real-adapter lanes, run the corresponding smoke as
 well:


### PR DESCRIPTION
## Summary
- Freeze the ST-2 stable candidate support boundary to the narrow shipped baseline only.
- Keep operator-managed beta lanes, deferred lanes, contract inventory, and example-only surfaces outside stable shipped support unless a later ST gate promotes them with new evidence.
- Clarify known bug, upgrade, and rollback docs so stable release checks do not fall back to beta/operator-managed lanes.

## Decision
- Current known bugs do not block the shipped baseline.
- ST-3 real-adapter certification is not a blocker for the narrow stable runtime release because real-adapter lanes are not stable shipped claims.
- ST-4 live-write rollback rehearsal is not a blocker for the narrow stable runtime release because live-write / remote side-effect surfaces are not stable shipped claims.
- Future promotion of `claude-code-cli`, `gh-cli-pr`, kernel API write-side actions, real-adapter benchmark full mode, or `bug_fix_flow` release closure requires a separate evidence gate.

Refs #344
Refs #329

## Validation
- `git diff --check`
- `python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py tests/test_cli.py tests/test_client.py`
- `python3 -m pytest -q tests/test_extension_dispatch.py`
- `python3 -m pytest -q tests/test_executor_policy_enforcer.py tests/test_executor_adapter_invoker.py tests/test_executor_policy_rollout_v311_p2.py tests/test_executor_integration.py`
- `python3 -m pytest -q tests/benchmarks/test_governed_review.py tests/benchmarks/test_governed_bugfix.py`
- `python3 scripts/truth_inventory_ratchet.py --output json > /tmp/ao-kernel-st2-truth.json`
- `python3 -m ao_kernel doctor`
- `python3 scripts/packaging_smoke.py`

Note: `tests/benchmarks/test_governed_review.py` by itself intentionally triggers the scorecard finalizer guard because both canonical benchmark scenarios must be present. The validation above reran the correct paired benchmark command.
