### PR TITLE
[codex] define ST-5 deferred correctness gate

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -354,7 +354,7 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Aktif slice: `ST-5` deferred correctness closure planning.
+Aktif slice: `ST-5` deferred correctness closure contract.
 
 1. Son kapanan slice: `GP-2.2` adapter-path `cost_usd` reconcile completeness
    closeout ([#333](https://github.com/Halildeu/ao-kernel/issues/333))
@@ -364,9 +364,11 @@ Aktif slice: `ST-5` deferred correctness closure planning.
 5. Son kapanan PR: [#346](https://github.com/Halildeu/ao-kernel/pull/346)
 6. ST-2 freeze kararı: dar stable runtime için ST-3/ST-4 blocker değildir;
    real-adapter/live-write promotion istenirse ayrı gate gerekir.
-7. Sonraki iş: `ST-5` altında deferred correctness kalemlerini `ship`, `beta`,
+7. Aktif issue: [#348](https://github.com/Halildeu/ao-kernel/issues/348)
+8. Aktif contract: `.claude/plans/ST-5-DEFERRED-CORRECTNESS-CLOSURE.md`
+9. Sonraki iş: `ST-5` altında deferred correctness kalemlerini `ship`, `beta`,
    `deferred` veya `retire` kararına indirmek.
-8. Stable release'e doğrudan geçilmez; önce `ST-5`, `ST-6` ve `ST-7` gates
+10. Stable release'e doğrudan geçilmez; önce `ST-5`, `ST-6` ve `ST-7` gates
    kapanır.
 
 `PB-8.2` completion kaydı:

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -192,7 +192,8 @@ gercekte denemek.
 
 ### ST-5 — Deferred Correctness Closure
 
-**Durum:** Next active gate.
+**Durum:** Active via [#348](https://github.com/Halildeu/ao-kernel/issues/348)
+and `.claude/plans/ST-5-DEFERRED-CORRECTNESS-CLOSURE.md`.
 
 **Amac:** Stable shipped yuzeyi etkileyen correctness borcunu kapatmak veya
 bilerek stable disina almak.

--- a/.claude/plans/ST-5-DEFERRED-CORRECTNESS-CLOSURE.md
+++ b/.claude/plans/ST-5-DEFERRED-CORRECTNESS-CLOSURE.md
@@ -1,0 +1,87 @@
+# ST-5 — Deferred Correctness Closure
+
+**Durum:** Active contract via
+[#348](https://github.com/Halildeu/ao-kernel/issues/348)
+**Umbrella:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
+**Precondition:** `ST-2` support boundary freeze completed via
+[#346](https://github.com/Halildeu/ao-kernel/pull/346) and
+[#347](https://github.com/Halildeu/ao-kernel/pull/347).
+
+## 1. Amaç
+
+Stable `4.0.0` kararı öncesi deferred correctness yüzeylerini belirsizlikten
+çıkarmak. Bu gate'in varsayılanı support widening değildir; her kalem tam olarak
+bir kategoriye düşer:
+
+- `ship`
+- `beta`
+- `deferred`
+- `retire`
+
+## 2. Kapsam
+
+| Kalem | Mevcut tier | ST-5 karar sorusu | Varsayılan eğilim |
+|---|---|---|---|
+| `bug_fix_flow` release closure | Deferred | Stable shipped baseline'a alınacak kadar kanıtlı mı? | `deferred` veya ayrı runtime closure PR |
+| `gh-cli-pr` full E2E remote PR opening | Deferred | Disposable sandbox + rollback olmadan support claim olabilir mi? | `deferred` |
+| Roadmap/spec demo live-support | Deferred/spec-only | Canlı demo yüzeyine çevrilecek mi, yoksa spec-only kalacak mı? | `retire` veya `deferred` |
+| Adapter-path `cost_usd` public support | Deferred | Internal hook + behavior evidence public support claim için yeterli mi? | Açık promotion kanıtı yoksa `deferred` |
+| Yeni shipped-baseline bug | Unknown | Stable blocker mı? | Fix edilene veya scope dışına alınana kadar blocker |
+
+## 3. Kapsam Dışı
+
+- Real-adapter production certification (`ST-3` parked for support widening).
+- Live-write rollback rehearsal (`ST-4` parked for support widening).
+- Genel amaçlı production coding automation platform claim'i.
+- Stable release tag/publish.
+
+## 4. Karar Kuralı
+
+Bir kalem `ship` yapılmak istenirse aynı PR içinde veya bağlı evidence PR'inde
+şunlar gerekir:
+
+1. Runtime/code path açık.
+2. Behavior-first test veya smoke mevcut.
+3. Docs/support matrix aynı şeyi söylüyor.
+4. Upgrade/rollback etkisi yazılı.
+5. Known-bugs registry ile çelişki yok.
+
+Bu beşli yoksa kalem `ship` olamaz; `beta`, `deferred` veya `retire` olarak
+kapatılır.
+
+## 5. DoD
+
+`ST-5` tamamlandığında:
+
+1. Kapsam tablosundaki her kalem tam olarak bir kategoriye düşer.
+2. İki kategoriye birden yazılan support surface kalmaz.
+3. Stable shipped baseline'ı bozan açık blocker varsa stable gate durur.
+4. Stable dışı kalan her kalemin gerekçesi ve sonraki gate'i yazılıdır.
+5. `docs/PUBLIC-BETA.md`, `docs/SUPPORT-BOUNDARY.md`,
+   `docs/KNOWN-BUGS.md`, `docs/UPGRADE-NOTES.md` ve `docs/ROLLBACK.md`
+   kararlarla uyumludur.
+
+## 6. Riskler
+
+| Risk | Etki | Önlem |
+|---|---|---|
+| Deferred item'ı kanıtsız stable'a almak | Yüksek | `ship` için beşli evidence rule |
+| Runtime closure işini docs-only kapatmak | Orta | Her kalemde karar tipi açık: `ship` değilse support widening yok |
+| Live-write yan etkisini yanlışlıkla stable yapmak | Yüksek | ST-4 rollback gate'i olmadan live-write stable olmaz |
+| `bug_fix_flow` kapsamının tekrar büyümesi | Orta | Ayrı runtime closure PR gerektir |
+
+## 7. Validation Plan
+
+Contract PR:
+
+```bash
+git diff --check
+```
+
+Runtime/docs karar PR'i:
+
+```bash
+git diff --check
+python3 -m pytest -q <touched-targeted-tests>
+python3 scripts/packaging_smoke.py  # only if shipped package behavior changes
+```


### PR DESCRIPTION
## Summary
- Add the ST-5 deferred correctness closure contract.
- Link issue #348 into the stable-live roadmap and active status surface.
- Define the decision rule that each deferred correctness item must become exactly one of `ship`, `beta`, `deferred`, or `retire` before stable release.

Refs #348
Refs #329

## Validation
- `git diff --check`
