### PR TITLE
[codex] close out ST-5 deferred correctness

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -354,7 +354,7 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Aktif slice: `ST-5` deferred correctness closure contract.
+Aktif slice: `ST-5` deferred correctness closure closeout.
 
 1. Son kapanan slice: `GP-2.2` adapter-path `cost_usd` reconcile completeness
    closeout ([#333](https://github.com/Halildeu/ao-kernel/issues/333))
@@ -366,10 +366,11 @@ Aktif slice: `ST-5` deferred correctness closure contract.
    real-adapter/live-write promotion istenirse ayrı gate gerekir.
 7. Aktif issue: [#348](https://github.com/Halildeu/ao-kernel/issues/348)
 8. Aktif contract: `.claude/plans/ST-5-DEFERRED-CORRECTNESS-CLOSURE.md`
-9. Sonraki iş: `ST-5` altında deferred correctness kalemlerini `ship`, `beta`,
-   `deferred` veya `retire` kararına indirmek.
+9. ST-5 closeout kararı: deferred correctness kalemleri stable shipped baseline'a
+   promote edilmiyor; tamamı `deferred` veya spec-only kalıyor.
 10. Stable release'e doğrudan geçilmez; önce `ST-5`, `ST-6` ve `ST-7` gates
    kapanır.
+11. Sonraki gate: `ST-6` operations readiness.
 
 `PB-8.2` completion kaydı:
 

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -192,8 +192,9 @@ gercekte denemek.
 
 ### ST-5 — Deferred Correctness Closure
 
-**Durum:** Active via [#348](https://github.com/Halildeu/ao-kernel/issues/348)
-and `.claude/plans/ST-5-DEFERRED-CORRECTNESS-CLOSURE.md`.
+**Durum:** Closeout PR active via
+[#348](https://github.com/Halildeu/ao-kernel/issues/348) and
+`.claude/plans/ST-5-DEFERRED-CORRECTNESS-CLOSURE.md`.
 
 **Amac:** Stable shipped yuzeyi etkileyen correctness borcunu kapatmak veya
 bilerek stable disina almak.
@@ -212,6 +213,8 @@ bilerek stable disina almak.
 - Iki kategoriye birden yazilan yuzey kalmaz.
 
 ### ST-6 — Operations Readiness
+
+**Durum:** Next active gate.
 
 **Amac:** Stable release'i isletilebilir hale getirmek.
 

--- a/.claude/plans/ST-5-DEFERRED-CORRECTNESS-CLOSURE.md
+++ b/.claude/plans/ST-5-DEFERRED-CORRECTNESS-CLOSURE.md
@@ -1,6 +1,6 @@
 # ST-5 — Deferred Correctness Closure
 
-**Durum:** Active contract via
+**Durum:** Closeout PR active via
 [#348](https://github.com/Halildeu/ao-kernel/issues/348)
 **Umbrella:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
 **Precondition:** `ST-2` support boundary freeze completed via
@@ -27,6 +27,22 @@ bir kategoriye düşer:
 | Roadmap/spec demo live-support | Deferred/spec-only | Canlı demo yüzeyine çevrilecek mi, yoksa spec-only kalacak mı? | `retire` veya `deferred` |
 | Adapter-path `cost_usd` public support | Deferred | Internal hook + behavior evidence public support claim için yeterli mi? | Açık promotion kanıtı yoksa `deferred` |
 | Yeni shipped-baseline bug | Unknown | Stable blocker mı? | Fix edilene veya scope dışına alınana kadar blocker |
+
+## 2.1 Closeout Decision
+
+ST-5 decision inventory:
+
+| Kalem | Final kategori | Kanıt / gerekçe | Sonraki gate |
+|---|---|---|---|
+| `bug_fix_flow` release closure | `deferred` | `PB-8.3` ve `GP-1.3` kararları `stay_deferred`; `open_pr` adımı explicit opt-in guard arkasında, ancak disposable/live rollback zinciri stable support kanıtı değil | Ayrı runtime closure + rollback gate gerekir |
+| `gh-cli-pr` full E2E remote PR opening | `deferred` | Preflight ve live-write readiness probe operator-managed beta; gerçek remote PR açılışı support claim değil | ST-4 tarzı live-write rollback rehearsal gerekir |
+| Roadmap/spec demo live-support | `deferred` / spec-only | `docs/roadmap/DEMO-SCRIPT-SPEC.md` canlı demo kontratı değil; shipped demo `examples/demo_review.py` olarak kalır | Yeni demo yüzeyi istenirse ayrı shipped-smoke PR gerekir |
+| Adapter-path `cost_usd` public support | `deferred` | `GP-2.2` runtime/evidence completeness doğrulandı, ama public support boundary genişletilmedi | Public support promotion için docs + behavior + operator evidence PR gerekir |
+| Yeni shipped-baseline bug | None known | `docs/KNOWN-BUGS.md` shipped baseline blocker status `none currently known` diyor | Yeni blocker bulunursa stable gate durur |
+
+Sonuç: ST-5 kapsamında stable shipped baseline'a yeni yüzey eklenmedi.
+Deferred kalemlerin hiçbiri stable `4.0.0` dar runtime claim'ini bloklamaz,
+çünkü `ST-2` boundary bu yüzeyleri stable dışına almıştır.
 
 ## 3. Kapsam Dışı
 


### PR DESCRIPTION
## Summary
- Add the ST-5 deferred correctness closeout decision inventory.
- Keep all deferred correctness items outside the stable shipped baseline.
- Move the stable roadmap pointer to ST-6 operations readiness.

## Decision
- `bug_fix_flow` release closure stays deferred.
- Full `gh-cli-pr` remote PR opening stays deferred.
- Roadmap/spec demo remains spec-only/deferred; shipped demo stays `examples/demo_review.py`.
- Adapter-path `cost_usd` public support stays deferred despite internal/runtime evidence completeness.
- No known shipped-baseline blocker is currently open.

Refs #348
Refs #329

## Validation
- `git diff --check`
