### PR TITLE
[codex] harden ST-6 operations readiness

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -354,7 +354,7 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Aktif slice: `ST-6` operations readiness contract.
+Aktif slice: `ST-6` operations readiness implementation.
 
 1. Son kapanan slice: `GP-2.2` adapter-path `cost_usd` reconcile completeness
    closeout ([#333](https://github.com/Halildeu/ao-kernel/issues/333))
@@ -370,6 +370,8 @@ Aktif slice: `ST-6` operations readiness contract.
 9. Aktif issue: [#351](https://github.com/Halildeu/ao-kernel/issues/351)
 10. Aktif contract: `.claude/plans/ST-6-OPERATIONS-READINESS.md`
 11. Stable release'e doğrudan geçilmez; önce `ST-6` ve `ST-7` gates kapanır.
+12. Aktif iş: runbook/rollback/upgrade/support/known-bugs operational readiness
+   parity patch.
 
 `PB-8.2` completion kaydı:
 

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -214,8 +214,9 @@ bilerek stable disina almak.
 
 ### ST-6 — Operations Readiness
 
-**Durum:** Active via [#351](https://github.com/Halildeu/ao-kernel/issues/351)
-and `.claude/plans/ST-6-OPERATIONS-READINESS.md`.
+**Durum:** Implementation PR active via
+[#351](https://github.com/Halildeu/ao-kernel/issues/351) and
+`.claude/plans/ST-6-OPERATIONS-READINESS.md`.
 
 **Amac:** Stable release'i isletilebilir hale getirmek.
 

--- a/.claude/plans/ST-6-OPERATIONS-READINESS.md
+++ b/.claude/plans/ST-6-OPERATIONS-READINESS.md
@@ -1,6 +1,6 @@
 # ST-6 — Operations Readiness
 
-**Durum:** Active contract via
+**Durum:** Implementation PR active via
 [#351](https://github.com/Halildeu/ao-kernel/issues/351)
 **Umbrella:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
 **Precondition:** `ST-5` completed via
@@ -23,6 +23,23 @@ anlamlı hale getirir.
 | Support boundary | Stable shipped, beta, deferred, known bugs ayrımı tutarlı mı? | `docs/SUPPORT-BOUNDARY.md`, `docs/PUBLIC-BETA.md` |
 | Known bugs | Stable shipped blocker status açık mı? | `docs/KNOWN-BUGS.md` |
 | Release gates | Required checks, packaging smoke ve publish verify yazılı mı? | `.github/workflows/*`, roadmap docs |
+
+## 2.1 Implementation Decision
+
+ST-6 implementation PR'i runtime feature eklemez. Karar:
+
+1. Operator incident akışı `OPERATIONS-RUNBOOK.md` içinde command-first hale
+   getirilecek.
+2. Rollback dokümanı merge, failed publish, bad published package, yank ve
+   beta-only regression kararlarını ayıracak.
+3. Upgrade dokümanı release doğrulamasında editable install yerine fresh venv
+   exact package install ve `scripts/packaging_smoke.py` kullanacağını yazacak.
+4. `KNOWN-BUGS.md` stable shipped blocker sorusunu release gate olarak açık
+   soracak.
+5. `SUPPORT-BOUNDARY.md` operational readiness'ın support boundary'yi
+   genişletmediğini yazacak.
+
+No support widening, no stable tag, no publish.
 
 ## 3. Kapsam Dışı
 

--- a/docs/KNOWN-BUGS.md
+++ b/docs/KNOWN-BUGS.md
@@ -23,3 +23,14 @@ lanes into stable shipped support.
 If a bug only affects a beta/operator-managed lane while the shipped baseline
 is green, do not silently widen support to cover the broken lane. Update this
 registry and keep the support tier narrow until the issue is resolved.
+
+## Release readiness rule
+
+Before a stable release candidate, this file must answer two questions:
+
+1. Is there any known bug that affects the shipped baseline?
+2. If a known bug remains open, is it explicitly outside stable shipped support?
+
+If the answer to the first question is yes, the stable release gate stops until
+the bug is fixed or the support boundary is narrowed. If the answer to the
+second question is no, update this registry before continuing release work.

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -125,6 +125,22 @@ stay narrow. Actions:
 3. If it is new, add it before describing the lane as reliable.
 4. Keep the lane in Beta / operator-managed status until a fix is verified.
 
+### 3.3 Failure-to-command map
+
+Use this table when triaging an operator report. It keeps the first response
+aligned with the current support boundary.
+
+| Failure report | First command(s) | Stable impact |
+|---|---|---|
+| Install or import fails | `python -m pip show ao-kernel`, `ao-kernel version`, `python -m ao_kernel version` | Stable blocker if package install or module entrypoint fails for the shipped channel |
+| Demo does not complete | `python3 examples/demo_review.py --cleanup`, then `python3 scripts/packaging_smoke.py` from a checkout | Stable blocker if the installed-package demo fails |
+| Doctor reports `FAIL` | `ao-kernel doctor` and capture the JSON/text output | Stable blocker if the failing check is part of the shipped baseline |
+| Doctor reports extension truth `WARN` only | `python3 scripts/truth_inventory_ratchet.py --output json` | Not automatically a blocker; compare with `SUPPORT-BOUNDARY.md` |
+| Policy/command deny looks wrong | Targeted executor policy tests plus workflow evidence `events.jsonl` | Blocker only if shipped baseline policy contract regresses |
+| `claude-code-cli` smoke fails | `python3 scripts/claude_code_cli_smoke.py --output text` | Beta lane incident unless the shipped baseline also fails |
+| `gh-cli-pr` smoke fails | `python3 scripts/gh_cli_pr_smoke.py --output text` | Beta/deferred lane incident unless shipped baseline also fails |
+| Publish or package verification fails | `python3 scripts/packaging_smoke.py`, `twine check dist/*`, post-publish fresh-venv install | Release blocker; do not publish or announce readiness |
+
 ## 4. Evidence to collect
 
 For any Sev 1 or Sev 2 incident, collect:
@@ -149,7 +165,26 @@ An incident is considered closed only when:
 3. the known-bugs registry is updated if the issue remains open but bounded,
 4. upgrade / rollback guidance does not contradict the current runtime state.
 
-## 6. Related documents
+## 6. Release readiness gates
+
+Before a stable release candidate can move forward, the operator must have a
+green gate bundle:
+
+1. PR CI: `lint`, Python `test` matrix, `coverage`, `typecheck`,
+   `benchmark-fast`, and `packaging-smoke`.
+2. Advisory PR surface: `scorecard` should run on pull requests, but it is
+   advisory and must not be described as a hard release blocker unless branch
+   protection changes.
+3. Publish workflow: tag-triggered `publish.yml` must run
+   `scripts/packaging_smoke.py`, `twine check dist/*`, and PyPI trusted
+   publishing successfully.
+4. Post-publish verification: install the exact published version in a fresh
+   venv, then run the entrypoint, doctor, and demo commands from section 2.
+
+Merge is not publish. A release is only live after the tag workflow succeeds
+and the public package install path is verified.
+
+## 7. Related documents
 
 - [`PUBLIC-BETA.md`](PUBLIC-BETA.md) — release support matrix
 - [`SUPPORT-BOUNDARY.md`](SUPPORT-BOUNDARY.md) — narrative support tiers

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -50,6 +50,19 @@ release boundary. That means:
 - a published package may need a package reinstall or follow-up release,
 - both may be needed if the bad state already reached users.
 
+### 3.1 Emergency decision matrix
+
+| Bad state | Preferred action | Notes |
+|---|---|---|
+| Bad PR merged but no tag published | Revert or fix-forward on `main` | Do not create a release tag until the shipped baseline is green again |
+| Tag pushed but publish workflow failed before upload | Fix the release workflow/package issue and retag only according to repository release policy | Do not announce the version as live |
+| Package published and shipped baseline fails | Prefer fast corrective release; use package-level rollback for affected operators | Update `KNOWN-BUGS.md` only if the issue remains bounded and understood |
+| Package published and install is dangerous or misleading for most users | Consider yanking the release in PyPI, then publish a corrective version | Yank is exceptional; record the reason in the release issue/changelog |
+| Only beta/operator-managed lane regresses | Keep stable package; update known bugs/operator guidance | Do not yank or rollback the shipped baseline for beta-only regressions |
+
+After any rollback, yank, or fix-forward decision, rerun the shipped baseline
+commands and record the exact version/commit used for verification.
+
 ## 4. Beta lane rule
 
 If only an operator-managed beta lane regresses while the shipped baseline

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -151,6 +151,17 @@ If a surface is not simultaneously backed by:
 
 then treat it as not widened.
 
+## 4.1 Stable operations rule
+
+For the narrow stable candidate, operational readiness follows the same support
+boundary:
+
+- shipped baseline failure is a release blocker,
+- beta/operator-managed failure is handled through smoke output and
+  `KNOWN-BUGS.md`,
+- deferred support claims do not become stable because a runbook exists,
+- publish readiness requires the same wheel-installed smoke used by CI.
+
 ## 5. Related documents
 
 - [`PUBLIC-BETA.md`](PUBLIC-BETA.md)

--- a/docs/UPGRADE-NOTES.md
+++ b/docs/UPGRADE-NOTES.md
@@ -95,6 +95,35 @@ Prerequisite contract:
 guard arkasındadır. Gerçek live-write denemesi yalnız disposable ortamda,
 explicit `AO_KERNEL_ALLOW_GH_CLI_PR_LIVE_WRITE=1` ile yapılmalıdır.
 
+## 3.1 Release operator verification
+
+For a release candidate or freshly published package, run this from a checkout
+that contains `examples/demo_review.py`, but prefer an isolated verification
+environment over the current editable install:
+
+```bash
+python3 -m venv /tmp/ao-kernel-release-verify
+/tmp/ao-kernel-release-verify/bin/python -m pip install -U pip
+/tmp/ao-kernel-release-verify/bin/python -m pip install ao-kernel==<version>
+/tmp/ao-kernel-release-verify/bin/ao-kernel version
+/tmp/ao-kernel-release-verify/bin/python -m ao_kernel version
+/tmp/ao-kernel-release-verify/bin/python -m ao_kernel.cli version
+/tmp/ao-kernel-release-verify/bin/ao-kernel doctor
+/tmp/ao-kernel-release-verify/bin/python examples/demo_review.py --cleanup
+```
+
+For pre-release validation, replace the install command with either an exact
+pre-release pin or `--pre`. Do not use an editable install as release evidence.
+
+From a source checkout, the equivalent package gate is:
+
+```bash
+python3 scripts/packaging_smoke.py
+```
+
+This script builds the sdist/wheel, installs the wheel into a fresh venv, and
+runs the shipped entrypoint/demo checks outside the editable install path.
+
 ## 4. Expected warnings
 
 These do not automatically mean the upgrade failed:


### PR DESCRIPTION
## Summary
- Add command-first operations triage for shipped baseline, beta lanes, and publish/package failures.
- Add rollback/yank/fix-forward decision matrix and fresh-venv release verification guidance.
- Tie known bugs, support boundary, and ST-6 status to stable release readiness without widening support.

Refs #351
Refs #329

## Validation
- `git diff --check`
- `python3 -m ao_kernel doctor` (`8 OK, 1 WARN, 0 FAIL`; expected extension truth inventory WARN)
- `python3 scripts/packaging_smoke.py`