### PR TITLE
[codex] define ST-7 stable release candidate gate

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -17,7 +17,7 @@ ayrı ayrı görünür kılmak.
 - **Program roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-6-OPERATIONS-READINESS.md` (`ST-6 completed`)
-- **Aktif decision/ordering contract:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md` (`ST-7 next`)
+- **Aktif decision/ordering contract:** `.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md` (`ST-7 active`)
 - **GP-2.2 closeout contract:** `.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md`
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
@@ -44,8 +44,9 @@ ayrı ayrı görünür kılmak.
 - **GP-2.2b issue:** [#336](https://github.com/Halildeu/ao-kernel/issues/336) (`closed`)
 - **ST-1 issue:** [#340](https://github.com/Halildeu/ao-kernel/issues/340) (`closed after closeout`)
 - **ST-2 issue:** [#344](https://github.com/Halildeu/ao-kernel/issues/344) (`closed`)
-- **ST-6 issue:** [#351](https://github.com/Halildeu/ao-kernel/issues/351) (`closing after closeout`)
-- **Aktif gate:** `ST-7` stable release candidate (`issue to open after ST-6 closeout`)
+- **ST-6 issue:** [#351](https://github.com/Halildeu/ao-kernel/issues/351) (`closed`)
+- **ST-7 issue:** [#355](https://github.com/Halildeu/ao-kernel/issues/355) (`active`)
+- **Aktif gate:** `ST-7` stable release candidate
 
 ## 2. Başlangıç Gerçeği
 
@@ -97,7 +98,7 @@ ayrı ayrı görünür kılmak.
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
 | `ST-5` deferred correctness closure | Completed on `main` ([#348](https://github.com/Halildeu/ao-kernel/issues/348), [#350](https://github.com/Halildeu/ao-kernel/pull/350)) | known deferred correctness kalemlerini stable blocker olmaktan çıkarıp açık support boundary'ye bağlamak | deferred bug contract + stable impact decision |
 | `ST-6` operations readiness | Completed on `main` ([#351](https://github.com/Halildeu/ao-kernel/issues/351), [#353](https://github.com/Halildeu/ao-kernel/pull/353)) | stable release öncesi incident, rollback, upgrade, known-bugs ve release-gate runbook'unu işletilebilir hale getirmek | operations runbook + rollback matrix + fresh-venv verification + packaging smoke parity |
-| `ST-7` stable release candidate | Next | `4.0.0` stable için final aday branch/PR hazırlamak | version/changelog/docs final + full CI + installed-package smoke |
+| `ST-7` stable release candidate | Active ([#355](https://github.com/Halildeu/ao-kernel/issues/355)) | `4.0.0` stable için final aday branch/PR hazırlamak | version/changelog/docs final + full CI + installed-package smoke |
 
 ## 5. Şimdi
 
@@ -372,8 +373,8 @@ Aktif slice: `ST-7` stable release candidate preparation.
 8. ST-5 closeout kararı: deferred correctness kalemleri stable shipped baseline'a
    promote edilmiyor; tamamı `deferred` veya spec-only kalıyor.
 9. Son kapanan issue: [#351](https://github.com/Halildeu/ao-kernel/issues/351)
-   (`ST-6` closeout sonrası kapatılacak)
-10. Aktif contract: `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
+   (`ST-6` closed)
+10. Aktif contract: `.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md`
 11. Stable release'e doğrudan geçilmez; önce `ST-7` release-candidate gate
    branch/PR ile kapanır.
 12. Aktif iş: `ST-7` için exact release-candidate checklist, version/changelog

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -237,7 +237,8 @@ bilerek stable disina almak.
 
 ### ST-7 — Stable Release Candidate
 
-**Durum:** Next active gate after `ST-6` closeout.
+**Durum:** Active via [#355](https://github.com/Halildeu/ao-kernel/issues/355)
+and `.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md`.
 
 **Amac:** `4.0.0` stable icin final aday cikarmak.
 

--- a/.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md
+++ b/.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md
@@ -1,0 +1,110 @@
+# ST-7 — Stable Release Candidate
+
+**Durum:** Active contract via
+[#355](https://github.com/Halildeu/ao-kernel/issues/355)
+**Umbrella:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
+**Precondition:** `ST-6` completed via
+[#354](https://github.com/Halildeu/ao-kernel/pull/354).
+
+## 1. Amaç
+
+`4.0.0` stable release candidate PR'ını hazırlanabilir hale getirmek. Bu gate
+stable tag veya PyPI publish yapmaz; yalnızca final aday PR'ının dosya
+kapsamını, karar sorularını ve kanıt paketini kilitler.
+
+## 2. Scope Boundary
+
+ST-7 stable support'u genişletmez. Stable candidate yalnız mevcut narrow
+shipped baseline için hazırlanır:
+
+1. CLI/module entrypoint'ler.
+2. `ao-kernel doctor`.
+3. `review_ai_flow + codex-stub`.
+4. `examples/demo_review.py`.
+5. policy command enforcement.
+6. wheel-installed packaging smoke.
+7. documented read-only kernel API actions.
+
+`claude-code-cli`, `gh-cli-pr`, write-side kernel API actions, real-adapter
+benchmark full mode ve deferred lanes stable support'a promote edilmez.
+
+## 3. Exact File List
+
+Stable candidate implementation PR'ı yalnız şu yüzeyleri değiştirebilir:
+
+| Dosya | Karar sorusu |
+|---|---|
+| `pyproject.toml` | package version `4.0.0` olacak mı? |
+| `ao_kernel/__init__.py` | runtime version `4.0.0` ile hizalı mı? |
+| `CHANGELOG.md` | `[4.0.0]` entry stable boundary'yi doğru anlatıyor mu? |
+| `README.md` | stable install quick-start pre-release dilinden ayrıldı mı? |
+| `docs/PUBLIC-BETA.md` | beta dokümanı stable claim üretmeden `4.0.0` sonrası rolünü koruyor mu? |
+| `docs/SUPPORT-BOUNDARY.md` | shipped/beta/deferred boundary stable aday için değişmeden duruyor mu? |
+| `docs/UPGRADE-NOTES.md` | stable install ve verification komutları exact package/fresh venv yolunu anlatıyor mu? |
+| `docs/OPERATIONS-RUNBOOK.md` | release readiness gates `4.0.0` adayına uygulanabilir mi? |
+| `docs/ROLLBACK.md` | bad stable publish / yank / fix-forward kararı yeterli mi? |
+| `docs/KNOWN-BUGS.md` | shipped baseline blocker var mı sorusu cevaplı mı? |
+| `.claude/plans/*STATUS*.md` ve bu contract | program status `ST-7` sonucu ile hizalı mı? |
+
+Bu liste dışı runtime değişiklikleri ST-7'de yapılmaz. Runtime blocker çıkarsa
+stable candidate durur ve ayrı bugfix PR açılır.
+
+## 4. Release Candidate Validation Bundle
+
+ST-7 implementation PR'ı merge edilmeden önce aşağıdaki kanıt paketi gerekir:
+
+```bash
+git diff --check
+python3 -m ao_kernel doctor
+python3 examples/demo_review.py --cleanup
+python3 scripts/packaging_smoke.py
+```
+
+CI tarafında ayrıca şunlar yeşil olmalıdır:
+
+1. `lint`
+2. Python `test` matrix
+3. `coverage`
+4. `typecheck`
+5. `benchmark-fast`
+6. `packaging-smoke`
+7. `scorecard` advisory result
+
+Stable publish'e geçmeden önce, tag workflow dışında ayrıca fresh venv exact
+install verification planı hazırlanır. Bu doğrulama `ST-8` publish gate'inde
+koşar; ST-7 bunu yalnız checklist olarak hazırlar.
+
+## 5. Release Blockers
+
+Aşağıdakilerden biri varsa `4.0.0` release candidate merge edilmez:
+
+1. `KNOWN-BUGS.md` içinde shipped baseline'ı etkileyen açık blocker var.
+2. `docs/PUBLIC-BETA.md`, `README.md` veya `SUPPORT-BOUNDARY.md` beta/deferred
+   lane'i stable gibi anlatıyor.
+3. `scripts/packaging_smoke.py` wheel-installed demo yolunda fail ediyor.
+4. `ao-kernel doctor` shipped baseline için `FAIL` üretiyor.
+5. Version değeri `pyproject.toml`, `ao_kernel/__init__.py`, CLI çıktısı ve
+   changelog arasında ayrışıyor.
+6. Publish workflow release gate'leri `test.yml` ile aynı smoke kontratını
+   taşımıyor.
+
+## 6. Out of Scope
+
+- `v4.0.0` tag push.
+- PyPI publish.
+- GitHub release yayını.
+- Support widening.
+- Real-adapter production certification.
+- Live-write remote PR opening.
+
+## 7. Done Definition
+
+ST-7 tamamlandığında:
+
+1. `4.0.0` stable candidate PR'ı merge edilmiştir.
+2. Version/changelog/docs aynı stable boundary'yi anlatır.
+3. Full CI ve local validation bundle geçmiştir.
+4. `ST-8` stable publish gate'i için public post-publish verification sırası
+   açık kalmıştır.
+5. `pip install ao-kernel` için stable live iddiası hâlâ yapılmamıştır; bu
+   iddia yalnız `ST-8` publish ve public install verify sonrası yapılır.


### PR DESCRIPTION
## Summary
- Add the ST-7 stable release candidate contract.
- Bind ST-7 to tracker issue #355.
- Update roadmap/status surfaces so the active gate is ST-7 after ST-6 closeout.

Refs #355
Refs #329

## Validation
- `git diff --check`