### PR TITLE
[codex] prepare 4.0.0 stable release candidate

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -377,8 +377,8 @@ Aktif slice: `ST-7` stable release candidate preparation.
 10. Aktif contract: `.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md`
 11. Stable release'e doğrudan geçilmez; önce `ST-7` release-candidate gate
    branch/PR ile kapanır.
-12. Aktif iş: `ST-7` için exact release-candidate checklist, version/changelog
-   finalization ve stable docs install language hazırlığı.
+12. Aktif iş: `ST-7` implementation PR ile `4.0.0` source candidate version,
+   changelog ve stable docs install language hazırlığı.
 
 `PB-8.2` completion kaydı:
 

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -237,8 +237,9 @@ bilerek stable disina almak.
 
 ### ST-7 — Stable Release Candidate
 
-**Durum:** Active via [#355](https://github.com/Halildeu/ao-kernel/issues/355)
-and `.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md`.
+**Durum:** Implementation PR active via
+[#355](https://github.com/Halildeu/ao-kernel/issues/355) and
+`.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md`.
 
 **Amac:** `4.0.0` stable icin final aday cikarmak.
 

--- a/.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md
+++ b/.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md
@@ -1,6 +1,6 @@
 # ST-7 — Stable Release Candidate
 
-**Durum:** Active contract via
+**Durum:** Implementation PR active via
 [#355](https://github.com/Halildeu/ao-kernel/issues/355)
 **Umbrella:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
 **Precondition:** `ST-6` completed via
@@ -56,9 +56,16 @@ ST-7 implementation PR'ı merge edilmeden önce aşağıdaki kanıt paketi gerek
 ```bash
 git diff --check
 python3 -m ao_kernel doctor
-python3 examples/demo_review.py --cleanup
 python3 scripts/packaging_smoke.py
 ```
+
+Raw `python3 examples/demo_review.py --cleanup` is valid only when the current
+Python environment already has `ao-kernel` installed. It is not standalone
+release evidence from an uninstalled source checkout because the demo switches
+into a disposable temp workspace before running `python -m ao_kernel init`.
+`scripts/packaging_smoke.py` is the authoritative release gate because it
+builds the wheel, installs it into a fresh venv, and then runs the installed
+demo path.
 
 CI tarafında ayrıca şunlar yeşil olmalıdır:
 
@@ -108,3 +115,15 @@ ST-7 tamamlandığında:
    açık kalmıştır.
 5. `pip install ao-kernel` için stable live iddiası hâlâ yapılmamıştır; bu
    iddia yalnız `ST-8` publish ve public install verify sonrası yapılır.
+
+## 8. Implementation Decision
+
+ST-7 implementation PR'i `4.0.0` source candidate hazırlar:
+
+1. `pyproject.toml` ve `ao_kernel/__init__.py` version değerleri `4.0.0` olur.
+2. `CHANGELOG.md` `[4.0.0]` entry'si narrow stable boundary'yi açık yazar.
+3. README ve support docs stable install dilini beta/pre-release dilinden
+   ayırır.
+4. Public package live claim'i yapılmaz; tag/publish/post-publish verify
+   `ST-8` kapsamındadır.
+5. Support widening yapılmaz.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,58 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-### Changed — Stable support boundary freeze
+No unreleased changes.
 
-- Added the ST-2 stable support boundary freeze decision:
-  - stable candidate support remains the narrow shipped baseline only
-  - operator-managed beta lanes are not promoted into stable support
-  - deferred lanes remain deferred unless later ST gates provide new evidence
-  - current known bugs do not block the shipped baseline
-- Clarified upgrade and rollback docs so stable checks do not fall back to
-  beta/operator-managed lanes.
+## [4.0.0] - 2026-04-24
+
+### Changed — Stable release candidate
+
+`v4.0.0` prepares the narrow stable runtime line from the proven `4.0.0b2`
+Public Beta baseline. This release candidate does **not** claim that
+ao-kernel is a general-purpose production coding automation platform. It makes
+the governed runtime baseline stable while keeping beta and deferred lanes
+outside the stable support boundary.
+
+- Stable shipped baseline remains narrow:
+  - CLI/module entrypoints
+  - `ao-kernel doctor`
+  - bundled `review_ai_flow` + bundled `codex-stub`
+  - `examples/demo_review.py`
+  - policy command enforcement
+  - wheel-installed packaging smoke
+  - documented read-only `PRJ-KERNEL-API` actions
+- Added and closed the stable gate sequence:
+  - `ST-2` stable support boundary freeze
+  - `ST-5` deferred correctness closure
+  - `ST-6` operations readiness
+  - `ST-7` stable release candidate contract
+- Clarified upgrade, rollback, known-bugs, and operations docs so stable
+  checks do not fall back to beta/operator-managed lanes.
+- Operator-managed lanes remain outside stable support:
+  - `claude-code-cli`
+  - `gh-cli-pr`
+  - `PRJ-KERNEL-API` write-side actions
+  - real-adapter benchmark full mode
+- Deferred lanes remain deferred:
+  - `bug_fix_flow` release closure
+  - full remote PR opening
+  - roadmap/spec demo widening
+  - adapter-path `cost_usd` as a public support claim
+- Known bugs currently affect operator-managed beta lanes only; there is no
+  known shipped-baseline blocker.
+- Legacy `save_store()` and `allow_overwrite=True` compatibility is retained
+  for this narrow stable line. Their deprecation text now targets a future
+  major release instead of promising removal/default flip inside `4.0.0`.
+- Version bump `4.0.0b2 -> 4.0.0` (git tag target: `v4.0.0`).
+
+### Migration note
+
+- Until the stable tag is pushed and the publish workflow succeeds,
+  `pip install ao-kernel` may still resolve to the previous stable package.
+- After publish verification, `pip install ao-kernel` and
+  `pip install ao-kernel==4.0.0` are the intended stable install paths.
+- Public Beta users who need the prior pre-release line can still pin
+  `ao-kernel==4.0.0b2`.
 
 ## [4.0.0b2] - 2026-04-24
 
@@ -1861,8 +1904,10 @@ objections were grep-verified and absorbed.
   catch the new error or restore a healthy file.
 - **`save_store` deprecated.** Production write paths must route
   through `save_store_cas(...)` or the `canonical_store` mutator
-  helpers; `save_store()` emits a `DeprecationWarning` since v3.0.0
-  and will be removed in v4.0.0.
+  helpers; `save_store()` emits a `DeprecationWarning` since v3.0.0.
+  It was originally targeted for a v4.0.0 removal; the v4.0.0 stable
+  line retained compatibility and retargeted removal to a future major
+  release.
 - **Evidence contract clarified.** CLAUDE.md §2 now documents the
   dual form: MCP events land in JSONL (fsync-only, daily-rotated),
   while workspace artefacts keep the SHA256 integrity manifest. The

--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ ao-kernel is **not** a general-purpose agent framework or a blanket "production 
 
 ```bash
 pip install ao-kernel                # Core (only jsonschema dependency)
+pip install ao-kernel==4.0.0         # Exact stable pin after v4.0.0 publish
 pip install ao-kernel[llm]           # LLM modules (tenacity + tiktoken)
 pip install ao-kernel[mcp]           # MCP server support
 pip install ao-kernel[otel]          # OpenTelemetry instrumentation
 pip install ao-kernel[llm,mcp,otel]  # Everything
 ```
+
+`4.0.0` stable source changes do not by themselves mean the public package is
+live. Treat the exact `ao-kernel==4.0.0` install path as live only after the
+tag-triggered publish workflow and fresh-venv public install verification pass.
 
 **For production-grade live LLM calls**, install the `[llm]` extra. Without it the runtime still dispatches requests, but two guarantees weaken: **retry / backoff** (`tenacity`) degrades to a single-attempt call so transient 429 / 5xx responses fail the request instead of being retried, and **exact token counting** (`tiktoken`) falls back to a heuristic estimator (~4 chars/token) so budget accounting is approximate. The core install is fully sufficient for policy evaluation, evidence replay, workflow inspection, and MCP server hosting.
 
@@ -89,7 +94,7 @@ See [`docs/PUBLIC-BETA.md`](docs/PUBLIC-BETA.md) for the support matrix (Shipped
 
 Treat the repo in three layers:
 
-- **Runtime-backed / supported**: core CLI and SDK surfaces, evidence tooling, worktree policy enforcement, bundled `review_ai_flow`, and `examples/demo_review.py`.
+- **Stable shipped baseline**: entrypoint/version commands, `ao-kernel doctor`, bundled `review_ai_flow` + `codex-stub`, `examples/demo_review.py`, policy command enforcement, wheel-installed packaging smoke, and documented read-only `PRJ-KERNEL-API` actions.
 - **Operator / evaluation only**: benchmark docs, real-adapter runbooks, prompt experiment runbooks, and other opt-in validation paths that are intentionally outside the default deterministic CI/demo lane.
 - **Contract / reference inventory**: bundled JSON defaults, adapter manifests, registry files, and example code such as `examples/hello-llm/`. Their presence in the tree is useful reference material, not blanket proof that every surface is production-ready end to end. The bundled extension inventory is especially narrow at runtime today: `PRJ-HELLO` is the explicit bootstrap-backed smoke path; the rest of the bundled manifests should be treated as contract inventory unless a support doc says otherwise.
 

--- a/ao_kernel/__init__.py
+++ b/ao_kernel/__init__.py
@@ -1,6 +1,6 @@
 """ao-kernel — Governed AI orchestration runtime."""
 
-__version__ = "4.0.0b2"
+__version__ = "4.0.0"
 
 from ao_kernel.client import AoKernelClient
 from ao_kernel.config import load_default, load_with_override, workspace_root

--- a/ao_kernel/context/canonical_store.py
+++ b/ao_kernel/context/canonical_store.py
@@ -135,12 +135,12 @@ def save_store(workspace_root: Path, store: dict[str, Any]) -> None:
     Deprecated since v3.0.0. New code should use :func:`save_store_cas`
     or rely on the mutator helpers (``promote_decision``, ``forget``, ...)
     which route through the locked + CAS-aware path. Scheduled for
-    removal in v4.0.0.
+    removal in a future major release.
     """
     warnings.warn(
         "save_store() is deprecated since v3.0.0; use save_store_cas() "
         "or the canonical_store mutator helpers instead. Scheduled for "
-        "removal in v4.0.0.",
+        "removal in a future major release.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -305,7 +305,7 @@ def promote_decision(
             raise :class:`CanonicalRevisionConflict`. ``None`` + the
             default ``allow_overwrite=True`` preserves the v2.x behavior.
         allow_overwrite: Default ``True`` for backward compatibility.
-            v4.0.0 will flip this to ``False`` and require callers to
+            A future major release will flip this to ``False`` and require callers to
             opt in to overwriting stale revisions.
     """
     now = _now_iso()

--- a/ao_kernel/context/self_edit_memory.py
+++ b/ao_kernel/context/self_edit_memory.py
@@ -115,8 +115,8 @@ def forget(
     Routes through the canonical CAS helper (CNS-20260414-010 Stage A),
     so the lock and revision guards are shared with ``promote_decision``.
     ``expected_revision`` / ``allow_overwrite`` match the pattern: default
-    ``allow_overwrite=True`` preserves v2.x behavior until v4.0.0 flips the
-    default.
+    ``allow_overwrite=True`` preserves v2.x behavior until a future major
+    release flips the default.
     """
     full_key = f"memory.{key}" if not key.startswith("memory.") else key
 

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -1,10 +1,10 @@
-# Public Beta (v4.0.0b2) — Support Matrix SSOT
+# Support Matrix SSOT (v4.0.0 stable candidate + beta lanes)
 
-> **Sürüm durumu (2026-04-24)**: stable kanal `pip install ao-kernel`
-> komutuyla, Public Beta ise explicit pre-release pin veya `--pre` ile
-> kurulur. Bu doküman `v4.0.0b2` için canlı destek matrisi ve
-> operator-facing SSOT'tur; stable kanalın exact sürüm numarası release
-> anında PyPI'dan doğrulanır, burada hard-code edilmez.
+> **Sürüm durumu (2026-04-24)**: bu source tree `4.0.0` stable candidate
+> için hazırlanmıştır. Public package live claim'i yalnız `v4.0.0` tag'i,
+> publish workflow success ve fresh-venv public install verify sonrası
+> yapılır. Bu doküman stable shipped baseline, beta lanes, deferred lanes ve
+> known bugs için operator-facing SSOT'tur.
 
 ## Kurulum
 
@@ -12,17 +12,19 @@
 
 ```bash
 pip install ao-kernel
+pip install ao-kernel==4.0.0  # exact stable pin after v4.0.0 publish
 ```
 
-### Public Beta pre-release
+### Historical Public Beta pre-release
 
 ```bash
 pip install ao-kernel==4.0.0b2
 pip install --pre ao-kernel
 ```
 
-`pip install ao-kernel` varsayılan olarak stable kanalda kalır; pre-release
-istemek gerekir.
+`--pre` yalnız pre-release hattını bilinçli takip etmek için kullanılmalıdır;
+stable `4.0.0` canlı hale geldiğinde varsayılan kullanıcı yolu stable kanal
+olur.
 
 ## Operational References
 
@@ -32,11 +34,11 @@ istemek gerekir.
 - [`ROLLBACK.md`](ROLLBACK.md)
 - [`KNOWN-BUGS.md`](KNOWN-BUGS.md)
 
-## Stable Candidate Freeze (ST-2)
+## Stable Support Boundary
 
-`ST-2` freezes the support boundary for a possible future `4.0.0` stable
-release. The stable candidate support set is exactly the `Shipped` table below
-unless a later ST gate changes this document with new evidence.
+`ST-2` froze the support boundary and `ST-7` keeps it unchanged for the
+`4.0.0` stable candidate. The stable support set is exactly the `Shipped`
+table below unless a later gate changes this document with new evidence.
 
 Stable candidate rules:
 
@@ -51,7 +53,7 @@ Stable candidate rules:
 5. This boundary still does not claim ao-kernel is a general-purpose
    production coding automation platform.
 
-## Shipped (v4.0.0b2)
+## Shipped (v4.0.0 stable candidate)
 
 | Yüzey | Durum | Not |
 |---|---|---|
@@ -75,7 +77,7 @@ Stable candidate rules:
 
 | Yüzey | Durum | Not |
 |---|---|---|
-| Public Beta yüzeyinin tamamı | Beta | Stable kanal pre-release kurmaz; genel kullanım için explicit pre-release install gerekir |
+| Historical Public Beta pre-release | Beta | `4.0.0b2` remains a pre-release pin for operators that intentionally stay on that line; stable support is the shipped baseline above |
 | `claude-code-cli` helper-backed real-adapter lane | Beta (operator-managed) | `python3 scripts/claude_code_cli_smoke.py --output text` sonucu `overall_status: pass` olmalıdır. Bu smoke içinde hem `auth_status` hem `prompt_access` check'i geçmelidir; yalnız `claude auth status` yeşili yeterli kabul edilmez. Varsayılan shipped demo değildir. `PB-6.6` closeout verdict'i: `stay_beta_operator_managed` |
 | `gh-cli-pr` helper-backed preflight lane | Beta (operator-managed preflight + live-write readiness probe) | Varsayılan `python3 scripts/gh_cli_pr_smoke.py --output text` preflight yoludur ve side-effect-safe `gh pr create --dry-run` zincirini çalıştırır. Live-write probe (`--mode live-write --allow-live-write --head <branch> --base <branch>`) explicit opt-in + create->verify->rollback ister. Varsayılan disposable guard keyword `sandbox`'dır; repo adında bu keyword yoksa lane `blocked` döner (`gh_pr_live_write_repo_not_disposable`). `--keep-live-write-pr-open` lane'i riskli sayar ve `blocked` döner. Support widening değildir |
 | `PRJ-KERNEL-API` write-side actions | Beta (operator-managed write contract) | `project_status`, `roadmap_follow`, `roadmap_finish` runtime-backed. `workspace_root` zorunlu, varsayılan `dry_run=true`, gerçek yazma için `confirm_write=I_UNDERSTAND_SIDE_EFFECTS` gerekir; conflict/idempotency/audit davranışı behavior testlerle pinlidir. Operator smoke: `python3 scripts/kernel_api_write_smoke.py --output text` |

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -17,8 +17,8 @@ operator-only, or just contract inventory?"
 
 ### 1.1 ST-2 stable candidate freeze
 
-For the possible future `4.0.0` stable release, the stable support candidate is
-the `Shipped baseline` layer only. This freeze deliberately excludes:
+For the `4.0.0` stable candidate, the stable support set is the `Shipped
+baseline` layer only. This freeze deliberately excludes:
 
 - operator-managed beta lanes,
 - live-write / remote side-effect flows,

--- a/docs/UPGRADE-NOTES.md
+++ b/docs/UPGRADE-NOTES.md
@@ -9,6 +9,8 @@ stable and beta channels.
 
 ```bash
 pip install -U ao-kernel
+# exact pin after v4.0.0 publish
+pip install ao-kernel==4.0.0
 ```
 
 ### Public Beta channel
@@ -19,8 +21,10 @@ pip install --pre ao-kernel
 pip install ao-kernel==4.0.0b2
 ```
 
-Do not assume `pip install ao-kernel` will pick the beta. It stays on the
-stable channel unless you ask for a pre-release explicitly.
+Do not assume `pip install ao-kernel` will pick a beta. It stays on the stable
+channel unless you ask for a pre-release explicitly. The exact
+`ao-kernel==4.0.0` pin is live only after the `v4.0.0` publish workflow and
+fresh-venv public install verification pass.
 
 ## 1.1 Stable support boundary
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ao-kernel"
-version = "4.0.0b2"
+version = "4.0.0"
 description = "Governed AI orchestration runtime — policy-driven, fail-closed, evidence-trail"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["ai", "orchestrator", "llm", "policy", "governance", "fail-closed", "evidence"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tests/test_pr_a6_features.py
+++ b/tests/test_pr_a6_features.py
@@ -93,10 +93,10 @@ class TestLlmFallback:
 
 
 class TestVersionBump:
-    def test_version_is_4_0_0b2(self) -> None:
+    def test_version_is_4_0_0(self) -> None:
         import ao_kernel
 
-        assert ao_kernel.__version__ == "4.0.0b2"
+        assert ao_kernel.__version__ == "4.0.0"
 
     def test_pyproject_version_matches(self) -> None:
         import tomllib
@@ -106,7 +106,7 @@ class TestVersionBump:
             pyproject = Path(__file__).parent.parent / "pyproject.toml"
         with open(pyproject, "rb") as f:
             data = tomllib.load(f)
-        assert data["project"]["version"] == "4.0.0b2"
+        assert data["project"]["version"] == "4.0.0"
 
 
 class TestMetaExtras:


### PR DESCRIPTION
## Summary
- Bump source/package version from `4.0.0b2` to `4.0.0` for the stable release candidate.
- Add the `[4.0.0]` changelog entry and tighten README/support docs around the narrow stable shipped baseline.
- Retarget legacy `save_store()` / `allow_overwrite=True` deprecation wording to a future major release instead of implying removal/default flip inside `4.0.0`.
- Keep public package live claims gated on ST-8 tag/publish/post-publish verification; no stable tag or publish is performed here.

Refs #355
Refs #329

## Validation
- `git diff --check`
- `python3 -m ao_kernel version` -> `ao-kernel 4.0.0`
- `python3 -m ao_kernel.cli version` -> `ao-kernel 4.0.0`
- `python3 -m ao_kernel doctor` (`8 OK, 1 WARN, 0 FAIL`; expected extension truth inventory WARN)
- `pytest tests/test_canonical_store_cas.py tests/test_self_edit_memory_cas.py -q`
- `pytest tests/test_cli_entrypoints.py -q` (`2 passed, 1 skipped`)
- `python3 scripts/packaging_smoke.py` (built `ao_kernel-4.0.0`, fresh venv install, installed demo completed)
- `python3 -m twine check dist/*`

## Notes
- Raw `python3 examples/demo_review.py --cleanup` from an uninstalled source checkout is not release evidence because the demo switches into a temp workspace before invoking `python -m ao_kernel init`. The authoritative installed-package path is `scripts/packaging_smoke.py`, which passed.
- This PR does not create `v4.0.0`, does not publish to PyPI, and does not widen support.