### PR TITLE
[codex] docs: close out ST-7 and open ST-8

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -16,8 +16,8 @@ ayrı ayrı görünür kılmak.
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
-- **Son tamamlanan stable-gate contract:** `.claude/plans/ST-6-OPERATIONS-READINESS.md` (`ST-6 completed`)
-- **Aktif decision/ordering contract:** `.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md` (`ST-7 active`)
+- **Son tamamlanan stable-gate contract:** `.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md` (`ST-7 completed`)
+- **Aktif decision/ordering contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 active`)
 - **GP-2.2 closeout contract:** `.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md`
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
@@ -45,8 +45,9 @@ ayrı ayrı görünür kılmak.
 - **ST-1 issue:** [#340](https://github.com/Halildeu/ao-kernel/issues/340) (`closed after closeout`)
 - **ST-2 issue:** [#344](https://github.com/Halildeu/ao-kernel/issues/344) (`closed`)
 - **ST-6 issue:** [#351](https://github.com/Halildeu/ao-kernel/issues/351) (`closed`)
-- **ST-7 issue:** [#355](https://github.com/Halildeu/ao-kernel/issues/355) (`active`)
-- **Aktif gate:** `ST-7` stable release candidate
+- **ST-7 issue:** [#355](https://github.com/Halildeu/ao-kernel/issues/355) (`closed after closeout`)
+- **ST-8 issue:** [#358](https://github.com/Halildeu/ao-kernel/issues/358) (`active`)
+- **Aktif gate:** `ST-8` stable publish and post-publish verification
 
 ## 2. Başlangıç Gerçeği
 
@@ -98,7 +99,8 @@ ayrı ayrı görünür kılmak.
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
 | `ST-5` deferred correctness closure | Completed on `main` ([#348](https://github.com/Halildeu/ao-kernel/issues/348), [#350](https://github.com/Halildeu/ao-kernel/pull/350)) | known deferred correctness kalemlerini stable blocker olmaktan çıkarıp açık support boundary'ye bağlamak | deferred bug contract + stable impact decision |
 | `ST-6` operations readiness | Completed on `main` ([#351](https://github.com/Halildeu/ao-kernel/issues/351), [#353](https://github.com/Halildeu/ao-kernel/pull/353)) | stable release öncesi incident, rollback, upgrade, known-bugs ve release-gate runbook'unu işletilebilir hale getirmek | operations runbook + rollback matrix + fresh-venv verification + packaging smoke parity |
-| `ST-7` stable release candidate | Active ([#355](https://github.com/Halildeu/ao-kernel/issues/355)) | `4.0.0` stable için final aday branch/PR hazırlamak | version/changelog/docs final + full CI + installed-package smoke |
+| `ST-7` stable release candidate | Completed on `main` ([#355](https://github.com/Halildeu/ao-kernel/issues/355), [#356](https://github.com/Halildeu/ao-kernel/pull/356), [#357](https://github.com/Halildeu/ao-kernel/pull/357)) | `4.0.0` stable için final aday branch/PR hazırlamak | version/changelog/docs final + full CI + installed-package smoke |
+| `ST-8` stable publish and post-publish verification | Active ([#358](https://github.com/Halildeu/ao-kernel/issues/358)) | `4.0.0` stable tag/publish ve public install gerçeğini doğrulamak | publish workflow success + PyPI exact/bare install verify + installed demo smoke |
 
 ## 5. Şimdi
 
@@ -359,7 +361,7 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Aktif slice: `ST-7` stable release candidate preparation.
+Aktif slice: `ST-8` stable publish and post-publish verification.
 
 1. Son kapanan slice: `GP-2.2` adapter-path `cost_usd` reconcile completeness
    closeout ([#333](https://github.com/Halildeu/ao-kernel/issues/333))
@@ -367,18 +369,19 @@ Aktif slice: `ST-7` stable release candidate preparation.
 3. Completed contract: `.claude/plans/ST-1-RELEASABLE-PRE-RELEASE-GATE.md`
 4. Completed contract: `.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md`
 5. Completed contract: `.claude/plans/ST-5-DEFERRED-CORRECTNESS-CLOSURE.md`
-6. Son kapanan PR: [#353](https://github.com/Halildeu/ao-kernel/pull/353)
+6. Son kapanan PR: [#357](https://github.com/Halildeu/ao-kernel/pull/357)
 7. ST-2 freeze kararı: dar stable runtime için ST-3/ST-4 blocker değildir;
    real-adapter/live-write promotion istenirse ayrı gate gerekir.
 8. ST-5 closeout kararı: deferred correctness kalemleri stable shipped baseline'a
    promote edilmiyor; tamamı `deferred` veya spec-only kalıyor.
-9. Son kapanan issue: [#351](https://github.com/Halildeu/ao-kernel/issues/351)
-   (`ST-6` closed)
-10. Aktif contract: `.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md`
-11. Stable release'e doğrudan geçilmez; önce `ST-7` release-candidate gate
-   branch/PR ile kapanır.
-12. Aktif iş: `ST-7` implementation PR ile `4.0.0` source candidate version,
-   changelog ve stable docs install language hazırlığı.
+9. Son kapanan issue: [#355](https://github.com/Halildeu/ao-kernel/issues/355)
+   (`ST-7` closed after closeout)
+10. Aktif contract:
+   `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md`
+11. Stable live iddiası yalnız `ST-8` tag/publish ve public fresh-venv verify
+   sonrası yapılır.
+12. Aktif iş: `v4.0.0` tag push, publish workflow izleme, PyPI exact/bare
+   install verification ve status closeout.
 
 `PB-8.2` completion kaydı:
 

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -237,8 +237,10 @@ bilerek stable disina almak.
 
 ### ST-7 — Stable Release Candidate
 
-**Durum:** Implementation PR active via
-[#355](https://github.com/Halildeu/ao-kernel/issues/355) and
+**Durum:** Completed on `main` via
+[#355](https://github.com/Halildeu/ao-kernel/issues/355), contract PR
+[#356](https://github.com/Halildeu/ao-kernel/pull/356), implementation PR
+[#357](https://github.com/Halildeu/ao-kernel/pull/357), and
 `.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md`.
 
 **Amac:** `4.0.0` stable icin final aday cikarmak.
@@ -258,6 +260,9 @@ bilerek stable disina almak.
 - Release blocker listesi bos.
 
 ### ST-8 — Stable Publish ve Post-Publish Verification
+
+**Durum:** Active via [#358](https://github.com/Halildeu/ao-kernel/issues/358)
+and `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md`.
 
 **Amac:** Stable'i canliya almak ve public install gercegini dogrulamak.
 

--- a/.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md
+++ b/.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md
@@ -1,7 +1,9 @@
 # ST-7 — Stable Release Candidate
 
-**Durum:** Implementation PR active via
-[#355](https://github.com/Halildeu/ao-kernel/issues/355)
+**Durum:** Completed on `main` via issue
+[#355](https://github.com/Halildeu/ao-kernel/issues/355), contract PR
+[#356](https://github.com/Halildeu/ao-kernel/pull/356), and implementation PR
+[#357](https://github.com/Halildeu/ao-kernel/pull/357).
 **Umbrella:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
 **Precondition:** `ST-6` completed via
 [#354](https://github.com/Halildeu/ao-kernel/pull/354).
@@ -116,14 +118,16 @@ ST-7 tamamlandığında:
 5. `pip install ao-kernel` için stable live iddiası hâlâ yapılmamıştır; bu
    iddia yalnız `ST-8` publish ve public install verify sonrası yapılır.
 
-## 8. Implementation Decision
+## 8. Implementation Result
 
-ST-7 implementation PR'i `4.0.0` source candidate hazırlar:
+ST-7 implementation PR'i `4.0.0` source candidate hazırladı:
 
-1. `pyproject.toml` ve `ao_kernel/__init__.py` version değerleri `4.0.0` olur.
-2. `CHANGELOG.md` `[4.0.0]` entry'si narrow stable boundary'yi açık yazar.
+1. `pyproject.toml` ve `ao_kernel/__init__.py` version değerleri `4.0.0` oldu.
+2. `CHANGELOG.md` `[4.0.0]` entry'si narrow stable boundary'yi açık yazıyor.
 3. README ve support docs stable install dilini beta/pre-release dilinden
    ayırır.
 4. Public package live claim'i yapılmaz; tag/publish/post-publish verify
    `ST-8` kapsamındadır.
 5. Support widening yapılmaz.
+6. PR CI gate'leri yeşil kapandı: test matrix, coverage, benchmark-fast,
+   packaging-smoke, scorecard.

--- a/.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md
+++ b/.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md
@@ -1,0 +1,102 @@
+# ST-8 — Stable Publish and Post-Publish Verification
+
+**Durum:** Active via issue
+[#358](https://github.com/Halildeu/ao-kernel/issues/358).
+**Umbrella:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
+**Precondition:** `ST-7` completed via
+[#357](https://github.com/Halildeu/ao-kernel/pull/357).
+
+## 1. Amaç
+
+`4.0.0` stable source candidate'i public package gerçeğine çevirmek. Bu gate
+yalnız tag, publish ve post-publish verification yapar; runtime feature veya
+support widening yapmaz.
+
+## 2. Scope Boundary
+
+ST-8 stable support boundary'yi değiştirmez. Publish edilen stable yüzey,
+`ST-2` freeze ve `ST-7` candidate sonucundaki dar shipped baseline ile sınırlıdır:
+
+1. CLI/module entrypoint'ler.
+2. `ao-kernel doctor`.
+3. `review_ai_flow + codex-stub`.
+4. `examples/demo_review.py`.
+5. policy command enforcement.
+6. wheel-installed packaging smoke.
+7. documented read-only kernel API actions.
+
+`claude-code-cli`, `gh-cli-pr`, live-write PR açılışı ve real-adapter production
+certification bu gate'te stable support'a alınmaz.
+
+## 3. Publish Sequence
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git status --short --branch
+git tag v4.0.0
+git push origin v4.0.0
+```
+
+Tag push sonrası `publish.yml` workflow'u izlenir. Workflow başarıya ulaşmadan
+PyPI veya README üzerinde live stable claim'i yapılmaz.
+
+## 4. Post-Publish Verification Bundle
+
+Public package doğrulaması tag workflow başarıya ulaştıktan sonra yapılır:
+
+```bash
+python3 -m venv /tmp/ao-kernel-4.0.0-verify
+/tmp/ao-kernel-4.0.0-verify/bin/python -m pip install --upgrade pip
+/tmp/ao-kernel-4.0.0-verify/bin/python -m pip install ao-kernel==4.0.0
+/tmp/ao-kernel-4.0.0-verify/bin/ao-kernel version
+/tmp/ao-kernel-4.0.0-verify/bin/python -m ao_kernel version
+/tmp/ao-kernel-4.0.0-verify/bin/python -m ao_kernel.cli version
+/tmp/ao-kernel-4.0.0-verify/bin/python -m ao_kernel doctor
+/tmp/ao-kernel-4.0.0-verify/bin/python examples/demo_review.py --cleanup
+```
+
+Ayrı bir fresh venv ile bare stable kanal da doğrulanır:
+
+```bash
+python3 -m venv /tmp/ao-kernel-stable-channel-verify
+/tmp/ao-kernel-stable-channel-verify/bin/python -m pip install --upgrade pip
+/tmp/ao-kernel-stable-channel-verify/bin/python -m pip install ao-kernel
+/tmp/ao-kernel-stable-channel-verify/bin/ao-kernel version
+```
+
+Beklenen sonuç: tüm version komutları `4.0.0` döner, doctor shipped baseline
+için `FAIL` üretmez ve installed demo `completed` olur.
+
+## 5. Release Blockers
+
+Aşağıdakilerden biri olursa release tamamlanmış sayılmaz:
+
+1. Publish workflow fail eder veya package upload yapmaz.
+2. PyPI project/version endpoint'leri `4.0.0` için görünür değildir.
+3. Exact pin install `ao-kernel==4.0.0` fail eder.
+4. Bare stable install `pip install ao-kernel` `4.0.0` döndürmez.
+5. Entry point'lerden biri farklı version döndürür.
+6. Public package installed demo `completed` durumuna ulaşmaz.
+7. Docs/status public package live claim'i ile PyPI gerçeği ayrışır.
+
+## 6. Out of Scope
+
+- Runtime code changes.
+- Support widening.
+- Adapter production promotion.
+- Live-write remote PR opening.
+- GitHub release marketing metni dışında yeni ürün iddiası.
+
+## 7. Done Definition
+
+ST-8 tamamlandığında:
+
+1. Tag `v4.0.0` origin'e pushed olur.
+2. `publish.yml` success olur.
+3. PyPI `ao-kernel==4.0.0` public olarak doğrulanır.
+4. Exact pin ve bare stable install fresh venv içinde `4.0.0` döndürür.
+5. Public package installed demo smoke geçer.
+6. Status dosyaları stable live sonucunu ve kalan support boundary'yi yazar.
+7. Issue [#358](https://github.com/Halildeu/ao-kernel/issues/358) closeout
+   comment ile kapatılır.


### PR DESCRIPTION
## Summary\n- mark ST-7 stable release candidate completed after #357\n- add ST-8 stable publish/post-publish verification contract\n- update production stable roadmap and execution status to make ST-8 the active gate\n\n## Validation\n- git diff --check\n- stale ST-7 active reference scan\n- verified #358 issue body after shell-safe correction\n\nCloses #355\nRefs #358\nRefs #329