### PR TITLE
[codex] docs: close out v4.0.0 stable publish

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -16,8 +16,8 @@ ayrı ayrı görünür kılmak.
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
-- **Son tamamlanan stable-gate contract:** `.claude/plans/ST-7-STABLE-RELEASE-CANDIDATE.md` (`ST-7 completed`)
-- **Aktif decision/ordering contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 active`)
+- **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
+- **Aktif decision/ordering contract:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md` (`post-stable next-slice selection`)
 - **GP-2.2 closeout contract:** `.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md`
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
@@ -46,13 +46,13 @@ ayrı ayrı görünür kılmak.
 - **ST-2 issue:** [#344](https://github.com/Halildeu/ao-kernel/issues/344) (`closed`)
 - **ST-6 issue:** [#351](https://github.com/Halildeu/ao-kernel/issues/351) (`closed`)
 - **ST-7 issue:** [#355](https://github.com/Halildeu/ao-kernel/issues/355) (`closed after closeout`)
-- **ST-8 issue:** [#358](https://github.com/Halildeu/ao-kernel/issues/358) (`active`)
-- **Aktif gate:** `ST-8` stable publish and post-publish verification
+- **ST-8 issue:** [#358](https://github.com/Halildeu/ao-kernel/issues/358) (`closed after closeout`)
+- **Aktif gate:** none; `v4.0.0` stable live completed. Next runtime/support widening work requires a new scoped slice under `GP-2` or a follow-up roadmap.
 
 ## 2. Başlangıç Gerçeği
 
 - `WP-5` ile `WP-9` production hardening programı `main` üzerinde kapanmıştır.
-- Repo bugün dar ama kanıtlı bir Public Beta / governed runtime yüzeyine sahiptir.
+- Repo bugün dar ama kanıtlı bir stable governed runtime yüzeyine sahiptir.
 - Support boundary hâlâ bilerek dardır; `review_ai_flow + codex-stub` shipped
   baseline, gerçek adapter lane'leri ise operator-managed beta durumundadır.
 - Public Beta closeout sonrası `PB-8.4` docs/runbook/release-gate parity
@@ -61,6 +61,8 @@ ayrı ayrı görünür kılmak.
   ve `PB-9.4` production claim decision closeout dilimleri kapanmıştır.
 - `GP-1` tracker kapanmıştır; `GP-1.1..GP-1.5` kararları tamamlanmış ve
   support boundary `stay_beta_operator_managed` çizgisinde korunmuştur.
+- `ST-8` tamamlanmıştır: `v4.0.0` PyPI üzerinde canlıdır, exact pin ve bare
+  stable install fresh venv içinde `ao-kernel 4.0.0` döndürmüştür.
 - Repo bugün hâlâ genel amaçlı production coding automation platformu değildir;
   bu programın amacı o iddiayı hemen widen etmek değil, önce kalan debt'i
   kontrollü kapatmaktır.
@@ -100,7 +102,7 @@ ayrı ayrı görünür kılmak.
 | `ST-5` deferred correctness closure | Completed on `main` ([#348](https://github.com/Halildeu/ao-kernel/issues/348), [#350](https://github.com/Halildeu/ao-kernel/pull/350)) | known deferred correctness kalemlerini stable blocker olmaktan çıkarıp açık support boundary'ye bağlamak | deferred bug contract + stable impact decision |
 | `ST-6` operations readiness | Completed on `main` ([#351](https://github.com/Halildeu/ao-kernel/issues/351), [#353](https://github.com/Halildeu/ao-kernel/pull/353)) | stable release öncesi incident, rollback, upgrade, known-bugs ve release-gate runbook'unu işletilebilir hale getirmek | operations runbook + rollback matrix + fresh-venv verification + packaging smoke parity |
 | `ST-7` stable release candidate | Completed on `main` ([#355](https://github.com/Halildeu/ao-kernel/issues/355), [#356](https://github.com/Halildeu/ao-kernel/pull/356), [#357](https://github.com/Halildeu/ao-kernel/pull/357)) | `4.0.0` stable için final aday branch/PR hazırlamak | version/changelog/docs final + full CI + installed-package smoke |
-| `ST-8` stable publish and post-publish verification | Active ([#358](https://github.com/Halildeu/ao-kernel/issues/358)) | `4.0.0` stable tag/publish ve public install gerçeğini doğrulamak | publish workflow success + PyPI exact/bare install verify + installed demo smoke |
+| `ST-8` stable publish and post-publish verification | Completed ([#358](https://github.com/Halildeu/ao-kernel/issues/358), tag `v4.0.0`, publish workflow [`24866683491`](https://github.com/Halildeu/ao-kernel/actions/runs/24866683491)) | `4.0.0` stable tag/publish ve public install gerçeğini doğrulamak | publish workflow success + PyPI exact/bare install verify + installed demo smoke |
 
 ## 5. Şimdi
 
@@ -361,7 +363,9 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Aktif slice: `ST-8` stable publish and post-publish verification.
+Aktif slice: none. `ST-8` stable publish and post-publish verification
+tamamlandı; sıradaki runtime/support widening işi yeni scoped slice olarak
+açılmalıdır.
 
 1. Son kapanan slice: `GP-2.2` adapter-path `cost_usd` reconcile completeness
    closeout ([#333](https://github.com/Halildeu/ao-kernel/issues/333))
@@ -369,19 +373,18 @@ Aktif slice: `ST-8` stable publish and post-publish verification.
 3. Completed contract: `.claude/plans/ST-1-RELEASABLE-PRE-RELEASE-GATE.md`
 4. Completed contract: `.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md`
 5. Completed contract: `.claude/plans/ST-5-DEFERRED-CORRECTNESS-CLOSURE.md`
-6. Son kapanan PR: [#357](https://github.com/Halildeu/ao-kernel/pull/357)
+6. Son kapanan PR: ST-8 closeout PR
 7. ST-2 freeze kararı: dar stable runtime için ST-3/ST-4 blocker değildir;
    real-adapter/live-write promotion istenirse ayrı gate gerekir.
 8. ST-5 closeout kararı: deferred correctness kalemleri stable shipped baseline'a
    promote edilmiyor; tamamı `deferred` veya spec-only kalıyor.
-9. Son kapanan issue: [#355](https://github.com/Halildeu/ao-kernel/issues/355)
-   (`ST-7` closed after closeout)
-10. Aktif contract:
+9. Son kapanan issue: [#358](https://github.com/Halildeu/ao-kernel/issues/358)
+   (`ST-8` closed after closeout)
+10. Completed contract:
    `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md`
-11. Stable live iddiası yalnız `ST-8` tag/publish ve public fresh-venv verify
-   sonrası yapılır.
-12. Aktif iş: `v4.0.0` tag push, publish workflow izleme, PyPI exact/bare
-   install verification ve status closeout.
+11. Stable live iddiası artık geçerlidir: `pip install ao-kernel` ve exact pin
+   `ao-kernel==4.0.0` fresh venv içinde `4.0.0` kurmuştur.
+12. Aktif iş: yeni scoped slice seçilmeden runtime/support widening yapılmaz.
 
 `PB-8.2` completion kaydı:
 

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -3,6 +3,7 @@
 **Durum tarihi:** 2026-04-24
 **Rol:** Public Beta / post-beta correctness hattindan production stable live
 release'e gecis icin takip edilebilir program kontrati.
+**Sonuç:** `v4.0.0` stable runtime baseline live on PyPI.
 **Kapsam mottosu:** once gercegi kilitle, sonra support'u genislet.
 
 ## 1. Hedef
@@ -25,16 +26,19 @@ Iki farkli hedef birbirine karistirilmeyecek:
 
 | Seviye | Anlam | Stable icin durum |
 |---|---|---|
-| Stable runtime release | Dar support boundary ile guvenilir, paketlenmis, isletilebilir cekirdek | `4.0.0` icin hedeflenebilir |
+| Stable runtime release | Dar support boundary ile guvenilir, paketlenmis, isletilebilir cekirdek | `v4.0.0` ile live |
 | General-purpose production coding automation platform | Gercek adapter'lar, live-write E2E, multi-agent safety ve operator runbook'lariyla genis platform | Ancak sertifikasyon kapilari kapandiktan sonra iddia edilir |
 
-`4.0.0` stable release dar ama dogru bir production runtime olabilir. "Genel
-amacli production coding automation platform" iddiasi, gercek adapter
+`4.0.0` stable release dar ama dogru bir production runtime olarak live'dir.
+"Genel amacli production coding automation platform" iddiasi, gercek adapter
 sertifikasyonu ve live-write rollback kanitlari kapanmadan kullanilmayacak.
 
 ## 3. Mevcut Baseline
 
 - `main` temiz ve `origin/main` ile senkron.
+- Public tag `v4.0.0` mevcut; PyPI exact pin `ao-kernel==4.0.0` ve bare
+  stable install `pip install ao-kernel` fresh venv ile doğrulandı.
+- GitHub Release `v4.0.0` latest release olarak yayımlandı.
 - `ST-1` release PR package metadata hedefi `4.0.0b2` idi ve tamamlandi.
 - Public tag `v4.0.0-beta.2` mevcut; PyPI exact pin
   `ao-kernel==4.0.0b2` fresh venv ile dogrulandi.
@@ -46,34 +50,31 @@ sertifikasyonu ve live-write rollback kanitlari kapanmadan kullanilmayacak.
 - Post-beta programda GP-2 hattinda deferred support lane'leri kanitla
   kapatiliyor.
 
-## 4. Immediate Drift Kayitlari
+## 4. Closed Drift Kayitlari
 
-Stable roadmap baslamadan once su drift'ler kapatilacak veya karar notuna
-baglanacak:
+Stable roadmap boyunca şu drift'ler kapatıldı veya karar notuna bağlandı:
 
-1. `docs/PUBLIC-BETA.md` stable kanal orneginde stale surum yazimi varsa
-   hard-code yerine kural yazacak.
+1. `docs/PUBLIC-BETA.md` stable kanal dili `v4.0.0` live sonucuna çekildi.
 2. `.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md` icinde GP-2.2b
    issue/status satirlari merge sonrasi gercekle hizalanacak.
 3. Adapter-path `cost_usd` reconcile icin "runtime fix gerekir mi, yoksa
    evidence/test/docs closeout yeterli mi" karari GP-2.2d'de kapanacak.
-4. `v4.0.0-beta.1` tag'i main'in gerisinde kaldigi icin bir sonraki public
-   beta/stable release eski tag uzerinden degil current `main` uzerinden
-   cikacak.
+4. `v4.0.0-beta.1` tag'i main'in gerisinde kaldigi icin stable release eski
+   tag üzerinden değil current `main` üzerinden çıktı.
 
 ## 5. Release Stratejisi
 
-Stable'a dogrudan ziplanmayacak. Varsayilan yol:
+Stable'a dogrudan ziplanmadi. Tamamlanan yol:
 
 1. `4.0.0b2` pre-release cikti ve fresh install / wheel / docs / smoke /
    runbook kanitlari toplandi.
-2. Siradaki adim `ST-2` stable support boundary freeze'dir.
-3. Support boundary genisletilecekse sadece kanitli yuzeyleri genislet.
-4. Blocker kalmazsa `4.0.0` stable tag ve PyPI publish yap.
+2. `ST-2` stable support boundary freeze tamamlandi.
+3. `ST-5` ve `ST-6` ile deferred correctness ve operations readiness kapandı.
+4. `ST-7` source candidate merge edildi.
+5. `ST-8` ile `v4.0.0` tag, PyPI publish ve public install verify tamamlandı.
 
-Eger `4.0.0b2` sirasinda shipped yuzeyi degistiren runtime bug bulunursa,
-stable yerine yeni beta devam eder. Stable release, takvim karari degil gate
-kararidir.
+Stable release takvim kararı değil gate kararıydı; gate'ler geçtikten sonra
+canlıya alındı.
 
 ## 6. Work Packages
 
@@ -261,7 +262,10 @@ bilerek stable disina almak.
 
 ### ST-8 — Stable Publish ve Post-Publish Verification
 
-**Durum:** Active via [#358](https://github.com/Halildeu/ao-kernel/issues/358)
+**Durum:** Completed via [#358](https://github.com/Halildeu/ao-kernel/issues/358),
+tag `v4.0.0`, publish workflow
+[`24866683491`](https://github.com/Halildeu/ao-kernel/actions/runs/24866683491),
+GitHub Release [`v4.0.0`](https://github.com/Halildeu/ao-kernel/releases/tag/v4.0.0),
 and `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md`.
 
 **Amac:** Stable'i canliya almak ve public install gercegini dogrulamak.

--- a/.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md
+++ b/.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md
@@ -1,7 +1,11 @@
 # ST-8 — Stable Publish and Post-Publish Verification
 
-**Durum:** Active via issue
-[#358](https://github.com/Halildeu/ao-kernel/issues/358).
+**Durum:** Completed via issue
+[#358](https://github.com/Halildeu/ao-kernel/issues/358), tag `v4.0.0`,
+publish workflow
+[`24866683491`](https://github.com/Halildeu/ao-kernel/actions/runs/24866683491),
+PyPI verification, and GitHub Release
+[`v4.0.0`](https://github.com/Halildeu/ao-kernel/releases/tag/v4.0.0).
 **Umbrella:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
 **Precondition:** `ST-7` completed via
 [#357](https://github.com/Halildeu/ao-kernel/pull/357).
@@ -100,3 +104,25 @@ ST-8 tamamlandığında:
 6. Status dosyaları stable live sonucunu ve kalan support boundary'yi yazar.
 7. Issue [#358](https://github.com/Halildeu/ao-kernel/issues/358) closeout
    comment ile kapatılır.
+
+## 8. Completion Evidence
+
+ST-8 completion sonucu:
+
+1. `v4.0.0` tag'i origin'e push edildi.
+2. `publish.yml` workflow `24866683491` başarılı oldu.
+3. PyPI project page `https://pypi.org/project/ao-kernel/4.0.0/` `HTTP/2 200`
+   döndü.
+4. PyPI JSON `info.version == "4.0.0"` ve release key `4.0.0` içeriyor.
+5. Fresh venv exact pin install `ao-kernel==4.0.0` başarılı oldu.
+6. Fresh venv bare stable install `ao-kernel` doğrudan `4.0.0` kurdu.
+7. `ao-kernel version`, `python -m ao_kernel version` ve
+   `python -m ao_kernel.cli version` `ao-kernel 4.0.0` döndürdü.
+8. Public package doctor `0 FAIL` döndürdü.
+9. Public package ile `examples/demo_review.py --cleanup` `completed` oldu.
+10. GitHub Release `v4.0.0` oluşturuldu ve latest release olarak işaretlendi.
+
+Sonuç: `ao-kernel` dar stable runtime baseline için public stable live'dır.
+Bu sonuç, genel amaçlı production coding automation platform claim'ini
+genişletmez; o claim hâlâ gerçek adapter/live-write sertifikasyon kapılarına
+bağlıdır.

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ ao-kernel is **not** a general-purpose agent framework or a blanket "production 
 
 ```bash
 pip install ao-kernel                # Core (only jsonschema dependency)
-pip install ao-kernel==4.0.0         # Exact stable pin after v4.0.0 publish
+pip install ao-kernel==4.0.0         # Exact stable pin
 pip install ao-kernel[llm]           # LLM modules (tenacity + tiktoken)
 pip install ao-kernel[mcp]           # MCP server support
 pip install ao-kernel[otel]          # OpenTelemetry instrumentation
 pip install ao-kernel[llm,mcp,otel]  # Everything
 ```
 
-`4.0.0` stable source changes do not by themselves mean the public package is
-live. Treat the exact `ao-kernel==4.0.0` install path as live only after the
-tag-triggered publish workflow and fresh-venv public install verification pass.
+`v4.0.0` is live on PyPI. Post-publish verification confirmed both
+`pip install ao-kernel` and `pip install ao-kernel==4.0.0` resolve to
+`ao-kernel 4.0.0` in fresh virtual environments.
 
 **For production-grade live LLM calls**, install the `[llm]` extra. Without it the runtime still dispatches requests, but two guarantees weaken: **retry / backoff** (`tenacity`) degrades to a single-attempt call so transient 429 / 5xx responses fail the request instead of being retried, and **exact token counting** (`tiktoken`) falls back to a heuristic estimator (~4 chars/token) so budget accounting is approximate. The core install is fully sufficient for policy evaluation, evidence replay, workflow inspection, and MCP server hosting.
 

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -1,10 +1,10 @@
-# Support Matrix SSOT (v4.0.0 stable candidate + beta lanes)
+# Support Matrix SSOT (v4.0.0 stable + beta lanes)
 
-> **Sürüm durumu (2026-04-24)**: bu source tree `4.0.0` stable candidate
-> için hazırlanmıştır. Public package live claim'i yalnız `v4.0.0` tag'i,
-> publish workflow success ve fresh-venv public install verify sonrası
-> yapılır. Bu doküman stable shipped baseline, beta lanes, deferred lanes ve
-> known bugs için operator-facing SSOT'tur.
+> **Sürüm durumu (2026-04-24)**: `v4.0.0` tag'i publish edilmiştir ve
+> `ao-kernel==4.0.0` PyPI üzerinde canlıdır. Fresh-venv doğrulaması hem exact
+> pin (`ao-kernel==4.0.0`) hem stable kanal (`pip install ao-kernel`) için
+> `ao-kernel 4.0.0` sonucunu verdi. Bu doküman stable shipped baseline, beta
+> lanes, deferred lanes ve known bugs için operator-facing SSOT'tur.
 
 ## Kurulum
 
@@ -12,7 +12,7 @@
 
 ```bash
 pip install ao-kernel
-pip install ao-kernel==4.0.0  # exact stable pin after v4.0.0 publish
+pip install ao-kernel==4.0.0  # exact stable pin
 ```
 
 ### Historical Public Beta pre-release
@@ -36,11 +36,11 @@ olur.
 
 ## Stable Support Boundary
 
-`ST-2` froze the support boundary and `ST-7` keeps it unchanged for the
-`4.0.0` stable candidate. The stable support set is exactly the `Shipped`
-table below unless a later gate changes this document with new evidence.
+`ST-2` froze the support boundary and `ST-8` published it unchanged for
+`4.0.0` stable. The stable support set is exactly the `Shipped` table below
+unless a later gate changes this document with new evidence.
 
-Stable candidate rules:
+Stable rules:
 
 1. `Beta`, `Deferred`, `Contract inventory`, and `Example-only` rows are not
    stable shipped support claims.
@@ -53,7 +53,7 @@ Stable candidate rules:
 5. This boundary still does not claim ao-kernel is a general-purpose
    production coding automation platform.
 
-## Shipped (v4.0.0 stable candidate)
+## Shipped (v4.0.0 stable)
 
 | Yüzey | Durum | Not |
 |---|---|---|
@@ -61,7 +61,7 @@ Stable candidate rules:
 | `python -m ao_kernel version` | Shipped | Module entrypoint kontratı |
 | `python -m ao_kernel.cli version` | Shipped | CLI module kontratı |
 | Bundled `review_ai_flow` + bundled `codex-stub` | Shipped | Desteklenen demo workflow |
-| `examples/demo_review.py` | Shipped | Disposable workspace + canlı smoke `completed`; komut, `ao-kernel` kurulu bir Python environment'ı içinde çalıştırılmalıdır |
+| `examples/demo_review.py` | Shipped | Disposable workspace + public package fresh-venv smoke `completed`; komut, `ao-kernel` kurulu bir Python environment'ı içinde çalıştırılmalıdır |
 | `ao-kernel doctor` | Shipped | Workspace health check + bundled extension truth audit; may emit WARN while quarantined inventory remains |
 | `PRJ-KERNEL-API` read-only runtime-backed actions | Shipped | `system_status` and `doc_nav_check`; explicit bootstrap handlers, offline, read-only, behavior-tested |
 | CI coverage gate 85% | Shipped | `pyproject.toml` ile hizalı (`test.yml --fail-under=85`) |

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -75,7 +75,7 @@ Rollback does not widen support. If a stable shipped baseline check fails,
 either rollback to the last known-good package or ship a corrective release.
 Do not substitute an operator-managed beta lane as the stable path.
 
-For the current stable candidate boundary:
+For the current stable boundary:
 
 - shipped baseline regressions are release blockers,
 - beta/operator-managed regressions stay in [`KNOWN-BUGS.md`](KNOWN-BUGS.md),

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -15,10 +15,10 @@ operator-only, or just contract inventory?"
 | Contract inventory | bundled defaults, manifests, extensions, example inventory | loader/validator and truth audit only |
 | Deferred | `bug_fix_flow` release closure, live `gh-cli-pr` PR opening, roadmap/spec-only demo flow, adapter-path `cost_usd` reconcile | not a public support claim; internal benchmark/runtime wiring may exist without widening the support boundary (`PB-8.3` verdict `stay_deferred`, `GP-1.3` revalidation ile teyitli) |
 
-### 1.1 ST-2 stable candidate freeze
+### 1.1 ST-2 stable boundary freeze
 
-For the `4.0.0` stable candidate, the stable support set is the `Shipped
-baseline` layer only. This freeze deliberately excludes:
+For `4.0.0` stable, the stable support set is the `Shipped baseline` layer
+only. This freeze deliberately excludes:
 
 - operator-managed beta lanes,
 - live-write / remote side-effect flows,
@@ -153,7 +153,7 @@ then treat it as not widened.
 
 ## 4.1 Stable operations rule
 
-For the narrow stable candidate, operational readiness follows the same support
+For the narrow stable release, operational readiness follows the same support
 boundary:
 
 - shipped baseline failure is a release blocker,

--- a/docs/UPGRADE-NOTES.md
+++ b/docs/UPGRADE-NOTES.md
@@ -9,7 +9,7 @@ stable and beta channels.
 
 ```bash
 pip install -U ao-kernel
-# exact pin after v4.0.0 publish
+# exact stable pin
 pip install ao-kernel==4.0.0
 ```
 
@@ -22,13 +22,14 @@ pip install ao-kernel==4.0.0b2
 ```
 
 Do not assume `pip install ao-kernel` will pick a beta. It stays on the stable
-channel unless you ask for a pre-release explicitly. The exact
-`ao-kernel==4.0.0` pin is live only after the `v4.0.0` publish workflow and
-fresh-venv public install verification pass.
+channel unless you ask for a pre-release explicitly. `v4.0.0` is live on PyPI;
+post-publish verification confirmed both `pip install ao-kernel` and
+`pip install ao-kernel==4.0.0` resolve to `ao-kernel 4.0.0` in fresh virtual
+environments.
 
 ## 1.1 Stable support boundary
 
-The stable candidate support boundary is intentionally narrow. Treat the
+The stable support boundary is intentionally narrow. Treat the
 `Shipped` table in [`PUBLIC-BETA.md`](PUBLIC-BETA.md) and the `Shipped
 baseline` layer in [`SUPPORT-BOUNDARY.md`](SUPPORT-BOUNDARY.md) as the supported
 runtime claim.


### PR DESCRIPTION
## Summary\n- mark ST-8 stable publish/post-publish verification completed\n- update README/support docs from candidate/after-publish language to live v4.0.0 language\n- record PyPI, fresh-venv exact/bare install, installed demo, and GitHub Release evidence\n\n## Release evidence\n- tag: v4.0.0\n- publish workflow: https://github.com/Halildeu/ao-kernel/actions/runs/24866683491\n- PyPI: https://pypi.org/project/ao-kernel/4.0.0/\n- GitHub Release: https://github.com/Halildeu/ao-kernel/releases/tag/v4.0.0\n- exact pin fresh venv: ao-kernel==4.0.0 -> ao-kernel 4.0.0\n- bare stable fresh venv: ao-kernel -> ao-kernel 4.0.0\n- installed demo: examples/demo_review.py --cleanup -> completed\n\n## Validation\n- bash .claude/scripts/check-branch-sync.sh\n- python3 -m ao_kernel version\n- python3 -m ao_kernel doctor\n- python3 scripts/packaging_smoke.py\n- python3 -m twine check dist/*\n- curl PyPI project/version endpoints\n- fresh venv exact pin install\n- fresh venv bare stable install\n- git diff --check\n\nCloses #358\nRefs #329