### PR TITLE
[codex] docs: start GP-2.3 post-stable adapter entry

### DIFF
--- a/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
+++ b/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
@@ -1,8 +1,8 @@
 # GP-2 — Deferred Support-Lane Backlog Reprioritization
 
-**Status:** Active  
-**Date:** 2026-04-23  
-**Tracker:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)  
+**Status:** Active
+**Date:** 2026-04-24
+**Tracker:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
 **Execution mode:** Kapsam disiplini, tek aktif planning/runtime tranche
 
 ## Amaç
@@ -23,8 +23,12 @@ giriş kapılarını netleştirmektir.
    - `gh-cli-pr` ile tam E2E remote PR açılışı
    - `docs/roadmap/DEMO-SCRIPT-SPEC.md` üç-adapter akışının canlı destek iddiası
    - adapter-path `cost_usd` reconcile
-3. Aktif widening tranche yoktur; yeni runtime işi açılmadan önce
-   sıralama ve kanıt boşluğu kararı yazılı olmalıdır.
+3. `GP-2.2` adapter-path `cost_usd` reconcile completeness hattı
+   tamamlanmıştır; ek runtime patch gerekmemiş ve public support claim
+   deferred kalmıştır.
+4. `ST-8` tamamlanmıştır: `v4.0.0` stable PyPI üzerinde canlıdır.
+5. Aktif widening tranche yoktur; yeni runtime/support işi açılmadan önce
+   post-stable giriş sırası ve kanıt boşluğu kararı yazılı olmalıdır.
 
 ## Tranche Sırası
 
@@ -42,7 +46,7 @@ giriş kapılarını netleştirmektir.
   3. Seçilen tranche için tek issue + tek contract referansı üretilir.
 - Kapanış: [#331](https://github.com/Halildeu/ao-kernel/issues/331) closed, PR [#332](https://github.com/Halildeu/ao-kernel/pull/332)
 
-### `GP-2.2` — First runtime slice kickoff (Active)
+### `GP-2.2` — First runtime slice kickoff (Completed)
 
 - Issue: [#333](https://github.com/Halildeu/ao-kernel/issues/333)
 - Contract:
@@ -53,7 +57,28 @@ giriş kapılarını netleştirmektir.
   `deferred` olarak kalır.
 - İlerleme:
   1. `GP-2.2a` truth-capture closure merged via PR [#335](https://github.com/Halildeu/ao-kernel/pull/335)
-  2. `GP-2.2b` deterministic assertion upgrade active on issue [#336](https://github.com/Halildeu/ao-kernel/issues/336)
+  2. `GP-2.2b` deterministic assertion upgrade closed via issue [#336](https://github.com/Halildeu/ao-kernel/issues/336) and PR [#337](https://github.com/Halildeu/ao-kernel/pull/337)
+  3. `GP-2.2c` runtime patch no-op closeout: ek runtime gap kanıtlanmadı
+  4. `GP-2.2d` docs/status parity closeout merged via PR [#338](https://github.com/Halildeu/ao-kernel/pull/338)
+- Sonuç: adapter-path `cost_usd` reconcile public support claim olarak
+  **Deferred** kalır; behavior/evidence assertions mevcut ama support widening
+  üretmez.
+
+### `GP-2.3` — Post-stable adapter certification entry decision (Active)
+
+- Issue: [#361](https://github.com/Halildeu/ao-kernel/issues/361)
+- Contract:
+  `.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md`
+- Hedef: `v4.0.0` stable live sonrası ilk support-widening giriş kapısını
+  seçmek; bu tranche runtime widening veya yeni stable claim üretmez.
+- Karar sırası:
+  1. **Now:** `claude-code-cli` read-only real-adapter certification decision
+  2. **Next:** `gh-cli-pr` live-write rollback rehearsal
+  3. **Later:** extension/support widening ve genel amaçlı platform claim'i
+- Sınır:
+  - Runtime değişikliği yok
+  - Version bump, tag veya publish yok
+  - Stable support boundary unchanged kalır
 
 ## Gate Modeli
 
@@ -65,8 +90,9 @@ giriş kapılarını netleştirmektir.
 ## Başarı Kriterleri
 
 1. `GP-2.1` sonunda deferred satırların sırasi tartışmasızdır.
-2. İlk aktif runtime slice açık issue/contract ile başlatılmıştır.
-3. Status SSOT'ta aktif issue/contract alanı günceldir.
+2. `GP-2.2` ilk runtime/evidence slice olarak tamamlanmıştır.
+3. `GP-2.3` post-stable next-slice kararını açık issue/contract ile taşır.
+4. Status SSOT'ta aktif issue/contract alanı günceldir.
 
 ## Risk Register
 

--- a/.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md
+++ b/.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md
@@ -1,0 +1,94 @@
+# GP-2.3 — Post-Stable Adapter Certification Entry Decision
+
+**Status:** Active
+**Date:** 2026-04-24
+**Tracker:** [#361](https://github.com/Halildeu/ao-kernel/issues/361)
+**Parent:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
+
+## Amaç
+
+`v4.0.0` stable runtime live olduktan sonra ilk support-widening giriş
+kapısını seçmek. Bu slice runtime implementasyonu değildir; support boundary
+genişletmez, yeni stable adapter claim'i üretmez ve release/publish işi
+yapmaz.
+
+## Başlangıç Gerçeği
+
+1. `v4.0.0` stable PyPI üzerinde canlıdır.
+2. Dar stable runtime claim geçerlidir: package install, entrypoint'ler,
+   `doctor`, `review_ai_flow + codex-stub`, policy command enforcement ve
+   packaging smoke kanıtlıdır.
+3. Genel amaçlı production coding automation platform claim'i hâlâ açık
+   değildir; gerçek adapter sertifikasyonu ve live-write rollback kanıtları
+   olmadan kullanılmayacaktır.
+4. `claude-code-cli` ve `gh-cli-pr` repo tarafından kurulan binary'ler değildir;
+   operator ortamındaki PATH/auth prerequisite'lerine dayanır.
+5. `codex-stub` repo-native deterministic stub'dır; production adapter olarak
+   sınıflandırılmayacaktır.
+
+## Aday Giriş Kapıları
+
+| Aday | Varsayılan karar | Gerekçe | Ana risk |
+|---|---|---|---|
+| `ST-3` `claude-code-cli` read-only real-adapter certification | **Now** | gerçek adapter hattı, live-write side effect yok, operator tercihi Claude Code CLI yönünde | auth/session drift, operator prerequisite, failure-mode evidence |
+| `ST-4` `gh-cli-pr` live-write rollback rehearsal | **Next** | write-side production iddiası için zorunlu kapı | remote side effect, disposable sandbox, rollback/idempotency |
+| extension/support widening | **Later** | platform yüzeyini genişletir | inventory genişliği, dead-ref/partial-ref drift, overclaim riski |
+
+## Karar
+
+İlk post-stable implementation/verification hattı
+`claude-code-cli` read-only real-adapter certification olacaktır.
+
+Bu karar `claude-code-cli` lane'ini stable shipped veya production-certified
+yapmaz. Bir sonraki slice yalnız sertifikasyon kanıt paketini çıkarır ve
+sonuç şu üç karardan birine bağlanır:
+
+1. `production_certified_read_only`
+2. `operator_managed_beta_keep`
+3. `stay_deferred`
+
+## Bir Sonraki Slice İçin Minimum Contract
+
+`claude-code-cli` certification slice'ı açılmadan önce kontrat şu soruları
+tek tek cevaplamalıdır:
+
+1. Operator prerequisite: `claude` PATH binary, auth/session ve prompt access
+   nasıl doğrulanır?
+2. Workflow path: hangi governed workflow read-only smoke olarak koşar?
+3. Evidence completeness: run/step/event kayıtlarında hangi alanlar zorunlu?
+4. Failure-mode matrix: missing binary, auth fail, timeout, non-zero exit,
+   malformed output ve policy deny nasıl yüzeye çıkar?
+5. Retry/cancel/idempotency: read-only lane için hangi davranışlar required,
+   hangileri not-applicable?
+6. Support boundary: lane geçse bile docs hangi tier'e yükselir veya neden
+   beta/deferred kalır?
+
+## Out of Scope
+
+- Runtime support widening.
+- Live-write PR creation.
+- `gh-cli-pr` remote side-effect execution.
+- Extension promotion.
+- Version bump, tag, publish veya release.
+
+## Definition of Done
+
+1. `GP-2` roadmap `GP-2.2`yi active göstermiyor.
+2. Status SSOT `GP-2.3` issue/contract'ını aktif karar slice'ı olarak
+   gösteriyor.
+3. `Now / Next / Later` sırası yazılı:
+   - Now: `claude-code-cli` read-only real-adapter certification
+   - Next: `gh-cli-pr` live-write rollback rehearsal
+   - Later: extension/support widening
+4. Stable support boundary unchanged kalıyor.
+5. Bir sonraki slice için uygulanacak contract soruları açık.
+
+## Kanıt Komutları
+
+Bu slice docs/status-only olduğu için runtime smoke zorunlu değildir.
+Minimum doğrulama:
+
+```bash
+python3 scripts/truth_inventory_ratchet.py --output json
+python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py
+```

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -17,7 +17,7 @@ ayrı ayrı görünür kılmak.
 - **Program roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
-- **Aktif decision/ordering contract:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md` (`post-stable next-slice selection`)
+- **Aktif decision/ordering contract:** `.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md`
 - **GP-2.2 closeout contract:** `.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md`
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
@@ -42,12 +42,13 @@ ayrı ayrı görünür kılmak.
 - **GP-2.1 issue:** [#331](https://github.com/Halildeu/ao-kernel/issues/331) (`closed`)
 - **GP-2.2 issue:** [#333](https://github.com/Halildeu/ao-kernel/issues/333) (`closed`)
 - **GP-2.2b issue:** [#336](https://github.com/Halildeu/ao-kernel/issues/336) (`closed`)
+- **GP-2.3 issue:** [#361](https://github.com/Halildeu/ao-kernel/issues/361) (`open`)
 - **ST-1 issue:** [#340](https://github.com/Halildeu/ao-kernel/issues/340) (`closed after closeout`)
 - **ST-2 issue:** [#344](https://github.com/Halildeu/ao-kernel/issues/344) (`closed`)
 - **ST-6 issue:** [#351](https://github.com/Halildeu/ao-kernel/issues/351) (`closed`)
 - **ST-7 issue:** [#355](https://github.com/Halildeu/ao-kernel/issues/355) (`closed after closeout`)
 - **ST-8 issue:** [#358](https://github.com/Halildeu/ao-kernel/issues/358) (`closed after closeout`)
-- **Aktif gate:** none; `v4.0.0` stable live completed. Next runtime/support widening work requires a new scoped slice under `GP-2` or a follow-up roadmap.
+- **Aktif gate:** `GP-2.3` post-stable adapter certification entry decision. Runtime/support widening yok; yalnız sıradaki gate seçimi.
 
 ## 2. Başlangıç Gerçeği
 
@@ -95,7 +96,7 @@ ayrı ayrı görünür kılmak.
 | `PB-8` general-purpose productionization roadmap | Completed on `main` ([#288](https://github.com/Halildeu/ao-kernel/issues/288), [#300](https://github.com/Halildeu/ao-kernel/pull/300), [#301](https://github.com/Halildeu/ao-kernel/pull/301)) | widening kararlarını tranche bazında kapatmak ve support closeout parity'yi tamamlamak | tracker closeout + docs/runbook/release-gate parity |
 | `PB-9` production claim readiness gates | Completed on `main` ([#302](https://github.com/Halildeu/ao-kernel/issues/302), closed tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303), closed tranche [#306](https://github.com/Halildeu/ao-kernel/issues/306), closed tranche [#309](https://github.com/Halildeu/ao-kernel/issues/309), closed tranche [#312](https://github.com/Halildeu/ao-kernel/issues/312)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | roadmap + decision records + tracker closeout |
 | `GP-1` general-purpose production widening | Completed on `main` ([#316](https://github.com/Halildeu/ao-kernel/issues/316), [#327](https://github.com/Halildeu/ao-kernel/pull/327), [#326](https://github.com/Halildeu/ao-kernel/issues/326)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde tamamlamak | GP-1.1..GP-1.5 decision records + closeout parity |
-| `GP-2` deferred support-lane backlog reprioritization | Active ([#329](https://github.com/Halildeu/ao-kernel/issues/329), latest slice [#333](https://github.com/Halildeu/ao-kernel/issues/333) closed) | `GP-1` sonrası deferred lane'leri tek anlamlı sıraya indirip ilk aktif runtime tranche'i seçmek | deferred lane evidence-delta map + `Now/Next/Later` kararı + GP-2.2 closeout |
+| `GP-2` deferred support-lane backlog reprioritization | Active ([#329](https://github.com/Halildeu/ao-kernel/issues/329), active slice [#361](https://github.com/Halildeu/ao-kernel/issues/361)) | `GP-1` ve `v4.0.0` stable sonrası deferred/support widening lane'lerini tek anlamlı sıraya indirip ilk post-stable certification gate'ini seçmek | GP-2.2 closeout + GP-2.3 `Now/Next/Later` post-stable karar kaydı |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -363,28 +364,27 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Aktif slice: none. `ST-8` stable publish and post-publish verification
-tamamlandı; sıradaki runtime/support widening işi yeni scoped slice olarak
-açılmalıdır.
+Aktif slice: `GP-2.3` post-stable adapter certification entry decision
+([#361](https://github.com/Halildeu/ao-kernel/issues/361)).
 
-1. Son kapanan slice: `GP-2.2` adapter-path `cost_usd` reconcile completeness
-   closeout ([#333](https://github.com/Halildeu/ao-kernel/issues/333))
-2. Production-stable roadmap: `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
-3. Completed contract: `.claude/plans/ST-1-RELEASABLE-PRE-RELEASE-GATE.md`
-4. Completed contract: `.claude/plans/ST-2-STABLE-SUPPORT-BOUNDARY-FREEZE.md`
-5. Completed contract: `.claude/plans/ST-5-DEFERRED-CORRECTNESS-CLOSURE.md`
-6. Son kapanan PR: ST-8 closeout PR
-7. ST-2 freeze kararı: dar stable runtime için ST-3/ST-4 blocker değildir;
-   real-adapter/live-write promotion istenirse ayrı gate gerekir.
-8. ST-5 closeout kararı: deferred correctness kalemleri stable shipped baseline'a
-   promote edilmiyor; tamamı `deferred` veya spec-only kalıyor.
-9. Son kapanan issue: [#358](https://github.com/Halildeu/ao-kernel/issues/358)
-   (`ST-8` closed after closeout)
-10. Completed contract:
-   `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md`
-11. Stable live iddiası artık geçerlidir: `pip install ao-kernel` ve exact pin
+Bu slice runtime/support widening yapmaz. Amaç `v4.0.0` stable sonrası ilk
+gerçek widening giriş kapısını seçmek ve sonraki implementation contract'ının
+sorularını sabitlemektir.
+
+1. Son kapanan slice: `ST-8` stable publish and post-publish verification
+   ([#358](https://github.com/Halildeu/ao-kernel/issues/358))
+2. Son kapanan GP slice: `GP-2.2` adapter-path `cost_usd` reconcile
+   completeness closeout ([#333](https://github.com/Halildeu/ao-kernel/issues/333))
+3. Aktif contract:
+   `.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md`
+4. Karar sırası:
+   - `Now`: `claude-code-cli` read-only real-adapter certification
+   - `Next`: `gh-cli-pr` live-write rollback rehearsal
+   - `Later`: extension/support widening ve genel amaçlı platform claim'i
+5. Stable live iddiası geçerlidir: `pip install ao-kernel` ve exact pin
    `ao-kernel==4.0.0` fresh venv içinde `4.0.0` kurmuştur.
-12. Aktif iş: yeni scoped slice seçilmeden runtime/support widening yapılmaz.
+6. Stable support boundary unchanged kalır; `GP-2.3` yeni production adapter
+   claim'i üretmez.
 
 `PB-8.2` completion kaydı:
 
@@ -630,3 +630,24 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
    - `GP-2.2c` runtime patch no-op kaldı
    - `GP-2.2d` docs/status parity PR [#338](https://github.com/Halildeu/ao-kernel/pull/338) ile tamamlandı
    - adapter-path `cost_usd` reconcile public support claim olarak deferred kaldı
+
+## 18. GP-2.3 Post-Stable Entry Snapshot
+
+`ST-8` stable publish closeout sonrası aktif karar slice'ı `GP-2.3` olarak
+açıldı.
+
+1. Issue: [#361](https://github.com/Halildeu/ao-kernel/issues/361) (`open`)
+2. Active contract:
+   `.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md`
+3. Scope:
+   - post-stable support-widening giriş kapısını seçmek
+   - `ST-3`, `ST-4` ve extension/support widening sırasını netleştirmek
+   - sonraki implementation slice için cevaplanacak contract sorularını yazmak
+4. Sınır:
+   - runtime değişikliği yok
+   - stable support boundary widening yok
+   - version bump, tag ve publish yok
+5. Varsayılan karar:
+   - `Now`: `claude-code-cli` read-only real-adapter certification
+   - `Next`: `gh-cli-pr` live-write rollback rehearsal
+   - `Later`: extension/support widening

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -148,9 +148,11 @@ kanitli pre-release'e cevirmek.
 
 ### ST-3 — Real Adapter Certification Decision
 
-**Durum:** Parked for support widening. Not a blocker for the narrow stable
-runtime release because real-adapter lanes are not stable shipped claims after
-`ST-2`.
+**Durum:** Parked for support widening. Post-stable entry ordering is tracked
+by `GP-2.3` ([#361](https://github.com/Halildeu/ao-kernel/issues/361)); the
+default first certification candidate is `claude-code-cli` read-only.
+Not a blocker for the narrow stable runtime release because real-adapter lanes
+are not stable shipped claims after `ST-2`.
 
 **Amac:** Gercek adapter yuzeylerinin stable scope'a girip girmeyecegini
 kanıtla karara baglamak.
@@ -331,6 +333,13 @@ dogrulanir.
 1. `ST-0` tamamlandi: GP-2.2 closeout ve status/docs drift temizligi.
 2. `ST-1` tamamlandi: current `main` icin `4.0.0b2` pre-release publish ve
    PyPI exact pin verify.
-3. `ST-2` ile stable support boundary freeze yap.
-4. Sonra stable scope kararina gore `ST-3` ve `ST-4` gerekli mi, yoksa dar
-   runtime stable release'e gecilebilir mi karar ver.
+3. `ST-2`, `ST-5`, `ST-6`, `ST-7` ve `ST-8` tamamlandi; `v4.0.0` stable live.
+4. Aktif post-stable karar hattı `GP-2.3`:
+   `.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md`
+5. Varsayılan sıra:
+   - `Now`: `claude-code-cli` read-only real-adapter certification
+   - `Next`: `gh-cli-pr` live-write rollback rehearsal
+   - `Later`: extension/support widening
+6. Bu roadmap stable runtime release'i tamamlanmış sayar; genel amaçlı
+   production platform claim'i için `GP-2.3` sonrası certification ve
+   rollback kanıtları gerekir.


### PR DESCRIPTION
## Summary

- opens `GP-2.3` as the active post-stable adapter certification entry decision slice
- marks `GP-2.2` as completed and moves the active GP-2/status pointers to issue #361
- records the default post-stable ordering: `claude-code-cli` read-only certification now, `gh-cli-pr` live-write rollback rehearsal next, extension/support widening later

## Scope boundary

- docs/status/plan only
- no runtime support widening
- no version bump, tag, publish, or release
- stable support boundary remains unchanged

## Validation

- `git diff --check`
- `python3 scripts/truth_inventory_ratchet.py --output json`
- `python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py` → `3 passed, 1 skipped`

Closes #361
Refs #329
