### PR TITLE
[codex] docs: start GP-2.4 Claude Code certification contract

### DIFF
--- a/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
+++ b/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
@@ -64,7 +64,7 @@ giriş kapılarını netleştirmektir.
   **Deferred** kalır; behavior/evidence assertions mevcut ama support widening
   üretmez.
 
-### `GP-2.3` — Post-stable adapter certification entry decision (Active)
+### `GP-2.3` — Post-stable adapter certification entry decision (Completed)
 
 - Issue: [#361](https://github.com/Halildeu/ao-kernel/issues/361)
 - Contract:
@@ -79,6 +79,28 @@ giriş kapılarını netleştirmektir.
   - Runtime değişikliği yok
   - Version bump, tag veya publish yok
   - Stable support boundary unchanged kalır
+- Closeout:
+  - Next active issue: [#363](https://github.com/Halildeu/ao-kernel/issues/363)
+  - Next active contract:
+    `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
+
+### `GP-2.4` — `claude-code-cli` read-only certification contract (Active)
+
+- Issue: [#363](https://github.com/Halildeu/ao-kernel/issues/363)
+- Contract:
+  `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
+- Hedef: `claude-code-cli` read-only real-adapter certification için
+  prerequisite, smoke, evidence, failure-mode ve support-boundary karar
+  kapılarını tek contract altında toplamak.
+- Sıra:
+  1. `GP-2.4a` preflight evidence contract
+  2. `GP-2.4b` governed workflow smoke evidence
+  3. `GP-2.4c` failure-mode matrix
+  4. `GP-2.4d` support boundary verdict
+- Sınır:
+  - `claude-code-cli` henüz production-certified değildir
+  - Live-write yok
+  - Stable support boundary unchanged kalır
 
 ## Gate Modeli
 
@@ -91,8 +113,9 @@ giriş kapılarını netleştirmektir.
 
 1. `GP-2.1` sonunda deferred satırların sırasi tartışmasızdır.
 2. `GP-2.2` ilk runtime/evidence slice olarak tamamlanmıştır.
-3. `GP-2.3` post-stable next-slice kararını açık issue/contract ile taşır.
-4. Status SSOT'ta aktif issue/contract alanı günceldir.
+3. `GP-2.3` post-stable next-slice kararını tamamlamıştır.
+4. `GP-2.4` certification contract'ı açık issue/contract ile aktiftir.
+5. Status SSOT'ta aktif issue/contract alanı günceldir.
 
 ## Risk Register
 

--- a/.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md
+++ b/.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md
@@ -1,6 +1,6 @@
 # GP-2.3 — Post-Stable Adapter Certification Entry Decision
 
-**Status:** Active
+**Status:** Completed
 **Date:** 2026-04-24
 **Tracker:** [#361](https://github.com/Halildeu/ao-kernel/issues/361)
 **Parent:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
@@ -82,6 +82,20 @@ tek tek cevaplamalıdır:
    - Later: extension/support widening
 4. Stable support boundary unchanged kalıyor.
 5. Bir sonraki slice için uygulanacak contract soruları açık.
+
+## Closeout
+
+`GP-2.3` karar slice'ı tamamlandı. Handoff:
+
+1. Next active issue: [#363](https://github.com/Halildeu/ao-kernel/issues/363)
+2. Next active contract:
+   `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
+3. Chosen first lane:
+   `claude-code-cli` read-only real-adapter certification
+4. Support boundary impact:
+   unchanged; certification contract support widening değildir
+5. Next default:
+   `GP-2.4a` preflight evidence contract
 
 ## Kanıt Komutları
 

--- a/.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md
+++ b/.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md
@@ -1,0 +1,175 @@
+# GP-2.4 — Claude Code CLI Read-Only Certification Contract
+
+**Status:** Active
+**Date:** 2026-04-24
+**Tracker:** [#363](https://github.com/Halildeu/ao-kernel/issues/363)
+**Parent:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
+**Handoff from:** `.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md`
+
+## Amaç
+
+`claude-code-cli` lane'ini stable support boundary'ye almadan önce read-only
+real-adapter certification için gereken kanıt paketini tek contract altında
+tanımlamak ve sonra küçük implementation/verification PR'larına bölmek.
+
+Bu slice tek başına adapter'ı production-certified yapmaz. Certification
+kararı ancak aşağıdaki evidence, failure-mode ve docs parity kapıları
+kapatıldıktan sonra verilir.
+
+## Başlangıç Gerçeği
+
+1. `claude-code-cli` repo-native binary değildir; operator ortamındaki
+   external `claude` PATH binary'sine dayanır.
+2. Varsayılan auth yolu Claude Code session auth'tur. API key/env-token yolu
+   fallback kabul edilir, primary recovery yolu değildir.
+3. `claude auth status` tek başına yeterli değildir; gerçek `claude -p`
+   prompt probe belirleyici sinyaldir.
+4. Current local baseline probe `2026-04-24` tarihinde geçti:
+   - `claude --version`: `2.1.87 (Claude Code)`
+   - `claude auth status`: pass, auth method `claude.ai`
+   - `claude -p "reply with the single token ok"`: pass
+   - bundled manifest invocation smoke: pass
+   - API key env route: not present
+5. Bu baseline operator ortamının sağlıklı olduğunu gösterir; destek sınırını
+   tek başına genişletmez.
+
+## Certification Adayı
+
+| Alan | Seçim |
+|---|---|
+| Adapter | `claude-code-cli` |
+| Workflow | `governed_review_claude_code_cli` |
+| Capability scope | `read_repo`, `review_findings` |
+| Side-effect scope | read-only; live write yok |
+| Required helper | `python3 scripts/claude_code_cli_smoke.py --output json` |
+| Existing runbook | `docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md` |
+| Current support tier | Beta (operator-managed) |
+
+## Work Breakdown
+
+### `GP-2.4a` — Preflight Evidence Contract
+
+Hedef: helper smoke sonucunu machine-readable certification evidence olarak
+pinlemek.
+
+Kapsam:
+
+1. `scripts/claude_code_cli_smoke.py --output json` çıktısında zorunlu alanları
+   yaz:
+   - `overall_status`
+   - `adapter_id`
+   - `binary_path`
+   - `api_key_env_present`
+   - `checks[].name`
+   - `checks[].status`
+   - `checks[].finding_code`
+   - `checks[].returncode`
+2. `overall_status=pass` için zorunlu check seti:
+   - `version`
+   - `auth_status`
+   - `prompt_access`
+   - `manifest_invocation`
+3. `auth_status=pass` ama `prompt_access=fail` durumunu blocker say.
+4. API key/env-token route'unu primary certification path yapma.
+
+DoD:
+
+1. Helper output contract test veya snapshot assertion ile pinli.
+2. Known bugs `KB-001` ve `KB-002` support boundary kararına bağlandı.
+3. Docs, helper smoke'u certification prerequisite olarak anlatıyor.
+
+### `GP-2.4b` — Governed Workflow Smoke Evidence
+
+Hedef: helper-level manifest smoke dışında governed workflow path'inin read-only
+şekilde çalıştığını kanıtlamak.
+
+Kapsam:
+
+1. `governed_review_claude_code_cli` workflow'u controlled workspace üzerinde
+   koşar.
+2. `review_findings` artifact'i schema-valid olarak materialize olur.
+3. Evidence JSONL en az şu eventleri içerir:
+   - `step_started`
+   - `policy_checked`
+   - `adapter_invoked`
+   - `step_completed`
+   - terminal workflow state
+4. Adapter invocation envelope redacted halde yazılır.
+5. Output parse fail-closed davranışı korunur.
+
+DoD:
+
+1. Read-only workflow smoke tekrarlanabilir komutla belgelenir.
+2. Evidence/artifact path'leri docs ve runbook ile aynı şeyi söyler.
+3. Smoke başarısı repo root/PYTHONPATH kontaminasyonuna dayanmaz.
+
+### `GP-2.4c` — Failure-Mode Matrix
+
+Hedef: production claim'i için gerekli negatif yolları fake-green bırakmamak.
+
+Minimum failure matrix:
+
+| Failure | Beklenen sonuç |
+|---|---|
+| `claude` binary missing | `claude_binary_missing`, overall blocked/fail |
+| `auth_status` fail | `claude_not_logged_in` veya eşdeğer finding |
+| `prompt_access` fail | prompt access blocker; auth status yeşili yeterli sayılmaz |
+| manifest invocation timeout | timeout finding, workflow başlamadan blocker |
+| non-zero exit | adapter step failed, evidence'da return code görünür |
+| malformed output | `output_parse_failed`, workflow fail-closed |
+| policy deny | subprocess invocation gerçekleşmeden `policy_denied` |
+
+DoD:
+
+1. En az helper-level negative tests var.
+2. En az workflow-level fail-closed path doğrulanır.
+3. Hata sınıfları `docs/KNOWN-BUGS.md` ve runbook diliyle çelişmez.
+
+### `GP-2.4d` — Support Boundary Verdict
+
+Hedef: certification sonucunu tek karara indirmek.
+
+Olası verdict'ler:
+
+1. `production_certified_read_only`
+2. `operator_managed_beta_keep`
+3. `stay_deferred`
+
+Karar kuralları:
+
+1. Helper smoke pass tek başına production certification değildir.
+2. Governed workflow smoke + evidence completeness + failure matrix kapanmadan
+   stable support boundary genişlemez.
+3. `KB-001` veya `KB-002` shipped baseline'ı etkilemez; ancak
+   `claude-code-cli` promotion kararını sınırlayabilir.
+4. Live-write kapsamı bu kararın dışında kalır; `gh-cli-pr` rollback
+   rehearsal ayrı lane'dir.
+
+## Out of Scope
+
+- `gh-cli-pr` live-write veya remote PR creation.
+- Claude API key-first integration.
+- Extension support widening.
+- Version bump, tag, publish veya release.
+- Stable support boundary promotion before `GP-2.4d`.
+
+## Zorunlu Kanıt Komutları
+
+Contract PR için minimum:
+
+```bash
+python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 10
+python3 scripts/truth_inventory_ratchet.py --output json
+python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py
+```
+
+Implementation PR'larda ek olarak hedef testler ve governed workflow smoke
+komutları yazılacaktır.
+
+## Exit Criteria
+
+1. `GP-2.4a..d` çıktıları tamamlanır.
+2. Certification verdict tek değere iner.
+3. Docs/runtime/tests/CI/support boundary aynı kararı anlatır.
+4. Stable support boundary yalnız kanıt kapıları kapanırsa genişler.
+

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -17,7 +17,7 @@ ayrı ayrı görünür kılmak.
 - **Program roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
-- **Aktif decision/ordering contract:** `.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md`
+- **Aktif certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
 - **GP-2.2 closeout contract:** `.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md`
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
@@ -42,13 +42,14 @@ ayrı ayrı görünür kılmak.
 - **GP-2.1 issue:** [#331](https://github.com/Halildeu/ao-kernel/issues/331) (`closed`)
 - **GP-2.2 issue:** [#333](https://github.com/Halildeu/ao-kernel/issues/333) (`closed`)
 - **GP-2.2b issue:** [#336](https://github.com/Halildeu/ao-kernel/issues/336) (`closed`)
-- **GP-2.3 issue:** [#361](https://github.com/Halildeu/ao-kernel/issues/361) (`open`)
+- **GP-2.3 issue:** [#361](https://github.com/Halildeu/ao-kernel/issues/361) (`closeout after handoff`)
+- **GP-2.4 issue:** [#363](https://github.com/Halildeu/ao-kernel/issues/363) (`open`)
 - **ST-1 issue:** [#340](https://github.com/Halildeu/ao-kernel/issues/340) (`closed after closeout`)
 - **ST-2 issue:** [#344](https://github.com/Halildeu/ao-kernel/issues/344) (`closed`)
 - **ST-6 issue:** [#351](https://github.com/Halildeu/ao-kernel/issues/351) (`closed`)
 - **ST-7 issue:** [#355](https://github.com/Halildeu/ao-kernel/issues/355) (`closed after closeout`)
 - **ST-8 issue:** [#358](https://github.com/Halildeu/ao-kernel/issues/358) (`closed after closeout`)
-- **Aktif gate:** `GP-2.3` post-stable adapter certification entry decision. Runtime/support widening yok; yalnız sıradaki gate seçimi.
+- **Aktif gate:** `GP-2.4` `claude-code-cli` read-only certification contract. Runtime/support widening yok; certification kanıt kapıları hazırlanıyor.
 
 ## 2. Başlangıç Gerçeği
 
@@ -96,7 +97,7 @@ ayrı ayrı görünür kılmak.
 | `PB-8` general-purpose productionization roadmap | Completed on `main` ([#288](https://github.com/Halildeu/ao-kernel/issues/288), [#300](https://github.com/Halildeu/ao-kernel/pull/300), [#301](https://github.com/Halildeu/ao-kernel/pull/301)) | widening kararlarını tranche bazında kapatmak ve support closeout parity'yi tamamlamak | tracker closeout + docs/runbook/release-gate parity |
 | `PB-9` production claim readiness gates | Completed on `main` ([#302](https://github.com/Halildeu/ao-kernel/issues/302), closed tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303), closed tranche [#306](https://github.com/Halildeu/ao-kernel/issues/306), closed tranche [#309](https://github.com/Halildeu/ao-kernel/issues/309), closed tranche [#312](https://github.com/Halildeu/ao-kernel/issues/312)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | roadmap + decision records + tracker closeout |
 | `GP-1` general-purpose production widening | Completed on `main` ([#316](https://github.com/Halildeu/ao-kernel/issues/316), [#327](https://github.com/Halildeu/ao-kernel/pull/327), [#326](https://github.com/Halildeu/ao-kernel/issues/326)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde tamamlamak | GP-1.1..GP-1.5 decision records + closeout parity |
-| `GP-2` deferred support-lane backlog reprioritization | Active ([#329](https://github.com/Halildeu/ao-kernel/issues/329), active slice [#361](https://github.com/Halildeu/ao-kernel/issues/361)) | `GP-1` ve `v4.0.0` stable sonrası deferred/support widening lane'lerini tek anlamlı sıraya indirip ilk post-stable certification gate'ini seçmek | GP-2.2 closeout + GP-2.3 `Now/Next/Later` post-stable karar kaydı |
+| `GP-2` deferred support-lane backlog reprioritization | Active ([#329](https://github.com/Halildeu/ao-kernel/issues/329), active slice [#363](https://github.com/Halildeu/ao-kernel/issues/363)) | `GP-1` ve `v4.0.0` stable sonrası deferred/support widening lane'lerini tek anlamlı sıraya indirip ilk post-stable certification gate'ini yürütmek | GP-2.3 handoff + GP-2.4 certification contract |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -364,26 +365,28 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Aktif slice: `GP-2.3` post-stable adapter certification entry decision
-([#361](https://github.com/Halildeu/ao-kernel/issues/361)).
+Aktif slice: `GP-2.4` `claude-code-cli` read-only certification contract
+([#363](https://github.com/Halildeu/ao-kernel/issues/363)).
 
-Bu slice runtime/support widening yapmaz. Amaç `v4.0.0` stable sonrası ilk
-gerçek widening giriş kapısını seçmek ve sonraki implementation contract'ının
-sorularını sabitlemektir.
+Bu slice runtime/support widening yapmaz. Amaç `claude-code-cli` lane'i için
+sertifikasyon kanıt paketini uygulanabilir alt dilimlere indirmektir.
 
-1. Son kapanan slice: `ST-8` stable publish and post-publish verification
+1. Son kapanan stable slice: `ST-8` stable publish and post-publish verification
    ([#358](https://github.com/Halildeu/ao-kernel/issues/358))
 2. Son kapanan GP slice: `GP-2.2` adapter-path `cost_usd` reconcile
    completeness closeout ([#333](https://github.com/Halildeu/ao-kernel/issues/333))
-3. Aktif contract:
-   `.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md`
-4. Karar sırası:
-   - `Now`: `claude-code-cli` read-only real-adapter certification
-   - `Next`: `gh-cli-pr` live-write rollback rehearsal
-   - `Later`: extension/support widening ve genel amaçlı platform claim'i
-5. Stable live iddiası geçerlidir: `pip install ao-kernel` ve exact pin
+3. Son karar slice'ı: `GP-2.3` post-stable entry decision
+   ([#361](https://github.com/Halildeu/ao-kernel/issues/361))
+4. Aktif contract:
+   `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
+5. GP-2.4 sıra:
+   - `GP-2.4a`: preflight evidence contract
+   - `GP-2.4b`: governed workflow smoke evidence
+   - `GP-2.4c`: failure-mode matrix
+   - `GP-2.4d`: support boundary verdict
+6. Stable live iddiası geçerlidir: `pip install ao-kernel` ve exact pin
    `ao-kernel==4.0.0` fresh venv içinde `4.0.0` kurmuştur.
-6. Stable support boundary unchanged kalır; `GP-2.3` yeni production adapter
+7. Stable support boundary unchanged kalır; `GP-2.4` yeni production adapter
    claim'i üretmez.
 
 `PB-8.2` completion kaydı:
@@ -636,7 +639,7 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
 `ST-8` stable publish closeout sonrası aktif karar slice'ı `GP-2.3` olarak
 açıldı.
 
-1. Issue: [#361](https://github.com/Halildeu/ao-kernel/issues/361) (`open`)
+1. Issue: [#361](https://github.com/Halildeu/ao-kernel/issues/361) (`closeout after handoff`)
 2. Active contract:
    `.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md`
 3. Scope:
@@ -651,3 +654,30 @@ açıldı.
    - `Now`: `claude-code-cli` read-only real-adapter certification
    - `Next`: `gh-cli-pr` live-write rollback rehearsal
    - `Later`: extension/support widening
+6. Closeout:
+   - next active issue: [#363](https://github.com/Halildeu/ao-kernel/issues/363)
+   - next active contract:
+     `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
+
+## 19. GP-2.4 Claude Code CLI Certification Snapshot
+
+`GP-2.3` handoff sonrası aktif contract slice `GP-2.4` olarak açıldı.
+
+1. Issue: [#363](https://github.com/Halildeu/ao-kernel/issues/363) (`open`)
+2. Active contract:
+   `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
+3. Scope:
+   - `claude-code-cli` read-only certification evidence package
+   - preflight helper contract
+   - governed workflow smoke requirements
+   - failure-mode matrix
+   - support boundary verdict criteria
+4. Sınır:
+   - runtime support widening yok
+   - live-write yok
+   - stable support boundary unchanged
+5. Current local baseline probe:
+   - `python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 10`
+   - `overall_status=pass`
+   - `version`, `auth_status`, `prompt_access`, `manifest_invocation` checks pass
+   - API key env route not present; session auth path used

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -148,9 +148,10 @@ kanitli pre-release'e cevirmek.
 
 ### ST-3 — Real Adapter Certification Decision
 
-**Durum:** Parked for support widening. Post-stable entry ordering is tracked
-by `GP-2.3` ([#361](https://github.com/Halildeu/ao-kernel/issues/361)); the
-default first certification candidate is `claude-code-cli` read-only.
+**Durum:** Parked for support widening. Post-stable first certification
+contract is tracked by `GP-2.4`
+([#363](https://github.com/Halildeu/ao-kernel/issues/363)); the active
+candidate is `claude-code-cli` read-only.
 Not a blocker for the narrow stable runtime release because real-adapter lanes
 are not stable shipped claims after `ST-2`.
 
@@ -334,12 +335,14 @@ dogrulanir.
 2. `ST-1` tamamlandi: current `main` icin `4.0.0b2` pre-release publish ve
    PyPI exact pin verify.
 3. `ST-2`, `ST-5`, `ST-6`, `ST-7` ve `ST-8` tamamlandi; `v4.0.0` stable live.
-4. Aktif post-stable karar hattı `GP-2.3`:
-   `.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md`
-5. Varsayılan sıra:
-   - `Now`: `claude-code-cli` read-only real-adapter certification
+4. `GP-2.3` tamamlandı: post-stable ilk giriş kapısı
+   `claude-code-cli` read-only certification olarak seçildi.
+5. Aktif post-stable contract hattı `GP-2.4`:
+   `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
+6. Varsayılan sıra:
+   - `Now`: `GP-2.4` `claude-code-cli` read-only certification contract
    - `Next`: `gh-cli-pr` live-write rollback rehearsal
    - `Later`: extension/support widening
-6. Bu roadmap stable runtime release'i tamamlanmış sayar; genel amaçlı
-   production platform claim'i için `GP-2.3` sonrası certification ve
-   rollback kanıtları gerekir.
+7. Bu roadmap stable runtime release'i tamamlanmış sayar; genel amaçlı
+   production platform claim'i için `GP-2.4` certification ve sonraki rollback
+   kanıtları gerekir.


### PR DESCRIPTION
## Summary

- opens `GP-2.4` as the active `claude-code-cli` read-only certification contract
- closes out `GP-2.3` as the post-stable entry decision and hands off to issue #363
- records the certification work breakdown: preflight evidence, governed workflow smoke, failure-mode matrix, and support-boundary verdict

## Scope boundary

- docs/status/plan only
- no runtime support widening
- no live-write
- no adapter support-tier promotion
- no version bump, tag, publish, or release

## Validation

- `python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 10` -> `overall_status=pass`; `version`, `auth_status`, `prompt_access`, `manifest_invocation` pass
- `python3 scripts/truth_inventory_ratchet.py --output json`
- `python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py` -> `3 passed, 1 skipped`
- `git diff --check`

Closes #361
Refs #363
Refs #329
