### PR TITLE
[codex] test: pin Claude Code preflight evidence

### DIFF
--- a/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
+++ b/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
@@ -93,10 +93,16 @@ giriş kapılarını netleştirmektir.
   prerequisite, smoke, evidence, failure-mode ve support-boundary karar
   kapılarını tek contract altında toplamak.
 - Sıra:
-  1. `GP-2.4a` preflight evidence contract
+  1. `GP-2.4a` preflight evidence contract (Completed via [#365](https://github.com/Halildeu/ao-kernel/issues/365))
   2. `GP-2.4b` governed workflow smoke evidence
   3. `GP-2.4c` failure-mode matrix
   4. `GP-2.4d` support boundary verdict
+- Son ilerleme:
+  - `tests/test_claude_code_cli_smoke.py` helper JSON output contract'ını pinler
+  - `auth_status=pass` + `prompt_access=fail` blocker olarak kalır
+  - API key/env-token presence başarı sinyali sayılmaz
+- Next default:
+  - `GP-2.4b` governed workflow smoke evidence
 - Sınır:
   - `claude-code-cli` henüz production-certified değildir
   - Live-write yok

--- a/.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md
+++ b/.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md
@@ -24,13 +24,16 @@ kapatıldıktan sonra verilir.
    fallback kabul edilir, primary recovery yolu değildir.
 3. `claude auth status` tek başına yeterli değildir; gerçek `claude -p`
    prompt probe belirleyici sinyaldir.
-4. Current local baseline probe `2026-04-24` tarihinde geçti:
+4. Current local baseline probe `2026-04-24` tarihinde 30 saniyelik helper
+   timeout ile geçti:
    - `claude --version`: `2.1.87 (Claude Code)`
    - `claude auth status`: pass, auth method `claude.ai`
    - `claude -p "reply with the single token ok"`: pass
    - bundled manifest invocation smoke: pass
    - API key env route: not present
-5. Bu baseline operator ortamının sağlıklı olduğunu gösterir; destek sınırını
+5. Aynı oturumda 10 saniyelik probe `prompt_smoke_timeout` üretebildiği için
+   certification prerequisite komutu 30 saniye timeout ile koşulacaktır.
+6. Bu baseline operator ortamının sağlıklı olduğunu gösterir; destek sınırını
    tek başına genişletmez.
 
 ## Certification Adayı
@@ -48,6 +51,8 @@ kapatıldıktan sonra verilir.
 ## Work Breakdown
 
 ### `GP-2.4a` — Preflight Evidence Contract
+
+Status: Completed by issue [#365](https://github.com/Halildeu/ao-kernel/issues/365).
 
 Hedef: helper smoke sonucunu machine-readable certification evidence olarak
 pinlemek.
@@ -77,6 +82,20 @@ DoD:
 1. Helper output contract test veya snapshot assertion ile pinli.
 2. Known bugs `KB-001` ve `KB-002` support boundary kararına bağlandı.
 3. Docs, helper smoke'u certification prerequisite olarak anlatıyor.
+
+Closeout:
+
+1. `tests/test_claude_code_cli_smoke.py` passing preflight JSON output shape'ini
+   top-level ve per-check zorunlu alanlarla pinler.
+2. Canonical passing check seti pinlidir:
+   `version`, `auth_status`, `prompt_access`, `manifest_invocation`.
+3. `auth_status=pass` + `prompt_access=fail` overall `blocked` kalır;
+   `KB-001` sınıfı fake green üretemez.
+4. `ANTHROPIC_API_KEY` varlığı gözlemlenir fakat prompt access fail durumunu
+   başarıya çeviremez; `KB-002` fallback/token route'u primary certification
+   path değildir.
+5. Support boundary unchanged kalır; helper pass tek başına production
+   certification değildir.
 
 ### `GP-2.4b` — Governed Workflow Smoke Evidence
 
@@ -158,7 +177,8 @@ Karar kuralları:
 Contract PR için minimum:
 
 ```bash
-python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 10
+python3 -m pytest -q tests/test_claude_code_cli_smoke.py
+python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 30
 python3 scripts/truth_inventory_ratchet.py --output json
 python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py
 ```
@@ -172,4 +192,3 @@ komutları yazılacaktır.
 2. Certification verdict tek değere iner.
 3. Docs/runtime/tests/CI/support boundary aynı kararı anlatır.
 4. Stable support boundary yalnız kanıt kapıları kapanırsa genişler.
-

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -44,6 +44,7 @@ ayrı ayrı görünür kılmak.
 - **GP-2.2b issue:** [#336](https://github.com/Halildeu/ao-kernel/issues/336) (`closed`)
 - **GP-2.3 issue:** [#361](https://github.com/Halildeu/ao-kernel/issues/361) (`closeout after handoff`)
 - **GP-2.4 issue:** [#363](https://github.com/Halildeu/ao-kernel/issues/363) (`open`)
+- **GP-2.4a issue:** [#365](https://github.com/Halildeu/ao-kernel/issues/365) (`closed after merge`)
 - **ST-1 issue:** [#340](https://github.com/Halildeu/ao-kernel/issues/340) (`closed after closeout`)
 - **ST-2 issue:** [#344](https://github.com/Halildeu/ao-kernel/issues/344) (`closed`)
 - **ST-6 issue:** [#351](https://github.com/Halildeu/ao-kernel/issues/351) (`closed`)
@@ -380,7 +381,7 @@ sertifikasyon kanıt paketini uygulanabilir alt dilimlere indirmektir.
 4. Aktif contract:
    `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
 5. GP-2.4 sıra:
-   - `GP-2.4a`: preflight evidence contract
+   - `GP-2.4a`: preflight evidence contract (`closed after merge`)
    - `GP-2.4b`: governed workflow smoke evidence
    - `GP-2.4c`: failure-mode matrix
    - `GP-2.4d`: support boundary verdict
@@ -677,7 +678,18 @@ açıldı.
    - live-write yok
    - stable support boundary unchanged
 5. Current local baseline probe:
-   - `python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 10`
+   - `python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 30`
    - `overall_status=pass`
    - `version`, `auth_status`, `prompt_access`, `manifest_invocation` checks pass
    - API key env route not present; session auth path used
+   - note: 10 saniyelik probe aynı oturumda `prompt_smoke_timeout`
+     üretebildiği için certification prerequisite 30 saniye timeout kullanır
+6. `GP-2.4a` closeout:
+   - issue: [#365](https://github.com/Halildeu/ao-kernel/issues/365)
+   - `tests/test_claude_code_cli_smoke.py` now pins the helper JSON evidence
+     contract shape
+   - `auth_status=pass` + `prompt_access=fail` remains `blocked`
+   - API key/env-token presence is observed but cannot turn prompt failure into
+     certification success
+7. Next default:
+   - `GP-2.4b` governed workflow smoke evidence

--- a/tests/test_claude_code_cli_smoke.py
+++ b/tests/test_claude_code_cli_smoke.py
@@ -4,8 +4,34 @@ import json
 import subprocess
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 from ao_kernel.real_adapter_smoke import CommandResult, run_claude_code_cli_smoke
+
+
+_SUCCESSFUL_CHECK_NAMES = [
+    "version",
+    "auth_status",
+    "prompt_access",
+    "manifest_invocation",
+]
+_REPORT_KEYS = {
+    "overall_status",
+    "adapter_id",
+    "binary_path",
+    "api_key_env_present",
+    "checks",
+    "findings",
+}
+_CHECK_KEYS = {
+    "name",
+    "status",
+    "detail",
+    "finding_code",
+    "argv",
+    "returncode",
+    "observed",
+}
 
 
 def _result(
@@ -21,6 +47,80 @@ def _result(
         stdout=stdout,
         stderr=stderr,
     )
+
+
+def _successful_runner(
+    argv: Sequence[str],
+    cwd: Path | None,
+    timeout: float | None,
+) -> CommandResult:
+    cmd = tuple(argv)
+    if cmd == ("/fake/claude", "--version"):
+        return _result(cmd, stdout="2.1.87 (Claude Code)\n")
+    if cmd == ("/fake/claude", "auth", "status"):
+        return _result(
+            cmd,
+            stdout=json.dumps(
+                {
+                    "loggedIn": True,
+                    "authMethod": "claude.ai",
+                    "orgName": "Test Org",
+                }
+            ),
+        )
+    if cmd == ("/fake/claude", "-p", "reply with the single token ok"):
+        return _result(cmd, stdout="ok\n")
+    if cmd[:1] == ("/fake/claude",):
+        return _result(
+            cmd,
+            stdout=json.dumps(
+                {
+                    "status": "ok",
+                    "review_findings": {
+                        "schema_version": "1",
+                        "findings": [],
+                        "summary": "smoke ok",
+                    },
+                }
+            ),
+        )
+    raise AssertionError(f"unexpected argv: {cmd!r}")
+
+
+def _prompt_access_denied_runner(
+    argv: Sequence[str],
+    cwd: Path | None,
+    timeout: float | None,
+) -> CommandResult:
+    cmd = tuple(argv)
+    if cmd == ("/fake/claude", "--version"):
+        return _result(cmd, stdout="2.1.87 (Claude Code)\n")
+    if cmd == ("/fake/claude", "auth", "status"):
+        return _result(
+            cmd,
+            stdout=json.dumps(
+                {
+                    "loggedIn": True,
+                    "authMethod": "claude.ai",
+                    "orgName": "Test Org",
+                }
+            ),
+        )
+    if cmd[:1] == ("/fake/claude",):
+        return _result(
+            cmd,
+            returncode=1,
+            stderr=(
+                "Your organization does not have access to Claude. "
+                "Please login again or contact your administrator."
+            ),
+        )
+    raise AssertionError(f"unexpected argv: {cmd!r}")
+
+
+def _json_payload(report: Any) -> dict[str, object]:
+    # Exercise the same JSON-safe shape emitted by scripts/claude_code_cli_smoke.py.
+    return json.loads(json.dumps(report.as_dict()))
 
 
 def test_binary_missing_blocks_and_skips_remaining_checks() -> None:
@@ -39,6 +139,83 @@ def test_binary_missing_blocks_and_skips_remaining_checks() -> None:
         "skip",
         "skip",
     ]
+
+
+def test_success_json_output_matches_preflight_evidence_contract() -> None:
+    report = run_claude_code_cli_smoke(
+        which=lambda command: "/fake/claude",
+        runner=_successful_runner,
+        env={},
+    )
+
+    payload = _json_payload(report)
+
+    assert set(payload) == _REPORT_KEYS
+    assert payload["overall_status"] == "pass"
+    assert payload["adapter_id"] == "claude-code-cli"
+    assert payload["binary_path"] == "/fake/claude"
+    assert payload["api_key_env_present"] is False
+    assert payload["findings"] == []
+
+    checks = payload["checks"]
+    assert isinstance(checks, list)
+    assert [check["name"] for check in checks] == _SUCCESSFUL_CHECK_NAMES
+    assert all(set(check) == _CHECK_KEYS for check in checks)
+    assert all(check["status"] == "pass" for check in checks)
+    assert all(check["finding_code"] is None for check in checks)
+    assert all(check["returncode"] == 0 for check in checks)
+    assert all(check["argv"][0] == "/fake/claude" for check in checks)
+
+    auth_check = next(check for check in checks if check["name"] == "auth_status")
+    assert auth_check["observed"] == {
+        "loggedIn": True,
+        "authMethod": "claude.ai",
+        "orgName": "Test Org",
+        "fallback_api_key_env_present": False,
+    }
+
+
+def test_auth_status_pass_prompt_access_fail_blocks_preflight_contract() -> None:
+    report = run_claude_code_cli_smoke(
+        which=lambda command: "/fake/claude",
+        runner=_prompt_access_denied_runner,
+        env={},
+    )
+
+    payload = _json_payload(report)
+
+    assert payload["overall_status"] == "blocked"
+    assert "prompt_access_denied" in payload["findings"]
+    checks = payload["checks"]
+    assert isinstance(checks, list)
+
+    auth_check = next(check for check in checks if check["name"] == "auth_status")
+    assert auth_check["status"] == "pass"
+    assert auth_check["finding_code"] is None
+
+    prompt_check = next(check for check in checks if check["name"] == "prompt_access")
+    assert prompt_check["status"] == "fail"
+    assert prompt_check["finding_code"] == "prompt_access_denied"
+    assert prompt_check["observed"]["failure_kind"] == "org_oauth_not_allowed"
+
+
+def test_api_key_env_presence_is_observed_not_primary_success_signal() -> None:
+    report = run_claude_code_cli_smoke(
+        which=lambda command: "/fake/claude",
+        runner=_prompt_access_denied_runner,
+        env={"ANTHROPIC_API_KEY": "fake"},
+    )
+
+    payload = _json_payload(report)
+
+    assert payload["api_key_env_present"] is True
+    assert payload["overall_status"] == "blocked"
+    assert "prompt_access_denied" in payload["findings"]
+
+    auth_check = next(
+        check for check in payload["checks"] if check["name"] == "auth_status"
+    )
+    assert auth_check["observed"]["fallback_api_key_env_present"] is True
 
 
 def test_prompt_access_denied_is_classified_explicitly() -> None:
@@ -242,46 +419,9 @@ def test_manifest_contract_mismatch_is_reported() -> None:
 
 
 def test_success_path_returns_pass_report() -> None:
-    def runner(
-        argv: Sequence[str],
-        cwd: Path | None,
-        timeout: float | None,
-    ) -> CommandResult:
-        cmd = tuple(argv)
-        if cmd == ("/fake/claude", "--version"):
-            return _result(cmd, stdout="2.1.87 (Claude Code)\n")
-        if cmd == ("/fake/claude", "auth", "status"):
-            return _result(
-                cmd,
-                stdout=json.dumps(
-                    {
-                        "loggedIn": True,
-                        "authMethod": "claude.ai",
-                        "orgName": "Test Org",
-                    }
-                ),
-            )
-        if cmd == ("/fake/claude", "-p", "reply with the single token ok"):
-            return _result(cmd, stdout="ok\n")
-        if cmd[:1] == ("/fake/claude",):
-            return _result(
-                cmd,
-                stdout=json.dumps(
-                    {
-                        "status": "ok",
-                        "review_findings": {
-                            "schema_version": "1",
-                            "findings": [],
-                            "summary": "smoke ok",
-                        },
-                    }
-                ),
-            )
-        raise AssertionError(f"unexpected argv: {cmd!r}")
-
     report = run_claude_code_cli_smoke(
         which=lambda command: "/fake/claude",
-        runner=runner,
+        runner=_successful_runner,
         env={},
     )
 


### PR DESCRIPTION
## Summary

- pins `claude-code-cli` helper smoke JSON output as the `GP-2.4a` preflight evidence contract
- requires canonical pass checks: `version`, `auth_status`, `prompt_access`, `manifest_invocation`
- verifies `auth_status=pass` + `prompt_access=fail` remains blocked and API-key/env presence is only observed, not treated as certification success
- updates GP-2.4/status notes and records the 30s certification timeout after a 10s prompt probe timed out locally

## Scope boundary

- test/docs/status only
- no runtime support widening
- no live-write
- no adapter support-tier promotion
- no version bump, tag, publish, or release

## Validation

- `python3 -m pytest -q tests/test_claude_code_cli_smoke.py` -> `9 passed`
- `python3 -m pytest -q tests/test_claude_code_cli_smoke.py tests/test_cli_entrypoints.py tests/test_doctor_cmd.py` -> `12 passed, 1 skipped`
- `python3 -m ruff check tests/test_claude_code_cli_smoke.py`
- `python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 30` -> `overall_status=pass`; `version`, `auth_status`, `prompt_access`, `manifest_invocation` pass
- `python3 scripts/truth_inventory_ratchet.py --output json`
- `git diff --check`

Closes #365
Refs #363
Refs #329
