### PR TITLE
[codex] test: close Claude failure-mode matrix

### DIFF
--- a/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
+++ b/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
@@ -94,8 +94,8 @@ giriş kapılarını netleştirmektir.
   kapılarını tek contract altında toplamak.
 - Sıra:
   1. `GP-2.4a` preflight evidence contract (Completed via [#365](https://github.com/Halildeu/ao-kernel/issues/365))
-  2. `GP-2.4b` governed workflow smoke evidence (Completed via [#367](https://github.com/Halildeu/ao-kernel/issues/367) implementation branch; pending PR merge)
-  3. `GP-2.4c` failure-mode matrix
+  2. `GP-2.4b` governed workflow smoke evidence (Completed via [#367](https://github.com/Halildeu/ao-kernel/issues/367))
+  3. `GP-2.4c` failure-mode matrix (Completed via [#369](https://github.com/Halildeu/ao-kernel/issues/369) implementation branch; pending PR merge)
   4. `GP-2.4d` support boundary verdict
 - Son ilerleme:
   - `tests/test_claude_code_cli_smoke.py` helper JSON output contract'ını pinler
@@ -105,8 +105,12 @@ giriş kapılarını netleştirmektir.
     canlı governed workflow smoke'u `completed` state, schema-valid
     `review_findings`, `policy_checked` dahil evidence seti ve redacted
     adapter log doğrulamasıyla geçti
+  - helper/workflow negative matrix stable finding code'larla pinlendi:
+    `claude_binary_missing`, `claude_not_logged_in`, `prompt_access_denied`,
+    `manifest_smoke_timeout`, `manifest_output_not_json`,
+    `adapter_non_zero_exit`, `output_parse_failed`, `policy_denied`
 - Next default:
-  - `GP-2.4c` failure-mode matrix
+  - `GP-2.4d` support boundary verdict
 - Sınır:
   - `claude-code-cli` henüz production-certified değildir
   - Live-write yok

--- a/.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md
+++ b/.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md
@@ -149,6 +149,9 @@ Closeout:
 
 ### `GP-2.4c` — Failure-Mode Matrix
 
+Status: completed in [#369](https://github.com/Halildeu/ao-kernel/issues/369)
+implementation branch; pending PR merge.
+
 Hedef: production claim'i için gerekli negatif yolları fake-green bırakmamak.
 
 Minimum failure matrix:
@@ -168,6 +171,23 @@ DoD:
 1. En az helper-level negative tests var.
 2. En az workflow-level fail-closed path doğrulanır.
 3. Hata sınıfları `docs/KNOWN-BUGS.md` ve runbook diliyle çelişmez.
+
+Closeout:
+
+| Failure | Finding code / kanıt | Test |
+|---|---|---|
+| `claude` binary missing | `claude_binary_missing`, remaining checks `skip` | `test_binary_missing_blocks_and_skips_remaining_checks` |
+| `auth_status` not logged in | `claude_not_logged_in` | `test_auth_status_not_logged_in_blocks_preflight_contract` |
+| `prompt_access` fail | `prompt_access_denied`; `auth_status=pass` başarıya çeviremez | `test_auth_status_pass_prompt_access_fail_blocks_preflight_contract` |
+| manifest invocation timeout | `manifest_smoke_timeout` | `test_manifest_timeout_is_reported_without_success_promotion` |
+| manifest non-JSON output | `manifest_output_not_json` | `test_manifest_non_json_output_is_contract_failure` |
+| adapter non-zero exit | `adapter_non_zero_exit` | `test_workflow_smoke_classifies_adapter_non_zero_exit` |
+| malformed workflow output | `output_parse_failed` | `test_workflow_smoke_classifies_output_parse_fail_closed` |
+| policy deny | `policy_denied` | `test_workflow_smoke_classifies_policy_denial_before_promotion` |
+
+`WorkflowSmokeCheck` artık `finding_code` taşır; `findings[]` stable code'ları
+önceler, prose-only failure üretmez. Support boundary unchanged kalır; GP-2.4d
+verdict kapanmadan production certification yoktur.
 
 ### `GP-2.4d` — Support Boundary Verdict
 

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -705,5 +705,15 @@ açıldı.
      `review_findings` schema-valid artifact, `policy_checked`,
      `adapter_invoked`, `step_completed`, `workflow_completed`, redacted
      `adapter-claude-code-cli.jsonl`
-8. Next default:
-   - `GP-2.4c` failure-mode matrix
+8. `GP-2.4c` closeout:
+   - issue: [#369](https://github.com/Halildeu/ao-kernel/issues/369)
+   - helper-level negative tests pin:
+     `claude_binary_missing`, `claude_not_logged_in`,
+     `prompt_access_denied`, `manifest_smoke_timeout`,
+     `manifest_output_not_json`
+   - workflow-level fail-closed tests pin:
+     `adapter_non_zero_exit`, `output_parse_failed`, `policy_denied`
+   - `WorkflowSmokeCheck.finding_code` makes workflow smoke failures stable
+     machine-readable evidence instead of prose-only failures
+9. Next default:
+   - `GP-2.4d` support boundary verdict

--- a/ao_kernel/real_adapter_workflow_smoke.py
+++ b/ao_kernel/real_adapter_workflow_smoke.py
@@ -26,6 +26,11 @@ from jsonschema import Draft202012Validator
 from ao_kernel.adapters import AdapterRegistry
 from ao_kernel.config import load_default
 from ao_kernel.executor import Executor, MultiStepDriver
+from ao_kernel.executor.errors import (
+    AdapterInvocationFailedError,
+    AdapterOutputParseError,
+    PolicyViolationError,
+)
 from ao_kernel.init_cmd import run as init_workspace
 from ao_kernel.real_adapter_smoke import ClaudeCodeSmokeReport, run_claude_code_cli_smoke
 from ao_kernel.workflow import WorkflowRegistry, create_run, load_run
@@ -66,6 +71,7 @@ class WorkflowSmokeCheck:
     name: str
     status: Literal["pass", "fail", "skip"]
     detail: str
+    finding_code: str | None = None
     path: str | None = None
     observed: Mapping[str, Any] = field(default_factory=dict)
 
@@ -106,6 +112,7 @@ def run_claude_code_cli_workflow_smoke(
                     name="helper_preflight",
                     status="fail",
                     detail="claude-code-cli helper smoke did not pass",
+                    finding_code="helper_preflight_blocked",
                     observed=preflight.as_dict(),
                 ),
             )
@@ -139,6 +146,7 @@ def run_claude_code_cli_workflow_smoke(
             cleanup_requested=cleanup,
         )
     except Exception as exc:  # noqa: BLE001 - operator smoke must summarize failures
+        finding_code, detail = _classify_workflow_exception(exc)
         return _finalize_report(
             run_id=locals().get("run_id"),
             workspace_root=root,
@@ -148,7 +156,8 @@ def run_claude_code_cli_workflow_smoke(
                 WorkflowSmokeCheck(
                     name="workflow_run",
                     status="fail",
-                    detail=f"{type(exc).__name__}: {exc}",
+                    detail=detail,
+                    finding_code=finding_code,
                 ),
             ),
             cleanup_requested=cleanup,
@@ -358,6 +367,7 @@ def _check_required_events(
         name="evidence_events",
         status=status,
         detail="required event kinds present" if not missing else f"missing: {missing}",
+        finding_code="evidence_events_missing" if missing else None,
         path=str(events_path),
         observed={"required": sorted(_REQUIRED_EVENT_KINDS), "seen": sorted(observed)},
     )
@@ -381,6 +391,7 @@ def _check_review_artifact(
                 name="review_findings_artifact",
                 status="fail",
                 detail=f"{_REVIEW_STEP_NAME!r} step record missing",
+                finding_code="review_step_missing",
             ),
             None,
         )
@@ -392,6 +403,7 @@ def _check_review_artifact(
                 name="review_findings_artifact",
                 status="fail",
                 detail="review_findings capability output ref missing",
+                finding_code="review_findings_artifact_missing",
             ),
             None,
         )
@@ -404,6 +416,7 @@ def _check_review_artifact(
             name="review_findings_artifact",
             status=status,
             detail="artifact materialized" if status == "pass" else "artifact file missing",
+            finding_code=None if status == "pass" else "review_findings_artifact_missing",
             path=str(artifact_path),
             observed={"artifact_ref": artifact_ref},
         ),
@@ -424,6 +437,7 @@ def _check_schema_valid_artifact(artifact_path: Path) -> WorkflowSmokeCheck:
             if not errors
             else "; ".join(error.message for error in errors[:3])
         ),
+        finding_code=None if not errors else "review_findings_schema_invalid",
         path=str(artifact_path),
     )
 
@@ -447,6 +461,7 @@ def _check_adapter_log(adapter_log_path: Path) -> WorkflowSmokeCheck:
             if status == "pass"
             else "adapter log missing or contains unredacted secret-like token"
         ),
+        finding_code=None if status == "pass" else "adapter_log_missing_or_unredacted",
         path=str(adapter_log_path),
         observed={"records": len(records), "redaction_leaks": redaction_leaks},
     )
@@ -462,7 +477,7 @@ def _finalize_report(
     cleanup_requested: bool,
 ) -> ClaudeWorkflowSmokeReport:
     findings = tuple(
-        f"{check.name}: {check.detail}"
+        check.finding_code or f"{check.name}: {check.detail}"
         for check in checks
         if check.status == "fail"
     )
@@ -482,6 +497,26 @@ def _finalize_report(
         findings=findings,
         cleanup_requested=cleanup_requested,
     )
+
+
+def _classify_workflow_exception(exc: Exception) -> tuple[str, str]:
+    if isinstance(exc, AdapterOutputParseError):
+        return (
+            "output_parse_failed",
+            f"workflow fail-closed on adapter output parse: {exc.detail}",
+        )
+    if isinstance(exc, PolicyViolationError):
+        kinds = [violation.kind for violation in exc.violations]
+        return (
+            "policy_denied",
+            f"workflow fail-closed on policy denial: {kinds}",
+        )
+    if isinstance(exc, AdapterInvocationFailedError):
+        return (
+            f"adapter_{exc.reason}",
+            f"workflow fail-closed on adapter invocation failure: {exc.reason}",
+        )
+    return "workflow_run_failed", f"{type(exc).__name__}: {exc}"
 
 
 def _read_resume_token(events_path: Path) -> str:

--- a/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
+++ b/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
@@ -87,6 +87,25 @@ Bu smoke helper-level manifest probe'dan daha kapsamlıdır:
 Bu komut `claude-code-cli` yüzeyini production-certified yapmaz. GP-2.4d
 verdict kapanana kadar bu lane Beta (operator-managed) olarak kalır.
 
+### 1.3 Failure-mode matrix
+
+Certification kararında yeşil sayılabilecek tek durum `overall_status: pass`'tir.
+Aşağıdaki stable finding code'lar ise promotion blocker'dır:
+
+| Failure | Stable finding code | Nerede yüzeye çıkar |
+|---|---|---|
+| `claude` binary missing | `claude_binary_missing` | helper preflight |
+| `auth_status` not logged in | `claude_not_logged_in` | helper preflight |
+| `prompt_access` fail despite auth pass | `prompt_access_denied` | helper preflight |
+| manifest invocation timeout | `manifest_smoke_timeout` | helper preflight |
+| manifest non-JSON output | `manifest_output_not_json` | helper preflight |
+| adapter non-zero exit | `adapter_non_zero_exit` | governed workflow smoke |
+| malformed workflow output | `output_parse_failed` | governed workflow smoke |
+| policy deny before invocation | `policy_denied` | governed workflow smoke |
+
+Bu matrix, "auth yeşil ama prompt erişimi yok" ve "workflow koştu ama output
+parse edilmedi" gibi fake-green durumlarını production certification dışı tutar.
+
 2026-04-22 canlı ayrım:
 
 - Aynı makinede ilk preflight, `claude auth status` yeşil olmasına rağmen

--- a/tests/test_claude_code_cli_smoke.py
+++ b/tests/test_claude_code_cli_smoke.py
@@ -118,6 +118,44 @@ def _prompt_access_denied_runner(
     raise AssertionError(f"unexpected argv: {cmd!r}")
 
 
+def _auth_not_logged_in_runner(
+    argv: Sequence[str],
+    cwd: Path | None,
+    timeout: float | None,
+) -> CommandResult:
+    cmd = tuple(argv)
+    if cmd == ("/fake/claude", "--version"):
+        return _result(cmd, stdout="2.1.87 (Claude Code)\n")
+    if cmd == ("/fake/claude", "auth", "status"):
+        return _result(
+            cmd,
+            stdout=json.dumps(
+                {
+                    "loggedIn": False,
+                    "authMethod": None,
+                    "orgName": None,
+                }
+            ),
+        )
+    if cmd == ("/fake/claude", "-p", "reply with the single token ok"):
+        return _result(cmd, stdout="ok\n")
+    if cmd[:1] == ("/fake/claude",):
+        return _result(
+            cmd,
+            stdout=json.dumps(
+                {
+                    "status": "ok",
+                    "review_findings": {
+                        "schema_version": "1",
+                        "findings": [],
+                        "summary": "smoke ok",
+                    },
+                }
+            ),
+        )
+    raise AssertionError(f"unexpected argv: {cmd!r}")
+
+
 def _json_payload(report: Any) -> dict[str, object]:
     # Exercise the same JSON-safe shape emitted by scripts/claude_code_cli_smoke.py.
     return json.loads(json.dumps(report.as_dict()))
@@ -216,6 +254,25 @@ def test_api_key_env_presence_is_observed_not_primary_success_signal() -> None:
         check for check in payload["checks"] if check["name"] == "auth_status"
     )
     assert auth_check["observed"]["fallback_api_key_env_present"] is True
+
+
+def test_auth_status_not_logged_in_blocks_preflight_contract() -> None:
+    report = run_claude_code_cli_smoke(
+        which=lambda command: "/fake/claude",
+        runner=_auth_not_logged_in_runner,
+        env={},
+    )
+
+    payload = _json_payload(report)
+
+    assert payload["overall_status"] == "blocked"
+    assert "claude_not_logged_in" in payload["findings"]
+    auth_check = next(
+        check for check in payload["checks"] if check["name"] == "auth_status"
+    )
+    assert auth_check["status"] == "fail"
+    assert auth_check["finding_code"] == "claude_not_logged_in"
+    assert auth_check["observed"]["loggedIn"] is False
 
 
 def test_prompt_access_denied_is_classified_explicitly() -> None:
@@ -416,6 +473,87 @@ def test_manifest_contract_mismatch_is_reported() -> None:
         check for check in report.checks if check.name == "manifest_invocation"
     )
     assert manifest_check.finding_code == "manifest_cli_contract_mismatch"
+
+
+def test_manifest_timeout_is_reported_without_success_promotion() -> None:
+    def runner(
+        argv: Sequence[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        cmd = tuple(argv)
+        if cmd == ("/fake/claude", "--version"):
+            return _result(cmd, stdout="2.1.87 (Claude Code)\n")
+        if cmd == ("/fake/claude", "auth", "status"):
+            return _result(
+                cmd,
+                stdout=json.dumps(
+                    {
+                        "loggedIn": True,
+                        "authMethod": "claude.ai",
+                        "orgName": "Test Org",
+                    }
+                ),
+            )
+        if cmd == ("/fake/claude", "-p", "reply with the single token ok"):
+            return _result(cmd, stdout="ok\n")
+        if cmd[:1] == ("/fake/claude",):
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout or 20.0)
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_claude_code_cli_smoke(
+        which=lambda command: "/fake/claude",
+        runner=runner,
+        env={},
+    )
+
+    assert report.overall_status == "blocked"
+    assert "manifest_smoke_timeout" in report.findings
+    manifest_check = next(
+        check for check in report.checks if check.name == "manifest_invocation"
+    )
+    assert manifest_check.finding_code == "manifest_smoke_timeout"
+    assert manifest_check.observed["timed_out"] == "true"
+
+
+def test_manifest_non_json_output_is_contract_failure() -> None:
+    def runner(
+        argv: Sequence[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        cmd = tuple(argv)
+        if cmd == ("/fake/claude", "--version"):
+            return _result(cmd, stdout="2.1.87 (Claude Code)\n")
+        if cmd == ("/fake/claude", "auth", "status"):
+            return _result(
+                cmd,
+                stdout=json.dumps(
+                    {
+                        "loggedIn": True,
+                        "authMethod": "claude.ai",
+                        "orgName": "Test Org",
+                    }
+                ),
+            )
+        if cmd == ("/fake/claude", "-p", "reply with the single token ok"):
+            return _result(cmd, stdout="ok\n")
+        if cmd[:1] == ("/fake/claude",):
+            return _result(cmd, stdout="not json\n")
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_claude_code_cli_smoke(
+        which=lambda command: "/fake/claude",
+        runner=runner,
+        env={},
+    )
+
+    assert report.overall_status == "blocked"
+    assert "manifest_output_not_json" in report.findings
+    manifest_check = next(
+        check for check in report.checks if check.name == "manifest_invocation"
+    )
+    assert manifest_check.finding_code == "manifest_output_not_json"
 
 
 def test_success_path_returns_pass_report() -> None:

--- a/tests/test_claude_code_cli_workflow_smoke.py
+++ b/tests/test_claude_code_cli_workflow_smoke.py
@@ -6,8 +6,18 @@ import json
 import uuid
 from pathlib import Path
 
+from pytest import MonkeyPatch
+
+import ao_kernel.real_adapter_workflow_smoke as workflow_smoke
+from ao_kernel.executor.errors import (
+    AdapterInvocationFailedError,
+    AdapterOutputParseError,
+    PolicyViolation,
+    PolicyViolationError,
+)
 from ao_kernel.real_adapter_workflow_smoke import (
     _operator_managed_policy,
+    run_claude_code_cli_workflow_smoke,
     verify_claude_workflow_evidence,
 )
 from ao_kernel.workflow import create_run, update_run
@@ -52,6 +62,100 @@ def test_verify_claude_workflow_evidence_rejects_missing_policy_checked(
 
     assert evidence.status == "fail"
     assert "policy_checked" in evidence.detail
+    assert evidence.finding_code == "evidence_events_missing"
+
+
+def test_workflow_smoke_classifies_output_parse_fail_closed(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(workflow_smoke, "_prepare_workspace", lambda root: None)
+
+    def _fail_output_parse(
+        workspace_root: Path,
+        run_id: str,
+        *,
+        timeout_seconds: float,
+    ) -> str:
+        raise AdapterOutputParseError(
+            raw_excerpt="not-json",
+            detail="stdout neither a valid JSON output_envelope",
+        )
+
+    monkeypatch.setattr(workflow_smoke, "_run_workflow", _fail_output_parse)
+
+    report = run_claude_code_cli_workflow_smoke(
+        skip_preflight=True,
+        workspace_root=tmp_path,
+    )
+
+    assert report.overall_status == "blocked"
+    assert report.findings == ("output_parse_failed",)
+    assert report.checks[0].name == "workflow_run"
+    assert report.checks[0].finding_code == "output_parse_failed"
+    assert "fail-closed" in report.checks[0].detail
+
+
+def test_workflow_smoke_classifies_policy_denial_before_promotion(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(workflow_smoke, "_prepare_workspace", lambda root: None)
+
+    def _fail_policy(
+        workspace_root: Path,
+        run_id: str,
+        *,
+        timeout_seconds: float,
+    ) -> str:
+        violation = PolicyViolation(
+            kind="command_not_allowlisted",
+            detail="claude denied by test policy",
+            policy_ref="ao_kernel/defaults/policies/policy_worktree_profile.v1.json",
+            field_path="command_allowlist",
+        )
+        raise PolicyViolationError(violations=[violation])
+
+    monkeypatch.setattr(workflow_smoke, "_run_workflow", _fail_policy)
+
+    report = run_claude_code_cli_workflow_smoke(
+        skip_preflight=True,
+        workspace_root=tmp_path,
+    )
+
+    assert report.overall_status == "blocked"
+    assert report.findings == ("policy_denied",)
+    assert report.checks[0].finding_code == "policy_denied"
+    assert "command_not_allowlisted" in report.checks[0].detail
+
+
+def test_workflow_smoke_classifies_adapter_non_zero_exit(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(workflow_smoke, "_prepare_workspace", lambda root: None)
+
+    def _fail_non_zero(
+        workspace_root: Path,
+        run_id: str,
+        *,
+        timeout_seconds: float,
+    ) -> str:
+        raise AdapterInvocationFailedError(
+            reason="non_zero_exit",
+            detail="claude exited 1",
+        )
+
+    monkeypatch.setattr(workflow_smoke, "_run_workflow", _fail_non_zero)
+
+    report = run_claude_code_cli_workflow_smoke(
+        skip_preflight=True,
+        workspace_root=tmp_path,
+    )
+
+    assert report.overall_status == "blocked"
+    assert report.findings == ("adapter_non_zero_exit",)
+    assert report.checks[0].finding_code == "adapter_non_zero_exit"
 
 
 def _seed_completed_run(tmp_path: Path, *, omit_event: str | None = None) -> str:


### PR DESCRIPTION
## Summary

- add stable `finding_code` values to governed Claude workflow smoke failures
- close GP-2.4c helper/workflow negative matrix: binary missing, not logged in, prompt denied, manifest timeout, manifest non-JSON, adapter non-zero exit, output parse failure, policy denial
- update GP-2.4 status and real-adapter runbook while keeping `claude-code-cli` Beta/operator-managed pending GP-2.4d verdict

## Validation

- `python3 -m pytest -q tests/test_claude_code_cli_smoke.py tests/test_claude_code_cli_workflow_smoke.py tests/test_cli_entrypoints.py tests/test_doctor_cmd.py`
- `python3 -m ruff check ao_kernel/real_adapter_workflow_smoke.py tests/test_claude_code_cli_smoke.py tests/test_claude_code_cli_workflow_smoke.py`
- `python3 -m mypy ao_kernel/`
- `python3 scripts/truth_inventory_ratchet.py --output json`
- `git diff --check`
- live: `python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 30` -> `overall_status=pass`
- live: `python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup` -> `overall_status=pass`, `final_state=completed`, `run_id=bdd92341-10d8-4b91-a060-51e3e9ca0850`

Closes #369.
Refs #363, #329.
