### PR TITLE
[codex] docs: start gh-cli-pr rollback rehearsal contract

### DIFF
--- a/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
+++ b/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
@@ -119,17 +119,25 @@ giriş kapılarını netleştirmektir.
   - Live-write yok
   - Stable support boundary unchanged kalır
 
-### `GP-2.5` — `gh-cli-pr` live-write rollback rehearsal (Next)
+### `GP-2.5` — `gh-cli-pr` live-write rollback rehearsal (Active)
 
-- Issue: TBD
-- Contract: TBD
+- Issue: [#373](https://github.com/Halildeu/ao-kernel/issues/373)
+- Contract:
+  `.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md`
 - Hedef: `GP-2.3` kararındaki next lane'i açmadan önce remote side-effect,
   disposable sandbox, rollback/idempotency ve support-boundary kapılarını
   yazılı hale getirmek.
+- No-side-effect kanıt:
+  - `python3 scripts/gh_cli_pr_smoke.py --mode preflight --output json --timeout-seconds 20`
+    -> `overall_status=pass`
+  - `python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head main --base main --output json --timeout-seconds 20`
+    -> `overall_status=blocked`, finding `gh_pr_live_write_same_head_base`
+- Next default:
+  - `GP-2.5a` disposable sandbox live-write rehearsal, ayrı onay/issue ile
 - Sınır:
-  - Bu roadmap güncellemesi runtime değişikliği yapmaz.
+  - Bu contract PR'ı runtime değişikliği yapmaz.
   - `gh-cli-pr` tam E2E remote PR açılışı hâlâ deferred support yüzeyidir.
-  - Yeni lane ayrı issue + ayrı contract ile açılmadan implementation başlamaz.
+  - Gerçek remote PR create bu contract PR'ında çalıştırılmaz.
 
 ## Gate Modeli
 

--- a/.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md
+++ b/.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md
@@ -1,0 +1,205 @@
+# GP-2.5 — gh-cli-pr Live-Write Rollback Rehearsal Contract
+
+**Status:** Active  
+**Date:** 2026-04-24  
+**Tracker:** [#373](https://github.com/Halildeu/ao-kernel/issues/373)  
+**Parent:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)  
+**Parent roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
+
+## Amaç
+
+`gh-cli-pr` lane'ini preflight/readiness seviyesinden gerçek remote PR opening
+support claim'ine taşımadan önce disposable sandbox ve rollback rehearsal
+sözleşmesini tek karar kaynağına indirmek.
+
+Bu slice tek başına live remote PR opening'i promote etmez. Amaç, yan etkili
+bir sonraki denemenin hangi repo, branch, komut, artifact, cleanup ve verdict
+kurallarıyla kabul edileceğini yazılı hale getirmektir.
+
+## Başlangıç Gerçeği
+
+1. `gh-cli-pr` repo-native binary değildir; operator ortamındaki external `gh`
+   PATH binary'sine ve GitHub auth durumuna dayanır.
+2. Public support boundary bugün iki ayrı çizgi taşır:
+   - `gh-cli-pr` helper-backed preflight + live-write readiness probe:
+     Beta/operator-managed
+   - full remote PR opening: Deferred
+3. `GP-1.2` canlı create -> verify -> rollback zinciri denemiştir; ancak
+   `--require-disposable-keyword ao-kernel` override ile ana repo üzerinde
+   doğrulandığı için verdict `stay_preflight` kalmıştır.
+4. `PB-8.1` ile helper tarafında explicit opt-in, disposable keyword guard,
+   create -> verify -> rollback ve keep-open risk guard'ları kod/test
+   seviyesinde mevcuttur.
+5. `GP-2.5` bu mevcut guard'ları support-boundary kararına çevirecek yeni
+   disposable rehearsal sözleşmesini tanımlar.
+
+## Current No-Side-Effect Evidence
+
+2026-04-24 tarihli yan etkisiz doğrulama:
+
+```bash
+python3 scripts/gh_cli_pr_smoke.py \
+  --mode preflight \
+  --output json \
+  --timeout-seconds 20 \
+  --report-path /tmp/gp25-gh-preflight.report.json
+```
+
+Sonuç:
+
+1. `overall_status=pass`
+2. `binary_path=/opt/homebrew/bin/gh`
+3. `repo_name=Halildeu/ao-kernel`
+4. `version`, `auth_status`, `manifest_contract`, `repo_view`,
+   `pr_dry_run` checks pass
+
+Fail-closed guard doğrulaması:
+
+```bash
+python3 scripts/gh_cli_pr_smoke.py \
+  --mode live-write \
+  --allow-live-write \
+  --head main \
+  --base main \
+  --output json \
+  --timeout-seconds 20 \
+  --report-path /tmp/gp25-gh-livewrite-guard.report.json
+```
+
+Sonuç:
+
+1. `overall_status=blocked`
+2. `findings=["gh_pr_live_write_same_head_base"]`
+3. `pr_live_write_verify` ve `pr_live_write_rollback` checks `skip`
+4. Remote PR side effect oluşmadı.
+
+## Rehearsal Target Contract
+
+Live-write rehearsal yalnız aşağıdaki koşulların tamamı sağlanırsa çalıştırılır:
+
+1. **Disposable repo:** `--repo <owner>/<repo>` explicit verilir ve repo adı
+   default guard keyword `sandbox` içerir.
+2. **No production target:** `Halildeu/ao-kernel` veya korunan production repo
+   hedef alınmaz. Eğer guard keyword override gerekiyorsa karar notunda nedeni
+   yazılır; bu override support widening kanıtı sayılmaz.
+3. **Explicit refs:** `--head` ve `--base` explicit verilir; default branch
+   fallback kabul edilmez.
+4. **Different refs:** `--head != --base`.
+5. **Ephemeral head branch:** head branch `smoke/gp25-livewrite-<timestamp>`
+   formatındadır ve rehearsal sonunda remote/local cleanup yapılır.
+6. **Rollback mandatory:** `--keep-live-write-pr-open` kullanılmaz. Rollback
+   check pass olmadan rehearsal success sayılmaz.
+7. **Artifact mandatory:** `--report-path` ile JSON raporu kalıcı artifact
+   olarak yazılır.
+
+Canonical command shape:
+
+```bash
+ARTIFACT_ROOT=/tmp/ao-kernel-gp25-gh-cli-pr-live-write
+mkdir -p "$ARTIFACT_ROOT"
+
+python3 scripts/gh_cli_pr_smoke.py \
+  --mode live-write \
+  --allow-live-write \
+  --repo <owner>/<sandbox-repo> \
+  --head smoke/gp25-livewrite-<timestamp> \
+  --base main \
+  --output json \
+  --report-path "$ARTIFACT_ROOT/gh-cli-pr-live-write.report.json"
+```
+
+## Required Evidence
+
+Bir rehearsal ancak aşağıdaki JSON koşullarıyla `pass` kabul edilir:
+
+| Alan | Beklenen |
+|---|---|
+| `overall_status` | `pass` |
+| `adapter_id` | `gh-cli-pr` |
+| `repo_name` | disposable/sandbox repo |
+| `findings` | `[]` |
+| `checks.version.status` | `pass` |
+| `checks.auth_status.status` | `pass` |
+| `checks.manifest_contract.status` | `pass` |
+| `checks.repo_view.status` | `pass` |
+| `checks.pr_live_write.status` | `pass` |
+| `checks.pr_live_write_verify.status` | `pass` |
+| `checks.pr_live_write_rollback.status` | `pass` |
+
+Ek artifact beklentileri:
+
+1. report path commit edilmez; issue/PR comment'inde summary + artifact path
+   yazılır.
+2. created PR URL raporda görünür.
+3. rollback sonrası PR `CLOSED` doğrulanır.
+4. ephemeral head branch local ve remote temizlenir.
+5. cleanup yapılamazsa rehearsal `pass` olsa bile support promotion açılmaz;
+   ayrı cleanup incident kaydı gerekir.
+
+## Failure Matrix
+
+| Failure | Stable finding code | Verdict etkisi |
+|---|---|---|
+| `gh` binary missing | `gh_binary_missing` | block |
+| auth fail | `gh_auth_failed` / auth status finding | block |
+| live-write opt-in yok | `gh_pr_live_write_opt_in_required` | block |
+| repo context yok | `gh_pr_live_write_repo_context_required` | block |
+| explicit base yok | `gh_pr_live_write_base_ref_required` | block |
+| explicit head yok | `gh_pr_live_write_head_ref_required` | block |
+| head/base aynı | `gh_pr_live_write_same_head_base` | block |
+| repo disposable değil | `gh_pr_live_write_repo_not_disposable` | block |
+| create fail | `gh_pr_live_write_failed` | block |
+| verify fail | `gh_pr_live_write_verify_failed` | block; rollback yine denenmeli |
+| keep-open istendi | `gh_pr_live_write_keep_open_requested` | block |
+| rollback timeout | `gh_pr_live_write_rollback_timeout` | block |
+| rollback fail | `gh_pr_live_write_rollback_failed` | block |
+
+## Verdict Options
+
+`GP-2.5` sonunda yalnız şu kararlardan biri verilir:
+
+1. `rehearsal_pass_keep_beta`: create -> verify -> rollback canlı geçti; lane
+   Beta/operator-managed kalır, production support için ek tekrar ve ops gate
+   gerekir.
+2. `rehearsal_fail_keep_deferred`: rehearsal guard veya rollback koşulları
+   kapanmadı; full remote PR opening Deferred kalır.
+3. `promotion_candidate_live_write`: disposable rehearsal tekrar edilebilir
+   evidence üretti; support widening için ayrı promotion PR'ı açılabilir.
+
+Bu slice'ın varsayılanı `rehearsal_pass_keep_beta` veya
+`rehearsal_fail_keep_deferred` olmalıdır. `promotion_candidate_live_write`
+ancak en az bir disposable sandbox pass + cleanup kanıtı ve docs parity ile
+değerlendirilir.
+
+## Out of Scope
+
+- Bu contract PR'ında gerçek remote PR create çalıştırmak.
+- `bug_fix_flow` release closure support promotion.
+- Stable support boundary widening.
+- Version bump, tag veya publish.
+- `claude-code-cli` support verdict'ini değiştirmek.
+
+## Validation Commands
+
+Contract PR için minimum:
+
+```bash
+python3 -m pytest -q tests/test_gh_cli_pr_smoke.py
+python3 scripts/gh_cli_pr_smoke.py --mode preflight --output json --timeout-seconds 20
+python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head main --base main --output json --timeout-seconds 20
+python3 scripts/truth_inventory_ratchet.py --output json
+python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py
+```
+
+Not: Üçüncü komutun `overall_status=blocked` ve
+`gh_pr_live_write_same_head_base` finding'i üretmesi beklenen güvenlik
+davranışıdır.
+
+## Exit Criteria
+
+1. Contract repo içinde merge edilir.
+2. GP-2 roadmap/status bu contract'ı aktif hat olarak gösterir.
+3. No-side-effect preflight ve guard smoke kanıtı yazılır.
+4. Disposable live-write rehearsal için exact command/artifact/cleanup/verdict
+   kuralları netleşir.
+5. Stable support boundary unchanged kalır.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -18,6 +18,7 @@ ayrı ayrı görünür kılmak.
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
+- **Aktif rollback rehearsal contract:** `.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md`
 - **GP-2.2 closeout contract:** `.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md`
 - **PB-9.2 karar notu:** `.claude/plans/PB-9.2-TRUTH-INVENTORY-DEBT-RATCHET.md`
 - **PB-9.3 karar notu:** `.claude/plans/PB-9.3-WRITE-LIVE-EVIDENCE-REHEARSAL.md`
@@ -45,13 +46,14 @@ ayrı ayrı görünür kılmak.
 - **GP-2.3 issue:** [#361](https://github.com/Halildeu/ao-kernel/issues/361) (`closeout after handoff`)
 - **GP-2.4 issue:** [#363](https://github.com/Halildeu/ao-kernel/issues/363) (`closeout after GP-2.4d merge`)
 - **GP-2.4a issue:** [#365](https://github.com/Halildeu/ao-kernel/issues/365) (`closed after merge`)
-- **GP-2.4d issue:** [#371](https://github.com/Halildeu/ao-kernel/issues/371) (`active closeout`)
+- **GP-2.4d issue:** [#371](https://github.com/Halildeu/ao-kernel/issues/371) (`closed after merge`)
+- **GP-2.5 issue:** [#373](https://github.com/Halildeu/ao-kernel/issues/373) (`active`)
 - **ST-1 issue:** [#340](https://github.com/Halildeu/ao-kernel/issues/340) (`closed after closeout`)
 - **ST-2 issue:** [#344](https://github.com/Halildeu/ao-kernel/issues/344) (`closed`)
 - **ST-6 issue:** [#351](https://github.com/Halildeu/ao-kernel/issues/351) (`closed`)
 - **ST-7 issue:** [#355](https://github.com/Halildeu/ao-kernel/issues/355) (`closed after closeout`)
 - **ST-8 issue:** [#358](https://github.com/Halildeu/ao-kernel/issues/358) (`closed after closeout`)
-- **Aktif gate:** `GP-2.5` `gh-cli-pr` live-write rollback rehearsal contract hazırlığı. Runtime/support widening yok; remote side-effect kapıları yazılı hale getirilecek.
+- **Aktif gate:** `GP-2.5` `gh-cli-pr` live-write rollback rehearsal contract. Runtime/support widening yok; remote side-effect yalnız ayrı disposable rehearsal onayıyla çalıştırılacak.
 
 ## 2. Başlangıç Gerçeği
 
@@ -99,7 +101,7 @@ ayrı ayrı görünür kılmak.
 | `PB-8` general-purpose productionization roadmap | Completed on `main` ([#288](https://github.com/Halildeu/ao-kernel/issues/288), [#300](https://github.com/Halildeu/ao-kernel/pull/300), [#301](https://github.com/Halildeu/ao-kernel/pull/301)) | widening kararlarını tranche bazında kapatmak ve support closeout parity'yi tamamlamak | tracker closeout + docs/runbook/release-gate parity |
 | `PB-9` production claim readiness gates | Completed on `main` ([#302](https://github.com/Halildeu/ao-kernel/issues/302), closed tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303), closed tranche [#306](https://github.com/Halildeu/ao-kernel/issues/306), closed tranche [#309](https://github.com/Halildeu/ao-kernel/issues/309), closed tranche [#312](https://github.com/Halildeu/ao-kernel/issues/312)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | roadmap + decision records + tracker closeout |
 | `GP-1` general-purpose production widening | Completed on `main` ([#316](https://github.com/Halildeu/ao-kernel/issues/316), [#327](https://github.com/Halildeu/ao-kernel/pull/327), [#326](https://github.com/Halildeu/ao-kernel/issues/326)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde tamamlamak | GP-1.1..GP-1.5 decision records + closeout parity |
-| `GP-2` deferred support-lane backlog reprioritization | Active ([#329](https://github.com/Halildeu/ao-kernel/issues/329), closeout slice [#371](https://github.com/Halildeu/ao-kernel/issues/371)) | `GP-1` ve `v4.0.0` stable sonrası deferred/support widening lane'lerini tek anlamlı sıraya indirip ilk post-stable certification gate'ini yürütmek | GP-2.4 verdict + GP-2.5 rollback rehearsal entry |
+| `GP-2` deferred support-lane backlog reprioritization | Active ([#329](https://github.com/Halildeu/ao-kernel/issues/329), active slice [#373](https://github.com/Halildeu/ao-kernel/issues/373)) | `GP-1` ve `v4.0.0` stable sonrası deferred/support widening lane'lerini tek anlamlı sıraya indirip post-stable support-lane gates yürütmek | GP-2.5 rollback rehearsal contract |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -367,13 +369,13 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Son kapanan slice: `GP-2.4` `claude-code-cli` read-only certification
-contract ([#363](https://github.com/Halildeu/ao-kernel/issues/363),
-verdict [#371](https://github.com/Halildeu/ao-kernel/issues/371)).
+Aktif slice: `GP-2.5` `gh-cli-pr` live-write rollback rehearsal contract
+([#373](https://github.com/Halildeu/ao-kernel/issues/373)).
 
-Bu slice runtime/support widening yapmadı. `claude-code-cli` lane'i için
-sertifikasyon kanıt paketi tamamlandı ve final verdict
-`operator_managed_beta_keep` olarak kapandı.
+Bu slice runtime/support widening yapmaz ve bu PR içinde gerçek remote PR
+create çalıştırmaz. Amaç, disposable sandbox, create -> verify -> rollback,
+artifact, cleanup ve support-boundary verdict kapılarını yazılı hale
+getirmektir.
 
 1. Son kapanan stable slice: `ST-8` stable publish and post-publish verification
    ([#358](https://github.com/Halildeu/ao-kernel/issues/358))
@@ -383,17 +385,21 @@ sertifikasyon kanıt paketi tamamlandı ve final verdict
    ([#361](https://github.com/Halildeu/ao-kernel/issues/361))
 4. Son certification contract:
    `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
-5. GP-2.4 sıra:
+5. Aktif rollback rehearsal contract:
+   `.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md`
+6. GP-2.4 sıra:
    - `GP-2.4a`: preflight evidence contract (`closed after merge`)
    - `GP-2.4b`: governed workflow smoke evidence (`closed after merge`)
    - `GP-2.4c`: failure-mode matrix (`closed after merge`)
    - `GP-2.4d`: support boundary verdict (`operator_managed_beta_keep`)
-6. Stable live iddiası geçerlidir: `pip install ao-kernel` ve exact pin
+7. GP-2.5 no-side-effect kanıtı:
+   - preflight smoke: `overall_status=pass`
+   - live-write guard smoke: `overall_status=blocked`,
+     finding `gh_pr_live_write_same_head_base`
+8. Stable live iddiası geçerlidir: `pip install ao-kernel` ve exact pin
    `ao-kernel==4.0.0` fresh venv içinde `4.0.0` kurmuştur.
-7. Stable support boundary unchanged kalır; `GP-2.4` yeni production adapter
-   claim'i üretmedi.
-8. Sıradaki tek aktif hat:
-   `gh-cli-pr` live-write rollback rehearsal contract hazırlığı.
+9. Stable support boundary unchanged kalır; `gh-cli-pr` full remote PR opening
+   hâlâ Deferred support yüzeyidir.
 
 `PB-8.2` completion kaydı:
 
@@ -729,4 +735,29 @@ açıldı.
     - production-certified read-only: hayır
     - stable support boundary: unchanged
 11. Next default:
-    - `gh-cli-pr` live-write rollback rehearsal contract
+    - `GP-2.5` `gh-cli-pr` live-write rollback rehearsal contract
+
+## 20. GP-2.5 gh-cli-pr Rollback Rehearsal Snapshot
+
+`GP-2.4` closeout sonrası aktif contract slice `GP-2.5` olarak açıldı.
+
+1. Issue: [#373](https://github.com/Halildeu/ao-kernel/issues/373) (`active`)
+2. Contract:
+   `.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md`
+3. Scope:
+   - `gh-cli-pr` live-write rollback rehearsal contract
+   - disposable sandbox target repo requirements
+   - create -> verify -> rollback evidence contract
+   - fail-closed matrix and verdict options
+4. Sınır:
+   - this contract PR does not create a remote PR
+   - stable support boundary unchanged
+   - full remote PR opening remains Deferred
+5. No-side-effect evidence:
+   - `python3 scripts/gh_cli_pr_smoke.py --mode preflight --output json --timeout-seconds 20`
+     -> `overall_status=pass`
+   - `python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head main --base main --output json --timeout-seconds 20`
+     -> `overall_status=blocked`, finding `gh_pr_live_write_same_head_base`
+6. Next default:
+   - `GP-2.5a` disposable sandbox live-write rehearsal only after explicit
+     operator approval and issue/contract update

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -341,7 +341,8 @@ dogrulanir.
    `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
    - Final verdict: `operator_managed_beta_keep`
 6. Varsayılan sıra:
-   - `Now`: `gh-cli-pr` live-write rollback rehearsal
+   - `Now`: `GP-2.5` `gh-cli-pr` live-write rollback rehearsal contract
+     (`.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md`)
    - `Next`: extension/support widening
    - `Later`: genel amaçlı production platform claim'i
 7. Bu roadmap stable runtime release'i tamamlanmış sayar; genel amaçlı


### PR DESCRIPTION
## Summary

Open GP-2.5 as the next support-lane contract after GP-2.4. This defines the `gh-cli-pr` live-write rollback rehearsal gate without running a real remote PR create in this PR.

## Changes

- Add `.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md`.
- Link issue #373 and mark GP-2.5 active in the GP-2 roadmap/status.
- Record no-side-effect evidence: preflight pass and live-write guard blocked by `gh_pr_live_write_same_head_base`.
- Keep full remote PR opening Deferred and stable support boundary unchanged.

## Validation

- `python3 -m pytest -q tests/test_gh_cli_pr_smoke.py tests/test_cli_entrypoints.py tests/test_doctor_cmd.py` -> `18 passed, 1 skipped`
- `python3 scripts/truth_inventory_ratchet.py --output json` -> pass
- `git diff --check` -> pass
- stale/TBD status grep -> no matches
- `python3 scripts/gh_cli_pr_smoke.py --mode preflight --output json --timeout-seconds 20 --report-path /tmp/gp25-gh-preflight.report.json` -> `overall_status=pass`
- `python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head main --base main --output json --timeout-seconds 20 --report-path /tmp/gp25-gh-livewrite-guard.report.json` -> expected exit 1, `overall_status=blocked`, finding `gh_pr_live_write_same_head_base`; no remote PR side effect

Closes #373. Refs #329.