### PR TITLE
[codex] docs: close GP-2 support-lane program

### DIFF
--- a/.claude/plans/GP-2-CLOSEOUT-DECISION.md
+++ b/.claude/plans/GP-2-CLOSEOUT-DECISION.md
@@ -1,0 +1,93 @@
+# GP-2 — Deferred Support-Lane Backlog Reprioritization Closeout
+
+**Status:** Completed
+**Date:** 2026-04-24
+**Tracker:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
+**Parent context:** post-`v4.0.0` stable support-lane cleanup
+
+## Verdict
+
+`GP-2` is complete. The deferred support-lane backlog was reprioritized,
+evidence gaps were made explicit, and the selected post-stable lanes were
+closed without widening the stable shipped support boundary.
+
+Final outcome:
+
+1. `claude-code-cli` remains `Beta (operator-managed)`.
+2. `gh-cli-pr` preflight/live-write readiness remains `Beta (operator-managed)`.
+3. `gh-cli-pr` full remote PR opening is not stable shipped support.
+4. `bug_fix_flow` release closure remains deferred.
+5. Adapter-path `cost_usd` reconcile remains deferred as a public support claim.
+6. General-purpose production platform claim remains out of scope until a
+   separate promotion program supplies repeatable adapter/write-side evidence.
+
+## Completed Slices
+
+| Slice | Issue | Result |
+|---|---|---|
+| `GP-2.1` evidence-delta map | [#331](https://github.com/Halildeu/ao-kernel/issues/331) | deferred lane order recorded |
+| `GP-2.2` `cost_usd` reconcile completeness | [#333](https://github.com/Halildeu/ao-kernel/issues/333) | no runtime patch required; claim remains deferred |
+| `GP-2.3` post-stable entry decision | [#361](https://github.com/Halildeu/ao-kernel/issues/361) | first certification lane selected |
+| `GP-2.4` `claude-code-cli` read-only certification | [#363](https://github.com/Halildeu/ao-kernel/issues/363) | final verdict `operator_managed_beta_keep` |
+| `GP-2.5` `gh-cli-pr` rollback contract | [#373](https://github.com/Halildeu/ao-kernel/issues/373) | contract recorded |
+| `GP-2.5a` sandbox rehearsal | [#375](https://github.com/Halildeu/ao-kernel/issues/375) | verdict `rehearsal_pass_keep_beta` |
+
+## Evidence Summary
+
+`claude-code-cli`:
+
+1. helper preflight, governed workflow smoke, and failure-mode matrix were
+   recorded under `GP-2.4`;
+2. `auth_status` and `prompt_access` both must pass for operator-managed use;
+3. the final decision did not promote the lane to production-certified read-only.
+
+`gh-cli-pr`:
+
+1. side-effect-safe preflight passed;
+2. fail-closed guard for same `--head` / `--base` passed;
+3. disposable sandbox live-write create -> verify -> rollback passed against
+   `Halildeu/ao-kernel-sandbox`;
+4. created PR `https://github.com/Halildeu/ao-kernel-sandbox/pull/1` ended
+   `CLOSED`;
+5. ephemeral head branch cleanup was verified;
+6. repo override helper regression was fixed and pinned.
+
+## Support Boundary Decision
+
+No stable support widening is granted by `GP-2`.
+
+Reason:
+
+1. a single sandbox rehearsal proves the guard/rollback path works, but does
+   not prove production-grade remote PR opening across repositories;
+2. `gh-cli-pr` and `claude-code-cli` still depend on operator-managed external
+   PATH binaries and auth state;
+3. the shipped stable baseline remains intentionally narrow and already live as
+   `v4.0.0`;
+4. support widening requires its own promotion decision PR, docs parity, CI
+   evidence, repeatable smoke, and rollback/runbook coverage.
+
+## Next Allowed Paths
+
+After `GP-2`, there is no active support-widening runtime slice.
+
+Allowed next paths:
+
+1. **Maintenance path:** keep `v4.0.0` stable baseline narrow and only fix bugs
+   under normal patch-release discipline.
+2. **Promotion path:** open a new promotion program, likely `GP-3`, for one
+   lane at a time.
+3. **Do not do:** silently widen `gh-cli-pr`, `claude-code-cli`, `bug_fix_flow`,
+   or extension surfaces based only on inventory presence or one-off smoke.
+
+## Closeout Criteria
+
+`GP-2` closes when:
+
+1. this decision record is merged;
+2. `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md` is marked
+   completed;
+3. `.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md` no longer lists an
+   active GP-2 gate;
+4. issue [#329](https://github.com/Halildeu/ao-kernel/issues/329) is closed;
+5. support boundary docs still say no automatic stable widening occurred.

--- a/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
+++ b/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
@@ -1,9 +1,10 @@
 # GP-2 — Deferred Support-Lane Backlog Reprioritization
 
-**Status:** Active
+**Status:** Completed
 **Date:** 2026-04-24
 **Tracker:** [#329](https://github.com/Halildeu/ao-kernel/issues/329)
-**Execution mode:** Kapsam disiplini, tek aktif planning/runtime tranche
+**Closeout decision:** `.claude/plans/GP-2-CLOSEOUT-DECISION.md`
+**Execution mode:** Kapsam disiplini, completed planning/runtime tranche
 
 ## Amaç
 
@@ -13,6 +14,22 @@ kanıt odaklı ve uygulanabilir bir sıraya indirmek.
 Bu hattın amacı doğrudan widening implementasyonu değildir.
 Amaç, bir sonraki runtime slice açılmadan önce backlog sırasını ve
 giriş kapılarını netleştirmektir.
+
+## Closeout Verdict
+
+`GP-2` tamamlandı. Backlog sırası ve kanıt boşlukları yazılı hale getirildi,
+`claude-code-cli` ve `gh-cli-pr` operator-managed lane'leri doğrulandı, fakat
+stable shipped support boundary genişletilmedi.
+
+Final karar:
+
+1. `claude-code-cli` production-certified değildir; Beta/operator-managed kalır.
+2. `gh-cli-pr` live-write readiness sandbox rehearsal geçti, fakat full remote
+   PR opening stable shipped support değildir.
+3. `bug_fix_flow`, roadmap/spec demo ve adapter-path `cost_usd` public support
+   claim olarak deferred kalır.
+4. Bundan sonraki support widening işi ayrı promotion decision programı
+   gerektirir; GP-2 içinde otomatik widening yoktur.
 
 ## Başlangıç Gerçeği
 
@@ -159,11 +176,14 @@ giriş kapılarını netleştirmektir.
 
 ## Başarı Kriterleri
 
-1. `GP-2.1` sonunda deferred satırların sırasi tartışmasızdır.
-2. `GP-2.2` ilk runtime/evidence slice olarak tamamlanmıştır.
-3. `GP-2.3` post-stable next-slice kararını tamamlamıştır.
-4. `GP-2.4` certification contract'ı açık issue/contract ile aktiftir.
-5. Status SSOT'ta aktif issue/contract alanı günceldir.
+1. `GP-2.1` sonunda deferred satırların sırası tartışmasız hale geldi.
+2. `GP-2.2` ilk runtime/evidence slice olarak tamamlandı.
+3. `GP-2.3` post-stable next-slice kararını tamamladı.
+4. `GP-2.4` certification contract'ı `operator_managed_beta_keep` verdict'iyle
+   kapandı.
+5. `GP-2.5a` disposable sandbox rehearsal geçti ve `rehearsal_pass_keep_beta`
+   verdict'iyle kapandı.
+6. Status SSOT artık GP-2 için aktif runtime gate taşımıyor.
 
 ## Risk Register
 
@@ -173,3 +193,10 @@ giriş kapılarını netleştirmektir.
 | Overclaim drift | Yüksek | PUBLIC-BETA ve SUPPORT-BOUNDARY parity zorunlu |
 | Paralel lane açma | Orta | tek aktif runtime slice kuralı |
 | Karar kaydı eksikliği | Orta | issue + contract + status üçlüsü zorunlu |
+
+## Next Boundary
+
+GP-2 sonrası varsayılan yol maintenance'tır. `gh-cli-pr`, `claude-code-cli`,
+`bug_fix_flow` veya extension yüzeylerinden herhangi biri stable support'a
+alınacaksa yeni bir promotion programı açılır ve tek lane/tek PR disiplini
+korunur.

--- a/.claude/plans/GP-2.1-DEFERRED-LANE-EVIDENCE-DELTA-MAP.md
+++ b/.claude/plans/GP-2.1-DEFERRED-LANE-EVIDENCE-DELTA-MAP.md
@@ -1,6 +1,6 @@
 # GP-2.1 — Deferred Lane Evidence-Delta Map
 
-**Status:** Active  
+**Status:** Completed
 **Date:** 2026-04-23  
 **Tracker:** [#331](https://github.com/Halildeu/ao-kernel/issues/331)  
 **Parent program:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`

--- a/.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md
+++ b/.claude/plans/GP-2.2-COST-USD-RECONCILE-COMPLETENESS.md
@@ -1,6 +1,6 @@
 # GP-2.2 — Adapter-Path `cost_usd` Reconcile Completeness
 
-**Status:** Active  
+**Status:** Completed
 **Date:** 2026-04-23  
 **Tracker:** [#333](https://github.com/Halildeu/ao-kernel/issues/333)  
 **Parent:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -15,6 +15,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan implementation contract:** `.claude/plans/PB-8-GENERAL-PURPOSE-PRODUCTIONIZATION-ROADMAP.md` (`PB-8` closeout)
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
+- **Son tamamlanan GP closeout decision:** `.claude/plans/GP-2-CLOSEOUT-DECISION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -39,22 +40,22 @@ ayrı ayrı görünür kılmak.
 - **PB-8 tracker issue:** [#288](https://github.com/Halildeu/ao-kernel/issues/288) (`closed`)
 - **PB-9 tracker issue:** [#302](https://github.com/Halildeu/ao-kernel/issues/302) (`closed`)
 - **GP-1 tracker issue:** [#316](https://github.com/Halildeu/ao-kernel/issues/316) (`closed`)
-- **GP-2 tracker issue:** [#329](https://github.com/Halildeu/ao-kernel/issues/329) (`open`)
+- **GP-2 tracker issue:** [#329](https://github.com/Halildeu/ao-kernel/issues/329) (`closed by GP-2 closeout PR`)
 - **GP-2.1 issue:** [#331](https://github.com/Halildeu/ao-kernel/issues/331) (`closed`)
 - **GP-2.2 issue:** [#333](https://github.com/Halildeu/ao-kernel/issues/333) (`closed`)
 - **GP-2.2b issue:** [#336](https://github.com/Halildeu/ao-kernel/issues/336) (`closed`)
-- **GP-2.3 issue:** [#361](https://github.com/Halildeu/ao-kernel/issues/361) (`closeout after handoff`)
-- **GP-2.4 issue:** [#363](https://github.com/Halildeu/ao-kernel/issues/363) (`closeout after GP-2.4d merge`)
+- **GP-2.3 issue:** [#361](https://github.com/Halildeu/ao-kernel/issues/361) (`closed`)
+- **GP-2.4 issue:** [#363](https://github.com/Halildeu/ao-kernel/issues/363) (`closed`)
 - **GP-2.4a issue:** [#365](https://github.com/Halildeu/ao-kernel/issues/365) (`closed after merge`)
 - **GP-2.4d issue:** [#371](https://github.com/Halildeu/ao-kernel/issues/371) (`closed after merge`)
 - **GP-2.5 issue:** [#373](https://github.com/Halildeu/ao-kernel/issues/373) (`closed`)
-- **GP-2.5a issue:** [#375](https://github.com/Halildeu/ao-kernel/issues/375) (`active until PR merge`)
+- **GP-2.5a issue:** [#375](https://github.com/Halildeu/ao-kernel/issues/375) (`closed`)
 - **ST-1 issue:** [#340](https://github.com/Halildeu/ao-kernel/issues/340) (`closed after closeout`)
 - **ST-2 issue:** [#344](https://github.com/Halildeu/ao-kernel/issues/344) (`closed`)
 - **ST-6 issue:** [#351](https://github.com/Halildeu/ao-kernel/issues/351) (`closed`)
 - **ST-7 issue:** [#355](https://github.com/Halildeu/ao-kernel/issues/355) (`closed after closeout`)
 - **ST-8 issue:** [#358](https://github.com/Halildeu/ao-kernel/issues/358) (`closed after closeout`)
-- **Aktif gate:** `GP-2.5a` closeout PR. Disposable sandbox live-write rehearsal geçti; support widening yok. `gh-cli-pr` full remote PR opening stable shipped support değildir.
+- **Aktif gate:** yok. GP-2 closeout tamamlandı; yeni support widening ancak ayrı promotion issue/contract ile açılır.
 
 ## 2. Başlangıç Gerçeği
 
@@ -102,7 +103,7 @@ ayrı ayrı görünür kılmak.
 | `PB-8` general-purpose productionization roadmap | Completed on `main` ([#288](https://github.com/Halildeu/ao-kernel/issues/288), [#300](https://github.com/Halildeu/ao-kernel/pull/300), [#301](https://github.com/Halildeu/ao-kernel/pull/301)) | widening kararlarını tranche bazında kapatmak ve support closeout parity'yi tamamlamak | tracker closeout + docs/runbook/release-gate parity |
 | `PB-9` production claim readiness gates | Completed on `main` ([#302](https://github.com/Halildeu/ao-kernel/issues/302), closed tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303), closed tranche [#306](https://github.com/Halildeu/ao-kernel/issues/306), closed tranche [#309](https://github.com/Halildeu/ao-kernel/issues/309), closed tranche [#312](https://github.com/Halildeu/ao-kernel/issues/312)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | roadmap + decision records + tracker closeout |
 | `GP-1` general-purpose production widening | Completed on `main` ([#316](https://github.com/Halildeu/ao-kernel/issues/316), [#327](https://github.com/Halildeu/ao-kernel/pull/327), [#326](https://github.com/Halildeu/ao-kernel/issues/326)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde tamamlamak | GP-1.1..GP-1.5 decision records + closeout parity |
-| `GP-2` deferred support-lane backlog reprioritization | Active ([#329](https://github.com/Halildeu/ao-kernel/issues/329), closeout slice [#375](https://github.com/Halildeu/ao-kernel/issues/375)) | `GP-1` ve `v4.0.0` stable sonrası deferred/support widening lane'lerini tek anlamlı sıraya indirip post-stable support-lane gates yürütmek | GP-2.5a sandbox rehearsal evidence + support boundary unchanged verdict |
+| `GP-2` deferred support-lane backlog reprioritization | Completed ([#329](https://github.com/Halildeu/ao-kernel/issues/329), closeout decision `.claude/plans/GP-2-CLOSEOUT-DECISION.md`) | `GP-1` ve `v4.0.0` stable sonrası deferred/support widening lane'lerini tek anlamlı sıraya indirip post-stable support-lane gates yürütmek | GP-2.5a sandbox rehearsal evidence + support boundary unchanged verdict |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -370,13 +371,12 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Aktif closeout slice: `GP-2.5a` `gh-cli-pr` disposable sandbox live-write
-rehearsal evidence ([#375](https://github.com/Halildeu/ao-kernel/issues/375)).
+Aktif GP-2 runtime slice yoktur. GP-2 closeout tamamlanmıştır ve support
+boundary değişmemiştir.
 
-Bu slice support widening yapmaz. Amaç, `GP-2.5` contract'ında yazılan
-disposable sandbox create -> verify -> rollback zincirinin canlı kanıtını
-kaydetmek, helper repo override regression'ını kapatmak ve support-boundary
-verdict'ini değiştirmeden closeout yapmaktır.
+Bundan sonraki varsayılan yol maintenance'tır. Support widening istenirse yeni
+bir promotion programı açılır; bu program tek lane, tek decision record, tek PR
+disipliniyle yürür.
 
 1. Son kapanan stable slice: `ST-8` stable publish and post-publish verification
    ([#358](https://github.com/Halildeu/ao-kernel/issues/358))
@@ -388,21 +388,23 @@ verdict'ini değiştirmeden closeout yapmaktır.
    `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
 5. Son rollback rehearsal contract:
    `.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md`
-6. GP-2.4 sıra:
+6. Son GP closeout decision:
+   `.claude/plans/GP-2-CLOSEOUT-DECISION.md`
+7. GP-2.4 sıra:
    - `GP-2.4a`: preflight evidence contract (`closed after merge`)
    - `GP-2.4b`: governed workflow smoke evidence (`closed after merge`)
    - `GP-2.4c`: failure-mode matrix (`closed after merge`)
    - `GP-2.4d`: support boundary verdict (`operator_managed_beta_keep`)
-7. GP-2.5/GP-2.5a kanıtı:
+8. GP-2.5/GP-2.5a kanıtı:
    - preflight smoke: `overall_status=pass`
    - live-write guard smoke: `overall_status=blocked`,
      finding `gh_pr_live_write_same_head_base`
    - sandbox live-write smoke: `overall_status=pass`,
      PR `https://github.com/Halildeu/ao-kernel-sandbox/pull/1`,
      final state `CLOSED`, remote head cleanup verified
-8. Stable live iddiası geçerlidir: `pip install ao-kernel` ve exact pin
+9. Stable live iddiası geçerlidir: `pip install ao-kernel` ve exact pin
    `ao-kernel==4.0.0` fresh venv içinde `4.0.0` kurmuştur.
-9. Stable support boundary unchanged kalır; `gh-cli-pr` full remote PR opening
+10. Stable support boundary unchanged kalır; `gh-cli-pr` full remote PR opening
    hâlâ Deferred support yüzeyidir.
 
 `PB-8.2` completion kaydı:
@@ -613,7 +615,7 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
    - bu kickoff dilimi runtime widening implementasyonu içermez
    - support boundary kararı yalnız yazılı kanıt/karar notu ile güncellenir
 
-## 16. GP-2.1 Active Snapshot
+## 16. GP-2.1 Completed Snapshot
 
 `GP-2` kickoff sonrası aktif ordering tranche `GP-2.1`e indirildi.
 
@@ -655,7 +657,7 @@ Her merge sonrası bu dosyada en az şu alanlar güncellenecek:
 `ST-8` stable publish closeout sonrası aktif karar slice'ı `GP-2.3` olarak
 açıldı.
 
-1. Issue: [#361](https://github.com/Halildeu/ao-kernel/issues/361) (`closeout after handoff`)
+1. Issue: [#361](https://github.com/Halildeu/ao-kernel/issues/361) (`closed`)
 2. Active contract:
    `.claude/plans/GP-2.3-POST-STABLE-ADAPTER-CERTIFICATION-ENTRY.md`
 3. Scope:
@@ -680,7 +682,7 @@ açıldı.
 `GP-2.3` handoff sonrası contract slice `GP-2.4` olarak açıldı ve
 `GP-2.4d` ile kapandı.
 
-1. Issue: [#363](https://github.com/Halildeu/ao-kernel/issues/363) (`closeout after GP-2.4d merge`)
+1. Issue: [#363](https://github.com/Halildeu/ao-kernel/issues/363) (`closed`)
 2. Verdict issue: [#371](https://github.com/Halildeu/ao-kernel/issues/371)
 3. Contract:
    `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -749,7 +751,7 @@ açıldı.
 
 1. Issue: [#373](https://github.com/Halildeu/ao-kernel/issues/373) (`closed`)
 2. Live rehearsal issue: [#375](https://github.com/Halildeu/ao-kernel/issues/375)
-   (`active until PR merge`)
+   (`closed`)
 3. Contract:
    `.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md`
 4. Scope:
@@ -773,5 +775,23 @@ açıldı.
    - remote head branch: deleted
    - verdict: `rehearsal_pass_keep_beta`
 8. Next default:
-   - GP-2 closeout or a separate `gh-cli-pr` promotion decision PR; no
-     automatic support widening from this rehearsal
+   - GP-2 closeout completed; any support widening requires a separate
+     promotion decision PR
+
+## 21. GP-2 Parent Closeout Snapshot
+
+GP-2 parent tracker, deferred support-lane reprioritization hedefini tamamladı.
+
+1. Issue: [#329](https://github.com/Halildeu/ao-kernel/issues/329)
+2. Decision record:
+   `.claude/plans/GP-2-CLOSEOUT-DECISION.md`
+3. Final verdict:
+   - `claude-code-cli`: `Beta (operator-managed)`, production-certified değil
+   - `gh-cli-pr`: `Beta (operator-managed)`, sandbox rehearsal geçti ama stable
+     shipped support değil
+   - `bug_fix_flow`: deferred
+   - adapter-path `cost_usd`: deferred public support claim
+4. Boundary:
+   - `v4.0.0` stable baseline dar kalır
+   - general-purpose production platform claim'i açılmadı
+   - support widening için ayrı promotion programı gerekir

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -47,8 +47,8 @@ sertifikasyonu ve live-write rollback kanitlari kapanmadan kullanilmayacak.
   cekirdek shipped yuzeydir.
 - `claude-code-cli`, `gh-cli-pr` ve write/live hatlari operator-managed beta
   veya karar bekleyen yuzeylerdir.
-- Post-beta programda GP-2 hattinda deferred support lane'leri kanitla
-  kapatiliyor.
+- Post-beta programda GP-2 hattı tamamlandı; deferred support lane'leri kanıtla
+  sınıflandırıldı ve support boundary genişletilmedi.
 
 ## 4. Closed Drift Kayitlari
 
@@ -343,12 +343,17 @@ dogrulanir.
 5. Son tamamlanan post-stable contract hattı `GP-2.4`:
    `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
    - Final verdict: `operator_managed_beta_keep`
-6. Varsayılan sıra:
-   - `Now`: `GP-2.5a` `gh-cli-pr` disposable sandbox rehearsal closeout
-     (`.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md`)
-   - `Next`: extension/support widening
+6. Son tamamlanan post-stable support-lane hattı `GP-2`:
+   `.claude/plans/GP-2-CLOSEOUT-DECISION.md`
+   - Final verdict: no stable support widening
+   - `claude-code-cli`: Beta/operator-managed
+   - `gh-cli-pr`: Beta/operator-managed; sandbox rehearsal passed
+   - full remote PR opening: not stable shipped support
+7. Varsayılan sıra:
+   - `Now`: stable maintenance, bugfix, and evidence hygiene
+   - `Next`: ayrı bir promotion programı açılırsa tek lane support widening
    - `Later`: genel amaçlı production platform claim'i
-7. Bu roadmap stable runtime release'i tamamlanmış sayar; genel amaçlı
-   production platform claim'i için `GP-2.4` sonucunda support boundary
-   genişlememiştir. `GP-2.5a` sandbox rehearsal kanıtı support widening'i
-   otomatik açmaz; ayrı promotion decision gerekir.
+8. Bu roadmap stable runtime release'i tamamlanmış sayar; genel amaçlı
+   production platform claim'i için support boundary genişlememiştir. `GP-2`
+   closeout ve `GP-2.5a` sandbox rehearsal support widening'i otomatik açmaz;
+   ayrı promotion decision gerekir.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `gh-cli-pr` created, verified, closed, and cleaned up a draft PR in
   `Halildeu/ao-kernel-sandbox`. This does not widen the stable support
   boundary; full remote PR opening remains outside the shipped baseline.
+- Added the `GP-2` parent closeout decision record. The deferred support-lane
+  reprioritization program is complete, with no automatic stable support
+  widening for `claude-code-cli`, `gh-cli-pr`, `bug_fix_flow`, or adapter-path
+  `cost_usd`.
 
 ## [4.0.0] - 2026-04-24
 


### PR DESCRIPTION
## Summary

Closes #329.

- Add `GP-2-CLOSEOUT-DECISION.md` as the parent closeout record for deferred support-lane reprioritization.
- Mark GP-2, GP-2.1, and GP-2.2 status surfaces completed.
- Update the program status and production stable roadmap so there is no active GP-2 runtime gate.
- Preserve support boundary: no stable widening for `claude-code-cli`, `gh-cli-pr`, `bug_fix_flow`, or adapter-path `cost_usd`.

## Decision

Final verdict: GP-2 is complete, and the default next path is stable maintenance. Any support widening must open a separate promotion program with one lane, one decision record, one PR, and fresh evidence.

## Validation

- `rg -n '^\\*\\*Status:\\*\\* Active|GP-2.*Active|active until PR merge|closeout after handoff|closeout after GP-2|GP-2 tracker issue.*open|Now`: `GP-2' .claude/plans/GP-2* .claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md .claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md -S && exit 1 || true`
- `python3 scripts/truth_inventory_ratchet.py --output json`
- `python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py`
- `git diff --check`
