### PR TITLE
[codex] docs: enter stable maintenance baseline

### DIFF
--- a/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
+++ b/.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md
@@ -148,7 +148,7 @@ Final karar:
 - No-side-effect kanıt:
   - `python3 scripts/gh_cli_pr_smoke.py --mode preflight --output json --timeout-seconds 20`
     -> `overall_status=pass`
-  - `python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head main --base main --output json --timeout-seconds 20`
+  - `python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --repo Halildeu/ao-kernel-sandbox --head main --base main --output json --timeout-seconds 20`
     -> `overall_status=blocked`, finding `gh_pr_live_write_same_head_base`
 - Live-write kanıt:
   - target repo: `Halildeu/ao-kernel-sandbox`

--- a/.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md
+++ b/.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md
@@ -243,7 +243,7 @@ Contract PR için minimum:
 ```bash
 python3 -m pytest -q tests/test_gh_cli_pr_smoke.py
 python3 scripts/gh_cli_pr_smoke.py --mode preflight --output json --timeout-seconds 20
-python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head main --base main --output json --timeout-seconds 20
+python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --repo Halildeu/ao-kernel-sandbox --head main --base main --output json --timeout-seconds 20
 python3 scripts/truth_inventory_ratchet.py --output json
 python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py
 ```

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -16,6 +16,7 @@ ayrı ayrı görünür kılmak.
 - **Son extension decision record:** `.claude/plans/PB-6.3-CONTEXT-ORCHESTRATION-DECISION.md`
 - **Program roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
 - **Son tamamlanan GP closeout decision:** `.claude/plans/GP-2-CLOSEOUT-DECISION.md`
+- **Son tamamlanan maintenance baseline:** `.claude/plans/SM-1-STABLE-MAINTENANCE-BASELINE.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -55,7 +56,8 @@ ayrı ayrı görünür kılmak.
 - **ST-6 issue:** [#351](https://github.com/Halildeu/ao-kernel/issues/351) (`closed`)
 - **ST-7 issue:** [#355](https://github.com/Halildeu/ao-kernel/issues/355) (`closed after closeout`)
 - **ST-8 issue:** [#358](https://github.com/Halildeu/ao-kernel/issues/358) (`closed after closeout`)
-- **Aktif gate:** yok. GP-2 closeout tamamlandı; yeni support widening ancak ayrı promotion issue/contract ile açılır.
+- **SM-1 issue:** [#378](https://github.com/Halildeu/ao-kernel/issues/378) (`closed by maintenance baseline PR`)
+- **Aktif gate:** yok. SM-1 stable maintenance baseline geçerlidir; yeni support widening ancak ayrı promotion issue/contract ile açılır.
 
 ## 2. Başlangıç Gerçeği
 
@@ -104,6 +106,7 @@ ayrı ayrı görünür kılmak.
 | `PB-9` production claim readiness gates | Completed on `main` ([#302](https://github.com/Halildeu/ao-kernel/issues/302), closed tranche [#303](https://github.com/Halildeu/ao-kernel/issues/303), closed tranche [#306](https://github.com/Halildeu/ao-kernel/issues/306), closed tranche [#309](https://github.com/Halildeu/ao-kernel/issues/309), closed tranche [#312](https://github.com/Halildeu/ao-kernel/issues/312)) | production claim kararını gate bazlı ve kanıt odaklı yürütmek | roadmap + decision records + tracker closeout |
 | `GP-1` general-purpose production widening | Completed on `main` ([#316](https://github.com/Halildeu/ao-kernel/issues/316), [#327](https://github.com/Halildeu/ao-kernel/pull/327), [#326](https://github.com/Halildeu/ao-kernel/issues/326)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde tamamlamak | GP-1.1..GP-1.5 decision records + closeout parity |
 | `GP-2` deferred support-lane backlog reprioritization | Completed ([#329](https://github.com/Halildeu/ao-kernel/issues/329), closeout decision `.claude/plans/GP-2-CLOSEOUT-DECISION.md`) | `GP-1` ve `v4.0.0` stable sonrası deferred/support widening lane'lerini tek anlamlı sıraya indirip post-stable support-lane gates yürütmek | GP-2.5a sandbox rehearsal evidence + support boundary unchanged verdict |
+| `SM-1` stable maintenance baseline | Completed ([#378](https://github.com/Halildeu/ao-kernel/issues/378), decision `.claude/plans/SM-1-STABLE-MAINTENANCE-BASELINE.md`) | GP-2 sonrası varsayılan çalışma modunu maintenance olarak sabitlemek | no active widening gate + support-boundary prerequisite drift fixed |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -371,8 +374,8 @@ Not:
 
 ## 8. Anlık Öncelik
 
-Aktif GP-2 runtime slice yoktur. GP-2 closeout tamamlanmıştır ve support
-boundary değişmemiştir.
+Aktif runtime/support-widening slice yoktur. GP-2 closeout tamamlanmıştır,
+SM-1 stable maintenance baseline geçerlidir ve support boundary değişmemiştir.
 
 Bundan sonraki varsayılan yol maintenance'tır. Support widening istenirse yeni
 bir promotion programı açılır; bu program tek lane, tek decision record, tek PR
@@ -390,21 +393,23 @@ disipliniyle yürür.
    `.claude/plans/GP-2.5-GH-CLI-PR-LIVE-WRITE-ROLLBACK-REHEARSAL.md`
 6. Son GP closeout decision:
    `.claude/plans/GP-2-CLOSEOUT-DECISION.md`
-7. GP-2.4 sıra:
+7. Son maintenance baseline:
+   `.claude/plans/SM-1-STABLE-MAINTENANCE-BASELINE.md`
+8. GP-2.4 sıra:
    - `GP-2.4a`: preflight evidence contract (`closed after merge`)
    - `GP-2.4b`: governed workflow smoke evidence (`closed after merge`)
    - `GP-2.4c`: failure-mode matrix (`closed after merge`)
    - `GP-2.4d`: support boundary verdict (`operator_managed_beta_keep`)
-8. GP-2.5/GP-2.5a kanıtı:
+9. GP-2.5/GP-2.5a kanıtı:
    - preflight smoke: `overall_status=pass`
    - live-write guard smoke: `overall_status=blocked`,
      finding `gh_pr_live_write_same_head_base`
    - sandbox live-write smoke: `overall_status=pass`,
      PR `https://github.com/Halildeu/ao-kernel-sandbox/pull/1`,
      final state `CLOSED`, remote head cleanup verified
-9. Stable live iddiası geçerlidir: `pip install ao-kernel` ve exact pin
+10. Stable live iddiası geçerlidir: `pip install ao-kernel` ve exact pin
    `ao-kernel==4.0.0` fresh venv içinde `4.0.0` kurmuştur.
-10. Stable support boundary unchanged kalır; `gh-cli-pr` full remote PR opening
+11. Stable support boundary unchanged kalır; `gh-cli-pr` full remote PR opening
    hâlâ Deferred support yüzeyidir.
 
 `PB-8.2` completion kaydı:
@@ -766,7 +771,7 @@ açıldı.
 6. No-side-effect evidence:
    - `python3 scripts/gh_cli_pr_smoke.py --mode preflight --output json --timeout-seconds 20`
      -> `overall_status=pass`
-   - `python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head main --base main --output json --timeout-seconds 20`
+   - `python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --repo Halildeu/ao-kernel-sandbox --head main --base main --output json --timeout-seconds 20`
      -> `overall_status=blocked`, finding `gh_pr_live_write_same_head_base`
 7. Disposable rehearsal evidence:
    - repo: `Halildeu/ao-kernel-sandbox`
@@ -795,3 +800,22 @@ GP-2 parent tracker, deferred support-lane reprioritization hedefini tamamladı.
    - `v4.0.0` stable baseline dar kalır
    - general-purpose production platform claim'i açılmadı
    - support widening için ayrı promotion programı gerekir
+
+## 22. SM-1 Stable Maintenance Baseline Snapshot
+
+GP-2 sonrası varsayılan yürütme modu maintenance olarak sabitlendi.
+
+1. Issue: [#378](https://github.com/Halildeu/ao-kernel/issues/378)
+2. Decision record:
+   `.claude/plans/SM-1-STABLE-MAINTENANCE-BASELINE.md`
+3. Mode:
+   - active runtime widening gate yok
+   - default path stable maintenance
+   - support widening için ayrı promotion programı gerekir
+4. Scope:
+   - runtime değişikliği yok
+   - version bump/tag/publish yok
+   - support boundary widening yok
+5. Drift fixed:
+   - operator-facing `gh-cli-pr` live-write prerequisite prose now includes
+     explicit `--repo <owner>/<sandbox-repo>`

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -49,6 +49,8 @@ sertifikasyonu ve live-write rollback kanitlari kapanmadan kullanilmayacak.
   veya karar bekleyen yuzeylerdir.
 - Post-beta programda GP-2 hattı tamamlandı; deferred support lane'leri kanıtla
   sınıflandırıldı ve support boundary genişletilmedi.
+- `SM-1` stable maintenance baseline geçerlidir; aktif support-widening gate
+  yoktur.
 
 ## 4. Closed Drift Kayitlari
 
@@ -349,11 +351,16 @@ dogrulanir.
    - `claude-code-cli`: Beta/operator-managed
    - `gh-cli-pr`: Beta/operator-managed; sandbox rehearsal passed
    - full remote PR opening: not stable shipped support
-7. Varsayılan sıra:
+7. Son tamamlanan maintenance baseline `SM-1`:
+   `.claude/plans/SM-1-STABLE-MAINTENANCE-BASELINE.md`
+   - active widening gate: none
+   - default path: stable maintenance
+   - future widening: separate promotion program only
+8. Varsayılan sıra:
    - `Now`: stable maintenance, bugfix, and evidence hygiene
    - `Next`: ayrı bir promotion programı açılırsa tek lane support widening
    - `Later`: genel amaçlı production platform claim'i
-8. Bu roadmap stable runtime release'i tamamlanmış sayar; genel amaçlı
+9. Bu roadmap stable runtime release'i tamamlanmış sayar; genel amaçlı
    production platform claim'i için support boundary genişlememiştir. `GP-2`
    closeout ve `GP-2.5a` sandbox rehearsal support widening'i otomatik açmaz;
    ayrı promotion decision gerekir.

--- a/.claude/plans/SM-1-STABLE-MAINTENANCE-BASELINE.md
+++ b/.claude/plans/SM-1-STABLE-MAINTENANCE-BASELINE.md
@@ -1,0 +1,89 @@
+# SM-1 — Stable Maintenance Baseline
+
+**Status:** Completed
+**Date:** 2026-04-24
+**Tracker:** [#378](https://github.com/Halildeu/ao-kernel/issues/378)
+**Parent context:** `GP-2` closeout and `v4.0.0` stable live baseline
+
+## Purpose
+
+Define the default operating mode after `GP-2` closed without stable support
+widening.
+
+This is not a runtime implementation tranche. It is the maintenance baseline
+that prevents the next work from silently reopening support widening,
+promotion, or production-platform claims without a new explicit program.
+
+## Current Stable Baseline
+
+1. `v4.0.0` is the live stable package.
+2. The shipped support boundary remains narrow.
+3. `review_ai_flow + codex-stub`, entrypoints, doctor, packaging smoke, policy
+   command enforcement, and documented read-only kernel API actions are the
+   stable supported surface.
+4. `claude-code-cli`, `gh-cli-pr`, kernel API write-side actions, and
+   real-adapter benchmark full mode remain Beta/operator-managed.
+5. `bug_fix_flow` release closure, full remote PR opening, roadmap/spec demo,
+   and adapter-path `cost_usd` public support claim remain Deferred.
+6. There is no active support-widening runtime gate.
+
+## Maintenance Rules
+
+Stable maintenance work is allowed when it fits one of these categories:
+
+1. bugfix for shipped stable baseline;
+2. docs/runtime/test parity correction;
+3. CI, packaging, release, or rollback gate hygiene;
+4. known-bug registry update;
+5. operator runbook clarification;
+6. evidence hygiene that does not widen support.
+
+Stable maintenance work must not:
+
+1. promote Beta or Deferred lanes;
+2. reinterpret a one-off smoke as production support;
+3. open live-write behavior against production repositories;
+4. claim general-purpose production coding automation platform readiness;
+5. bundle multiple support-widening lanes into one PR.
+
+## Promotion Protocol
+
+Any future support widening must open a new promotion program, likely `GP-3`,
+with:
+
+1. one lane only;
+2. one tracker issue;
+3. one decision record;
+4. explicit support-boundary delta;
+5. repeatable positive and negative evidence;
+6. docs/runtime/tests/CI parity;
+7. rollback/incident path when write-side or remote side effects are involved.
+
+No lane may be promoted by editing docs alone.
+
+## Drift Fixed In This Slice
+
+`docs/SUPPORT-BOUNDARY.md`, `docs/OPERATIONS-RUNBOOK.md`, and
+`docs/UPGRADE-NOTES.md` described the `gh-cli-pr` live-write probe in some
+operator prerequisite text without showing the explicit `--repo
+<owner>/<sandbox-repo>` guard. `SM-1` aligns those examples and prerequisite
+sentences with the actual helper contract.
+
+## Validation
+
+Minimum validation for this maintenance baseline:
+
+```bash
+python3 scripts/truth_inventory_ratchet.py --output json
+python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py
+git diff --check
+```
+
+## Exit Criteria
+
+1. This decision record is merged.
+2. Program status references `SM-1` as the current maintenance baseline.
+3. Production roadmap says the default path is stable maintenance.
+4. Operator-facing docs no longer omit the explicit sandbox repo parameter from
+   live-write prerequisite prose.
+5. Issue [#378](https://github.com/Halildeu/ao-kernel/issues/378) is closed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   reprioritization program is complete, with no automatic stable support
   widening for `claude-code-cli`, `gh-cli-pr`, `bug_fix_flow`, or adapter-path
   `cost_usd`.
+- Added the `SM-1` stable maintenance baseline decision record and aligned the
+  operator-facing `gh-cli-pr` live-write prerequisite prose with the explicit
+  sandbox `--repo` requirement.
 
 ## [4.0.0] - 2026-04-24
 

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -37,9 +37,9 @@ python3 scripts/claude_code_cli_smoke.py --output text
 python3 scripts/gh_cli_pr_smoke.py --output text
 python3 scripts/kernel_api_write_smoke.py --output text
 # Optional readiness probe (live-write, explicit opt-in + disposable guard):
-# python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch>
+# python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --repo <owner>/<sandbox-repo> --head <branch> --base <branch>
 # Optional: persist canonical JSON evidence artifact
-# python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch> --output json --report-path /tmp/gh-cli-pr-live-write.report.json
+# python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --repo <owner>/<sandbox-repo> --head <branch> --base <branch> --output json --report-path /tmp/gh-cli-pr-live-write.report.json
 ```
 
 Prerequisite contract (operator-managed lanes):
@@ -50,7 +50,8 @@ Prerequisite contract (operator-managed lanes):
 2. `gh-cli-pr` preflight için `gh` binary + aktif auth + repo context çözümü
    gerekir; preflight lane side-effect-safe dry-run'dır.
 3. `gh-cli-pr` live-write probe için explicit
-   `--mode live-write --allow-live-write --head ... --base ...` zorunludur.
+   `--mode live-write --allow-live-write --repo <owner>/<sandbox-repo> --head ... --base ...`
+   zorunludur.
 4. Varsayılan disposable guard keyword `sandbox`'dır; repo adı keyword'ü
    taşımıyorsa probe bilerek `blocked` döner.
 5. `--keep-live-write-pr-open` lane'i riskli kabul ettirir; bu sonucu support

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -89,7 +89,8 @@ Operator prerequisite contract (PB-9.1):
 2. `gh-cli-pr` preflight lane için `gh` binary + aktif auth + repo context
    (`gh repo view`) çözümü gerekir; preflight side-effect-safe dry-run zinciridir.
 3. `gh-cli-pr` live-write probe yalnız explicit
-   `--mode live-write --allow-live-write --head ... --base ...` ile açılır.
+   `--mode live-write --allow-live-write --repo <owner>/<sandbox-repo> --head ... --base ...`
+   ile açılır.
 4. Live-write probe varsayılan disposable guard keyword `sandbox` uygular;
    repo adı bu keyword'ü içermiyorsa lane bilerek `blocked` olur.
 5. `--keep-live-write-pr-open` lane'i bilinçli riskli kabul ettirir ve

--- a/docs/UPGRADE-NOTES.md
+++ b/docs/UPGRADE-NOTES.md
@@ -79,7 +79,7 @@ well:
 python3 scripts/claude_code_cli_smoke.py --output text
 python3 scripts/gh_cli_pr_smoke.py --output text
 # Optional readiness probe (live-write, explicit opt-in + disposable guard):
-# python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --head <branch> --base <branch>
+# python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --repo <owner>/<sandbox-repo> --head <branch> --base <branch>
 ```
 
 Prerequisite contract:
@@ -90,7 +90,8 @@ Prerequisite contract:
 2. `gh-cli-pr` preflight lane için `gh` binary + aktif auth + repo context
    çözümü gerekir; preflight lane side-effect-safe dry-run olarak çalışır.
 3. `gh-cli-pr` live-write probe explicit
-   `--mode live-write --allow-live-write --head ... --base ...` ister.
+   `--mode live-write --allow-live-write --repo <owner>/<sandbox-repo> --head ... --base ...`
+   ister.
 4. Varsayılan disposable guard keyword `sandbox` olup, repo adında yoksa
    probe bilerek `blocked` döner.
 5. `--keep-live-write-pr-open` seçeneği lane'i riskli sayar ve `blocked`


### PR DESCRIPTION
## Summary

Closes #378.

- Add SM-1 stable maintenance baseline decision record.
- Make stable maintenance the default post-GP-2 operating mode.
- Keep future support widening behind a separate promotion program/issue/contract.
- Align operator-facing gh-cli-pr live-write docs with the explicit --repo <owner>/<sandbox-repo> guard.

## Boundary

No runtime behavior change, no version bump, no tag/publish, no support widening.

## Validation

- rg stale live-write/head examples check
- rg stale active-GP/status wording check
- python3 scripts/truth_inventory_ratchet.py --output json
- python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py
- git diff --check
