### PR TITLE
[codex] docs: refresh stable baseline evidence

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -17,6 +17,7 @@ ayrı ayrı görünür kılmak.
 - **Program roadmap:** `.claude/plans/GP-2-DEFERRED-SUPPORT-LANES-REPRIORITIZATION.md`
 - **Son tamamlanan GP closeout decision:** `.claude/plans/GP-2-CLOSEOUT-DECISION.md`
 - **Son tamamlanan maintenance baseline:** `.claude/plans/SM-1-STABLE-MAINTENANCE-BASELINE.md`
+- **Son tamamlanan stable evidence refresh:** `.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -57,6 +58,7 @@ ayrı ayrı görünür kılmak.
 - **ST-7 issue:** [#355](https://github.com/Halildeu/ao-kernel/issues/355) (`closed after closeout`)
 - **ST-8 issue:** [#358](https://github.com/Halildeu/ao-kernel/issues/358) (`closed after closeout`)
 - **SM-1 issue:** [#378](https://github.com/Halildeu/ao-kernel/issues/378) (`closed by maintenance baseline PR`)
+- **SM-2 issue:** [#380](https://github.com/Halildeu/ao-kernel/issues/380) (`closed by evidence refresh PR`)
 - **Aktif gate:** yok. SM-1 stable maintenance baseline geçerlidir; yeni support widening ancak ayrı promotion issue/contract ile açılır.
 
 ## 2. Başlangıç Gerçeği
@@ -107,6 +109,7 @@ ayrı ayrı görünür kılmak.
 | `GP-1` general-purpose production widening | Completed on `main` ([#316](https://github.com/Halildeu/ao-kernel/issues/316), [#327](https://github.com/Halildeu/ao-kernel/pull/327), [#326](https://github.com/Halildeu/ao-kernel/issues/326)) | PB-9 sonrası widening kararlarını tranche bazında ve gate-first disiplinde tamamlamak | GP-1.1..GP-1.5 decision records + closeout parity |
 | `GP-2` deferred support-lane backlog reprioritization | Completed ([#329](https://github.com/Halildeu/ao-kernel/issues/329), closeout decision `.claude/plans/GP-2-CLOSEOUT-DECISION.md`) | `GP-1` ve `v4.0.0` stable sonrası deferred/support widening lane'lerini tek anlamlı sıraya indirip post-stable support-lane gates yürütmek | GP-2.5a sandbox rehearsal evidence + support boundary unchanged verdict |
 | `SM-1` stable maintenance baseline | Completed ([#378](https://github.com/Halildeu/ao-kernel/issues/378), decision `.claude/plans/SM-1-STABLE-MAINTENANCE-BASELINE.md`) | GP-2 sonrası varsayılan çalışma modunu maintenance olarak sabitlemek | no active widening gate + support-boundary prerequisite drift fixed |
+| `SM-2` stable baseline evidence refresh | Completed ([#380](https://github.com/Halildeu/ao-kernel/issues/380), evidence `.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md`) | SM-1 sonrası shipped baseline kanıtını tazelemek | entrypoints + doctor + truth inventory + wheel-installed packaging smoke + targeted tests |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -51,6 +51,8 @@ sertifikasyonu ve live-write rollback kanitlari kapanmadan kullanilmayacak.
   sınıflandırıldı ve support boundary genişletilmedi.
 - `SM-1` stable maintenance baseline geçerlidir; aktif support-widening gate
   yoktur.
+- `SM-2` stable evidence refresh tamamlandı; entrypoint, doctor, truth
+  inventory, wheel-installed packaging smoke ve targeted tests tekrar geçti.
 
 ## 4. Closed Drift Kayitlari
 
@@ -356,11 +358,17 @@ dogrulanir.
    - active widening gate: none
    - default path: stable maintenance
    - future widening: separate promotion program only
-8. Varsayılan sıra:
+8. Son tamamlanan stable evidence refresh `SM-2`:
+   `.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md`
+   - entrypoints: `ao-kernel 4.0.0`
+   - doctor: `8 OK, 1 WARN, 0 FAIL`
+   - packaging smoke: wheel install + `demo_review.py --cleanup` completed
+   - targeted tests: `3 passed, 1 skipped`
+9. Varsayılan sıra:
    - `Now`: stable maintenance, bugfix, and evidence hygiene
    - `Next`: ayrı bir promotion programı açılırsa tek lane support widening
    - `Later`: genel amaçlı production platform claim'i
-9. Bu roadmap stable runtime release'i tamamlanmış sayar; genel amaçlı
+10. Bu roadmap stable runtime release'i tamamlanmış sayar; genel amaçlı
    production platform claim'i için support boundary genişlememiştir. `GP-2`
    closeout ve `GP-2.5a` sandbox rehearsal support widening'i otomatik açmaz;
    ayrı promotion decision gerekir.

--- a/.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md
+++ b/.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md
@@ -1,0 +1,137 @@
+# SM-2 — Stable Baseline Evidence Refresh
+
+**Status:** Completed
+**Date:** 2026-04-24
+**Tracker:** [#380](https://github.com/Halildeu/ao-kernel/issues/380)
+**Parent context:** `SM-1` stable maintenance baseline
+
+## Purpose
+
+Refresh the evidence for the current narrow stable baseline after `SM-1`
+established stable maintenance as the default operating mode.
+
+This is evidence hygiene only. It does not change runtime behavior, widen
+support, bump the package version, tag, or publish.
+
+## Boundary
+
+The stable support boundary remains unchanged:
+
+1. `v4.0.0` is the live stable package.
+2. The shipped support surface remains narrow: entrypoints, `doctor`,
+   bundled `review_ai_flow + codex-stub`, `examples/demo_review.py`,
+   policy command enforcement, packaging smoke, and documented read-only
+   `PRJ-KERNEL-API` actions.
+3. `claude-code-cli`, `gh-cli-pr`, kernel API write-side actions, and
+   real-adapter benchmark full mode remain Beta/operator-managed.
+4. `bug_fix_flow` release closure, full remote PR opening, roadmap/spec demo,
+   and adapter-path `cost_usd` public support remain Deferred.
+5. There is still no active support-widening runtime gate.
+
+## Evidence
+
+### Entrypoints
+
+```bash
+python3 -m ao_kernel version
+python3 -m ao_kernel.cli version
+```
+
+Result:
+
+```text
+ao-kernel 4.0.0
+ao-kernel 4.0.0
+```
+
+### Doctor
+
+```bash
+python3 -m ao_kernel doctor
+```
+
+Result:
+
+```text
+ao-kernel doctor v4.0.0
+8 OK, 1 WARN, 0 FAIL
+runtime_backed=2 contract_only=1 quarantined=16
+remap_candidate_refs=61 missing_runtime_refs=152
+runtime_backed_ids=PRJ-HELLO, PRJ-KERNEL-API
+```
+
+The warning is the expected extension truth inventory warning. It does not
+block the shipped baseline because the support boundary does not promote the
+quarantined inventory.
+
+### Truth Inventory Ratchet
+
+```bash
+python3 scripts/truth_inventory_ratchet.py --output json
+```
+
+Summary:
+
+```text
+contract_only: 1
+missing_runtime_refs: 152
+quarantined: 16
+remap_candidate_refs: 61
+runtime_backed: 2
+total_extensions: 19
+```
+
+This snapshot is unchanged from the expected support-boundary interpretation:
+truth inventory visibility is not support widening.
+
+### Wheel-Installed Packaging Smoke
+
+```bash
+python3 scripts/packaging_smoke.py
+```
+
+Result:
+
+```text
+Successfully built ao_kernel-4.0.0.tar.gz and ao_kernel-4.0.0-py3-none-any.whl
+Successfully installed ao-kernel-4.0.0
+ao-kernel 4.0.0
+ao-kernel 4.0.0
+ao-kernel 4.0.0
+[demo] final state: completed
+[demo] workspace cleaned up
+```
+
+The smoke used a fresh venv and installed the built wheel, then ran:
+
+1. `ao-kernel version`
+2. `python -m ao_kernel version`
+3. `python -m ao_kernel.cli version`
+4. `examples/demo_review.py --cleanup`
+
+### Targeted Tests
+
+```bash
+python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py
+```
+
+Result:
+
+```text
+3 passed, 1 skipped
+```
+
+There is no separate `tests/test_packaging_smoke.py` file; packaging smoke is
+covered by the executable `scripts/packaging_smoke.py` and the blocking CI job.
+
+## Decision
+
+The stable shipped baseline is still green under the narrow support boundary.
+No production-platform support widening is granted by this refresh.
+
+## Exit Criteria
+
+1. Evidence record is merged.
+2. Program status points to `SM-2` as the latest stable evidence refresh.
+3. `SM-1` remains the operating-mode baseline.
+4. Issue [#380](https://github.com/Halildeu/ao-kernel/issues/380) is closed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added the `SM-1` stable maintenance baseline decision record and aligned the
   operator-facing `gh-cli-pr` live-write prerequisite prose with the explicit
   sandbox `--repo` requirement.
+- Added the `SM-2` stable baseline evidence refresh, recording entrypoint,
+  doctor, truth inventory, wheel-installed packaging smoke, and targeted test
+  results without runtime changes or support widening.
 
 ## [4.0.0] - 2026-04-24
 


### PR DESCRIPTION
## Summary

Closes #380.

- Add SM-2 stable baseline evidence refresh decision/evidence record.
- Update program status and stable-live roadmap to point at the latest evidence refresh.
- Record current entrypoint, doctor, truth inventory, wheel-installed packaging smoke, and targeted test evidence.

## Boundary

No runtime behavior change, no version bump, no tag/publish, no support widening. SM-1 remains the operating-mode baseline; SM-2 only refreshes evidence.

## Validation

- `python3 -m ao_kernel version`
- `python3 -m ao_kernel.cli version`
- `python3 -m ao_kernel doctor`
- `python3 scripts/truth_inventory_ratchet.py --output json`
- `python3 scripts/packaging_smoke.py`
- `python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py`
- `git diff --check`
