### PR TITLE
[codex] docs: clarify historical beta pin wording

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -19,6 +19,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan maintenance baseline:** `.claude/plans/SM-1-STABLE-MAINTENANCE-BASELINE.md`
 - **Son tamamlanan stable evidence refresh:** `.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md`
 - **Son tamamlanan status truth cleanup:** `.claude/plans/SM-3-PROGRAM-STATUS-ACTIVE-SECTION-CLEANUP.md`
+- **Son tamamlanan historical beta pin wording cleanup:** `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -61,6 +62,7 @@ ayrı ayrı görünür kılmak.
 - **SM-1 issue:** [#378](https://github.com/Halildeu/ao-kernel/issues/378) (`closed by maintenance baseline PR`)
 - **SM-2 issue:** [#380](https://github.com/Halildeu/ao-kernel/issues/380) (`closed by evidence refresh PR`)
 - **SM-3 issue:** [#382](https://github.com/Halildeu/ao-kernel/issues/382) (`closed by status cleanup PR`)
+- **SM-4 issue:** [#384](https://github.com/Halildeu/ao-kernel/issues/384) (`closed by docs wording PR`)
 - **Aktif gate:** yok. SM-1 stable maintenance baseline geçerlidir; yeni support widening ancak ayrı promotion issue/contract ile açılır.
 
 ## 2. Başlangıç Gerçeği
@@ -113,6 +115,7 @@ ayrı ayrı görünür kılmak.
 | `SM-1` stable maintenance baseline | Completed ([#378](https://github.com/Halildeu/ao-kernel/issues/378), decision `.claude/plans/SM-1-STABLE-MAINTENANCE-BASELINE.md`) | GP-2 sonrası varsayılan çalışma modunu maintenance olarak sabitlemek | no active widening gate + support-boundary prerequisite drift fixed |
 | `SM-2` stable baseline evidence refresh | Completed ([#380](https://github.com/Halildeu/ao-kernel/issues/380), evidence `.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md`) | SM-1 sonrası shipped baseline kanıtını tazelemek | entrypoints + doctor + truth inventory + wheel-installed packaging smoke + targeted tests |
 | `SM-3` program status active-section cleanup | Completed ([#382](https://github.com/Halildeu/ao-kernel/issues/382), record `.claude/plans/SM-3-PROGRAM-STATUS-ACTIVE-SECTION-CLEANUP.md`) | yaşayan status dosyasındaki stale historical `ST-2` anlatımını temizlemek | no active widening gate + historical records clearly non-active |
+| `SM-4` historical beta pin wording | Completed ([#384](https://github.com/Halildeu/ao-kernel/issues/384), record `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`) | `4.0.0b2` beta pinini aktif kanal gibi değil historical pre-release yolu gibi anlatmak | stable `4.0.0` remains default + no support widening |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -127,8 +130,8 @@ ayrı ayrı görünür kılmak.
 
 Aktif runtime/support-widening slice yoktur. `SM-1` stable maintenance
 baseline geçerlidir; `SM-2` stable baseline evidence refresh son kanıt
-kaydıdır. `SM-3` yalnız yaşayan status dosyasındaki stale active wording
-drift'ini temizler.
+kaydıdır. `SM-3` ve `SM-4` yalnız yaşayan status / operator-facing docs
+wording drift'ini temizler.
 
 Varsayılan yol:
 
@@ -340,7 +343,7 @@ Not:
 Aktif runtime/support-widening slice yoktur. GP-2 closeout tamamlanmıştır,
 SM-1 stable maintenance baseline geçerlidir ve support boundary değişmemiştir.
 SM-2 stable evidence refresh tamamlanmıştır; SM-3 yalnız status drift
-temizliğidir.
+temizliğidir. SM-4 historical beta pin wording cleanup olarak tamamlanmıştır.
 
 Bundan sonraki varsayılan yol maintenance'tır. Support widening istenirse yeni
 bir promotion programı açılır; bu program tek lane, tek decision record, tek PR
@@ -364,21 +367,23 @@ disipliniyle yürür.
    `.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md`
 9. Son status cleanup:
    `.claude/plans/SM-3-PROGRAM-STATUS-ACTIVE-SECTION-CLEANUP.md`
-10. GP-2.4 sıra:
+10. Son historical beta pin wording cleanup:
+   `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`
+11. GP-2.4 sıra:
    - `GP-2.4a`: preflight evidence contract (`closed after merge`)
    - `GP-2.4b`: governed workflow smoke evidence (`closed after merge`)
    - `GP-2.4c`: failure-mode matrix (`closed after merge`)
    - `GP-2.4d`: support boundary verdict (`operator_managed_beta_keep`)
-11. GP-2.5/GP-2.5a kanıtı:
+12. GP-2.5/GP-2.5a kanıtı:
    - preflight smoke: `overall_status=pass`
    - live-write guard smoke: `overall_status=blocked`,
      finding `gh_pr_live_write_same_head_base`
    - sandbox live-write smoke: `overall_status=pass`,
      PR `https://github.com/Halildeu/ao-kernel-sandbox/pull/1`,
      final state `CLOSED`, remote head cleanup verified
-12. Stable live iddiası geçerlidir: `pip install ao-kernel` ve exact pin
+13. Stable live iddiası geçerlidir: `pip install ao-kernel` ve exact pin
    `ao-kernel==4.0.0` fresh venv içinde `4.0.0` kurmuştur.
-13. Stable support boundary unchanged kalır; `gh-cli-pr` full remote PR opening
+14. Stable support boundary unchanged kalır; `gh-cli-pr` full remote PR opening
    hâlâ Deferred support yüzeyidir.
 
 `PB-8.2` completion kaydı:
@@ -812,3 +817,22 @@ doğruluğu tazelendi.
    - targeted tests: `3 passed`, `1 skipped`
 7. SM-3 fixed:
    - stale historical `ST-2` wording removed from `## 5. Şimdi`
+
+## 24. SM-4 Historical Beta Pin Wording Snapshot
+
+Stable maintenance hattında `4.0.0b2` historical Public Beta pin'i korunurken
+operator-facing dil netleştirildi.
+
+1. Issue: [#384](https://github.com/Halildeu/ao-kernel/issues/384)
+2. Decision record:
+   `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`
+3. Scope:
+   - runtime değişikliği yok
+   - version bump/tag/publish yok
+   - support boundary widening yok
+4. Drift fixed:
+   - `docs/UPGRADE-NOTES.md` no longer presents `4.0.0b2` as a normal active
+     beta channel
+   - `docs/ROLLBACK.md` labels the beta rollback path as historical
+     pre-release rollback
+   - `docs/PUBLIC-BETA.md` keeps stable `4.0.0` as the default user path

--- a/.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md
+++ b/.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md
@@ -1,0 +1,47 @@
+# SM-4 — Historical Beta Pin Wording
+
+**Status:** Completed
+**Date:** 2026-04-24
+**Tracker:** [#384](https://github.com/Halildeu/ao-kernel/issues/384)
+**Parent context:** `SM-1` stable maintenance baseline + `SM-3` status
+truth cleanup
+
+## Purpose
+
+Operator-facing upgrade and rollback docs still showed the `4.0.0b2` Public
+Beta pin. The pin is intentionally retained for historical pre-release testing
+and rollback, but it must not read like the normal active install path now that
+`4.0.0` is the stable channel.
+
+## Boundary
+
+This cleanup is docs/status only.
+
+1. No runtime behavior change.
+2. No support boundary widening.
+3. No version bump, tag, or publish.
+4. No removal of historical beta install information.
+
+## Drift Fixed
+
+1. Upgrade guidance now labels `4.0.0b2` as a historical Public Beta
+   pre-release pin, not a normal active beta channel.
+2. Rollback guidance now labels the beta rollback path as historical
+   pre-release rollback.
+3. `PUBLIC-BETA.md` keeps stable `4.0.0` as the default user path and clarifies
+   that pre-release installs are intentional operator choices.
+
+## Validation
+
+1. Historical beta pin wording search:
+   `rg -n "Historical Public Beta|historical Public Beta|4.0.0b2" docs/PUBLIC-BETA.md docs/UPGRADE-NOTES.md docs/ROLLBACK.md`
+2. Targeted tests:
+   `python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py`
+3. Diff hygiene:
+   `git diff --check`
+
+## Decision
+
+Stable `4.0.0` remains the default user path. `4.0.0b2` remains available only
+as an intentional historical pre-release pin; it does not widen support and it
+does not replace the stable channel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added the `SM-3` program-status cleanup, removing stale historical `ST-2`
   wording from the living status board while keeping stable maintenance / no
   active widening as the current mode.
+- Added the `SM-4` historical beta pin wording cleanup, clarifying that
+  `4.0.0b2` is an intentional historical Public Beta pre-release path while
+  stable `4.0.0` remains the default user and rollback path.
 
 ## [4.0.0] - 2026-04-24
 

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -22,9 +22,11 @@ pip install ao-kernel==4.0.0b2
 pip install --pre ao-kernel
 ```
 
-`--pre` yalnız pre-release hattını bilinçli takip etmek için kullanılmalıdır;
-stable `4.0.0` canlı hale geldiğinde varsayılan kullanıcı yolu stable kanal
-olur.
+`4.0.0b2` historical Public Beta pre-release pin'idir. Normal kullanıcı ve
+stable rollback yolu değildir. `--pre` yalnız pre-release hattını bilinçli
+takip eden operatörler için kullanılmalıdır; gelecekte yeni pre-release varsa
+onu da seçebilir. Stable `4.0.0` canlı hale geldiğinde varsayılan kullanıcı
+yolu stable kanal olur.
 
 ## Operational References
 

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -14,11 +14,15 @@ pip install --force-reinstall ao-kernel
 `ao-kernel` stable channel pin'i dokümana sabit yazılmaz; bu komut pre-release
 flag olmadan en güncel stable hattı geri yükler.
 
-### Return to the documented beta pin
+### Return to the historical Public Beta pre-release pin
 
 ```bash
 pip install --force-reinstall ao-kernel==4.0.0b2
 ```
+
+This is not the normal stable rollback path. Use it only when intentionally
+returning an operator-managed environment to the historical Public Beta
+pre-release line. The default rollback path remains the stable channel above.
 
 After either rollback, verify:
 

--- a/docs/UPGRADE-NOTES.md
+++ b/docs/UPGRADE-NOTES.md
@@ -13,19 +13,21 @@ pip install -U ao-kernel
 pip install ao-kernel==4.0.0
 ```
 
-### Public Beta channel
+### Historical Public Beta pre-release / future pre-release testing
 
 ```bash
-pip install --pre ao-kernel
-# or pin explicitly
 pip install ao-kernel==4.0.0b2
+# or intentionally follow the latest available pre-release
+pip install --pre ao-kernel
 ```
 
 Do not assume `pip install ao-kernel` will pick a beta. It stays on the stable
-channel unless you ask for a pre-release explicitly. `v4.0.0` is live on PyPI;
-post-publish verification confirmed both `pip install ao-kernel` and
-`pip install ao-kernel==4.0.0` resolve to `ao-kernel 4.0.0` in fresh virtual
-environments.
+channel unless you ask for a pre-release explicitly. `4.0.0b2` is a historical
+Public Beta pre-release pin, not the normal production upgrade path. `--pre`
+is for intentional pre-release testing and may resolve to a newer pre-release
+if one exists later. `v4.0.0` is live on PyPI; post-publish verification
+confirmed both `pip install ao-kernel` and `pip install ao-kernel==4.0.0`
+resolve to `ao-kernel 4.0.0` in fresh virtual environments.
 
 ## 1.1 Stable support boundary
 


### PR DESCRIPTION
Closes #384.

Summary:
- Add the SM-4 historical beta pin wording record.
- Clarify `4.0.0b2` as a historical Public Beta pre-release pin, not the normal active/default install path.
- Align upgrade, rollback, Public Beta, status, and changelog wording around stable `4.0.0` as the default user/rollback path.

Boundary:
- No runtime behavior change.
- No version bump, tag, or publish.
- No support widening.
- Historical beta install information is retained.

Validation:
- `rg -n "Historical Public Beta|historical Public Beta|historical pre-release|4.0.0b2" docs/PUBLIC-BETA.md docs/UPGRADE-NOTES.md docs/ROLLBACK.md .claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md .claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md CHANGELOG.md`
- `python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py` -> 3 passed, 1 skipped
- `git diff --check`
