### PR TITLE
[codex] docs: open GP-3 adapter promotion roadmap

### DIFF
--- a/.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md
+++ b/.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md
@@ -1,0 +1,100 @@
+# GP-3 — Production-Certified Adapter Promotion Roadmap
+
+**Status:** Active program, scope freeze recorded
+**Date:** 2026-04-24
+**Tracker:** [#386](https://github.com/Halildeu/ao-kernel/issues/386)
+**Parent context:** `v4.0.0` narrow stable live + `GP-2` closeout +
+`SM-1..SM-4` stable maintenance baseline
+
+## Purpose
+
+`GP-3` is the first post-stable promotion program for moving one real adapter
+lane from `Beta (operator-managed)` toward a production-certified support
+claim.
+
+The program does not widen support by being opened. Promotion requires code
+path evidence, behavior tests, smoke, docs parity, runbook guidance, and CI
+evidence to agree.
+
+## Current Baseline
+
+1. `v4.0.0` narrow stable runtime is live.
+2. Stable shipped support remains intentionally narrow.
+3. `claude-code-cli` remains `Beta (operator-managed)`.
+4. `gh-cli-pr` remains `Beta (operator-managed)` for preflight/readiness and
+   deferred for full remote PR opening.
+5. General-purpose production platform claim remains out of scope until a
+   separate closeout decision proves enough promoted surface.
+
+## Selected First Lane
+
+`claude-code-cli` read-only governed workflow lane is the first candidate.
+
+Reason:
+
+1. it is lower risk than live-write PR creation;
+2. it already has helper smoke and governed workflow evidence history;
+3. failures can be classified without remote repository side effects;
+4. it is the shortest credible path to a production-certified real-adapter
+   claim.
+
+## Non-Goals
+
+1. No stable support widening in `GP-3.0`.
+2. No version bump, tag, or publish in `GP-3.0`.
+3. No `gh-cli-pr` full remote PR opening promotion in this lane.
+4. No general-purpose production platform claim until a later closeout gate.
+5. No promotion from one-off smoke, manifest inventory, or docs-only changes.
+
+## Slice Plan
+
+| Slice | Goal | Exit |
+|---|---|---|
+| `GP-3.0` scope freeze | Record promotion boundary, first lane, and gates | roadmap/status PR merged, no runtime change |
+| `GP-3.1` prerequisite truth refresh | Re-run `claude-code-cli` binary/auth/prompt-access truth checks | pass/fail evidence recorded; blockers mapped |
+| `GP-3.2` governed workflow repeatability | Run/read the governed workflow smoke path and pin repeatability requirements | smoke contract updated or lane remains beta |
+| `GP-3.3` failure-mode matrix | Classify missing binary, auth missing, prompt denied, timeout, malformed output, policy denied | behavior assertions or helper contract updates merged |
+| `GP-3.4` evidence completeness | Verify artifacts, events, cost/usage fields, and operator-readable failure metadata | evidence gaps closed or deferred explicitly |
+| `GP-3.5` support-boundary decision | Decide `promote_read_only`, `keep_operator_beta`, or `defer` | docs/status/support matrix updated |
+| `GP-3.6` closeout | Record final verdict and next allowed path | tracker closed or next lane opened intentionally |
+
+## Promotion Criteria
+
+A lane may become production-certified read-only only if all criteria pass.
+
+1. The adapter command is real and available through documented prerequisites.
+2. Prompt access is verified by an actual prompt smoke, not only auth status.
+3. The governed workflow completes in a clean workspace with deterministic
+   artifacts and evidence.
+4. Failure modes are fail-closed, classified, and operator-actionable.
+5. Timeout/cancel behavior is documented or explicitly bounded.
+6. Policy events and adapter invocation evidence are complete enough for audit.
+7. Docs and support boundary name the exact promoted surface.
+8. CI or an explicit release-gate smoke represents the supported path.
+
+## Demotion / No-Promotion Rules
+
+The lane stays `Beta (operator-managed)` if any of these remain true.
+
+1. Access depends on local auth state that cannot be verified repeatably.
+2. Prompt access is unavailable in the operator environment.
+3. The governed workflow smoke is flaky or requires manual interpretation.
+4. Failure metadata is not actionable.
+5. The lane cannot be tested without external side effects not covered by a
+   rollback/rehearsal contract.
+
+## Required Evidence Package
+
+Every implementation slice must record:
+
+1. command output or structured smoke report;
+2. related test command and result;
+3. docs/support-boundary impact;
+4. known-bug impact;
+5. explicit support decision.
+
+## Initial Decision
+
+`GP-3.0` opens the program but does not promote anything. The only accepted
+next implementation slice is `GP-3.1` for `claude-code-cli` prerequisite truth
+refresh.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -20,6 +20,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan stable evidence refresh:** `.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md`
 - **Son tamamlanan status truth cleanup:** `.claude/plans/SM-3-PROGRAM-STATUS-ACTIVE-SECTION-CLEANUP.md`
 - **Son tamamlanan historical beta pin wording cleanup:** `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`
+- **Aktif GP-3 promotion roadmap:** `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -63,7 +64,8 @@ ayrı ayrı görünür kılmak.
 - **SM-2 issue:** [#380](https://github.com/Halildeu/ao-kernel/issues/380) (`closed by evidence refresh PR`)
 - **SM-3 issue:** [#382](https://github.com/Halildeu/ao-kernel/issues/382) (`closed by status cleanup PR`)
 - **SM-4 issue:** [#384](https://github.com/Halildeu/ao-kernel/issues/384) (`closed by docs wording PR`)
-- **Aktif gate:** yok. SM-1 stable maintenance baseline geçerlidir; yeni support widening ancak ayrı promotion issue/contract ile açılır.
+- **GP-3 tracker issue:** [#386](https://github.com/Halildeu/ao-kernel/issues/386) (`open`)
+- **Aktif gate:** `GP-3.0` production-certified adapter promotion scope freeze. Stable support boundary unchanged kalır; promotion ancak sonraki evidence gates ile mümkündür.
 
 ## 2. Başlangıç Gerçeği
 
@@ -116,6 +118,7 @@ ayrı ayrı görünür kılmak.
 | `SM-2` stable baseline evidence refresh | Completed ([#380](https://github.com/Halildeu/ao-kernel/issues/380), evidence `.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md`) | SM-1 sonrası shipped baseline kanıtını tazelemek | entrypoints + doctor + truth inventory + wheel-installed packaging smoke + targeted tests |
 | `SM-3` program status active-section cleanup | Completed ([#382](https://github.com/Halildeu/ao-kernel/issues/382), record `.claude/plans/SM-3-PROGRAM-STATUS-ACTIVE-SECTION-CLEANUP.md`) | yaşayan status dosyasındaki stale historical `ST-2` anlatımını temizlemek | no active widening gate + historical records clearly non-active |
 | `SM-4` historical beta pin wording | Completed ([#384](https://github.com/Halildeu/ao-kernel/issues/384), record `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`) | `4.0.0b2` beta pinini aktif kanal gibi değil historical pre-release yolu gibi anlatmak | stable `4.0.0` remains default + no support widening |
+| `GP-3` production-certified adapter promotion | Active ([#386](https://github.com/Halildeu/ao-kernel/issues/386), roadmap `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`) | ilk real-adapter lane'i production-certified read-only seviyesine aday yapmak | `GP-3.0` scope freeze + `GP-3.1` prerequisite truth refresh next |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -126,24 +129,25 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — stable maintenance
+### Current mode — GP-3 promotion scope freeze
 
-Aktif runtime/support-widening slice yoktur. `SM-1` stable maintenance
-baseline geçerlidir; `SM-2` stable baseline evidence refresh son kanıt
-kaydıdır. `SM-3` ve `SM-4` yalnız yaşayan status / operator-facing docs
-wording drift'ini temizler.
+`GP-3` parent promotion programı açılmıştır. Bu, support widening değildir.
+Aktif implementation slice `GP-3.0` scope freeze'dir ve stable support
+boundary unchanged kalır. `SM-1` stable maintenance baseline ve `SM-2` stable
+baseline evidence refresh geçerlidir.
 
-Varsayılan yol:
+Mevcut yol:
 
-1. shipped baseline bugfix
-2. docs/runtime/test parity cleanup
-3. CI/package/release/rollback hygiene
-4. known-bug registry / runbook clarification
-5. evidence hygiene without widening support
+1. `GP-3.0` scope freeze / roadmap kayıt
+2. `GP-3.1` `claude-code-cli` prerequisite truth refresh
+3. `GP-3.2` governed workflow repeatability
+4. `GP-3.3` failure-mode matrix
+5. `GP-3.4` evidence completeness
+6. `GP-3.5` support-boundary decision
 
-Support widening istenirse `GP-3` gibi ayrı bir promotion programı açılır.
-Bu program başlamadan önce ayrı issue, karar notu, support-boundary diff'i,
-runtime/test/smoke kanıtı ve PR gerekir.
+Promotion sadece code path + behavior tests + smoke + docs + runbook + CI
+evidence aynı yönde ise yapılır. Aksi halde lane `Beta (operator-managed)`
+kalır.
 
 Tarihi `ST`, `PB` ve `GP` kayıtları aşağıda korunur; bunlar güncel aktif gate
 değildir.
@@ -836,3 +840,25 @@ operator-facing dil netleştirildi.
    - `docs/ROLLBACK.md` labels the beta rollback path as historical
      pre-release rollback
    - `docs/PUBLIC-BETA.md` keeps stable `4.0.0` as the default user path
+
+## 25. GP-3 Production-Certified Adapter Promotion Snapshot
+
+Stable maintenance sonrası ilk kontrollü promotion programı açıldı.
+
+1. Tracker: [#386](https://github.com/Halildeu/ao-kernel/issues/386)
+2. Roadmap:
+   `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`
+3. Initial lane:
+   - `claude-code-cli` read-only governed workflow lane
+4. Current slice:
+   - `GP-3.0` scope freeze
+5. Boundary:
+   - runtime değişikliği yok
+   - version bump/tag/publish yok
+   - stable support boundary widening yok
+6. Next implementation slice:
+   - `GP-3.1` prerequisite truth refresh
+7. Promotion rule:
+   - no promotion from one-off smoke, manifest inventory, or docs-only changes
+   - promotion requires code path, behavior tests, smoke, docs, runbook, and CI
+     evidence alignment

--- a/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
+++ b/.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md
@@ -364,11 +364,16 @@ dogrulanir.
    - doctor: `8 OK, 1 WARN, 0 FAIL`
    - packaging smoke: wheel install + `demo_review.py --cleanup` completed
    - targeted tests: `3 passed, 1 skipped`
-9. Varsayılan sıra:
-   - `Now`: stable maintenance, bugfix, and evidence hygiene
-   - `Next`: ayrı bir promotion programı açılırsa tek lane support widening
+9. `GP-3` production-certified adapter promotion programı açıldı:
+   `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`
+   - first lane: `claude-code-cli` read-only governed workflow
+   - current slice: `GP-3.0` scope freeze
+   - stable support boundary: unchanged
+10. Varsayılan sıra:
+   - `Now`: `GP-3.0` scope freeze, then `GP-3.1` prerequisite truth refresh
+   - `Next`: one-lane promotion evidence gates
    - `Later`: genel amaçlı production platform claim'i
-10. Bu roadmap stable runtime release'i tamamlanmış sayar; genel amaçlı
+11. Bu roadmap stable runtime release'i tamamlanmış sayar; genel amaçlı
    production platform claim'i için support boundary genişlememiştir. `GP-2`
    closeout ve `GP-2.5a` sandbox rehearsal support widening'i otomatik açmaz;
    ayrı promotion decision gerekir.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added the `SM-4` historical beta pin wording cleanup, clarifying that
   `4.0.0b2` is an intentional historical Public Beta pre-release path while
   stable `4.0.0` remains the default user and rollback path.
+- Opened the `GP-3` production-certified adapter promotion roadmap. The first
+  candidate lane is `claude-code-cli` read-only governed workflow, but this
+  roadmap does not widen support without later evidence gates.
 
 ## [4.0.0] - 2026-04-24
 


### PR DESCRIPTION
Refs #386.

Summary:
- Add the GP-3 production-certified adapter promotion roadmap.
- Select `claude-code-cli` read-only governed workflow as the first candidate lane.
- Update the living status board and stable-live roadmap from SM maintenance-only mode to GP-3.0 scope freeze.
- Keep stable support boundary unchanged; this PR does not promote any lane.

Boundary:
- No runtime behavior change.
- No version bump, tag, or publish.
- No support widening.
- No `gh-cli-pr` full remote PR opening promotion.

Validation:
- `rg -n "GP-3|production-certified|claude-code-cli|support widening|stable support boundary|GP-3\\.1|one-off smoke" .claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md .claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md .claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md CHANGELOG.md`
- `python3 -m pytest -q tests/test_cli_entrypoints.py tests/test_doctor_cmd.py tests/test_claude_code_cli_smoke.py` -> 15 passed, 1 skipped
- `git diff --check`
