### PR TITLE
[codex] docs: record GP-3.1 claude prereq truth

### DIFF
--- a/.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md
+++ b/.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md
@@ -1,6 +1,6 @@
 # GP-3 — Production-Certified Adapter Promotion Roadmap
 
-**Status:** Active program, scope freeze recorded
+**Status:** Active program, GP-3.1 prerequisite truth refresh recorded
 **Date:** 2026-04-24
 **Tracker:** [#386](https://github.com/Halildeu/ao-kernel/issues/386)
 **Parent context:** `v4.0.0` narrow stable live + `GP-2` closeout +
@@ -50,9 +50,9 @@ Reason:
 
 | Slice | Goal | Exit |
 |---|---|---|
-| `GP-3.0` scope freeze | Record promotion boundary, first lane, and gates | roadmap/status PR merged, no runtime change |
-| `GP-3.1` prerequisite truth refresh | Re-run `claude-code-cli` binary/auth/prompt-access truth checks | pass/fail evidence recorded; blockers mapped |
-| `GP-3.2` governed workflow repeatability | Run/read the governed workflow smoke path and pin repeatability requirements | smoke contract updated or lane remains beta |
+| `GP-3.0` scope freeze | Record promotion boundary, first lane, and gates | completed; roadmap/status PR merged, no runtime change |
+| `GP-3.1` prerequisite truth refresh | Re-run `claude-code-cli` binary/auth/prompt-access truth checks | completed on branch; preflight and workflow smoke passed; no support widening |
+| `GP-3.2` governed workflow repeatability | Run/read the governed workflow smoke path and pin repeatability requirements | next; smoke contract updated or lane remains beta |
 | `GP-3.3` failure-mode matrix | Classify missing binary, auth missing, prompt denied, timeout, malformed output, policy denied | behavior assertions or helper contract updates merged |
 | `GP-3.4` evidence completeness | Verify artifacts, events, cost/usage fields, and operator-readable failure metadata | evidence gaps closed or deferred explicitly |
 | `GP-3.5` support-boundary decision | Decide `promote_read_only`, `keep_operator_beta`, or `defer` | docs/status/support matrix updated |
@@ -98,3 +98,29 @@ Every implementation slice must record:
 `GP-3.0` opens the program but does not promote anything. The only accepted
 next implementation slice is `GP-3.1` for `claude-code-cli` prerequisite truth
 refresh.
+
+## GP-3.1 Evidence Refresh
+
+`GP-3.1` refreshed the current operator-environment truth for
+`claude-code-cli`.
+
+1. Decision record:
+   `.claude/plans/GP-3.1-CLAUDE-CODE-CLI-PREREQUISITE-TRUTH-REFRESH.md`
+2. Tracker: [#388](https://github.com/Halildeu/ao-kernel/issues/388)
+3. Preflight command:
+   `python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 30`
+4. Workflow command:
+   `python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup`
+5. Result:
+   - preflight `overall_status="pass"`
+   - workflow `overall_status="pass"`
+   - workflow final state `completed`
+6. Boundary:
+   - no runtime change
+   - no version bump, tag, or publish
+   - no stable support widening
+   - `claude-code-cli` remains `Beta (operator-managed)`
+
+The next accepted implementation slice is `GP-3.2` governed workflow
+repeatability. A single passing smoke is not enough for production-certified
+support.

--- a/.claude/plans/GP-3.1-CLAUDE-CODE-CLI-PREREQUISITE-TRUTH-REFRESH.md
+++ b/.claude/plans/GP-3.1-CLAUDE-CODE-CLI-PREREQUISITE-TRUTH-REFRESH.md
@@ -1,0 +1,90 @@
+# GP-3.1 — Claude Code CLI Prerequisite Truth Refresh
+
+**Status:** Completed on branch, pending PR merge
+**Date:** 2026-04-24
+**Tracker:** [#388](https://github.com/Halildeu/ao-kernel/issues/388)
+**Parent tracker:** [#386](https://github.com/Halildeu/ao-kernel/issues/386)
+**Lane:** `claude-code-cli` read-only governed workflow
+
+## Purpose
+
+Refresh the current operator-environment truth for the `claude-code-cli` lane
+before any production-certified support claim is considered.
+
+This is not a support widening. It only answers whether the local prerequisite
+chain is currently available enough to proceed to the next evidence gate.
+
+## Scope
+
+Included:
+
+1. Claude Code binary discovery.
+2. Claude Code auth status.
+3. Real prompt access smoke.
+4. Bundled manifest invocation smoke.
+5. Governed read-only workflow smoke.
+6. Evidence/artifact materialization checks performed by the smoke helper.
+
+Excluded:
+
+1. No runtime code change.
+2. No version bump, tag, or publish.
+3. No production-certified support promotion.
+4. No `gh-cli-pr` live-write promotion.
+5. No general-purpose production platform claim.
+
+## Commands
+
+```bash
+python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 30
+python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup
+```
+
+## Live Evidence
+
+| Check | Result | Notes |
+|---|---|---|
+| preflight exit code | `0` | helper returned success |
+| preflight `overall_status` | `pass` | all prerequisite checks passed |
+| binary/version | `pass` | `claude version: 2.1.87 (Claude Code)` |
+| auth status | `pass` | logged in via `claude.ai`; API-key env fallback not present |
+| prompt access | `pass` | real `claude -p` prompt smoke passed |
+| manifest invocation | `pass` | bundled manifest smoke passed |
+| workflow exit code | `0` | helper returned success |
+| workflow `overall_status` | `pass` | governed read-only workflow smoke passed |
+| workflow id | `governed_review_claude_code_cli` | read-only governed review lane |
+| workflow run id | `01407154-b7a1-4b44-8b66-6b37a23fd02d` | temp workspace smoke run |
+| final state | `completed` | workflow reached completed state |
+| evidence events | `pass` | required events present |
+| `review_findings` artifact | `pass` | artifact materialized and schema-valid |
+| adapter log | `pass` | redacted adapter log present |
+
+The workflow smoke used `--cleanup`; the helper verified the evidence and
+artifact checks before cleaning up the temporary workspace.
+
+## Decision
+
+`claude-code-cli` prerequisites are currently available in this operator
+environment.
+
+The lane may proceed to `GP-3.2` governed workflow repeatability, but it remains
+`Beta (operator-managed)` until later gates prove repeatability, failure-mode
+behavior, evidence completeness, docs parity, runbook coverage, and support
+boundary fit.
+
+## Support Boundary Impact
+
+No support boundary widening.
+
+Current support tier remains:
+
+1. `claude-code-cli`: `Beta (operator-managed)`
+2. production-certified read-only claim: not yet granted
+3. stable shipped baseline: unchanged
+
+## Next Gate
+
+`GP-3.2` should prove repeatability instead of relying on one successful smoke.
+At minimum it should define and run a bounded repeatability contract for the
+governed read-only workflow, then record whether the lane is stable enough to
+advance to failure-mode testing.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -21,6 +21,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan status truth cleanup:** `.claude/plans/SM-3-PROGRAM-STATUS-ACTIVE-SECTION-CLEANUP.md`
 - **Son tamamlanan historical beta pin wording cleanup:** `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`
 - **Aktif GP-3 promotion roadmap:** `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`
+- **Son tamamlanan GP-3 prerequisite truth refresh:** `.claude/plans/GP-3.1-CLAUDE-CODE-CLI-PREREQUISITE-TRUTH-REFRESH.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -65,7 +66,8 @@ ayrı ayrı görünür kılmak.
 - **SM-3 issue:** [#382](https://github.com/Halildeu/ao-kernel/issues/382) (`closed by status cleanup PR`)
 - **SM-4 issue:** [#384](https://github.com/Halildeu/ao-kernel/issues/384) (`closed by docs wording PR`)
 - **GP-3 tracker issue:** [#386](https://github.com/Halildeu/ao-kernel/issues/386) (`open`)
-- **Aktif gate:** `GP-3.0` production-certified adapter promotion scope freeze. Stable support boundary unchanged kalır; promotion ancak sonraki evidence gates ile mümkündür.
+- **GP-3.1 issue:** [#388](https://github.com/Halildeu/ao-kernel/issues/388) (`open until PR merge`)
+- **Aktif gate:** `GP-3.1` `claude-code-cli` prerequisite truth refresh. Stable support boundary unchanged kalır; promotion ancak sonraki evidence gates ile mümkündür.
 
 ## 2. Başlangıç Gerçeği
 
@@ -118,7 +120,7 @@ ayrı ayrı görünür kılmak.
 | `SM-2` stable baseline evidence refresh | Completed ([#380](https://github.com/Halildeu/ao-kernel/issues/380), evidence `.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md`) | SM-1 sonrası shipped baseline kanıtını tazelemek | entrypoints + doctor + truth inventory + wheel-installed packaging smoke + targeted tests |
 | `SM-3` program status active-section cleanup | Completed ([#382](https://github.com/Halildeu/ao-kernel/issues/382), record `.claude/plans/SM-3-PROGRAM-STATUS-ACTIVE-SECTION-CLEANUP.md`) | yaşayan status dosyasındaki stale historical `ST-2` anlatımını temizlemek | no active widening gate + historical records clearly non-active |
 | `SM-4` historical beta pin wording | Completed ([#384](https://github.com/Halildeu/ao-kernel/issues/384), record `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`) | `4.0.0b2` beta pinini aktif kanal gibi değil historical pre-release yolu gibi anlatmak | stable `4.0.0` remains default + no support widening |
-| `GP-3` production-certified adapter promotion | Active ([#386](https://github.com/Halildeu/ao-kernel/issues/386), roadmap `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`) | ilk real-adapter lane'i production-certified read-only seviyesine aday yapmak | `GP-3.0` scope freeze + `GP-3.1` prerequisite truth refresh next |
+| `GP-3` production-certified adapter promotion | Active ([#386](https://github.com/Halildeu/ao-kernel/issues/386), [#388](https://github.com/Halildeu/ao-kernel/issues/388), roadmap `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`) | ilk real-adapter lane'i production-certified read-only seviyesine aday yapmak | `GP-3.1` prerequisite truth refresh recorded; `GP-3.2` repeatability next |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -129,18 +131,18 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — GP-3 promotion scope freeze
+### Current mode — GP-3 prerequisite truth refresh
 
 `GP-3` parent promotion programı açılmıştır. Bu, support widening değildir.
-Aktif implementation slice `GP-3.0` scope freeze'dir ve stable support
-boundary unchanged kalır. `SM-1` stable maintenance baseline ve `SM-2` stable
-baseline evidence refresh geçerlidir.
+Aktif implementation slice `GP-3.1` prerequisite truth refresh'tir ve stable
+support boundary unchanged kalır. `SM-1` stable maintenance baseline ve `SM-2`
+stable baseline evidence refresh geçerlidir.
 
 Mevcut yol:
 
-1. `GP-3.0` scope freeze / roadmap kayıt
-2. `GP-3.1` `claude-code-cli` prerequisite truth refresh
-3. `GP-3.2` governed workflow repeatability
+1. `GP-3.0` scope freeze / roadmap kayıt — completed
+2. `GP-3.1` `claude-code-cli` prerequisite truth refresh — current PR records pass
+3. `GP-3.2` governed workflow repeatability — next
 4. `GP-3.3` failure-mode matrix
 5. `GP-3.4` evidence completeness
 6. `GP-3.5` support-boundary decision
@@ -862,3 +864,28 @@ Stable maintenance sonrası ilk kontrollü promotion programı açıldı.
    - no promotion from one-off smoke, manifest inventory, or docs-only changes
    - promotion requires code path, behavior tests, smoke, docs, runbook, and CI
      evidence alignment
+
+## 26. GP-3.1 Claude Code CLI Prerequisite Truth Refresh Snapshot
+
+`claude-code-cli` için production-certified support promotion öncesi canlı
+prerequisite gerçeği tazelendi.
+
+1. Tracker: [#388](https://github.com/Halildeu/ao-kernel/issues/388)
+2. Decision record:
+   `.claude/plans/GP-3.1-CLAUDE-CODE-CLI-PREREQUISITE-TRUTH-REFRESH.md`
+3. Commands:
+   - `python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 30`
+   - `python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup`
+4. Results:
+   - preflight `overall_status="pass"`
+   - binary/version, auth status, prompt access and manifest invocation passed
+   - workflow `overall_status="pass"`
+   - workflow final state `completed`
+   - evidence events, `review_findings` artifact, adapter log and schema checks passed
+5. Boundary:
+   - runtime değişikliği yok
+   - version bump/tag/publish yok
+   - stable support boundary widening yok
+   - `claude-code-cli` remains `Beta (operator-managed)`
+6. Next slice:
+   - `GP-3.2` governed workflow repeatability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Opened the `GP-3` production-certified adapter promotion roadmap. The first
   candidate lane is `claude-code-cli` read-only governed workflow, but this
   roadmap does not widen support without later evidence gates.
+- Recorded the `GP-3.1` `claude-code-cli` prerequisite truth refresh. Live
+  preflight and governed workflow smoke both passed, but the lane remains
+  `Beta (operator-managed)` until repeatability, failure-mode, evidence,
+  runbook, docs, and support-boundary gates close.
 
 ## [4.0.0] - 2026-04-24
 


### PR DESCRIPTION
## Summary

Records the `GP-3.1` prerequisite truth refresh for the `claude-code-cli` read-only governed workflow lane.

This PR does not widen the stable support boundary. It records the live prerequisite evidence needed before moving to the next GP-3 gate.

## Evidence captured

- `python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 30`
  - `overall_status="pass"`
  - binary/version passed: `claude version: 2.1.87 (Claude Code)`
  - auth status passed through `claude.ai`
  - prompt access passed through a real `claude -p` smoke
  - bundled manifest invocation passed
- `python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup`
  - `overall_status="pass"`
  - workflow final state `completed`
  - evidence events present
  - `review_findings` artifact materialized and schema-valid
  - redacted adapter log present

## Changes

- Adds `.claude/plans/GP-3.1-CLAUDE-CODE-CLI-PREREQUISITE-TRUTH-REFRESH.md`.
- Updates the GP-3 roadmap and living status SSOT to point at GP-3.2 as the next gate.
- Adds a changelog note for the evidence refresh.

## Boundary

- No runtime code change.
- No version bump, tag, or publish.
- No production-certified support promotion.
- `claude-code-cli` remains `Beta (operator-managed)` until repeatability, failure-mode, evidence, runbook, docs, and support-boundary gates close.

## Validation

- `python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 30`
- `python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup`
- `python3 -m pytest -q tests/test_claude_code_cli_smoke.py tests/test_cli_entrypoints.py tests/test_doctor_cmd.py`
- `python3 -m ao_kernel doctor`
- `git diff --check`

Refs #386.
Closes #388.
