### PR TITLE
[codex] docs: record GP-3.2 claude repeatability

### DIFF
--- a/.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md
+++ b/.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md
@@ -1,6 +1,6 @@
 # GP-3 — Production-Certified Adapter Promotion Roadmap
 
-**Status:** Active program, GP-3.1 prerequisite truth refresh recorded
+**Status:** Active program, GP-3.2 governed workflow repeatability recorded
 **Date:** 2026-04-24
 **Tracker:** [#386](https://github.com/Halildeu/ao-kernel/issues/386)
 **Parent context:** `v4.0.0` narrow stable live + `GP-2` closeout +
@@ -51,9 +51,9 @@ Reason:
 | Slice | Goal | Exit |
 |---|---|---|
 | `GP-3.0` scope freeze | Record promotion boundary, first lane, and gates | completed; roadmap/status PR merged, no runtime change |
-| `GP-3.1` prerequisite truth refresh | Re-run `claude-code-cli` binary/auth/prompt-access truth checks | completed on branch; preflight and workflow smoke passed; no support widening |
-| `GP-3.2` governed workflow repeatability | Run/read the governed workflow smoke path and pin repeatability requirements | next; smoke contract updated or lane remains beta |
-| `GP-3.3` failure-mode matrix | Classify missing binary, auth missing, prompt denied, timeout, malformed output, policy denied | behavior assertions or helper contract updates merged |
+| `GP-3.1` prerequisite truth refresh | Re-run `claude-code-cli` binary/auth/prompt-access truth checks | completed; preflight and workflow smoke passed; no support widening |
+| `GP-3.2` governed workflow repeatability | Run/read the governed workflow smoke path and pin repeatability requirements | completed on branch; 3 independent workflow smoke runs passed; no support widening |
+| `GP-3.3` failure-mode matrix | Classify missing binary, auth missing, prompt denied, timeout, malformed output, policy denied | next; behavior assertions or helper contract updates merged |
 | `GP-3.4` evidence completeness | Verify artifacts, events, cost/usage fields, and operator-readable failure metadata | evidence gaps closed or deferred explicitly |
 | `GP-3.5` support-boundary decision | Decide `promote_read_only`, `keep_operator_beta`, or `defer` | docs/status/support matrix updated |
 | `GP-3.6` closeout | Record final verdict and next allowed path | tracker closed or next lane opened intentionally |
@@ -124,3 +124,32 @@ refresh.
 The next accepted implementation slice is `GP-3.2` governed workflow
 repeatability. A single passing smoke is not enough for production-certified
 support.
+
+## GP-3.2 Repeatability Evidence
+
+`GP-3.2` checked whether the `claude-code-cli` governed read-only workflow can
+repeat successfully in independent temp workspaces.
+
+1. Decision record:
+   `.claude/plans/GP-3.2-CLAUDE-CODE-CLI-GOVERNED-WORKFLOW-REPEATABILITY.md`
+2. Tracker: [#390](https://github.com/Halildeu/ao-kernel/issues/390)
+3. Command:
+   `python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup`
+4. Repetition:
+   - run 1: `overall_status="pass"`, final state `completed`
+   - run 2: `overall_status="pass"`, final state `completed`
+   - run 3: `overall_status="pass"`, final state `completed`
+5. Required checks:
+   - `final_state`
+   - `evidence_events`
+   - `review_findings_artifact`
+   - `adapter_log`
+   - `review_findings_schema`
+6. Boundary:
+   - no runtime change
+   - no version bump, tag, or publish
+   - no stable support widening
+   - `claude-code-cli` remains `Beta (operator-managed)`
+
+The next accepted implementation slice is `GP-3.3` failure-mode matrix. Passing
+repeatability does not prove failure behavior or general operator support.

--- a/.claude/plans/GP-3.1-CLAUDE-CODE-CLI-PREREQUISITE-TRUTH-REFRESH.md
+++ b/.claude/plans/GP-3.1-CLAUDE-CODE-CLI-PREREQUISITE-TRUTH-REFRESH.md
@@ -1,6 +1,6 @@
 # GP-3.1 — Claude Code CLI Prerequisite Truth Refresh
 
-**Status:** Completed on branch, pending PR merge
+**Status:** Completed on `main`
 **Date:** 2026-04-24
 **Tracker:** [#388](https://github.com/Halildeu/ao-kernel/issues/388)
 **Parent tracker:** [#386](https://github.com/Halildeu/ao-kernel/issues/386)

--- a/.claude/plans/GP-3.2-CLAUDE-CODE-CLI-GOVERNED-WORKFLOW-REPEATABILITY.md
+++ b/.claude/plans/GP-3.2-CLAUDE-CODE-CLI-GOVERNED-WORKFLOW-REPEATABILITY.md
@@ -1,0 +1,101 @@
+# GP-3.2 — Claude Code CLI Governed Workflow Repeatability
+
+**Status:** Completed on branch, pending PR merge
+**Date:** 2026-04-24
+**Tracker:** [#390](https://github.com/Halildeu/ao-kernel/issues/390)
+**Parent tracker:** [#386](https://github.com/Halildeu/ao-kernel/issues/386)
+**Lane:** `claude-code-cli` read-only governed workflow
+
+## Purpose
+
+Prove that the `claude-code-cli` governed read-only workflow path is not only a
+single successful smoke. This gate checks whether repeated independent runs can
+complete with the same required evidence shape.
+
+This is still not a production-certified support claim. Repeatability is one
+required input for later failure-mode, evidence completeness, runbook, docs, CI,
+and support-boundary gates.
+
+## Scope
+
+Included:
+
+1. Three independent governed workflow smoke runs.
+2. Clean temporary workspace per run.
+3. `--cleanup` enabled for each run.
+4. Preflight execution through the workflow smoke helper.
+5. Verification of final state, evidence events, `review_findings` artifact,
+   redacted adapter log, and schema validity.
+
+Excluded:
+
+1. No runtime code change.
+2. No helper contract change.
+3. No version bump, tag, or publish.
+4. No production-certified support promotion.
+5. No `gh-cli-pr` live-write promotion.
+
+## Command
+
+```bash
+for i in 1 2 3; do
+  python3 scripts/claude_code_cli_workflow_smoke.py \
+    --output json \
+    --timeout-seconds 60 \
+    --cleanup
+done
+```
+
+## Live Evidence
+
+| Run | Exit code | `overall_status` | `preflight_status` | Final state | Run id |
+|---|---:|---|---|---|---|
+| 1 | `0` | `pass` | `pass` | `completed` | `41127974-7455-4581-a2cc-cdda3f707a83` |
+| 2 | `0` | `pass` | `pass` | `completed` | `6aa8d377-8519-4579-91ef-f282b3549416` |
+| 3 | `0` | `pass` | `pass` | `completed` | `9ba81196-febd-4a53-9492-a6cbcb1a98b6` |
+
+Each run reported the same required check set:
+
+1. `final_state`: `pass`
+2. `evidence_events`: `pass`
+3. `review_findings_artifact`: `pass`
+4. `adapter_log`: `pass`
+5. `review_findings_schema`: `pass`
+
+No stderr output was produced by any run.
+
+## Decision
+
+`claude-code-cli` governed read-only workflow repeatability is sufficient to
+advance to `GP-3.3` failure-mode matrix work.
+
+This decision is narrow:
+
+1. It proves three consecutive smoke runs in this operator environment.
+2. It does not prove failure behavior.
+3. It does not prove supportability for all operators.
+4. It does not widen the stable support boundary.
+
+## Support Boundary Impact
+
+No support boundary widening.
+
+Current support tier remains:
+
+1. `claude-code-cli`: `Beta (operator-managed)`
+2. production-certified read-only claim: not yet granted
+3. stable shipped baseline: unchanged
+
+## Next Gate
+
+`GP-3.3` should classify failure modes before any promotion decision:
+
+1. missing binary
+2. auth missing
+3. prompt denied
+4. timeout
+5. malformed output
+6. policy denied
+
+The lane must remain beta if these failures are not fail-closed and
+operator-actionable.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -22,6 +22,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan historical beta pin wording cleanup:** `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`
 - **Aktif GP-3 promotion roadmap:** `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`
 - **Son tamamlanan GP-3 prerequisite truth refresh:** `.claude/plans/GP-3.1-CLAUDE-CODE-CLI-PREREQUISITE-TRUTH-REFRESH.md`
+- **Aktif GP-3 repeatability record:** `.claude/plans/GP-3.2-CLAUDE-CODE-CLI-GOVERNED-WORKFLOW-REPEATABILITY.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -66,8 +67,9 @@ ayrı ayrı görünür kılmak.
 - **SM-3 issue:** [#382](https://github.com/Halildeu/ao-kernel/issues/382) (`closed by status cleanup PR`)
 - **SM-4 issue:** [#384](https://github.com/Halildeu/ao-kernel/issues/384) (`closed by docs wording PR`)
 - **GP-3 tracker issue:** [#386](https://github.com/Halildeu/ao-kernel/issues/386) (`open`)
-- **GP-3.1 issue:** [#388](https://github.com/Halildeu/ao-kernel/issues/388) (`open until PR merge`)
-- **Aktif gate:** `GP-3.1` `claude-code-cli` prerequisite truth refresh. Stable support boundary unchanged kalır; promotion ancak sonraki evidence gates ile mümkündür.
+- **GP-3.1 issue:** [#388](https://github.com/Halildeu/ao-kernel/issues/388) (`closed`)
+- **GP-3.2 issue:** [#390](https://github.com/Halildeu/ao-kernel/issues/390) (`open until PR merge`)
+- **Aktif gate:** `GP-3.2` `claude-code-cli` governed workflow repeatability. Stable support boundary unchanged kalır; promotion ancak sonraki evidence gates ile mümkündür.
 
 ## 2. Başlangıç Gerçeği
 
@@ -120,7 +122,7 @@ ayrı ayrı görünür kılmak.
 | `SM-2` stable baseline evidence refresh | Completed ([#380](https://github.com/Halildeu/ao-kernel/issues/380), evidence `.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md`) | SM-1 sonrası shipped baseline kanıtını tazelemek | entrypoints + doctor + truth inventory + wheel-installed packaging smoke + targeted tests |
 | `SM-3` program status active-section cleanup | Completed ([#382](https://github.com/Halildeu/ao-kernel/issues/382), record `.claude/plans/SM-3-PROGRAM-STATUS-ACTIVE-SECTION-CLEANUP.md`) | yaşayan status dosyasındaki stale historical `ST-2` anlatımını temizlemek | no active widening gate + historical records clearly non-active |
 | `SM-4` historical beta pin wording | Completed ([#384](https://github.com/Halildeu/ao-kernel/issues/384), record `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`) | `4.0.0b2` beta pinini aktif kanal gibi değil historical pre-release yolu gibi anlatmak | stable `4.0.0` remains default + no support widening |
-| `GP-3` production-certified adapter promotion | Active ([#386](https://github.com/Halildeu/ao-kernel/issues/386), [#388](https://github.com/Halildeu/ao-kernel/issues/388), roadmap `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`) | ilk real-adapter lane'i production-certified read-only seviyesine aday yapmak | `GP-3.1` prerequisite truth refresh recorded; `GP-3.2` repeatability next |
+| `GP-3` production-certified adapter promotion | Active ([#386](https://github.com/Halildeu/ao-kernel/issues/386), [#388](https://github.com/Halildeu/ao-kernel/issues/388), [#390](https://github.com/Halildeu/ao-kernel/issues/390), roadmap `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`) | ilk real-adapter lane'i production-certified read-only seviyesine aday yapmak | `GP-3.2` repeatability recorded; `GP-3.3` failure-mode matrix next |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -131,19 +133,19 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — GP-3 prerequisite truth refresh
+### Current mode — GP-3 governed workflow repeatability
 
 `GP-3` parent promotion programı açılmıştır. Bu, support widening değildir.
-Aktif implementation slice `GP-3.1` prerequisite truth refresh'tir ve stable
-support boundary unchanged kalır. `SM-1` stable maintenance baseline ve `SM-2`
-stable baseline evidence refresh geçerlidir.
+Aktif implementation slice `GP-3.2` governed workflow repeatability'dir ve
+stable support boundary unchanged kalır. `SM-1` stable maintenance baseline ve
+`SM-2` stable baseline evidence refresh geçerlidir.
 
 Mevcut yol:
 
 1. `GP-3.0` scope freeze / roadmap kayıt — completed
-2. `GP-3.1` `claude-code-cli` prerequisite truth refresh — current PR records pass
-3. `GP-3.2` governed workflow repeatability — next
-4. `GP-3.3` failure-mode matrix
+2. `GP-3.1` `claude-code-cli` prerequisite truth refresh — completed
+3. `GP-3.2` governed workflow repeatability — current PR records 3-pass evidence
+4. `GP-3.3` failure-mode matrix — next
 5. `GP-3.4` evidence completeness
 6. `GP-3.5` support-boundary decision
 
@@ -889,3 +891,34 @@ prerequisite gerçeği tazelendi.
    - `claude-code-cli` remains `Beta (operator-managed)`
 6. Next slice:
    - `GP-3.2` governed workflow repeatability
+
+## 27. GP-3.2 Claude Code CLI Governed Workflow Repeatability Snapshot
+
+`claude-code-cli` governed read-only workflow için tek başarılı smoke yerine
+tekrarlanabilirlik kanıtı üretildi.
+
+1. Tracker: [#390](https://github.com/Halildeu/ao-kernel/issues/390)
+2. Decision record:
+   `.claude/plans/GP-3.2-CLAUDE-CODE-CLI-GOVERNED-WORKFLOW-REPEATABILITY.md`
+3. Command:
+   - `python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup`
+4. Repetition:
+   - run 1: `overall_status="pass"`, `preflight_status="pass"`,
+     final state `completed`
+   - run 2: `overall_status="pass"`, `preflight_status="pass"`,
+     final state `completed`
+   - run 3: `overall_status="pass"`, `preflight_status="pass"`,
+     final state `completed`
+5. Required checks passed in every run:
+   - `final_state`
+   - `evidence_events`
+   - `review_findings_artifact`
+   - `adapter_log`
+   - `review_findings_schema`
+6. Boundary:
+   - runtime değişikliği yok
+   - version bump/tag/publish yok
+   - stable support boundary widening yok
+   - `claude-code-cli` remains `Beta (operator-managed)`
+7. Next slice:
+   - `GP-3.3` failure-mode matrix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   preflight and governed workflow smoke both passed, but the lane remains
   `Beta (operator-managed)` until repeatability, failure-mode, evidence,
   runbook, docs, and support-boundary gates close.
+- Recorded the `GP-3.2` `claude-code-cli` governed workflow repeatability
+  evidence: three independent read-only workflow smoke runs passed with
+  `completed` final state, required evidence events, `review_findings`
+  artifact, redacted adapter log, and schema validation. This does not widen
+  support; failure-mode classification remains next.
 
 ## [4.0.0] - 2026-04-24
 


### PR DESCRIPTION
## Summary

Records `GP-3.2` repeatability evidence for the `claude-code-cli` read-only governed workflow lane.

This PR does not widen support. It proves that the governed workflow smoke passed three independent runs in the current operator environment, then moves the next GP-3 gate to failure-mode classification.

## Evidence captured

Command repeated three times:

```bash
python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup
```

Results:

- run 1: `overall_status="pass"`, `preflight_status="pass"`, final state `completed`, run id `41127974-7455-4581-a2cc-cdda3f707a83`
- run 2: `overall_status="pass"`, `preflight_status="pass"`, final state `completed`, run id `6aa8d377-8519-4579-91ef-f282b3549416`
- run 3: `overall_status="pass"`, `preflight_status="pass"`, final state `completed`, run id `9ba81196-febd-4a53-9492-a6cbcb1a98b6`

Every run passed the required check set:

- `final_state`
- `evidence_events`
- `review_findings_artifact`
- `adapter_log`
- `review_findings_schema`

## Changes

- Adds `.claude/plans/GP-3.2-CLAUDE-CODE-CLI-GOVERNED-WORKFLOW-REPEATABILITY.md`.
- Updates the GP-3 roadmap and living status SSOT to mark GP-3.2 as recorded and GP-3.3 as next.
- Corrects the GP-3.1 record status now that it is on `main`.
- Adds a changelog note for the repeatability evidence.

## Boundary

- No runtime code change.
- No version bump, tag, or publish.
- No production-certified support promotion.
- `claude-code-cli` remains `Beta (operator-managed)`.
- Next gate is `GP-3.3` failure-mode matrix.

## Validation

- `python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup` x3
- `python3 -m pytest -q tests/test_claude_code_cli_smoke.py tests/test_cli_entrypoints.py tests/test_doctor_cmd.py`
- `python3 -m ao_kernel doctor`
- `git diff --check`

Refs #386.
Closes #390.
