### PR TITLE
[codex] test: record GP-3.3 claude failure matrix

### DIFF
--- a/.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md
+++ b/.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md
@@ -1,6 +1,6 @@
 # GP-3 — Production-Certified Adapter Promotion Roadmap
 
-**Status:** Active program, GP-3.2 governed workflow repeatability recorded
+**Status:** Active program, GP-3.3 failure-mode matrix recorded
 **Date:** 2026-04-24
 **Tracker:** [#386](https://github.com/Halildeu/ao-kernel/issues/386)
 **Parent context:** `v4.0.0` narrow stable live + `GP-2` closeout +
@@ -52,9 +52,9 @@ Reason:
 |---|---|---|
 | `GP-3.0` scope freeze | Record promotion boundary, first lane, and gates | completed; roadmap/status PR merged, no runtime change |
 | `GP-3.1` prerequisite truth refresh | Re-run `claude-code-cli` binary/auth/prompt-access truth checks | completed; preflight and workflow smoke passed; no support widening |
-| `GP-3.2` governed workflow repeatability | Run/read the governed workflow smoke path and pin repeatability requirements | completed on branch; 3 independent workflow smoke runs passed; no support widening |
-| `GP-3.3` failure-mode matrix | Classify missing binary, auth missing, prompt denied, timeout, malformed output, policy denied | next; behavior assertions or helper contract updates merged |
-| `GP-3.4` evidence completeness | Verify artifacts, events, cost/usage fields, and operator-readable failure metadata | evidence gaps closed or deferred explicitly |
+| `GP-3.2` governed workflow repeatability | Run/read the governed workflow smoke path and pin repeatability requirements | completed; 3 independent workflow smoke runs passed; no support widening |
+| `GP-3.3` failure-mode matrix | Classify missing binary, auth missing, prompt denied, timeout, malformed output, policy denied | completed on branch; helper/workflow failure modes fail-closed and typed |
+| `GP-3.4` evidence completeness | Verify artifacts, events, cost/usage fields, and operator-readable failure metadata | next; evidence gaps closed or deferred explicitly |
 | `GP-3.5` support-boundary decision | Decide `promote_read_only`, `keep_operator_beta`, or `defer` | docs/status/support matrix updated |
 | `GP-3.6` closeout | Record final verdict and next allowed path | tracker closed or next lane opened intentionally |
 
@@ -153,3 +153,31 @@ repeat successfully in independent temp workspaces.
 
 The next accepted implementation slice is `GP-3.3` failure-mode matrix. Passing
 repeatability does not prove failure behavior or general operator support.
+
+## GP-3.3 Failure-Mode Matrix
+
+`GP-3.3` classified the `claude-code-cli` preflight and governed workflow
+failure modes that must block promotion.
+
+1. Decision record:
+   `.claude/plans/GP-3.3-CLAUDE-CODE-CLI-FAILURE-MODE-MATRIX.md`
+2. Tracker: [#392](https://github.com/Halildeu/ao-kernel/issues/392)
+3. Covered categories:
+   - missing binary
+   - auth missing or malformed
+   - prompt denied
+   - timeout
+   - malformed output
+   - policy denied
+4. Test delta:
+   - `manifest_output_missing_status`
+   - `adapter_timeout`
+5. Validation:
+   `python3 -m pytest -q tests/test_claude_code_cli_smoke.py tests/test_claude_code_cli_workflow_smoke.py`
+6. Boundary:
+   - no runtime behavior change
+   - no version bump, tag, or publish
+   - no stable support widening
+   - `claude-code-cli` remains `Beta (operator-managed)`
+
+The next accepted implementation slice is `GP-3.4` evidence completeness.

--- a/.claude/plans/GP-3.3-CLAUDE-CODE-CLI-FAILURE-MODE-MATRIX.md
+++ b/.claude/plans/GP-3.3-CLAUDE-CODE-CLI-FAILURE-MODE-MATRIX.md
@@ -1,0 +1,110 @@
+# GP-3.3 — Claude Code CLI Failure-Mode Matrix
+
+**Status:** Completed on branch, pending PR merge
+**Date:** 2026-04-24
+**Tracker:** [#392](https://github.com/Halildeu/ao-kernel/issues/392)
+**Parent tracker:** [#386](https://github.com/Halildeu/ao-kernel/issues/386)
+**Lane:** `claude-code-cli` read-only governed workflow
+
+## Purpose
+
+Classify the failure modes that must stay promotion blockers before the
+`claude-code-cli` lane can be considered for a production-certified read-only
+support claim.
+
+This gate verifies that failure cases are fail-closed, typed, and
+operator-actionable instead of silently looking like a successful smoke.
+
+## Scope
+
+Included:
+
+1. Preflight helper failure modes.
+2. Governed workflow smoke failure modes.
+3. Existing behavior-test coverage audit.
+4. Narrow missing assertion coverage for malformed manifest output and workflow
+   timeout.
+5. Operator-facing failure matrix wording.
+
+Excluded:
+
+1. No runtime behavior change.
+2. No version bump, tag, or publish.
+3. No support-boundary promotion.
+4. No CI-required live `claude-code-cli` execution.
+5. No `gh-cli-pr` live-write promotion.
+
+## Failure-Mode Contract
+
+| Mode | Stable finding code | Surface | Evidence |
+|---|---|---|---|
+| Missing binary | `claude_binary_missing` | helper preflight | `tests/test_claude_code_cli_smoke.py::test_binary_missing_blocks_and_skips_remaining_checks` |
+| Auth missing | `claude_not_logged_in` | helper preflight | `tests/test_claude_code_cli_smoke.py::test_auth_status_not_logged_in_blocks_preflight_contract` |
+| Auth status malformed | `claude_auth_status_not_json` | helper preflight | `tests/test_claude_code_cli_smoke.py::test_auth_status_non_json_blocks_preflight_contract` |
+| Prompt denied despite auth pass | `prompt_access_denied` | helper preflight | `tests/test_claude_code_cli_smoke.py::test_auth_status_pass_prompt_access_fail_blocks_preflight_contract` |
+| Invalid bearer token fallback | `prompt_access_denied` with `failure_kind=invalid_bearer_token` | helper preflight | `tests/test_claude_code_cli_smoke.py::test_invalid_bearer_token_is_classified_explicitly` |
+| Prompt timeout | `prompt_smoke_timeout` | helper preflight | `tests/test_claude_code_cli_smoke.py::test_prompt_timeout_is_reported_without_crashing` |
+| Manifest CLI contract mismatch | `manifest_cli_contract_mismatch` | helper preflight | `tests/test_claude_code_cli_smoke.py::test_manifest_contract_mismatch_is_reported` |
+| Manifest timeout | `manifest_smoke_timeout` | helper preflight | `tests/test_claude_code_cli_smoke.py::test_manifest_timeout_is_reported_without_success_promotion` |
+| Manifest non-JSON output | `manifest_output_not_json` | helper preflight | `tests/test_claude_code_cli_smoke.py::test_manifest_non_json_output_is_contract_failure` |
+| Manifest JSON missing status | `manifest_output_missing_status` | helper preflight | `tests/test_claude_code_cli_smoke.py::test_manifest_json_missing_status_is_contract_failure` |
+| Workflow malformed output | `output_parse_failed` | governed workflow smoke | `tests/test_claude_code_cli_workflow_smoke.py::test_workflow_smoke_classifies_output_parse_fail_closed` |
+| Workflow policy denied | `policy_denied` | governed workflow smoke | `tests/test_claude_code_cli_workflow_smoke.py::test_workflow_smoke_classifies_policy_denial_before_promotion` |
+| Workflow adapter non-zero exit | `adapter_non_zero_exit` | governed workflow smoke | `tests/test_claude_code_cli_workflow_smoke.py::test_workflow_smoke_classifies_adapter_non_zero_exit` |
+| Workflow adapter timeout | `adapter_timeout` | governed workflow smoke | `tests/test_claude_code_cli_workflow_smoke.py::test_workflow_smoke_classifies_adapter_timeout` |
+
+## Test Delta
+
+Three behavior assertions were added:
+
+1. `test_auth_status_non_json_blocks_preflight_contract`
+   - proves malformed auth status payloads are blocked;
+   - pins `claude_auth_status_not_json`.
+2. `test_manifest_json_missing_status_is_contract_failure`
+   - proves valid JSON with the wrong shape is still blocked;
+   - pins `manifest_output_missing_status`.
+3. `test_workflow_smoke_classifies_adapter_timeout`
+   - proves workflow-level adapter timeout is blocked;
+   - pins `adapter_timeout`.
+
+No production code change was required.
+
+## Validation
+
+```bash
+python3 -m pytest -q tests/test_claude_code_cli_smoke.py tests/test_claude_code_cli_workflow_smoke.py
+```
+
+Result:
+
+```text
+21 passed
+```
+
+## Decision
+
+The failure-mode matrix is sufficiently classified to move to `GP-3.4`
+evidence completeness.
+
+This does not mean the lane is production-certified. It only means the known
+failure categories are visible and fail-closed enough for the next gate.
+
+## Support Boundary Impact
+
+No support boundary widening.
+
+Current support tier remains:
+
+1. `claude-code-cli`: `Beta (operator-managed)`
+2. production-certified read-only claim: not yet granted
+3. stable shipped baseline: unchanged
+
+## Next Gate
+
+`GP-3.4` should verify evidence completeness:
+
+1. artifact contents and schema;
+2. event order and required event kinds;
+3. adapter log redaction;
+4. cost/usage fields or explicit non-claim;
+5. operator-readable failure metadata.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -22,7 +22,8 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan historical beta pin wording cleanup:** `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`
 - **Aktif GP-3 promotion roadmap:** `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`
 - **Son tamamlanan GP-3 prerequisite truth refresh:** `.claude/plans/GP-3.1-CLAUDE-CODE-CLI-PREREQUISITE-TRUTH-REFRESH.md`
-- **Aktif GP-3 repeatability record:** `.claude/plans/GP-3.2-CLAUDE-CODE-CLI-GOVERNED-WORKFLOW-REPEATABILITY.md`
+- **Son tamamlanan GP-3 repeatability record:** `.claude/plans/GP-3.2-CLAUDE-CODE-CLI-GOVERNED-WORKFLOW-REPEATABILITY.md`
+- **Aktif GP-3 failure-mode matrix:** `.claude/plans/GP-3.3-CLAUDE-CODE-CLI-FAILURE-MODE-MATRIX.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -68,8 +69,9 @@ ayrı ayrı görünür kılmak.
 - **SM-4 issue:** [#384](https://github.com/Halildeu/ao-kernel/issues/384) (`closed by docs wording PR`)
 - **GP-3 tracker issue:** [#386](https://github.com/Halildeu/ao-kernel/issues/386) (`open`)
 - **GP-3.1 issue:** [#388](https://github.com/Halildeu/ao-kernel/issues/388) (`closed`)
-- **GP-3.2 issue:** [#390](https://github.com/Halildeu/ao-kernel/issues/390) (`open until PR merge`)
-- **Aktif gate:** `GP-3.2` `claude-code-cli` governed workflow repeatability. Stable support boundary unchanged kalır; promotion ancak sonraki evidence gates ile mümkündür.
+- **GP-3.2 issue:** [#390](https://github.com/Halildeu/ao-kernel/issues/390) (`closed`)
+- **GP-3.3 issue:** [#392](https://github.com/Halildeu/ao-kernel/issues/392) (`open until PR merge`)
+- **Aktif gate:** `GP-3.3` `claude-code-cli` failure-mode matrix. Stable support boundary unchanged kalır; promotion ancak sonraki evidence gates ile mümkündür.
 
 ## 2. Başlangıç Gerçeği
 
@@ -122,7 +124,7 @@ ayrı ayrı görünür kılmak.
 | `SM-2` stable baseline evidence refresh | Completed ([#380](https://github.com/Halildeu/ao-kernel/issues/380), evidence `.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md`) | SM-1 sonrası shipped baseline kanıtını tazelemek | entrypoints + doctor + truth inventory + wheel-installed packaging smoke + targeted tests |
 | `SM-3` program status active-section cleanup | Completed ([#382](https://github.com/Halildeu/ao-kernel/issues/382), record `.claude/plans/SM-3-PROGRAM-STATUS-ACTIVE-SECTION-CLEANUP.md`) | yaşayan status dosyasındaki stale historical `ST-2` anlatımını temizlemek | no active widening gate + historical records clearly non-active |
 | `SM-4` historical beta pin wording | Completed ([#384](https://github.com/Halildeu/ao-kernel/issues/384), record `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`) | `4.0.0b2` beta pinini aktif kanal gibi değil historical pre-release yolu gibi anlatmak | stable `4.0.0` remains default + no support widening |
-| `GP-3` production-certified adapter promotion | Active ([#386](https://github.com/Halildeu/ao-kernel/issues/386), [#388](https://github.com/Halildeu/ao-kernel/issues/388), [#390](https://github.com/Halildeu/ao-kernel/issues/390), roadmap `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`) | ilk real-adapter lane'i production-certified read-only seviyesine aday yapmak | `GP-3.2` repeatability recorded; `GP-3.3` failure-mode matrix next |
+| `GP-3` production-certified adapter promotion | Active ([#386](https://github.com/Halildeu/ao-kernel/issues/386), [#388](https://github.com/Halildeu/ao-kernel/issues/388), [#390](https://github.com/Halildeu/ao-kernel/issues/390), [#392](https://github.com/Halildeu/ao-kernel/issues/392), roadmap `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`) | ilk real-adapter lane'i production-certified read-only seviyesine aday yapmak | `GP-3.3` failure-mode matrix recorded; `GP-3.4` evidence completeness next |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -133,20 +135,20 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — GP-3 governed workflow repeatability
+### Current mode — GP-3 failure-mode matrix
 
 `GP-3` parent promotion programı açılmıştır. Bu, support widening değildir.
-Aktif implementation slice `GP-3.2` governed workflow repeatability'dir ve
-stable support boundary unchanged kalır. `SM-1` stable maintenance baseline ve
-`SM-2` stable baseline evidence refresh geçerlidir.
+Aktif implementation slice `GP-3.3` failure-mode matrix'tir ve stable support
+boundary unchanged kalır. `SM-1` stable maintenance baseline ve `SM-2` stable
+baseline evidence refresh geçerlidir.
 
 Mevcut yol:
 
 1. `GP-3.0` scope freeze / roadmap kayıt — completed
 2. `GP-3.1` `claude-code-cli` prerequisite truth refresh — completed
-3. `GP-3.2` governed workflow repeatability — current PR records 3-pass evidence
-4. `GP-3.3` failure-mode matrix — next
-5. `GP-3.4` evidence completeness
+3. `GP-3.2` governed workflow repeatability — completed
+4. `GP-3.3` failure-mode matrix — current PR records fail-closed matrix
+5. `GP-3.4` evidence completeness — next
 6. `GP-3.5` support-boundary decision
 
 Promotion sadece code path + behavior tests + smoke + docs + runbook + CI
@@ -922,3 +924,33 @@ tekrarlanabilirlik kanıtı üretildi.
    - `claude-code-cli` remains `Beta (operator-managed)`
 7. Next slice:
    - `GP-3.3` failure-mode matrix
+
+## 28. GP-3.3 Claude Code CLI Failure-Mode Matrix Snapshot
+
+`claude-code-cli` helper ve governed workflow smoke için promotion blocker
+failure-mode matrix'i davranışsal testlerle hizalandı.
+
+1. Tracker: [#392](https://github.com/Halildeu/ao-kernel/issues/392)
+2. Decision record:
+   `.claude/plans/GP-3.3-CLAUDE-CODE-CLI-FAILURE-MODE-MATRIX.md`
+3. Covered categories:
+   - missing binary
+   - auth missing / malformed auth status
+   - prompt denied
+   - timeout
+   - malformed manifest/workflow output
+   - policy denied
+4. Added tests:
+   - `test_auth_status_non_json_blocks_preflight_contract`
+   - `test_manifest_json_missing_status_is_contract_failure`
+   - `test_workflow_smoke_classifies_adapter_timeout`
+5. Validation:
+   - `python3 -m pytest -q tests/test_claude_code_cli_smoke.py tests/test_claude_code_cli_workflow_smoke.py`
+   - result: `21 passed`
+6. Boundary:
+   - runtime behavior değişikliği yok
+   - version bump/tag/publish yok
+   - stable support boundary widening yok
+   - `claude-code-cli` remains `Beta (operator-managed)`
+7. Next slice:
+   - `GP-3.4` evidence completeness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `completed` final state, required evidence events, `review_findings`
   artifact, redacted adapter log, and schema validation. This does not widen
   support; failure-mode classification remains next.
+- Recorded the `GP-3.3` `claude-code-cli` failure-mode matrix. The helper and
+  governed workflow smoke now explicitly pin malformed auth status JSON,
+  malformed manifest JSON missing `status`, and workflow adapter timeout as
+  fail-closed promotion blockers, with operator-facing failure codes aligned in
+  the real-adapter runbook.
 
 ## [4.0.0] - 2026-04-24
 

--- a/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
+++ b/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
@@ -97,10 +97,14 @@ Aşağıdaki stable finding code'lar ise promotion blocker'dır:
 |---|---|---|
 | `claude` binary missing | `claude_binary_missing` | helper preflight |
 | `auth_status` not logged in | `claude_not_logged_in` | helper preflight |
+| `auth_status` malformed JSON | `claude_auth_status_not_json` | helper preflight |
 | `prompt_access` fail despite auth pass | `prompt_access_denied` | helper preflight |
+| prompt invocation timeout | `prompt_smoke_timeout` | helper preflight |
 | manifest invocation timeout | `manifest_smoke_timeout` | helper preflight |
 | manifest non-JSON output | `manifest_output_not_json` | helper preflight |
+| manifest JSON missing `status` | `manifest_output_missing_status` | helper preflight |
 | adapter non-zero exit | `adapter_non_zero_exit` | governed workflow smoke |
+| adapter timeout | `adapter_timeout` | governed workflow smoke |
 | malformed workflow output | `output_parse_failed` | governed workflow smoke |
 | policy deny before invocation | `policy_denied` | governed workflow smoke |
 

--- a/tests/test_claude_code_cli_smoke.py
+++ b/tests/test_claude_code_cli_smoke.py
@@ -275,6 +275,52 @@ def test_auth_status_not_logged_in_blocks_preflight_contract() -> None:
     assert auth_check["observed"]["loggedIn"] is False
 
 
+def test_auth_status_non_json_blocks_preflight_contract() -> None:
+    def runner(
+        argv: Sequence[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        cmd = tuple(argv)
+        if cmd == ("/fake/claude", "--version"):
+            return _result(cmd, stdout="2.1.87 (Claude Code)\n")
+        if cmd == ("/fake/claude", "auth", "status"):
+            return _result(cmd, stdout="not json\n")
+        if cmd == ("/fake/claude", "-p", "reply with the single token ok"):
+            return _result(cmd, stdout="ok\n")
+        if cmd[:1] == ("/fake/claude",):
+            return _result(
+                cmd,
+                stdout=json.dumps(
+                    {
+                        "status": "ok",
+                        "review_findings": {
+                            "schema_version": "1",
+                            "findings": [],
+                            "summary": "smoke ok",
+                        },
+                    }
+                ),
+            )
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_claude_code_cli_smoke(
+        which=lambda command: "/fake/claude",
+        runner=runner,
+        env={},
+    )
+
+    payload = _json_payload(report)
+
+    assert payload["overall_status"] == "blocked"
+    assert "claude_auth_status_not_json" in payload["findings"]
+    auth_check = next(
+        check for check in payload["checks"] if check["name"] == "auth_status"
+    )
+    assert auth_check["status"] == "fail"
+    assert auth_check["finding_code"] == "claude_auth_status_not_json"
+
+
 def test_prompt_access_denied_is_classified_explicitly() -> None:
     def runner(
         argv: Sequence[str],
@@ -554,6 +600,47 @@ def test_manifest_non_json_output_is_contract_failure() -> None:
         check for check in report.checks if check.name == "manifest_invocation"
     )
     assert manifest_check.finding_code == "manifest_output_not_json"
+
+
+def test_manifest_json_missing_status_is_contract_failure() -> None:
+    def runner(
+        argv: Sequence[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> CommandResult:
+        cmd = tuple(argv)
+        if cmd == ("/fake/claude", "--version"):
+            return _result(cmd, stdout="2.1.87 (Claude Code)\n")
+        if cmd == ("/fake/claude", "auth", "status"):
+            return _result(
+                cmd,
+                stdout=json.dumps(
+                    {
+                        "loggedIn": True,
+                        "authMethod": "claude.ai",
+                        "orgName": "Test Org",
+                    }
+                ),
+            )
+        if cmd == ("/fake/claude", "-p", "reply with the single token ok"):
+            return _result(cmd, stdout="ok\n")
+        if cmd[:1] == ("/fake/claude",):
+            return _result(cmd, stdout=json.dumps({"review_findings": {}}))
+        raise AssertionError(f"unexpected argv: {cmd!r}")
+
+    report = run_claude_code_cli_smoke(
+        which=lambda command: "/fake/claude",
+        runner=runner,
+        env={},
+    )
+
+    assert report.overall_status == "blocked"
+    assert "manifest_output_missing_status" in report.findings
+    manifest_check = next(
+        check for check in report.checks if check.name == "manifest_invocation"
+    )
+    assert manifest_check.finding_code == "manifest_output_missing_status"
+    assert manifest_check.observed["stdout_keys"] == ["review_findings"]
 
 
 def test_success_path_returns_pass_report() -> None:

--- a/tests/test_claude_code_cli_workflow_smoke.py
+++ b/tests/test_claude_code_cli_workflow_smoke.py
@@ -158,6 +158,37 @@ def test_workflow_smoke_classifies_adapter_non_zero_exit(
     assert report.checks[0].finding_code == "adapter_non_zero_exit"
 
 
+def test_workflow_smoke_classifies_adapter_timeout(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(workflow_smoke, "_prepare_workspace", lambda root: None)
+
+    def _fail_timeout(
+        workspace_root: Path,
+        run_id: str,
+        *,
+        timeout_seconds: float,
+    ) -> str:
+        raise AdapterInvocationFailedError(
+            reason="timeout",
+            detail=f"claude exceeded {timeout_seconds}s",
+        )
+
+    monkeypatch.setattr(workflow_smoke, "_run_workflow", _fail_timeout)
+
+    report = run_claude_code_cli_workflow_smoke(
+        skip_preflight=True,
+        workspace_root=tmp_path,
+        timeout_seconds=1.0,
+    )
+
+    assert report.overall_status == "blocked"
+    assert report.findings == ("adapter_timeout",)
+    assert report.checks[0].finding_code == "adapter_timeout"
+    assert "fail-closed" in report.checks[0].detail
+
+
 def _seed_completed_run(tmp_path: Path, *, omit_event: str | None = None) -> str:
     run_id = str(uuid.uuid4())
     create_run(


### PR DESCRIPTION
## Summary

Records `GP-3.3` failure-mode matrix evidence for the `claude-code-cli` read-only governed workflow lane.

This PR does not widen support. It classifies promotion-blocking failures and adds narrow tests for gaps found during the matrix audit.

## Changes

- Adds `.claude/plans/GP-3.3-CLAUDE-CODE-CLI-FAILURE-MODE-MATRIX.md`.
- Updates the GP-3 roadmap and living status SSOT to mark GP-3.3 as recorded and GP-3.4 as next.
- Aligns `docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md` failure-code table with the typed matrix.
- Adds behavior assertions for:
  - malformed Claude auth status JSON: `claude_auth_status_not_json`
  - manifest JSON missing `status`: `manifest_output_missing_status`
  - governed workflow adapter timeout: `adapter_timeout`

## Boundary

- No runtime behavior change.
- No version bump, tag, or publish.
- No production-certified support promotion.
- `claude-code-cli` remains `Beta (operator-managed)`.
- Next gate is `GP-3.4` evidence completeness.

## Validation

- `python3 -m pytest -q tests/test_claude_code_cli_smoke.py tests/test_claude_code_cli_workflow_smoke.py` → `21 passed`
- `python3 -m pytest -q tests/test_claude_code_cli_smoke.py tests/test_claude_code_cli_workflow_smoke.py tests/test_cli_entrypoints.py tests/test_doctor_cmd.py` → `24 passed, 1 skipped`
- `python3 -m ao_kernel doctor` → `8 OK, 1 WARN, 0 FAIL`
- `git diff --check`

Refs #386.
Closes #392.
