### PR TITLE
[codex] test: record GP-3.4 claude evidence completeness

### DIFF
--- a/.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md
+++ b/.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md
@@ -1,6 +1,6 @@
 # GP-3 — Production-Certified Adapter Promotion Roadmap
 
-**Status:** Active program, GP-3.3 failure-mode matrix recorded
+**Status:** Active program, GP-3.4 evidence completeness recorded
 **Date:** 2026-04-24
 **Tracker:** [#386](https://github.com/Halildeu/ao-kernel/issues/386)
 **Parent context:** `v4.0.0` narrow stable live + `GP-2` closeout +
@@ -53,9 +53,9 @@ Reason:
 | `GP-3.0` scope freeze | Record promotion boundary, first lane, and gates | completed; roadmap/status PR merged, no runtime change |
 | `GP-3.1` prerequisite truth refresh | Re-run `claude-code-cli` binary/auth/prompt-access truth checks | completed; preflight and workflow smoke passed; no support widening |
 | `GP-3.2` governed workflow repeatability | Run/read the governed workflow smoke path and pin repeatability requirements | completed; 3 independent workflow smoke runs passed; no support widening |
-| `GP-3.3` failure-mode matrix | Classify missing binary, auth missing, prompt denied, timeout, malformed output, policy denied | completed on branch; helper/workflow failure modes fail-closed and typed |
-| `GP-3.4` evidence completeness | Verify artifacts, events, cost/usage fields, and operator-readable failure metadata | next; evidence gaps closed or deferred explicitly |
-| `GP-3.5` support-boundary decision | Decide `promote_read_only`, `keep_operator_beta`, or `defer` | docs/status/support matrix updated |
+| `GP-3.3` failure-mode matrix | Classify missing binary, auth missing, prompt denied, timeout, malformed output, policy denied | completed; helper/workflow failure modes fail-closed and typed |
+| `GP-3.4` evidence completeness | Verify artifacts, events, cost/usage fields, and operator-readable failure metadata | completed on branch; evidence checks widened and live smoke passed |
+| `GP-3.5` support-boundary decision | Decide `promote_read_only`, `keep_operator_beta`, or `defer` | next; docs/status/support matrix updated |
 | `GP-3.6` closeout | Record final verdict and next allowed path | tracker closed or next lane opened intentionally |
 
 ## Promotion Criteria
@@ -181,3 +181,30 @@ failure modes that must block promotion.
    - `claude-code-cli` remains `Beta (operator-managed)`
 
 The next accepted implementation slice is `GP-3.4` evidence completeness.
+
+## GP-3.4 Evidence Completeness
+
+`GP-3.4` widened the `claude-code-cli` governed workflow smoke evidence checks
+and recorded a live pass.
+
+1. Decision record:
+   `.claude/plans/GP-3.4-CLAUDE-CODE-CLI-EVIDENCE-COMPLETENESS.md`
+2. Tracker: [#394](https://github.com/Halildeu/ao-kernel/issues/394)
+3. Added smoke checks:
+   - `event_order`
+   - `review_findings_contents`
+4. Added negative coverage:
+   - out-of-order required events
+   - adapter log secret-like leak
+5. Live smoke:
+   - `overall_status="pass"`
+   - final state `completed`
+   - run id `d269c4f7-78d5-4773-b609-a0891513e464`
+6. Cost/usage:
+   - explicit non-claim for adapter-path `cost_usd` / token usage completeness
+7. Boundary:
+   - no stable support widening
+   - no version bump, tag, or publish
+   - `claude-code-cli` remains `Beta (operator-managed)`
+
+The next accepted implementation slice is `GP-3.5` support-boundary decision.

--- a/.claude/plans/GP-3.4-CLAUDE-CODE-CLI-EVIDENCE-COMPLETENESS.md
+++ b/.claude/plans/GP-3.4-CLAUDE-CODE-CLI-EVIDENCE-COMPLETENESS.md
@@ -1,0 +1,142 @@
+# GP-3.4 — Claude Code CLI Evidence Completeness
+
+**Status:** Completed on branch, pending PR merge
+**Date:** 2026-04-24
+**Tracker:** [#394](https://github.com/Halildeu/ao-kernel/issues/394)
+**Parent tracker:** [#386](https://github.com/Halildeu/ao-kernel/issues/386)
+**Lane:** `claude-code-cli` read-only governed workflow
+
+## Purpose
+
+Close the evidence completeness gate for the `claude-code-cli` read-only
+governed workflow lane before any support-boundary promotion decision.
+
+This gate verifies that a successful workflow smoke carries enough audit
+surface to be useful: final state, required events, canonical event order,
+artifact materialization, artifact schema/content, adapter log presence, and
+redaction checks.
+
+## Scope
+
+Included:
+
+1. Event order verification for the canonical governed workflow sequence.
+2. Semantic `review_findings` artifact content verification.
+3. Adapter log redaction negative coverage.
+4. Live smoke proof with the widened evidence check set.
+5. Operator-facing runbook wording for the widened evidence checks.
+6. Explicit cost/usage non-claim for this lane.
+
+Excluded:
+
+1. No stable support widening.
+2. No version bump, tag, or publish.
+3. No production-certified support promotion.
+4. No CI-required live `claude-code-cli` execution.
+5. No adapter-path `cost_usd` public support claim.
+
+## Evidence Checks
+
+The governed workflow smoke now verifies this check set:
+
+| Check | Meaning | Failure code |
+|---|---|---|
+| `final_state` | workflow record reached `completed` | implicit check detail |
+| `evidence_events` | required event kinds exist | `evidence_events_missing` |
+| `event_order` | required event kinds appear in canonical order | `evidence_event_order_invalid` |
+| `review_findings_artifact` | `review_findings` capability output materialized | `review_findings_artifact_missing` |
+| `adapter_log` | adapter log exists and has no secret-like leak | `adapter_log_missing_or_unredacted` |
+| `review_findings_schema` | artifact validates against `review-findings.schema.v1.json` | `review_findings_schema_invalid` / `review_findings_artifact_not_json` |
+| `review_findings_contents` | artifact has `schema_version`, list `findings`, and non-empty `summary` | `review_findings_contents_invalid` |
+
+## Live Smoke Evidence
+
+Command:
+
+```bash
+python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup
+```
+
+Result:
+
+| Field | Value |
+|---|---|
+| exit code | `0` |
+| `overall_status` | `pass` |
+| `preflight_status` | `pass` |
+| final state | `completed` |
+| workflow id | `governed_review_claude_code_cli` |
+| run id | `d269c4f7-78d5-4773-b609-a0891513e464` |
+| adapter log records | `1` |
+| adapter log redaction leaks | `[]` |
+| `review_findings.schema_version` | `1` |
+| `review_findings.findings_count` | `0` |
+| `review_findings.summary_present` | `true` |
+
+The helper used `--cleanup`; checks were evaluated before the temporary
+workspace was removed.
+
+## Test Delta
+
+Three behavior assertions were added:
+
+1. successful evidence verification now includes `event_order` and
+   `review_findings_contents`;
+2. out-of-order required events fail with `evidence_event_order_invalid`;
+3. adapter log secret-like output fails with
+   `adapter_log_missing_or_unredacted`.
+
+## Validation
+
+```bash
+python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup
+python3 -m pytest -q tests/test_claude_code_cli_workflow_smoke.py tests/test_claude_code_cli_smoke.py tests/test_cli_entrypoints.py tests/test_doctor_cmd.py
+python3 -m ruff check ao_kernel/real_adapter_workflow_smoke.py tests/test_claude_code_cli_workflow_smoke.py
+python3 -m ao_kernel doctor
+git diff --check
+```
+
+Results:
+
+1. workflow smoke: `overall_status="pass"`, final state `completed`;
+2. targeted tests: `26 passed, 1 skipped`;
+3. ruff: all checks passed;
+4. doctor: `8 OK, 1 WARN, 0 FAIL`;
+5. diff check: clean.
+
+## Cost / Usage Non-Claim
+
+This lane does not claim adapter-path `cost_usd` or token usage completeness.
+The governed workflow smoke records adapter/evidence correctness only.
+
+Adapter-path cost/usage public support remains outside this promotion lane and
+must not be inferred from a passing GP-3.4 smoke.
+
+## Decision
+
+The evidence completeness gate is sufficiently covered to move to `GP-3.5`
+support-boundary decision.
+
+This does not promote the lane. It only proves the current smoke evidence is
+complete enough for a promotion decision to be evaluated in the next gate.
+
+## Support Boundary Impact
+
+No support boundary widening.
+
+Current support tier remains:
+
+1. `claude-code-cli`: `Beta (operator-managed)`
+2. production-certified read-only claim: not yet granted
+3. stable shipped baseline: unchanged
+
+## Next Gate
+
+`GP-3.5` should decide one of:
+
+1. `promote_read_only`
+2. `keep_operator_beta`
+3. `defer`
+
+The decision must reconcile all previous GP-3 gates, docs/support matrix,
+runbook wording, known bugs, and CI feasibility.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -23,7 +23,8 @@ ayrı ayrı görünür kılmak.
 - **Aktif GP-3 promotion roadmap:** `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`
 - **Son tamamlanan GP-3 prerequisite truth refresh:** `.claude/plans/GP-3.1-CLAUDE-CODE-CLI-PREREQUISITE-TRUTH-REFRESH.md`
 - **Son tamamlanan GP-3 repeatability record:** `.claude/plans/GP-3.2-CLAUDE-CODE-CLI-GOVERNED-WORKFLOW-REPEATABILITY.md`
-- **Aktif GP-3 failure-mode matrix:** `.claude/plans/GP-3.3-CLAUDE-CODE-CLI-FAILURE-MODE-MATRIX.md`
+- **Son tamamlanan GP-3 failure-mode matrix:** `.claude/plans/GP-3.3-CLAUDE-CODE-CLI-FAILURE-MODE-MATRIX.md`
+- **Aktif GP-3 evidence completeness record:** `.claude/plans/GP-3.4-CLAUDE-CODE-CLI-EVIDENCE-COMPLETENESS.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -70,8 +71,9 @@ ayrı ayrı görünür kılmak.
 - **GP-3 tracker issue:** [#386](https://github.com/Halildeu/ao-kernel/issues/386) (`open`)
 - **GP-3.1 issue:** [#388](https://github.com/Halildeu/ao-kernel/issues/388) (`closed`)
 - **GP-3.2 issue:** [#390](https://github.com/Halildeu/ao-kernel/issues/390) (`closed`)
-- **GP-3.3 issue:** [#392](https://github.com/Halildeu/ao-kernel/issues/392) (`open until PR merge`)
-- **Aktif gate:** `GP-3.3` `claude-code-cli` failure-mode matrix. Stable support boundary unchanged kalır; promotion ancak sonraki evidence gates ile mümkündür.
+- **GP-3.3 issue:** [#392](https://github.com/Halildeu/ao-kernel/issues/392) (`closed`)
+- **GP-3.4 issue:** [#394](https://github.com/Halildeu/ao-kernel/issues/394) (`open until PR merge`)
+- **Aktif gate:** `GP-3.4` `claude-code-cli` evidence completeness. Stable support boundary unchanged kalır; promotion ancak sonraki support-boundary gate ile mümkündür.
 
 ## 2. Başlangıç Gerçeği
 
@@ -124,7 +126,7 @@ ayrı ayrı görünür kılmak.
 | `SM-2` stable baseline evidence refresh | Completed ([#380](https://github.com/Halildeu/ao-kernel/issues/380), evidence `.claude/plans/SM-2-STABLE-BASELINE-EVIDENCE-REFRESH.md`) | SM-1 sonrası shipped baseline kanıtını tazelemek | entrypoints + doctor + truth inventory + wheel-installed packaging smoke + targeted tests |
 | `SM-3` program status active-section cleanup | Completed ([#382](https://github.com/Halildeu/ao-kernel/issues/382), record `.claude/plans/SM-3-PROGRAM-STATUS-ACTIVE-SECTION-CLEANUP.md`) | yaşayan status dosyasındaki stale historical `ST-2` anlatımını temizlemek | no active widening gate + historical records clearly non-active |
 | `SM-4` historical beta pin wording | Completed ([#384](https://github.com/Halildeu/ao-kernel/issues/384), record `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`) | `4.0.0b2` beta pinini aktif kanal gibi değil historical pre-release yolu gibi anlatmak | stable `4.0.0` remains default + no support widening |
-| `GP-3` production-certified adapter promotion | Active ([#386](https://github.com/Halildeu/ao-kernel/issues/386), [#388](https://github.com/Halildeu/ao-kernel/issues/388), [#390](https://github.com/Halildeu/ao-kernel/issues/390), [#392](https://github.com/Halildeu/ao-kernel/issues/392), roadmap `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`) | ilk real-adapter lane'i production-certified read-only seviyesine aday yapmak | `GP-3.3` failure-mode matrix recorded; `GP-3.4` evidence completeness next |
+| `GP-3` production-certified adapter promotion | Active ([#386](https://github.com/Halildeu/ao-kernel/issues/386), [#388](https://github.com/Halildeu/ao-kernel/issues/388), [#390](https://github.com/Halildeu/ao-kernel/issues/390), [#392](https://github.com/Halildeu/ao-kernel/issues/392), [#394](https://github.com/Halildeu/ao-kernel/issues/394), roadmap `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`) | ilk real-adapter lane'i production-certified read-only seviyesine aday yapmak | `GP-3.4` evidence completeness recorded; `GP-3.5` support-boundary decision next |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -135,10 +137,10 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — GP-3 failure-mode matrix
+### Current mode — GP-3 evidence completeness
 
 `GP-3` parent promotion programı açılmıştır. Bu, support widening değildir.
-Aktif implementation slice `GP-3.3` failure-mode matrix'tir ve stable support
+Aktif implementation slice `GP-3.4` evidence completeness'tir ve stable support
 boundary unchanged kalır. `SM-1` stable maintenance baseline ve `SM-2` stable
 baseline evidence refresh geçerlidir.
 
@@ -147,9 +149,9 @@ Mevcut yol:
 1. `GP-3.0` scope freeze / roadmap kayıt — completed
 2. `GP-3.1` `claude-code-cli` prerequisite truth refresh — completed
 3. `GP-3.2` governed workflow repeatability — completed
-4. `GP-3.3` failure-mode matrix — current PR records fail-closed matrix
-5. `GP-3.4` evidence completeness — next
-6. `GP-3.5` support-boundary decision
+4. `GP-3.3` failure-mode matrix — completed
+5. `GP-3.4` evidence completeness — current PR records evidence completeness
+6. `GP-3.5` support-boundary decision — next
 
 Promotion sadece code path + behavior tests + smoke + docs + runbook + CI
 evidence aynı yönde ise yapılır. Aksi halde lane `Beta (operator-managed)`
@@ -954,3 +956,36 @@ failure-mode matrix'i davranışsal testlerle hizalandı.
    - `claude-code-cli` remains `Beta (operator-managed)`
 7. Next slice:
    - `GP-3.4` evidence completeness
+
+## 29. GP-3.4 Claude Code CLI Evidence Completeness Snapshot
+
+`claude-code-cli` governed workflow smoke için evidence completeness gate'i
+kapandı.
+
+1. Tracker: [#394](https://github.com/Halildeu/ao-kernel/issues/394)
+2. Decision record:
+   `.claude/plans/GP-3.4-CLAUDE-CODE-CLI-EVIDENCE-COMPLETENESS.md`
+3. Added smoke checks:
+   - `event_order`
+   - `review_findings_contents`
+4. Added negative tests:
+   - out-of-order required events fail with `evidence_event_order_invalid`
+   - adapter log secret-like leak fails with
+     `adapter_log_missing_or_unredacted`
+5. Live smoke:
+   - `python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup`
+   - result: `overall_status="pass"`, final state `completed`
+   - run id: `d269c4f7-78d5-4773-b609-a0891513e464`
+6. Validation:
+   - targeted tests: `26 passed, 1 skipped`
+   - ruff: all checks passed
+   - doctor: `8 OK, 1 WARN, 0 FAIL`
+7. Cost/usage:
+   - adapter-path `cost_usd` / token usage completeness is explicit non-claim
+   - no public support widening should be inferred from this gate
+8. Boundary:
+   - stable support boundary widening yok
+   - version bump/tag/publish yok
+   - `claude-code-cli` remains `Beta (operator-managed)`
+9. Next slice:
+   - `GP-3.5` support-boundary decision

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   malformed manifest JSON missing `status`, and workflow adapter timeout as
   fail-closed promotion blockers, with operator-facing failure codes aligned in
   the real-adapter runbook.
+- Recorded the `GP-3.4` `claude-code-cli` evidence completeness gate. The
+  governed workflow smoke now checks canonical event order and semantic
+  `review_findings` contents, pins adapter-log secret-like leaks as failures,
+  and keeps adapter-path `cost_usd` / token usage as an explicit non-claim.
 
 ## [4.0.0] - 2026-04-24
 

--- a/ao_kernel/real_adapter_workflow_smoke.py
+++ b/ao_kernel/real_adapter_workflow_smoke.py
@@ -181,12 +181,16 @@ def verify_claude_workflow_evidence(
     checks: list[WorkflowSmokeCheck] = [
         _check_final_state(record),
         _check_required_events(events_path, events),
+        _check_event_order(events_path, events),
     ]
     artifact_check, artifact_path = _check_review_artifact(workspace_root, run_id, record)
     checks.append(artifact_check)
     checks.append(_check_adapter_log(run_dir / f"adapter-{_ADAPTER_ID}.jsonl"))
     if artifact_path is not None:
-        checks.append(_check_schema_valid_artifact(artifact_path))
+        schema_check = _check_schema_valid_artifact(artifact_path)
+        checks.append(schema_check)
+        if schema_check.status == "pass":
+            checks.append(_check_review_artifact_contents(artifact_path))
     return tuple(checks)
 
 
@@ -373,6 +377,41 @@ def _check_required_events(
     )
 
 
+def _check_event_order(
+    events_path: Path,
+    events: Sequence[Mapping[str, Any]],
+) -> WorkflowSmokeCheck:
+    expected = [
+        "step_started",
+        "policy_checked",
+        "adapter_invoked",
+        "step_completed",
+        "workflow_completed",
+    ]
+    seen = [str(event.get("kind")) for event in events]
+    cursor = 0
+    positions: dict[str, int] = {}
+    for index, kind in enumerate(seen):
+        if cursor >= len(expected):
+            break
+        if kind == expected[cursor]:
+            positions[kind] = index
+            cursor += 1
+    status: Literal["pass", "fail"] = "pass" if cursor == len(expected) else "fail"
+    return WorkflowSmokeCheck(
+        name="event_order",
+        status=status,
+        detail=(
+            "required event order present"
+            if status == "pass"
+            else "required event order missing or out of order"
+        ),
+        finding_code=None if status == "pass" else "evidence_event_order_invalid",
+        path=str(events_path),
+        observed={"expected": expected, "seen": seen, "positions": positions},
+    )
+
+
 def _check_review_artifact(
     workspace_root: Path,
     run_id: str,
@@ -425,7 +464,16 @@ def _check_review_artifact(
 
 
 def _check_schema_valid_artifact(artifact_path: Path) -> WorkflowSmokeCheck:
-    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return WorkflowSmokeCheck(
+            name="review_findings_schema",
+            status="fail",
+            detail=f"review_findings artifact is not JSON: {exc.msg}",
+            finding_code="review_findings_artifact_not_json",
+            path=str(artifact_path),
+        )
     schema = load_default("schemas", "review-findings.schema.v1.json")
     errors = list(Draft202012Validator(schema).iter_errors(payload))
     status: Literal["pass", "fail"] = "pass" if not errors else "fail"
@@ -439,6 +487,37 @@ def _check_schema_valid_artifact(artifact_path: Path) -> WorkflowSmokeCheck:
         ),
         finding_code=None if not errors else "review_findings_schema_invalid",
         path=str(artifact_path),
+    )
+
+
+def _check_review_artifact_contents(artifact_path: Path) -> WorkflowSmokeCheck:
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    findings = payload.get("findings") if isinstance(payload, Mapping) else None
+    summary = payload.get("summary") if isinstance(payload, Mapping) else None
+    ok = (
+        isinstance(payload, Mapping)
+        and payload.get("schema_version") == "1"
+        and isinstance(findings, list)
+        and isinstance(summary, str)
+        and bool(summary.strip())
+    )
+    return WorkflowSmokeCheck(
+        name="review_findings_contents",
+        status="pass" if ok else "fail",
+        detail=(
+            "review_findings semantic fields present"
+            if ok
+            else "review_findings semantic fields missing or empty"
+        ),
+        finding_code=None if ok else "review_findings_contents_invalid",
+        path=str(artifact_path),
+        observed={
+            "schema_version": (
+                payload.get("schema_version") if isinstance(payload, Mapping) else None
+            ),
+            "findings_count": len(findings) if isinstance(findings, list) else None,
+            "summary_present": isinstance(summary, str) and bool(summary.strip()),
+        },
     )
 
 

--- a/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
+++ b/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
@@ -76,9 +76,12 @@ Bu smoke helper-level manifest probe'dan daha kapsamlıdır:
 
 1. kontrollü disposable workspace hazırlar,
 2. `governed_review_claude_code_cli` workflow'unu read-only prompt ile çalıştırır,
-3. `review_findings` artifact'inin schema-valid materialize olduğunu doğrular,
+3. `review_findings` artifact'inin materialize olduğunu, schema-valid olduğunu
+   ve `schema_version` / `findings` / `summary` semantik alanlarını taşıdığını
+   doğrular,
 4. `events.jsonl` içinde `step_started`, `policy_checked`, `adapter_invoked`,
-   `step_completed` ve terminal `workflow_completed` eventlerini arar,
+   `step_completed` ve terminal `workflow_completed` eventlerini arar ve bu
+   eventlerin canonical sırada göründüğünü doğrular,
 5. `adapter-claude-code-cli.jsonl` evidence log'unun varlığını ve temel redaction
    kontrolünü doğrular.
 

--- a/tests/test_claude_code_cli_workflow_smoke.py
+++ b/tests/test_claude_code_cli_workflow_smoke.py
@@ -45,11 +45,19 @@ def test_verify_claude_workflow_evidence_accepts_complete_success(
     assert {check.name for check in checks} == {
         "final_state",
         "evidence_events",
+        "event_order",
         "review_findings_artifact",
         "adapter_log",
         "review_findings_schema",
+        "review_findings_contents",
     }
     assert all(check.status == "pass" for check in checks)
+    contents = next(check for check in checks if check.name == "review_findings_contents")
+    assert contents.observed == {
+        "schema_version": "1",
+        "findings_count": 0,
+        "summary_present": True,
+    }
 
 
 def test_verify_claude_workflow_evidence_rejects_missing_policy_checked(
@@ -63,6 +71,49 @@ def test_verify_claude_workflow_evidence_rejects_missing_policy_checked(
     assert evidence.status == "fail"
     assert "policy_checked" in evidence.detail
     assert evidence.finding_code == "evidence_events_missing"
+
+
+def test_verify_claude_workflow_evidence_rejects_out_of_order_events(
+    tmp_path: Path,
+) -> None:
+    run_id = _seed_completed_run(
+        tmp_path,
+        event_kinds=[
+            "step_started",
+            "adapter_invoked",
+            "policy_checked",
+            "step_completed",
+            "workflow_completed",
+        ],
+    )
+
+    checks = verify_claude_workflow_evidence(tmp_path, run_id)
+    required = next(check for check in checks if check.name == "evidence_events")
+    order = next(check for check in checks if check.name == "event_order")
+
+    assert required.status == "pass"
+    assert order.status == "fail"
+    assert order.finding_code == "evidence_event_order_invalid"
+
+
+def test_verify_claude_workflow_evidence_rejects_adapter_log_secret_leak(
+    tmp_path: Path,
+) -> None:
+    run_id = _seed_completed_run(
+        tmp_path,
+        adapter_log_record={
+            "adapter_id": "claude-code-cli",
+            "stdout": "sk-ant-leaked",
+            "stderr": "",
+        },
+    )
+
+    checks = verify_claude_workflow_evidence(tmp_path, run_id)
+    adapter_log = next(check for check in checks if check.name == "adapter_log")
+
+    assert adapter_log.status == "fail"
+    assert adapter_log.finding_code == "adapter_log_missing_or_unredacted"
+    assert adapter_log.observed["redaction_leaks"] == ["sk-ant-"]
 
 
 def test_workflow_smoke_classifies_output_parse_fail_closed(
@@ -189,7 +240,14 @@ def test_workflow_smoke_classifies_adapter_timeout(
     assert "fail-closed" in report.checks[0].detail
 
 
-def _seed_completed_run(tmp_path: Path, *, omit_event: str | None = None) -> str:
+def _seed_completed_run(
+    tmp_path: Path,
+    *,
+    omit_event: str | None = None,
+    event_kinds: list[str] | None = None,
+    artifact_payload: dict[str, object] | None = None,
+    adapter_log_record: dict[str, object] | None = None,
+) -> str:
     run_id = str(uuid.uuid4())
     create_run(
         tmp_path,
@@ -209,28 +267,22 @@ def _seed_completed_run(tmp_path: Path, *, omit_event: str | None = None) -> str
     artifact_rel = "artifacts/review-findings.json"
     artifact_path = run_dir / artifact_rel
     artifact_path.parent.mkdir(parents=True, exist_ok=True)
-    artifact_path.write_text(
-        json.dumps(
-            {
-                "schema_version": "1",
-                "findings": [],
-                "summary": "synthetic smoke success",
-            }
-        ),
-        encoding="utf-8",
-    )
+    artifact_payload = artifact_payload or {
+        "schema_version": "1",
+        "findings": [],
+        "summary": "synthetic smoke success",
+    }
+    artifact_path.write_text(json.dumps(artifact_payload), encoding="utf-8")
+    adapter_log_record = adapter_log_record or {
+        "adapter_id": "claude-code-cli",
+        "stdout": "{}",
+        "stderr": "",
+    }
     (run_dir / "adapter-claude-code-cli.jsonl").write_text(
-        json.dumps(
-            {
-                "adapter_id": "claude-code-cli",
-                "stdout": "{}",
-                "stderr": "",
-            }
-        )
-        + "\n",
+        json.dumps(adapter_log_record) + "\n",
         encoding="utf-8",
     )
-    event_kinds = [
+    event_kinds = event_kinds or [
         "step_started",
         "policy_checked",
         "adapter_invoked",


### PR DESCRIPTION
## Summary

Records `GP-3.4` evidence completeness for the `claude-code-cli` read-only governed workflow lane.

This PR does not widen support. It strengthens the governed workflow smoke evidence checks and records a live pass with the expanded check set.

## Changes

- Adds `.claude/plans/GP-3.4-CLAUDE-CODE-CLI-EVIDENCE-COMPLETENESS.md`.
- Adds `event_order` evidence verification for canonical workflow event order.
- Adds `review_findings_contents` semantic artifact verification.
- Keeps schema validation and makes non-JSON artifacts fail as structured evidence checks.
- Adds negative tests for out-of-order required events and adapter-log secret-like leaks.
- Updates the real-adapter runbook, GP-3 roadmap, living status SSOT, and changelog.

## Live evidence

- `python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup`
- `overall_status="pass"`
- final state `completed`
- run id `d269c4f7-78d5-4773-b609-a0891513e464`
- `event_order` passed
- `review_findings_contents` passed
- adapter log redaction leaks `[]`

## Boundary

- No stable support widening.
- No version bump, tag, or publish.
- No production-certified support promotion.
- Adapter-path `cost_usd` / token usage completeness remains an explicit non-claim.
- `claude-code-cli` remains `Beta (operator-managed)`.
- Next gate is `GP-3.5` support-boundary decision.

## Validation

- `python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup`
- `python3 -m pytest -q tests/test_claude_code_cli_workflow_smoke.py tests/test_claude_code_cli_smoke.py tests/test_cli_entrypoints.py tests/test_doctor_cmd.py` → `26 passed, 1 skipped`
- `python3 -m ruff check ao_kernel/real_adapter_workflow_smoke.py tests/test_claude_code_cli_workflow_smoke.py`
- `python3 -m ao_kernel doctor` → `8 OK, 1 WARN, 0 FAIL`
- `git diff --check`

Refs #386.
Closes #394.
