### PR TITLE
[codex] docs: design GP-4 live adapter gate

### DIFF
--- a/.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md
+++ b/.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md
@@ -1,0 +1,135 @@
+# GP-4 — CI-Managed Live Adapter Gate Design
+
+**Status:** Active design program
+**Date:** 2026-04-24
+**Tracker:** [#400](https://github.com/Halildeu/ao-kernel/issues/400)
+**Predecessor:** `GP-3` closeout
+
+## Purpose
+
+Define the missing gate that blocked `claude-code-cli` from becoming
+production-certified in `GP-3`.
+
+`GP-3` proved that the lane is evidence-backed and operator-managed, but it did
+not prove ao-kernel-owned production support because live adapter execution was
+not managed by CI or an equivalent release gate. `GP-4` exists to design that
+gate before any future support widening is attempted.
+
+## Current Decision
+
+**Decision:** `design_only_no_widening`
+
+This slice does not:
+
+1. add CI secrets;
+2. run live external adapter calls in default CI;
+3. promote `claude-code-cli`;
+4. change runtime behavior;
+5. publish or tag a release.
+
+## Required Gate Properties
+
+A future live-adapter gate may support production-certified real-adapter claims
+only if it satisfies all properties below.
+
+| Property | Requirement |
+|---|---|
+| Controlled identity | The live adapter account/session is owned by the project or release process, not by an arbitrary local operator shell. |
+| Explicit trigger | The gate is never accidentally invoked by forks or untrusted PRs. It is scheduled, manual, protected-branch-only, or release-gate-only. |
+| Secret isolation | Secrets are scoped to the smallest workflow/environment and never exposed to pull_request from forks. |
+| Deterministic skip/block semantics | Missing credentials produce `skipped` or `blocked` with explicit finding codes, not green success. |
+| Evidence artifacts | The gate uploads machine-readable preflight and governed workflow smoke reports. |
+| Policy parity | The same policy/event/evidence assertions used by local helper smoke are checked in the gate. |
+| Cost/budget guard | The gate has timeout and cost/run-count boundaries; cost fields remain non-claim until separately reconciled. |
+| Branch protection decision | Promotion requires deciding whether the gate is a required check, release-only check, or advisory scheduled check. |
+
+## Candidate Gate Models
+
+### Model A — Required PR Check
+
+Runs on every protected-branch PR.
+
+Verdict: **not accepted now**.
+
+Reason: live external adapter credentials would need to be available to PR
+workflows. That creates unnecessary secret and cost exposure unless the gate is
+heavily restricted. It is also too expensive and brittle for routine docs/test
+changes.
+
+### Model B — Protected Manual / Scheduled Workflow
+
+Runs via `workflow_dispatch` or schedule on protected branches using a GitHub
+environment with restricted secrets.
+
+Verdict: **preferred design direction**.
+
+Reason: it can exercise the live adapter under project-managed credentials
+without exposing secrets to untrusted PRs. It can upload evidence artifacts and
+be referenced by a release or promotion decision.
+
+Minimum constraints:
+
+1. only `main` or protected release branches;
+2. only maintainers can dispatch;
+3. no fork-triggered execution;
+4. timeout lower than the local helper default unless explicitly justified;
+5. artifact upload includes preflight JSON, workflow-smoke JSON, and run
+   metadata;
+6. failure codes mirror local helper finding codes.
+
+### Model C — Release-Gate Operator Attestation
+
+Release manager runs the existing local helpers and attaches structured output
+to a release decision record.
+
+Verdict: **acceptable fallback, not enough for production-certified support by
+itself**.
+
+Reason: it is better than ad-hoc local smoke, but it still depends on local
+operator state. It can support beta confidence, not project-owned production
+certification.
+
+## Required Implementation Slices
+
+Future implementation must be split. No slice below should promote support by
+itself.
+
+| Slice | Goal | Exit |
+|---|---|---|
+| `GP-4.1` workflow design stub | Add non-secret workflow skeleton or documented manual gate contract | no live secrets, no live calls, CI-safe |
+| `GP-4.2` evidence artifact contract | Define/upload JSON report shapes for live gate | local tests validate report schema |
+| `GP-4.3` protected environment contract | Document required GitHub environment/secrets and fork safety | no repository secret values committed |
+| `GP-4.4` live rehearsal | Run protected manual gate once and record artifacts | only if project-owned credentials exist |
+| `GP-4.5` support-boundary decision | Decide promote/keep beta/defer | requires all prior slices and docs parity |
+
+## Promotion Preconditions
+
+The `claude-code-cli` lane may be reconsidered only after:
+
+1. a protected live gate exists or an explicit release-gate equivalent is
+   approved;
+2. live gate evidence includes preflight and governed workflow smoke JSON;
+3. missing credentials do not create fake green CI;
+4. the gate cannot run on untrusted forks;
+5. support docs name the exact promoted surface;
+6. `KB-001` and `KB-002` are either resolved or explicitly bounded by the new
+   gate;
+7. cost/usage support remains explicitly out of scope unless separately
+   reconciled.
+
+## Support Boundary Impact
+
+No support widening.
+
+Current tier remains:
+
+1. `claude-code-cli`: `Beta (operator-managed)`;
+2. production-certified real-adapter support: not granted;
+3. shipped stable baseline: unchanged;
+4. general-purpose production coding automation platform claim: not granted.
+
+## Next Step
+
+The next implementation slice should be `GP-4.1`: add a CI-safe manual workflow
+design stub or a narrower written workflow contract. It must not introduce live
+secrets or run live adapter calls by default.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -27,6 +27,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan GP-3 evidence completeness record:** `.claude/plans/GP-3.4-CLAUDE-CODE-CLI-EVIDENCE-COMPLETENESS.md`
 - **Son tamamlanan GP-3 support-boundary decision record:** `.claude/plans/GP-3.5-CLAUDE-CODE-CLI-SUPPORT-BOUNDARY-DECISION.md`
 - **Son tamamlanan GP-3 closeout decision:** `.claude/plans/GP-3.6-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-CLOSEOUT.md`
+- **Aktif GP-4 CI-managed live adapter gate design:** `.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -77,7 +78,8 @@ ayrı ayrı görünür kılmak.
 - **GP-3.4 issue:** [#394](https://github.com/Halildeu/ao-kernel/issues/394) (`closed`)
 - **GP-3.5 issue:** [#396](https://github.com/Halildeu/ao-kernel/issues/396) (`closed`)
 - **GP-3.6 issue:** [#398](https://github.com/Halildeu/ao-kernel/issues/398) (`closed by closeout PR`)
-- **Aktif gate:** Stable maintenance mode / no active widening gate. `GP-3` final verdict `close_keep_operator_beta`; stable support boundary unchanged kalır.
+- **GP-4 tracker issue:** [#400](https://github.com/Halildeu/ao-kernel/issues/400) (`open`)
+- **Aktif gate:** `GP-4` CI-managed live adapter gate design. Bu support widening değildir; stable support boundary unchanged kalır.
 
 ## 2. Başlangıç Gerçeği
 
@@ -131,6 +133,7 @@ ayrı ayrı görünür kılmak.
 | `SM-3` program status active-section cleanup | Completed ([#382](https://github.com/Halildeu/ao-kernel/issues/382), record `.claude/plans/SM-3-PROGRAM-STATUS-ACTIVE-SECTION-CLEANUP.md`) | yaşayan status dosyasındaki stale historical `ST-2` anlatımını temizlemek | no active widening gate + historical records clearly non-active |
 | `SM-4` historical beta pin wording | Completed ([#384](https://github.com/Halildeu/ao-kernel/issues/384), record `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`) | `4.0.0b2` beta pinini aktif kanal gibi değil historical pre-release yolu gibi anlatmak | stable `4.0.0` remains default + no support widening |
 | `GP-3` production-certified adapter promotion | Completed ([#386](https://github.com/Halildeu/ao-kernel/issues/386), [#388](https://github.com/Halildeu/ao-kernel/issues/388), [#390](https://github.com/Halildeu/ao-kernel/issues/390), [#392](https://github.com/Halildeu/ao-kernel/issues/392), [#394](https://github.com/Halildeu/ao-kernel/issues/394), [#396](https://github.com/Halildeu/ao-kernel/issues/396), [#398](https://github.com/Halildeu/ao-kernel/issues/398), roadmap `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`) | ilk real-adapter lane'i production-certified read-only seviyesine aday yapmak | final verdict `close_keep_operator_beta`; support boundary unchanged |
+| `GP-4` CI-managed live adapter gate design | Active ([#400](https://github.com/Halildeu/ao-kernel/issues/400), design `.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md`) | GP-3'te eksik kalan project-owned live-adapter gate'i support widening olmadan tasarlamak | design-only, no secrets, no live default CI call, no support widening |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -141,11 +144,12 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — Stable maintenance / no active widening
+### Current mode — GP-4 design-only live adapter gate
 
 `GP-3` parent promotion programı `close_keep_operator_beta` kararıyla
-kapanmıştır. Bu, support widening değildir. `SM-1` stable maintenance baseline
-ve `SM-2` stable baseline evidence refresh geçerlidir.
+kapanmıştır. `GP-4` şimdi CI-managed live adapter gate tasarım hattını açar.
+Bu support widening değildir; `SM-1` stable maintenance baseline ve `SM-2`
+stable baseline evidence refresh geçerlidir.
 
 Mevcut yol:
 
@@ -160,7 +164,8 @@ Mevcut yol:
 Promotion sadece code path + behavior tests + smoke + docs + runbook + CI
 evidence aynı yönde ise yapılır. `GP-3` closeout sonucunda CI-managed live
 adapter gate'i ve açık known-bug durumu yeterli olmadığı için lane
-`Beta (operator-managed)` kaldı. Aktif widening gate yoktur.
+`Beta (operator-managed)` kaldı. `GP-4`, bu eksik gate'i tasarlar; live
+secrets, default CI live call veya support promotion içermez.
 
 Tarihi `ST`, `PB` ve `GP` kayıtları aşağıda korunur; bunlar güncel aktif gate
 değildir.
@@ -1060,4 +1065,30 @@ kapandı.
    - no CI-managed live `claude-code-cli` governed workflow gate exists
    - adapter-path `cost_usd` / token usage remains explicit non-claim
 8. Next mode:
-   - stable maintenance / no active widening gate
+   - stable maintenance or a new explicit CI-managed live adapter gate design
+
+## 32. GP-4 CI-Managed Live Adapter Gate Design
+
+`GP-4` support widening değildir. `GP-3` sonucunda eksik kalan project-owned
+live adapter gate'i tasarlar.
+
+1. Tracker: [#400](https://github.com/Halildeu/ao-kernel/issues/400)
+2. Design record:
+   `.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md`
+3. Current decision:
+   - `design_only_no_widening`
+4. Preferred direction:
+   - protected manual or scheduled workflow using restricted GitHub
+     environment secrets
+   - no fork-triggered live execution
+   - machine-readable evidence artifacts
+   - missing credentials become explicit `skipped`/`blocked`, not fake green
+5. Rejected for now:
+   - required live adapter PR check on every PR
+6. Boundary:
+   - `claude-code-cli` remains `Beta (operator-managed)`
+   - no version bump/tag/publish
+   - no runtime behavior change
+   - no support widening
+7. Next slice:
+   - `GP-4.1` CI-safe manual workflow skeleton or written workflow contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   evidence-backed operator-managed beta, but no production-certified
   real-adapter support claim or general-purpose production platform claim is
   granted.
+- Opened the `GP-4` CI-managed live adapter gate design program. This records
+  the missing gate required before future real-adapter production support can
+  be reconsidered; it adds no secrets, live default CI calls, runtime changes,
+  version bump, tag, publish, or support widening.
 
 ## [4.0.0] - 2026-04-24
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -233,6 +233,9 @@ HTTP adapters must explicitly set `exposure_modes` to include `"http_header"` vi
 - Expected operator prerequisite: valid Claude Code session auth
 - This lane is not the default shipped demo; the shipped baseline remains
   bundled `review_ai_flow` + bundled `codex-stub`
+- Future production-certified support requires a protected CI-managed live
+  adapter gate or equivalent release gate. `GP-4` is a design program for that
+  missing gate, not a support widening.
 
 ### Failure modes
 

--- a/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
+++ b/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
@@ -92,6 +92,8 @@ closeout verdict'i `close_keep_operator_beta` olduğu için lane Beta
 (operator-managed) olarak kalır. Fresh smoke'ların geçmesi operator setup'ını
 doğrular; external `claude` binary/session auth, açık `KB-001`/`KB-002` ve
 CI-managed live adapter gate'i olmaması support widening'i engeller.
+`GP-4` bu eksik gate'i tasarım konusu yapar; runbook'taki lokal helper geçişi
+tek başına production-certified support değildir.
 
 ### 1.3 Failure-mode matrix
 

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -149,5 +149,9 @@ Canlı snapshot üretimi için: `python3 scripts/truth_inventory_ratchet.py --ou
 - Bu doküman, ao-kernel'in genel amaçlı bir production coding automation
   platformu olduğunu iddia etmez; destek vaadi dar ve açıkça tablolanmış
   yüzeyler içindir.
+- `GP-4` CI-managed live adapter gate tasarımı support widening değildir.
+  `claude-code-cli` production-certified support için gelecekte protected
+  manual/scheduled live gate veya eşdeğer release gate gerekir; bu dokümanda
+  shipped veya beta satırı otomatik değişmez.
 - `docs/roadmap/DEMO-SCRIPT-SPEC.md` roadmap/spec dokümanıdır; canlı
   CLI komut listesi değildir.

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -103,6 +103,8 @@ lane shipped baseline'a veya production-certified read-only tier'ına yükselmez
 Fresh preflight ve governed workflow smoke geçmiştir; promotion yine de
 reddedilmiştir çünkü external `claude` binary/session auth operatör durumudur,
 `KB-001`/`KB-002` açıktır ve live adapter gate'i CI-managed değildir.
+`GP-4` bu eksik CI-managed live adapter gate'i tasarlar, fakat tasarım kaydı
+tek başına support tier'ı yükseltmez.
 
 `gh-cli-pr` live-write probe, `PB-8.1` ile explicit precondition (opt-in,
 disposable repo, explicit `--repo` + `--head` + `--base`) ve create -> verify
@@ -144,6 +146,8 @@ The following do not, by themselves, justify a broader support claim:
 
 - a manifest file existing in `ao_kernel/defaults/`
 - a runbook describing an operator flow
+- a CI/live-gate design document without a protected implementation and
+  recorded evidence artifacts
 - a roadmap/spec document
 - a contract loader or truth-audit warning surface
 - a smoke passing only in one operator environment without the support docs


### PR DESCRIPTION
## Summary

- add the GP-4 CI-managed live adapter gate design record
- define the missing protected live-adapter gate needed before future production-certified real-adapter support can be reconsidered
- keep `claude-code-cli` at `Beta (operator-managed)` with no support widening
- align status, support boundary, adapter docs, runbook, and changelog with design-only/no-widening language

## Evidence

- `python3 scripts/claude_code_cli_smoke.py --output json --timeout-seconds 30` -> pass
- `python3 scripts/claude_code_cli_workflow_smoke.py --output json --timeout-seconds 60 --cleanup` -> pass (`final_state=completed`)
- `python3 -m pytest -q tests/test_claude_code_cli_smoke.py tests/test_claude_code_cli_workflow_smoke.py tests/test_cli_entrypoints.py tests/test_doctor_cmd.py` -> 26 passed, 1 skipped
- `python3 -m ao_kernel doctor` -> 8 OK, 1 WARN, 0 FAIL (expected extension truth inventory WARN)
- `git diff --check` -> clean

## Support boundary

No support widening. GP-4 is design-only: no secrets, no default live CI calls, no runtime behavior change, no version bump, no tag, no publish. Issue #400 remains the open GP-4 tracker.

Refs #400
