### PR TITLE
[codex] ci: add GP-4.1 live adapter gate skeleton

### DIFF
--- a/.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md
+++ b/.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md
@@ -96,7 +96,7 @@ itself.
 
 | Slice | Goal | Exit |
 |---|---|---|
-| `GP-4.1` workflow design stub | Add non-secret workflow skeleton or documented manual gate contract | no live secrets, no live calls, CI-safe |
+| `GP-4.1` workflow design stub | Add non-secret workflow skeleton or documented manual gate contract | implemented by `.github/workflows/live-adapter-gate.yml`; report remains `blocked`; no live secrets, no live calls, CI-safe |
 | `GP-4.2` evidence artifact contract | Define/upload JSON report shapes for live gate | local tests validate report schema |
 | `GP-4.3` protected environment contract | Document required GitHub environment/secrets and fork safety | no repository secret values committed |
 | `GP-4.4` live rehearsal | Run protected manual gate once and record artifacts | only if project-owned credentials exist |
@@ -128,8 +128,22 @@ Current tier remains:
 3. shipped stable baseline: unchanged;
 4. general-purpose production coding automation platform claim: not granted.
 
+## GP-4.1 Implementation
+
+`GP-4.1` adds a manual contract skeleton:
+
+1. workflow: `.github/workflows/live-adapter-gate.yml`;
+2. report builder: `ao_kernel/live_adapter_gate.py`;
+3. script wrapper: `scripts/live_adapter_gate_contract.py`;
+4. expected artifact: `live-adapter-gate-contract.v1.json`.
+
+The report intentionally says `overall_status="blocked"` and
+`finding_code="live_gate_not_implemented"`. A successful workflow run means
+the contract artifact was emitted; it does not mean the live adapter passed.
+
 ## Next Step
 
-The next implementation slice should be `GP-4.1`: add a CI-safe manual workflow
-design stub or a narrower written workflow contract. It must not introduce live
-secrets or run live adapter calls by default.
+The next implementation slice should be `GP-4.2`: define the evidence artifact
+contract for actual protected live gate outcomes. It must still avoid support
+widening until protected live evidence exists and support docs are explicitly
+updated.

--- a/.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md
+++ b/.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md
@@ -1,0 +1,80 @@
+# GP-4.1 — CI-Safe Live Adapter Gate Skeleton
+
+**Status:** Implemented slice
+**Date:** 2026-04-24
+**Tracker:** [#402](https://github.com/Halildeu/ao-kernel/issues/402)
+**Parent tracker:** [#400](https://github.com/Halildeu/ao-kernel/issues/400)
+**Program:** `GP-4` CI-managed live adapter gate design
+
+## Purpose
+
+Add the first concrete live-adapter gate surface without granting production
+support. This slice gives the repo a manual workflow and machine-readable
+artifact shape for the future gate, while intentionally avoiding live adapter
+execution.
+
+## Scope
+
+Included:
+
+1. `workflow_dispatch`-only GitHub Actions workflow:
+   `.github/workflows/live-adapter-gate.yml`.
+2. Deterministic report builder:
+   `ao_kernel/live_adapter_gate.py`.
+3. Operator wrapper:
+   `scripts/live_adapter_gate_contract.py`.
+4. Tests for report shape, script output, and workflow trigger safety.
+5. Status/docs wording that keeps support unchanged.
+
+Excluded:
+
+1. No repository or environment secrets.
+2. No `claude` binary invocation.
+3. No `claude_code_cli_smoke.py` or governed workflow smoke from CI.
+4. No live external adapter call.
+5. No support widening, version bump, tag, or publish.
+
+## Contract
+
+The workflow emits `live-adapter-gate-contract.v1.json` as an artifact. The
+current report is expected to say:
+
+| Field | Value |
+|---|---|
+| `program_id` | `GP-4.1` |
+| `adapter_id` | `claude-code-cli` |
+| `support_tier` | `Beta (operator-managed)` |
+| `overall_status` | `blocked` |
+| `finding_code` | `live_gate_not_implemented` |
+| `live_execution_attempted` | `false` |
+| `support_widening` | `false` |
+
+The GitHub Actions job may pass when it successfully emits this contract. That
+does **not** mean the live adapter passed. The artifact itself remains
+`blocked` until a later GP-4 slice implements protected live execution.
+
+## Workflow Safety
+
+The skeleton is intentionally narrow:
+
+1. trigger is `workflow_dispatch` only;
+2. `target_ref` is restricted to `main`;
+3. `adapter_lane` is restricted to `claude-code-cli`;
+4. workflow permissions are `contents: read`;
+5. no secrets are referenced;
+6. no live smoke helper is invoked.
+
+## Support Boundary Impact
+
+No support widening.
+
+`claude-code-cli` remains `Beta (operator-managed)`. Production-certified
+real-adapter support is still not granted because the gate does not yet run a
+project-owned live adapter identity and does not record live preflight or
+governed workflow smoke evidence.
+
+## Next Slice
+
+`GP-4.2` should define the evidence artifact contract for the eventual
+protected live gate, including exact JSON report fields for preflight,
+workflow-smoke, missing credential, policy, timeout, and cost/budget outcomes.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -28,6 +28,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan GP-3 support-boundary decision record:** `.claude/plans/GP-3.5-CLAUDE-CODE-CLI-SUPPORT-BOUNDARY-DECISION.md`
 - **Son tamamlanan GP-3 closeout decision:** `.claude/plans/GP-3.6-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-CLOSEOUT.md`
 - **Aktif GP-4 CI-managed live adapter gate design:** `.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md`
+- **Aktif GP-4.1 CI-safe live adapter gate skeleton:** `.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -79,7 +80,8 @@ ayrı ayrı görünür kılmak.
 - **GP-3.5 issue:** [#396](https://github.com/Halildeu/ao-kernel/issues/396) (`closed`)
 - **GP-3.6 issue:** [#398](https://github.com/Halildeu/ao-kernel/issues/398) (`closed by closeout PR`)
 - **GP-4 tracker issue:** [#400](https://github.com/Halildeu/ao-kernel/issues/400) (`open`)
-- **Aktif gate:** `GP-4` CI-managed live adapter gate design. Bu support widening değildir; stable support boundary unchanged kalır.
+- **GP-4.1 issue:** [#402](https://github.com/Halildeu/ao-kernel/issues/402) (`active`)
+- **Aktif gate:** `GP-4.1` CI-safe live adapter gate skeleton. Bu support widening değildir; stable support boundary unchanged kalır.
 
 ## 2. Başlangıç Gerçeği
 
@@ -134,6 +136,7 @@ ayrı ayrı görünür kılmak.
 | `SM-4` historical beta pin wording | Completed ([#384](https://github.com/Halildeu/ao-kernel/issues/384), record `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`) | `4.0.0b2` beta pinini aktif kanal gibi değil historical pre-release yolu gibi anlatmak | stable `4.0.0` remains default + no support widening |
 | `GP-3` production-certified adapter promotion | Completed ([#386](https://github.com/Halildeu/ao-kernel/issues/386), [#388](https://github.com/Halildeu/ao-kernel/issues/388), [#390](https://github.com/Halildeu/ao-kernel/issues/390), [#392](https://github.com/Halildeu/ao-kernel/issues/392), [#394](https://github.com/Halildeu/ao-kernel/issues/394), [#396](https://github.com/Halildeu/ao-kernel/issues/396), [#398](https://github.com/Halildeu/ao-kernel/issues/398), roadmap `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`) | ilk real-adapter lane'i production-certified read-only seviyesine aday yapmak | final verdict `close_keep_operator_beta`; support boundary unchanged |
 | `GP-4` CI-managed live adapter gate design | Active ([#400](https://github.com/Halildeu/ao-kernel/issues/400), design `.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md`) | GP-3'te eksik kalan project-owned live-adapter gate'i support widening olmadan tasarlamak | design-only, no secrets, no live default CI call, no support widening |
+| `GP-4.1` CI-safe live adapter gate skeleton | Active ([#402](https://github.com/Halildeu/ao-kernel/issues/402), record `.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md`) | workflow-dispatch-only contract artifact yüzeyini eklemek | no secrets, no live adapter execution, report `overall_status=blocked`, no support widening |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -144,10 +147,10 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — GP-4 design-only live adapter gate
+### Current mode — GP-4.1 CI-safe live adapter gate skeleton
 
 `GP-3` parent promotion programı `close_keep_operator_beta` kararıyla
-kapanmıştır. `GP-4` şimdi CI-managed live adapter gate tasarım hattını açar.
+kapanmıştır. `GP-4.1` şimdi CI-safe live adapter gate skeleton hattını yürütür.
 Bu support widening değildir; `SM-1` stable maintenance baseline ve `SM-2`
 stable baseline evidence refresh geçerlidir.
 
@@ -164,8 +167,9 @@ Mevcut yol:
 Promotion sadece code path + behavior tests + smoke + docs + runbook + CI
 evidence aynı yönde ise yapılır. `GP-3` closeout sonucunda CI-managed live
 adapter gate'i ve açık known-bug durumu yeterli olmadığı için lane
-`Beta (operator-managed)` kaldı. `GP-4`, bu eksik gate'i tasarlar; live
-secrets, default CI live call veya support promotion içermez.
+`Beta (operator-managed)` kaldı. `GP-4.1`, bu eksik gate için manual workflow
+contract skeleton'ı ekler; live secrets, default CI live call veya support
+promotion içermez.
 
 Tarihi `ST`, `PB` ve `GP` kayıtları aşağıda korunur; bunlar güncel aktif gate
 değildir.
@@ -1090,5 +1094,13 @@ live adapter gate'i tasarlar.
    - no version bump/tag/publish
    - no runtime behavior change
    - no support widening
-7. Next slice:
-   - `GP-4.1` CI-safe manual workflow skeleton or written workflow contract
+7. `GP-4.1` slice:
+   - tracker [#402](https://github.com/Halildeu/ao-kernel/issues/402)
+   - record `.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md`
+   - workflow `.github/workflows/live-adapter-gate.yml`
+   - script `scripts/live_adapter_gate_contract.py`
+   - report artifact `live-adapter-gate-contract.v1.json`
+   - expected report status `blocked` / `live_gate_not_implemented`
+   - no live adapter execution, no secret access, no support widening
+8. Next slice:
+   - `GP-4.2` evidence artifact contract for protected live gate outcomes

--- a/.github/workflows/live-adapter-gate.yml
+++ b/.github/workflows/live-adapter-gate.yml
@@ -1,0 +1,76 @@
+name: Live Adapter Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this design-only gate was dispatched"
+        required: true
+        type: string
+      target_ref:
+        description: "Protected ref to evaluate; GP-4.1 skeleton allows main only"
+        required: false
+        default: "main"
+        type: string
+      adapter_lane:
+        description: "Adapter lane under gate design"
+        required: false
+        default: "claude-code-cli"
+        type: choice
+        options:
+          - claude-code-cli
+
+permissions:
+  contents: read
+
+jobs:
+  live-adapter-gate-contract:
+    name: live-adapter-gate-contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate GP-4.1 dispatch scope
+        env:
+          TARGET_REF: ${{ inputs.target_ref }}
+          ADAPTER_LANE: ${{ inputs.adapter_lane }}
+        run: |
+          if [ "$TARGET_REF" != "main" ]; then
+            echo "::error::GP-4.1 skeleton only allows target_ref=main"
+            exit 1
+          fi
+          if [ "$ADAPTER_LANE" != "claude-code-cli" ]; then
+            echo "::error::GP-4.1 skeleton only covers claude-code-cli"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.target_ref }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Emit design-only contract report
+        env:
+          TARGET_REF: ${{ inputs.target_ref }}
+          DISPATCH_REASON: ${{ inputs.reason }}
+          REQUESTED_BY: ${{ github.actor }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          python3 scripts/live_adapter_gate_contract.py \
+            --output json \
+            --report-path live-adapter-gate-contract.v1.json \
+            --target-ref "$TARGET_REF" \
+            --reason "$DISPATCH_REASON" \
+            --requested-by "$REQUESTED_BY" \
+            --event-name "$EVENT_NAME" \
+            --head-sha "$HEAD_SHA"
+
+      - name: Upload contract artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: live-adapter-gate-contract-${{ github.run_id }}
+          path: live-adapter-gate-contract.v1.json
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   the missing gate required before future real-adapter production support can
   be reconsidered; it adds no secrets, live default CI calls, runtime changes,
   version bump, tag, publish, or support widening.
+- Added the `GP-4.1` CI-safe live adapter gate skeleton. The new manual
+  `live-adapter-gate` workflow emits a blocked
+  `live-adapter-gate-contract.v1.json` artifact and deliberately performs no
+  secret access, live adapter execution, version bump, tag, publish, or support
+  widening.
 
 ## [4.0.0] - 2026-04-24
 

--- a/ao_kernel/live_adapter_gate.py
+++ b/ao_kernel/live_adapter_gate.py
@@ -1,0 +1,156 @@
+"""CI-managed live adapter gate contract helpers.
+
+The GP-4.1 gate is intentionally a skeleton: it emits a machine-readable
+contract report but does not execute external live adapters.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal, TypedDict
+
+SCHEMA_VERSION = "1"
+PROGRAM_ID = "GP-4.1"
+GATE_ID = "ci-managed-live-adapter-gate"
+ADAPTER_ID = "claude-code-cli"
+SUPPORT_TIER = "Beta (operator-managed)"
+BLOCKED_FINDING = "live_gate_not_implemented"
+
+
+CheckStatus = Literal["pass", "blocked", "skipped"]
+OverallStatus = Literal["blocked"]
+
+
+class LiveAdapterGateTrigger(TypedDict):
+    """Dispatch metadata captured by the gate contract report."""
+
+    event_name: str
+    target_ref: str
+    head_sha: str
+    requested_by: str
+    reason: str
+
+
+class LiveAdapterGateCheck(TypedDict):
+    """Single deterministic check emitted by the GP-4.1 skeleton."""
+
+    name: str
+    status: CheckStatus
+    finding_code: str | None
+    detail: str
+
+
+class LiveAdapterGateReport(TypedDict):
+    """Machine-readable GP-4.1 live adapter gate report."""
+
+    schema_version: str
+    program_id: str
+    gate_id: str
+    adapter_id: str
+    support_tier: str
+    overall_status: OverallStatus
+    finding_code: str
+    generated_at: str
+    live_execution_attempted: bool
+    support_widening: bool
+    trigger: LiveAdapterGateTrigger
+    checks: list[LiveAdapterGateCheck]
+    findings: list[str]
+
+
+def utc_timestamp() -> str:
+    """Return a stable UTC timestamp representation for reports."""
+
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def build_live_adapter_gate_report(
+    *,
+    target_ref: str = "main",
+    reason: str = "",
+    requested_by: str = "",
+    event_name: str = "workflow_dispatch",
+    head_sha: str = "",
+    generated_at: str | None = None,
+) -> LiveAdapterGateReport:
+    """Build the GP-4.1 design-only live adapter gate report.
+
+    ``overall_status`` is deliberately ``blocked`` because this skeleton proves
+    that a live gate contract exists, not that the live adapter is certified.
+    """
+
+    timestamp = generated_at or utc_timestamp()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "program_id": PROGRAM_ID,
+        "gate_id": GATE_ID,
+        "adapter_id": ADAPTER_ID,
+        "support_tier": SUPPORT_TIER,
+        "overall_status": "blocked",
+        "finding_code": BLOCKED_FINDING,
+        "generated_at": timestamp,
+        "live_execution_attempted": False,
+        "support_widening": False,
+        "trigger": {
+            "event_name": event_name,
+            "target_ref": target_ref,
+            "head_sha": head_sha,
+            "requested_by": requested_by,
+            "reason": reason,
+        },
+        "checks": [
+            {
+                "name": "dispatch_scope",
+                "status": "pass",
+                "finding_code": None,
+                "detail": "Workflow surface is manual workflow_dispatch only.",
+            },
+            {
+                "name": "live_execution",
+                "status": "blocked",
+                "finding_code": BLOCKED_FINDING,
+                "detail": "GP-4.1 skeleton does not execute live external adapters.",
+            },
+            {
+                "name": "secret_access",
+                "status": "skipped",
+                "finding_code": "live_gate_secrets_not_configured",
+                "detail": "No repository or environment secret is read by this skeleton.",
+            },
+            {
+                "name": "support_boundary",
+                "status": "pass",
+                "finding_code": None,
+                "detail": "No support widening is granted by this report.",
+            },
+        ],
+        "findings": [BLOCKED_FINDING],
+    }
+
+
+def write_live_adapter_gate_report(path: Path, report: LiveAdapterGateReport) -> None:
+    """Write a canonical JSON report to ``path``."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def render_live_adapter_gate_text(report: LiveAdapterGateReport) -> str:
+    """Render a concise operator-facing summary for logs."""
+
+    lines = [
+        f"program_id: {report['program_id']}",
+        f"gate_id: {report['gate_id']}",
+        f"adapter_id: {report['adapter_id']}",
+        f"overall_status: {report['overall_status']}",
+        f"finding_code: {report['finding_code']}",
+        f"live_execution_attempted: {str(report['live_execution_attempted']).lower()}",
+        f"support_widening: {str(report['support_widening']).lower()}",
+        "checks:",
+    ]
+    for check in report["checks"]:
+        suffix = f" ({check['finding_code']})" if check["finding_code"] else ""
+        lines.append(f"- {check['name']}: {check['status']}{suffix}")
+    return "\n".join(lines)

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -236,6 +236,9 @@ HTTP adapters must explicitly set `exposure_modes` to include `"http_header"` vi
 - Future production-certified support requires a protected CI-managed live
   adapter gate or equivalent release gate. `GP-4` is a design program for that
   missing gate, not a support widening.
+- `GP-4.1` adds a manual `live-adapter-gate` workflow skeleton that emits a
+  blocked contract artifact only. It does not call `claude`, does not read
+  secrets, and does not promote this lane.
 
 ### Failure modes
 

--- a/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
+++ b/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
@@ -94,6 +94,9 @@ doğrular; external `claude` binary/session auth, açık `KB-001`/`KB-002` ve
 CI-managed live adapter gate'i olmaması support widening'i engeller.
 `GP-4` bu eksik gate'i tasarım konusu yapar; runbook'taki lokal helper geçişi
 tek başına production-certified support değildir.
+`GP-4.1` manual workflow skeleton'ı yalnız `live-adapter-gate-contract.v1.json`
+üretir ve artifact `overall_status="blocked"` döner; bu live benchmark veya
+real-adapter support kanıtı değildir.
 
 ### 1.3 Failure-mode matrix
 

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -42,6 +42,12 @@ python3 scripts/kernel_api_write_smoke.py --output text
 # python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --repo <owner>/<sandbox-repo> --head <branch> --base <branch> --output json --report-path /tmp/gh-cli-pr-live-write.report.json
 ```
 
+`live-adapter-gate` workflow'u (`GP-4.1`) farklı bir yüzeydir: bugün canlı
+adapter çalıştırmaz. Manual workflow yalnız `live-adapter-gate-contract.v1.json`
+artifact'i üretir ve bu artifact'in `overall_status="blocked"` /
+`finding_code="live_gate_not_implemented"` dönmesi beklenir. Workflow'un yeşil
+olması production-certified `claude-code-cli` support anlamına gelmez.
+
 Prerequisite contract (operator-managed lanes):
 
 1. `claude-code-cli` lane için `claude auth status` tek başına yeterli sinyal

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -153,5 +153,8 @@ Canlı snapshot üretimi için: `python3 scripts/truth_inventory_ratchet.py --ou
   `claude-code-cli` production-certified support için gelecekte protected
   manual/scheduled live gate veya eşdeğer release gate gerekir; bu dokümanda
   shipped veya beta satırı otomatik değişmez.
+- `GP-4.1` manual workflow skeleton'ı sadece
+  `live-adapter-gate-contract.v1.json` artifact'i üretir. Bu artifact bugün
+  `overall_status="blocked"` döner ve canlı adapter execution kanıtı değildir.
 - `docs/roadmap/DEMO-SCRIPT-SPEC.md` roadmap/spec dokümanıdır; canlı
   CLI komut listesi değildir.

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -105,6 +105,10 @@ reddedilmiştir çünkü external `claude` binary/session auth operatör durumud
 `KB-001`/`KB-002` açıktır ve live adapter gate'i CI-managed değildir.
 `GP-4` bu eksik CI-managed live adapter gate'i tasarlar, fakat tasarım kaydı
 tek başına support tier'ı yükseltmez.
+`GP-4.1` ile eklenen `live-adapter-gate` workflow skeleton'ı da support
+widening değildir: sadece manual contract artifact üretir, canlı `claude`
+çağrısı yapmaz ve artifact içinde `overall_status="blocked"` /
+`finding_code="live_gate_not_implemented"` beklenir.
 
 `gh-cli-pr` live-write probe, `PB-8.1` ile explicit precondition (opt-in,
 disposable repo, explicit `--repo` + `--head` + `--base`) ve create -> verify
@@ -148,6 +152,8 @@ The following do not, by themselves, justify a broader support claim:
 - a runbook describing an operator flow
 - a CI/live-gate design document without a protected implementation and
   recorded evidence artifacts
+- a CI-safe live-gate skeleton that emits a blocked contract artifact without
+  executing a protected live adapter identity
 - a roadmap/spec document
 - a contract loader or truth-audit warning surface
 - a smoke passing only in one operator environment without the support docs

--- a/scripts/live_adapter_gate_contract.py
+++ b/scripts/live_adapter_gate_contract.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Emit the GP-4.1 CI-managed live adapter gate skeleton report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel.live_adapter_gate import (  # noqa: E402
+    build_live_adapter_gate_report,
+    render_live_adapter_gate_text,
+    write_live_adapter_gate_report,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="live_adapter_gate_contract.py",
+        description=(
+            "Emit the design-only GP-4.1 live-adapter gate contract report. "
+            "This command never executes a live external adapter."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        choices=("text", "json"),
+        default="json",
+        help="Render mode for stdout.",
+    )
+    parser.add_argument(
+        "--report-path",
+        type=Path,
+        default=Path("live-adapter-gate-contract.v1.json"),
+        help="Path for the canonical JSON report artifact.",
+    )
+    parser.add_argument("--target-ref", default="main", help="Protected target ref being evaluated.")
+    parser.add_argument("--reason", default="", help="Manual dispatch reason.")
+    parser.add_argument("--requested-by", default="", help="Actor that requested the gate.")
+    parser.add_argument("--event-name", default="workflow_dispatch", help="GitHub event name.")
+    parser.add_argument("--head-sha", default="", help="Commit SHA evaluated by the gate.")
+    args = parser.parse_args()
+
+    report = build_live_adapter_gate_report(
+        target_ref=args.target_ref,
+        reason=args.reason,
+        requested_by=args.requested_by,
+        event_name=args.event_name,
+        head_sha=args.head_sha,
+    )
+    write_live_adapter_gate_report(args.report_path, report)
+
+    if args.output == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_live_adapter_gate_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_adapter_gate_contract.py
+++ b/tests/test_live_adapter_gate_contract.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from ao_kernel.live_adapter_gate import (
+    BLOCKED_FINDING,
+    build_live_adapter_gate_report,
+    render_live_adapter_gate_text,
+    write_live_adapter_gate_report,
+)
+
+
+def test_build_live_adapter_gate_report_is_explicitly_blocked() -> None:
+    report = build_live_adapter_gate_report(
+        target_ref="main",
+        reason="release rehearsal",
+        requested_by="maintainer",
+        event_name="workflow_dispatch",
+        head_sha="abc123",
+        generated_at="2026-04-24T00:00:00Z",
+    )
+
+    assert report["schema_version"] == "1"
+    assert report["program_id"] == "GP-4.1"
+    assert report["adapter_id"] == "claude-code-cli"
+    assert report["support_tier"] == "Beta (operator-managed)"
+    assert report["overall_status"] == "blocked"
+    assert report["finding_code"] == BLOCKED_FINDING
+    assert report["live_execution_attempted"] is False
+    assert report["support_widening"] is False
+    assert report["trigger"] == {
+        "event_name": "workflow_dispatch",
+        "target_ref": "main",
+        "head_sha": "abc123",
+        "requested_by": "maintainer",
+        "reason": "release rehearsal",
+    }
+
+    checks = {check["name"]: check for check in report["checks"]}
+    assert checks["live_execution"]["status"] == "blocked"
+    assert checks["live_execution"]["finding_code"] == BLOCKED_FINDING
+    assert checks["secret_access"]["status"] == "skipped"
+    assert checks["support_boundary"]["status"] == "pass"
+
+
+def test_write_live_adapter_gate_report_round_trips_json(tmp_path: Path) -> None:
+    report = build_live_adapter_gate_report(generated_at="2026-04-24T00:00:00Z")
+    path = tmp_path / "live-adapter-gate-contract.v1.json"
+
+    write_live_adapter_gate_report(path, report)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload == report
+    assert path.read_text(encoding="utf-8").endswith("\n")
+
+
+def test_render_live_adapter_gate_text_marks_no_live_execution() -> None:
+    report = build_live_adapter_gate_report(generated_at="2026-04-24T00:00:00Z")
+    rendered = render_live_adapter_gate_text(report)
+
+    assert "overall_status: blocked" in rendered
+    assert "live_execution_attempted: false" in rendered
+    assert "support_widening: false" in rendered
+    assert f"live_execution: blocked ({BLOCKED_FINDING})" in rendered
+
+
+def test_script_emits_json_and_report_file(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    report_path = tmp_path / "contract.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/live_adapter_gate_contract.py",
+            "--output",
+            "json",
+            "--report-path",
+            str(report_path),
+            "--target-ref",
+            "main",
+            "--reason",
+            "test",
+            "--requested-by",
+            "pytest",
+            "--event-name",
+            "workflow_dispatch",
+            "--head-sha",
+            "abc123",
+        ],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    stdout_payload = json.loads(result.stdout)
+    file_payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert stdout_payload == file_payload
+    assert stdout_payload["overall_status"] == "blocked"
+    assert stdout_payload["live_execution_attempted"] is False
+
+
+def test_live_adapter_gate_workflow_is_manual_contract_only() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    workflow = (repo_root / ".github/workflows/live-adapter-gate.yml").read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "\n  push:" not in workflow
+    assert "\n  pull_request:" not in workflow
+    assert "live_adapter_gate_contract.py" in workflow
+    assert "claude_code_cli_smoke.py" not in workflow
+    assert "claude_code_cli_workflow_smoke.py" not in workflow
+    assert "secrets." not in workflow
+    assert "contents: read" in workflow


### PR DESCRIPTION
## Summary

- add a `workflow_dispatch`-only `live-adapter-gate` skeleton for GP-4.1
- add `ao_kernel.live_adapter_gate` plus `scripts/live_adapter_gate_contract.py` to emit `live-adapter-gate-contract.v1.json`
- pin the contract as explicit `overall_status=blocked` / `finding_code=live_gate_not_implemented`
- test that the workflow is manual-only, does not call Claude live smokes, and does not reference secrets
- align GP-4 status, support boundary, adapter docs, runbook, and changelog

## Evidence

- `python3 scripts/live_adapter_gate_contract.py --output json --report-path /tmp/live-adapter-gate-contract.v1.json --target-ref main --reason local-validation --requested-by codex --event-name workflow_dispatch --head-sha $(git rev-parse HEAD)` -> blocked contract emitted, `live_execution_attempted=false`, `support_widening=false`
- `python3 -m pytest -q tests/test_live_adapter_gate_contract.py tests/test_claude_code_cli_smoke.py tests/test_claude_code_cli_workflow_smoke.py tests/test_cli_entrypoints.py tests/test_doctor_cmd.py` -> 31 passed, 1 skipped
- `python3 -m ruff check ao_kernel/live_adapter_gate.py scripts/live_adapter_gate_contract.py tests/test_live_adapter_gate_contract.py` -> pass
- `python3 -m mypy ao_kernel/live_adapter_gate.py` -> pass
- `python3 -m ao_kernel doctor` -> 8 OK, 1 WARN, 0 FAIL (expected extension truth inventory WARN)
- `python3 scripts/packaging_smoke.py` -> pass; wheel install, entrypoints, and installed demo completed
- `git diff --check` -> clean

## Support boundary

No support widening. GP-4.1 does not add secrets, does not execute `claude`, does not run live adapter smoke from CI, does not change runtime adapter support tier, and does not publish/tag. The new workflow passing only means a blocked design contract artifact was emitted.

Closes #402
Refs #400
