### PR TITLE
[codex] ci: add GP-4.2 live adapter evidence contract

### DIFF
--- a/.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md
+++ b/.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md
@@ -97,7 +97,7 @@ itself.
 | Slice | Goal | Exit |
 |---|---|---|
 | `GP-4.1` workflow design stub | Add non-secret workflow skeleton or documented manual gate contract | implemented by `.github/workflows/live-adapter-gate.yml`; report remains `blocked`; no live secrets, no live calls, CI-safe |
-| `GP-4.2` evidence artifact contract | Define/upload JSON report shapes for live gate | local tests validate report schema |
+| `GP-4.2` evidence artifact contract | Define/upload JSON report shapes for live gate | implemented by schema-backed `live-adapter-gate-evidence.v1.json`; local tests validate schema; no live execution or support widening |
 | `GP-4.3` protected environment contract | Document required GitHub environment/secrets and fork safety | no repository secret values committed |
 | `GP-4.4` live rehearsal | Run protected manual gate once and record artifacts | only if project-owned credentials exist |
 | `GP-4.5` support-boundary decision | Decide promote/keep beta/defer | requires all prior slices and docs parity |
@@ -141,9 +141,28 @@ The report intentionally says `overall_status="blocked"` and
 `finding_code="live_gate_not_implemented"`. A successful workflow run means
 the contract artifact was emitted; it does not mean the live adapter passed.
 
+## GP-4.2 Implementation
+
+`GP-4.2` adds the schema-backed evidence artifact contract for the manual gate:
+
+1. schema: `ao_kernel/defaults/schemas/live-adapter-gate-evidence.schema.v1.json`;
+2. helper: `build_live_adapter_gate_evidence_artifact()`;
+3. validator: `validate_live_adapter_gate_evidence_artifact()`;
+4. expected artifact: `live-adapter-gate-evidence.v1.json`.
+
+The artifact records the required future evidence slots:
+
+1. gate contract report;
+2. protected live preflight report;
+3. protected governed workflow-smoke report;
+4. protected environment attestation.
+
+The current artifact is intentionally blocked. It may be schema-valid and
+uploaded by CI, but it still says `support_widening=false` and
+`production_certified=false`.
+
 ## Next Step
 
-The next implementation slice should be `GP-4.2`: define the evidence artifact
-contract for actual protected live gate outcomes. It must still avoid support
-widening until protected live evidence exists and support docs are explicitly
-updated.
+The next implementation slice should be `GP-4.3`: define the protected
+GitHub environment / secret contract and fork-safety rules. It must not commit
+secret values and must not widen support without protected live evidence.

--- a/.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md
+++ b/.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md
@@ -75,6 +75,7 @@ governed workflow smoke evidence.
 
 ## Next Slice
 
-`GP-4.2` should define the evidence artifact contract for the eventual
-protected live gate, including exact JSON report fields for preflight,
-workflow-smoke, missing credential, policy, timeout, and cost/budget outcomes.
+`GP-4.2` has since added the schema-backed evidence artifact contract in
+`.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md`. The next
+active GP-4 slice is `GP-4.3`: protected GitHub environment / secret contract
+and fork-safety rules.

--- a/.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md
+++ b/.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md
@@ -1,0 +1,82 @@
+# GP-4.2 — Live Adapter Evidence Artifact Contract
+
+**Status:** Implemented slice
+**Date:** 2026-04-24
+**Parent tracker:** [#400](https://github.com/Halildeu/ao-kernel/issues/400)
+**Slice issue:** [#404](https://github.com/Halildeu/ao-kernel/issues/404)
+**Predecessor:** `GP-4.1` CI-safe live adapter gate skeleton
+
+## Purpose
+
+Define the machine-readable evidence artifact contract for the future protected
+`claude-code-cli` live adapter gate without running a live adapter and without
+widening support.
+
+`GP-4.1` proved that a manual workflow can emit a blocked contract report.
+`GP-4.2` makes the next layer explicit: which evidence files must exist before a
+future support-boundary decision can even be considered.
+
+## Implemented Surface
+
+1. Bundled schema:
+   `ao_kernel/defaults/schemas/live-adapter-gate-evidence.schema.v1.json`
+2. Runtime helpers:
+   `build_live_adapter_gate_evidence_artifact()`,
+   `write_live_adapter_gate_evidence_artifact()`,
+   `validate_live_adapter_gate_evidence_artifact()`
+3. CLI output:
+   `scripts/live_adapter_gate_contract.py` writes both:
+   - `live-adapter-gate-contract.v1.json`
+   - `live-adapter-gate-evidence.v1.json`
+4. Workflow artifact upload:
+   `.github/workflows/live-adapter-gate.yml` uploads both JSON files.
+
+## Evidence Slots
+
+The artifact records four promotion-gating requirements:
+
+1. `gate_contract_report`
+2. `preflight_report`
+3. `governed_workflow_smoke_report`
+4. `protected_environment_attestation`
+
+Only the design contract report is present in this slice. The live preflight,
+workflow smoke, and protected environment attestation are explicitly `blocked`
+with stable finding codes.
+
+## Support Boundary
+
+No support widening.
+
+The artifact schema intentionally requires:
+
+1. `support_widening=false`
+2. `promotion_decision.support_widening_allowed=false`
+3. `promotion_decision.production_certified=false`
+
+If a future slice wants a promoted/support-widening artifact, it must use a new
+schema version and update the support docs through a separate decision gate.
+
+## Non-Goals
+
+1. No repository or environment secrets.
+2. No live `claude` invocation.
+3. No governed workflow smoke execution inside the manual gate.
+4. No production-certified adapter claim.
+5. No version bump, tag, publish, or stable support-boundary change.
+
+## Required Validation
+
+1. Schema self-validation with Draft 2020-12.
+2. Builder output validates against the bundled schema.
+3. Schema rejects fake support-widening artifacts.
+4. CLI writes both canonical JSON files.
+5. Workflow remains `workflow_dispatch` only and does not reference live smoke
+   helpers or secrets.
+
+## Next Slice
+
+`GP-4.3` should define the protected GitHub environment / secret contract and
+fork-safety rules. It should still avoid committing secret values and should not
+run live adapters unless project-owned credentials and protected dispatch rules
+exist.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -28,7 +28,8 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan GP-3 support-boundary decision record:** `.claude/plans/GP-3.5-CLAUDE-CODE-CLI-SUPPORT-BOUNDARY-DECISION.md`
 - **Son tamamlanan GP-3 closeout decision:** `.claude/plans/GP-3.6-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-CLOSEOUT.md`
 - **Aktif GP-4 CI-managed live adapter gate design:** `.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md`
-- **Aktif GP-4.1 CI-safe live adapter gate skeleton:** `.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md`
+- **Son tamamlanan GP-4.1 CI-safe live adapter gate skeleton:** `.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md`
+- **Son tamamlanan GP-4.2 live adapter evidence artifact contract:** `.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -80,8 +81,9 @@ ayrı ayrı görünür kılmak.
 - **GP-3.5 issue:** [#396](https://github.com/Halildeu/ao-kernel/issues/396) (`closed`)
 - **GP-3.6 issue:** [#398](https://github.com/Halildeu/ao-kernel/issues/398) (`closed by closeout PR`)
 - **GP-4 tracker issue:** [#400](https://github.com/Halildeu/ao-kernel/issues/400) (`open`)
-- **GP-4.1 issue:** [#402](https://github.com/Halildeu/ao-kernel/issues/402) (`active`)
-- **Aktif gate:** `GP-4.1` CI-safe live adapter gate skeleton. Bu support widening değildir; stable support boundary unchanged kalır.
+- **GP-4.1 issue:** [#402](https://github.com/Halildeu/ao-kernel/issues/402) (`closed`)
+- **GP-4.2 issue:** [#404](https://github.com/Halildeu/ao-kernel/issues/404) (`closes with GP-4.2 PR`)
+- **Sıradaki gate:** `GP-4.3` protected environment / secret contract. Bu support widening değildir; stable support boundary unchanged kalır.
 
 ## 2. Başlangıç Gerçeği
 
@@ -136,7 +138,8 @@ ayrı ayrı görünür kılmak.
 | `SM-4` historical beta pin wording | Completed ([#384](https://github.com/Halildeu/ao-kernel/issues/384), record `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`) | `4.0.0b2` beta pinini aktif kanal gibi değil historical pre-release yolu gibi anlatmak | stable `4.0.0` remains default + no support widening |
 | `GP-3` production-certified adapter promotion | Completed ([#386](https://github.com/Halildeu/ao-kernel/issues/386), [#388](https://github.com/Halildeu/ao-kernel/issues/388), [#390](https://github.com/Halildeu/ao-kernel/issues/390), [#392](https://github.com/Halildeu/ao-kernel/issues/392), [#394](https://github.com/Halildeu/ao-kernel/issues/394), [#396](https://github.com/Halildeu/ao-kernel/issues/396), [#398](https://github.com/Halildeu/ao-kernel/issues/398), roadmap `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`) | ilk real-adapter lane'i production-certified read-only seviyesine aday yapmak | final verdict `close_keep_operator_beta`; support boundary unchanged |
 | `GP-4` CI-managed live adapter gate design | Active ([#400](https://github.com/Halildeu/ao-kernel/issues/400), design `.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md`) | GP-3'te eksik kalan project-owned live-adapter gate'i support widening olmadan tasarlamak | design-only, no secrets, no live default CI call, no support widening |
-| `GP-4.1` CI-safe live adapter gate skeleton | Active ([#402](https://github.com/Halildeu/ao-kernel/issues/402), record `.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md`) | workflow-dispatch-only contract artifact yüzeyini eklemek | no secrets, no live adapter execution, report `overall_status=blocked`, no support widening |
+| `GP-4.1` CI-safe live adapter gate skeleton | Completed on `main` ([#402](https://github.com/Halildeu/ao-kernel/issues/402), record `.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md`) | workflow-dispatch-only contract artifact yüzeyini eklemek | no secrets, no live adapter execution, report `overall_status=blocked`, no support widening |
+| `GP-4.2` live adapter evidence artifact contract | Completed by GP-4.2 PR ([#404](https://github.com/Halildeu/ao-kernel/issues/404), record `.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md`) | live gate evidence artifact shape'i schema-backed hale getirmek | schema validation + blocked evidence slots + no live adapter execution + no support widening |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -147,10 +150,12 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — GP-4.1 CI-safe live adapter gate skeleton
+### Current mode — GP-4.3 protected environment / secret contract
 
 `GP-3` parent promotion programı `close_keep_operator_beta` kararıyla
-kapanmıştır. `GP-4.1` şimdi CI-safe live adapter gate skeleton hattını yürütür.
+kapanmıştır. `GP-4.2` live adapter evidence artifact contract hattını
+tamamlamıştır. Sıradaki GP-4 slice `GP-4.3` protected GitHub environment /
+secret contract ve fork-safety kurallarını netleştirmektir.
 Bu support widening değildir; `SM-1` stable maintenance baseline ve `SM-2`
 stable baseline evidence refresh geçerlidir.
 
@@ -168,7 +173,8 @@ Promotion sadece code path + behavior tests + smoke + docs + runbook + CI
 evidence aynı yönde ise yapılır. `GP-3` closeout sonucunda CI-managed live
 adapter gate'i ve açık known-bug durumu yeterli olmadığı için lane
 `Beta (operator-managed)` kaldı. `GP-4.1`, bu eksik gate için manual workflow
-contract skeleton'ı ekler; live secrets, default CI live call veya support
+contract skeleton'ı ekledi; `GP-4.2` ise bu gate'in evidence artifact shape'ini
+schema-backed hale getirir. Live secrets, default CI live call veya support
 promotion içermez.
 
 Tarihi `ST`, `PB` ve `GP` kayıtları aşağıda korunur; bunlar güncel aktif gate
@@ -1102,5 +1108,13 @@ live adapter gate'i tasarlar.
    - report artifact `live-adapter-gate-contract.v1.json`
    - expected report status `blocked` / `live_gate_not_implemented`
    - no live adapter execution, no secret access, no support widening
-8. Next slice:
-   - `GP-4.2` evidence artifact contract for protected live gate outcomes
+8. `GP-4.2` slice:
+   - tracker [#404](https://github.com/Halildeu/ao-kernel/issues/404)
+   - record `.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md`
+   - schema `ao_kernel/defaults/schemas/live-adapter-gate-evidence.schema.v1.json`
+   - evidence artifact `live-adapter-gate-evidence.v1.json`
+   - expected artifact status `blocked`, `support_widening=false`,
+     `production_certified=false`
+   - no live adapter execution, no secret access, no support widening
+9. Next slice:
+   - `GP-4.3` protected environment / secret contract and fork-safety rules

--- a/.github/workflows/live-adapter-gate.yml
+++ b/.github/workflows/live-adapter-gate.yml
@@ -62,15 +62,18 @@ jobs:
           python3 scripts/live_adapter_gate_contract.py \
             --output json \
             --report-path live-adapter-gate-contract.v1.json \
+            --evidence-path live-adapter-gate-evidence.v1.json \
             --target-ref "$TARGET_REF" \
             --reason "$DISPATCH_REASON" \
             --requested-by "$REQUESTED_BY" \
             --event-name "$EVENT_NAME" \
             --head-sha "$HEAD_SHA"
 
-      - name: Upload contract artifact
+      - name: Upload gate artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: live-adapter-gate-contract-${{ github.run_id }}
-          path: live-adapter-gate-contract.v1.json
+          name: live-adapter-gate-evidence-${{ github.run_id }}
+          path: |
+            live-adapter-gate-contract.v1.json
+            live-adapter-gate-evidence.v1.json
           if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `live-adapter-gate-contract.v1.json` artifact and deliberately performs no
   secret access, live adapter execution, version bump, tag, publish, or support
   widening.
+- Added the `GP-4.2` live adapter evidence artifact contract. The manual
+  `live-adapter-gate` workflow now also emits schema-backed
+  `live-adapter-gate-evidence.v1.json`, with required live preflight,
+  governed workflow-smoke, and protected-environment evidence slots recorded as
+  blocked promotion gates. This still performs no secret access, live adapter
+  execution, version bump, tag, publish, or support widening.
 
 ## [4.0.0] - 2026-04-24
 

--- a/ao_kernel/defaults/schemas/live-adapter-gate-evidence.schema.v1.json
+++ b/ao_kernel/defaults/schemas/live-adapter-gate-evidence.schema.v1.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:live-adapter-gate-evidence:v1",
+  "title": "Live Adapter Gate Evidence Artifact",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "program_id",
+    "gate_id",
+    "adapter_id",
+    "support_tier",
+    "overall_status",
+    "finding_code",
+    "generated_at",
+    "live_execution_attempted",
+    "support_widening",
+    "trigger",
+    "source_report",
+    "evidence_requirements",
+    "promotion_decision",
+    "findings"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1"
+    },
+    "artifact_kind": {
+      "const": "live_adapter_gate_evidence"
+    },
+    "program_id": {
+      "type": "string",
+      "pattern": "^GP-4\\.[0-9]+$"
+    },
+    "gate_id": {
+      "const": "ci-managed-live-adapter-gate"
+    },
+    "adapter_id": {
+      "const": "claude-code-cli"
+    },
+    "support_tier": {
+      "const": "Beta (operator-managed)"
+    },
+    "overall_status": {
+      "enum": ["pass", "fail", "blocked"]
+    },
+    "finding_code": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "live_execution_attempted": {
+      "type": "boolean"
+    },
+    "support_widening": {
+      "const": false
+    },
+    "trigger": {
+      "$ref": "#/$defs/trigger"
+    },
+    "source_report": {
+      "$ref": "#/$defs/source_report"
+    },
+    "evidence_requirements": {
+      "type": "array",
+      "minItems": 4,
+      "items": {
+        "$ref": "#/$defs/evidence_requirement"
+      }
+    },
+    "promotion_decision": {
+      "$ref": "#/$defs/promotion_decision"
+    },
+    "findings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "trigger": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["event_name", "target_ref", "head_sha", "requested_by", "reason"],
+      "properties": {
+        "event_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "head_sha": {
+          "type": "string"
+        },
+        "requested_by": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        }
+      }
+    },
+    "source_report": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "schema_version", "sha256"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "schema_version": {
+          "const": "1"
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "evidence_requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requirement_id",
+        "artifact_path",
+        "status",
+        "finding_code",
+        "required_for_promotion",
+        "detail"
+      ],
+      "properties": {
+        "requirement_id": {
+          "enum": [
+            "gate_contract_report",
+            "preflight_report",
+            "governed_workflow_smoke_report",
+            "protected_environment_attestation"
+          ]
+        },
+        "artifact_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": ["present", "missing", "blocked", "skipped"]
+        },
+        "finding_code": {
+          "type": ["string", "null"]
+        },
+        "required_for_promotion": {
+          "type": "boolean"
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "promotion_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "support_widening_allowed",
+        "production_certified",
+        "reason",
+        "required_before_widening"
+      ],
+      "properties": {
+        "support_widening_allowed": {
+          "const": false
+        },
+        "production_certified": {
+          "const": false
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required_before_widening": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/ao_kernel/live_adapter_gate.py
+++ b/ao_kernel/live_adapter_gate.py
@@ -1,26 +1,37 @@
 """CI-managed live adapter gate contract helpers.
 
-The GP-4.1 gate is intentionally a skeleton: it emits a machine-readable
-contract report but does not execute external live adapters.
+The GP-4 gate is intentionally fail-closed: current helpers emit
+machine-readable blocked reports/artifacts but do not execute external live
+adapters.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import UTC, datetime
+from importlib import resources
 from pathlib import Path
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict, cast
+
+from jsonschema import Draft202012Validator
 
 SCHEMA_VERSION = "1"
 PROGRAM_ID = "GP-4.1"
+EVIDENCE_PROGRAM_ID = "GP-4.2"
 GATE_ID = "ci-managed-live-adapter-gate"
 ADAPTER_ID = "claude-code-cli"
 SUPPORT_TIER = "Beta (operator-managed)"
 BLOCKED_FINDING = "live_gate_not_implemented"
+EVIDENCE_ARTIFACT_KIND = "live_adapter_gate_evidence"
+EVIDENCE_SCHEMA_NAME = "live-adapter-gate-evidence.schema.v1.json"
+CONTRACT_REPORT_ARTIFACT = "live-adapter-gate-contract.v1.json"
+EVIDENCE_ARTIFACT = "live-adapter-gate-evidence.v1.json"
 
 
 CheckStatus = Literal["pass", "blocked", "skipped"]
 OverallStatus = Literal["blocked"]
+EvidenceRequirementStatus = Literal["present", "blocked"]
 
 
 class LiveAdapterGateTrigger(TypedDict):
@@ -57,6 +68,55 @@ class LiveAdapterGateReport(TypedDict):
     support_widening: bool
     trigger: LiveAdapterGateTrigger
     checks: list[LiveAdapterGateCheck]
+    findings: list[str]
+
+
+class LiveAdapterGateSourceReport(TypedDict):
+    """Digest pointer to the underlying gate contract report."""
+
+    path: str
+    schema_version: str
+    sha256: str
+
+
+class LiveAdapterGateEvidenceRequirement(TypedDict):
+    """Single evidence slot required before support can be widened."""
+
+    requirement_id: str
+    artifact_path: str
+    status: EvidenceRequirementStatus
+    finding_code: str | None
+    required_for_promotion: bool
+    detail: str
+
+
+class LiveAdapterGatePromotionDecision(TypedDict):
+    """Fail-closed promotion decision encoded in the evidence artifact."""
+
+    support_widening_allowed: bool
+    production_certified: bool
+    reason: str
+    required_before_widening: list[str]
+
+
+class LiveAdapterGateEvidenceArtifact(TypedDict):
+    """Machine-readable GP-4.2 evidence artifact contract."""
+
+    schema_version: str
+    artifact_kind: str
+    program_id: str
+    gate_id: str
+    adapter_id: str
+    support_tier: str
+    overall_status: OverallStatus
+    finding_code: str
+    generated_at: str
+    live_execution_attempted: bool
+    support_widening: bool
+    trigger: LiveAdapterGateTrigger
+    source_report: LiveAdapterGateSourceReport
+    evidence_requirements: list[LiveAdapterGateEvidenceRequirement]
+    promotion_decision: LiveAdapterGatePromotionDecision
     findings: list[str]
 
 
@@ -130,11 +190,132 @@ def build_live_adapter_gate_report(
     }
 
 
+def _canonical_json_bytes(payload: object) -> bytes:
+    """Return deterministic bytes for report digests."""
+
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def live_adapter_gate_report_sha256(report: LiveAdapterGateReport) -> str:
+    """Hash the logical contract report payload, independent of pretty-printing."""
+
+    return hashlib.sha256(_canonical_json_bytes(report)).hexdigest()
+
+
+def build_live_adapter_gate_evidence_artifact(
+    report: LiveAdapterGateReport,
+    *,
+    contract_report_path: str = CONTRACT_REPORT_ARTIFACT,
+    generated_at: str | None = None,
+) -> LiveAdapterGateEvidenceArtifact:
+    """Build the GP-4.2 evidence artifact wrapper.
+
+    The artifact is intentionally blocked until the protected live preflight and
+    governed workflow-smoke reports are attached by a later slice.
+    """
+
+    timestamp = generated_at or report["generated_at"]
+    preflight_finding = "live_gate_preflight_not_collected"
+    workflow_finding = "live_gate_workflow_smoke_not_collected"
+    environment_finding = "live_gate_protected_environment_not_attested"
+    findings = [BLOCKED_FINDING, preflight_finding, workflow_finding, environment_finding]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_kind": EVIDENCE_ARTIFACT_KIND,
+        "program_id": EVIDENCE_PROGRAM_ID,
+        "gate_id": report["gate_id"],
+        "adapter_id": report["adapter_id"],
+        "support_tier": report["support_tier"],
+        "overall_status": report["overall_status"],
+        "finding_code": report["finding_code"],
+        "generated_at": timestamp,
+        "live_execution_attempted": report["live_execution_attempted"],
+        "support_widening": report["support_widening"],
+        "trigger": report["trigger"],
+        "source_report": {
+            "path": contract_report_path,
+            "schema_version": report["schema_version"],
+            "sha256": live_adapter_gate_report_sha256(report),
+        },
+        "evidence_requirements": [
+            {
+                "requirement_id": "gate_contract_report",
+                "artifact_path": contract_report_path,
+                "status": "present",
+                "finding_code": None,
+                "required_for_promotion": True,
+                "detail": "Design-only gate contract report is attached.",
+            },
+            {
+                "requirement_id": "preflight_report",
+                "artifact_path": "claude-code-cli-preflight.v1.json",
+                "status": "blocked",
+                "finding_code": preflight_finding,
+                "required_for_promotion": True,
+                "detail": "Protected live preflight report is not collected by GP-4.2.",
+            },
+            {
+                "requirement_id": "governed_workflow_smoke_report",
+                "artifact_path": "claude-code-cli-workflow-smoke.v1.json",
+                "status": "blocked",
+                "finding_code": workflow_finding,
+                "required_for_promotion": True,
+                "detail": "Protected governed workflow-smoke report is not collected by GP-4.2.",
+            },
+            {
+                "requirement_id": "protected_environment_attestation",
+                "artifact_path": "live-adapter-gate-environment.v1.json",
+                "status": "blocked",
+                "finding_code": environment_finding,
+                "required_for_promotion": True,
+                "detail": "Protected GitHub environment and project-owned identity are not attested by GP-4.2.",
+            },
+        ],
+        "promotion_decision": {
+            "support_widening_allowed": False,
+            "production_certified": False,
+            "reason": (
+                "The manual gate emitted schema-valid blocked evidence, but no protected live "
+                "adapter preflight or governed workflow-smoke evidence exists."
+            ),
+            "required_before_widening": [
+                "project_owned_identity",
+                "protected_environment",
+                "preflight_report",
+                "governed_workflow_smoke_report",
+                "docs_parity",
+            ],
+        },
+        "findings": findings,
+    }
+
+
+def load_live_adapter_gate_evidence_schema() -> dict[str, Any]:
+    """Load the bundled GP-4.2 evidence artifact JSON Schema."""
+
+    schema_path = resources.files("ao_kernel.defaults.schemas").joinpath(EVIDENCE_SCHEMA_NAME)
+    return cast(dict[str, Any], json.loads(schema_path.read_text(encoding="utf-8")))
+
+
+def validate_live_adapter_gate_evidence_artifact(artifact: object) -> None:
+    """Validate a GP-4.2 evidence artifact against the bundled schema."""
+
+    Draft202012Validator(load_live_adapter_gate_evidence_schema()).validate(artifact)
+
+
 def write_live_adapter_gate_report(path: Path, report: LiveAdapterGateReport) -> None:
     """Write a canonical JSON report to ``path``."""
 
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_live_adapter_gate_evidence_artifact(path: Path, artifact: LiveAdapterGateEvidenceArtifact) -> None:
+    """Write a canonical GP-4.2 evidence artifact to ``path``."""
+
+    validate_live_adapter_gate_evidence_artifact(artifact)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def render_live_adapter_gate_text(report: LiveAdapterGateReport) -> str:

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -239,6 +239,10 @@ HTTP adapters must explicitly set `exposure_modes` to include `"http_header"` vi
 - `GP-4.1` adds a manual `live-adapter-gate` workflow skeleton that emits a
   blocked contract artifact only. It does not call `claude`, does not read
   secrets, and does not promote this lane.
+- `GP-4.2` adds a schema-backed `live-adapter-gate-evidence.v1.json` artifact
+  beside the contract artifact. It records missing preflight/workflow-smoke
+  and protected-environment evidence as promotion blockers; it still does not
+  call `claude`, read secrets, or promote this lane.
 
 ### Failure modes
 

--- a/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
+++ b/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
@@ -94,9 +94,12 @@ doğrular; external `claude` binary/session auth, açık `KB-001`/`KB-002` ve
 CI-managed live adapter gate'i olmaması support widening'i engeller.
 `GP-4` bu eksik gate'i tasarım konusu yapar; runbook'taki lokal helper geçişi
 tek başına production-certified support değildir.
-`GP-4.1` manual workflow skeleton'ı yalnız `live-adapter-gate-contract.v1.json`
-üretir ve artifact `overall_status="blocked"` döner; bu live benchmark veya
-real-adapter support kanıtı değildir.
+`GP-4.1` manual workflow skeleton'ı `live-adapter-gate-contract.v1.json`
+üretir. `GP-4.2` ayrıca schema-backed `live-adapter-gate-evidence.v1.json`
+artifact'ini üretir; bu artifact live preflight, governed workflow smoke ve
+protected environment attestation slotlarını promotion blocker olarak listeler.
+Her iki artifact de bugün blocked/no-widening semantiğindedir; bu live benchmark
+veya real-adapter support kanıtı değildir.
 
 ### 1.3 Failure-mode matrix
 

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -42,11 +42,13 @@ python3 scripts/kernel_api_write_smoke.py --output text
 # python3 scripts/gh_cli_pr_smoke.py --mode live-write --allow-live-write --repo <owner>/<sandbox-repo> --head <branch> --base <branch> --output json --report-path /tmp/gh-cli-pr-live-write.report.json
 ```
 
-`live-adapter-gate` workflow'u (`GP-4.1`) farklı bir yüzeydir: bugün canlı
-adapter çalıştırmaz. Manual workflow yalnız `live-adapter-gate-contract.v1.json`
-artifact'i üretir ve bu artifact'in `overall_status="blocked"` /
-`finding_code="live_gate_not_implemented"` dönmesi beklenir. Workflow'un yeşil
-olması production-certified `claude-code-cli` support anlamına gelmez.
+`live-adapter-gate` workflow'u (`GP-4.1`/`GP-4.2`) farklı bir yüzeydir: bugün
+canlı adapter çalıştırmaz. Manual workflow
+`live-adapter-gate-contract.v1.json` ve schema-backed
+`live-adapter-gate-evidence.v1.json` artifact'lerini üretir; artifact'lerin
+`overall_status="blocked"` / `finding_code="live_gate_not_implemented"` /
+`support_widening=false` dönmesi beklenir. Workflow'un yeşil olması
+production-certified `claude-code-cli` support anlamına gelmez.
 
 Prerequisite contract (operator-managed lanes):
 

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -153,8 +153,11 @@ Canlı snapshot üretimi için: `python3 scripts/truth_inventory_ratchet.py --ou
   `claude-code-cli` production-certified support için gelecekte protected
   manual/scheduled live gate veya eşdeğer release gate gerekir; bu dokümanda
   shipped veya beta satırı otomatik değişmez.
-- `GP-4.1` manual workflow skeleton'ı sadece
-  `live-adapter-gate-contract.v1.json` artifact'i üretir. Bu artifact bugün
-  `overall_status="blocked"` döner ve canlı adapter execution kanıtı değildir.
+- `GP-4.1` manual workflow skeleton'ı
+  `live-adapter-gate-contract.v1.json` artifact'i üretir. `GP-4.2` bunun
+  yanına schema-backed `live-adapter-gate-evidence.v1.json` artifact'ini
+  ekler. Bu artifact bugün `overall_status="blocked"` /
+  `support_widening=false` / `production_certified=false` döner ve canlı
+  adapter execution kanıtı değildir.
 - `docs/roadmap/DEMO-SCRIPT-SPEC.md` roadmap/spec dokümanıdır; canlı
   CLI komut listesi değildir.

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -109,6 +109,10 @@ tek başına support tier'ı yükseltmez.
 widening değildir: sadece manual contract artifact üretir, canlı `claude`
 çağrısı yapmaz ve artifact içinde `overall_status="blocked"` /
 `finding_code="live_gate_not_implemented"` beklenir.
+`GP-4.2` bu gate'e schema-backed `live-adapter-gate-evidence.v1.json` artifact
+contract'ını ekler. Artifact, preflight/workflow-smoke/protected-environment
+kanıt slotlarını promotion blocker olarak listeler; yine canlı adapter çağrısı,
+secret okuma veya support widening içermez.
 
 `gh-cli-pr` live-write probe, `PB-8.1` ile explicit precondition (opt-in,
 disposable repo, explicit `--repo` + `--head` + `--base`) ve create -> verify
@@ -154,6 +158,8 @@ The following do not, by themselves, justify a broader support claim:
   recorded evidence artifacts
 - a CI-safe live-gate skeleton that emits a blocked contract artifact without
   executing a protected live adapter identity
+- a schema-valid live-gate evidence artifact that still marks required live
+  evidence slots as blocked and `support_widening=false`
 - a roadmap/spec document
 - a contract loader or truth-audit warning surface
 - a smoke passing only in one operator environment without the support docs

--- a/scripts/live_adapter_gate_contract.py
+++ b/scripts/live_adapter_gate_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Emit the GP-4.1 CI-managed live adapter gate skeleton report."""
+"""Emit the fail-closed GP-4 live adapter gate reports."""
 
 from __future__ import annotations
 
@@ -13,8 +13,11 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from ao_kernel.live_adapter_gate import (  # noqa: E402
+    EVIDENCE_ARTIFACT,
     build_live_adapter_gate_report,
+    build_live_adapter_gate_evidence_artifact,
     render_live_adapter_gate_text,
+    write_live_adapter_gate_evidence_artifact,
     write_live_adapter_gate_report,
 )
 
@@ -24,7 +27,8 @@ def main() -> int:
         prog="live_adapter_gate_contract.py",
         description=(
             "Emit the design-only GP-4.1 live-adapter gate contract report. "
-            "This command never executes a live external adapter."
+            "This command also writes the GP-4.2 evidence artifact and never "
+            "executes a live external adapter."
         ),
     )
     parser.add_argument(
@@ -38,6 +42,12 @@ def main() -> int:
         type=Path,
         default=Path("live-adapter-gate-contract.v1.json"),
         help="Path for the canonical JSON report artifact.",
+    )
+    parser.add_argument(
+        "--evidence-path",
+        type=Path,
+        default=Path(EVIDENCE_ARTIFACT),
+        help="Path for the canonical GP-4.2 evidence artifact.",
     )
     parser.add_argument("--target-ref", default="main", help="Protected target ref being evaluated.")
     parser.add_argument("--reason", default="", help="Manual dispatch reason.")
@@ -54,6 +64,11 @@ def main() -> int:
         head_sha=args.head_sha,
     )
     write_live_adapter_gate_report(args.report_path, report)
+    evidence_artifact = build_live_adapter_gate_evidence_artifact(
+        report,
+        contract_report_path=args.report_path.name,
+    )
+    write_live_adapter_gate_evidence_artifact(args.evidence_path, evidence_artifact)
 
     if args.output == "json":
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/test_live_adapter_gate_contract.py
+++ b/tests/test_live_adapter_gate_contract.py
@@ -5,10 +5,20 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
 from ao_kernel.live_adapter_gate import (
     BLOCKED_FINDING,
+    EVIDENCE_ARTIFACT,
+    build_live_adapter_gate_evidence_artifact,
     build_live_adapter_gate_report,
+    live_adapter_gate_report_sha256,
+    load_live_adapter_gate_evidence_schema,
     render_live_adapter_gate_text,
+    validate_live_adapter_gate_evidence_artifact,
+    write_live_adapter_gate_evidence_artifact,
     write_live_adapter_gate_report,
 )
 
@@ -57,6 +67,71 @@ def test_write_live_adapter_gate_report_round_trips_json(tmp_path: Path) -> None
     assert path.read_text(encoding="utf-8").endswith("\n")
 
 
+def test_live_adapter_gate_evidence_schema_is_valid() -> None:
+    schema = load_live_adapter_gate_evidence_schema()
+
+    Draft202012Validator.check_schema(schema)
+    assert schema["$id"] == "urn:ao:live-adapter-gate-evidence:v1"
+
+
+def test_build_live_adapter_gate_evidence_artifact_is_schema_valid_and_blocked() -> None:
+    report = build_live_adapter_gate_report(
+        target_ref="main",
+        reason="release rehearsal",
+        requested_by="maintainer",
+        event_name="workflow_dispatch",
+        head_sha="abc123",
+        generated_at="2026-04-24T00:00:00Z",
+    )
+
+    artifact = build_live_adapter_gate_evidence_artifact(report, contract_report_path="contract.json")
+
+    validate_live_adapter_gate_evidence_artifact(artifact)
+    assert artifact["schema_version"] == "1"
+    assert artifact["artifact_kind"] == "live_adapter_gate_evidence"
+    assert artifact["program_id"] == "GP-4.2"
+    assert artifact["overall_status"] == "blocked"
+    assert artifact["live_execution_attempted"] is False
+    assert artifact["support_widening"] is False
+    assert artifact["source_report"] == {
+        "path": "contract.json",
+        "schema_version": "1",
+        "sha256": live_adapter_gate_report_sha256(report),
+    }
+    assert artifact["promotion_decision"]["support_widening_allowed"] is False
+    assert artifact["promotion_decision"]["production_certified"] is False
+
+    requirements = {item["requirement_id"]: item for item in artifact["evidence_requirements"]}
+    assert requirements["gate_contract_report"]["status"] == "present"
+    assert requirements["gate_contract_report"]["finding_code"] is None
+    assert requirements["preflight_report"]["status"] == "blocked"
+    assert requirements["preflight_report"]["finding_code"] == "live_gate_preflight_not_collected"
+    assert requirements["governed_workflow_smoke_report"]["status"] == "blocked"
+    assert requirements["protected_environment_attestation"]["status"] == "blocked"
+
+
+def test_live_adapter_gate_evidence_schema_rejects_support_widening() -> None:
+    report = build_live_adapter_gate_report(generated_at="2026-04-24T00:00:00Z")
+    artifact = build_live_adapter_gate_evidence_artifact(report)
+    artifact["support_widening"] = True
+
+    with pytest.raises(ValidationError):
+        validate_live_adapter_gate_evidence_artifact(artifact)
+
+
+def test_write_live_adapter_gate_evidence_artifact_round_trips_json(tmp_path: Path) -> None:
+    report = build_live_adapter_gate_report(generated_at="2026-04-24T00:00:00Z")
+    artifact = build_live_adapter_gate_evidence_artifact(report)
+    path = tmp_path / EVIDENCE_ARTIFACT
+
+    write_live_adapter_gate_evidence_artifact(path, artifact)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload == artifact
+    validate_live_adapter_gate_evidence_artifact(payload)
+    assert path.read_text(encoding="utf-8").endswith("\n")
+
+
 def test_render_live_adapter_gate_text_marks_no_live_execution() -> None:
     report = build_live_adapter_gate_report(generated_at="2026-04-24T00:00:00Z")
     rendered = render_live_adapter_gate_text(report)
@@ -70,6 +145,7 @@ def test_render_live_adapter_gate_text_marks_no_live_execution() -> None:
 def test_script_emits_json_and_report_file(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     report_path = tmp_path / "contract.json"
+    evidence_path = tmp_path / "evidence.json"
 
     result = subprocess.run(
         [
@@ -79,6 +155,8 @@ def test_script_emits_json_and_report_file(tmp_path: Path) -> None:
             "json",
             "--report-path",
             str(report_path),
+            "--evidence-path",
+            str(evidence_path),
             "--target-ref",
             "main",
             "--reason",
@@ -99,9 +177,13 @@ def test_script_emits_json_and_report_file(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     stdout_payload = json.loads(result.stdout)
     file_payload = json.loads(report_path.read_text(encoding="utf-8"))
+    evidence_payload = json.loads(evidence_path.read_text(encoding="utf-8"))
     assert stdout_payload == file_payload
     assert stdout_payload["overall_status"] == "blocked"
     assert stdout_payload["live_execution_attempted"] is False
+    validate_live_adapter_gate_evidence_artifact(evidence_payload)
+    assert evidence_payload["source_report"]["path"] == report_path.name
+    assert evidence_payload["support_widening"] is False
 
 
 def test_live_adapter_gate_workflow_is_manual_contract_only() -> None:
@@ -112,6 +194,8 @@ def test_live_adapter_gate_workflow_is_manual_contract_only() -> None:
     assert "\n  push:" not in workflow
     assert "\n  pull_request:" not in workflow
     assert "live_adapter_gate_contract.py" in workflow
+    assert "live-adapter-gate-contract.v1.json" in workflow
+    assert "live-adapter-gate-evidence.v1.json" in workflow
     assert "claude_code_cli_smoke.py" not in workflow
     assert "claude_code_cli_workflow_smoke.py" not in workflow
     assert "secrets." not in workflow


### PR DESCRIPTION
## Summary

Implements GP-4.2 for #400 and closes #404.

- Add bundled Draft 2020-12 schema for `live-adapter-gate-evidence.v1.json`.
- Add helpers to build/write/validate the evidence artifact and digest the source contract report.
- Update `scripts/live_adapter_gate_contract.py` and the manual `live-adapter-gate` workflow to emit/upload both the contract report and the evidence artifact.
- Keep the gate fail-closed: no secrets, no live adapter execution, no support widening, no production-certified promotion.
- Update GP-4 plan/status, support-boundary docs, runbook notes, and changelog.

## Validation

- `python3 -m pytest -q tests/test_live_adapter_gate_contract.py tests/test_cli_entrypoints.py tests/test_doctor_cmd.py`
- `python3 -m ruff check ao_kernel/live_adapter_gate.py scripts/live_adapter_gate_contract.py tests/test_live_adapter_gate_contract.py`
- `python3 -m mypy ao_kernel/live_adapter_gate.py`
- `git diff --check`
- `python3 -m ao_kernel doctor` (`8 OK, 1 WARN, 0 FAIL`; expected extension truth warning)
- `python3 scripts/live_adapter_gate_contract.py --output json --report-path <tmp>/live-adapter-gate-contract.v1.json --evidence-path <tmp>/live-adapter-gate-evidence.v1.json --target-ref main --reason local-validation --requested-by codex --event-name workflow_dispatch --head-sha <sha>`
- `python3 scripts/packaging_smoke.py`

## Support Boundary

No support widening. The new evidence artifact is schema-valid but blocked: required live preflight, governed workflow smoke, and protected environment attestation remain promotion blockers until later GP-4 slices.
