### PR TITLE
[codex] ops: require separate worktrees for feature work

### DIFF
--- a/.claude/scripts/check-branch-sync.sh
+++ b/.claude/scripts/check-branch-sync.sh
@@ -47,6 +47,16 @@ if [[ "$branch" =~ ^backup/ ]]; then
   exit 1
 fi
 
+primary_worktree=$(git worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
+repo_root=$(git rev-parse --show-toplevel)
+if [ "$branch" != "main" ] && [ "$repo_root" = "$primary_worktree" ]; then
+  echo "🚨 Primary checkout üstünde feature branch yasak: $branch"
+  echo "  Ayrı worktree zorunlu:"
+  echo "    git worktree add ../ao-kernel-<topic> -b codex/<topic> origin/main"
+  echo "  Uncommitted değişiklik varsa önce commit/stash/archive ile koru; sonra branch/worktree değiştir."
+  exit 1
+fi
+
 # Fetch main (silent, timeout 10s)
 git fetch origin main --quiet --prune 2>/dev/null || {
   echo "⚠ origin/main fetch failed — offline?"
@@ -58,7 +68,8 @@ if [ "$branch" = "main" ]; then
   behind=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
   if [ "$behind" -gt 0 ]; then
     echo "⚠ main is $behind commits behind origin/main"
-    echo "  Run: git pull"
+    echo "  Önce worktree clean olmalı; dirty ise commit/stash/archive ile koru."
+    echo "  Clean ise: git merge --ff-only origin/main"
     exit 1
   fi
   echo "✓ main, up-to-date with origin/main"
@@ -77,12 +88,13 @@ if [ "$behind" -gt 20 ]; then
   echo "🚨 BRANCH STALE: $behind commits behind — bu branch üstünde ÇALIŞMA"
   echo "  CLAUDE.md §17:"
   echo "    Opsiyon 1 (önerilen): git checkout -b <new> origin/main"
-  echo "    Opsiyon 2: git rebase origin/main (conflict manageable ise)"
+  echo "    Opsiyon 2: git rebase origin/main (yalnız worktree clean veya state korunmuşsa)"
   exit 1
 elif [ "$behind" -gt 5 ]; then
   echo ""
   echo "⚠ WARN: branch $behind commits behind — rebase önerilir"
-  echo "  git rebase origin/main"
+  echo "  Önce worktree clean olmalı; dirty ise commit/stash/archive ile koru."
+  echo "  Clean ise: git rebase origin/main"
   exit 0
 fi
 

--- a/.claude/scripts/ops.sh
+++ b/.claude/scripts/ops.sh
@@ -156,6 +156,7 @@ run_preflight() {
     printf '⚠ Preflight completed with warnings\n'
     if [ "$current_dirty" -eq 1 ]; then
       printf '  - current worktree dirty\n'
+      printf '  - do not run pull/rebase/switch until changes are committed, stashed, or archived\n'
     fi
     if [ "$upstream" = "(none)" ] && [ "$branch" != "main" ]; then
       printf '  - branch has no upstream yet\n'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,20 +455,38 @@ Komut exit 1 dönerse DUR, kullanıcı ile karar ver:
 
 ### Worktree-per-branch denkliği
 
-Her worktree ayrı short-lived branch'te çalışır. Session başlangıç:
+Her implementation/runtime/docs patch işi ayrı short-lived branch + ayrı
+worktree'de çalışır. Primary checkout (`/Users/halilkocoglu/Documents/ao-kernel`)
+yalnız `main` doğrulama, `origin/main` senkronizasyonu ve final release
+kontrolü içindir; primary checkout üstünde feature branch ile edit yapılmaz.
+Session başlangıç:
 
 ```bash
 # Primary worktree (/Users/halilkocoglu/Documents/ao-kernel)
 cd /Users/halilkocoglu/Documents/ao-kernel
-git checkout main && git pull
+bash .claude/scripts/ops.sh preflight
 
-# Feature → ya primary'de short-lived branch'e geç, ya yeni worktree yarat
-git worktree add ../ao-kernel-feat-X -b feat/X origin/main
+# Feature/docs/runtime işi → ayrı worktree zorunlu
+git worktree add ../ao-kernel-feat-X -b codex/feat-X origin/main
+cd ../ao-kernel-feat-X
+bash .claude/scripts/ops.sh preflight
 
 # Bitince
 bash .claude/scripts/ops.sh close-worktree ../ao-kernel-feat-X
-git branch -D feat/X  # merge edildikten sonra
+git branch -D codex/feat-X  # merge edildikten ve origin/main doğrulandıktan sonra
 ```
+
+### Origin/main authority ve dirty-state koruma
+
+- Merge sonrası tek authority `origin/main` kabul edilir. Lokal `main` veya
+  merge edilmiş worktree state'i karar kaynağı değildir; önce `git fetch origin
+  main --prune`, sonra clean primary checkout üzerinde `git merge --ff-only
+  origin/main` ile hizalanır.
+- `git pull`, `git rebase`, `git switch`, `git checkout` veya worktree kaldırma
+  işlemleri dirty state üstünde çalıştırılmaz. Önce değişiklikler commit edilir,
+  stash edilir veya `ops.sh archive-worktree <path>` ile arşivlenir.
+- Dirty state korunmadan branch değiştirme, rebase/pull yapma veya worktree
+  kapatma veri kaybı riski sayılır ve işlem durdurulur.
 
 ### Version bump — base freshness zorunlu
 
@@ -486,6 +504,8 @@ Farklı worktree'lerde çalışan Claude/Codex session'ları için:
 - Birden fazla attached worktree varsa edit başlamadan önce `ops.sh overlap-check`
   ile path-overlap görünürlüğü alınır
 - Shared implementation branch yok — her session fresh branch from main
+- Primary checkout üstünde feature branch yok — edit işi için ayrı worktree
+  zorunlu
 - Backup branch (`backup/*`) sadece kurtarma için, üstünde impl yapılmaz
 
 ## 18. Pre-commit Hook: Stale Base Version Bump Engeli (2026-04-20)

--- a/tests/test_ops_preflight_script.py
+++ b/tests/test_ops_preflight_script.py
@@ -123,6 +123,7 @@ def test_ops_preflight_warns_on_dirty_worktree(tmp_path: Path) -> None:
     assert "Current worktree: dirty" in proc.stdout
     assert "⚠ Preflight completed with warnings" in proc.stdout
     assert "  - current worktree dirty" in proc.stdout
+    assert "do not run pull/rebase/switch" in proc.stdout
 
 
 def test_ops_preflight_fails_on_forbidden_branch_pattern(
@@ -135,6 +136,44 @@ def test_ops_preflight_fails_on_forbidden_branch_pattern(
 
     assert proc.returncode == 1
     assert "YASAK branch pattern: claude/stale" in proc.stdout
+
+
+def test_ops_preflight_rejects_feature_branch_on_primary_worktree(
+    tmp_path: Path,
+) -> None:
+    work = _init_remote_clone(tmp_path)
+    _git(work, "checkout", "-b", "codex/primary-edit", "origin/main")
+
+    proc = _run_preflight(work)
+
+    assert proc.returncode == 1
+    assert "Primary checkout üstünde feature branch yasak" in proc.stdout
+    assert "Ayrı worktree zorunlu" in proc.stdout
+
+
+def test_ops_preflight_allows_feature_branch_on_secondary_worktree(
+    tmp_path: Path,
+) -> None:
+    work = _init_remote_clone(tmp_path)
+    wt = tmp_path / "feature-wt"
+    _run(
+        [
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            "codex/secondary-edit",
+            wt.as_posix(),
+            "origin/main",
+        ],
+        cwd=work,
+    )
+
+    proc = _run_preflight(wt)
+
+    assert proc.returncode == 0
+    assert "Branch: codex/secondary-edit" in proc.stdout
+    assert "✓ Branch fresh" in proc.stdout
 
 
 def test_ops_overlap_check_clean_single_worktree(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- make separate worktrees mandatory for feature/docs/runtime patch work
- treat `origin/main` as the post-merge authority and replace unsafe `pull` guidance with clean-state `ff-only` sync guidance
- make `ops.sh preflight` surface dirty-state protection before pull/rebase/switch
- add regression coverage for primary-checkout feature branch rejection and secondary worktree allowance

## Validation

- `python3 -m pytest -q tests/test_ops_preflight_script.py`
- `git diff --check`
- `bash .claude/scripts/ops.sh preflight`
