### PR TITLE
[codex] ci: add GP-4.3 live adapter environment contract

### DIFF
--- a/.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md
+++ b/.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md
@@ -98,7 +98,7 @@ itself.
 |---|---|---|
 | `GP-4.1` workflow design stub | Add non-secret workflow skeleton or documented manual gate contract | implemented by `.github/workflows/live-adapter-gate.yml`; report remains `blocked`; no live secrets, no live calls, CI-safe |
 | `GP-4.2` evidence artifact contract | Define/upload JSON report shapes for live gate | implemented by schema-backed `live-adapter-gate-evidence.v1.json`; local tests validate schema; no live execution or support widening |
-| `GP-4.3` protected environment contract | Document required GitHub environment/secrets and fork safety | no repository secret values committed |
+| `GP-4.3` protected environment contract | Document required GitHub environment/secrets and fork safety | implemented by schema-backed `live-adapter-gate-environment-contract.v1.json`; no repository secret values, no live execution, no support widening |
 | `GP-4.4` live rehearsal | Run protected manual gate once and record artifacts | only if project-owned credentials exist |
 | `GP-4.5` support-boundary decision | Decide promote/keep beta/defer | requires all prior slices and docs parity |
 
@@ -161,8 +161,25 @@ The current artifact is intentionally blocked. It may be schema-valid and
 uploaded by CI, but it still says `support_widening=false` and
 `production_certified=false`.
 
+## GP-4.3 Implementation
+
+`GP-4.3` adds the schema-backed protected environment / secret contract:
+
+1. schema: `ao_kernel/defaults/schemas/live-adapter-gate-environment.schema.v1.json`;
+2. helper: `build_live_adapter_gate_environment_contract()`;
+3. validator: `validate_live_adapter_gate_environment_contract()`;
+4. expected artifact: `live-adapter-gate-environment-contract.v1.json`.
+
+The contract names the future protected GitHub environment
+`ao-kernel-live-adapter-gate`, requires maintainer review, forbids fork and
+pull-request secret exposure, and names `AO_CLAUDE_CODE_CLI_AUTH` as the
+project-owned Claude Code CLI auth handle. It does not create the environment,
+read a secret, call `claude`, or widen support.
+
 ## Next Step
 
-The next implementation slice should be `GP-4.3`: define the protected
-GitHub environment / secret contract and fork-safety rules. It must not commit
-secret values and must not widen support without protected live evidence.
+The next implementation slice should be `GP-4.4`: either run a protected live
+rehearsal after the required environment and credential are configured, or
+record an explicit blocked decision if project-owned credentials are not
+available. It must still avoid support widening until protected live evidence
+and docs parity exist.

--- a/.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md
+++ b/.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md
@@ -76,6 +76,7 @@ governed workflow smoke evidence.
 ## Next Slice
 
 `GP-4.2` has since added the schema-backed evidence artifact contract in
-`.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md`. The next
-active GP-4 slice is `GP-4.3`: protected GitHub environment / secret contract
-and fork-safety rules.
+`.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md`, and
+`GP-4.3` has added the protected environment / secret contract in
+`.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`. The next GP-4
+slice is `GP-4.4`: protected live rehearsal or explicit blocked decision.

--- a/.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md
+++ b/.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md
@@ -76,7 +76,8 @@ schema version and update the support docs through a separate decision gate.
 
 ## Next Slice
 
-`GP-4.3` should define the protected GitHub environment / secret contract and
-fork-safety rules. It should still avoid committing secret values and should not
-run live adapters unless project-owned credentials and protected dispatch rules
-exist.
+`GP-4.3` has since added the protected GitHub environment / secret contract in
+`.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`. The next slice
+is `GP-4.4`: either run a protected live rehearsal after project-owned
+credentials exist, or record an explicit blocked decision without support
+widening.

--- a/.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md
+++ b/.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md
@@ -1,0 +1,94 @@
+# GP-4.3 — Protected Environment / Secret Contract
+
+**Status:** Implemented slice
+**Date:** 2026-04-24
+**Parent tracker:** [#400](https://github.com/Halildeu/ao-kernel/issues/400)
+**Slice issue:** [#407](https://github.com/Halildeu/ao-kernel/issues/407)
+**Predecessor:** `GP-4.2` live adapter evidence artifact contract
+
+## Purpose
+
+Define the protected GitHub environment, secret handle, and fork-safety
+contract required before any project-owned `claude-code-cli` live adapter gate
+can run.
+
+This slice is still no-widening. It does not configure secret values, does not
+call `claude`, and does not claim production-certified real-adapter support.
+
+## Implemented Surface
+
+1. Schema:
+   `ao_kernel/defaults/schemas/live-adapter-gate-environment.schema.v1.json`
+2. Runtime helpers:
+   `build_live_adapter_gate_environment_contract()`,
+   `write_live_adapter_gate_environment_contract()`,
+   `validate_live_adapter_gate_environment_contract()`
+3. CLI output:
+   `scripts/live_adapter_gate_contract.py` now writes:
+   - `live-adapter-gate-contract.v1.json`
+   - `live-adapter-gate-evidence.v1.json`
+   - `live-adapter-gate-environment-contract.v1.json`
+4. Workflow artifact upload:
+   `.github/workflows/live-adapter-gate.yml` uploads all three JSON files.
+
+## Protected Environment Contract
+
+The required future environment is:
+
+| Field | Value |
+|---|---|
+| Environment name | `ao-kernel-live-adapter-gate` |
+| Allowed refs | `main` |
+| Required reviewers | `true` |
+| Prevent self-review | `true` |
+| Fork secrets | `false` |
+| Forbidden events | `pull_request`, `pull_request_target`, `push` |
+
+The required future secret handle is:
+
+| Secret id | Purpose |
+|---|---|
+| `AO_CLAUDE_CODE_CLI_AUTH` | Project-owned Claude Code CLI auth material or equivalent non-API-key credential for protected live rehearsal |
+
+No secret value is committed or read by this slice.
+
+## Support Boundary
+
+No support widening.
+
+The new environment contract artifact is intentionally blocked:
+
+1. `overall_status="blocked"`
+2. `finding_code="live_gate_protected_environment_not_attested"`
+3. `live_execution_allowed=false`
+4. `support_widening=false`
+
+The current repository environment inventory does not include
+`ao-kernel-live-adapter-gate`; only `pypi` exists at implementation time. A
+later slice must either configure and attest that environment or record an
+explicit release-gate equivalent.
+
+## Non-Goals
+
+1. No GitHub environment creation in code.
+2. No repository or environment secret values.
+3. No live adapter execution.
+4. No `pull_request_target` or fork-accessible secret path.
+5. No support-tier promotion.
+
+## Required Validation
+
+1. Schema self-validation with Draft 2020-12.
+2. Builder output validates against the bundled schema.
+3. Schema rejects fake `live_execution_allowed=true`.
+4. CLI writes the environment contract artifact.
+5. Workflow remains manual, has no `secrets.` references, and does not bind a
+   GitHub environment yet.
+
+## Next Slice
+
+`GP-4.4` may run a protected live rehearsal only after the protected environment
+and project-owned credential are configured outside the repository and the run
+can attach preflight + governed workflow smoke evidence. If that cannot be
+done, `GP-4.4` should record an explicit blocked decision instead of widening
+support.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -83,7 +83,8 @@ ayrı ayrı görünür kılmak.
 - **GP-4 tracker issue:** [#400](https://github.com/Halildeu/ao-kernel/issues/400) (`open`)
 - **GP-4.1 issue:** [#402](https://github.com/Halildeu/ao-kernel/issues/402) (`closed`)
 - **GP-4.2 issue:** [#404](https://github.com/Halildeu/ao-kernel/issues/404) (`closes with GP-4.2 PR`)
-- **Sıradaki gate:** `GP-4.3` protected environment / secret contract. Bu support widening değildir; stable support boundary unchanged kalır.
+- **GP-4.3 issue:** [#407](https://github.com/Halildeu/ao-kernel/issues/407) (`closes with GP-4.3 PR`)
+- **Sıradaki gate:** `GP-4.4` protected live rehearsal veya explicit blocked decision. Bu support widening değildir; stable support boundary unchanged kalır.
 
 ## 2. Başlangıç Gerçeği
 
@@ -140,6 +141,7 @@ ayrı ayrı görünür kılmak.
 | `GP-4` CI-managed live adapter gate design | Active ([#400](https://github.com/Halildeu/ao-kernel/issues/400), design `.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md`) | GP-3'te eksik kalan project-owned live-adapter gate'i support widening olmadan tasarlamak | design-only, no secrets, no live default CI call, no support widening |
 | `GP-4.1` CI-safe live adapter gate skeleton | Completed on `main` ([#402](https://github.com/Halildeu/ao-kernel/issues/402), record `.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md`) | workflow-dispatch-only contract artifact yüzeyini eklemek | no secrets, no live adapter execution, report `overall_status=blocked`, no support widening |
 | `GP-4.2` live adapter evidence artifact contract | Completed by GP-4.2 PR ([#404](https://github.com/Halildeu/ao-kernel/issues/404), record `.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md`) | live gate evidence artifact shape'i schema-backed hale getirmek | schema validation + blocked evidence slots + no live adapter execution + no support widening |
+| `GP-4.3` protected environment / secret contract | Completed by GP-4.3 PR ([#407](https://github.com/Halildeu/ao-kernel/issues/407), record `.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`) | protected GitHub environment, secret handle ve fork-safety contract'ini schema-backed hale getirmek | no secret values, no environment creation, no live adapter execution, no support widening |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -150,12 +152,13 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — GP-4.3 protected environment / secret contract
+### Current mode — GP-4.4 protected live rehearsal decision
 
 `GP-3` parent promotion programı `close_keep_operator_beta` kararıyla
-kapanmıştır. `GP-4.2` live adapter evidence artifact contract hattını
-tamamlamıştır. Sıradaki GP-4 slice `GP-4.3` protected GitHub environment /
-secret contract ve fork-safety kurallarını netleştirmektir.
+kapanmıştır. `GP-4.2` live adapter evidence artifact contract hattını,
+`GP-4.3` protected environment / secret contract hattını tamamlamıştır.
+Sıradaki GP-4 slice `GP-4.4` protected live rehearsal veya project-owned
+credential yoksa explicit blocked decision hattıdır.
 Bu support widening değildir; `SM-1` stable maintenance baseline ve `SM-2`
 stable baseline evidence refresh geçerlidir.
 
@@ -1116,5 +1119,14 @@ live adapter gate'i tasarlar.
    - expected artifact status `blocked`, `support_widening=false`,
      `production_certified=false`
    - no live adapter execution, no secret access, no support widening
-9. Next slice:
-   - `GP-4.3` protected environment / secret contract and fork-safety rules
+9. `GP-4.3` slice:
+   - record `.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`
+   - schema `ao_kernel/defaults/schemas/live-adapter-gate-environment.schema.v1.json`
+   - environment contract artifact `live-adapter-gate-environment-contract.v1.json`
+   - required protected environment `ao-kernel-live-adapter-gate`
+   - required secret handle `AO_CLAUDE_CODE_CLI_AUTH`
+   - expected contract status `blocked`, `live_execution_allowed=false`,
+     `support_widening=false`
+   - no live adapter execution, no secret value, no support widening
+10. Next slice:
+   - `GP-4.4` protected live rehearsal or explicit blocked decision

--- a/.github/workflows/live-adapter-gate.yml
+++ b/.github/workflows/live-adapter-gate.yml
@@ -63,6 +63,7 @@ jobs:
             --output json \
             --report-path live-adapter-gate-contract.v1.json \
             --evidence-path live-adapter-gate-evidence.v1.json \
+            --environment-contract-path live-adapter-gate-environment-contract.v1.json \
             --target-ref "$TARGET_REF" \
             --reason "$DISPATCH_REASON" \
             --requested-by "$REQUESTED_BY" \
@@ -76,4 +77,5 @@ jobs:
           path: |
             live-adapter-gate-contract.v1.json
             live-adapter-gate-evidence.v1.json
+            live-adapter-gate-environment-contract.v1.json
           if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   governed workflow-smoke, and protected-environment evidence slots recorded as
   blocked promotion gates. This still performs no secret access, live adapter
   execution, version bump, tag, publish, or support widening.
+- Added the `GP-4.3` protected environment / secret contract. The manual
+  `live-adapter-gate` workflow now also emits schema-backed
+  `live-adapter-gate-environment-contract.v1.json`, naming the required
+  `ao-kernel-live-adapter-gate` protected environment and
+  `AO_CLAUDE_CODE_CLI_AUTH` secret handle without committing secret values,
+  binding a live environment, calling `claude`, or widening support.
 
 ## [4.0.0] - 2026-04-24
 

--- a/ao_kernel/defaults/schemas/live-adapter-gate-environment.schema.v1.json
+++ b/ao_kernel/defaults/schemas/live-adapter-gate-environment.schema.v1.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:live-adapter-gate-environment:v1",
+  "title": "Live Adapter Gate Protected Environment Contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "program_id",
+    "gate_id",
+    "adapter_id",
+    "support_tier",
+    "overall_status",
+    "finding_code",
+    "generated_at",
+    "protected_environment",
+    "trigger_policy",
+    "required_secrets",
+    "live_execution_allowed",
+    "support_widening",
+    "promotion_blockers",
+    "findings"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1"
+    },
+    "artifact_kind": {
+      "const": "live_adapter_gate_environment_contract"
+    },
+    "program_id": {
+      "const": "GP-4.3"
+    },
+    "gate_id": {
+      "const": "ci-managed-live-adapter-gate"
+    },
+    "adapter_id": {
+      "const": "claude-code-cli"
+    },
+    "support_tier": {
+      "const": "Beta (operator-managed)"
+    },
+    "overall_status": {
+      "const": "blocked"
+    },
+    "finding_code": {
+      "const": "live_gate_protected_environment_not_attested"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "protected_environment": {
+      "$ref": "#/$defs/protected_environment"
+    },
+    "trigger_policy": {
+      "$ref": "#/$defs/trigger_policy"
+    },
+    "required_secrets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/required_secret"
+      }
+    },
+    "live_execution_allowed": {
+      "const": false
+    },
+    "support_widening": {
+      "const": false
+    },
+    "promotion_blockers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "findings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "protected_environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "required",
+        "required_reviewers",
+        "prevent_self_review",
+        "allowed_refs",
+        "detail"
+      ],
+      "properties": {
+        "name": {
+          "const": "ao-kernel-live-adapter-gate"
+        },
+        "required": {
+          "const": true
+        },
+        "required_reviewers": {
+          "const": true
+        },
+        "prevent_self_review": {
+          "const": true
+        },
+        "allowed_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "const": "main"
+          }
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "trigger_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "allowed_events",
+        "forbidden_events",
+        "allowed_refs",
+        "forks_allowed",
+        "pull_request_secrets_allowed",
+        "detail"
+      ],
+      "properties": {
+        "allowed_events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": ["workflow_dispatch", "schedule"]
+          }
+        },
+        "forbidden_events": {
+          "type": "array",
+          "minItems": 1,
+          "contains": {
+            "const": "pull_request"
+          },
+          "items": {
+            "enum": ["pull_request", "pull_request_target", "push"]
+          }
+        },
+        "allowed_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "const": "main"
+          }
+        },
+        "forks_allowed": {
+          "const": false
+        },
+        "pull_request_secrets_allowed": {
+          "const": false
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "required_secret": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "secret_id",
+        "required",
+        "exposure",
+        "secret_value_committed",
+        "purpose"
+      ],
+      "properties": {
+        "secret_id": {
+          "const": "AO_CLAUDE_CODE_CLI_AUTH"
+        },
+        "required": {
+          "const": true
+        },
+        "exposure": {
+          "const": "github_environment_secret"
+        },
+        "secret_value_committed": {
+          "const": false
+        },
+        "purpose": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/ao_kernel/live_adapter_gate.py
+++ b/ao_kernel/live_adapter_gate.py
@@ -27,6 +27,12 @@ EVIDENCE_ARTIFACT_KIND = "live_adapter_gate_evidence"
 EVIDENCE_SCHEMA_NAME = "live-adapter-gate-evidence.schema.v1.json"
 CONTRACT_REPORT_ARTIFACT = "live-adapter-gate-contract.v1.json"
 EVIDENCE_ARTIFACT = "live-adapter-gate-evidence.v1.json"
+ENVIRONMENT_CONTRACT_PROGRAM_ID = "GP-4.3"
+ENVIRONMENT_CONTRACT_ARTIFACT_KIND = "live_adapter_gate_environment_contract"
+ENVIRONMENT_CONTRACT_SCHEMA_NAME = "live-adapter-gate-environment.schema.v1.json"
+ENVIRONMENT_CONTRACT_ARTIFACT = "live-adapter-gate-environment-contract.v1.json"
+PROTECTED_ENVIRONMENT_NAME = "ao-kernel-live-adapter-gate"
+ENVIRONMENT_CONTRACT_FINDING = "live_gate_protected_environment_not_attested"
 
 
 CheckStatus = Literal["pass", "blocked", "skipped"]
@@ -117,6 +123,59 @@ class LiveAdapterGateEvidenceArtifact(TypedDict):
     source_report: LiveAdapterGateSourceReport
     evidence_requirements: list[LiveAdapterGateEvidenceRequirement]
     promotion_decision: LiveAdapterGatePromotionDecision
+    findings: list[str]
+
+
+class LiveAdapterGateProtectedEnvironment(TypedDict):
+    """Protected GitHub environment requirements for the future live gate."""
+
+    name: str
+    required: bool
+    required_reviewers: bool
+    prevent_self_review: bool
+    allowed_refs: list[str]
+    detail: str
+
+
+class LiveAdapterGateTriggerPolicy(TypedDict):
+    """Fork-safe trigger policy for future live execution."""
+
+    allowed_events: list[str]
+    forbidden_events: list[str]
+    allowed_refs: list[str]
+    forks_allowed: bool
+    pull_request_secrets_allowed: bool
+    detail: str
+
+
+class LiveAdapterGateSecretRequirement(TypedDict):
+    """Named secret requirement without storing a secret value."""
+
+    secret_id: str
+    required: bool
+    exposure: str
+    secret_value_committed: bool
+    purpose: str
+
+
+class LiveAdapterGateEnvironmentContract(TypedDict):
+    """Machine-readable GP-4.3 protected environment contract."""
+
+    schema_version: str
+    artifact_kind: str
+    program_id: str
+    gate_id: str
+    adapter_id: str
+    support_tier: str
+    overall_status: OverallStatus
+    finding_code: str
+    generated_at: str
+    protected_environment: LiveAdapterGateProtectedEnvironment
+    trigger_policy: LiveAdapterGateTriggerPolicy
+    required_secrets: list[LiveAdapterGateSecretRequirement]
+    live_execution_allowed: bool
+    support_widening: bool
+    promotion_blockers: list[str]
     findings: list[str]
 
 
@@ -290,6 +349,74 @@ def build_live_adapter_gate_evidence_artifact(
     }
 
 
+def build_live_adapter_gate_environment_contract(
+    *,
+    generated_at: str | None = None,
+) -> LiveAdapterGateEnvironmentContract:
+    """Build the GP-4.3 protected environment / secret contract artifact.
+
+    The contract names the required GitHub environment and secret handles, but
+    it deliberately does not prove that the environment exists and never stores
+    a secret value. A later GP-4 slice must attach a real attestation before live
+    execution or support widening can be considered.
+    """
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_kind": ENVIRONMENT_CONTRACT_ARTIFACT_KIND,
+        "program_id": ENVIRONMENT_CONTRACT_PROGRAM_ID,
+        "gate_id": GATE_ID,
+        "adapter_id": ADAPTER_ID,
+        "support_tier": SUPPORT_TIER,
+        "overall_status": "blocked",
+        "finding_code": ENVIRONMENT_CONTRACT_FINDING,
+        "generated_at": generated_at or utc_timestamp(),
+        "protected_environment": {
+            "name": PROTECTED_ENVIRONMENT_NAME,
+            "required": True,
+            "required_reviewers": True,
+            "prevent_self_review": True,
+            "allowed_refs": ["main"],
+            "detail": (
+                "Future live execution must run through this protected GitHub "
+                "environment or an explicitly approved release-gate equivalent."
+            ),
+        },
+        "trigger_policy": {
+            "allowed_events": ["workflow_dispatch", "schedule"],
+            "forbidden_events": ["pull_request", "pull_request_target", "push"],
+            "allowed_refs": ["main"],
+            "forks_allowed": False,
+            "pull_request_secrets_allowed": False,
+            "detail": (
+                "Project-owned live credentials must never be exposed to fork or "
+                "untrusted pull_request contexts."
+            ),
+        },
+        "required_secrets": [
+            {
+                "secret_id": "AO_CLAUDE_CODE_CLI_AUTH",
+                "required": True,
+                "exposure": "github_environment_secret",
+                "secret_value_committed": False,
+                "purpose": (
+                    "Project-owned Claude Code CLI auth material or equivalent "
+                    "non-API-key credential required for protected live rehearsal."
+                ),
+            }
+        ],
+        "live_execution_allowed": False,
+        "support_widening": False,
+        "promotion_blockers": [
+            "github_environment_not_attested",
+            "project_owned_credential_not_verified",
+            "live_preflight_not_collected",
+            "governed_workflow_smoke_not_collected",
+        ],
+        "findings": [ENVIRONMENT_CONTRACT_FINDING],
+    }
+
+
 def load_live_adapter_gate_evidence_schema() -> dict[str, Any]:
     """Load the bundled GP-4.2 evidence artifact JSON Schema."""
 
@@ -297,10 +424,23 @@ def load_live_adapter_gate_evidence_schema() -> dict[str, Any]:
     return cast(dict[str, Any], json.loads(schema_path.read_text(encoding="utf-8")))
 
 
+def load_live_adapter_gate_environment_schema() -> dict[str, Any]:
+    """Load the bundled GP-4.3 protected environment contract JSON Schema."""
+
+    schema_path = resources.files("ao_kernel.defaults.schemas").joinpath(ENVIRONMENT_CONTRACT_SCHEMA_NAME)
+    return cast(dict[str, Any], json.loads(schema_path.read_text(encoding="utf-8")))
+
+
 def validate_live_adapter_gate_evidence_artifact(artifact: object) -> None:
     """Validate a GP-4.2 evidence artifact against the bundled schema."""
 
     Draft202012Validator(load_live_adapter_gate_evidence_schema()).validate(artifact)
+
+
+def validate_live_adapter_gate_environment_contract(contract: object) -> None:
+    """Validate a GP-4.3 protected environment contract against the bundled schema."""
+
+    Draft202012Validator(load_live_adapter_gate_environment_schema()).validate(contract)
 
 
 def write_live_adapter_gate_report(path: Path, report: LiveAdapterGateReport) -> None:
@@ -316,6 +456,14 @@ def write_live_adapter_gate_evidence_artifact(path: Path, artifact: LiveAdapterG
     validate_live_adapter_gate_evidence_artifact(artifact)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_live_adapter_gate_environment_contract(path: Path, contract: LiveAdapterGateEnvironmentContract) -> None:
+    """Write a canonical GP-4.3 protected environment contract to ``path``."""
+
+    validate_live_adapter_gate_environment_contract(contract)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(contract, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def render_live_adapter_gate_text(report: LiveAdapterGateReport) -> str:

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -243,6 +243,10 @@ HTTP adapters must explicitly set `exposure_modes` to include `"http_header"` vi
   beside the contract artifact. It records missing preflight/workflow-smoke
   and protected-environment evidence as promotion blockers; it still does not
   call `claude`, read secrets, or promote this lane.
+- `GP-4.3` adds `live-adapter-gate-environment-contract.v1.json`. It defines
+  the required protected environment (`ao-kernel-live-adapter-gate`) and secret
+  handle (`AO_CLAUDE_CODE_CLI_AUTH`) without committing secret values, binding a
+  live environment, invoking `claude`, or promoting this lane.
 
 ### Failure modes
 

--- a/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
+++ b/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
@@ -98,7 +98,10 @@ tek başına production-certified support değildir.
 üretir. `GP-4.2` ayrıca schema-backed `live-adapter-gate-evidence.v1.json`
 artifact'ini üretir; bu artifact live preflight, governed workflow smoke ve
 protected environment attestation slotlarını promotion blocker olarak listeler.
-Her iki artifact de bugün blocked/no-widening semantiğindedir; bu live benchmark
+`GP-4.3` `live-adapter-gate-environment-contract.v1.json` artifact'ini ekler;
+bu required protected environment (`ao-kernel-live-adapter-gate`) ve secret
+handle (`AO_CLAUDE_CODE_CLI_AUTH`) adlarını kaydeder ama secret değeri içermez.
+Tüm artifact'ler bugün blocked/no-widening semantiğindedir; bu live benchmark
 veya real-adapter support kanıtı değildir.
 
 ### 1.3 Failure-mode matrix

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -45,10 +45,16 @@ python3 scripts/kernel_api_write_smoke.py --output text
 `live-adapter-gate` workflow'u (`GP-4.1`/`GP-4.2`) farklı bir yüzeydir: bugün
 canlı adapter çalıştırmaz. Manual workflow
 `live-adapter-gate-contract.v1.json` ve schema-backed
-`live-adapter-gate-evidence.v1.json` artifact'lerini üretir; artifact'lerin
-`overall_status="blocked"` / `finding_code="live_gate_not_implemented"` /
-`support_widening=false` dönmesi beklenir. Workflow'un yeşil olması
-production-certified `claude-code-cli` support anlamına gelmez.
+`live-adapter-gate-evidence.v1.json` artifact'lerini üretir. `GP-4.3` aynı
+bundle'a `live-adapter-gate-environment-contract.v1.json` artifact'ini ekler.
+Bu üçüncü artifact required protected environment
+`ao-kernel-live-adapter-gate` ve secret handle `AO_CLAUDE_CODE_CLI_AUTH`
+adlarını kaydeder, ama secret değerlerini okumaz veya yazmaz. Contract/evidence
+artifact'lerinde `finding_code="live_gate_not_implemented"`, environment
+contract artifact'inde `finding_code="live_gate_protected_environment_not_attested"`
+beklenir; hepsi `overall_status="blocked"` / `support_widening=false`
+semantiğindedir. Workflow'un yeşil olması production-certified
+`claude-code-cli` support anlamına gelmez.
 
 Prerequisite contract (operator-managed lanes):
 

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -159,5 +159,11 @@ Canlı snapshot üretimi için: `python3 scripts/truth_inventory_ratchet.py --ou
   ekler. Bu artifact bugün `overall_status="blocked"` /
   `support_widening=false` / `production_certified=false` döner ve canlı
   adapter execution kanıtı değildir.
+- `GP-4.3` protected environment / secret contract hattı
+  `live-adapter-gate-environment-contract.v1.json` artifact'ini ekler. Bu
+  artifact required environment olarak `ao-kernel-live-adapter-gate` ve secret
+  handle olarak `AO_CLAUDE_CODE_CLI_AUTH` adlarını tanımlar; secret değeri
+  içermez, environment oluşturmaz, canlı `claude` çağırmaz ve support widening
+  yapmaz.
 - `docs/roadmap/DEMO-SCRIPT-SPEC.md` roadmap/spec dokümanıdır; canlı
   CLI komut listesi değildir.

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -113,6 +113,12 @@ widening değildir: sadece manual contract artifact üretir, canlı `claude`
 contract'ını ekler. Artifact, preflight/workflow-smoke/protected-environment
 kanıt slotlarını promotion blocker olarak listeler; yine canlı adapter çağrısı,
 secret okuma veya support widening içermez.
+`GP-4.3` ayrıca `live-adapter-gate-environment-contract.v1.json` artifact'ini
+ekler. Bu contract required protected environment adını
+`ao-kernel-live-adapter-gate`, required secret handle adını
+`AO_CLAUDE_CODE_CLI_AUTH` olarak kaydeder; secret değeri commit etmez,
+environment oluşturmaz ve artifact hâlâ `live_execution_allowed=false` /
+`support_widening=false` döner.
 
 `gh-cli-pr` live-write probe, `PB-8.1` ile explicit precondition (opt-in,
 disposable repo, explicit `--repo` + `--head` + `--base`) ve create -> verify

--- a/scripts/live_adapter_gate_contract.py
+++ b/scripts/live_adapter_gate_contract.py
@@ -14,9 +14,12 @@ if str(_REPO_ROOT) not in sys.path:
 
 from ao_kernel.live_adapter_gate import (  # noqa: E402
     EVIDENCE_ARTIFACT,
+    ENVIRONMENT_CONTRACT_ARTIFACT,
+    build_live_adapter_gate_environment_contract,
     build_live_adapter_gate_report,
     build_live_adapter_gate_evidence_artifact,
     render_live_adapter_gate_text,
+    write_live_adapter_gate_environment_contract,
     write_live_adapter_gate_evidence_artifact,
     write_live_adapter_gate_report,
 )
@@ -27,8 +30,9 @@ def main() -> int:
         prog="live_adapter_gate_contract.py",
         description=(
             "Emit the design-only GP-4.1 live-adapter gate contract report. "
-            "This command also writes the GP-4.2 evidence artifact and never "
-            "executes a live external adapter."
+            "This command also writes the GP-4.2 evidence artifact plus the "
+            "GP-4.3 protected environment contract and never executes a live "
+            "external adapter."
         ),
     )
     parser.add_argument(
@@ -48,6 +52,12 @@ def main() -> int:
         type=Path,
         default=Path(EVIDENCE_ARTIFACT),
         help="Path for the canonical GP-4.2 evidence artifact.",
+    )
+    parser.add_argument(
+        "--environment-contract-path",
+        type=Path,
+        default=Path(ENVIRONMENT_CONTRACT_ARTIFACT),
+        help="Path for the canonical GP-4.3 protected environment contract.",
     )
     parser.add_argument("--target-ref", default="main", help="Protected target ref being evaluated.")
     parser.add_argument("--reason", default="", help="Manual dispatch reason.")
@@ -69,6 +79,13 @@ def main() -> int:
         contract_report_path=args.report_path.name,
     )
     write_live_adapter_gate_evidence_artifact(args.evidence_path, evidence_artifact)
+    environment_contract = build_live_adapter_gate_environment_contract(
+        generated_at=report["generated_at"],
+    )
+    write_live_adapter_gate_environment_contract(
+        args.environment_contract_path,
+        environment_contract,
+    )
 
     if args.output == "json":
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/test_live_adapter_gate_contract.py
+++ b/tests/test_live_adapter_gate_contract.py
@@ -12,13 +12,18 @@ from jsonschema.exceptions import ValidationError
 from ao_kernel.live_adapter_gate import (
     BLOCKED_FINDING,
     EVIDENCE_ARTIFACT,
+    ENVIRONMENT_CONTRACT_ARTIFACT,
     build_live_adapter_gate_evidence_artifact,
+    build_live_adapter_gate_environment_contract,
     build_live_adapter_gate_report,
     live_adapter_gate_report_sha256,
     load_live_adapter_gate_evidence_schema,
+    load_live_adapter_gate_environment_schema,
     render_live_adapter_gate_text,
     validate_live_adapter_gate_evidence_artifact,
+    validate_live_adapter_gate_environment_contract,
     write_live_adapter_gate_evidence_artifact,
+    write_live_adapter_gate_environment_contract,
     write_live_adapter_gate_report,
 )
 
@@ -74,6 +79,13 @@ def test_live_adapter_gate_evidence_schema_is_valid() -> None:
     assert schema["$id"] == "urn:ao:live-adapter-gate-evidence:v1"
 
 
+def test_live_adapter_gate_environment_schema_is_valid() -> None:
+    schema = load_live_adapter_gate_environment_schema()
+
+    Draft202012Validator.check_schema(schema)
+    assert schema["$id"] == "urn:ao:live-adapter-gate-environment:v1"
+
+
 def test_build_live_adapter_gate_evidence_artifact_is_schema_valid_and_blocked() -> None:
     report = build_live_adapter_gate_report(
         target_ref="main",
@@ -110,6 +122,47 @@ def test_build_live_adapter_gate_evidence_artifact_is_schema_valid_and_blocked()
     assert requirements["protected_environment_attestation"]["status"] == "blocked"
 
 
+def test_build_live_adapter_gate_environment_contract_is_schema_valid_and_blocked() -> None:
+    contract = build_live_adapter_gate_environment_contract(
+        generated_at="2026-04-24T00:00:00Z",
+    )
+
+    validate_live_adapter_gate_environment_contract(contract)
+    assert contract["schema_version"] == "1"
+    assert contract["artifact_kind"] == "live_adapter_gate_environment_contract"
+    assert contract["program_id"] == "GP-4.3"
+    assert contract["overall_status"] == "blocked"
+    assert contract["finding_code"] == "live_gate_protected_environment_not_attested"
+    assert contract["live_execution_allowed"] is False
+    assert contract["support_widening"] is False
+    assert contract["protected_environment"] == {
+        "name": "ao-kernel-live-adapter-gate",
+        "required": True,
+        "required_reviewers": True,
+        "prevent_self_review": True,
+        "allowed_refs": ["main"],
+        "detail": (
+            "Future live execution must run through this protected GitHub "
+            "environment or an explicitly approved release-gate equivalent."
+        ),
+    }
+    assert contract["trigger_policy"]["forks_allowed"] is False
+    assert contract["trigger_policy"]["pull_request_secrets_allowed"] is False
+    assert "pull_request" in contract["trigger_policy"]["forbidden_events"]
+    assert contract["required_secrets"] == [
+        {
+            "secret_id": "AO_CLAUDE_CODE_CLI_AUTH",
+            "required": True,
+            "exposure": "github_environment_secret",
+            "secret_value_committed": False,
+            "purpose": (
+                "Project-owned Claude Code CLI auth material or equivalent "
+                "non-API-key credential required for protected live rehearsal."
+            ),
+        }
+    ]
+
+
 def test_live_adapter_gate_evidence_schema_rejects_support_widening() -> None:
     report = build_live_adapter_gate_report(generated_at="2026-04-24T00:00:00Z")
     artifact = build_live_adapter_gate_evidence_artifact(report)
@@ -117,6 +170,16 @@ def test_live_adapter_gate_evidence_schema_rejects_support_widening() -> None:
 
     with pytest.raises(ValidationError):
         validate_live_adapter_gate_evidence_artifact(artifact)
+
+
+def test_live_adapter_gate_environment_schema_rejects_fake_live_execution() -> None:
+    contract = build_live_adapter_gate_environment_contract(
+        generated_at="2026-04-24T00:00:00Z",
+    )
+    contract["live_execution_allowed"] = True
+
+    with pytest.raises(ValidationError):
+        validate_live_adapter_gate_environment_contract(contract)
 
 
 def test_write_live_adapter_gate_evidence_artifact_round_trips_json(tmp_path: Path) -> None:
@@ -129,6 +192,20 @@ def test_write_live_adapter_gate_evidence_artifact_round_trips_json(tmp_path: Pa
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert payload == artifact
     validate_live_adapter_gate_evidence_artifact(payload)
+    assert path.read_text(encoding="utf-8").endswith("\n")
+
+
+def test_write_live_adapter_gate_environment_contract_round_trips_json(tmp_path: Path) -> None:
+    contract = build_live_adapter_gate_environment_contract(
+        generated_at="2026-04-24T00:00:00Z",
+    )
+    path = tmp_path / ENVIRONMENT_CONTRACT_ARTIFACT
+
+    write_live_adapter_gate_environment_contract(path, contract)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload == contract
+    validate_live_adapter_gate_environment_contract(payload)
     assert path.read_text(encoding="utf-8").endswith("\n")
 
 
@@ -146,6 +223,7 @@ def test_script_emits_json_and_report_file(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     report_path = tmp_path / "contract.json"
     evidence_path = tmp_path / "evidence.json"
+    environment_contract_path = tmp_path / "environment.json"
 
     result = subprocess.run(
         [
@@ -157,6 +235,8 @@ def test_script_emits_json_and_report_file(tmp_path: Path) -> None:
             str(report_path),
             "--evidence-path",
             str(evidence_path),
+            "--environment-contract-path",
+            str(environment_contract_path),
             "--target-ref",
             "main",
             "--reason",
@@ -178,12 +258,16 @@ def test_script_emits_json_and_report_file(tmp_path: Path) -> None:
     stdout_payload = json.loads(result.stdout)
     file_payload = json.loads(report_path.read_text(encoding="utf-8"))
     evidence_payload = json.loads(evidence_path.read_text(encoding="utf-8"))
+    environment_payload = json.loads(environment_contract_path.read_text(encoding="utf-8"))
     assert stdout_payload == file_payload
     assert stdout_payload["overall_status"] == "blocked"
     assert stdout_payload["live_execution_attempted"] is False
     validate_live_adapter_gate_evidence_artifact(evidence_payload)
+    validate_live_adapter_gate_environment_contract(environment_payload)
     assert evidence_payload["source_report"]["path"] == report_path.name
     assert evidence_payload["support_widening"] is False
+    assert environment_payload["support_widening"] is False
+    assert environment_payload["live_execution_allowed"] is False
 
 
 def test_live_adapter_gate_workflow_is_manual_contract_only() -> None:
@@ -196,7 +280,9 @@ def test_live_adapter_gate_workflow_is_manual_contract_only() -> None:
     assert "live_adapter_gate_contract.py" in workflow
     assert "live-adapter-gate-contract.v1.json" in workflow
     assert "live-adapter-gate-evidence.v1.json" in workflow
+    assert "live-adapter-gate-environment-contract.v1.json" in workflow
     assert "claude_code_cli_smoke.py" not in workflow
     assert "claude_code_cli_workflow_smoke.py" not in workflow
     assert "secrets." not in workflow
+    assert "\n    environment:" not in workflow
     assert "contents: read" in workflow


### PR DESCRIPTION
## Summary
- Implements GP-4.3 for #400 and closes #407.
- Adds a schema-backed `live-adapter-gate-environment-contract.v1.json` artifact for the protected environment / secret contract.
- Keeps the lane blocked: no GitHub environment creation, no secret values, no workflow environment binding, no live adapter execution, no support widening.

## Contract
- Required protected environment: `ao-kernel-live-adapter-gate`.
- Required secret handle: `AO_CLAUDE_CODE_CLI_AUTH`.
- Allowed trigger posture remains manual/scheduled only; no pull_request/pull_request_target/push live trigger.
- Current contract status is intentionally `blocked` until GP-4.4 decides live rehearsal or explicit blocked closeout.

## Validation
- `python3 -m pytest -q tests/test_live_adapter_gate_contract.py`
- `python3 -m ruff check ao_kernel/live_adapter_gate.py scripts/live_adapter_gate_contract.py tests/test_live_adapter_gate_contract.py`
- `python3 -m mypy ao_kernel/live_adapter_gate.py`
- `git diff --check`
- Earlier full slice validation in this worktree: targeted policy/doctor tests, `python3 -m ao_kernel doctor`, artifact smoke, and `python3 scripts/packaging_smoke.py`.
