### PR TITLE
[codex] ci: add GP-4.4 live rehearsal blocked decision

### DIFF
--- a/.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md
+++ b/.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md
@@ -99,7 +99,7 @@ itself.
 | `GP-4.1` workflow design stub | Add non-secret workflow skeleton or documented manual gate contract | implemented by `.github/workflows/live-adapter-gate.yml`; report remains `blocked`; no live secrets, no live calls, CI-safe |
 | `GP-4.2` evidence artifact contract | Define/upload JSON report shapes for live gate | implemented by schema-backed `live-adapter-gate-evidence.v1.json`; local tests validate schema; no live execution or support widening |
 | `GP-4.3` protected environment contract | Document required GitHub environment/secrets and fork safety | implemented by schema-backed `live-adapter-gate-environment-contract.v1.json`; no repository secret values, no live execution, no support widening |
-| `GP-4.4` live rehearsal | Run protected manual gate once and record artifacts | only if project-owned credentials exist |
+| `GP-4.4` live rehearsal decision | Run protected manual gate once, or record blocked decision if prerequisites are absent | implemented as blocked decision artifact; no protected environment/credential attested, no live execution |
 | `GP-4.5` support-boundary decision | Decide promote/keep beta/defer | requires all prior slices and docs parity |
 
 ## Promotion Preconditions
@@ -176,10 +176,23 @@ pull-request secret exposure, and names `AO_CLAUDE_CODE_CLI_AUTH` as the
 project-owned Claude Code CLI auth handle. It does not create the environment,
 read a secret, call `claude`, or widen support.
 
+## GP-4.4 Implementation
+
+`GP-4.4` records the protected live rehearsal decision:
+
+1. schema:
+   `ao_kernel/defaults/schemas/live-adapter-gate-rehearsal-decision.schema.v1.json`;
+2. helper: `build_live_adapter_gate_rehearsal_decision()`;
+3. validator: `validate_live_adapter_gate_rehearsal_decision()`;
+4. expected artifact: `live-adapter-gate-rehearsal-decision.v1.json`.
+
+The decision is `blocked_no_rehearsal` because the required protected
+environment and project-owned credential are not attested. The workflow still
+does not create environments, read secrets, bind `environment:`, call `claude`,
+or widen support.
+
 ## Next Step
 
-The next implementation slice should be `GP-4.4`: either run a protected live
-rehearsal after the required environment and credential are configured, or
-record an explicit blocked decision if project-owned credentials are not
-available. It must still avoid support widening until protected live evidence
-and docs parity exist.
+The next implementation slice should be `GP-4.5`: close the support-boundary
+decision for `claude-code-cli` against the blocked GP-4 evidence. It must still
+avoid support widening unless protected live evidence and docs parity exist.

--- a/.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md
+++ b/.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md
@@ -78,5 +78,6 @@ governed workflow smoke evidence.
 `GP-4.2` has since added the schema-backed evidence artifact contract in
 `.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md`, and
 `GP-4.3` has added the protected environment / secret contract in
-`.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`. The next GP-4
-slice is `GP-4.4`: protected live rehearsal or explicit blocked decision.
+`.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`. `GP-4.4`
+has since recorded the protected live rehearsal blocked decision in
+`.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md`.

--- a/.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md
+++ b/.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md
@@ -77,7 +77,6 @@ schema version and update the support docs through a separate decision gate.
 ## Next Slice
 
 `GP-4.3` has since added the protected GitHub environment / secret contract in
-`.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`. The next slice
-is `GP-4.4`: either run a protected live rehearsal after project-owned
-credentials exist, or record an explicit blocked decision without support
-widening.
+`.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`. `GP-4.4`
+has since recorded the protected live rehearsal blocked decision in
+`.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md`.

--- a/.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md
+++ b/.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md
@@ -87,8 +87,7 @@ explicit release-gate equivalent.
 
 ## Next Slice
 
-`GP-4.4` may run a protected live rehearsal only after the protected environment
-and project-owned credential are configured outside the repository and the run
-can attach preflight + governed workflow smoke evidence. If that cannot be
-done, `GP-4.4` should record an explicit blocked decision instead of widening
-support.
+`GP-4.4` has since recorded an explicit blocked decision in
+`.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md`, because
+the protected environment and project-owned credential are not attested. The
+next GP-4 slice is `GP-4.5` support-boundary closeout.

--- a/.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md
+++ b/.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md
@@ -1,0 +1,95 @@
+# GP-4.4 — Protected Live Rehearsal Blocked Decision
+
+**Status:** Implemented slice
+**Date:** 2026-04-24
+**Parent tracker:** [#400](https://github.com/Halildeu/ao-kernel/issues/400)
+**Slice issue:** [#410](https://github.com/Halildeu/ao-kernel/issues/410)
+**Predecessor:** `GP-4.3` protected environment / secret contract
+
+## Purpose
+
+Record the `GP-4.4` decision for the CI-managed live adapter gate.
+
+The required protected GitHub environment and project-owned Claude Code CLI
+credential are not attested, so the correct outcome is an explicit blocked
+decision. This slice does not run a live adapter, does not configure secrets,
+does not bind a GitHub environment, and does not widen support.
+
+## Live Prerequisite Check
+
+At implementation time the repository environment inventory contains only:
+
+| Environment | Meaning |
+|---|---|
+| `pypi` | existing publish environment |
+
+The required future live adapter gate environment is not present:
+
+| Required environment | Status |
+|---|---|
+| `ao-kernel-live-adapter-gate` | not attested |
+
+The required future project-owned credential is also not attested:
+
+| Secret handle | Status |
+|---|---|
+| `AO_CLAUDE_CODE_CLI_AUTH` | not attested |
+
+## Implemented Surface
+
+1. Schema:
+   `ao_kernel/defaults/schemas/live-adapter-gate-rehearsal-decision.schema.v1.json`
+2. Runtime helpers:
+   `build_live_adapter_gate_rehearsal_decision()`,
+   `write_live_adapter_gate_rehearsal_decision()`,
+   `validate_live_adapter_gate_rehearsal_decision()`
+3. CLI output:
+   `scripts/live_adapter_gate_contract.py` now writes:
+   - `live-adapter-gate-contract.v1.json`
+   - `live-adapter-gate-evidence.v1.json`
+   - `live-adapter-gate-environment-contract.v1.json`
+   - `live-adapter-gate-rehearsal-decision.v1.json`
+4. Workflow artifact upload:
+   `.github/workflows/live-adapter-gate.yml` uploads all four JSON files.
+
+## Decision
+
+The new rehearsal decision artifact is intentionally blocked:
+
+1. `overall_status="blocked"`
+2. `decision="blocked_no_rehearsal"`
+3. `finding_code="live_gate_rehearsal_blocked_missing_protected_prerequisites"`
+4. `live_rehearsal_attempted=false`
+5. `live_execution_allowed=false`
+6. `support_widening=false`
+
+## Support Boundary
+
+No support widening.
+
+`claude-code-cli` remains `Beta (operator-managed)`. A green
+`live-adapter-gate` workflow means blocked artifacts were emitted, not that a
+live adapter passed.
+
+## Non-Goals
+
+1. No GitHub environment creation.
+2. No repository or environment secret values.
+3. No workflow `environment:` binding.
+4. No `claude` invocation.
+5. No support-tier promotion.
+
+## Required Validation
+
+1. Schema self-validation with Draft 2020-12.
+2. Builder output validates against the bundled schema.
+3. Schema rejects fake `live_rehearsal_attempted=true`.
+4. CLI writes the rehearsal decision artifact.
+5. Workflow remains manual, has no `secrets.` references, and does not bind a
+   GitHub environment.
+
+## Next Slice
+
+`GP-4.5` should close the support-boundary decision: keep
+`claude-code-cli` as operator-managed beta unless a future separately approved
+protected live gate is configured and attested.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -84,7 +84,8 @@ ayrı ayrı görünür kılmak.
 - **GP-4.1 issue:** [#402](https://github.com/Halildeu/ao-kernel/issues/402) (`closed`)
 - **GP-4.2 issue:** [#404](https://github.com/Halildeu/ao-kernel/issues/404) (`closes with GP-4.2 PR`)
 - **GP-4.3 issue:** [#407](https://github.com/Halildeu/ao-kernel/issues/407) (`closes with GP-4.3 PR`)
-- **Sıradaki gate:** `GP-4.4` protected live rehearsal veya explicit blocked decision. Bu support widening değildir; stable support boundary unchanged kalır.
+- **GP-4.4 issue:** [#410](https://github.com/Halildeu/ao-kernel/issues/410) (`closes with GP-4.4 PR`)
+- **Sıradaki gate:** `GP-4.5` support-boundary closeout. Bu support widening değildir; stable support boundary unchanged kalır.
 
 ## 2. Başlangıç Gerçeği
 
@@ -142,6 +143,7 @@ ayrı ayrı görünür kılmak.
 | `GP-4.1` CI-safe live adapter gate skeleton | Completed on `main` ([#402](https://github.com/Halildeu/ao-kernel/issues/402), record `.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md`) | workflow-dispatch-only contract artifact yüzeyini eklemek | no secrets, no live adapter execution, report `overall_status=blocked`, no support widening |
 | `GP-4.2` live adapter evidence artifact contract | Completed by GP-4.2 PR ([#404](https://github.com/Halildeu/ao-kernel/issues/404), record `.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md`) | live gate evidence artifact shape'i schema-backed hale getirmek | schema validation + blocked evidence slots + no live adapter execution + no support widening |
 | `GP-4.3` protected environment / secret contract | Completed by GP-4.3 PR ([#407](https://github.com/Halildeu/ao-kernel/issues/407), record `.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`) | protected GitHub environment, secret handle ve fork-safety contract'ini schema-backed hale getirmek | no secret values, no environment creation, no live adapter execution, no support widening |
+| `GP-4.4` protected live rehearsal blocked decision | Completed by GP-4.4 PR ([#410](https://github.com/Halildeu/ao-kernel/issues/410), record `.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md`) | protected live rehearsal prerequisite eksikse fake live success üretmeden blocked decision kaydetmek | schema validation + blocked rehearsal decision artifact + no live adapter execution + no support widening |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -152,13 +154,13 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — GP-4.4 protected live rehearsal decision
+### Current mode — GP-4.5 support-boundary closeout
 
 `GP-3` parent promotion programı `close_keep_operator_beta` kararıyla
 kapanmıştır. `GP-4.2` live adapter evidence artifact contract hattını,
-`GP-4.3` protected environment / secret contract hattını tamamlamıştır.
-Sıradaki GP-4 slice `GP-4.4` protected live rehearsal veya project-owned
-credential yoksa explicit blocked decision hattıdır.
+`GP-4.3` protected environment / secret contract hattını ve `GP-4.4` protected
+live rehearsal blocked decision hattını tamamlamıştır. Sıradaki GP-4 slice
+`GP-4.5` support-boundary closeout hattıdır.
 Bu support widening değildir; `SM-1` stable maintenance baseline ve `SM-2`
 stable baseline evidence refresh geçerlidir.
 
@@ -1128,5 +1130,11 @@ live adapter gate'i tasarlar.
    - expected contract status `blocked`, `live_execution_allowed=false`,
      `support_widening=false`
    - no live adapter execution, no secret value, no support widening
-10. Next slice:
-   - `GP-4.4` protected live rehearsal or explicit blocked decision
+10. `GP-4.4` slice:
+   - record `.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md`
+   - schema `ao_kernel/defaults/schemas/live-adapter-gate-rehearsal-decision.schema.v1.json`
+   - rehearsal decision artifact `live-adapter-gate-rehearsal-decision.v1.json`
+   - expected decision status `blocked_no_rehearsal`
+   - no live adapter execution, no secret value, no support widening
+11. Next slice:
+   - `GP-4.5` support-boundary closeout

--- a/.github/workflows/live-adapter-gate.yml
+++ b/.github/workflows/live-adapter-gate.yml
@@ -64,6 +64,7 @@ jobs:
             --report-path live-adapter-gate-contract.v1.json \
             --evidence-path live-adapter-gate-evidence.v1.json \
             --environment-contract-path live-adapter-gate-environment-contract.v1.json \
+            --rehearsal-decision-path live-adapter-gate-rehearsal-decision.v1.json \
             --target-ref "$TARGET_REF" \
             --reason "$DISPATCH_REASON" \
             --requested-by "$REQUESTED_BY" \
@@ -78,4 +79,5 @@ jobs:
             live-adapter-gate-contract.v1.json
             live-adapter-gate-evidence.v1.json
             live-adapter-gate-environment-contract.v1.json
+            live-adapter-gate-rehearsal-decision.v1.json
           if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `ao-kernel-live-adapter-gate` protected environment and
   `AO_CLAUDE_CODE_CLI_AUTH` secret handle without committing secret values,
   binding a live environment, calling `claude`, or widening support.
+- Added the `GP-4.4` protected live rehearsal blocked decision. The manual
+  `live-adapter-gate` workflow now also emits schema-backed
+  `live-adapter-gate-rehearsal-decision.v1.json` with
+  `decision="blocked_no_rehearsal"` because the protected environment and
+  project-owned credential are not attested; it still does not bind a live
+  environment, call `claude`, or widen support.
 
 ## [4.0.0] - 2026-04-24
 

--- a/ao_kernel/defaults/schemas/live-adapter-gate-rehearsal-decision.schema.v1.json
+++ b/ao_kernel/defaults/schemas/live-adapter-gate-rehearsal-decision.schema.v1.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:live-adapter-gate-rehearsal-decision:v1",
+  "title": "Live Adapter Gate Protected Live Rehearsal Decision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "program_id",
+    "gate_id",
+    "adapter_id",
+    "support_tier",
+    "overall_status",
+    "decision",
+    "finding_code",
+    "generated_at",
+    "live_rehearsal_attempted",
+    "live_execution_allowed",
+    "support_widening",
+    "prerequisite_status",
+    "promotion_decision",
+    "findings"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1"
+    },
+    "artifact_kind": {
+      "const": "live_adapter_gate_rehearsal_decision"
+    },
+    "program_id": {
+      "const": "GP-4.4"
+    },
+    "gate_id": {
+      "const": "ci-managed-live-adapter-gate"
+    },
+    "adapter_id": {
+      "const": "claude-code-cli"
+    },
+    "support_tier": {
+      "const": "Beta (operator-managed)"
+    },
+    "overall_status": {
+      "const": "blocked"
+    },
+    "decision": {
+      "const": "blocked_no_rehearsal"
+    },
+    "finding_code": {
+      "const": "live_gate_rehearsal_blocked_missing_protected_prerequisites"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "live_rehearsal_attempted": {
+      "const": false
+    },
+    "live_execution_allowed": {
+      "const": false
+    },
+    "support_widening": {
+      "const": false
+    },
+    "prerequisite_status": {
+      "type": "array",
+      "minItems": 4,
+      "items": {
+        "$ref": "#/$defs/prerequisite_status"
+      }
+    },
+    "promotion_decision": {
+      "$ref": "#/$defs/promotion_decision"
+    },
+    "findings": {
+      "type": "array",
+      "minItems": 1,
+      "contains": {
+        "const": "live_gate_rehearsal_blocked_missing_protected_prerequisites"
+      },
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "prerequisite_status": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prerequisite_id", "status", "finding_code", "detail"],
+      "properties": {
+        "prerequisite_id": {
+          "enum": [
+            "protected_environment_attestation",
+            "project_owned_credential",
+            "protected_live_preflight",
+            "governed_workflow_smoke"
+          ]
+        },
+        "status": {
+          "enum": ["blocked", "not_attested"]
+        },
+        "finding_code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "promotion_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "support_widening_allowed",
+        "production_certified",
+        "next_gate",
+        "reason"
+      ],
+      "properties": {
+        "support_widening_allowed": {
+          "const": false
+        },
+        "production_certified": {
+          "const": false
+        },
+        "next_gate": {
+          "const": "GP-4.5"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/ao_kernel/live_adapter_gate.py
+++ b/ao_kernel/live_adapter_gate.py
@@ -33,11 +33,17 @@ ENVIRONMENT_CONTRACT_SCHEMA_NAME = "live-adapter-gate-environment.schema.v1.json
 ENVIRONMENT_CONTRACT_ARTIFACT = "live-adapter-gate-environment-contract.v1.json"
 PROTECTED_ENVIRONMENT_NAME = "ao-kernel-live-adapter-gate"
 ENVIRONMENT_CONTRACT_FINDING = "live_gate_protected_environment_not_attested"
+REHEARSAL_DECISION_PROGRAM_ID = "GP-4.4"
+REHEARSAL_DECISION_ARTIFACT_KIND = "live_adapter_gate_rehearsal_decision"
+REHEARSAL_DECISION_SCHEMA_NAME = "live-adapter-gate-rehearsal-decision.schema.v1.json"
+REHEARSAL_DECISION_ARTIFACT = "live-adapter-gate-rehearsal-decision.v1.json"
+REHEARSAL_DECISION_FINDING = "live_gate_rehearsal_blocked_missing_protected_prerequisites"
 
 
 CheckStatus = Literal["pass", "blocked", "skipped"]
 OverallStatus = Literal["blocked"]
 EvidenceRequirementStatus = Literal["present", "blocked"]
+PrerequisiteStatus = Literal["blocked", "not_attested"]
 
 
 class LiveAdapterGateTrigger(TypedDict):
@@ -176,6 +182,45 @@ class LiveAdapterGateEnvironmentContract(TypedDict):
     live_execution_allowed: bool
     support_widening: bool
     promotion_blockers: list[str]
+    findings: list[str]
+
+
+class LiveAdapterGatePrerequisiteStatus(TypedDict):
+    """Single prerequisite for a future protected live rehearsal."""
+
+    prerequisite_id: str
+    status: PrerequisiteStatus
+    finding_code: str
+    detail: str
+
+
+class LiveAdapterGateRehearsalPromotionDecision(TypedDict):
+    """Fail-closed GP-4.4 promotion decision."""
+
+    support_widening_allowed: bool
+    production_certified: bool
+    next_gate: str
+    reason: str
+
+
+class LiveAdapterGateRehearsalDecision(TypedDict):
+    """Machine-readable GP-4.4 protected live rehearsal decision."""
+
+    schema_version: str
+    artifact_kind: str
+    program_id: str
+    gate_id: str
+    adapter_id: str
+    support_tier: str
+    overall_status: OverallStatus
+    decision: str
+    finding_code: str
+    generated_at: str
+    live_rehearsal_attempted: bool
+    live_execution_allowed: bool
+    support_widening: bool
+    prerequisite_status: list[LiveAdapterGatePrerequisiteStatus]
+    promotion_decision: LiveAdapterGateRehearsalPromotionDecision
     findings: list[str]
 
 
@@ -417,6 +462,76 @@ def build_live_adapter_gate_environment_contract(
     }
 
 
+def build_live_adapter_gate_rehearsal_decision(
+    *,
+    generated_at: str | None = None,
+) -> LiveAdapterGateRehearsalDecision:
+    """Build the GP-4.4 protected live rehearsal decision artifact.
+
+    The current decision is fail-closed: no protected environment or
+    project-owned credential is attested, so no live adapter call is attempted
+    and support remains unchanged.
+    """
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_kind": REHEARSAL_DECISION_ARTIFACT_KIND,
+        "program_id": REHEARSAL_DECISION_PROGRAM_ID,
+        "gate_id": GATE_ID,
+        "adapter_id": ADAPTER_ID,
+        "support_tier": SUPPORT_TIER,
+        "overall_status": "blocked",
+        "decision": "blocked_no_rehearsal",
+        "finding_code": REHEARSAL_DECISION_FINDING,
+        "generated_at": generated_at or utc_timestamp(),
+        "live_rehearsal_attempted": False,
+        "live_execution_allowed": False,
+        "support_widening": False,
+        "prerequisite_status": [
+            {
+                "prerequisite_id": "protected_environment_attestation",
+                "status": "not_attested",
+                "finding_code": "live_gate_protected_environment_not_attested",
+                "detail": (
+                    f"Required GitHub environment {PROTECTED_ENVIRONMENT_NAME!r} "
+                    "is not attested by this repository lane."
+                ),
+            },
+            {
+                "prerequisite_id": "project_owned_credential",
+                "status": "not_attested",
+                "finding_code": "live_gate_project_owned_credential_not_attested",
+                "detail": (
+                    "Required project-owned Claude Code CLI credential handle "
+                    "AO_CLAUDE_CODE_CLI_AUTH is not attested by this lane."
+                ),
+            },
+            {
+                "prerequisite_id": "protected_live_preflight",
+                "status": "blocked",
+                "finding_code": "live_gate_preflight_not_collected",
+                "detail": "Protected live preflight cannot run before environment and credential attestation.",
+            },
+            {
+                "prerequisite_id": "governed_workflow_smoke",
+                "status": "blocked",
+                "finding_code": "live_gate_workflow_smoke_not_collected",
+                "detail": "Governed workflow smoke cannot run before protected live preflight passes.",
+            },
+        ],
+        "promotion_decision": {
+            "support_widening_allowed": False,
+            "production_certified": False,
+            "next_gate": "GP-4.5",
+            "reason": (
+                "GP-4.4 records an explicit blocked decision because protected "
+                "live rehearsal prerequisites are not attested."
+            ),
+        },
+        "findings": [REHEARSAL_DECISION_FINDING],
+    }
+
+
 def load_live_adapter_gate_evidence_schema() -> dict[str, Any]:
     """Load the bundled GP-4.2 evidence artifact JSON Schema."""
 
@@ -431,6 +546,13 @@ def load_live_adapter_gate_environment_schema() -> dict[str, Any]:
     return cast(dict[str, Any], json.loads(schema_path.read_text(encoding="utf-8")))
 
 
+def load_live_adapter_gate_rehearsal_decision_schema() -> dict[str, Any]:
+    """Load the bundled GP-4.4 protected live rehearsal decision JSON Schema."""
+
+    schema_path = resources.files("ao_kernel.defaults.schemas").joinpath(REHEARSAL_DECISION_SCHEMA_NAME)
+    return cast(dict[str, Any], json.loads(schema_path.read_text(encoding="utf-8")))
+
+
 def validate_live_adapter_gate_evidence_artifact(artifact: object) -> None:
     """Validate a GP-4.2 evidence artifact against the bundled schema."""
 
@@ -441,6 +563,12 @@ def validate_live_adapter_gate_environment_contract(contract: object) -> None:
     """Validate a GP-4.3 protected environment contract against the bundled schema."""
 
     Draft202012Validator(load_live_adapter_gate_environment_schema()).validate(contract)
+
+
+def validate_live_adapter_gate_rehearsal_decision(decision: object) -> None:
+    """Validate a GP-4.4 protected live rehearsal decision against the bundled schema."""
+
+    Draft202012Validator(load_live_adapter_gate_rehearsal_decision_schema()).validate(decision)
 
 
 def write_live_adapter_gate_report(path: Path, report: LiveAdapterGateReport) -> None:
@@ -464,6 +592,14 @@ def write_live_adapter_gate_environment_contract(path: Path, contract: LiveAdapt
     validate_live_adapter_gate_environment_contract(contract)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(contract, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_live_adapter_gate_rehearsal_decision(path: Path, decision: LiveAdapterGateRehearsalDecision) -> None:
+    """Write a canonical GP-4.4 protected live rehearsal decision to ``path``."""
+
+    validate_live_adapter_gate_rehearsal_decision(decision)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(decision, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def render_live_adapter_gate_text(report: LiveAdapterGateReport) -> str:

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -247,6 +247,10 @@ HTTP adapters must explicitly set `exposure_modes` to include `"http_header"` vi
   the required protected environment (`ao-kernel-live-adapter-gate`) and secret
   handle (`AO_CLAUDE_CODE_CLI_AUTH`) without committing secret values, binding a
   live environment, invoking `claude`, or promoting this lane.
+- `GP-4.4` adds `live-adapter-gate-rehearsal-decision.v1.json`. The current
+  decision is `blocked_no_rehearsal` because the protected environment and
+  project-owned credential are not attested. It does not run `claude`, bind an
+  environment, or promote this lane.
 
 ### Failure modes
 

--- a/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
+++ b/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
@@ -101,6 +101,9 @@ protected environment attestation slotlarını promotion blocker olarak listeler
 `GP-4.3` `live-adapter-gate-environment-contract.v1.json` artifact'ini ekler;
 bu required protected environment (`ao-kernel-live-adapter-gate`) ve secret
 handle (`AO_CLAUDE_CODE_CLI_AUTH`) adlarını kaydeder ama secret değeri içermez.
+`GP-4.4` `live-adapter-gate-rehearsal-decision.v1.json` artifact'ini ekler;
+bugünkü karar `blocked_no_rehearsal`dir çünkü protected environment ve
+project-owned credential attested değildir.
 Tüm artifact'ler bugün blocked/no-widening semantiğindedir; bu live benchmark
 veya real-adapter support kanıtı değildir.
 

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -47,11 +47,16 @@ canlı adapter çalıştırmaz. Manual workflow
 `live-adapter-gate-contract.v1.json` ve schema-backed
 `live-adapter-gate-evidence.v1.json` artifact'lerini üretir. `GP-4.3` aynı
 bundle'a `live-adapter-gate-environment-contract.v1.json` artifact'ini ekler.
-Bu üçüncü artifact required protected environment
+`GP-4.4` aynı bundle'a
+`live-adapter-gate-rehearsal-decision.v1.json` artifact'ini ekler.
+Environment contract artifact'i required protected environment
 `ao-kernel-live-adapter-gate` ve secret handle `AO_CLAUDE_CODE_CLI_AUTH`
-adlarını kaydeder, ama secret değerlerini okumaz veya yazmaz. Contract/evidence
+adlarını kaydeder, ama secret değerlerini okumaz veya yazmaz. Rehearsal
+decision artifact'i `decision="blocked_no_rehearsal"` döner. Contract/evidence
 artifact'lerinde `finding_code="live_gate_not_implemented"`, environment
-contract artifact'inde `finding_code="live_gate_protected_environment_not_attested"`
+contract artifact'inde `finding_code="live_gate_protected_environment_not_attested"`,
+rehearsal decision artifact'inde
+`finding_code="live_gate_rehearsal_blocked_missing_protected_prerequisites"`
 beklenir; hepsi `overall_status="blocked"` / `support_widening=false`
 semantiğindedir. Workflow'un yeşil olması production-certified
 `claude-code-cli` support anlamına gelmez.

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -166,5 +166,10 @@ Canlı snapshot üretimi için: `python3 scripts/truth_inventory_ratchet.py --ou
   handle olarak `AO_CLAUDE_CODE_CLI_AUTH` adlarını tanımlar; secret değeri
   içermez, environment oluşturmaz, canlı `claude` çağırmaz ve support widening
   yapmaz.
+- `GP-4.4` protected live rehearsal decision hattı
+  `live-adapter-gate-rehearsal-decision.v1.json` artifact'ini ekler. Bugünkü
+  karar `blocked_no_rehearsal`dir; required environment ve project-owned
+  credential attested olmadığı için live rehearsal denenmez ve support boundary
+  değişmez.
 - `docs/roadmap/DEMO-SCRIPT-SPEC.md` roadmap/spec dokümanıdır; canlı
   CLI komut listesi değildir.

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -121,6 +121,10 @@ ekler. Bu contract required protected environment adını
 `AO_CLAUDE_CODE_CLI_AUTH` olarak kaydeder; secret değeri commit etmez,
 environment oluşturmaz ve artifact hâlâ `live_execution_allowed=false` /
 `support_widening=false` döner.
+`GP-4.4` `live-adapter-gate-rehearsal-decision.v1.json` artifact'ini ekler.
+Mevcut karar `blocked_no_rehearsal`dir; protected environment ve
+project-owned credential attested olmadığı için canlı rehearsal denenmez,
+workflow environment'a bağlanmaz ve support widening yapılmaz.
 
 `gh-cli-pr` live-write probe, `PB-8.1` ile explicit precondition (opt-in,
 disposable repo, explicit `--repo` + `--head` + `--base`) ve create -> verify

--- a/scripts/live_adapter_gate_contract.py
+++ b/scripts/live_adapter_gate_contract.py
@@ -15,12 +15,15 @@ if str(_REPO_ROOT) not in sys.path:
 from ao_kernel.live_adapter_gate import (  # noqa: E402
     EVIDENCE_ARTIFACT,
     ENVIRONMENT_CONTRACT_ARTIFACT,
+    REHEARSAL_DECISION_ARTIFACT,
     build_live_adapter_gate_environment_contract,
-    build_live_adapter_gate_report,
     build_live_adapter_gate_evidence_artifact,
+    build_live_adapter_gate_rehearsal_decision,
+    build_live_adapter_gate_report,
     render_live_adapter_gate_text,
     write_live_adapter_gate_environment_contract,
     write_live_adapter_gate_evidence_artifact,
+    write_live_adapter_gate_rehearsal_decision,
     write_live_adapter_gate_report,
 )
 
@@ -31,8 +34,8 @@ def main() -> int:
         description=(
             "Emit the design-only GP-4.1 live-adapter gate contract report. "
             "This command also writes the GP-4.2 evidence artifact plus the "
-            "GP-4.3 protected environment contract and never executes a live "
-            "external adapter."
+            "GP-4.3 protected environment contract plus the GP-4.4 blocked "
+            "live rehearsal decision and never executes a live external adapter."
         ),
     )
     parser.add_argument(
@@ -58,6 +61,12 @@ def main() -> int:
         type=Path,
         default=Path(ENVIRONMENT_CONTRACT_ARTIFACT),
         help="Path for the canonical GP-4.3 protected environment contract.",
+    )
+    parser.add_argument(
+        "--rehearsal-decision-path",
+        type=Path,
+        default=Path(REHEARSAL_DECISION_ARTIFACT),
+        help="Path for the canonical GP-4.4 protected live rehearsal decision.",
     )
     parser.add_argument("--target-ref", default="main", help="Protected target ref being evaluated.")
     parser.add_argument("--reason", default="", help="Manual dispatch reason.")
@@ -85,6 +94,13 @@ def main() -> int:
     write_live_adapter_gate_environment_contract(
         args.environment_contract_path,
         environment_contract,
+    )
+    rehearsal_decision = build_live_adapter_gate_rehearsal_decision(
+        generated_at=report["generated_at"],
+    )
+    write_live_adapter_gate_rehearsal_decision(
+        args.rehearsal_decision_path,
+        rehearsal_decision,
     )
 
     if args.output == "json":

--- a/tests/test_live_adapter_gate_contract.py
+++ b/tests/test_live_adapter_gate_contract.py
@@ -13,17 +13,22 @@ from ao_kernel.live_adapter_gate import (
     BLOCKED_FINDING,
     EVIDENCE_ARTIFACT,
     ENVIRONMENT_CONTRACT_ARTIFACT,
+    REHEARSAL_DECISION_ARTIFACT,
     build_live_adapter_gate_evidence_artifact,
     build_live_adapter_gate_environment_contract,
+    build_live_adapter_gate_rehearsal_decision,
     build_live_adapter_gate_report,
     live_adapter_gate_report_sha256,
     load_live_adapter_gate_evidence_schema,
     load_live_adapter_gate_environment_schema,
+    load_live_adapter_gate_rehearsal_decision_schema,
     render_live_adapter_gate_text,
     validate_live_adapter_gate_evidence_artifact,
     validate_live_adapter_gate_environment_contract,
+    validate_live_adapter_gate_rehearsal_decision,
     write_live_adapter_gate_evidence_artifact,
     write_live_adapter_gate_environment_contract,
+    write_live_adapter_gate_rehearsal_decision,
     write_live_adapter_gate_report,
 )
 
@@ -84,6 +89,13 @@ def test_live_adapter_gate_environment_schema_is_valid() -> None:
 
     Draft202012Validator.check_schema(schema)
     assert schema["$id"] == "urn:ao:live-adapter-gate-environment:v1"
+
+
+def test_live_adapter_gate_rehearsal_decision_schema_is_valid() -> None:
+    schema = load_live_adapter_gate_rehearsal_decision_schema()
+
+    Draft202012Validator.check_schema(schema)
+    assert schema["$id"] == "urn:ao:live-adapter-gate-rehearsal-decision:v1"
 
 
 def test_build_live_adapter_gate_evidence_artifact_is_schema_valid_and_blocked() -> None:
@@ -163,6 +175,38 @@ def test_build_live_adapter_gate_environment_contract_is_schema_valid_and_blocke
     ]
 
 
+def test_build_live_adapter_gate_rehearsal_decision_is_schema_valid_and_blocked() -> None:
+    decision = build_live_adapter_gate_rehearsal_decision(
+        generated_at="2026-04-24T00:00:00Z",
+    )
+
+    validate_live_adapter_gate_rehearsal_decision(decision)
+    assert decision["schema_version"] == "1"
+    assert decision["artifact_kind"] == "live_adapter_gate_rehearsal_decision"
+    assert decision["program_id"] == "GP-4.4"
+    assert decision["overall_status"] == "blocked"
+    assert decision["decision"] == "blocked_no_rehearsal"
+    assert decision["finding_code"] == "live_gate_rehearsal_blocked_missing_protected_prerequisites"
+    assert decision["live_rehearsal_attempted"] is False
+    assert decision["live_execution_allowed"] is False
+    assert decision["support_widening"] is False
+    assert decision["promotion_decision"] == {
+        "support_widening_allowed": False,
+        "production_certified": False,
+        "next_gate": "GP-4.5",
+        "reason": (
+            "GP-4.4 records an explicit blocked decision because protected "
+            "live rehearsal prerequisites are not attested."
+        ),
+    }
+
+    prerequisites = {item["prerequisite_id"]: item for item in decision["prerequisite_status"]}
+    assert prerequisites["protected_environment_attestation"]["status"] == "not_attested"
+    assert prerequisites["project_owned_credential"]["status"] == "not_attested"
+    assert prerequisites["protected_live_preflight"]["status"] == "blocked"
+    assert prerequisites["governed_workflow_smoke"]["status"] == "blocked"
+
+
 def test_live_adapter_gate_evidence_schema_rejects_support_widening() -> None:
     report = build_live_adapter_gate_report(generated_at="2026-04-24T00:00:00Z")
     artifact = build_live_adapter_gate_evidence_artifact(report)
@@ -180,6 +224,16 @@ def test_live_adapter_gate_environment_schema_rejects_fake_live_execution() -> N
 
     with pytest.raises(ValidationError):
         validate_live_adapter_gate_environment_contract(contract)
+
+
+def test_live_adapter_gate_rehearsal_decision_schema_rejects_fake_live_execution() -> None:
+    decision = build_live_adapter_gate_rehearsal_decision(
+        generated_at="2026-04-24T00:00:00Z",
+    )
+    decision["live_rehearsal_attempted"] = True
+
+    with pytest.raises(ValidationError):
+        validate_live_adapter_gate_rehearsal_decision(decision)
 
 
 def test_write_live_adapter_gate_evidence_artifact_round_trips_json(tmp_path: Path) -> None:
@@ -209,6 +263,20 @@ def test_write_live_adapter_gate_environment_contract_round_trips_json(tmp_path:
     assert path.read_text(encoding="utf-8").endswith("\n")
 
 
+def test_write_live_adapter_gate_rehearsal_decision_round_trips_json(tmp_path: Path) -> None:
+    decision = build_live_adapter_gate_rehearsal_decision(
+        generated_at="2026-04-24T00:00:00Z",
+    )
+    path = tmp_path / REHEARSAL_DECISION_ARTIFACT
+
+    write_live_adapter_gate_rehearsal_decision(path, decision)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload == decision
+    validate_live_adapter_gate_rehearsal_decision(payload)
+    assert path.read_text(encoding="utf-8").endswith("\n")
+
+
 def test_render_live_adapter_gate_text_marks_no_live_execution() -> None:
     report = build_live_adapter_gate_report(generated_at="2026-04-24T00:00:00Z")
     rendered = render_live_adapter_gate_text(report)
@@ -224,6 +292,7 @@ def test_script_emits_json_and_report_file(tmp_path: Path) -> None:
     report_path = tmp_path / "contract.json"
     evidence_path = tmp_path / "evidence.json"
     environment_contract_path = tmp_path / "environment.json"
+    rehearsal_decision_path = tmp_path / "rehearsal-decision.json"
 
     result = subprocess.run(
         [
@@ -237,6 +306,8 @@ def test_script_emits_json_and_report_file(tmp_path: Path) -> None:
             str(evidence_path),
             "--environment-contract-path",
             str(environment_contract_path),
+            "--rehearsal-decision-path",
+            str(rehearsal_decision_path),
             "--target-ref",
             "main",
             "--reason",
@@ -259,15 +330,19 @@ def test_script_emits_json_and_report_file(tmp_path: Path) -> None:
     file_payload = json.loads(report_path.read_text(encoding="utf-8"))
     evidence_payload = json.loads(evidence_path.read_text(encoding="utf-8"))
     environment_payload = json.loads(environment_contract_path.read_text(encoding="utf-8"))
+    rehearsal_decision_payload = json.loads(rehearsal_decision_path.read_text(encoding="utf-8"))
     assert stdout_payload == file_payload
     assert stdout_payload["overall_status"] == "blocked"
     assert stdout_payload["live_execution_attempted"] is False
     validate_live_adapter_gate_evidence_artifact(evidence_payload)
     validate_live_adapter_gate_environment_contract(environment_payload)
+    validate_live_adapter_gate_rehearsal_decision(rehearsal_decision_payload)
     assert evidence_payload["source_report"]["path"] == report_path.name
     assert evidence_payload["support_widening"] is False
     assert environment_payload["support_widening"] is False
     assert environment_payload["live_execution_allowed"] is False
+    assert rehearsal_decision_payload["support_widening"] is False
+    assert rehearsal_decision_payload["live_rehearsal_attempted"] is False
 
 
 def test_live_adapter_gate_workflow_is_manual_contract_only() -> None:
@@ -281,6 +356,7 @@ def test_live_adapter_gate_workflow_is_manual_contract_only() -> None:
     assert "live-adapter-gate-contract.v1.json" in workflow
     assert "live-adapter-gate-evidence.v1.json" in workflow
     assert "live-adapter-gate-environment-contract.v1.json" in workflow
+    assert "live-adapter-gate-rehearsal-decision.v1.json" in workflow
     assert "claude_code_cli_smoke.py" not in workflow
     assert "claude_code_cli_workflow_smoke.py" not in workflow
     assert "secrets." not in workflow


### PR DESCRIPTION
## Summary
- Implements GP-4.4 for #400 and closes #410.
- Adds schema-backed `live-adapter-gate-rehearsal-decision.v1.json` for the protected live rehearsal decision.
- Records the current decision as `blocked_no_rehearsal` because `ao-kernel-live-adapter-gate` and `AO_CLAUDE_CODE_CLI_AUTH` are not attested.

## No Widening / Safety
- No GitHub environment creation.
- No secret values or `secrets.` workflow references.
- No workflow `environment:` binding.
- No live `claude` invocation.
- No support-tier promotion; `claude-code-cli` remains Beta (operator-managed).

## Validation
- `python3 -m pytest -q tests/test_live_adapter_gate_contract.py tests/test_cli_entrypoints.py tests/test_doctor_cmd.py`
- `python3 -m ruff check ao_kernel/live_adapter_gate.py scripts/live_adapter_gate_contract.py tests/test_live_adapter_gate_contract.py`
- `python3 -m mypy ao_kernel/live_adapter_gate.py`
- `python3 -m ao_kernel doctor` (`8 OK, 1 WARN, 0 FAIL`; existing extension truth WARN)
- `python3 scripts/packaging_smoke.py`
- `git diff --check`
