### PR TITLE
[codex] docs: close GP-4 support boundary

### DIFF
--- a/.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md
+++ b/.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md
@@ -1,6 +1,6 @@
 # GP-4 — CI-Managed Live Adapter Gate Design
 
-**Status:** Active design program
+**Status:** Completed with no support widening
 **Date:** 2026-04-24
 **Tracker:** [#400](https://github.com/Halildeu/ao-kernel/issues/400)
 **Predecessor:** `GP-3` closeout
@@ -17,9 +17,9 @@ gate before any future support widening is attempted.
 
 ## Current Decision
 
-**Decision:** `design_only_no_widening`
+**Decision:** `close_no_widening_keep_operator_beta`
 
-This slice does not:
+This program closed after `GP-4.5` without support widening. It does not:
 
 1. add CI secrets;
 2. run live external adapter calls in default CI;
@@ -100,7 +100,7 @@ itself.
 | `GP-4.2` evidence artifact contract | Define/upload JSON report shapes for live gate | implemented by schema-backed `live-adapter-gate-evidence.v1.json`; local tests validate schema; no live execution or support widening |
 | `GP-4.3` protected environment contract | Document required GitHub environment/secrets and fork safety | implemented by schema-backed `live-adapter-gate-environment-contract.v1.json`; no repository secret values, no live execution, no support widening |
 | `GP-4.4` live rehearsal decision | Run protected manual gate once, or record blocked decision if prerequisites are absent | implemented as blocked decision artifact; no protected environment/credential attested, no live execution |
-| `GP-4.5` support-boundary decision | Decide promote/keep beta/defer | requires all prior slices and docs parity |
+| `GP-4.5` support-boundary decision | Decide promote/keep beta/defer | completed with verdict `close_no_widening_keep_operator_beta` |
 
 ## Promotion Preconditions
 
@@ -191,8 +191,33 @@ environment and project-owned credential are not attested. The workflow still
 does not create environments, read secrets, bind `environment:`, call `claude`,
 or widen support.
 
+## GP-4.5 Closeout
+
+`GP-4.5` closes the program with verdict
+`close_no_widening_keep_operator_beta`.
+
+Evidence considered:
+
+1. `GP-4.1` contract artifact remains blocked;
+2. `GP-4.2` evidence artifact records missing live preflight, governed
+   workflow-smoke, and protected-environment evidence slots;
+3. `GP-4.3` records required protected environment and secret handle, but does
+   not attest either as configured;
+4. `GP-4.4` records `decision="blocked_no_rehearsal"`;
+5. support docs still identify `claude-code-cli` as
+   `Beta (operator-managed)`.
+
+Final impact:
+
+1. no stable support widening;
+2. no production-certified real-adapter support;
+3. no general-purpose production platform claim;
+4. no version bump, tag, publish, secret, environment binding, or live
+   `claude` invocation.
+
 ## Next Step
 
-The next implementation slice should be `GP-4.5`: close the support-boundary
-decision for `claude-code-cli` against the blocked GP-4 evidence. It must still
-avoid support widening unless protected live evidence and docs parity exist.
+There is no active GP-4 widening gate after this closeout. A future widening
+attempt must open a new explicit gate only after the protected environment,
+project-owned credential, protected live preflight, protected governed workflow
+smoke, docs parity, and release/CI evidence all exist.

--- a/.claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md
+++ b/.claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md
@@ -1,0 +1,85 @@
+# GP-4.5 — Support-Boundary Closeout
+
+**Status:** Completed decision record
+**Date:** 2026-04-24
+**Tracker:** [#400](https://github.com/Halildeu/ao-kernel/issues/400)
+**Slice issue:** [#413](https://github.com/Halildeu/ao-kernel/issues/413)
+**Predecessors:** `GP-4.1`, `GP-4.2`, `GP-4.3`, `GP-4.4`
+
+## Decision
+
+**Verdict:** `close_no_widening_keep_operator_beta`
+
+`GP-4` is closed without support widening. The `claude-code-cli` lane remains
+`Beta (operator-managed)`. It is not promoted to shipped baseline,
+production-certified read-only support, or general-purpose production platform
+support.
+
+## Evidence Considered
+
+| Gate | Evidence | Result |
+|---|---|---|
+| `GP-4.1` workflow skeleton | `live-adapter-gate-contract.v1.json` | `overall_status="blocked"`, no live execution |
+| `GP-4.2` evidence contract | `live-adapter-gate-evidence.v1.json` | required live evidence slots remain blocked |
+| `GP-4.3` protected environment contract | `live-adapter-gate-environment-contract.v1.json` | required environment/secret handle documented, not attested |
+| `GP-4.4` rehearsal decision | `live-adapter-gate-rehearsal-decision.v1.json` | `decision="blocked_no_rehearsal"` |
+| Support docs | `PUBLIC-BETA.md`, `SUPPORT-BOUNDARY.md`, adapter/runbook docs | lane remains operator-managed beta |
+
+## Blocking Gaps
+
+These gaps are intentionally not papered over by GP-4:
+
+1. The required protected GitHub environment
+   `ao-kernel-live-adapter-gate` is not attested as configured.
+2. The required project-owned credential handle `AO_CLAUDE_CODE_CLI_AUTH` is
+   documented but no secret value is read, committed, or verified.
+3. No protected live preflight report exists.
+4. No protected governed workflow-smoke report exists.
+5. No workflow `environment:` binding exists.
+6. No live `claude` invocation is made by the gate.
+7. `KB-001` and `KB-002` remain open operator-managed lane caveats.
+
+## Support Boundary Impact
+
+No support tier changes:
+
+1. Stable shipped baseline: unchanged.
+2. `claude-code-cli`: remains `Beta (operator-managed)`.
+3. Production-certified real-adapter support: not granted.
+4. General-purpose production coding automation platform claim: not granted.
+5. Version, tag, and publish state: unchanged.
+
+## Reopen Conditions
+
+A future support-widening attempt must open a new explicit gate and satisfy all
+of the following before promotion can be reconsidered:
+
+1. protected environment is configured and attested;
+2. project-owned credential is configured through that protected environment;
+3. protected live preflight report is collected;
+4. protected governed workflow-smoke report is collected;
+5. missing credentials remain explicit `blocked` / `skipped`, never fake green;
+6. untrusted fork and pull-request secret exposure remain impossible;
+7. docs, support matrix, runbook, tests/smoke, and CI/release gate evidence all
+   agree on the promoted surface.
+
+## Non-Changes
+
+This closeout deliberately does not:
+
+1. create GitHub environments;
+2. add, read, or commit secret values;
+3. bind workflow `environment:`;
+4. call `claude`;
+5. modify runtime behavior;
+6. publish or tag a release;
+7. widen support.
+
+## Validation Scope
+
+This slice is a truth/status patch. Required validation:
+
+1. targeted docs/status parity checks;
+2. `tests/test_live_adapter_gate_contract.py`;
+3. `python3 -m ao_kernel doctor`;
+4. `python3 scripts/packaging_smoke.py`.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -27,9 +27,12 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan GP-3 evidence completeness record:** `.claude/plans/GP-3.4-CLAUDE-CODE-CLI-EVIDENCE-COMPLETENESS.md`
 - **Son tamamlanan GP-3 support-boundary decision record:** `.claude/plans/GP-3.5-CLAUDE-CODE-CLI-SUPPORT-BOUNDARY-DECISION.md`
 - **Son tamamlanan GP-3 closeout decision:** `.claude/plans/GP-3.6-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-CLOSEOUT.md`
-- **Aktif GP-4 CI-managed live adapter gate design:** `.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md`
+- **Son tamamlanan GP-4 CI-managed live adapter gate design:** `.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md`
 - **Son tamamlanan GP-4.1 CI-safe live adapter gate skeleton:** `.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md`
 - **Son tamamlanan GP-4.2 live adapter evidence artifact contract:** `.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md`
+- **Son tamamlanan GP-4.3 protected environment / secret contract:** `.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`
+- **Son tamamlanan GP-4.4 protected live rehearsal blocked decision:** `.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md`
+- **Son tamamlanan GP-4.5 support-boundary closeout:** `.claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
 - **Son tamamlanan certification contract:** `.claude/plans/GP-2.4-CLAUDE-CODE-CLI-READ-ONLY-CERTIFICATION.md`
@@ -80,12 +83,13 @@ ayrı ayrı görünür kılmak.
 - **GP-3.4 issue:** [#394](https://github.com/Halildeu/ao-kernel/issues/394) (`closed`)
 - **GP-3.5 issue:** [#396](https://github.com/Halildeu/ao-kernel/issues/396) (`closed`)
 - **GP-3.6 issue:** [#398](https://github.com/Halildeu/ao-kernel/issues/398) (`closed by closeout PR`)
-- **GP-4 tracker issue:** [#400](https://github.com/Halildeu/ao-kernel/issues/400) (`open`)
+- **GP-4 tracker issue:** [#400](https://github.com/Halildeu/ao-kernel/issues/400) (`closes with GP-4.5 PR`)
 - **GP-4.1 issue:** [#402](https://github.com/Halildeu/ao-kernel/issues/402) (`closed`)
 - **GP-4.2 issue:** [#404](https://github.com/Halildeu/ao-kernel/issues/404) (`closes with GP-4.2 PR`)
 - **GP-4.3 issue:** [#407](https://github.com/Halildeu/ao-kernel/issues/407) (`closes with GP-4.3 PR`)
 - **GP-4.4 issue:** [#410](https://github.com/Halildeu/ao-kernel/issues/410) (`closes with GP-4.4 PR`)
-- **Sıradaki gate:** `GP-4.5` support-boundary closeout. Bu support widening değildir; stable support boundary unchanged kalır.
+- **GP-4.5 issue:** [#413](https://github.com/Halildeu/ao-kernel/issues/413) (`closes with GP-4.5 PR`)
+- **Current mode:** stable maintenance / no active support-widening gate. Future widening requires a new explicit gate.
 
 ## 2. Başlangıç Gerçeği
 
@@ -139,11 +143,12 @@ ayrı ayrı görünür kılmak.
 | `SM-3` program status active-section cleanup | Completed ([#382](https://github.com/Halildeu/ao-kernel/issues/382), record `.claude/plans/SM-3-PROGRAM-STATUS-ACTIVE-SECTION-CLEANUP.md`) | yaşayan status dosyasındaki stale historical `ST-2` anlatımını temizlemek | no active widening gate + historical records clearly non-active |
 | `SM-4` historical beta pin wording | Completed ([#384](https://github.com/Halildeu/ao-kernel/issues/384), record `.claude/plans/SM-4-HISTORICAL-BETA-PIN-WORDING.md`) | `4.0.0b2` beta pinini aktif kanal gibi değil historical pre-release yolu gibi anlatmak | stable `4.0.0` remains default + no support widening |
 | `GP-3` production-certified adapter promotion | Completed ([#386](https://github.com/Halildeu/ao-kernel/issues/386), [#388](https://github.com/Halildeu/ao-kernel/issues/388), [#390](https://github.com/Halildeu/ao-kernel/issues/390), [#392](https://github.com/Halildeu/ao-kernel/issues/392), [#394](https://github.com/Halildeu/ao-kernel/issues/394), [#396](https://github.com/Halildeu/ao-kernel/issues/396), [#398](https://github.com/Halildeu/ao-kernel/issues/398), roadmap `.claude/plans/GP-3-PRODUCTION-CERTIFIED-ADAPTER-PROMOTION-ROADMAP.md`) | ilk real-adapter lane'i production-certified read-only seviyesine aday yapmak | final verdict `close_keep_operator_beta`; support boundary unchanged |
-| `GP-4` CI-managed live adapter gate design | Active ([#400](https://github.com/Halildeu/ao-kernel/issues/400), design `.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md`) | GP-3'te eksik kalan project-owned live-adapter gate'i support widening olmadan tasarlamak | design-only, no secrets, no live default CI call, no support widening |
+| `GP-4` CI-managed live adapter gate design | Completed by GP-4.5 closeout ([#400](https://github.com/Halildeu/ao-kernel/issues/400), design `.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md`) | GP-3'te eksik kalan project-owned live-adapter gate'i support widening olmadan tasarlamak | final verdict `close_no_widening_keep_operator_beta`; no secrets, no live default CI call, no support widening |
 | `GP-4.1` CI-safe live adapter gate skeleton | Completed on `main` ([#402](https://github.com/Halildeu/ao-kernel/issues/402), record `.claude/plans/GP-4.1-CI-SAFE-LIVE-ADAPTER-GATE-SKELETON.md`) | workflow-dispatch-only contract artifact yüzeyini eklemek | no secrets, no live adapter execution, report `overall_status=blocked`, no support widening |
 | `GP-4.2` live adapter evidence artifact contract | Completed by GP-4.2 PR ([#404](https://github.com/Halildeu/ao-kernel/issues/404), record `.claude/plans/GP-4.2-LIVE-ADAPTER-EVIDENCE-ARTIFACT-CONTRACT.md`) | live gate evidence artifact shape'i schema-backed hale getirmek | schema validation + blocked evidence slots + no live adapter execution + no support widening |
 | `GP-4.3` protected environment / secret contract | Completed by GP-4.3 PR ([#407](https://github.com/Halildeu/ao-kernel/issues/407), record `.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`) | protected GitHub environment, secret handle ve fork-safety contract'ini schema-backed hale getirmek | no secret values, no environment creation, no live adapter execution, no support widening |
 | `GP-4.4` protected live rehearsal blocked decision | Completed by GP-4.4 PR ([#410](https://github.com/Halildeu/ao-kernel/issues/410), record `.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md`) | protected live rehearsal prerequisite eksikse fake live success üretmeden blocked decision kaydetmek | schema validation + blocked rehearsal decision artifact + no live adapter execution + no support widening |
+| `GP-4.5` support-boundary closeout | Completed by GP-4.5 PR ([#413](https://github.com/Halildeu/ao-kernel/issues/413), record `.claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md`) | blocked GP-4 evidence against support boundary kararını kapatmak | verdict `close_no_widening_keep_operator_beta`; `claude-code-cli` remains Beta/operator-managed |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -154,15 +159,19 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — GP-4.5 support-boundary closeout
+### Current mode — stable maintenance / no active widening gate
 
 `GP-3` parent promotion programı `close_keep_operator_beta` kararıyla
-kapanmıştır. `GP-4.2` live adapter evidence artifact contract hattını,
-`GP-4.3` protected environment / secret contract hattını ve `GP-4.4` protected
-live rehearsal blocked decision hattını tamamlamıştır. Sıradaki GP-4 slice
-`GP-4.5` support-boundary closeout hattıdır.
-Bu support widening değildir; `SM-1` stable maintenance baseline ve `SM-2`
-stable baseline evidence refresh geçerlidir.
+kapanmıştır. `GP-4.1` workflow skeleton, `GP-4.2` evidence artifact,
+`GP-4.3` protected environment contract, `GP-4.4` blocked rehearsal decision ve
+`GP-4.5` support-boundary closeout tamamlanmıştır.
+
+Final GP-4 verdict: `close_no_widening_keep_operator_beta`.
+
+Bu nedenle `claude-code-cli` lane hâlâ `Beta (operator-managed)` kalır;
+production-certified real-adapter support, stable support widening ve genel
+amaçlı production coding automation platform claim'i verilmez. `SM-1` stable
+maintenance baseline ve `SM-2` stable baseline evidence refresh geçerlidir.
 
 Mevcut yol:
 
@@ -175,12 +184,10 @@ Mevcut yol:
 7. `GP-3.6` program closeout — completed; final verdict `close_keep_operator_beta`
 
 Promotion sadece code path + behavior tests + smoke + docs + runbook + CI
-evidence aynı yönde ise yapılır. `GP-3` closeout sonucunda CI-managed live
-adapter gate'i ve açık known-bug durumu yeterli olmadığı için lane
-`Beta (operator-managed)` kaldı. `GP-4.1`, bu eksik gate için manual workflow
-contract skeleton'ı ekledi; `GP-4.2` ise bu gate'in evidence artifact shape'ini
-schema-backed hale getirir. Live secrets, default CI live call veya support
-promotion içermez.
+evidence aynı yönde ise yapılır. `GP-4` bu eksik gate'in contract/evidence
+yüzeyini hazırladı, ancak required protected environment ve project-owned
+credential attested olmadığı için live rehearsal `blocked_no_rehearsal` kaldı.
+Bu yüzden support boundary değişmedi.
 
 Tarihi `ST`, `PB` ve `GP` kayıtları aşağıda korunur; bunlar güncel aktif gate
 değildir.
@@ -1090,8 +1097,8 @@ live adapter gate'i tasarlar.
 1. Tracker: [#400](https://github.com/Halildeu/ao-kernel/issues/400)
 2. Design record:
    `.claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md`
-3. Current decision:
-   - `design_only_no_widening`
+3. Final decision:
+   - `close_no_widening_keep_operator_beta`
 4. Preferred direction:
    - protected manual or scheduled workflow using restricted GitHub
      environment secrets
@@ -1136,5 +1143,14 @@ live adapter gate'i tasarlar.
    - rehearsal decision artifact `live-adapter-gate-rehearsal-decision.v1.json`
    - expected decision status `blocked_no_rehearsal`
    - no live adapter execution, no secret value, no support widening
-11. Next slice:
-   - `GP-4.5` support-boundary closeout
+11. `GP-4.5` closeout:
+   - record `.claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md`
+   - slice issue [#413](https://github.com/Halildeu/ao-kernel/issues/413)
+   - final verdict `close_no_widening_keep_operator_beta`
+   - `claude-code-cli` remains `Beta (operator-managed)`
+   - production-certified real-adapter support not granted
+   - general-purpose production platform claim not granted
+12. Next slice:
+   - no active GP-4 widening gate
+   - future widening requires a new explicit gate after protected live evidence
+     exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `decision="blocked_no_rehearsal"` because the protected environment and
   project-owned credential are not attested; it still does not bind a live
   environment, call `claude`, or widen support.
+- Closed the `GP-4` CI-managed live adapter gate design program with
+  `GP-4.5` verdict `close_no_widening_keep_operator_beta`. `claude-code-cli`
+  remains `Beta (operator-managed)`; production-certified real-adapter support,
+  stable support widening, general-purpose production platform claims, version
+  bump, tag, publish, secret access, workflow environment binding, and live
+  `claude` invocation are all explicitly not included.
 
 ## [4.0.0] - 2026-04-24
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -230,6 +230,8 @@ HTTP adapters must explicitly set `exposure_modes` to include `"http_header"` vi
 - Helper-backed preflight: `python3 scripts/claude_code_cli_smoke.py`
 - Governed workflow smoke: `python3 scripts/claude_code_cli_workflow_smoke.py`
 - Support-boundary verdict: `GP-3.6` `close_keep_operator_beta`
+- GP-4 closeout verdict: `GP-4.5`
+  `close_no_widening_keep_operator_beta`
 - Expected operator prerequisite: valid Claude Code session auth
 - This lane is not the default shipped demo; the shipped baseline remains
   bundled `review_ai_flow` + bundled `codex-stub`
@@ -251,6 +253,9 @@ HTTP adapters must explicitly set `exposure_modes` to include `"http_header"` vi
   decision is `blocked_no_rehearsal` because the protected environment and
   project-owned credential are not attested. It does not run `claude`, bind an
   environment, or promote this lane.
+- `GP-4.5` closes the support-boundary decision without widening. The lane
+  remains `Beta (operator-managed)`; production-certified real-adapter support
+  and general-purpose production platform support are not granted.
 
 ### Failure modes
 

--- a/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
+++ b/docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md
@@ -106,6 +106,9 @@ bugünkü karar `blocked_no_rehearsal`dir çünkü protected environment ve
 project-owned credential attested değildir.
 Tüm artifact'ler bugün blocked/no-widening semantiğindedir; bu live benchmark
 veya real-adapter support kanıtı değildir.
+`GP-4.5` closeout verdict'i `close_no_widening_keep_operator_beta` olduğu için
+bu lane production-certified real-adapter veya live benchmark support claim'i
+üretmez.
 
 ### 1.3 Failure-mode matrix
 

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -60,6 +60,8 @@ rehearsal decision artifact'inde
 beklenir; hepsi `overall_status="blocked"` / `support_widening=false`
 semantiğindedir. Workflow'un yeşil olması production-certified
 `claude-code-cli` support anlamına gelmez.
+`GP-4.5` closeout kararı `close_no_widening_keep_operator_beta` olduğu için bu
+yüzey artık aktif widening gate değil, blocked/no-widening operasyon kaydıdır.
 
 Prerequisite contract (operator-managed lanes):
 

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -80,7 +80,7 @@ Stable rules:
 | Yüzey | Durum | Not |
 |---|---|---|
 | Historical Public Beta pre-release | Beta | `4.0.0b2` remains a pre-release pin for operators that intentionally stay on that line; stable support is the shipped baseline above |
-| `claude-code-cli` helper-backed real-adapter lane | Beta (operator-managed) | `python3 scripts/claude_code_cli_smoke.py --output text --timeout-seconds 30` sonucu `overall_status: pass` olmalıdır. Bu smoke içinde hem `auth_status` hem `prompt_access` check'i geçmelidir; yalnız `claude auth status` yeşili yeterli kabul edilmez. Governed workflow evidence için ek komut: `python3 scripts/claude_code_cli_workflow_smoke.py --output text --timeout-seconds 60`. Varsayılan shipped demo değildir. `GP-3.6` closeout verdict'i `close_keep_operator_beta`; production-certified read-only değildir. Gerekçe: external `claude` binary/session auth operatör durumudur, `KB-001`/`KB-002` açıktır ve live `claude-code-cli` gate'i CI-managed değildir |
+| `claude-code-cli` helper-backed real-adapter lane | Beta (operator-managed) | `python3 scripts/claude_code_cli_smoke.py --output text --timeout-seconds 30` sonucu `overall_status: pass` olmalıdır. Bu smoke içinde hem `auth_status` hem `prompt_access` check'i geçmelidir; yalnız `claude auth status` yeşili yeterli kabul edilmez. Governed workflow evidence için ek komut: `python3 scripts/claude_code_cli_workflow_smoke.py --output text --timeout-seconds 60`. Varsayılan shipped demo değildir. `GP-3.6` closeout verdict'i `close_keep_operator_beta`; `GP-4.5` closeout verdict'i `close_no_widening_keep_operator_beta`; production-certified read-only değildir. Gerekçe: external `claude` binary/session auth operatör durumudur, `KB-001`/`KB-002` açıktır ve protected live gate evidence hâlâ blocked durumdadır |
 | `gh-cli-pr` helper-backed preflight lane | Beta (operator-managed preflight + live-write readiness probe) | Varsayılan `python3 scripts/gh_cli_pr_smoke.py --output text` preflight yoludur ve side-effect-safe `gh pr create --dry-run` zincirini çalıştırır. Live-write probe (`--mode live-write --allow-live-write --repo <owner>/<sandbox-repo> --head <branch> --base <branch>`) explicit opt-in + create->verify->rollback ister. Varsayılan disposable guard keyword `sandbox`'dır; repo adında bu keyword yoksa lane `blocked` döner (`gh_pr_live_write_repo_not_disposable`). `GP-2.5a` sandbox rehearsal geçmiştir, fakat `--keep-live-write-pr-open` lane'i hâlâ riskli sayar ve `blocked` döner. Support widening değildir |
 | `PRJ-KERNEL-API` write-side actions | Beta (operator-managed write contract) | `project_status`, `roadmap_follow`, `roadmap_finish` runtime-backed. `workspace_root` zorunlu, varsayılan `dry_run=true`, gerçek yazma için `confirm_write=I_UNDERSTAND_SIDE_EFFECTS` gerekir; conflict/idempotency/audit davranışı behavior testlerle pinlidir. Operator smoke: `python3 scripts/kernel_api_write_smoke.py --output text` |
 | Real-adapter benchmark tam modu | Beta (operator-managed) | Deterministik stub lane kadar stabil değildir; adapter-altı gerçek tier sınırları yukarıdaki satırlarda tanımlanır |
@@ -171,5 +171,10 @@ Canlı snapshot üretimi için: `python3 scripts/truth_inventory_ratchet.py --ou
   karar `blocked_no_rehearsal`dir; required environment ve project-owned
   credential attested olmadığı için live rehearsal denenmez ve support boundary
   değişmez.
+- `GP-4.5` support-boundary closeout kararı
+  `close_no_widening_keep_operator_beta` olarak kapanmıştır. Bu karar
+  `claude-code-cli` lane'ini Beta/operator-managed tutar; shipped baseline,
+  production-certified real-adapter support ve genel amaçlı production platform
+  claim'i genişlemez.
 - `docs/roadmap/DEMO-SCRIPT-SPEC.md` roadmap/spec dokümanıdır; canlı
   CLI komut listesi değildir.

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -126,6 +126,10 @@ environment oluşturmaz ve artifact hâlâ `live_execution_allowed=false` /
 Mevcut karar `blocked_no_rehearsal`dir; protected environment ve
 project-owned credential attested olmadığı için canlı rehearsal denenmez,
 workflow environment'a bağlanmaz ve support widening yapılmaz.
+`GP-4.5` closeout kararı `close_no_widening_keep_operator_beta` olarak
+kapanmıştır. Bu karar `claude-code-cli` lane'ini `Beta (operator-managed)`
+katmanında tutar; production-certified real-adapter support ve genel amaçlı
+production platform claim'i verilmez.
 
 `gh-cli-pr` live-write probe, `PB-8.1` ile explicit precondition (opt-in,
 disposable repo, explicit `--repo` + `--head` + `--base`) ve create -> verify
@@ -180,6 +184,8 @@ The following do not, by themselves, justify a broader support claim:
   executing a protected live adapter identity
 - a schema-valid live-gate evidence artifact that still marks required live
   evidence slots as blocked and `support_widening=false`
+- a support-boundary closeout decision that explicitly records blocked live
+  rehearsal evidence and keeps support unchanged
 - a roadmap/spec document
 - a contract loader or truth-audit warning surface
 - a smoke passing only in one operator environment without the support docs

--- a/tests/test_live_adapter_gate_contract.py
+++ b/tests/test_live_adapter_gate_contract.py
@@ -362,3 +362,34 @@ def test_live_adapter_gate_workflow_is_manual_contract_only() -> None:
     assert "secrets." not in workflow
     assert "\n    environment:" not in workflow
     assert "contents: read" in workflow
+
+
+def test_gp4_closeout_docs_keep_support_boundary_narrow() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    expected_verdict = "close_no_widening_keep_operator_beta"
+    docs = [
+        ".claude/plans/GP-4-CI-MANAGED-LIVE-ADAPTER-GATE-DESIGN.md",
+        ".claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md",
+        ".claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md",
+        "docs/SUPPORT-BOUNDARY.md",
+        "docs/PUBLIC-BETA.md",
+        "docs/ADAPTERS.md",
+        "docs/BENCHMARK-REAL-ADAPTER-RUNBOOK.md",
+        "docs/OPERATIONS-RUNBOOK.md",
+    ]
+
+    for doc in docs:
+        text = (repo_root / doc).read_text(encoding="utf-8")
+        assert "GP-4.5" in text, doc
+        assert expected_verdict in text, doc
+
+    status = (repo_root / ".claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md").read_text(
+        encoding="utf-8"
+    )
+    assert "stable maintenance / no active widening gate" in status
+
+    decision = (repo_root / ".claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md").read_text(
+        encoding="utf-8"
+    )
+    assert "No support tier changes" in decision
+    assert "No live `claude` invocation is made by the gate." in decision


### PR DESCRIPTION
## Summary

- add the GP-4.5 support-boundary closeout decision record
- mark GP-4 completed with verdict `close_no_widening_keep_operator_beta`
- align support/public docs, adapter docs, runbook, benchmark runbook, status SSOT, changelog, and docs-parity test

## Boundary

- no runtime behavior change
- no GitHub environment creation
- no secret values or secret reads
- no workflow `environment:` binding
- no live `claude` invocation
- no support widening, version bump, tag, or publish

## Validation

- `python3 -m pytest -q tests/test_live_adapter_gate_contract.py tests/test_cli_entrypoints.py tests/test_doctor_cmd.py`
- `python3 -m ruff check tests/test_live_adapter_gate_contract.py`
- `python3 -m ao_kernel doctor`
- `python3 scripts/packaging_smoke.py`
- `git diff --check`
- docs/status grep for stale GP-4 active wording

Closes #413
Closes #400