### PR TITLE
docs(repo-intelligence): close RI-5 plan gate

### DIFF
--- a/.claude/plans/RI-4-REPO-INTELLIGENCE-CHUNKING-VECTOR-INDEXING.md
+++ b/.claude/plans/RI-4-REPO-INTELLIGENCE-CHUNKING-VECTOR-INDEXING.md
@@ -2,13 +2,13 @@
 
 **Status:** Completed on `main`
 **Date:** 2026-04-24
-**Authority:** `origin/main` at `b2e404b`
+**Authority:** `origin/main` at `33c4d22`
 **Closed PRs:** [#419](https://github.com/Halildeu/ao-kernel/pull/419),
 [#421](https://github.com/Halildeu/ao-kernel/pull/421),
 [#422](https://github.com/Halildeu/ao-kernel/pull/422)
 **Implementation branches:** cleaned after merge
 **Implementation worktrees:** cleaned after merge
-**Base:** `origin/main` at `b2e404b`
+**Base:** `origin/main` at `33c4d22`
 **Next slice:** RI-5 explicit root/context export design gate
 **Rule:** Never work directly on `main`.
 

--- a/.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md
+++ b/.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md
@@ -1,11 +1,13 @@
 # RI-5 - Repo Intelligence Explicit Root/Context Export Design Gate
 
-**Status:** Design gate only
+**Status:** Design gate accepted on `main`
 **Date:** 2026-04-24
-**Authority:** `origin/main` at `b2e404b`
-**Branch:** `codex/repo-intelligence-ri5-plan`
-**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-ri5-plan`
-**Base:** `origin/main` at `b2e404b`
+**Authority:** `origin/main` at `33c4d22`
+**Planning PR:** [#423](https://github.com/Halildeu/ao-kernel/pull/423)
+**Planning branch:** cleaned after merge
+**Planning worktree:** cleaned after merge
+**Base:** `origin/main` at `33c4d22`
+**Next slice:** RI-5a export-plan preview implementation
 **Implementation:** Not started
 **Rule:** Never work directly on `main`.
 
@@ -239,3 +241,4 @@ CHANGELOG.md
 | Date | Status | Notes |
 |---|---|---|
 | 2026-04-24 | Design gate opened | RI-5 is explicitly separated from RI-4 and split into preview-only RI-5a plus confirmed create-only RI-5b. |
+| 2026-04-24 | Design gate merged | PR [#423](https://github.com/Halildeu/ao-kernel/pull/423) merged to `main` at `33c4d22`; CI passed including lint, typecheck, coverage, Python 3.11/3.12/3.13 tests, benchmark-fast, packaging-smoke, extras-install, and scorecard. Post-merge branch/worktree cleanup completed and local `main` is synchronized with `origin/main`. |


### PR DESCRIPTION
## Summary
- mark RI-5 design gate as accepted on main after PR #423
- replace stale planning branch/worktree fields with cleaned-after-merge status
- update RI-4 authority to the current documented planning commit

## Boundary
- docs-only closeout
- no runtime, CLI, schema, or root export implementation change

## Validation
- git diff --check
- python3 -m ao_kernel doctor -> 8 OK, 1 WARN, 0 FAIL (expected bundled extension truth WARN)