### PR TITLE
docs(gp5): record protected gate audit

### DIFF
--- a/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
+++ b/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
@@ -1,14 +1,12 @@
 # GP-5 - General-Purpose Production Platform Integration
 
-**Status:** Active program setup
+**Status:** Active program setup / `GP-5.1a` audit closeout
 **Date:** 2026-04-24
-**Authority:** `origin/main` at `d7f7b37` for the `GP-5.0a` consultation
-absorb slice
+**Authority:** `origin/main` at `7580303` for the `GP-5.1a` prerequisite audit
 **Tracker:** [#424](https://github.com/Halildeu/ao-kernel/issues/424)
-**Current slice:** `GP-5.0a` - evidence gates and `RI-5` / `GP-5.3`
-interface contract
-**Branch:** `codex/gp5-0a-ri5-interface-gates`
-**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gp5-0a`
+**Current slice:** `GP-5.1a` - protected gate prerequisite audit
+**Branch:** `codex/gp5-1a-protected-gate-audit`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gp5-1a`
 **Predecessors:** `v4.0.0` stable runtime, `GP-3`, `GP-4`, `RI-4`
 closed, `RI-5` opened
 **Motto:** Kapsam disiplini: once kanitli entegrasyon, sonra support widening.
@@ -159,6 +157,18 @@ runtime integration starts.
 
 **Goal:** Convert the GP-4 live-adapter gate design from blocked contract into
 an executable protected gate.
+
+**GP-5.1a audit result:** `blocked_unattested_keep_operator_beta`.
+
+`GP-5.1a` checked the current GitHub environment and secret-handle metadata
+without creating environments, reading secret values, binding workflow
+environments, or invoking `claude`. The only configured environment is `pypi`;
+the required `ao-kernel-live-adapter-gate` environment is absent, and
+`AO_CLAUDE_CODE_CLI_AUTH` is not attested as a repository or environment
+secret handle. Therefore `GP-5.1b` must not bind the workflow yet.
+
+The detailed decision record is
+`.claude/plans/GP-5.1a-PROTECTED-GATE-PREREQUISITE-AUDIT.md`.
 
 **Work:**
 
@@ -458,11 +468,11 @@ promotion.
 | Order | Slice | Output | Notes |
 |---:|---|---|---|
 | 1 | `GP-5.0` | Program roadmap PR | Completed on `main`; no runtime change. |
-| 2 | `GP-5.0a` | Claude/MCP consultation absorb + RI-5/GP-5.3 interface contract | Current slice; no runtime change. |
-| 3 | `GP-5.1a` | Protected gate prerequisite audit | Check whether GitHub environment/secret can exist; no secret value in repo. |
-| 4 | `GP-5.3a` | Repo-intelligence retrieval evidence contract | May run in parallel with `GP-5.1a`; use current `repo query` / Markdown context baseline from `RI-4`. |
-| 5 | `GP-5.3b` | Agent context handoff contract | May run in parallel with `GP-5.1a`; explicit stdout/manual handoff; no `context_compiler` auto-feed. |
-| 6 | `GP-5.1b` | Protected workflow binding patch | Bind live gate to protected environment with blocked semantics preserved. |
+| 2 | `GP-5.0a` | Claude/MCP consultation absorb + RI-5/GP-5.3 interface contract | Completed on `main`; no runtime change. |
+| 3 | `GP-5.1a` | Protected gate prerequisite audit | Closeout candidate: required environment/secret handle not attested; no secret value in repo. |
+| 4 | `GP-5.3a` | Repo-intelligence retrieval evidence contract | Next unblocked slice; use current `repo query` / Markdown context baseline from `RI-4`. |
+| 5 | `GP-5.3b` | Agent context handoff contract | Can follow `GP-5.3a`; explicit stdout/manual handoff; no `context_compiler` auto-feed. |
+| 6 | `GP-5.1b` | Protected workflow binding patch | Blocked until `ao-kernel-live-adapter-gate` and `AO_CLAUDE_CODE_CLI_AUTH` are attested. |
 | 7 | `GP-5.2a` | `claude-code-cli` protected gate rehearsal | Only after GP-5.1 can produce real protected evidence. |
 | 8 | `GP-5.4a` | Read-only E2E workflow rehearsal | Requires repo-intelligence handoff plus adapter gate evidence. |
 | 9 | `GP-5.5a` | Controlled patch/test design | No remote side effects; runbook skeleton update required. |
@@ -493,6 +503,6 @@ Current product wording remains:
 2. general-purpose production coding automation platform: not yet;
 3. real adapter production-certified support: not yet;
 4. repo-intelligence production workflow integration: not yet;
-5. next step: merge `GP-5.0a`, then start `GP-5.1a` and the independent
-   `GP-5.3a` / `GP-5.3b` repo-intelligence contract slices without support
-   widening.
+5. next step: merge `GP-5.1a`, then start `GP-5.3a` repo-intelligence
+   retrieval evidence contract unless protected environment/credential
+   attestation is provided first.

--- a/.claude/plans/GP-5.1a-PROTECTED-GATE-PREREQUISITE-AUDIT.md
+++ b/.claude/plans/GP-5.1a-PROTECTED-GATE-PREREQUISITE-AUDIT.md
@@ -1,0 +1,193 @@
+# GP-5.1a - Protected Gate Prerequisite Audit
+
+**Status:** Closeout candidate
+**Date:** 2026-04-24
+**Authority:** `origin/main` at `7580303`
+**Parent tracker:** [#424](https://github.com/Halildeu/ao-kernel/issues/424)
+**Slice issue:** [#429](https://github.com/Halildeu/ao-kernel/issues/429)
+**Branch:** `codex/gp5-1a-protected-gate-audit`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gp5-1a`
+**Decision:** `blocked_unattested_keep_operator_beta`
+
+## Purpose
+
+Record the project-owned protected live-adapter gate prerequisites before any
+workflow binding, secret usage, live `claude` invocation, or support widening.
+
+This slice answers one narrow question: can the next protected gate slice rely
+on an attested GitHub environment and project-owned Claude Code credential
+today?
+
+## Scope
+
+1. Inspect current GitHub environment inventory.
+2. Inspect whether the required secret handle is attested as metadata.
+3. Verify the existing live-adapter gate still emits blocked evidence and does
+   not read secrets or run a live adapter.
+4. Update the GP-5 roadmap and execution status.
+
+## Non-Goals
+
+1. No GitHub environment creation.
+2. No repository or environment secret value creation.
+3. No secret value read, print, commit, or storage.
+4. No workflow `environment:` binding.
+5. No live `claude` / `claude-code-cli` invocation.
+6. No support boundary widening.
+
+## Audit Evidence
+
+### GitHub environment inventory
+
+Command:
+
+```bash
+gh api repos/Halildeu/ao-kernel/environments \
+  --jq '{total_count, environments: [.environments[] | {name, protection_rules, deployment_branch_policy}]}'
+```
+
+Observed result:
+
+```json
+{
+  "total_count": 1,
+  "environments": [
+    {
+      "name": "pypi",
+      "protection_rules": [],
+      "deployment_branch_policy": null
+    }
+  ]
+}
+```
+
+Decision:
+
+| Required environment | Status |
+|---|---|
+| `ao-kernel-live-adapter-gate` | `absent / not_attested` |
+
+### Secret handle metadata
+
+Repository-level lookup:
+
+```bash
+gh secret list --repo Halildeu/ao-kernel --json name,updatedAt \
+  --jq '[.[] | select(.name == "AO_CLAUDE_CODE_CLI_AUTH")]'
+```
+
+Observed result:
+
+```json
+[]
+```
+
+Environment-level lookup:
+
+```bash
+gh secret list \
+  --repo Halildeu/ao-kernel \
+  --env ao-kernel-live-adapter-gate \
+  --json name,updatedAt \
+  --jq '[.[] | select(.name == "AO_CLAUDE_CODE_CLI_AUTH")]'
+```
+
+Observed result:
+
+```text
+HTTP 404: Not Found
+```
+
+Decision:
+
+| Required secret handle | Status |
+|---|---|
+| `AO_CLAUDE_CODE_CLI_AUTH` repository secret | `absent / not_attested` |
+| `AO_CLAUDE_CODE_CLI_AUTH` environment secret | `blocked` because the environment is absent |
+
+### Current workflow safety posture
+
+Current workflow:
+
+```text
+.github/workflows/live-adapter-gate.yml
+```
+
+Observed properties:
+
+1. trigger is `workflow_dispatch`;
+2. no `environment:` binding exists;
+3. no `secrets.` references exist;
+4. no `pull_request_target` trigger exists;
+5. the workflow emits design-only contract artifacts.
+
+### Blocked evidence artifact check
+
+Command:
+
+```bash
+python3 scripts/live_adapter_gate_contract.py \
+  --output json \
+  --report-path /tmp/gp5-1a-live-adapter-gate-contract.v1.json \
+  --evidence-path /tmp/gp5-1a-live-adapter-gate-evidence.v1.json \
+  --environment-contract-path /tmp/gp5-1a-live-adapter-gate-environment-contract.v1.json \
+  --rehearsal-decision-path /tmp/gp5-1a-live-adapter-gate-rehearsal-decision.v1.json \
+  --target-ref main \
+  --reason gp5-1a-prerequisite-audit \
+  --requested-by codex \
+  --event-name local-audit \
+  --head-sha 7580303f697f7be95321a711fcfc9684531af08a
+```
+
+Observed artifact statuses:
+
+| Artifact | Status | Key finding |
+|---|---|---|
+| `live-adapter-gate-contract.v1.json` | `blocked` | `live_gate_not_implemented` |
+| `live-adapter-gate-evidence.v1.json` | `blocked` | `live_gate_protected_environment_not_attested` |
+| `live-adapter-gate-environment-contract.v1.json` | `blocked` | `live_gate_protected_environment_not_attested` |
+| `live-adapter-gate-rehearsal-decision.v1.json` | `blocked_no_rehearsal` | `live_gate_rehearsal_blocked_missing_protected_prerequisites` |
+
+The blocked artifact path remains the correct behavior. It is not a live
+adapter success signal.
+
+## Decision
+
+`GP-5.1a` closes as `blocked_unattested_keep_operator_beta`.
+
+The project cannot start `GP-5.1b` workflow binding yet because the required
+environment and credential handle are not attested. The right next action is an
+out-of-band repo administration step, not a code change:
+
+1. create or designate protected environment `ao-kernel-live-adapter-gate`;
+2. configure required reviewers and branch/ref restrictions;
+3. configure project-owned credential handle `AO_CLAUDE_CODE_CLI_AUTH` in that
+   environment;
+4. provide metadata-only attestation that the environment and handle exist;
+5. then open `GP-5.1b` to bind the workflow while preserving blocked semantics
+   for missing prerequisites.
+
+## Support Boundary Impact
+
+No support widening.
+
+`claude-code-cli` remains `Beta (operator-managed)`. Local Claude Code auth or
+operator smoke success is still not project-owned production-certified support.
+
+## Next Slices
+
+1. `GP-5.3a` can proceed independently: repo-intelligence retrieval evidence
+   quality contract.
+2. `GP-5.3b` can proceed independently: stdout/manual agent context handoff
+   contract.
+3. `GP-5.1b` is blocked until protected environment and credential handle
+   attestation exists.
+
+## Validation
+
+Required validation for this slice:
+
+1. `git diff --check`
+2. `python3 -m ao_kernel doctor`
+3. `python3 scripts/live_adapter_gate_contract.py ...`
+4. PR CI

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -34,6 +34,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan GP-4.4 protected live rehearsal blocked decision:** `.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md`
 - **Son tamamlanan GP-4.5 support-boundary closeout:** `.claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md`
 - **Son tamamlanan GP-5 roadmap setup:** `.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md`
+- **Aktif GP-5.1a protected gate prerequisite audit:** `.claude/plans/GP-5.1a-PROTECTED-GATE-PREREQUISITE-AUDIT.md`
 - **Son tamamlanan RI-5 design gate:** `.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md`
 - **Aktif GP-5 integration roadmap:** `.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
@@ -93,6 +94,7 @@ ayrı ayrı görünür kılmak.
 - **GP-4.4 issue:** [#410](https://github.com/Halildeu/ao-kernel/issues/410) (`closes with GP-4.4 PR`)
 - **GP-4.5 issue:** [#413](https://github.com/Halildeu/ao-kernel/issues/413) (`closes with GP-4.5 PR`)
 - **GP-5 tracker issue:** [#424](https://github.com/Halildeu/ao-kernel/issues/424) (`active`)
+- **GP-5.1a issue:** [#429](https://github.com/Halildeu/ao-kernel/issues/429) (`closes with GP-5.1a PR`)
 - **RI-5 design gate:** PR `#426` merged; next slice is RI-5a export-plan preview implementation
 - **Current mode:** GP-5 active integration planning / no support widening yet.
   Future widening requires protected live-adapter evidence, repo-intelligence
@@ -157,7 +159,7 @@ ayrı ayrı görünür kılmak.
 | `GP-4.3` protected environment / secret contract | Completed by GP-4.3 PR ([#407](https://github.com/Halildeu/ao-kernel/issues/407), record `.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`) | protected GitHub environment, secret handle ve fork-safety contract'ini schema-backed hale getirmek | no secret values, no environment creation, no live adapter execution, no support widening |
 | `GP-4.4` protected live rehearsal blocked decision | Completed by GP-4.4 PR ([#410](https://github.com/Halildeu/ao-kernel/issues/410), record `.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md`) | protected live rehearsal prerequisite eksikse fake live success üretmeden blocked decision kaydetmek | schema validation + blocked rehearsal decision artifact + no live adapter execution + no support widening |
 | `GP-4.5` support-boundary closeout | Completed by GP-4.5 PR ([#413](https://github.com/Halildeu/ao-kernel/issues/413), record `.claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md`) | blocked GP-4 evidence against support boundary kararını kapatmak | verdict `close_no_widening_keep_operator_beta`; `claude-code-cli` remains Beta/operator-managed |
-| `GP-5` general-purpose platform integration | Active setup / `GP-5.0a` current | repo intelligence, protected real-adapter gate, governed read-only E2E, controlled patch/test, disposable PR rehearsal ve ops widening paketini tek entegrasyon programına bağlamak | roadmap merged; `GP-5.0a` adds evidence gates + `RI-5` / `GP-5.3` interface contract; no support widening until GP-5.9 closeout |
+| `GP-5` general-purpose platform integration | Active setup / `GP-5.1a` current | repo intelligence, protected real-adapter gate, governed read-only E2E, controlled patch/test, disposable PR rehearsal ve ops widening paketini tek entegrasyon programına bağlamak | roadmap merged; `GP-5.1a` records protected gate prerequisites as not attested; no support widening until GP-5.9 closeout |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -232,16 +234,34 @@ genişletmez.
 
 `GP-5` aktif yol artık:
 
-1. `GP-5.0a` evidence gates + `RI-5` / `GP-5.3` interface contract — current
-2. `GP-5.1a` protected gate prerequisite audit
-3. `GP-5.3a` repo-intelligence retrieval evidence contract
-4. `GP-5.3b` agent context handoff contract
-5. `GP-5.1b` protected workflow binding patch
+1. `GP-5.1a` protected gate prerequisite audit — current closeout candidate
+2. `GP-5.3a` repo-intelligence retrieval evidence contract
+3. `GP-5.3b` agent context handoff contract
+4. `GP-5.1b` protected workflow binding patch — blocked until attestation
 
 `GP-5.3a` ve `GP-5.3b`, `GP-5.1a` ile paralel yürüyebilir; çünkü read-only
 retrieval evidence ve manual/stdout handoff protected real-adapter credential'a
 bağlı değildir. Buna rağmen support widening ancak GP-5 closeout kapıları
 tamamlanınca yapılır.
+
+`GP-5.1a` canlı audit sonucu:
+
+1. GitHub environments inventory yalnız `pypi` döndürdü.
+2. Required environment `ao-kernel-live-adapter-gate` yoktur.
+3. Repository secret lookup `AO_CLAUDE_CODE_CLI_AUTH` için boş liste döndürdü.
+4. Environment secret lookup `ao-kernel-live-adapter-gate` için `HTTP 404`
+   döndürdü; environment yokken env-secret attestation yapılamaz.
+5. `.github/workflows/live-adapter-gate.yml` hâlâ `workflow_dispatch` only,
+   `environment:` binding yok, `secrets.` referansı yok ve live adapter
+   çalıştırmıyor.
+6. `scripts/live_adapter_gate_contract.py` blocked evidence üretmeye devam
+   ediyor: `overall_status=blocked`, `decision=blocked_no_rehearsal`,
+   `support_widening=false`.
+
+Karar: `blocked_unattested_keep_operator_beta`. `GP-5.1b` workflow binding
+patch'i, protected environment ve credential handle metadata attestation
+gelmeden açılmayacak. Bu blokaj `GP-5.3a` ve `GP-5.3b` read-only
+repo-intelligence contract slice'larını engellemez.
 
 Tarihi `ST`, `PB` ve `GP` kayıtları aşağıda korunur; bunlar güncel aktif gate
 değildir.


### PR DESCRIPTION
## Summary
- add GP-5.1a protected gate prerequisite audit decision record
- record current GitHub environment inventory: only pypi exists, ao-kernel-live-adapter-gate is not attested
- record AO_CLAUDE_CODE_CLI_AUTH secret-handle metadata as not attested without reading any secret value
- keep live-adapter gate fail-closed and support boundary unchanged
- update GP-5 roadmap/status so GP-5.3a is the next unblocked slice while GP-5.1b remains blocked pending attestation

## Validation
- gh api repos/Halildeu/ao-kernel/environments
- gh secret list --repo Halildeu/ao-kernel --json name,updatedAt
- gh secret list --repo Halildeu/ao-kernel --env ao-kernel-live-adapter-gate --json name,updatedAt (expected HTTP 404 because env is absent)
- python3 scripts/live_adapter_gate_contract.py ...
- python3 -m ao_kernel doctor
- pytest -q tests/test_live_adapter_gate_contract.py
- git diff --check

Closes #429
Part of #424