### PR TITLE
docs(gp5): define retrieval evidence contract

### DIFF
--- a/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
+++ b/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
@@ -1,14 +1,14 @@
 # GP-5 - General-Purpose Production Platform Integration
 
-**Status:** Active program setup / `GP-5.1a` audit closeout
+**Status:** Active program setup / `GP-5.3a` retrieval evidence closeout
 **Date:** 2026-04-24
-**Authority:** `origin/main` at `7580303` for the `GP-5.1a` prerequisite audit
+**Authority:** `origin/main` at `3656939` for the `GP-5.3a` retrieval evidence contract
 **Tracker:** [#424](https://github.com/Halildeu/ao-kernel/issues/424)
-**Current slice:** `GP-5.1a` - protected gate prerequisite audit
-**Branch:** `codex/gp5-1a-protected-gate-audit`
-**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gp5-1a`
+**Current slice:** `GP-5.3a` - repo-intelligence retrieval evidence contract
+**Branch:** `codex/gp5-3a-retrieval-evidence`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gp5-3a`
 **Predecessors:** `v4.0.0` stable runtime, `GP-3`, `GP-4`, `RI-4`
-closed, `RI-5` opened
+closed, `RI-5` opened, `GP-5.1a` completed
 **Motto:** Kapsam disiplini: once kanitli entegrasyon, sonra support widening.
 
 ## 1. Purpose
@@ -256,7 +256,8 @@ integration pillars.
 
 1. `GP-5.3a` - Retrieval evidence quality contract:
    define relevance, stale-result, snippet-boundary, and hash-validation
-   assertions for `repo query`.
+   assertions for `repo query`. Result:
+   `keep_beta_read_only_retrieval_contract`.
 2. `GP-5.3b` - Agent context handoff contract:
    document and test stdout-only Markdown handoff as explicit operator input,
    not hidden prompt injection.
@@ -269,6 +270,21 @@ integration pillars.
 5. `GP-5.3e` - Promotion decision:
    decide whether repo-intelligence read-only context can become a supported
    building block for GP-5 workflows.
+
+**GP-5.3a closeout candidate:**
+
+`GP-5.3a` keeps repo intelligence in beta read-only mode, but strengthens the
+evidence contract that later workflow handoff slices can rely on. The focused
+tests now pin source artifact hashes, `min_similarity`, current-only results,
+untruncated snippet hashes, same-prefix metadata filtering, stale-source
+diagnostics, path-escape exclusion, and CLI read-only behavior.
+
+The detailed decision record is
+`.claude/plans/GP-5.3a-REPO-INTELLIGENCE-RETRIEVAL-EVIDENCE-CONTRACT.md`.
+
+This slice does not consume `.ao/context/repo_export_plan.json`, does not write
+root authority files, does not auto-feed `context_compiler`, and does not widen
+support.
 
 **DoD:**
 
@@ -469,9 +485,9 @@ promotion.
 |---:|---|---|---|
 | 1 | `GP-5.0` | Program roadmap PR | Completed on `main`; no runtime change. |
 | 2 | `GP-5.0a` | Claude/MCP consultation absorb + RI-5/GP-5.3 interface contract | Completed on `main`; no runtime change. |
-| 3 | `GP-5.1a` | Protected gate prerequisite audit | Closeout candidate: required environment/secret handle not attested; no secret value in repo. |
-| 4 | `GP-5.3a` | Repo-intelligence retrieval evidence contract | Next unblocked slice; use current `repo query` / Markdown context baseline from `RI-4`. |
-| 5 | `GP-5.3b` | Agent context handoff contract | Can follow `GP-5.3a`; explicit stdout/manual handoff; no `context_compiler` auto-feed. |
+| 3 | `GP-5.1a` | Protected gate prerequisite audit | Completed on `main`; required environment/secret handle not attested; no secret value in repo. |
+| 4 | `GP-5.3a` | Repo-intelligence retrieval evidence contract | Closeout candidate: beta read-only evidence contract strengthened; no support widening. |
+| 5 | `GP-5.3b` | Agent context handoff contract | Next unblocked slice; explicit stdout/manual handoff; no `context_compiler` auto-feed. |
 | 6 | `GP-5.1b` | Protected workflow binding patch | Blocked until `ao-kernel-live-adapter-gate` and `AO_CLAUDE_CODE_CLI_AUTH` are attested. |
 | 7 | `GP-5.2a` | `claude-code-cli` protected gate rehearsal | Only after GP-5.1 can produce real protected evidence. |
 | 8 | `GP-5.4a` | Read-only E2E workflow rehearsal | Requires repo-intelligence handoff plus adapter gate evidence. |
@@ -503,6 +519,6 @@ Current product wording remains:
 2. general-purpose production coding automation platform: not yet;
 3. real adapter production-certified support: not yet;
 4. repo-intelligence production workflow integration: not yet;
-5. next step: merge `GP-5.1a`, then start `GP-5.3a` repo-intelligence
-   retrieval evidence contract unless protected environment/credential
-   attestation is provided first.
+5. next step: merge `GP-5.3a`, then start `GP-5.3b` agent context handoff
+   contract unless protected environment/credential attestation is provided
+   first for `GP-5.1b`.

--- a/.claude/plans/GP-5.3a-REPO-INTELLIGENCE-RETRIEVAL-EVIDENCE-CONTRACT.md
+++ b/.claude/plans/GP-5.3a-REPO-INTELLIGENCE-RETRIEVAL-EVIDENCE-CONTRACT.md
@@ -1,0 +1,124 @@
+# GP-5.3a - Repo Intelligence Retrieval Evidence Contract
+
+**Status:** Closeout candidate
+**Date:** 2026-04-24
+**Authority:** `origin/main` at `3656939`
+**Parent tracker:** [#424](https://github.com/Halildeu/ao-kernel/issues/424)
+**Slice issue:** [#431](https://github.com/Halildeu/ao-kernel/issues/431)
+**Branch:** `codex/gp5-3a-retrieval-evidence`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gp5-3a`
+**Decision:** `keep_beta_read_only_retrieval_contract`
+
+## Purpose
+
+Define the minimum evidence contract that `repo query` must satisfy before its
+output can be considered as explicit input for governed workflow context in a
+later GP-5 slice.
+
+This slice does not promote repo intelligence to production workflow support.
+It tightens the read-only retrieval boundary and records what is already
+behavior-tested.
+
+## Scope
+
+1. Pin query-result evidence fields that downstream workflow handoff can trust.
+2. Strengthen behavior tests for namespace filtering, source-hash freshness,
+   snippet boundaries, and path-escape exclusion.
+3. Record the limits of the current relevance signal.
+4. Keep `RI-5` root export and `context_compiler` auto-feed out of scope.
+
+## Non-Goals
+
+1. No `context_compiler` auto-injection.
+2. No MCP tool wiring for repo query.
+3. No root export and no dependency on `.ao/context/repo_export_plan.json`.
+4. No root authority file writes.
+5. No vector backend writes.
+6. No support boundary widening.
+
+## Retrieval Evidence Contract
+
+A valid `repo query` JSON result must carry these evidence groups:
+
+| Group | Required evidence | Purpose |
+|---|---|---|
+| Generator | `generator.name`, `generator.version`, `generated_at` | identify producing runtime |
+| Query parameters | query text, `top_k`, `candidate_limit`, `min_similarity`, token/snippet limits, filters | make retrieval reproducible and bounded |
+| Embedding space | provider, model, dimension, chunker version, embedding space id | prevent cross-model/vector-space mixing |
+| Namespace | `repo_chunk::<project_identity>::<embedding_space_id>::...` plus metadata checks | keep canonical/session memory out of repo retrieval |
+| Source artifacts | repo chunks digest and vector index manifest digest | bind result to local index artifacts |
+| Result source | source path, line range, language, kind, chunk id, content hash | make every snippet attributable |
+| Relevance signal | vector similarity and applied filters | expose ranking evidence without claiming human relevance |
+| Freshness signal | `content_status="current"` only in returned results; stale candidates appear in diagnostics | prevent deleted/refactored code from becoming prompt context |
+| Bounds | token estimate, snippet truncation flag, max snippet chars | keep handoff size explicit |
+| Diagnostics | filtered/stale/token-budget reasons | show why candidates were excluded |
+
+## Behavior Pinned By This Slice
+
+The focused tests now assert:
+
+1. result source artifact hashes are present and tied to the index manifest;
+2. all returned results meet the recorded `min_similarity`;
+3. all returned results are `content_status="current"`;
+4. untruncated snippets hash back to `content_sha256`;
+5. non-repo namespace candidates are filtered;
+6. same-key-prefix candidates with wrong repo metadata are filtered;
+7. path-escape source candidates are excluded and diagnosed;
+8. stale source chunks are excluded and diagnosed;
+9. CLI `repo query` remains read-only for `.ao/context` and root authority
+   files.
+
+## Relevance Boundary
+
+Current relevance evidence is intentionally limited to:
+
+1. vector-store similarity score;
+2. configured `min_similarity`;
+3. path/language/symbol filters;
+4. deterministic result ordering.
+
+This is enough for a read-only evidence contract. It is not yet enough for a
+production claim that the answer is semantically correct for arbitrary coding
+tasks. Human-labeled or fixture-level retrieval quality thresholds remain a
+future GP-5.4 / GP-5.7 concern.
+
+## RI-5 / GP-5.3 Interface
+
+`GP-5.3a` does not consume RI-5 export artifacts.
+
+| Artifact | GP-5.3a status |
+|---|---|
+| `.ao/context/repo_export_plan.json` | `not_used` |
+| `CLAUDE.md` / `AGENTS.md` root exports | `not_used` |
+| stdout Markdown from `repo query --output markdown` | input candidate for `GP-5.3b`, not consumed here |
+| JSON query result | evidence contract defined here |
+
+`RI-5a` may continue independently as root/export preview work. It must not be
+treated as a prerequisite for read-only retrieval evidence.
+
+## Support Boundary Impact
+
+No support widening.
+
+`repo query` remains `Beta / experimental read-only retrieval`. The slice makes
+the evidence contract clearer and better tested, but it does not make
+repo-intelligence workflow integration production-supported.
+
+## Next Slice
+
+`GP-5.3b` should define the explicit agent context handoff contract:
+
+1. stdout-only Markdown as manual/operator-visible input;
+2. no hidden prompt injection;
+3. no context compiler auto-feed;
+4. no root export writes;
+5. no support widening.
+
+## Validation
+
+Required validation for this slice:
+
+1. `pytest -q tests/test_repo_intelligence_vector_retriever.py tests/test_cli_repo_query.py`
+2. `python3 -m ao_kernel doctor`
+3. `git diff --check`
+4. PR CI

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -34,7 +34,8 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan GP-4.4 protected live rehearsal blocked decision:** `.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md`
 - **Son tamamlanan GP-4.5 support-boundary closeout:** `.claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md`
 - **Son tamamlanan GP-5 roadmap setup:** `.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md`
-- **Aktif GP-5.1a protected gate prerequisite audit:** `.claude/plans/GP-5.1a-PROTECTED-GATE-PREREQUISITE-AUDIT.md`
+- **Son tamamlanan GP-5.1a protected gate prerequisite audit:** `.claude/plans/GP-5.1a-PROTECTED-GATE-PREREQUISITE-AUDIT.md`
+- **Aktif GP-5.3a repo-intelligence retrieval evidence contract:** `.claude/plans/GP-5.3a-REPO-INTELLIGENCE-RETRIEVAL-EVIDENCE-CONTRACT.md`
 - **Son tamamlanan RI-5 design gate:** `.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md`
 - **Aktif GP-5 integration roadmap:** `.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
@@ -94,7 +95,8 @@ ayrı ayrı görünür kılmak.
 - **GP-4.4 issue:** [#410](https://github.com/Halildeu/ao-kernel/issues/410) (`closes with GP-4.4 PR`)
 - **GP-4.5 issue:** [#413](https://github.com/Halildeu/ao-kernel/issues/413) (`closes with GP-4.5 PR`)
 - **GP-5 tracker issue:** [#424](https://github.com/Halildeu/ao-kernel/issues/424) (`active`)
-- **GP-5.1a issue:** [#429](https://github.com/Halildeu/ao-kernel/issues/429) (`closes with GP-5.1a PR`)
+- **GP-5.1a issue:** [#429](https://github.com/Halildeu/ao-kernel/issues/429) (`closed after GP-5.1a PR`)
+- **GP-5.3a issue:** [#431](https://github.com/Halildeu/ao-kernel/issues/431) (`closes with GP-5.3a PR`)
 - **RI-5 design gate:** PR `#426` merged; next slice is RI-5a export-plan preview implementation
 - **Current mode:** GP-5 active integration planning / no support widening yet.
   Future widening requires protected live-adapter evidence, repo-intelligence
@@ -159,7 +161,7 @@ ayrı ayrı görünür kılmak.
 | `GP-4.3` protected environment / secret contract | Completed by GP-4.3 PR ([#407](https://github.com/Halildeu/ao-kernel/issues/407), record `.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`) | protected GitHub environment, secret handle ve fork-safety contract'ini schema-backed hale getirmek | no secret values, no environment creation, no live adapter execution, no support widening |
 | `GP-4.4` protected live rehearsal blocked decision | Completed by GP-4.4 PR ([#410](https://github.com/Halildeu/ao-kernel/issues/410), record `.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md`) | protected live rehearsal prerequisite eksikse fake live success üretmeden blocked decision kaydetmek | schema validation + blocked rehearsal decision artifact + no live adapter execution + no support widening |
 | `GP-4.5` support-boundary closeout | Completed by GP-4.5 PR ([#413](https://github.com/Halildeu/ao-kernel/issues/413), record `.claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md`) | blocked GP-4 evidence against support boundary kararını kapatmak | verdict `close_no_widening_keep_operator_beta`; `claude-code-cli` remains Beta/operator-managed |
-| `GP-5` general-purpose platform integration | Active setup / `GP-5.1a` current | repo intelligence, protected real-adapter gate, governed read-only E2E, controlled patch/test, disposable PR rehearsal ve ops widening paketini tek entegrasyon programına bağlamak | roadmap merged; `GP-5.1a` records protected gate prerequisites as not attested; no support widening until GP-5.9 closeout |
+| `GP-5` general-purpose platform integration | Active setup / `GP-5.3a` current | repo intelligence, protected real-adapter gate, governed read-only E2E, controlled patch/test, disposable PR rehearsal ve ops widening paketini tek entegrasyon programına bağlamak | `GP-5.1a` completed blocked protected gate audit; `GP-5.3a` pins retrieval evidence; no support widening until GP-5.9 closeout |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -209,8 +211,9 @@ Amaç, genel amaçlı production coding automation platform claim'ini hemen
 vermek değil; repo-intelligence context, protected real-adapter evidence,
 governed read-only E2E, controlled patch/test, disposable PR rehearsal ve ops
 support widening kapılarını sırayla kapatmaktır. `GP-5.0` roadmap/authority
-freeze tamamlandı; aktif slice `GP-5.0a` Claude/MCP consultation absorb ve
-`RI-5` / `GP-5.3` interface contract kayıt işidir. Bu slice support boundary'yi
+freeze, `GP-5.0a` Claude/MCP consultation absorb ve `GP-5.1a` protected gate
+prerequisite audit tamamlandı. Aktif slice `GP-5.3a` repo-intelligence
+retrieval evidence contract closeout adayıdır. Bu slice support boundary'yi
 genişletmez.
 
 `GP-5.0a` ile yazılı hale getirilen ek kapılar:
@@ -234,9 +237,9 @@ genişletmez.
 
 `GP-5` aktif yol artık:
 
-1. `GP-5.1a` protected gate prerequisite audit — current closeout candidate
-2. `GP-5.3a` repo-intelligence retrieval evidence contract
-3. `GP-5.3b` agent context handoff contract
+1. `GP-5.1a` protected gate prerequisite audit — completed on `main`
+2. `GP-5.3a` repo-intelligence retrieval evidence contract — current closeout candidate
+3. `GP-5.3b` agent context handoff contract — next unblocked slice
 4. `GP-5.1b` protected workflow binding patch — blocked until attestation
 
 `GP-5.3a` ve `GP-5.3b`, `GP-5.1a` ile paralel yürüyebilir; çünkü read-only
@@ -262,6 +265,21 @@ Karar: `blocked_unattested_keep_operator_beta`. `GP-5.1b` workflow binding
 patch'i, protected environment ve credential handle metadata attestation
 gelmeden açılmayacak. Bu blokaj `GP-5.3a` ve `GP-5.3b` read-only
 repo-intelligence contract slice'larını engellemez.
+
+`GP-5.3a` closeout adayı:
+
+1. Karar: `keep_beta_read_only_retrieval_contract`.
+2. `repo query` sonucu source artifact hash'leri, `min_similarity`,
+   current-only result sınırı, untruncated snippet hash'i, namespace/metadata
+   filtreleri, path-escape exclusion ve stale-source diagnostics davranışları
+   focused testlerle pinlenmiştir.
+3. `RI-5a` export-plan preview bu slice için `not_used`; `.ao/context`,
+   `CLAUDE.md`, `AGENTS.md`, `ARCHITECTURE.md` ve `CODEX_CONTEXT.md` root
+   yazıları yapılmaz.
+4. Relevance sınırı bilinçli olarak vector similarity + filtreler +
+   deterministic ordering ile sınırlıdır; arbitrary coding task semantic
+   correctness iddiası yoktur.
+5. Sonraki unblocked slice `GP-5.3b` agent context handoff contract'tır.
 
 Tarihi `ST`, `PB` ve `GP` kayıtları aşağıda korunur; bunlar güncel aktif gate
 değildir.

--- a/tests/test_repo_intelligence_vector_retriever.py
+++ b/tests/test_repo_intelligence_vector_retriever.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 from typing import Any
 
@@ -65,6 +66,19 @@ def _indexed_store(project: Path) -> tuple[InMemoryVectorStore, dict[str, Any]]:
     return store, manifest
 
 
+def _namespace_prefix(manifest: dict[str, Any]) -> str:
+    return (
+        "repo_chunk::"
+        f"{manifest['project']['root_identity_sha256']}::"
+        f"{manifest['embedding_space']['embedding_space_id']}::"
+    )
+
+
+def _first_stored_record(store: InMemoryVectorStore) -> tuple[str, dict[str, Any]]:
+    key, record = next(iter(store._store.items()))  # noqa: SLF001 - test inspects fixture state.
+    return key, dict(record["metadata"])
+
+
 def test_query_repo_vectors_returns_schema_valid_current_chunks(tmp_path: Path) -> None:
     project = _make_project(tmp_path)
     store, manifest = _indexed_store(project)
@@ -84,8 +98,18 @@ def test_query_repo_vectors_returns_schema_valid_current_chunks(tmp_path: Path) 
     assert result["artifact_kind"] == "repo_vector_query_result"
     assert result["summary"]["matches"] >= 1
     assert result["summary"]["embedding_calls"] == 1
+    assert result["query"]["min_similarity"] == 0.3
+    assert result["source_artifacts"]["repo_chunks_sha256"] == manifest["source_artifacts"]["repo_chunks_sha256"]
+    assert len(result["source_artifacts"]["repo_vector_index_manifest_sha256"]) == 64
     assert result["results"][0]["content_status"] == "current"
     assert result["results"][0]["source_path"].startswith("pkg/")
+    assert all(item["similarity"] >= result["query"]["min_similarity"] for item in result["results"])
+    assert all(item["content_status"] == "current" for item in result["results"])
+    assert all(
+        hashlib.sha256(item["snippet"].encode("utf-8")).hexdigest() == item["content_sha256"]
+        for item in result["results"]
+        if not item["snippet_truncated"]
+    )
     assert "return VALUE" in "".join(item["snippet"] for item in result["results"])
 
 
@@ -169,6 +193,58 @@ def test_query_repo_vectors_filters_non_repo_namespace_candidates(tmp_path: Path
     validate_repo_vector_query_result(result)
     assert result["summary"]["filtered_candidates"] >= 1
     assert all(item["key"].startswith("repo_chunk::" + manifest["project"]["root_identity_sha256"]) for item in result["results"])
+
+
+def test_query_repo_vectors_filters_same_prefix_metadata_mismatch(tmp_path: Path) -> None:
+    project = _make_project(tmp_path)
+    store, manifest = _indexed_store(project)
+    _key, metadata = _first_stored_record(store)
+    bad_key = f"{_namespace_prefix(manifest)}repo-chunk-v1:{'d' * 64}"
+    metadata["project_root_identity_sha256"] = "0" * 64
+    store.store(bad_key, [0.1, 0.2, 0.3], metadata=metadata)
+
+    result = query_repo_vectors(
+        project_root=project,
+        vector_index_manifest=manifest,
+        vector_store=store,
+        embedding_config=_embedding_config(),
+        query="run",
+        top_k=10,
+        candidate_limit=20,
+        embed_text_fn=_embed_text,
+    )
+
+    validate_repo_vector_query_result(result)
+    assert result["summary"]["filtered_candidates"] >= 1
+    assert all(item["key"] != bad_key for item in result["results"])
+
+
+def test_query_repo_vectors_excludes_path_escape_candidates(tmp_path: Path) -> None:
+    project = _make_project(tmp_path)
+    store, manifest = _indexed_store(project)
+    _key, metadata = _first_stored_record(store)
+    bad_key = f"{_namespace_prefix(manifest)}repo-chunk-v1:{'e' * 64}"
+    metadata["source_path"] = "../pyproject.toml"
+    store.store(bad_key, [0.1, 0.2, 0.3], metadata=metadata)
+
+    result = query_repo_vectors(
+        project_root=project,
+        vector_index_manifest=manifest,
+        vector_store=store,
+        embedding_config=_embedding_config(),
+        query="run",
+        top_k=10,
+        candidate_limit=20,
+        embed_text_fn=_embed_text,
+    )
+
+    validate_repo_vector_query_result(result)
+    assert result["summary"]["stale_candidates"] >= 1
+    assert all(item["key"] != bad_key for item in result["results"])
+    assert any(
+        item["code"] == "repo_vector_query_source_path_escape" and item["key"] == bad_key
+        for item in result["diagnostics"]
+    )
 
 
 def test_query_repo_vectors_excludes_stale_source_chunks(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Record GP-5.3a retrieval evidence contract and keep `repo query` beta/read-only with no support widening.
- Strengthen repo-intelligence retrieval tests for source artifact hashes, min similarity, current-only results, snippet hashes, metadata mismatch filtering, stale diagnostics, and path-escape exclusion.
- Move GP-5 status forward: GP-5.1a completed, GP-5.3a closeout candidate, GP-5.3b next unblocked slice.

## Validation
- `pytest -q tests/test_repo_intelligence_vector_retriever.py tests/test_cli_repo_query.py` -> 15 passed
- `python3 -m ao_kernel doctor` -> 8 OK, 1 WARN, 0 FAIL (known extension truth inventory warning)
- `git diff --check`

Closes #431
Part of #424
