### PR TITLE
test(gp5): pin repo intelligence negative boundary

### DIFF
--- a/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
+++ b/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
@@ -1,15 +1,15 @@
 # GP-5 - General-Purpose Production Platform Integration
 
-**Status:** Active program setup / `GP-5.3c` workflow opt-in design closeout
+**Status:** Active program setup / `GP-5.3d` no-MCP/no-root-export guard closeout
 **Date:** 2026-04-24
-**Authority:** `origin/main` at `5eedaa0` for the `GP-5.3c` workflow opt-in design contract
+**Authority:** `origin/main` at `54de6e9` for the `GP-5.3d` no-MCP/no-root-export guard
 **Tracker:** [#424](https://github.com/Halildeu/ao-kernel/issues/424)
-**Current slice:** `GP-5.3c` - workflow opt-in design contract
-**Branch:** `codex/gp5-3c-workflow-opt-in`
-**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gp5-3c`
+**Current slice:** `GP-5.3d` - no-MCP/no-root-export guard
+**Branch:** `codex/gp5-3d-no-mcp-root-export`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gp5-3d`
 **Predecessors:** `v4.0.0` stable runtime, `GP-3`, `GP-4`, `RI-4`
 closed, `RI-5` opened, `GP-5.1a` completed, `GP-5.3a` completed,
-`GP-5.3b` completed
+`GP-5.3b` completed, `GP-5.3c` completed
 **Motto:** Kapsam disiplini: once kanitli entegrasyon, sonra support widening.
 
 ## 1. Purpose
@@ -313,6 +313,18 @@ tool, no root export, and no automatic `context_compiler` feed.
 The detailed decision record is
 `.claude/plans/GP-5.3c-WORKFLOW-OPT-IN-DESIGN-CONTRACT.md`.
 
+**GP-5.3d closeout candidate:**
+
+`GP-5.3d` keeps repo-intelligence integration in beta read-only mode, but adds
+regression guards for the negative boundary that matters before any workflow
+promotion decision. The MCP tool surface remains free of repo-intelligence
+tools, the `repo` CLI surface remains limited to `scan`, `index`, and `query`,
+and `repo query` is pinned not to create root authority files, MCP config
+exports, or `.ao/context/repo_export_plan.json`.
+
+The detailed decision record is
+`.claude/plans/GP-5.3d-NO-MCP-NO-ROOT-EXPORT-GUARD.md`.
+
 **DoD:**
 
 1. Retrieval output is evidence-backed, bounded, and stale-safe.
@@ -515,13 +527,15 @@ promotion.
 | 3 | `GP-5.1a` | Protected gate prerequisite audit | Completed on `main`; required environment/secret handle not attested; no secret value in repo. |
 | 4 | `GP-5.3a` | Repo-intelligence retrieval evidence contract | Completed on `main`; beta read-only evidence contract strengthened; no support widening. |
 | 5 | `GP-5.3b` | Agent context handoff contract | Completed on `main`; explicit stdout/manual handoff; no `context_compiler` auto-feed. |
-| 6 | `GP-5.3c` | Workflow opt-in design contract | Closeout candidate: schema-backed future opt-in; runtime remains unwired. |
-| 7 | `GP-5.1b` | Protected workflow binding patch | Blocked until `ao-kernel-live-adapter-gate` and `AO_CLAUDE_CODE_CLI_AUTH` are attested. |
-| 8 | `GP-5.2a` | `claude-code-cli` protected gate rehearsal | Only after GP-5.1 can produce real protected evidence. |
-| 9 | `GP-5.4a` | Read-only E2E workflow rehearsal | Requires repo-intelligence handoff plus adapter gate evidence. |
-| 10 | `GP-5.5a` | Controlled patch/test design | No remote side effects; runbook skeleton update required. |
-| 11 | `GP-5.6a` | Disposable PR write rehearsal | Sandbox-only, rollback and runbook update required. |
-| 12 | `GP-5.9` | Production platform claim decision | Only after all prior gate evidence exists. |
+| 6 | `GP-5.3c` | Workflow opt-in design contract | Completed on `main`; schema-backed future opt-in; runtime remains unwired. |
+| 7 | `GP-5.3d` | No-MCP/no-root-export guard | Closeout candidate: negative boundary pinned; no support widening. |
+| 8 | `GP-5.3e` | Repo-intelligence workflow building-block promotion decision | Next unblocked decision slice after `GP-5.3d`. |
+| 9 | `GP-5.1b` | Protected workflow binding patch | Blocked until `ao-kernel-live-adapter-gate` and `AO_CLAUDE_CODE_CLI_AUTH` are attested. |
+| 10 | `GP-5.2a` | `claude-code-cli` protected gate rehearsal | Only after GP-5.1 can produce real protected evidence. |
+| 11 | `GP-5.4a` | Read-only E2E workflow rehearsal | Requires repo-intelligence handoff plus adapter gate evidence. |
+| 12 | `GP-5.5a` | Controlled patch/test design | No remote side effects; runbook skeleton update required. |
+| 13 | `GP-5.6a` | Disposable PR write rehearsal | Sandbox-only, rollback and runbook update required. |
+| 14 | `GP-5.9` | Production platform claim decision | Only after all prior gate evidence exists. |
 
 ## 8. Standard Slice DoD
 

--- a/.claude/plans/GP-5.3d-NO-MCP-NO-ROOT-EXPORT-GUARD.md
+++ b/.claude/plans/GP-5.3d-NO-MCP-NO-ROOT-EXPORT-GUARD.md
@@ -1,0 +1,73 @@
+# GP-5.3d - No-MCP / No-Root-Export Guard
+
+**Status:** Closeout candidate
+**Date:** 2026-04-24
+**Authority:** `origin/main` at `54de6e9`
+**Tracker:** [#424](https://github.com/Halildeu/ao-kernel/issues/424)
+**Slice issue:** [#437](https://github.com/Halildeu/ao-kernel/issues/437)
+**Branch:** `codex/gp5-3d-no-mcp-root-export`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gp5-3d`
+**Decision:** `keep_beta_read_only_negative_boundary_pinned`
+
+## Purpose
+
+`GP-5.3a`, `GP-5.3b`, and `GP-5.3c` made repo-intelligence retrieval,
+operator-visible handoff, and future opt-in shape more explicit. This slice
+pins the negative boundary before any promotion decision: repo-intelligence
+must not silently become an MCP tool, root authority export, root context
+export, or hidden workflow/context feed.
+
+## Scope
+
+1. Add regression checks that the MCP tool surface has no repo-intelligence
+   tool registration or dispatch entry.
+2. Add regression checks that the `repo` CLI public subcommands remain limited
+   to `scan`, `index`, and `query`.
+3. Add help-text checks that repo-intelligence CLI commands do not advertise
+   MCP or root-export flags.
+4. Strengthen `repo query` side-effect tests so root authority files, MCP
+   config exports, and `.ao/context/repo_export_plan.json` stay absent.
+5. Update GP-5 status and support-boundary docs without widening support.
+
+## Non-Goals
+
+1. No MCP repo-intelligence tool implementation.
+2. No root export implementation.
+3. No `context_compiler` or executor auto-feed.
+4. No RI-5 export-plan implementation.
+5. No live adapter or protected environment gate change.
+6. No support boundary widening.
+
+## Evidence
+
+Targeted local validation:
+
+```bash
+pytest -q tests/test_repo_intelligence_no_mcp_root_export_guard.py tests/test_cli_repo_query.py
+python3 -m ao_kernel doctor
+git diff --check
+```
+
+PR validation must include the regular CI gates before merge.
+
+## Support Boundary Impact
+
+Unchanged. Repo intelligence remains `Beta / experimental read-only` for
+`repo scan`, `repo index`, and `repo query`. `repo query --output markdown`
+remains an operator-visible stdout handoff only. There is still no supported
+MCP repo-intelligence tool, no root export, no workflow runtime wiring, and no
+automatic `context_compiler` feed.
+
+## RI-5 Interface
+
+`RI-5` continues to own explicit root/context export. `GP-5.3d` does not
+consume `.ao/context/repo_export_plan.json`, does not require it, and does not
+produce it. This slice only protects the current beta read-only surface from
+accidental support widening.
+
+## Next Slice
+
+`GP-5.3e` should decide whether repo-intelligence read-only context can become
+a governed workflow building block. That decision remains blocked from claiming
+production support until protected live-adapter evidence and later GP-5 gates
+exist.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -37,7 +37,8 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan GP-5.1a protected gate prerequisite audit:** `.claude/plans/GP-5.1a-PROTECTED-GATE-PREREQUISITE-AUDIT.md`
 - **Son tamamlanan GP-5.3a repo-intelligence retrieval evidence contract:** `.claude/plans/GP-5.3a-REPO-INTELLIGENCE-RETRIEVAL-EVIDENCE-CONTRACT.md`
 - **Son tamamlanan GP-5.3b agent context handoff contract:** `.claude/plans/GP-5.3b-AGENT-CONTEXT-HANDOFF-CONTRACT.md`
-- **Aktif GP-5.3c workflow opt-in design contract:** `.claude/plans/GP-5.3c-WORKFLOW-OPT-IN-DESIGN-CONTRACT.md`
+- **Son tamamlanan GP-5.3c workflow opt-in design contract:** `.claude/plans/GP-5.3c-WORKFLOW-OPT-IN-DESIGN-CONTRACT.md`
+- **Aktif GP-5.3d no-MCP/no-root-export guard:** `.claude/plans/GP-5.3d-NO-MCP-NO-ROOT-EXPORT-GUARD.md`
 - **Son tamamlanan RI-5 design gate:** `.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md`
 - **Aktif GP-5 integration roadmap:** `.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
@@ -100,7 +101,8 @@ ayrı ayrı görünür kılmak.
 - **GP-5.1a issue:** [#429](https://github.com/Halildeu/ao-kernel/issues/429) (`closed after GP-5.1a PR`)
 - **GP-5.3a issue:** [#431](https://github.com/Halildeu/ao-kernel/issues/431) (`closed after GP-5.3a PR`)
 - **GP-5.3b issue:** [#433](https://github.com/Halildeu/ao-kernel/issues/433) (`closed after GP-5.3b PR`)
-- **GP-5.3c issue:** [#435](https://github.com/Halildeu/ao-kernel/issues/435) (`closes with GP-5.3c PR`)
+- **GP-5.3c issue:** [#435](https://github.com/Halildeu/ao-kernel/issues/435) (`closed after GP-5.3c PR`)
+- **GP-5.3d issue:** [#437](https://github.com/Halildeu/ao-kernel/issues/437) (`closes with GP-5.3d PR`)
 - **RI-5 design gate:** PR `#426` merged; next slice is RI-5a export-plan preview implementation
 - **Current mode:** GP-5 active integration planning / no support widening yet.
   Future widening requires protected live-adapter evidence, repo-intelligence
@@ -165,7 +167,7 @@ ayrı ayrı görünür kılmak.
 | `GP-4.3` protected environment / secret contract | Completed by GP-4.3 PR ([#407](https://github.com/Halildeu/ao-kernel/issues/407), record `.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md`) | protected GitHub environment, secret handle ve fork-safety contract'ini schema-backed hale getirmek | no secret values, no environment creation, no live adapter execution, no support widening |
 | `GP-4.4` protected live rehearsal blocked decision | Completed by GP-4.4 PR ([#410](https://github.com/Halildeu/ao-kernel/issues/410), record `.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md`) | protected live rehearsal prerequisite eksikse fake live success üretmeden blocked decision kaydetmek | schema validation + blocked rehearsal decision artifact + no live adapter execution + no support widening |
 | `GP-4.5` support-boundary closeout | Completed by GP-4.5 PR ([#413](https://github.com/Halildeu/ao-kernel/issues/413), record `.claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md`) | blocked GP-4 evidence against support boundary kararını kapatmak | verdict `close_no_widening_keep_operator_beta`; `claude-code-cli` remains Beta/operator-managed |
-| `GP-5` general-purpose platform integration | Active setup / `GP-5.3c` current | repo intelligence, protected real-adapter gate, governed read-only E2E, controlled patch/test, disposable PR rehearsal ve ops widening paketini tek entegrasyon programına bağlamak | `GP-5.1a` completed blocked protected gate audit; `GP-5.3a` pins retrieval evidence; `GP-5.3b` pins explicit handoff; `GP-5.3c` defines future opt-in contract; no support widening until GP-5.9 closeout |
+| `GP-5` general-purpose platform integration | Active setup / `GP-5.3d` current | repo intelligence, protected real-adapter gate, governed read-only E2E, controlled patch/test, disposable PR rehearsal ve ops widening paketini tek entegrasyon programına bağlamak | `GP-5.1a` completed blocked protected gate audit; `GP-5.3a` pins retrieval evidence; `GP-5.3b` pins explicit handoff; `GP-5.3c` defines future opt-in contract; `GP-5.3d` pins no-MCP/no-root-export guard; no support widening until GP-5.9 closeout |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -216,9 +218,10 @@ vermek değil; repo-intelligence context, protected real-adapter evidence,
 governed read-only E2E, controlled patch/test, disposable PR rehearsal ve ops
 support widening kapılarını sırayla kapatmaktır. `GP-5.0` roadmap/authority
 freeze, `GP-5.0a` Claude/MCP consultation absorb, `GP-5.1a` protected gate
-prerequisite audit, `GP-5.3a` retrieval evidence contract ve `GP-5.3b` agent
-context handoff contract tamamlandı. Aktif slice `GP-5.3c` workflow opt-in
-design contract closeout adayıdır. Bu slice support boundary'yi genişletmez.
+prerequisite audit, `GP-5.3a` retrieval evidence contract, `GP-5.3b` agent
+context handoff contract ve `GP-5.3c` workflow opt-in design contract
+tamamlandı. Aktif slice `GP-5.3d` no-MCP/no-root-export guard closeout
+adayıdır. Bu slice support boundary'yi genişletmez.
 
 `GP-5.0a` ile yazılı hale getirilen ek kapılar:
 
@@ -244,9 +247,10 @@ design contract closeout adayıdır. Bu slice support boundary'yi genişletmez.
 1. `GP-5.1a` protected gate prerequisite audit — completed on `main`
 2. `GP-5.3a` repo-intelligence retrieval evidence contract — completed on `main`
 3. `GP-5.3b` agent context handoff contract — completed on `main`
-4. `GP-5.3c` workflow opt-in design — current closeout candidate
-5. `GP-5.3d` no-MCP/no-root-export guard — next unblocked slice after `GP-5.3c`
-6. `GP-5.1b` protected workflow binding patch — blocked until attestation
+4. `GP-5.3c` workflow opt-in design — completed on `main`
+5. `GP-5.3d` no-MCP/no-root-export guard — current closeout candidate
+6. `GP-5.3e` repo-intelligence workflow building-block promotion decision — next unblocked slice
+7. `GP-5.1b` protected workflow binding patch — blocked until attestation
 
 `GP-5.3a` ve `GP-5.3b`, `GP-5.1a` ile paralel yürüyebilir; çünkü read-only
 retrieval evidence ve manual/stdout handoff protected real-adapter credential'a
@@ -312,6 +316,17 @@ repo-intelligence contract slice'larını engellemez.
 5. Mevcut `compile_context()` arbitrary `repo_query_context` session input'unu
    ingest etmez.
 6. Runtime schema/executor/`context_compiler` wiring yoktur; support boundary
+   genişlemez.
+
+`GP-5.3d` closeout adayı:
+
+1. Karar: `keep_beta_read_only_negative_boundary_pinned`.
+2. MCP tool registry/dispatch yüzeyi repo-intelligence tool'u expose etmez.
+3. `repo` CLI subcommand listesi `scan`, `index`, `query` dışına çıkmaz.
+4. CLI help yüzeyi MCP/root-export flag'i advertise etmez.
+5. `repo query` root authority file, MCP config export veya
+   `.ao/context/repo_export_plan.json` yazmaz.
+6. `RI-5a` export-plan preview bu slice için `not_used`; support boundary
    genişlemez.
 
 Tarihi `ST`, `PB` ve `GP` kayıtları aşağıda korunur; bunlar güncel aktif gate

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -183,6 +183,11 @@ must copy or supply it as visible agent input. It does not write root authority
 files, `.ao/context` artifacts, vector backend records, expose MCP tools, or
 feed `context_compiler` automatically.
 
+`GP-5.3d` pins this negative boundary with regression tests: no
+repo-intelligence MCP tool is registered, the `repo` CLI surface remains
+limited to `scan`, `index`, and `query`, and `repo query` does not create root
+authority exports, MCP config exports, or `.ao/context/repo_export_plan.json`.
+
 The bundled
 `repo-intelligence-workflow-context-opt-in.schema.v1.json` is a contract-only
 future opt-in shape. It is not wired into workflow definitions, executor

--- a/tests/test_cli_repo_query.py
+++ b/tests/test_cli_repo_query.py
@@ -8,6 +8,18 @@ from ao_kernel.cli import main
 from ao_kernel._internal.repo_intelligence.repo_vector_indexer import CONFIRM_VECTOR_INDEX
 from ao_kernel.context.semantic_retrieval import cosine_similarity
 
+ROOT_AUTHORITY_EXPORT_FILES = (
+    "CLAUDE.md",
+    "AGENTS.md",
+    "ARCHITECTURE.md",
+    "CODEX_CONTEXT.md",
+)
+ROOT_MCP_EXPORT_FILES = (
+    ".mcp.json",
+    "mcp.json",
+    ".cursor/mcp.json",
+)
+
 
 class _FakeVectorStore:
     def __init__(self) -> None:
@@ -72,6 +84,12 @@ def _context_snapshot(project: Path) -> dict[str, bytes]:
         for item in sorted(context_dir.rglob("*"))
         if item.is_file()
     }
+
+
+def _assert_no_root_or_mcp_exports(project: Path) -> None:
+    for relative_path in (*ROOT_AUTHORITY_EXPORT_FILES, *ROOT_MCP_EXPORT_FILES):
+        assert not (project / relative_path).exists()
+    assert not (project / ".ao" / "context" / "repo_export_plan.json").exists()
 
 
 def _scan_and_write_vectors(project: Path, store: _FakeVectorStore, capsys: Any, monkeypatch: Any) -> None:
@@ -185,10 +203,7 @@ def test_repo_query_returns_matches_without_writing_root_files(tmp_path: Path, c
     assert payload["query_result"]["artifact_kind"] == "repo_vector_query_result"
     assert all(item["source_path"].startswith("pkg/") for item in payload["results"])
     assert _context_snapshot(project) == context_before
-    assert not (project / "CLAUDE.md").exists()
-    assert not (project / "AGENTS.md").exists()
-    assert not (project / "ARCHITECTURE.md").exists()
-    assert not (project / "CODEX_CONTEXT.md").exists()
+    _assert_no_root_or_mcp_exports(project)
 
 
 def test_repo_query_markdown_output_is_agent_readable_and_read_only(tmp_path: Path, capsys, monkeypatch) -> None:
@@ -225,10 +240,7 @@ def test_repo_query_markdown_output_is_agent_readable_and_read_only(tmp_path: Pa
     assert "```python\n" in captured.out
     assert "def main():" in captured.out
     assert _context_snapshot(project) == context_before
-    assert not (project / "CLAUDE.md").exists()
-    assert not (project / "AGENTS.md").exists()
-    assert not (project / "ARCHITECTURE.md").exists()
-    assert not (project / "CODEX_CONTEXT.md").exists()
+    _assert_no_root_or_mcp_exports(project)
 
 
 def test_repo_query_default_output_is_text(tmp_path: Path, capsys, monkeypatch) -> None:

--- a/tests/test_repo_intelligence_no_mcp_root_export_guard.py
+++ b/tests/test_repo_intelligence_no_mcp_root_export_guard.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+
+from ao_kernel.cli import _build_parser, main
+from ao_kernel.mcp_server import TOOL_DEFINITIONS, TOOL_DISPATCH
+
+
+DISALLOWED_REPO_MCP_TOOL_NAMES = {
+    "ao_repo_scan",
+    "ao_repo_index",
+    "ao_repo_query",
+    "ao_repo_export",
+    "ao_repo_export_plan",
+    "ao_repo_intelligence",
+}
+
+DISALLOWED_REPO_CLI_FLAGS = {
+    "--mcp",
+    "--mcp-tool",
+    "--root-export",
+    "--export-root",
+    "--write-root",
+    "--confirm-root-export",
+}
+
+
+def test_repo_intelligence_is_not_exposed_as_mcp_tool() -> None:
+    tool_names = {str(tool["name"]) for tool in TOOL_DEFINITIONS}
+
+    assert tool_names == set(TOOL_DISPATCH)
+    assert tool_names.isdisjoint(DISALLOWED_REPO_MCP_TOOL_NAMES)
+    assert not any(name.startswith("ao_repo_") for name in tool_names)
+    assert not any("repo_intelligence" in name for name in tool_names)
+
+
+def test_repo_cli_has_no_root_export_or_mcp_subcommand() -> None:
+    # argparse keeps subparser choices behind protected attributes; this test
+    # intentionally reads them to pin the public CLI contract.
+    parser = _build_parser()
+    command_subparsers = [action for action in parser._subparsers._group_actions if action.dest == "command"]
+    assert len(command_subparsers) == 1
+
+    repo_parser = command_subparsers[0].choices["repo"]
+    repo_subparsers = [action for action in repo_parser._subparsers._group_actions if action.dest == "repo_command"]
+    assert len(repo_subparsers) == 1
+    assert set(repo_subparsers[0].choices) == {"scan", "index", "query"}
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["repo", "--help"],
+        ["repo", "scan", "--help"],
+        ["repo", "index", "--help"],
+        ["repo", "query", "--help"],
+    ],
+)
+def test_repo_cli_help_does_not_advertise_root_export_or_mcp_flags(argv: list[str], capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(argv)
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 0
+    assert captured.err == ""
+    for flag in DISALLOWED_REPO_CLI_FLAGS:
+        assert flag not in captured.out


### PR DESCRIPTION
## Summary

- Add GP-5.3d decision/status record for the repo-intelligence no-MCP/no-root-export guard.
- Add regression tests proving repo-intelligence is not registered as an MCP tool and the `repo` CLI remains limited to `scan`, `index`, and `query`.
- Strengthen `repo query` side-effect assertions so root authority files, MCP config exports, and `.ao/context/repo_export_plan.json` stay absent.

## Support boundary

No support widening. Repo intelligence remains beta read-only; MCP repo-intelligence tools, root exports, workflow runtime wiring, and `context_compiler` auto-feed remain unsupported.

## Validation

- `pytest -q tests/test_repo_intelligence_no_mcp_root_export_guard.py tests/test_cli_repo_query.py` -> 12 passed
- `python3 -m ao_kernel doctor` -> 8 OK, 1 WARN, 0 FAIL
- `git diff --check`

Closes #437
Part of #424
