### PR TITLE
[codex] GP-5.5a controlled patch/test contract

### DIFF
--- a/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
+++ b/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
@@ -1,16 +1,16 @@
 # GP-5 - General-Purpose Production Platform Integration
 
-**Status:** Active program setup / `GP-5.4a` governed read-only workflow rehearsal closeout
+**Status:** Active program setup / `GP-5.5a` controlled patch/test design closeout
 **Date:** 2026-04-24
-**Authority:** `origin/main` at `d4f3d9b` for the `GP-5.3e` workflow building-block decision
+**Authority:** `origin/main` at `9ce74da` for the `GP-5.4a` governed read-only workflow rehearsal
 **Tracker:** [#424](https://github.com/Halildeu/ao-kernel/issues/424)
-**Current slice:** `GP-5.4a` - governed read-only workflow rehearsal
-**Branch:** `codex/gp5-4a-read-only-rehearsal`
-**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gp5-4a`
+**Current slice:** `GP-5.5a` - controlled patch/test design
+**Branch:** `codex/gp5-5a-controlled-patch-test-design`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gp5-5a`
 **Predecessors:** `v4.0.0` stable runtime, `GP-3`, `GP-4`, `RI-4`
 closed, `RI-5` opened, `GP-5.1a` completed, `GP-5.3a` completed,
 `GP-5.3b` completed, `GP-5.3c` completed, `GP-5.3d` completed,
-`GP-5.3e` completed
+`GP-5.3e` completed, `GP-5.4a` completed
 **Motto:** Kapsam disiplini: once kanitli entegrasyon, sonra support widening.
 
 ## 1. Purpose
@@ -545,8 +545,9 @@ promotion.
 | 8 | `GP-5.3e` | Repo-intelligence workflow building-block promotion decision | Completed on `main`; beta explicit-handoff building block; no production support widening. |
 | 9 | `GP-5.1b` | Protected workflow binding patch | Blocked until `ao-kernel-live-adapter-gate` and `AO_CLAUDE_CODE_CLI_AUTH` are attested. |
 | 10 | `GP-5.2a` | `claude-code-cli` protected gate rehearsal | Only after GP-5.1 can produce real protected evidence. |
-| 11 | `GP-5.4a` | Read-only E2E workflow rehearsal | Active closeout candidate: wheel-installed `review_ai_flow + codex-stub` with explicit repo-intelligence handoff fixture; no production support widening. |
-| 12 | `GP-5.5a` | Controlled patch/test design | No remote side effects; runbook skeleton update required. |
+| 11 | `GP-5.4a` | Read-only E2E workflow rehearsal | Completed on `main`; wheel-installed `review_ai_flow + codex-stub` with explicit repo-intelligence handoff fixture; no production support widening. |
+| 12 | `GP-5.5a` | Controlled patch/test design | Active closeout candidate: schema-backed contract and runbook skeleton; no runtime write support widening. |
+| 12.5 | `GP-5.5b` | Controlled local patch/test rehearsal | Next gate: execute GP-5.5a contract in disposable/dedicated worktree with rollback/test evidence. |
 | 13 | `GP-5.6a` | Disposable PR write rehearsal | Sandbox-only, rollback and runbook update required. |
 | 14 | `GP-5.9` | Production platform claim decision | Only after all prior gate evidence exists. |
 
@@ -566,15 +567,15 @@ Every GP-5 slice must include:
 
 ## 9. Current Decision
 
-GP-5.4a closes the first governed read-only workflow rehearsal with
-`pass_read_only_rehearsal_no_support_widening` when
-`python3 scripts/gp5_read_only_rehearsal.py --output json` passes. The
-rehearsal uses wheel-installed `review_ai_flow + codex-stub` and supplies a
-deterministic repo-intelligence Markdown handoff through `--intent-file`.
+GP-5.5a closes the controlled patch/test design gate with
+`design_contract_ready_no_runtime_write_support`. The slice adds the
+schema-backed contract for future controlled local patch/test rehearsals:
+disposable or dedicated worktree, path-scoped write ownership, diff preview,
+explicit apply decision, explainable targeted tests with full-gate fallback,
+rollback verification, cleanup, and runbook evidence.
 
-The handoff remains explicit operator-visible input. It is not MCP, root
-export, `context_compiler` auto-feed, real-adapter promotion, or production
-semantic-correctness evidence.
+This is not runtime patch support widening. It does not enable live remote PR
+creation, real-adapter live-write support, or production write-side support.
 
 Current product wording remains:
 
@@ -582,6 +583,6 @@ Current product wording remains:
 2. general-purpose production coding automation platform: not yet;
 3. real adapter production-certified support: not yet;
 4. repo-intelligence production workflow integration: not yet;
-5. next step after `GP-5.4a`: start `GP-5.5a` controlled patch/test design
-   unless protected environment/credential attestation arrives first for
-   `GP-5.1b`.
+5. next step after `GP-5.5a`: start `GP-5.5b` controlled local patch/test
+   rehearsal unless protected environment/credential attestation arrives first
+   for `GP-5.1b`.

--- a/.claude/plans/GP-5.5a-CONTROLLED-PATCH-TEST-DESIGN.md
+++ b/.claude/plans/GP-5.5a-CONTROLLED-PATCH-TEST-DESIGN.md
@@ -1,0 +1,97 @@
+# GP-5.5a — Controlled Patch/Test Design
+
+**Issue:** [#443](https://github.com/Halildeu/ao-kernel/issues/443)
+**Parent tracker:** [#424](https://github.com/Halildeu/ao-kernel/issues/424)
+**Status:** closeout candidate
+
+## Purpose
+
+Define the write-side contract for the first controlled patch/test lane before
+any GP-5 runtime patch rehearsal or support widening. This slice does not add a
+new write-capable workflow. It records what future GP-5.5 runtime work must
+prove.
+
+## Scope Boundary
+
+Included:
+
+1. schema-backed `gp5_controlled_patch_test_contract`;
+2. required disposable or dedicated worktree boundary;
+3. path-scoped write ownership requirement;
+4. diff preview and explicit apply decision requirement;
+5. explainable targeted test selection plus full-gate fallback requirement;
+6. rollback, cleanup, idempotency, and incident/runbook evidence requirement.
+
+Excluded:
+
+1. runtime patch application support widening;
+2. live remote PR creation;
+3. real-adapter live-write support;
+4. patching the operator's active `main` worktree;
+5. production support claim.
+
+## Decision
+
+`design_contract_ready_no_runtime_write_support`
+
+The GP-5 controlled patch/test lane is ready for a future rehearsal design
+gate, but not ready for support widening. The next gate is `GP-5.5b`, which
+must execute the contract in a disposable or dedicated worktree and produce
+real rollback/test evidence.
+
+## Existing Runtime Facts
+
+The repository already has lower-level patch primitives and path-scoped write
+ownership enforcement:
+
+1. `patch_preview` is claim-free and does not mutate workspace files.
+2. `patch_apply` and `patch_rollback` acquire path-scoped claims when
+   coordination is enabled.
+3. rollback primitives can use reverse-diff artifacts.
+
+Those facts are not enough to claim a GP-5 general-purpose write lane. GP-5
+needs end-to-end target worktree isolation, explicit apply approval,
+test-selection evidence, rollback verification, and cleanup evidence in one
+controlled rehearsal.
+
+## Evidence Contract
+
+Schema:
+
+```text
+ao_kernel/defaults/schemas/gp5-controlled-patch-test-contract.schema.v1.json
+```
+
+Required facts:
+
+1. `support_widening=false`;
+2. `runtime_patch_application_enabled=false`;
+3. `remote_side_effects_allowed=false`;
+4. `active_main_worktree_allowed=false`;
+5. target worktree is `disposable_worktree` or `dedicated_worktree`;
+6. path-scoped claims are required;
+7. diff preview artifact is required before apply;
+8. explicit operator apply decision is required;
+9. targeted tests are explainable and have full-gate fallback;
+10. reverse-diff rollback, rollback verification, cleanup, and idempotency are
+    required.
+
+## Runbook Skeleton
+
+Future GP-5.5b cannot close unless the operator can answer:
+
+1. Which disposable/dedicated worktree was patched?
+2. Which path ownership claims were acquired and released?
+3. Which diff preview artifact was approved?
+4. Which targeted tests ran, and what full-gate fallback exists?
+5. Which rollback artifact was produced and verified?
+6. Was cleanup completed without touching the operator's active `main`
+   worktree?
+
+## Next Gate
+
+`GP-5.5b` controlled local patch/test rehearsal.
+
+`GP-5.6a` remains later and must not start until GP-5.5 produces local
+rollback evidence. `GP-5.1b` remains blocked until protected live-adapter
+environment/credential attestation exists.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -40,7 +40,8 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan GP-5.3c workflow opt-in design contract:** `.claude/plans/GP-5.3c-WORKFLOW-OPT-IN-DESIGN-CONTRACT.md`
 - **Son tamamlanan GP-5.3d no-MCP/no-root-export guard:** `.claude/plans/GP-5.3d-NO-MCP-NO-ROOT-EXPORT-GUARD.md`
 - **Son tamamlanan GP-5.3e workflow building-block decision:** `.claude/plans/GP-5.3e-REPO-INTELLIGENCE-WORKFLOW-BUILDING-BLOCK-DECISION.md`
-- **Aktif GP-5.4a governed read-only workflow rehearsal:** `.claude/plans/GP-5.4a-GOVERNED-READ-ONLY-WORKFLOW-REHEARSAL.md`
+- **Son tamamlanan GP-5.4a governed read-only workflow rehearsal:** `.claude/plans/GP-5.4a-GOVERNED-READ-ONLY-WORKFLOW-REHEARSAL.md`
+- **Aktif GP-5.5a controlled patch/test design:** `.claude/plans/GP-5.5a-CONTROLLED-PATCH-TEST-DESIGN.md`
 - **Son tamamlanan RI-5 design gate:** `.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md`
 - **Aktif GP-5 integration roadmap:** `.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
@@ -106,7 +107,8 @@ ayrı ayrı görünür kılmak.
 - **GP-5.3c issue:** [#435](https://github.com/Halildeu/ao-kernel/issues/435) (`closed after GP-5.3c PR`)
 - **GP-5.3d issue:** [#437](https://github.com/Halildeu/ao-kernel/issues/437) (`closed after GP-5.3d PR`)
 - **GP-5.3e issue:** [#439](https://github.com/Halildeu/ao-kernel/issues/439) (`closed after GP-5.3e PR`)
-- **GP-5.4a issue:** [#441](https://github.com/Halildeu/ao-kernel/issues/441) (`active closeout candidate`)
+- **GP-5.4a issue:** [#441](https://github.com/Halildeu/ao-kernel/issues/441) (`closed after GP-5.4a PR`)
+- **GP-5.5a issue:** [#443](https://github.com/Halildeu/ao-kernel/issues/443) (`active closeout candidate`)
 - **RI-5 design gate:** PR `#426` merged; next slice is RI-5a export-plan preview implementation
 - **Current mode:** GP-5 active integration planning / no support widening yet.
   Future widening requires protected live-adapter evidence, repo-intelligence
@@ -364,6 +366,21 @@ repo-intelligence contract slice'larını engellemez.
    repo retrieval semantic correctness iddiası vermez.
 6. Sıradaki unblocked slice `GP-5.5a` controlled patch/test design'dır;
    `GP-5.1b` protected gate attestation gelene kadar bloklu kalır.
+
+`GP-5.5a` closeout adayı:
+
+1. Karar: `design_contract_ready_no_runtime_write_support`.
+2. `gp5-controlled-patch-test-contract.schema.v1.json` future controlled
+   local patch/test rehearsal için zorunlu evidence alanlarını pinler:
+   disposable/dedicated worktree, path ownership, diff preview, explicit apply
+   decision, targeted tests + full-gate fallback, rollback, cleanup ve runbook.
+3. `runtime_patch_application_enabled=false`,
+   `remote_side_effects_allowed=false`, `active_main_worktree_allowed=false`
+   ve `support_widening=false` zorunludur.
+4. Existing lower-level `patch_preview` / `patch_apply` / `patch_rollback`
+   runtime varlığı bu slice'ta GP-5 support widening üretmez.
+5. Sıradaki unblocked slice `GP-5.5b` controlled local patch/test rehearsal'dır;
+   `GP-5.6a` remote PR rehearsal GP-5.5 rollback evidence olmadan başlamaz.
 
 Tarihi `ST`, `PB` ve `GP` kayıtları aşağıda korunur; bunlar güncel aktif gate
 değildir.

--- a/ao_kernel/defaults/schemas/gp5-controlled-patch-test-contract.schema.v1.json
+++ b/ao_kernel/defaults/schemas/gp5-controlled-patch-test-contract.schema.v1.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:gp5-controlled-patch-test-contract:v1",
+  "title": "GP-5 controlled patch/test contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "program_id",
+    "decision",
+    "lane_status",
+    "support_widening",
+    "runtime_patch_application_enabled",
+    "remote_side_effects_allowed",
+    "active_main_worktree_allowed",
+    "target_worktree",
+    "write_ownership",
+    "diff_preview",
+    "apply_boundary",
+    "test_plan",
+    "rollback_plan",
+    "evidence_requirements",
+    "excluded_surfaces",
+    "promotion_decision"
+  ],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "artifact_kind": { "const": "gp5_controlled_patch_test_contract" },
+    "program_id": { "const": "GP-5.5a" },
+    "decision": { "const": "design_contract_ready_no_runtime_write_support" },
+    "lane_status": { "const": "contract_design_only" },
+    "support_widening": { "const": false },
+    "runtime_patch_application_enabled": { "const": false },
+    "remote_side_effects_allowed": { "const": false },
+    "active_main_worktree_allowed": { "const": false },
+    "target_worktree": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "separate_from_operator_main",
+        "cleanup_required",
+        "dirty_state_preflight_required"
+      ],
+      "properties": {
+        "kind": { "enum": ["disposable_worktree", "dedicated_worktree"] },
+        "separate_from_operator_main": { "const": true },
+        "cleanup_required": { "const": true },
+        "dirty_state_preflight_required": { "const": true }
+      }
+    },
+    "write_ownership": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path_scoped_claims_required",
+        "owner_record_required",
+        "takeover_or_handoff_record_required"
+      ],
+      "properties": {
+        "path_scoped_claims_required": { "const": true },
+        "owner_record_required": { "const": true },
+        "takeover_or_handoff_record_required": { "const": true }
+      }
+    },
+    "diff_preview": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "preview_required",
+        "preview_artifact_required",
+        "files_changed_required"
+      ],
+      "properties": {
+        "preview_required": { "const": true },
+        "preview_artifact_required": { "const": true },
+        "files_changed_required": { "const": true }
+      }
+    },
+    "apply_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "explicit_operator_approval_required",
+        "write_without_preview_allowed",
+        "future_runtime_rehearsal_required"
+      ],
+      "properties": {
+        "explicit_operator_approval_required": { "const": true },
+        "write_without_preview_allowed": { "const": false },
+        "future_runtime_rehearsal_required": { "const": true }
+      }
+    },
+    "test_plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targeted_tests_required",
+        "explainable_selection_required",
+        "fallback_full_gate_required",
+        "commands"
+      ],
+      "properties": {
+        "targeted_tests_required": { "const": true },
+        "explainable_selection_required": { "const": true },
+        "fallback_full_gate_required": { "const": true },
+        "commands": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "rollback_plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reverse_diff_required",
+        "rollback_verification_required",
+        "cleanup_evidence_required",
+        "idempotency_check_required"
+      ],
+      "properties": {
+        "reverse_diff_required": { "const": true },
+        "rollback_verification_required": { "const": true },
+        "cleanup_evidence_required": { "const": true },
+        "idempotency_check_required": { "const": true }
+      }
+    },
+    "evidence_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "changed_paths",
+        "diff_preview_artifact",
+        "apply_decision_record",
+        "tests_run",
+        "rollback_evidence",
+        "cleanup_evidence",
+        "incident_runbook_reference"
+      ],
+      "properties": {
+        "changed_paths": { "const": true },
+        "diff_preview_artifact": { "const": true },
+        "apply_decision_record": { "const": true },
+        "tests_run": { "const": true },
+        "rollback_evidence": { "const": true },
+        "cleanup_evidence": { "const": true },
+        "incident_runbook_reference": { "const": true }
+      }
+    },
+    "excluded_surfaces": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "live_remote_pr",
+        "real_adapter_live_write",
+        "production_support_claim"
+      ],
+      "properties": {
+        "live_remote_pr": { "const": false },
+        "real_adapter_live_write": { "const": false },
+        "production_support_claim": { "const": false }
+      }
+    },
+    "promotion_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "support_widening_allowed",
+        "next_gate",
+        "reason"
+      ],
+      "properties": {
+        "support_widening_allowed": { "const": false },
+        "next_gate": { "const": "GP-5.5b" },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -161,7 +161,28 @@ aligned with the current support boundary.
 | Policy/command deny looks wrong | Targeted executor policy tests plus workflow evidence `events.jsonl` | Blocker only if shipped baseline policy contract regresses |
 | `claude-code-cli` smoke fails | `python3 scripts/claude_code_cli_smoke.py --output text` | Beta lane incident unless the shipped baseline also fails |
 | `gh-cli-pr` smoke fails | `python3 scripts/gh_cli_pr_smoke.py --output text` | Beta/deferred lane incident unless shipped baseline also fails |
+| GP-5 controlled patch/test contract fails | Validate `gp5-controlled-patch-test-contract.schema.v1.json` and run `pytest -q tests/test_gp5_controlled_patch_test_contract.py` | Design-gate blocker only; not a stable shipped baseline incident |
 | Publish or package verification fails | `python3 scripts/packaging_smoke.py`, `twine check dist/*`, post-publish fresh-venv install | Release blocker; do not publish or announce readiness |
+
+### 3.4 GP-5 controlled patch/test rehearsal skeleton
+
+This is a design skeleton, not shipped runtime write support. A future GP-5
+controlled patch/test rehearsal must be blocked unless the operator can collect:
+
+1. disposable or dedicated worktree path, with proof it is not the active
+   operator `main` worktree;
+2. preflight dirty-state output for the target worktree;
+3. path-scoped write ownership claim ids and release evidence;
+4. diff preview artifact and changed-path list;
+5. explicit apply decision record;
+6. targeted test commands plus the full-gate fallback decision;
+7. reverse-diff rollback artifact;
+8. rollback verification and idempotency evidence;
+9. cleanup evidence showing the disposable/dedicated worktree was removed or
+   intentionally retained for investigation.
+
+If any item is missing, the result is `blocked` for GP-5 support widening. It
+does not change the shipped baseline support claim.
 
 ## 4. Evidence to collect
 

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -98,6 +98,7 @@ Stable rules:
 |---|---|---|
 | Extension loader + manifest validation | Shipped infra | Loader/validator kodu ve truth-tier audit gerçektir; bu, her bundled manifestin end-to-end production-ready olduğu anlamına gelmez |
 | Bundled `defaults/registry`, `defaults/extensions`, `defaults/operations`, `defaults/adapters` içeriği | Contract inventory | Ağaçta görünmesi destek vaadi değildir; ancak ilgili doküman/test/Public Beta matrisi o yüzeyi ayrıca işaretliyorsa destekli sayılır |
+| GP-5 controlled patch/test lane | Contract / design-only | `gp5-controlled-patch-test-contract.schema.v1.json` future controlled local patch/test rehearsal için disposable/dedicated worktree, path-scoped ownership, diff preview, explicit apply decision, targeted tests, rollback, cleanup ve runbook evidence gerektirir. Bu satır runtime patch support, live remote PR, real-adapter live-write veya production support widening değildir |
 | `examples/hello-llm/` | Example-only | SDK kullanım örneğidir; Public Beta destek vaadinin parçası değildir |
 
 ### Truth-tier yorum kuralı

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -203,6 +203,16 @@ supplied through `--intent-file`. This is still beta rehearsal evidence only:
 `support_widening=false`, no live real adapter, no MCP/root export, no
 `context_compiler` auto-feed, and no write-side support.
 
+`GP-5.5a` adds only the controlled patch/test design contract,
+`gp5-controlled-patch-test-contract.schema.v1.json`. The contract requires a
+disposable or dedicated worktree, path-scoped ownership, diff preview, explicit
+apply decision, explainable targeted tests with full-gate fallback, rollback
+verification, cleanup evidence, and an incident/runbook reference. It records
+`support_widening=false`, `runtime_patch_application_enabled=false`,
+`remote_side_effects_allowed=false`, and `active_main_worktree_allowed=false`.
+This is not runtime write support widening and does not promote live remote PR
+creation or real-adapter live-write support.
+
 The bundled
 `repo-intelligence-workflow-context-opt-in.schema.v1.json` is a contract-only
 future opt-in shape. It is not wired into workflow definitions, executor

--- a/tests/test_gp5_controlled_patch_test_contract.py
+++ b/tests/test_gp5_controlled_patch_test_contract.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", "gp5-controlled-patch-test-contract.schema.v1.json")
+
+
+def _errors(payload: dict[str, Any]) -> list[str]:
+    return sorted(error.message for error in Draft202012Validator(_schema()).iter_errors(payload))
+
+
+def _valid_contract() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "artifact_kind": "gp5_controlled_patch_test_contract",
+        "program_id": "GP-5.5a",
+        "decision": "design_contract_ready_no_runtime_write_support",
+        "lane_status": "contract_design_only",
+        "support_widening": False,
+        "runtime_patch_application_enabled": False,
+        "remote_side_effects_allowed": False,
+        "active_main_worktree_allowed": False,
+        "target_worktree": {
+            "kind": "disposable_worktree",
+            "separate_from_operator_main": True,
+            "cleanup_required": True,
+            "dirty_state_preflight_required": True,
+        },
+        "write_ownership": {
+            "path_scoped_claims_required": True,
+            "owner_record_required": True,
+            "takeover_or_handoff_record_required": True,
+        },
+        "diff_preview": {
+            "preview_required": True,
+            "preview_artifact_required": True,
+            "files_changed_required": True,
+        },
+        "apply_boundary": {
+            "explicit_operator_approval_required": True,
+            "write_without_preview_allowed": False,
+            "future_runtime_rehearsal_required": True,
+        },
+        "test_plan": {
+            "targeted_tests_required": True,
+            "explainable_selection_required": True,
+            "fallback_full_gate_required": True,
+            "commands": [
+                "pytest -q <targeted-tests>",
+                "python3 -m ruff check <changed-paths>",
+            ],
+        },
+        "rollback_plan": {
+            "reverse_diff_required": True,
+            "rollback_verification_required": True,
+            "cleanup_evidence_required": True,
+            "idempotency_check_required": True,
+        },
+        "evidence_requirements": {
+            "changed_paths": True,
+            "diff_preview_artifact": True,
+            "apply_decision_record": True,
+            "tests_run": True,
+            "rollback_evidence": True,
+            "cleanup_evidence": True,
+            "incident_runbook_reference": True,
+        },
+        "excluded_surfaces": {
+            "live_remote_pr": False,
+            "real_adapter_live_write": False,
+            "production_support_claim": False,
+        },
+        "promotion_decision": {
+            "support_widening_allowed": False,
+            "next_gate": "GP-5.5b",
+            "reason": "GP-5.5a is design-only; runtime rehearsal is a separate gate.",
+        },
+    }
+
+
+def test_controlled_patch_test_contract_accepts_complete_design_only_payload() -> None:
+    Draft202012Validator.check_schema(_schema())
+    assert _errors(_valid_contract()) == []
+
+
+def test_controlled_patch_test_contract_rejects_support_widening() -> None:
+    payload = _valid_contract()
+    payload["support_widening"] = True
+    payload["excluded_surfaces"]["production_support_claim"] = True
+
+    errors = _errors(payload)
+
+    assert "False was expected" in errors
+
+
+def test_controlled_patch_test_contract_requires_disposable_or_dedicated_worktree() -> None:
+    payload = _valid_contract()
+    payload["active_main_worktree_allowed"] = True
+    payload["target_worktree"]["kind"] = "operator_main"
+
+    errors = _errors(payload)
+
+    assert "False was expected" in errors
+    assert "'operator_main' is not one of ['disposable_worktree', 'dedicated_worktree']" in errors
+
+
+def test_controlled_patch_test_contract_requires_rollback_and_test_evidence() -> None:
+    payload = _valid_contract()
+    del payload["rollback_plan"]["rollback_verification_required"]
+    del payload["test_plan"]["fallback_full_gate_required"]
+    payload["evidence_requirements"]["rollback_evidence"] = False
+
+    errors = _errors(payload)
+
+    assert "'rollback_verification_required' is a required property" in errors
+    assert "'fallback_full_gate_required' is a required property" in errors
+    assert "True was expected" in errors
+
+
+def test_controlled_patch_test_docs_stay_design_only() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    public_beta = (repo_root / "docs" / "PUBLIC-BETA.md").read_text(encoding="utf-8")
+    support_boundary = (repo_root / "docs" / "SUPPORT-BOUNDARY.md").read_text(encoding="utf-8")
+    runbook = (repo_root / "docs" / "OPERATIONS-RUNBOOK.md").read_text(encoding="utf-8")
+
+    assert "GP-5 controlled patch/test lane" in public_beta
+    assert "Contract / design-only" in public_beta
+    assert "gp5-controlled-patch-test-contract.schema.v1.json" in public_beta
+    assert "support_widening=false" in support_boundary
+    assert "GP-5 controlled patch/test rehearsal skeleton" in runbook


### PR DESCRIPTION
## Summary
- add GP-5.5a controlled patch/test design contract schema
- add behavior tests that reject support widening, active-main patching, and missing rollback/test evidence
- update GP-5/status/support/runbook docs to keep the lane design-only with no runtime write support widening

## Validation
- `pytest -q tests/test_gp5_controlled_patch_test_contract.py tests/test_path_write_ownership.py tests/test_patch_write_ownership_enforcement.py`
- `python3 -m ruff check tests/test_gp5_controlled_patch_test_contract.py`
- `python3 -m mypy --explicit-package-bases tests/test_gp5_controlled_patch_test_contract.py`
- `python3 -m ao_kernel doctor`
- `git diff --check`

Closes #443.
