### PR TITLE
[codex] GP-5.5b controlled patch rehearsal

### DIFF
--- a/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
+++ b/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
@@ -1,16 +1,16 @@
 # GP-5 - General-Purpose Production Platform Integration
 
-**Status:** Active program setup / `GP-5.5a` controlled patch/test design closeout
+**Status:** Active program setup / `GP-5.5b` controlled local patch/test rehearsal closeout
 **Date:** 2026-04-24
-**Authority:** `origin/main` at `9ce74da` for the `GP-5.4a` governed read-only workflow rehearsal
+**Authority:** `origin/main` at `e2d5f91` for the `GP-5.5a` controlled patch/test design
 **Tracker:** [#424](https://github.com/Halildeu/ao-kernel/issues/424)
-**Current slice:** `GP-5.5a` - controlled patch/test design
-**Branch:** `codex/gp5-5a-controlled-patch-test-design`
-**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gp5-5a`
+**Current slice:** `GP-5.5b` - controlled local patch/test rehearsal
+**Branch:** `codex/gp5-5b-controlled-patch-rehearsal`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gp5-5b`
 **Predecessors:** `v4.0.0` stable runtime, `GP-3`, `GP-4`, `RI-4`
 closed, `RI-5` opened, `GP-5.1a` completed, `GP-5.3a` completed,
 `GP-5.3b` completed, `GP-5.3c` completed, `GP-5.3d` completed,
-`GP-5.3e` completed, `GP-5.4a` completed
+`GP-5.3e` completed, `GP-5.4a` completed, `GP-5.5a` completed
 **Motto:** Kapsam disiplini: once kanitli entegrasyon, sonra support widening.
 
 ## 1. Purpose
@@ -546,8 +546,8 @@ promotion.
 | 9 | `GP-5.1b` | Protected workflow binding patch | Blocked until `ao-kernel-live-adapter-gate` and `AO_CLAUDE_CODE_CLI_AUTH` are attested. |
 | 10 | `GP-5.2a` | `claude-code-cli` protected gate rehearsal | Only after GP-5.1 can produce real protected evidence. |
 | 11 | `GP-5.4a` | Read-only E2E workflow rehearsal | Completed on `main`; wheel-installed `review_ai_flow + codex-stub` with explicit repo-intelligence handoff fixture; no production support widening. |
-| 12 | `GP-5.5a` | Controlled patch/test design | Active closeout candidate: schema-backed contract and runbook skeleton; no runtime write support widening. |
-| 12.5 | `GP-5.5b` | Controlled local patch/test rehearsal | Next gate: execute GP-5.5a contract in disposable/dedicated worktree with rollback/test evidence. |
+| 12 | `GP-5.5a` | Controlled patch/test design | Completed on `main`; schema-backed contract and runbook skeleton; no runtime write support widening. |
+| 12.5 | `GP-5.5b` | Controlled local patch/test rehearsal | Active closeout candidate: disposable worktree preview/apply/test/rollback/idempotency/cleanup evidence; no support widening. |
 | 13 | `GP-5.6a` | Disposable PR write rehearsal | Sandbox-only, rollback and runbook update required. |
 | 14 | `GP-5.9` | Production platform claim decision | Only after all prior gate evidence exists. |
 
@@ -567,15 +567,17 @@ Every GP-5 slice must include:
 
 ## 9. Current Decision
 
-GP-5.5a closes the controlled patch/test design gate with
-`design_contract_ready_no_runtime_write_support`. The slice adds the
-schema-backed contract for future controlled local patch/test rehearsals:
-disposable or dedicated worktree, path-scoped write ownership, diff preview,
-explicit apply decision, explainable targeted tests with full-gate fallback,
-rollback verification, cleanup, and runbook evidence.
+GP-5.5b closes the first controlled local patch/test rehearsal gate with
+`pass_controlled_local_patch_test_rehearsal_no_support_widening`. The slice
+adds a schema-backed report and a deterministic local command that creates a
+disposable detached worktree, previews a patch, requires explicit
+`--approve-apply`, acquires path-scoped claims for apply and rollback, runs a
+targeted verification command, rolls back through the reverse diff, checks
+rollback idempotency, and removes the worktree.
 
-This is not runtime patch support widening. It does not enable live remote PR
-creation, real-adapter live-write support, or production write-side support.
+This is still not runtime patch support widening. It does not enable live
+remote PR creation, real-adapter live-write support, arbitrary repository
+patch generation, or production write-side support.
 
 Current product wording remains:
 
@@ -583,6 +585,6 @@ Current product wording remains:
 2. general-purpose production coding automation platform: not yet;
 3. real adapter production-certified support: not yet;
 4. repo-intelligence production workflow integration: not yet;
-5. next step after `GP-5.5a`: start `GP-5.5b` controlled local patch/test
-   rehearsal unless protected environment/credential attestation arrives first
-   for `GP-5.1b`.
+5. next step after `GP-5.5b`: start `GP-5.6a` disposable PR write rehearsal
+   unless protected environment/credential attestation arrives first for
+   `GP-5.1b`.

--- a/.claude/plans/GP-5.5b-CONTROLLED-LOCAL-PATCH-TEST-REHEARSAL.md
+++ b/.claude/plans/GP-5.5b-CONTROLLED-LOCAL-PATCH-TEST-REHEARSAL.md
@@ -1,0 +1,83 @@
+# GP-5.5b — Controlled Local Patch/Test Rehearsal
+
+**Issue:** [#445](https://github.com/Halildeu/ao-kernel/issues/445)
+**Parent tracker:** [#424](https://github.com/Halildeu/ao-kernel/issues/424)
+**Status:** closeout candidate
+
+## Purpose
+
+Execute the GP-5.5a controlled patch/test contract in a disposable local
+worktree and produce real evidence for preview, explicit apply approval,
+path-scoped ownership, targeted tests, rollback, idempotency, and cleanup.
+
+This slice does not promote production write support. It proves the local
+mechanics required before GP-5.6 can attempt any remote PR rehearsal.
+
+## Scope Boundary
+
+Included:
+
+1. schema-backed `gp5_controlled_patch_test_rehearsal_report`;
+2. `scripts/gp5_controlled_patch_test_rehearsal.py`;
+3. disposable detached git worktree created from the current checkout `HEAD`;
+4. deterministic patch preview and explicit `--approve-apply` boundary;
+5. path-scoped claim acquire/release around apply and rollback;
+6. targeted verification command and full-gate fallback record;
+7. reverse-diff rollback, idempotency verification, and cleanup evidence.
+
+Excluded:
+
+1. active `main` worktree patching;
+2. production runtime patch support widening;
+3. live remote PR creation;
+4. real-adapter live-write support;
+5. arbitrary repository patch generation.
+
+## Decision
+
+`pass_controlled_local_patch_test_rehearsal_no_support_widening`
+
+The GP-5 controlled patch/test lane has one local disposable-worktree
+rehearsal command. It is sufficient to unblock GP-5.6a disposable PR rehearsal
+planning, but not sufficient to claim general-purpose production write support.
+
+## Evidence Contract
+
+Schema:
+
+```text
+ao_kernel/defaults/schemas/gp5-controlled-patch-test-rehearsal-report.schema.v1.json
+```
+
+Command:
+
+```bash
+python3 scripts/gp5_controlled_patch_test_rehearsal.py --approve-apply --output json
+```
+
+The report must carry:
+
+1. `support_widening=false`;
+2. `runtime_patch_support_widening=false`;
+3. `remote_side_effects_allowed=false`;
+4. `active_main_worktree_touched=false`;
+5. disposable worktree path and dirty-state preflight;
+6. diff preview artifact and explicit apply decision artifact;
+7. path-scoped apply and rollback claim ids;
+8. targeted test command plus full-gate fallback command;
+9. rollback verification and rollback idempotency;
+10. cleanup evidence.
+
+## No-Approval Boundary
+
+Without `--approve-apply`, the command exits non-zero with a schema-valid
+`blocked` report after preview and before write ownership / patch apply. This
+keeps the explicit approval gate testable.
+
+## Next Gate
+
+`GP-5.6a` disposable PR write rehearsal.
+
+That gate remains sandbox-only and must not start without using the GP-5.5b
+rollback evidence as its local precondition. `GP-5.1b` remains blocked until
+protected live-adapter environment/credential attestation exists.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -41,7 +41,8 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan GP-5.3d no-MCP/no-root-export guard:** `.claude/plans/GP-5.3d-NO-MCP-NO-ROOT-EXPORT-GUARD.md`
 - **Son tamamlanan GP-5.3e workflow building-block decision:** `.claude/plans/GP-5.3e-REPO-INTELLIGENCE-WORKFLOW-BUILDING-BLOCK-DECISION.md`
 - **Son tamamlanan GP-5.4a governed read-only workflow rehearsal:** `.claude/plans/GP-5.4a-GOVERNED-READ-ONLY-WORKFLOW-REHEARSAL.md`
-- **Aktif GP-5.5a controlled patch/test design:** `.claude/plans/GP-5.5a-CONTROLLED-PATCH-TEST-DESIGN.md`
+- **Son tamamlanan GP-5.5a controlled patch/test design:** `.claude/plans/GP-5.5a-CONTROLLED-PATCH-TEST-DESIGN.md`
+- **Aktif GP-5.5b controlled local patch/test rehearsal:** `.claude/plans/GP-5.5b-CONTROLLED-LOCAL-PATCH-TEST-REHEARSAL.md`
 - **Son tamamlanan RI-5 design gate:** `.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md`
 - **Aktif GP-5 integration roadmap:** `.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
@@ -108,7 +109,8 @@ ayrı ayrı görünür kılmak.
 - **GP-5.3d issue:** [#437](https://github.com/Halildeu/ao-kernel/issues/437) (`closed after GP-5.3d PR`)
 - **GP-5.3e issue:** [#439](https://github.com/Halildeu/ao-kernel/issues/439) (`closed after GP-5.3e PR`)
 - **GP-5.4a issue:** [#441](https://github.com/Halildeu/ao-kernel/issues/441) (`closed after GP-5.4a PR`)
-- **GP-5.5a issue:** [#443](https://github.com/Halildeu/ao-kernel/issues/443) (`active closeout candidate`)
+- **GP-5.5a issue:** [#443](https://github.com/Halildeu/ao-kernel/issues/443) (`closed after GP-5.5a PR`)
+- **GP-5.5b issue:** [#445](https://github.com/Halildeu/ao-kernel/issues/445) (`active closeout candidate`)
 - **RI-5 design gate:** PR `#426` merged; next slice is RI-5a export-plan preview implementation
 - **Current mode:** GP-5 active integration planning / no support widening yet.
   Future widening requires protected live-adapter evidence, repo-intelligence
@@ -364,10 +366,10 @@ repo-intelligence contract slice'larını engellemez.
    validate edilir ve `support_widening=false` taşır.
 5. Bu slice production real-adapter support, live-write support veya arbitrary
    repo retrieval semantic correctness iddiası vermez.
-6. Sıradaki unblocked slice `GP-5.5a` controlled patch/test design'dır;
-   `GP-5.1b` protected gate attestation gelene kadar bloklu kalır.
+6. `GP-5.5a` controlled patch/test design tamamlandı; sıradaki unblocked
+   slice `GP-5.5b` controlled local patch/test rehearsal'dır.
 
-`GP-5.5a` closeout adayı:
+`GP-5.5a` completed:
 
 1. Karar: `design_contract_ready_no_runtime_write_support`.
 2. `gp5-controlled-patch-test-contract.schema.v1.json` future controlled
@@ -379,8 +381,22 @@ repo-intelligence contract slice'larını engellemez.
    ve `support_widening=false` zorunludur.
 4. Existing lower-level `patch_preview` / `patch_apply` / `patch_rollback`
    runtime varlığı bu slice'ta GP-5 support widening üretmez.
-5. Sıradaki unblocked slice `GP-5.5b` controlled local patch/test rehearsal'dır;
-   `GP-5.6a` remote PR rehearsal GP-5.5 rollback evidence olmadan başlamaz.
+5. `GP-5.5b` controlled local patch/test rehearsal aktif closeout adayıdır.
+
+`GP-5.5b` closeout adayı:
+
+1. Karar: `pass_controlled_local_patch_test_rehearsal_no_support_widening`.
+2. `gp5-controlled-patch-test-rehearsal-report.schema.v1.json` local
+   disposable worktree rehearsal evidence'ını pinler: preview, explicit
+   apply approval, path-scoped apply/rollback claims, targeted test,
+   reverse-diff rollback, idempotency ve cleanup.
+3. `scripts/gp5_controlled_patch_test_rehearsal.py --approve-apply --output json`
+   deterministic rehearsal komutudur.
+4. Bu slice `runtime_patch_support_widening=false`,
+   `remote_side_effects_allowed=false`, `active_main_worktree_touched=false`
+   ve `support_widening=false` taşır.
+5. Sıradaki unblocked slice `GP-5.6a` disposable PR write rehearsal'dır;
+   remote PR rehearsal GP-5.5b rollback evidence olmadan başlamaz.
 
 Tarihi `ST`, `PB` ve `GP` kayıtları aşağıda korunur; bunlar güncel aktif gate
 değildir.

--- a/ao_kernel/defaults/schemas/gp5-controlled-patch-test-rehearsal-report.schema.v1.json
+++ b/ao_kernel/defaults/schemas/gp5-controlled-patch-test-rehearsal-report.schema.v1.json
@@ -1,0 +1,267 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ao-kernel.local/schemas/gp5-controlled-patch-test-rehearsal-report.schema.v1.json",
+  "title": "GP-5.5b controlled patch/test rehearsal report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "program_id",
+    "overall_status",
+    "decision",
+    "support_widening",
+    "runtime_patch_support_widening",
+    "remote_side_effects_allowed",
+    "active_main_worktree_touched",
+    "source_repo",
+    "target_worktree",
+    "patch",
+    "write_ownership",
+    "apply_boundary",
+    "test_plan",
+    "rollback_plan",
+    "cleanup",
+    "evidence_artifacts",
+    "promotion_decision"
+  ],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "artifact_kind": { "const": "gp5_controlled_patch_test_rehearsal_report" },
+    "program_id": { "const": "GP-5.5b" },
+    "overall_status": { "enum": ["pass", "blocked"] },
+    "decision": {
+      "enum": [
+        "pass_controlled_local_patch_test_rehearsal_no_support_widening",
+        "blocked_controlled_local_patch_test_rehearsal_no_support_widening"
+      ]
+    },
+    "support_widening": { "const": false },
+    "runtime_patch_support_widening": { "const": false },
+    "remote_side_effects_allowed": { "const": false },
+    "active_main_worktree_touched": { "const": false },
+    "blocked_reason": { "type": "string", "minLength": 1 },
+    "source_repo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "head_sha", "dirty_state"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "head_sha": { "type": "string", "minLength": 7 },
+        "dirty_state": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "target_worktree": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "path",
+        "separate_from_operator_main",
+        "dirty_state_preflight",
+        "dirty_state_after_rollback",
+        "cleanup_required"
+      ],
+      "properties": {
+        "kind": { "const": "disposable_worktree" },
+        "path": { "type": "string", "minLength": 1 },
+        "separate_from_operator_main": { "const": true },
+        "dirty_state_preflight": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "dirty_state_after_rollback": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "cleanup_required": { "const": true }
+      }
+    },
+    "patch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "patch_id",
+        "changed_paths",
+        "lines_added",
+        "lines_removed",
+        "diff_preview_status",
+        "apply_status"
+      ],
+      "properties": {
+        "patch_id": { "type": "string", "minLength": 1 },
+        "changed_paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "lines_added": { "type": "integer", "minimum": 0 },
+        "lines_removed": { "type": "integer", "minimum": 0 },
+        "diff_preview_status": { "const": "pass" },
+        "apply_status": { "enum": ["pass", "blocked_not_approved", "not_run"] },
+        "reverse_diff_id": { "type": "string", "minLength": 1 },
+        "reverse_diff_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "write_ownership": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path_scoped_claims_required",
+        "owner_agent_id",
+        "apply_claims",
+        "rollback_claims",
+        "claims_released",
+        "live_claims_after"
+      ],
+      "properties": {
+        "path_scoped_claims_required": { "const": true },
+        "owner_agent_id": { "type": "string", "minLength": 1 },
+        "apply_claims": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/claim" }
+        },
+        "rollback_claims": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/claim" }
+        },
+        "claims_released": { "type": "boolean" },
+        "live_claims_after": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "apply_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "diff_preview_artifact_required",
+        "explicit_operator_approval_required",
+        "explicit_operator_approval_observed",
+        "write_without_preview_allowed"
+      ],
+      "properties": {
+        "diff_preview_artifact_required": { "const": true },
+        "explicit_operator_approval_required": { "const": true },
+        "explicit_operator_approval_observed": { "type": "boolean" },
+        "write_without_preview_allowed": { "const": false }
+      }
+    },
+    "test_plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targeted_tests_required",
+        "explainable_selection_required",
+        "targeted_test_commands",
+        "targeted_test_status",
+        "full_gate_fallback_required",
+        "full_gate_fallback_command",
+        "full_gate_fallback_status"
+      ],
+      "properties": {
+        "targeted_tests_required": { "const": true },
+        "explainable_selection_required": { "const": true },
+        "selection_reason": { "type": "string" },
+        "targeted_test_commands": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "targeted_test_status": { "enum": ["pass", "not_run"] },
+        "full_gate_fallback_required": { "const": true },
+        "full_gate_fallback_command": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "full_gate_fallback_status": { "enum": ["available_not_run", "not_run"] }
+      }
+    },
+    "rollback_plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reverse_diff_required",
+        "rollback_status",
+        "rollback_verification_status",
+        "idempotency_check_status"
+      ],
+      "properties": {
+        "reverse_diff_required": { "const": true },
+        "rollback_status": { "enum": ["pass", "not_run"] },
+        "rollback_verification_status": { "enum": ["pass", "not_run"] },
+        "idempotency_check_status": { "enum": ["pass", "not_run"] }
+      }
+    },
+    "cleanup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["worktree_remove_attempted", "worktree_removed", "temp_root_removed"],
+      "properties": {
+        "worktree_remove_attempted": { "type": "boolean" },
+        "worktree_removed": { "type": "boolean" },
+        "temp_root_removed": { "type": "boolean" },
+        "retained_reason": { "type": "string" }
+      }
+    },
+    "evidence_artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "diff_preview_artifact",
+        "apply_decision_artifact",
+        "reverse_diff_artifact"
+      ],
+      "properties": {
+        "diff_preview_artifact": { "$ref": "#/$defs/artifact" },
+        "apply_decision_artifact": { "$ref": "#/$defs/artifact" },
+        "reverse_diff_artifact": { "$ref": "#/$defs/artifact" }
+      }
+    },
+    "promotion_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["support_widening_allowed", "next_gate", "reason"],
+      "properties": {
+        "support_widening_allowed": { "const": false },
+        "next_gate": { "const": "GP-5.6a" },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["present", "not_created"] },
+        "path": { "type": "string" },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["area", "resource_id", "claim_id", "fencing_token"],
+      "properties": {
+        "area": { "type": "string", "minLength": 1 },
+        "resource_id": { "type": "string", "minLength": 1 },
+        "claim_id": { "type": "string", "minLength": 1 },
+        "fencing_token": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -162,6 +162,7 @@ aligned with the current support boundary.
 | `claude-code-cli` smoke fails | `python3 scripts/claude_code_cli_smoke.py --output text` | Beta lane incident unless the shipped baseline also fails |
 | `gh-cli-pr` smoke fails | `python3 scripts/gh_cli_pr_smoke.py --output text` | Beta/deferred lane incident unless shipped baseline also fails |
 | GP-5 controlled patch/test contract fails | Validate `gp5-controlled-patch-test-contract.schema.v1.json` and run `pytest -q tests/test_gp5_controlled_patch_test_contract.py` | Design-gate blocker only; not a stable shipped baseline incident |
+| GP-5.5b controlled patch/test rehearsal fails | `python3 scripts/gp5_controlled_patch_test_rehearsal.py --approve-apply --output json` and `pytest -q tests/test_gp5_controlled_patch_test_rehearsal.py` | Rehearsal-gate blocker only; do not widen write-side support |
 | Publish or package verification fails | `python3 scripts/packaging_smoke.py`, `twine check dist/*`, post-publish fresh-venv install | Release blocker; do not publish or announce readiness |
 
 ### 3.4 GP-5 controlled patch/test rehearsal skeleton
@@ -183,6 +184,37 @@ controlled patch/test rehearsal must be blocked unless the operator can collect:
 
 If any item is missing, the result is `blocked` for GP-5 support widening. It
 does not change the shipped baseline support claim.
+
+### 3.5 GP-5.5b controlled local patch/test rehearsal
+
+`GP-5.5b` provides one deterministic local rehearsal command:
+
+```bash
+python3 scripts/gp5_controlled_patch_test_rehearsal.py --approve-apply --output json
+```
+
+Expected pass evidence:
+
+1. `gp5_controlled_patch_test_rehearsal_report` validates against
+   `gp5-controlled-patch-test-rehearsal-report.schema.v1.json`;
+2. `overall_status=pass`;
+3. `support_widening=false`;
+4. `runtime_patch_support_widening=false`;
+5. `remote_side_effects_allowed=false`;
+6. `active_main_worktree_touched=false`;
+7. `target_worktree.kind=disposable_worktree`;
+8. apply and rollback path-scoped claims are present and released;
+9. targeted verification and rollback verification pass;
+10. rollback idempotency passes;
+11. cleanup shows the disposable worktree and temporary root were removed.
+
+Without `--approve-apply`, the command must stop after preview and emit a
+schema-valid `blocked` report. That is an expected safety behavior, not a
+runtime incident.
+
+This rehearsal does not enable live remote PR creation, arbitrary repository
+patching, real-adapter live-write, or production write-side support. Those
+remain GP-5.6+ gates.
 
 ## 4. Evidence to collect
 

--- a/docs/PUBLIC-BETA.md
+++ b/docs/PUBLIC-BETA.md
@@ -98,7 +98,7 @@ Stable rules:
 |---|---|---|
 | Extension loader + manifest validation | Shipped infra | Loader/validator kodu ve truth-tier audit gerçektir; bu, her bundled manifestin end-to-end production-ready olduğu anlamına gelmez |
 | Bundled `defaults/registry`, `defaults/extensions`, `defaults/operations`, `defaults/adapters` içeriği | Contract inventory | Ağaçta görünmesi destek vaadi değildir; ancak ilgili doküman/test/Public Beta matrisi o yüzeyi ayrıca işaretliyorsa destekli sayılır |
-| GP-5 controlled patch/test lane | Contract / design-only | `gp5-controlled-patch-test-contract.schema.v1.json` future controlled local patch/test rehearsal için disposable/dedicated worktree, path-scoped ownership, diff preview, explicit apply decision, targeted tests, rollback, cleanup ve runbook evidence gerektirir. Bu satır runtime patch support, live remote PR, real-adapter live-write veya production support widening değildir |
+| GP-5 controlled patch/test lane | Rehearsal / no support widening | `gp5-controlled-patch-test-contract.schema.v1.json` design contract'ı ve `gp5-controlled-patch-test-rehearsal-report.schema.v1.json` local disposable worktree rehearsal raporu vardır. `python3 scripts/gp5_controlled_patch_test_rehearsal.py --approve-apply --output json` yalnız deterministic local patch preview/apply/test/rollback/cleanup kanıtı üretir. Bu satır runtime patch support, live remote PR, real-adapter live-write veya production support widening değildir |
 | `examples/hello-llm/` | Example-only | SDK kullanım örneğidir; Public Beta destek vaadinin parçası değildir |
 
 ### Truth-tier yorum kuralı

--- a/docs/SUPPORT-BOUNDARY.md
+++ b/docs/SUPPORT-BOUNDARY.md
@@ -213,6 +213,19 @@ verification, cleanup evidence, and an incident/runbook reference. It records
 This is not runtime write support widening and does not promote live remote PR
 creation or real-adapter live-write support.
 
+`GP-5.5b` adds the first controlled local patch/test rehearsal command,
+`python3 scripts/gp5_controlled_patch_test_rehearsal.py --approve-apply --output json`.
+It creates a disposable detached worktree, previews a deterministic patch,
+requires explicit apply approval, acquires path-scoped apply and rollback
+claims, runs a targeted verification command, rolls back through the reverse
+diff, verifies rollback idempotency, and removes the worktree. The report is
+validated by `gp5-controlled-patch-test-rehearsal-report.schema.v1.json` and
+records `support_widening=false`, `runtime_patch_support_widening=false`,
+`remote_side_effects_allowed=false`, and `active_main_worktree_touched=false`.
+This is rehearsal evidence only. It does not make arbitrary patch generation,
+live remote PR creation, real-adapter live-write, or production write-side
+support shipped.
+
 The bundled
 `repo-intelligence-workflow-context-opt-in.schema.v1.json` is a contract-only
 future opt-in shape. It is not wired into workflow definitions, executor

--- a/scripts/gp5_controlled_patch_test_rehearsal.py
+++ b/scripts/gp5_controlled_patch_test_rehearsal.py
@@ -1,0 +1,786 @@
+#!/usr/bin/env python3
+"""Run the GP-5.5b controlled local patch/test rehearsal.
+
+This helper deliberately does not widen the shipped write support boundary. It
+creates a disposable detached git worktree, previews a deterministic patch,
+requires an explicit apply flag, acquires path-scoped write ownership, applies
+the patch, runs a targeted verification command, rolls the patch back, verifies
+rollback idempotency, and cleans the worktree up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel.config import load_default  # noqa: E402
+from ao_kernel.coordination import (  # noqa: E402
+    ClaimRegistry,
+    PathWriteLeaseSet,
+    acquire_path_write_claims,
+    load_coordination_policy,
+    release_path_write_claims,
+)
+from ao_kernel.executor.policy_enforcer import (  # noqa: E402
+    RedactionConfig,
+    SandboxedEnvironment,
+)
+from ao_kernel.patch import apply_patch, preview_diff, rollback_patch  # noqa: E402
+
+JsonDict = dict[str, Any]
+
+_PATCH_ID = "gp5-5b-rehearsal"
+_OWNER_AGENT_ID = "gp5-5b-controlled-patch-test-rehearsal"
+_TARGET_FILE = "gp5_controlled_patch_rehearsal_target.txt"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the GP-5.5b controlled local patch/test rehearsal"
+    )
+    parser.add_argument(
+        "--approve-apply",
+        action="store_true",
+        help="Explicitly approve the deterministic rehearsal patch apply step",
+    )
+    parser.add_argument(
+        "--output",
+        choices=("json", "text"),
+        default="text",
+        help="Output format",
+    )
+    parser.add_argument(
+        "--report-path",
+        type=Path,
+        help="Optional path to persist the JSON report",
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        help="Optional directory for persistent preview/decision/reverse-diff artifacts",
+    )
+    parser.add_argument(
+        "--keep-worktree",
+        action="store_true",
+        help="Retain the disposable worktree for investigation instead of cleaning it up",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=60.0,
+        help="Timeout for git and targeted verification commands",
+    )
+    args = parser.parse_args(argv)
+
+    artifact_dir = args.artifact_dir
+    if artifact_dir is None and args.report_path is not None:
+        artifact_dir = args.report_path.with_name(f"{args.report_path.stem}.artifacts")
+
+    report = run_rehearsal(
+        repo_root=_REPO_ROOT,
+        approve_apply=args.approve_apply,
+        keep_worktree=args.keep_worktree,
+        timeout_seconds=args.timeout_seconds,
+        artifact_dir=artifact_dir,
+    )
+    validate_report(report)
+
+    if args.report_path is not None:
+        args.report_path.parent.mkdir(parents=True, exist_ok=True)
+        args.report_path.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    if args.output == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"overall_status: {report['overall_status']}")
+        print(f"decision: {report['decision']}")
+        print(f"target_worktree: {report['target_worktree']['path']}")
+        print(f"changed_paths: {', '.join(report['patch']['changed_paths'])}")
+        print(f"targeted_test_status: {report['test_plan']['targeted_test_status']}")
+        print(f"rollback_status: {report['rollback_plan']['rollback_status']}")
+        if report["overall_status"] == "blocked":
+            print(f"blocked_reason: {report['blocked_reason']}")
+    return 0 if report["overall_status"] == "pass" else 1
+
+
+def run_rehearsal(
+    *,
+    repo_root: Path,
+    approve_apply: bool,
+    keep_worktree: bool,
+    timeout_seconds: float,
+    artifact_dir: Path | None,
+) -> JsonDict:
+    repo_root = repo_root.resolve()
+    temp_root = Path(tempfile.mkdtemp(prefix="ao-kernel-gp5-5b-")).resolve()
+    target_worktree = temp_root / "target-worktree"
+    run_dir = temp_root / "run-evidence"
+    patch_content = _rehearsal_patch()
+    sandbox: SandboxedEnvironment | None = None
+    cleanup_attempted = False
+    worktree_removed = False
+    temp_root_removed = False
+
+    source_head = _run_git(repo_root, ["rev-parse", "HEAD"], timeout_seconds).stdout.strip()
+    source_dirty = _git_status(repo_root, timeout_seconds)
+
+    report: JsonDict | None = None
+    try:
+        _run_git(
+            repo_root,
+            ["worktree", "add", "--detach", str(target_worktree), "HEAD"],
+            timeout_seconds,
+        )
+        if target_worktree.resolve() == repo_root:
+            raise RuntimeError("target worktree resolved to operator main worktree")
+
+        _write_worktree_excludes(target_worktree, timeout_seconds)
+        _write_enabled_coordination_policy(target_worktree)
+        sandbox = _sandbox_for_git(target_worktree)
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        dirty_preflight = _git_status(target_worktree, timeout_seconds)
+        preview = preview_diff(
+            target_worktree,
+            patch_content,
+            sandbox,
+            patch_id=_PATCH_ID,
+            timeout=timeout_seconds,
+        )
+        preview_artifact = _write_json(
+            run_dir / "gp5-5b-diff-preview.json",
+            {
+                "patch_id": preview.patch_id,
+                "files_changed": list(preview.files_changed),
+                "lines_added": preview.lines_added,
+                "lines_removed": preview.lines_removed,
+                "binary_paths": list(preview.binary_paths),
+                "conflicts_detected": preview.conflicts_detected,
+            },
+        )
+        persistent_preview = _persist_artifact(preview_artifact, artifact_dir)
+
+        apply_decision = {
+            "approved": approve_apply,
+            "decision": "approve_apply" if approve_apply else "blocked_missing_approval",
+            "reason": (
+                "Operator supplied --approve-apply for the deterministic GP-5.5b rehearsal."
+                if approve_apply
+                else "GP-5.5b requires explicit apply approval before any write."
+            ),
+            "write_without_preview_allowed": False,
+        }
+        apply_decision_artifact = _write_json(
+            run_dir / "gp5-5b-apply-decision.json",
+            apply_decision,
+        )
+        persistent_decision = _persist_artifact(apply_decision_artifact, artifact_dir)
+
+        if not approve_apply:
+            dirty_after_block = _git_status(target_worktree, timeout_seconds)
+            report = _build_blocked_report(
+                repo_root=repo_root,
+                source_head=source_head,
+                source_dirty=source_dirty,
+                target_worktree=target_worktree,
+                dirty_preflight=dirty_preflight,
+                dirty_after_rollback=dirty_after_block,
+                preview=preview,
+                preview_artifact=persistent_preview,
+                apply_decision_artifact=persistent_decision,
+                blocked_reason="explicit apply approval was not supplied",
+            )
+            return report
+
+        registry = ClaimRegistry(target_worktree)
+        policy = load_coordination_policy(target_worktree)
+
+        apply_lease = acquire_path_write_claims(
+            registry,
+            target_worktree,
+            owner_agent_id=_OWNER_AGENT_ID,
+            paths=preview.files_changed,
+            policy=policy,
+        )
+        apply_claims = _lease_payload(apply_lease)
+        try:
+            apply_result = apply_patch(
+                target_worktree,
+                patch_content,
+                sandbox,
+                run_dir,
+                patch_id=_PATCH_ID,
+                timeout=timeout_seconds,
+            )
+        finally:
+            release_path_write_claims(registry, apply_lease)
+
+        persistent_reverse_diff = _persist_artifact(apply_result.reverse_diff_path, artifact_dir)
+        targeted_command = _targeted_test_command(expected="patched")
+        targeted_result = _run_command(targeted_command, cwd=target_worktree, timeout=timeout_seconds)
+        if targeted_result["returncode"] != 0:
+            raise RuntimeError(f"targeted verification failed: {targeted_result['stderr']}")
+
+        rollback_lease = acquire_path_write_claims(
+            registry,
+            target_worktree,
+            owner_agent_id=_OWNER_AGENT_ID,
+            paths=apply_result.files_changed,
+            policy=policy,
+        )
+        rollback_claims = _lease_payload(rollback_lease)
+        try:
+            rollback_result = rollback_patch(
+                target_worktree,
+                apply_result.reverse_diff_id,
+                sandbox,
+                run_dir,
+                timeout=timeout_seconds,
+            )
+        finally:
+            release_path_write_claims(registry, rollback_lease)
+
+        rollback_verify_command = _targeted_absence_command()
+        rollback_verify = _run_command(
+            rollback_verify_command,
+            cwd=target_worktree,
+            timeout=timeout_seconds,
+        )
+        if rollback_verify["returncode"] != 0:
+            raise RuntimeError(f"rollback verification failed: {rollback_verify['stderr']}")
+
+        idempotency_lease = acquire_path_write_claims(
+            registry,
+            target_worktree,
+            owner_agent_id=_OWNER_AGENT_ID,
+            paths=apply_result.files_changed,
+            policy=policy,
+        )
+        try:
+            idempotency_result = rollback_patch(
+                target_worktree,
+                apply_result.reverse_diff_id,
+                sandbox,
+                run_dir,
+                timeout=timeout_seconds,
+            )
+        finally:
+            release_path_write_claims(registry, idempotency_lease)
+        if not idempotency_result.idempotent_skip:
+            raise RuntimeError("rollback idempotency check did not report idempotent_skip")
+
+        dirty_after_rollback = _git_status(target_worktree, timeout_seconds)
+        live_claims_after = [
+            claim.resource_id for claim in registry.list_agent_claims(_OWNER_AGENT_ID)
+        ]
+        if dirty_after_rollback:
+            raise RuntimeError(f"target worktree not clean after rollback: {dirty_after_rollback!r}")
+        if live_claims_after:
+            raise RuntimeError(f"path write claims leaked after rehearsal: {live_claims_after!r}")
+
+        report = _build_pass_report(
+            repo_root=repo_root,
+            source_head=source_head,
+            source_dirty=source_dirty,
+            target_worktree=target_worktree,
+            dirty_preflight=dirty_preflight,
+            dirty_after_rollback=dirty_after_rollback,
+            preview=preview,
+            apply_claims=apply_claims,
+            rollback_claims=rollback_claims,
+            live_claims_after=live_claims_after,
+            apply_result=apply_result,
+            rollback_result=rollback_result,
+            preview_artifact=persistent_preview,
+            apply_decision_artifact=persistent_decision,
+            reverse_diff_artifact=persistent_reverse_diff,
+            targeted_command=targeted_command,
+            rollback_verify_command=rollback_verify_command,
+        )
+        return report
+    finally:
+        if target_worktree.exists() and not keep_worktree:
+            cleanup_attempted = True
+            try:
+                _run_git(repo_root, ["worktree", "remove", "--force", str(target_worktree)], timeout_seconds)
+                worktree_removed = not target_worktree.exists()
+            except Exception:
+                worktree_removed = False
+        elif target_worktree.exists() and keep_worktree:
+            cleanup_attempted = False
+            worktree_removed = False
+        else:
+            worktree_removed = True
+
+        if report is not None:
+            report["cleanup"]["worktree_remove_attempted"] = cleanup_attempted
+            report["cleanup"]["worktree_removed"] = worktree_removed
+            report["cleanup"]["temp_root_removed"] = False
+            if keep_worktree:
+                report["cleanup"]["retained_reason"] = "--keep-worktree supplied"
+
+        if not keep_worktree:
+            try:
+                shutil.rmtree(temp_root)
+                temp_root_removed = not temp_root.exists()
+            except OSError:
+                temp_root_removed = False
+            if report is not None:
+                report["cleanup"]["temp_root_removed"] = temp_root_removed
+
+
+def validate_report(report: JsonDict) -> None:
+    schema = load_default(
+        "schemas",
+        "gp5-controlled-patch-test-rehearsal-report.schema.v1.json",
+    )
+    errors = sorted(Draft202012Validator(schema).iter_errors(report), key=str)
+    if errors:
+        messages = "; ".join(error.message for error in errors[:3])
+        raise ValueError(f"invalid GP-5.5b rehearsal report: {messages}")
+
+
+def _build_pass_report(
+    *,
+    repo_root: Path,
+    source_head: str,
+    source_dirty: list[str],
+    target_worktree: Path,
+    dirty_preflight: list[str],
+    dirty_after_rollback: list[str],
+    preview: Any,
+    apply_claims: list[JsonDict],
+    rollback_claims: list[JsonDict],
+    live_claims_after: list[str],
+    apply_result: Any,
+    rollback_result: Any,
+    preview_artifact: JsonDict,
+    apply_decision_artifact: JsonDict,
+    reverse_diff_artifact: JsonDict,
+    targeted_command: list[str],
+    rollback_verify_command: list[str],
+) -> JsonDict:
+    del rollback_result  # status is carried in the rollback fields below.
+    return {
+        "schema_version": "1",
+        "artifact_kind": "gp5_controlled_patch_test_rehearsal_report",
+        "program_id": "GP-5.5b",
+        "overall_status": "pass",
+        "decision": "pass_controlled_local_patch_test_rehearsal_no_support_widening",
+        "support_widening": False,
+        "runtime_patch_support_widening": False,
+        "remote_side_effects_allowed": False,
+        "active_main_worktree_touched": False,
+        "source_repo": _source_repo(repo_root, source_head, source_dirty),
+        "target_worktree": _target_worktree(
+            target_worktree,
+            dirty_preflight,
+            dirty_after_rollback,
+        ),
+        "patch": {
+            "patch_id": apply_result.patch_id,
+            "changed_paths": list(apply_result.files_changed),
+            "lines_added": apply_result.lines_added,
+            "lines_removed": apply_result.lines_removed,
+            "diff_preview_status": "pass",
+            "apply_status": "pass",
+            "reverse_diff_id": apply_result.reverse_diff_id,
+            "reverse_diff_sha256": _sha256_path(apply_result.reverse_diff_path),
+        },
+        "write_ownership": {
+            "path_scoped_claims_required": True,
+            "owner_agent_id": _OWNER_AGENT_ID,
+            "apply_claims": apply_claims,
+            "rollback_claims": rollback_claims,
+            "claims_released": True,
+            "live_claims_after": live_claims_after,
+        },
+        "apply_boundary": {
+            "diff_preview_artifact_required": True,
+            "explicit_operator_approval_required": True,
+            "explicit_operator_approval_observed": True,
+            "write_without_preview_allowed": False,
+        },
+        "test_plan": {
+            "targeted_tests_required": True,
+            "explainable_selection_required": True,
+            "selection_reason": (
+                "The deterministic patch touches one rehearsal target file; "
+                "the targeted command verifies exactly that changed path."
+            ),
+            "targeted_test_commands": [targeted_command, rollback_verify_command],
+            "targeted_test_status": "pass",
+            "full_gate_fallback_required": True,
+            "full_gate_fallback_command": [sys.executable, "-m", "pytest", "-q"],
+            "full_gate_fallback_status": "available_not_run",
+        },
+        "rollback_plan": {
+            "reverse_diff_required": True,
+            "rollback_status": "pass",
+            "rollback_verification_status": "pass",
+            "idempotency_check_status": "pass",
+        },
+        "cleanup": {
+            "worktree_remove_attempted": False,
+            "worktree_removed": False,
+            "temp_root_removed": False,
+        },
+        "evidence_artifacts": {
+            "diff_preview_artifact": preview_artifact,
+            "apply_decision_artifact": apply_decision_artifact,
+            "reverse_diff_artifact": reverse_diff_artifact,
+        },
+        "promotion_decision": _promotion_decision(),
+    }
+
+
+def _build_blocked_report(
+    *,
+    repo_root: Path,
+    source_head: str,
+    source_dirty: list[str],
+    target_worktree: Path,
+    dirty_preflight: list[str],
+    dirty_after_rollback: list[str],
+    preview: Any,
+    preview_artifact: JsonDict,
+    apply_decision_artifact: JsonDict,
+    blocked_reason: str,
+) -> JsonDict:
+    return {
+        "schema_version": "1",
+        "artifact_kind": "gp5_controlled_patch_test_rehearsal_report",
+        "program_id": "GP-5.5b",
+        "overall_status": "blocked",
+        "decision": "blocked_controlled_local_patch_test_rehearsal_no_support_widening",
+        "support_widening": False,
+        "runtime_patch_support_widening": False,
+        "remote_side_effects_allowed": False,
+        "active_main_worktree_touched": False,
+        "blocked_reason": blocked_reason,
+        "source_repo": _source_repo(repo_root, source_head, source_dirty),
+        "target_worktree": _target_worktree(
+            target_worktree,
+            dirty_preflight,
+            dirty_after_rollback,
+        ),
+        "patch": {
+            "patch_id": preview.patch_id,
+            "changed_paths": list(preview.files_changed),
+            "lines_added": preview.lines_added,
+            "lines_removed": preview.lines_removed,
+            "diff_preview_status": "pass",
+            "apply_status": "blocked_not_approved",
+        },
+        "write_ownership": {
+            "path_scoped_claims_required": True,
+            "owner_agent_id": _OWNER_AGENT_ID,
+            "apply_claims": [],
+            "rollback_claims": [],
+            "claims_released": True,
+            "live_claims_after": [],
+        },
+        "apply_boundary": {
+            "diff_preview_artifact_required": True,
+            "explicit_operator_approval_required": True,
+            "explicit_operator_approval_observed": False,
+            "write_without_preview_allowed": False,
+        },
+        "test_plan": {
+            "targeted_tests_required": True,
+            "explainable_selection_required": True,
+            "selection_reason": "Targeted tests are not run without explicit apply approval.",
+            "targeted_test_commands": [],
+            "targeted_test_status": "not_run",
+            "full_gate_fallback_required": True,
+            "full_gate_fallback_command": [sys.executable, "-m", "pytest", "-q"],
+            "full_gate_fallback_status": "not_run",
+        },
+        "rollback_plan": {
+            "reverse_diff_required": True,
+            "rollback_status": "not_run",
+            "rollback_verification_status": "not_run",
+            "idempotency_check_status": "not_run",
+        },
+        "cleanup": {
+            "worktree_remove_attempted": False,
+            "worktree_removed": False,
+            "temp_root_removed": False,
+        },
+        "evidence_artifacts": {
+            "diff_preview_artifact": preview_artifact,
+            "apply_decision_artifact": apply_decision_artifact,
+            "reverse_diff_artifact": {"status": "not_created"},
+        },
+        "promotion_decision": _promotion_decision(),
+    }
+
+
+def _source_repo(repo_root: Path, source_head: str, source_dirty: list[str]) -> JsonDict:
+    return {
+        "path": str(repo_root),
+        "head_sha": source_head,
+        "dirty_state": source_dirty,
+    }
+
+
+def _target_worktree(
+    target_worktree: Path,
+    dirty_preflight: list[str],
+    dirty_after_rollback: list[str],
+) -> JsonDict:
+    return {
+        "kind": "disposable_worktree",
+        "path": str(target_worktree),
+        "separate_from_operator_main": True,
+        "dirty_state_preflight": dirty_preflight,
+        "dirty_state_after_rollback": dirty_after_rollback,
+        "cleanup_required": True,
+    }
+
+
+def _promotion_decision() -> JsonDict:
+    return {
+        "support_widening_allowed": False,
+        "next_gate": "GP-5.6a",
+        "reason": (
+            "GP-5.5b proves local disposable patch/test rollback mechanics only; "
+            "remote PR rehearsal and production write support remain separate gates."
+        ),
+    }
+
+
+def _rehearsal_patch() -> str:
+    return (
+        f"diff --git a/{_TARGET_FILE} b/{_TARGET_FILE}\n"
+        "new file mode 100644\n"
+        "index 0000000..b87f674\n"
+        "--- /dev/null\n"
+        f"+++ b/{_TARGET_FILE}\n"
+        "@@ -0,0 +1 @@\n"
+        "+status=patched\n"
+    )
+
+
+def _targeted_test_command(*, expected: str) -> list[str]:
+    script = (
+        "from pathlib import Path; "
+        f"path = Path({_TARGET_FILE!r}); "
+        "assert path.read_text(encoding='utf-8').strip() == "
+        f"{f'status={expected}'!r}"
+    )
+    return [sys.executable, "-c", script]
+
+
+def _targeted_absence_command() -> list[str]:
+    script = (
+        "from pathlib import Path; "
+        f"path = Path({_TARGET_FILE!r}); "
+        "assert not path.exists()"
+    )
+    return [sys.executable, "-c", script]
+
+
+def _write_enabled_coordination_policy(worktree: Path) -> None:
+    policy_dir = worktree / ".ao" / "policies"
+    policy_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": "v1",
+        "enabled": True,
+        "heartbeat_interval_seconds": 30,
+        "expiry_seconds": 90,
+        "takeover_grace_period_seconds": 15,
+        "max_claims_per_agent": 5,
+        "claim_resource_patterns": ["*"],
+        "evidence_redaction": {"patterns": []},
+    }
+    (policy_dir / "policy_coordination_claims.v1.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_worktree_excludes(worktree: Path, timeout_seconds: float) -> None:
+    """Keep rehearsal-only coordination files out of git dirty checks.
+
+    Linked worktrees have their own git-dir, so this does not mutate the
+    operator's active main worktree exclude file.
+    """
+    proc = _run_git(worktree, ["rev-parse", "--git-path", "info/exclude"], timeout_seconds)
+    exclude_path = Path(proc.stdout.strip())
+    if not exclude_path.is_absolute():
+        exclude_path = worktree / exclude_path
+    exclude_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = exclude_path.read_text(encoding="utf-8") if exclude_path.exists() else ""
+    additions = [
+        "# ao-kernel GP-5.5b disposable worktree coordination state",
+        ".ao/policies/",
+        ".ao/claims/",
+    ]
+    lines = existing.splitlines()
+    changed = False
+    for line in additions:
+        if line not in lines:
+            lines.append(line)
+            changed = True
+    if changed:
+        exclude_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _sandbox_for_git(worktree: Path) -> SandboxedEnvironment:
+    git_path = shutil.which("git")
+    if git_path is None:
+        raise RuntimeError("git is not available on PATH")
+    real_git = Path(os.path.realpath(git_path))
+    prefix_candidates = {
+        str(real_git.parent),
+        "/usr/bin",
+        "/usr/local/bin",
+        "/opt/homebrew/bin",
+        "/opt/local/bin",
+    }
+    prefixes = tuple(
+        str(Path(prefix).resolve())
+        for prefix in sorted(prefix_candidates)
+        if Path(prefix).exists()
+    )
+    env_vars = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", ""),
+        "LANG": os.environ.get("LANG", "C"),
+    }
+    if "TMPDIR" in os.environ:
+        env_vars["TMPDIR"] = os.environ["TMPDIR"]
+    return SandboxedEnvironment(
+        env_vars=env_vars,
+        cwd=worktree,
+        allowed_commands_exact=frozenset({"git"}),
+        allowed_command_prefixes=prefixes,
+        policy_derived_path_entries=tuple(Path(prefix) for prefix in prefixes),
+        exposure_modes=frozenset(),
+        evidence_redaction=RedactionConfig(
+            env_keys_matching=(),
+            stdout_patterns=(),
+            file_content_patterns=(),
+        ),
+        inherit_from_parent=True,
+    )
+
+
+def _lease_payload(lease_set: PathWriteLeaseSet) -> list[JsonDict]:
+    return [
+        {
+            "area": lease.scope.area,
+            "resource_id": lease.scope.resource_id,
+            "claim_id": lease.claim.claim_id,
+            "fencing_token": lease.claim.fencing_token,
+        }
+        for lease in lease_set.leases
+    ]
+
+
+def _git_status(path: Path, timeout_seconds: float) -> list[str]:
+    proc = _run_git(path, ["status", "--porcelain"], timeout_seconds)
+    return [line for line in proc.stdout.splitlines() if line]
+
+
+def _run_git(path: Path, args: list[str], timeout_seconds: float) -> subprocess.CompletedProcess[str]:
+    return _run_checked_command(["git", "-C", str(path), *args], cwd=path, timeout=timeout_seconds)
+
+
+def _run_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    timeout: float,
+) -> JsonDict:
+    start = time.monotonic()
+    proc = subprocess.run(
+        command,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    elapsed = time.monotonic() - start
+    return {
+        "command": command,
+        "returncode": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "duration_seconds": elapsed,
+    }
+
+
+def _run_checked_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    timeout: float,
+) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        command,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if proc.returncode != 0:
+        rendered = " ".join(command)
+        detail = proc.stderr.strip() or proc.stdout.strip() or "no output"
+        raise RuntimeError(f"command failed: {rendered}: {detail}")
+    return proc
+
+
+def _write_json(path: Path, payload: JsonDict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _persist_artifact(path: Path, artifact_dir: Path | None) -> JsonDict:
+    if not path.exists():
+        return {"status": "not_created"}
+    sha = _sha256_path(path)
+    if artifact_dir is None:
+        return {
+            "status": "present",
+            "path": str(path),
+            "sha256": sha,
+        }
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    dest = artifact_dir / path.name
+    shutil.copyfile(path, dest)
+    return {
+        "status": "present",
+        "path": str(dest),
+        "sha256": sha,
+    }
+
+
+def _sha256_path(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gp5_controlled_patch_test_contract.py
+++ b/tests/test_gp5_controlled_patch_test_contract.py
@@ -124,14 +124,14 @@ def test_controlled_patch_test_contract_requires_rollback_and_test_evidence() ->
     assert "True was expected" in errors
 
 
-def test_controlled_patch_test_docs_stay_design_only() -> None:
+def test_controlled_patch_test_docs_keep_no_support_widening_boundary() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     public_beta = (repo_root / "docs" / "PUBLIC-BETA.md").read_text(encoding="utf-8")
     support_boundary = (repo_root / "docs" / "SUPPORT-BOUNDARY.md").read_text(encoding="utf-8")
     runbook = (repo_root / "docs" / "OPERATIONS-RUNBOOK.md").read_text(encoding="utf-8")
 
     assert "GP-5 controlled patch/test lane" in public_beta
-    assert "Contract / design-only" in public_beta
+    assert "Rehearsal / no support widening" in public_beta
     assert "gp5-controlled-patch-test-contract.schema.v1.json" in public_beta
     assert "support_widening=false" in support_boundary
     assert "GP-5 controlled patch/test rehearsal skeleton" in runbook

--- a/tests/test_gp5_controlled_patch_test_rehearsal.py
+++ b/tests/test_gp5_controlled_patch_test_rehearsal.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", "gp5-controlled-patch-test-rehearsal-report.schema.v1.json")
+
+
+def _errors(payload: dict[str, Any]) -> list[str]:
+    return sorted(error.message for error in Draft202012Validator(_schema()).iter_errors(payload))
+
+
+def _run_rehearsal(*args: str, tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    repo_root = _repo_root()
+    return subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "scripts" / "gp5_controlled_patch_test_rehearsal.py"),
+            *args,
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+
+
+def test_gp55b_rehearsal_passes_with_explicit_apply_and_cleans_up(tmp_path: Path) -> None:
+    report_path = tmp_path / "gp55b-report.json"
+
+    proc = _run_rehearsal(
+        "--approve-apply",
+        "--output",
+        "json",
+        "--report-path",
+        str(report_path),
+        tmp_path=tmp_path,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    stdout_report = json.loads(proc.stdout)
+    persisted_report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert stdout_report == persisted_report
+    assert _errors(persisted_report) == []
+
+    assert persisted_report["overall_status"] == "pass"
+    assert persisted_report["decision"] == (
+        "pass_controlled_local_patch_test_rehearsal_no_support_widening"
+    )
+    assert persisted_report["support_widening"] is False
+    assert persisted_report["runtime_patch_support_widening"] is False
+    assert persisted_report["remote_side_effects_allowed"] is False
+    assert persisted_report["active_main_worktree_touched"] is False
+    assert persisted_report["target_worktree"]["separate_from_operator_main"] is True
+    assert persisted_report["target_worktree"]["dirty_state_preflight"] == []
+    assert persisted_report["target_worktree"]["dirty_state_after_rollback"] == []
+    assert persisted_report["patch"]["changed_paths"] == [
+        "gp5_controlled_patch_rehearsal_target.txt"
+    ]
+    assert persisted_report["patch"]["apply_status"] == "pass"
+    assert persisted_report["write_ownership"]["apply_claims"]
+    assert persisted_report["write_ownership"]["rollback_claims"]
+    assert persisted_report["write_ownership"]["claims_released"] is True
+    assert persisted_report["write_ownership"]["live_claims_after"] == []
+    assert persisted_report["apply_boundary"]["explicit_operator_approval_observed"] is True
+    assert persisted_report["test_plan"]["targeted_test_status"] == "pass"
+    assert persisted_report["test_plan"]["full_gate_fallback_status"] == "available_not_run"
+    assert persisted_report["rollback_plan"]["rollback_status"] == "pass"
+    assert persisted_report["rollback_plan"]["rollback_verification_status"] == "pass"
+    assert persisted_report["rollback_plan"]["idempotency_check_status"] == "pass"
+    assert persisted_report["cleanup"]["worktree_remove_attempted"] is True
+    assert persisted_report["cleanup"]["worktree_removed"] is True
+    assert persisted_report["cleanup"]["temp_root_removed"] is True
+    assert not Path(persisted_report["target_worktree"]["path"]).exists()
+
+    artifact_dir = tmp_path / "gp55b-report.artifacts"
+    assert artifact_dir.is_dir()
+    for artifact in persisted_report["evidence_artifacts"].values():
+        assert artifact["status"] == "present"
+        assert Path(artifact["path"]).is_file()
+
+
+def test_gp55b_rehearsal_blocks_without_explicit_apply(tmp_path: Path) -> None:
+    report_path = tmp_path / "gp55b-blocked.json"
+
+    proc = _run_rehearsal(
+        "--output",
+        "json",
+        "--report-path",
+        str(report_path),
+        tmp_path=tmp_path,
+    )
+
+    assert proc.returncode == 1
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert _errors(report) == []
+    assert report["overall_status"] == "blocked"
+    assert report["patch"]["apply_status"] == "blocked_not_approved"
+    assert report["apply_boundary"]["explicit_operator_approval_observed"] is False
+    assert report["test_plan"]["targeted_test_status"] == "not_run"
+    assert report["rollback_plan"]["rollback_status"] == "not_run"
+    assert report["cleanup"]["worktree_removed"] is True
+    assert report["cleanup"]["temp_root_removed"] is True
+    assert not Path(report["target_worktree"]["path"]).exists()
+
+
+def test_gp55b_rehearsal_schema_rejects_support_widening(tmp_path: Path) -> None:
+    report_path = tmp_path / "gp55b-report.json"
+    proc = _run_rehearsal(
+        "--approve-apply",
+        "--output",
+        "json",
+        "--report-path",
+        str(report_path),
+        tmp_path=tmp_path,
+    )
+    assert proc.returncode == 0, proc.stderr
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+
+    report["support_widening"] = True
+    report["runtime_patch_support_widening"] = True
+    report["active_main_worktree_touched"] = True
+    report["promotion_decision"]["support_widening_allowed"] = True
+
+    errors = _errors(report)
+
+    assert "False was expected" in errors
+
+
+def test_gp55b_docs_keep_rehearsal_boundary_explicit() -> None:
+    repo_root = _repo_root()
+    public_beta = (repo_root / "docs" / "PUBLIC-BETA.md").read_text(encoding="utf-8")
+    support_boundary = (repo_root / "docs" / "SUPPORT-BOUNDARY.md").read_text(encoding="utf-8")
+    runbook = (repo_root / "docs" / "OPERATIONS-RUNBOOK.md").read_text(encoding="utf-8")
+
+    assert "GP-5 controlled patch/test lane" in public_beta
+    assert "Rehearsal / no support widening" in public_beta
+    assert "gp5-controlled-patch-test-rehearsal-report.schema.v1.json" in public_beta
+    assert "runtime_patch_support_widening=false" in support_boundary
+    assert "GP-5.5b controlled local patch/test rehearsal" in runbook


### PR DESCRIPTION
## Summary

- Adds the GP-5.5b controlled local patch/test rehearsal command and schema-backed report.
- Runs the rehearsal in a disposable detached worktree with explicit `--approve-apply`, path-scoped apply/rollback claims, targeted verification, reverse-diff rollback, idempotency, and cleanup evidence.
- Updates GP-5 status, Public Beta/support boundary, runbook, and tests while keeping `support_widening=false` and no production write-side support claim.

## Validation

- `python3 scripts/gp5_controlled_patch_test_rehearsal.py --approve-apply --output json --report-path /tmp/gp55b-clean-report.json`
- `pytest -q tests/test_gp5_controlled_patch_test_rehearsal.py tests/test_gp5_controlled_patch_test_contract.py tests/test_path_write_ownership.py tests/test_patch_write_ownership_enforcement.py`
- `python3 -m ruff check scripts/gp5_controlled_patch_test_rehearsal.py tests/test_gp5_controlled_patch_test_rehearsal.py`
- `python3 -m mypy --explicit-package-bases scripts/gp5_controlled_patch_test_rehearsal.py tests/test_gp5_controlled_patch_test_rehearsal.py`
- `python3 -m ao_kernel doctor` (`8 OK, 1 WARN, 0 FAIL`; existing bundled extension truth WARN)
- `git diff --check`

Closes #445.
