### PR TITLE
[codex] docs: open RI-5b root export design gate

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -49,6 +49,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan GP-5.8 operations support package:** `.claude/plans/GP-5.8-OPERATIONS-SUPPORT-PACKAGE.md`
 - **Aktif GP-5.9 production platform claim decision:** `.claude/plans/GP-5.9-PRODUCTION-PLATFORM-CLAIM-DECISION.md`
 - **Son tamamlanan RI-5a export-plan preview:** `.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md`
+- **Aktif RI-5b confirmed create-only root export design gate:** `.claude/plans/RI-5b-CONFIRMED-CREATE-ONLY-ROOT-EXPORT-DESIGN-GATE.md`
 - **Aktif GP-5 integration roadmap:** `.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
@@ -121,7 +122,8 @@ ayrı ayrı görünür kılmak.
 - **GP-5.7b issue:** [#451](https://github.com/Halildeu/ao-kernel/issues/451) (`closed after GP-5.7b PR`)
 - **GP-5.8 issue:** [#453](https://github.com/Halildeu/ao-kernel/issues/453) (`closed after GP-5.8 PR`)
 - **GP-5.9 issue:** [#455](https://github.com/Halildeu/ao-kernel/issues/455) (`active`)
-- **RI-5a export-plan preview:** PR `#457` merged at `a2144da`; next slice is RI-5b confirmed create-only root export design gate
+- **RI-5a export-plan preview:** PR `#457` merged at `a2144da`; closeout PR `#458` merged at `0a6eacb`
+- **RI-5b design gate issue:** [#459](https://github.com/Halildeu/ao-kernel/issues/459) (`active`)
 - **Current mode:** GP-5 active integration planning / no support widening yet.
   Future widening requires protected live-adapter evidence, repo-intelligence
   integration gates, write-side rollback evidence, and an explicit closeout
@@ -186,6 +188,7 @@ ayrı ayrı görünür kılmak.
 | `GP-4.4` protected live rehearsal blocked decision | Completed by GP-4.4 PR ([#410](https://github.com/Halildeu/ao-kernel/issues/410), record `.claude/plans/GP-4.4-PROTECTED-LIVE-REHEARSAL-BLOCKED-DECISION.md`) | protected live rehearsal prerequisite eksikse fake live success üretmeden blocked decision kaydetmek | schema validation + blocked rehearsal decision artifact + no live adapter execution + no support widening |
 | `GP-4.5` support-boundary closeout | Completed by GP-4.5 PR ([#413](https://github.com/Halildeu/ao-kernel/issues/413), record `.claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md`) | blocked GP-4 evidence against support boundary kararını kapatmak | verdict `close_no_widening_keep_operator_beta`; `claude-code-cli` remains Beta/operator-managed |
 | `GP-5` general-purpose platform integration | Active setup / `GP-5.9` current | repo intelligence, protected real-adapter gate, governed read-only E2E, controlled patch/test, disposable PR rehearsal ve operations support paketini tek entegrasyon programına bağlamak | `GP-5.1a` completed blocked protected gate audit; `GP-5.3a..GP-5.3e` close repo-intelligence handoff gates; `GP-5.4a` read-only rehearsal passed; `GP-5.5b` local patch/test rehearsal passed; `GP-5.6a` disposable PR rehearsal passed; `GP-5.7a` defines the full rehearsal contract; `GP-5.7b` aggregates execution evidence; `GP-5.8` packages operations readiness; `GP-5.9` closes the claim decision; no production support widening unless the decision explicitly grants it |
+| `RI-5b` confirmed create-only root export design gate | Active ([#459](https://github.com/Halildeu/ao-kernel/issues/459)) | RI-5a preview planından root authority file create-only write yoluna geçmeden önce exact confirmation, path ownership, deny matrix ve rollback evidence kontratını kilitlemek | docs/status-only design gate; no runtime `repo export`; no root write; no support widening |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -1482,3 +1485,31 @@ This is not support widening and does not grant root authority write support.
    default behavior, path ownership checks, root snapshot/rollback evidence,
    and deny-path tests for missing/stale plans, existing-file conflicts,
    symlinks, and path escapes.
+
+## 34. RI-5b Confirmed Create-Only Root Export Design Gate
+
+`RI-5b` design gate is active. This is not the implementation slice.
+
+1. Issue:
+   [#459](https://github.com/Halildeu/ao-kernel/issues/459)
+2. Design record:
+   `.claude/plans/RI-5b-CONFIRMED-CREATE-ONLY-ROOT-EXPORT-DESIGN-GATE.md`
+3. Branch:
+   `codex/ri5b-root-export-design-gate`
+4. Worktree:
+   `/Users/halilkocoglu/Documents/ao-kernel-ri5b-root-export-design-gate`
+5. Base:
+   `origin/main` at `0a6eacb`
+6. Scope:
+   docs/status only; no runtime code, no root writes, no support widening
+7. Pinned design decisions:
+   - exact token `CONFIRM_RI5B_ROOT_EXPORT_V1`
+   - `.ao/context/repo_export_plan.json` is the required write-intent input
+   - first implementation defaults to create-only
+   - overwrite/update remains denied in the first implementation slice
+   - path-scoped ownership must pass before any root write
+   - deny paths cover missing/stale plans, existing-file conflicts, symlinks,
+     path escapes, unsupported targets, and invalid confirmation
+   - root snapshot and rollback/no-corruption evidence is required
+8. Next slice:
+   RI-5b create-only implementation PR, only after this design gate is merged.

--- a/.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md
+++ b/.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md
@@ -1,19 +1,21 @@
 # RI-5 - Repo Intelligence Explicit Root/Context Export Design Gate
 
-**Status:** RI-5a merged; RI-5b gated
+**Status:** RI-5b design gate active
 **Date:** 2026-04-24
-**Authority:** `origin/main` at `a2144da`
+**Authority:** `origin/main` at `0a6eacb`
 **Planning PR:** [#423](https://github.com/Halildeu/ao-kernel/pull/423)
 **Closeout PR:** [#426](https://github.com/Halildeu/ao-kernel/pull/426)
 **Implementation PR:** [#457](https://github.com/Halildeu/ao-kernel/pull/457)
+**RI-5b issue:** [#459](https://github.com/Halildeu/ao-kernel/issues/459)
+**RI-5b design record:** `.claude/plans/RI-5b-CONFIRMED-CREATE-ONLY-ROOT-EXPORT-DESIGN-GATE.md`
 **Planning branch:** cleaned after merge
 **Planning worktree:** cleaned after merge
 **Implementation branch:** cleaned after merge
 **Implementation worktree:** cleaned after merge
-**Tracking branch:** `codex/ri5a-closeout-status`
-**Tracking worktree:** `/Users/halilkocoglu/Documents/ao-kernel-ri5a-closeout-status`
-**Base:** `origin/main` at `a2144da`
-**Next slice:** RI-5b confirmed create-only root export design gate
+**Tracking branch:** `codex/ri5b-root-export-design-gate`
+**Tracking worktree:** `/Users/halilkocoglu/Documents/ao-kernel-ri5b-root-export-design-gate`
+**Base:** `origin/main` at `0a6eacb`
+**Next slice:** RI-5b create-only implementation PR after design gate merge
 **Implementation:** Merged to `main` at `a2144da`; preview-only export-plan
 support is live as Beta / experimental.
 **Rule:** Never work directly on `main`.
@@ -385,6 +387,11 @@ these constraints:
 7. support docs remain Beta / operator-managed or Deferred until live write
    evidence and rollback evidence exist.
 
+The dedicated design gate is tracked in
+`.claude/plans/RI-5b-CONFIRMED-CREATE-ONLY-ROOT-EXPORT-DESIGN-GATE.md` and
+issue [#459](https://github.com/Halildeu/ao-kernel/issues/459). Runtime
+implementation remains blocked until that design gate is merged.
+
 ## Non-Negotiable Boundaries
 
 1. `repo scan`, `repo index`, and `repo query` must remain free of root export
@@ -501,3 +508,4 @@ CHANGELOG.md
 | 2026-04-24 | RI-5a local validation passed | `ruff check ao_kernel/ tests/`; `mypy ao_kernel/`; targeted pytest `28 passed`; `python3 -m ao_kernel repo export-plan --help`; `python3 -m ao_kernel doctor` (`8 OK, 1 WARN, 0 FAIL`); `python3 scripts/packaging_smoke.py`; full coverage `3046 passed, 1 skipped`, total coverage `85.44%`; `git diff --check`. |
 | 2026-04-24 | RI-5a implementation merged | PR [#457](https://github.com/Halildeu/ao-kernel/pull/457) merged to `main` at `a2144da`; `repo export-plan` is live as Beta / experimental preview-only and still writes no root authority files. |
 | 2026-04-24 | RI-5a cleanup completed | Local `main` synchronized with `origin/main`, implementation branch/worktree cleaned, and RI-5b is gated behind a separate confirmed create-only root export design slice. |
+| 2026-04-24 | RI-5b design gate opened | Issue [#459](https://github.com/Halildeu/ao-kernel/issues/459) and branch `codex/ri5b-root-export-design-gate` opened from `origin/main` at `0a6eacb`; runtime implementation remains blocked until design gate merge. |

--- a/.claude/plans/RI-5b-CONFIRMED-CREATE-ONLY-ROOT-EXPORT-DESIGN-GATE.md
+++ b/.claude/plans/RI-5b-CONFIRMED-CREATE-ONLY-ROOT-EXPORT-DESIGN-GATE.md
@@ -1,0 +1,269 @@
+# RI-5b - Confirmed Create-Only Root Export Design Gate
+
+**Status:** Design gate active / no runtime implementation
+**Date:** 2026-04-24
+**Authority:** `origin/main` at `0a6eacb`
+**Issue:** [#459](https://github.com/Halildeu/ao-kernel/issues/459)
+**Branch:** `codex/ri5b-root-export-design-gate`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-ri5b-root-export-design-gate`
+**Base:** `origin/main` at `0a6eacb`
+**Previous slice:** RI-5a export-plan preview merged by PR
+[#457](https://github.com/Halildeu/ao-kernel/pull/457) and closed out by PR
+[#458](https://github.com/Halildeu/ao-kernel/pull/458)
+**Next allowed slice:** RI-5b create-only implementation PR after this design
+gate merges
+**Support impact:** none; no support widening
+
+## Purpose
+
+RI-5a made root/context export intent explicit by writing only
+`.ao/context/repo_export_plan.json`. RI-5b may add an explicit root export write
+command, but only after this design gate is merged and the implementation
+slice follows the contract below.
+
+This gate exists because root authority files influence future agent behavior.
+They must not be created, modified, truncated, or overwritten as a side effect
+of scan, index, query, context compilation, MCP exposure, or workflow execution.
+
+## Scope
+
+This slice is documentation and program-status only.
+
+It may:
+
+1. define the RI-5b write contract;
+2. pin exact confirmation and create-only defaults;
+3. define deny-path tests and rollback evidence requirements;
+4. update RI-5 and post-beta status surfaces.
+
+It must not:
+
+1. add `python3 -m ao_kernel repo export`;
+2. add a root exporter implementation;
+3. write root authority files;
+4. widen support boundary;
+5. add MCP, workflow runtime, or `context_compiler` integration;
+6. call LLMs, network services, vector backends, or external adapters.
+
+## Proposed User Command
+
+The future implementation slice may add this command shape:
+
+```text
+python3 -m ao_kernel repo export \
+  --project-root . \
+  --workspace-root .ao \
+  --targets codex,agents \
+  --confirm-root-export CONFIRM_RI5B_ROOT_EXPORT_V1
+```
+
+The exact confirmation token is:
+
+```text
+CONFIRM_RI5B_ROOT_EXPORT_V1
+```
+
+No alias, fuzzy match, environment variable, interactive prompt, or default
+confirmation is allowed in the first implementation slice.
+
+## Authority Model
+
+Root authority files are human/operator authority unless the operator provides
+explicit write intent. Existing root files therefore block writes by default.
+
+Initial targets:
+
+| Target | Root file | First implementation default |
+|---|---|---|
+| `codex` | `CODEX_CONTEXT.md` | create-only |
+| `agents` | `AGENTS.md` | create-only |
+
+Deferred targets:
+
+| Root file | Reason |
+|---|---|
+| `CLAUDE.md` | high-authority, hand-maintained, higher overwrite risk |
+| `ARCHITECTURE.md` | project architecture authority, higher semantic-risk |
+
+## Required Input
+
+RI-5b must consume the existing RI-5a artifact:
+
+```text
+.ao/context/repo_export_plan.json
+```
+
+The exporter must not silently recompute a hidden write plan. If the plan is
+missing, stale, malformed, schema-invalid, or inconsistent with current source
+artifacts, the command must fail before any root file write.
+
+## Create-Only Write Algorithm
+
+The first implementation should follow this order:
+
+1. resolve and validate `project_root`;
+2. resolve and validate `workspace_root`;
+3. parse `--targets` as an explicit allowlist;
+4. require exact `--confirm-root-export CONFIRM_RI5B_ROOT_EXPORT_V1`;
+5. load `.ao/context/repo_export_plan.json`;
+6. validate the artifact against `repo-export-plan.schema.v1.json`;
+7. verify recorded source artifact digests against current files;
+8. verify requested targets exist in the plan and are supported;
+9. verify each target root path is project-root-contained and not a symlink;
+10. verify path-scoped ownership is available for each root target;
+11. take a before snapshot for each root target path;
+12. write only absent target files whose plan action is `create`;
+13. verify after snapshots and content digests;
+14. emit machine-readable evidence with written, skipped, and denied targets.
+
+No write may happen before steps 1-11 pass for the target.
+
+## Deny Matrix
+
+| Condition | Result | Root write |
+|---|---|---:|
+| Missing confirmation token | fail closed | No |
+| Wrong confirmation token | fail closed | No |
+| Missing export plan | fail closed | No |
+| Schema-invalid export plan | fail closed | No |
+| Stale source artifact digest | fail closed | No |
+| Unsupported target | fail closed | No |
+| Target absent from plan | fail closed | No |
+| Target action is `blocked` | fail closed | No |
+| Target action is `update` | fail closed in first slice | No |
+| Existing root file differs | fail closed | No |
+| Existing root file matches generated content | no-op / unchanged | No |
+| Target root path is symlink | fail closed | No |
+| Target root path escapes project root | fail closed | No |
+| Path ownership unavailable | fail closed | No |
+| Snapshot/verification failure | fail closed | No |
+| Target action is `create` and file is absent | write allowed | Yes |
+
+## Path-Scoped Ownership Requirement
+
+Before any future root write, RI-5b must check ownership for target root paths.
+The root export implementation must not bypass path-scoped write ownership.
+
+Initial ownership scope:
+
+```text
+CODEX_CONTEXT.md
+AGENTS.md
+```
+
+If the ownership layer cannot confirm the current actor may write those paths,
+the command must fail closed before writing. The evidence payload must record
+the ownership status per target.
+
+## Snapshot And Rollback Evidence
+
+The implementation PR must include tests proving root-file safety:
+
+1. before/after root snapshot is captured;
+2. create-only happy path writes only absent target files;
+3. existing files are not overwritten;
+4. failed verification leaves root paths unchanged;
+5. rollback or cleanup restores sandbox test roots after failure;
+6. evidence records written, skipped, denied, and unchanged targets.
+
+Live support widening must not be considered until this evidence exists in CI.
+
+## Evidence Shape
+
+The future implementation should emit a machine-readable result with at least:
+
+```json
+{
+  "schema_version": "1",
+  "artifact_kind": "repo_root_export_result",
+  "project_root": ".",
+  "workspace_root": ".ao",
+  "confirmation": {
+    "required_token": "CONFIRM_RI5B_ROOT_EXPORT_V1",
+    "provided": true
+  },
+  "targets": [],
+  "summary": {
+    "written_count": 0,
+    "unchanged_count": 0,
+    "denied_count": 0
+  },
+  "support_widening": false
+}
+```
+
+The exact schema can be added in the implementation slice, but the support
+claim must remain false unless a later promotion decision explicitly changes
+it.
+
+## Test Requirements For Implementation
+
+The implementation PR must add behavior tests covering:
+
+1. missing confirmation token;
+2. wrong confirmation token;
+3. missing export plan;
+4. schema-invalid export plan;
+5. stale source artifact digest;
+6. unsupported target;
+7. target absent from plan;
+8. blocked target action;
+9. `update` action denied in create-only mode;
+10. existing root file conflict;
+11. matching existing root file unchanged no-op;
+12. symlink target denial;
+13. path escape denial;
+14. path ownership denial;
+15. create-only happy path;
+16. root snapshot unchanged on failure;
+17. evidence payload shape.
+
+## Documentation Requirements For Implementation
+
+The implementation PR must update:
+
+```text
+docs/PUBLIC-BETA.md
+docs/SUPPORT-BOUNDARY.md
+CHANGELOG.md
+.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md
+.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+```
+
+The public docs must keep the surface Beta / operator-managed until write
+evidence and rollback evidence are merged and a later support decision grants a
+promotion. The shipped stable baseline must not imply automatic root-context
+management.
+
+## Acceptance For This Design Gate
+
+- [x] Dedicated branch and worktree are created from current `origin/main`.
+- [x] Issue [#459](https://github.com/Halildeu/ao-kernel/issues/459) tracks the
+  RI-5b design gate.
+- [x] Exact confirmation token is pinned.
+- [x] Create-only default is pinned.
+- [x] Export-plan-as-input requirement is pinned.
+- [x] Deny matrix is pinned.
+- [x] Path ownership requirement is pinned.
+- [x] Snapshot/rollback evidence requirement is pinned.
+- [x] Support boundary remains unchanged.
+
+## Acceptance For Future RI-5b Implementation
+
+- [ ] Starts only after this design gate merges.
+- [ ] Adds runtime code in a separate branch and PR.
+- [ ] Requires exact confirmation token.
+- [ ] Requires explicit target allowlist.
+- [ ] Consumes `.ao/context/repo_export_plan.json`.
+- [ ] Defaults to create-only root writes.
+- [ ] Refuses overwrite/update in the first slice.
+- [ ] Checks path-scoped ownership before any root write.
+- [ ] Proves root snapshots and rollback/no-corruption behavior.
+- [ ] Emits machine-readable evidence.
+- [ ] Keeps `support_widening=false`.
+
+## Tracking Log
+
+| Date | Status | Notes |
+|---|---|---|
+| 2026-04-24 | Design gate opened | Dedicated branch `codex/ri5b-root-export-design-gate` and worktree `/Users/halilkocoglu/Documents/ao-kernel-ri5b-root-export-design-gate` opened from `origin/main` at `0a6eacb`; issue [#459](https://github.com/Halildeu/ao-kernel/issues/459) created. |


### PR DESCRIPTION
## Summary
- add the RI-5b confirmed create-only root export design record
- pin the exact confirmation token, create-only default, deny matrix, path ownership, and snapshot/rollback evidence requirements
- update RI-5 and post-beta status surfaces so runtime implementation remains blocked until this gate merges

Closes #459.

## Validation
- git diff --check
- python3 -m ao_kernel repo export-plan --help
- python3 -m pytest tests/test_repo_intelligence_export_plan.py tests/test_cli_repo_export_plan.py -q