### PR TITLE
[codex] close RI-5b root export status

### DIFF
--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -50,7 +50,7 @@ ayrı ayrı görünür kılmak.
 - **Son tamamlanan GP-5.9 production platform claim decision:** `.claude/plans/GP-5.9-PRODUCTION-PLATFORM-CLAIM-DECISION.md`
 - **Son tamamlanan RI-5a export-plan preview:** `.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md`
 - **Son tamamlanan RI-5b confirmed create-only root export design gate:** `.claude/plans/RI-5b-CONFIRMED-CREATE-ONLY-ROOT-EXPORT-DESIGN-GATE.md`
-- **Aktif RI-5b create-only root export implementation:** `.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md`
+- **Son tamamlanan RI-5b create-only root export implementation:** `.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md`
 - **Son tamamlanan GP-5 integration roadmap:** `.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md`
 - **Production stable live roadmap:** `.claude/plans/PRODUCTION-STABLE-LIVE-ROADMAP.md`
 - **Son tamamlanan stable-gate contract:** `.claude/plans/ST-8-STABLE-PUBLISH-AND-POST-PUBLISH-VERIFICATION.md` (`ST-8 completed`)
@@ -125,12 +125,13 @@ ayrı ayrı görünür kılmak.
 - **GP-5.9 issue:** [#455](https://github.com/Halildeu/ao-kernel/issues/455) (`closed`)
 - **RI-5a export-plan preview:** PR `#457` merged at `a2144da`; closeout PR `#458` merged at `0a6eacb`
 - **RI-5b design gate issue:** [#459](https://github.com/Halildeu/ao-kernel/issues/459) (`closed by PR #460`)
-- **RI-5b implementation issue:** [#464](https://github.com/Halildeu/ao-kernel/issues/464) (`active`)
-- **Current mode:** stable maintenance + active RI-5b beta/operator-managed
-  root export implementation. This is not a production platform claim; future
-  stable widening still requires protected live-adapter evidence,
-  repo-intelligence integration gates, write-side rollback evidence, and an
-  explicit closeout decision.
+- **RI-5b implementation issue:** [#464](https://github.com/Halildeu/ao-kernel/issues/464) (`closed by PR #465`)
+- **RI-5b closeout issue:** [#466](https://github.com/Halildeu/ao-kernel/issues/466) (`closes with closeout PR`)
+- **Current mode:** stable maintenance / no active general-purpose widening
+  gate. RI-5b is merged as Beta/operator-managed root export, not a production
+  platform claim. Future stable widening still requires protected
+  live-adapter evidence, repo-intelligence integration gates, write-side
+  rollback evidence, and an explicit closeout decision.
 
 ## 2. Başlangıç Gerçeği
 
@@ -192,7 +193,7 @@ ayrı ayrı görünür kılmak.
 | `GP-4.5` support-boundary closeout | Completed by GP-4.5 PR ([#413](https://github.com/Halildeu/ao-kernel/issues/413), record `.claude/plans/GP-4.5-SUPPORT-BOUNDARY-CLOSEOUT.md`) | blocked GP-4 evidence against support boundary kararını kapatmak | verdict `close_no_widening_keep_operator_beta`; `claude-code-cli` remains Beta/operator-managed |
 | `GP-5` general-purpose platform integration | Completed / closed with no support widening | repo intelligence, protected real-adapter gate, governed read-only E2E, controlled patch/test, disposable PR rehearsal ve operations support paketini tek entegrasyon programına bağlamak | `GP-5.1a` completed blocked protected gate audit; `GP-5.3a..GP-5.3e` close repo-intelligence handoff gates; `GP-5.4a` read-only rehearsal passed; `GP-5.5b` local patch/test rehearsal passed; `GP-5.6a` disposable PR rehearsal passed; `GP-5.7a` defines the full rehearsal contract; `GP-5.7b` aggregates execution evidence; `GP-5.8` packages operations readiness; `GP-5.9` closed with `keep_narrow_stable_runtime`; no production support widening |
 | `RI-5b` confirmed create-only root export design gate | Completed ([#459](https://github.com/Halildeu/ao-kernel/issues/459), [#460](https://github.com/Halildeu/ao-kernel/pull/460)) | RI-5a preview planından root authority file create-only write yoluna geçmeden önce exact confirmation, path ownership, deny matrix ve rollback evidence kontratını kilitlemek | docs/status-only design gate; no runtime `repo export`; no root write; no support widening |
-| `RI-5b` create-only root export implementation | Active / local validation passed ([#464](https://github.com/Halildeu/ao-kernel/issues/464)) | RI-5a preview planını exact-token, path-owned, create-only root write yoluna bağlamak | Beta/operator-managed; consumes `.ao/context/repo_export_plan.json`; no overwrite/update/MCP/LLM/network; support_widening=false; targeted tests, packaging smoke, installed-wheel export smoke, and full coverage gate passed in branch |
+| `RI-5b` create-only root export implementation | Completed / merged ([#464](https://github.com/Halildeu/ao-kernel/issues/464), [#465](https://github.com/Halildeu/ao-kernel/pull/465)) | RI-5a preview planını exact-token, path-owned, create-only root write yoluna bağlamak | Beta/operator-managed; consumes `.ao/context/repo_export_plan.json`; no overwrite/update/MCP/LLM/network; support_widening=false; targeted tests, packaging smoke, installed-wheel export smoke, full coverage gate and CI passed; branch/worktree cleaned |
 | `ST-0` production stable truth closeout | Completed on `main` ([#338](https://github.com/Halildeu/ao-kernel/pull/338), [#339](https://github.com/Halildeu/ao-kernel/pull/339)) | stable/live yol haritasını eklemek ve GP-2.2 drift'i kapatmak | production stable roadmap + GP-2.2 closeout verdict |
 | `ST-1` releasable pre-release gate | Completed on `main` ([#340](https://github.com/Halildeu/ao-kernel/issues/340), [#341](https://github.com/Halildeu/ao-kernel/pull/341), [#342](https://github.com/Halildeu/ao-kernel/pull/342)) | current `main`i `4.0.0b2` pre-release gate'e hazırlamak ve publish etmek | release contract + exact file/test/publish checklist + PyPI exact pin verify |
 | `ST-2` stable support boundary freeze | Completed on `main` ([#344](https://github.com/Halildeu/ao-kernel/issues/344), [#347](https://github.com/Halildeu/ao-kernel/pull/347)) | `4.0.0` stable öncesinde shipped/beta/deferred/known-bug boundary'yi kanıtla dondurmak | support matrix evidence map + docs parity + stable blocker decision |
@@ -203,7 +204,7 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — stable maintenance + active RI-5b beta root export slice
+### Current mode — stable maintenance / no active general-purpose widening gate
 
 `GP-3` parent promotion programı `close_keep_operator_beta` kararıyla
 kapanmıştır. `GP-4.1` workflow skeleton, `GP-4.2` evidence artifact,

--- a/.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md
+++ b/.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md
@@ -1,27 +1,32 @@
 # RI-5 - Repo Intelligence Explicit Root/Context Export Design Gate
 
-**Status:** RI-5b create-only implementation active
+**Status:** RI-5b create-only implementation merged / closed
 **Date:** 2026-04-24
-**Authority:** `origin/main` at `91c1bc0`
+**Authority:** `origin/main` at `6234476`
 **Planning PR:** [#423](https://github.com/Halildeu/ao-kernel/pull/423)
 **Closeout PR:** [#426](https://github.com/Halildeu/ao-kernel/pull/426)
-**Implementation PR:** [#457](https://github.com/Halildeu/ao-kernel/pull/457)
+**RI-5a implementation PR:** [#457](https://github.com/Halildeu/ao-kernel/pull/457)
 **RI-5b issue:** [#459](https://github.com/Halildeu/ao-kernel/issues/459) (closed)
 **RI-5b design PR:** [#460](https://github.com/Halildeu/ao-kernel/pull/460)
 **RI-5b design record:** `.claude/plans/RI-5b-CONFIRMED-CREATE-ONLY-ROOT-EXPORT-DESIGN-GATE.md`
-**RI-5b implementation issue:** [#464](https://github.com/Halildeu/ao-kernel/issues/464)
-**RI-5b implementation branch:** `codex/ri5b-create-only-root-export`
-**RI-5b implementation worktree:** `/Users/halilkocoglu/Documents/ao-kernel-ri5b-create-only-root-export`
+**RI-5b implementation issue:** [#464](https://github.com/Halildeu/ao-kernel/issues/464) (closed)
+**RI-5b implementation PR:** [#465](https://github.com/Halildeu/ao-kernel/pull/465)
+**RI-5b closeout issue:** [#466](https://github.com/Halildeu/ao-kernel/issues/466)
+**RI-5b implementation branch:** cleaned after merge
+**RI-5b implementation worktree:** cleaned after merge
 **Planning branch:** cleaned after merge
 **Planning worktree:** cleaned after merge
 **Implementation branch:** cleaned after merge
 **Implementation worktree:** cleaned after merge
 **RI-5b design branch:** cleaned after merge
 **RI-5b design worktree:** cleaned after merge
-**Base:** `origin/main` at `91c1bc0`
-**Next slice:** RI-5b implementation review / merge
-**Implementation:** Merged to `main` at `a2144da`; preview-only export-plan
-support is live as Beta / experimental.
+**Base:** `origin/main` at `6234476`
+**Next slice:** none active. Any overwrite, higher-authority target, support
+promotion, MCP wiring, or context compiler integration requires a separate
+design gate.
+**Implementation:** RI-5a preview-only export-plan support is live as Beta /
+experimental. RI-5b confirmed create-only root export is merged as Beta /
+operator-managed at `6234476` with `support_widening=false`.
 **Rule:** Never work directly on `main`.
 
 ## Operational Rules
@@ -518,3 +523,5 @@ CHANGELOG.md
 | 2026-04-24 | RI-5b design cleanup completed | Local `main` synchronized with `origin/main`; design branch/worktree cleaned; next allowed slice is RI-5b create-only implementation from current `origin/main`. |
 | 2026-04-24 | RI-5b implementation started | Issue [#464](https://github.com/Halildeu/ao-kernel/issues/464), branch `codex/ri5b-create-only-root-export`, and worktree `/Users/halilkocoglu/Documents/ao-kernel-ri5b-create-only-root-export` opened from current `origin/main` at `49c4482`. |
 | 2026-04-24 | RI-5b local validation passed | `ruff check` on touched Python/tests; `mypy ao_kernel/`; targeted pytest `36 passed`; repo-intelligence pytest `95 passed`; `python3 -m ao_kernel repo export --help`; `python3 -m ao_kernel doctor` (`8 OK, 1 WARN, 0 FAIL`); `python3 scripts/packaging_smoke.py`; fresh-venv installed-wheel `repo scan -> export-plan -> export` smoke; full coverage `3061 passed, 1 skipped`, total coverage `85.31%`; `git diff --check`. |
+| 2026-04-24 | RI-5b implementation merged | PR [#465](https://github.com/Halildeu/ao-kernel/pull/465) squash-merged to `main` at `6234476`; issue [#464](https://github.com/Halildeu/ao-kernel/issues/464) closed; CI passed including lint, typecheck, Python 3.11/3.12/3.13 tests, coverage, benchmark-fast, packaging-smoke, and scorecard. |
+| 2026-04-24 | RI-5b implementation cleanup completed | Local `main` synchronized with `origin/main`; implementation branch/worktree and remote branch cleaned. Closeout issue [#466](https://github.com/Halildeu/ao-kernel/issues/466) records this status cleanup. |

--- a/.claude/plans/RI-5b-CONFIRMED-CREATE-ONLY-ROOT-EXPORT-DESIGN-GATE.md
+++ b/.claude/plans/RI-5b-CONFIRMED-CREATE-ONLY-ROOT-EXPORT-DESIGN-GATE.md
@@ -1,19 +1,26 @@
 # RI-5b - Confirmed Create-Only Root Export Design Gate
 
-**Status:** Design gate merged / implementation active in RI-5b slice
+**Status:** Design gate merged / RI-5b implementation merged
 **Date:** 2026-04-24
-**Authority:** `origin/main` at `91c1bc0`
+**Authority:** `origin/main` at `6234476`
 **Issue:** [#459](https://github.com/Halildeu/ao-kernel/issues/459) (closed)
 **Design PR:** [#460](https://github.com/Halildeu/ao-kernel/pull/460)
+**Implementation issue:** [#464](https://github.com/Halildeu/ao-kernel/issues/464) (closed)
+**Implementation PR:** [#465](https://github.com/Halildeu/ao-kernel/pull/465)
+**Closeout issue:** [#466](https://github.com/Halildeu/ao-kernel/issues/466)
 **Design branch:** cleaned after merge
 **Design worktree:** cleaned after merge
-**Base:** `origin/main` at `91c1bc0`
+**Implementation branch:** cleaned after merge
+**Implementation worktree:** cleaned after merge
+**Base:** `origin/main` at `6234476`
 **Previous slice:** RI-5a export-plan preview merged by PR
 [#457](https://github.com/Halildeu/ao-kernel/pull/457) and closed out by PR
 [#458](https://github.com/Halildeu/ao-kernel/pull/458)
-**Next allowed slice:** RI-5b create-only implementation PR from current
-`origin/main`
-**Support impact:** none; no support widening
+**Next allowed slice:** none active. Overwrite/update, higher-authority target
+promotion, MCP/root export tooling, or context compiler wiring requires a new
+design gate.
+**Support impact:** Beta/operator-managed root export only; no stable support
+widening.
 
 ## Purpose
 
@@ -272,3 +279,5 @@ management.
 | 2026-04-24 | Design branch cleanup completed | Local `main` synchronized with `origin/main`; design branch and worktree cleaned. Next allowed slice is RI-5b create-only implementation from current `origin/main`. |
 | 2026-04-24 | Implementation started | Issue [#464](https://github.com/Halildeu/ao-kernel/issues/464) and branch `codex/ri5b-create-only-root-export` opened from `origin/main` at `49c4482`; runtime code, CLI, schema, tests, docs, and status updates live in that implementation slice. |
 | 2026-04-24 | Implementation local validation passed | Targeted deny/happy-path tests, schema validation, CLI behavior tests, mypy, packaging smoke, fresh-venv installed-wheel `repo export` smoke, doctor, and full coverage gate all passed in the RI-5b implementation worktree. |
+| 2026-04-24 | Implementation merged | PR [#465](https://github.com/Halildeu/ao-kernel/pull/465) merged to `main` at `6234476`; issue [#464](https://github.com/Halildeu/ao-kernel/issues/464) closed. |
+| 2026-04-24 | Implementation cleanup completed | Local `main` synchronized with `origin/main`; implementation branch/worktree and remote branch cleaned; closeout issue [#466](https://github.com/Halildeu/ao-kernel/issues/466) records status cleanup. |


### PR DESCRIPTION
## Summary
- mark RI-5b confirmed create-only root export as merged/closed after PR #465 at 6234476
- record issue #464 closure, closeout issue #466, CI evidence, and branch/worktree cleanup
- keep support boundary explicit: beta/operator-managed root export only, no stable support widening and no runtime code change

## Validation
- rg stale active/gated RI-5b references in plan/status docs
- git diff --check
- python3 -m ao_kernel repo export --help
- python3 -m ao_kernel doctor
- pytest -q tests/test_cli_repo_export.py tests/test_repo_intelligence_root_exporter.py

Closes #466