### PR TITLE
[codex] clean RI-5b post-closeout next-slice status

### DIFF
--- a/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
+++ b/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
@@ -666,5 +666,9 @@ Final product wording remains:
 2. general-purpose production coding automation platform: not yet;
 3. real adapter production-certified support: not yet;
 4. repo-intelligence production workflow integration: not yet;
-5. next scoped runtime slice: `RI-5b` create-only root export implementation
-   from current `origin/main`.
+5. next scoped runtime slice: none active. `RI-5b` create-only root export has
+   merged as Beta/operator-managed with `support_widening=false`; any future
+   overwrite/update, higher-authority export target, MCP wiring,
+   `context_compiler` integration, real-adapter promotion, or production
+   platform claim must open as a new scoped issue/branch from current
+   `origin/main`.

--- a/.claude/plans/GP-5.9-PRODUCTION-PLATFORM-CLAIM-DECISION.md
+++ b/.claude/plans/GP-5.9-PRODUCTION-PLATFORM-CLAIM-DECISION.md
@@ -81,6 +81,8 @@ the same PR.
 5. `BC-10` blocked by missing real-adapter usage/cost evidence.
 
 No adapter, workflow, repo-intelligence, write-side, remote PR, or support tier
-was promoted by this decision. The next active runtime work must be opened as a
-new scoped slice from current `origin/main`; current recommendation is
-`RI-5b` create-only root export implementation.
+was promoted by this decision. Any future runtime work must be opened as a new
+scoped slice from current `origin/main`. `RI-5b` create-only root export has
+since merged as Beta/operator-managed with `support_widening=false`, so there
+is currently no active general-purpose widening/runtime recommendation left by
+`GP-5.9`.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -126,7 +126,8 @@ ayrı ayrı görünür kılmak.
 - **RI-5a export-plan preview:** PR `#457` merged at `a2144da`; closeout PR `#458` merged at `0a6eacb`
 - **RI-5b design gate issue:** [#459](https://github.com/Halildeu/ao-kernel/issues/459) (`closed by PR #460`)
 - **RI-5b implementation issue:** [#464](https://github.com/Halildeu/ao-kernel/issues/464) (`closed by PR #465`)
-- **RI-5b closeout issue:** [#466](https://github.com/Halildeu/ao-kernel/issues/466) (`closes with closeout PR`)
+- **RI-5b closeout issue:** [#466](https://github.com/Halildeu/ao-kernel/issues/466) (`closed by PR #467`)
+- **RI-5b post-closeout next-slice cleanup issue:** [#468](https://github.com/Halildeu/ao-kernel/issues/468) (`closes with this status cleanup PR`)
 - **Current mode:** stable maintenance / no active general-purpose widening
   gate. RI-5b is merged as Beta/operator-managed root export, not a production
   platform claim. Future stable widening still requires protected
@@ -1484,16 +1485,18 @@ This is not support widening and does not grant root authority write support.
 9. Closeout evidence:
    PR CI passed, local validation recorded in the RI-5 record includes lint,
    mypy, targeted tests, doctor, packaging smoke, full coverage, and diff check
-10. Next slice:
-   RI-5b confirmed create-only root export design gate. Implementation must not
-   start until the design gate pins `CONFIRM_RI5B_ROOT_EXPORT_V1`, create-only
-   default behavior, path ownership checks, root snapshot/rollback evidence,
-   and deny-path tests for missing/stale plans, existing-file conflicts,
-   symlinks, and path escapes.
+10. Subsequent slices:
+   RI-5b confirmed create-only root export design and implementation have since
+   closed. The preview-only RI-5a boundary remains historical context; current
+   status is no active RI-5 widening slice beyond Beta/operator-managed
+   create-only root export.
 
 ## 34. RI-5b Confirmed Create-Only Root Export Design Gate
 
-`RI-5b` design gate is complete. This is not the implementation slice.
+`RI-5b` design gate and create-only implementation are complete. The remaining
+root export expansion lanes are not active; overwrite/update, higher-authority
+targets, MCP/root export tooling, `context_compiler` wiring, or support
+widening require a new scoped design gate from current `origin/main`.
 
 1. Issue:
    [#459](https://github.com/Halildeu/ao-kernel/issues/459) (`closed`)
@@ -1517,7 +1520,16 @@ This is not support widening and does not grant root authority write support.
    - deny paths cover missing/stale plans, existing-file conflicts, symlinks,
      path escapes, unsupported targets, and invalid confirmation
    - root snapshot and rollback/no-corruption evidence is required
-8. Closeout:
-   local `main` synchronized with `origin/main`; design branch/worktree cleaned
-9. Next slice:
-   RI-5b create-only implementation PR from current `origin/main`.
+8. Implementation:
+   PR [#465](https://github.com/Halildeu/ao-kernel/pull/465), merged to `main`
+   at `6234476`; issue [#464](https://github.com/Halildeu/ao-kernel/issues/464)
+   closed
+9. Closeout:
+   local `main` synchronized with `origin/main`; design and implementation
+   branch/worktree cleanup completed; closeout issue
+   [#466](https://github.com/Halildeu/ao-kernel/issues/466) closed by PR
+   [#467](https://github.com/Halildeu/ao-kernel/pull/467)
+10. Next slice:
+   none active. Any widening beyond Beta/operator-managed create-only root
+   export requires a new scoped issue, design gate, branch, PR, and support
+   boundary decision.

--- a/.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md
+++ b/.claude/plans/RI-5-REPO-INTELLIGENCE-ROOT-EXPORT.md
@@ -2,7 +2,7 @@
 
 **Status:** RI-5b create-only implementation merged / closed
 **Date:** 2026-04-24
-**Authority:** `origin/main` at `6234476`
+**Authority:** `origin/main` at `fcaff20`
 **Planning PR:** [#423](https://github.com/Halildeu/ao-kernel/pull/423)
 **Closeout PR:** [#426](https://github.com/Halildeu/ao-kernel/pull/426)
 **RI-5a implementation PR:** [#457](https://github.com/Halildeu/ao-kernel/pull/457)
@@ -11,7 +11,8 @@
 **RI-5b design record:** `.claude/plans/RI-5b-CONFIRMED-CREATE-ONLY-ROOT-EXPORT-DESIGN-GATE.md`
 **RI-5b implementation issue:** [#464](https://github.com/Halildeu/ao-kernel/issues/464) (closed)
 **RI-5b implementation PR:** [#465](https://github.com/Halildeu/ao-kernel/pull/465)
-**RI-5b closeout issue:** [#466](https://github.com/Halildeu/ao-kernel/issues/466)
+**RI-5b closeout issue:** [#466](https://github.com/Halildeu/ao-kernel/issues/466) (closed)
+**RI-5b closeout PR:** [#467](https://github.com/Halildeu/ao-kernel/pull/467)
 **RI-5b implementation branch:** cleaned after merge
 **RI-5b implementation worktree:** cleaned after merge
 **Planning branch:** cleaned after merge
@@ -20,13 +21,14 @@
 **Implementation worktree:** cleaned after merge
 **RI-5b design branch:** cleaned after merge
 **RI-5b design worktree:** cleaned after merge
-**Base:** `origin/main` at `6234476`
+**Base:** `origin/main` at `fcaff20`
 **Next slice:** none active. Any overwrite, higher-authority target, support
 promotion, MCP wiring, or context compiler integration requires a separate
 design gate.
 **Implementation:** RI-5a preview-only export-plan support is live as Beta /
 experimental. RI-5b confirmed create-only root export is merged as Beta /
-operator-managed at `6234476` with `support_widening=false`.
+operator-managed at `6234476` with `support_widening=false`; closeout/status
+cleanup is merged at `fcaff20`.
 **Rule:** Never work directly on `main`.
 
 ## Operational Rules
@@ -525,3 +527,4 @@ CHANGELOG.md
 | 2026-04-24 | RI-5b local validation passed | `ruff check` on touched Python/tests; `mypy ao_kernel/`; targeted pytest `36 passed`; repo-intelligence pytest `95 passed`; `python3 -m ao_kernel repo export --help`; `python3 -m ao_kernel doctor` (`8 OK, 1 WARN, 0 FAIL`); `python3 scripts/packaging_smoke.py`; fresh-venv installed-wheel `repo scan -> export-plan -> export` smoke; full coverage `3061 passed, 1 skipped`, total coverage `85.31%`; `git diff --check`. |
 | 2026-04-24 | RI-5b implementation merged | PR [#465](https://github.com/Halildeu/ao-kernel/pull/465) squash-merged to `main` at `6234476`; issue [#464](https://github.com/Halildeu/ao-kernel/issues/464) closed; CI passed including lint, typecheck, Python 3.11/3.12/3.13 tests, coverage, benchmark-fast, packaging-smoke, and scorecard. |
 | 2026-04-24 | RI-5b implementation cleanup completed | Local `main` synchronized with `origin/main`; implementation branch/worktree and remote branch cleaned. Closeout issue [#466](https://github.com/Halildeu/ao-kernel/issues/466) records this status cleanup. |
+| 2026-04-24 | RI-5b closeout status merged | PR [#467](https://github.com/Halildeu/ao-kernel/pull/467) merged to `main` at `fcaff20`; issue [#466](https://github.com/Halildeu/ao-kernel/issues/466) closed; no active RI-5 widening slice remains. |

--- a/.claude/plans/RI-5b-CONFIRMED-CREATE-ONLY-ROOT-EXPORT-DESIGN-GATE.md
+++ b/.claude/plans/RI-5b-CONFIRMED-CREATE-ONLY-ROOT-EXPORT-DESIGN-GATE.md
@@ -2,17 +2,18 @@
 
 **Status:** Design gate merged / RI-5b implementation merged
 **Date:** 2026-04-24
-**Authority:** `origin/main` at `6234476`
+**Authority:** `origin/main` at `fcaff20`
 **Issue:** [#459](https://github.com/Halildeu/ao-kernel/issues/459) (closed)
 **Design PR:** [#460](https://github.com/Halildeu/ao-kernel/pull/460)
 **Implementation issue:** [#464](https://github.com/Halildeu/ao-kernel/issues/464) (closed)
 **Implementation PR:** [#465](https://github.com/Halildeu/ao-kernel/pull/465)
-**Closeout issue:** [#466](https://github.com/Halildeu/ao-kernel/issues/466)
+**Closeout issue:** [#466](https://github.com/Halildeu/ao-kernel/issues/466) (closed)
+**Closeout PR:** [#467](https://github.com/Halildeu/ao-kernel/pull/467)
 **Design branch:** cleaned after merge
 **Design worktree:** cleaned after merge
 **Implementation branch:** cleaned after merge
 **Implementation worktree:** cleaned after merge
-**Base:** `origin/main` at `6234476`
+**Base:** `origin/main` at `fcaff20`
 **Previous slice:** RI-5a export-plan preview merged by PR
 [#457](https://github.com/Halildeu/ao-kernel/pull/457) and closed out by PR
 [#458](https://github.com/Halildeu/ao-kernel/pull/458)
@@ -281,3 +282,4 @@ management.
 | 2026-04-24 | Implementation local validation passed | Targeted deny/happy-path tests, schema validation, CLI behavior tests, mypy, packaging smoke, fresh-venv installed-wheel `repo export` smoke, doctor, and full coverage gate all passed in the RI-5b implementation worktree. |
 | 2026-04-24 | Implementation merged | PR [#465](https://github.com/Halildeu/ao-kernel/pull/465) merged to `main` at `6234476`; issue [#464](https://github.com/Halildeu/ao-kernel/issues/464) closed. |
 | 2026-04-24 | Implementation cleanup completed | Local `main` synchronized with `origin/main`; implementation branch/worktree and remote branch cleaned; closeout issue [#466](https://github.com/Halildeu/ao-kernel/issues/466) records status cleanup. |
+| 2026-04-24 | Closeout status merged | PR [#467](https://github.com/Halildeu/ao-kernel/pull/467) merged to `main` at `fcaff20`; issue [#466](https://github.com/Halildeu/ao-kernel/issues/466) closed; no active RI-5b implementation slice remains. |


### PR DESCRIPTION
## Summary
- remove stale GP-5 / GP-5.9 wording that still recommended RI-5b as the next runtime slice after RI-5b merged
- record RI-5b closeout PR #467 and issue #466 closure in RI/status surfaces
- keep current mode explicit: stable maintenance, no active general-purpose widening/runtime gate

## Validation
- rg stale current-recommendation / next-slice RI-5b patterns
- git diff --check
- python3 -m ao_kernel repo export --help
- python3 -m ao_kernel doctor
- pytest -q tests/test_cli_repo_export.py tests/test_repo_intelligence_root_exporter.py

No runtime code, support widening, version bump, tag, or publish.

Closes #468