### PR TITLE
[codex] record GPP-1 live-adapter prerequisite block

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,11 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-0 tracker active
+**Status:** GPP-1 prerequisite attestation closeout
 **Date:** 2026-04-25
-**Authority:** `origin/main` at `1b8078f`
-**Issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Branch:** `codex/gpp0-production-promotion-tracker`
-**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp0-production-promotion-tracker`
+**Authority:** `origin/main` at `f3823be`
+**Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
+**Current slice issue:** [#472](https://github.com/Halildeu/ao-kernel/issues/472)
+**Current slice record:** `.claude/plans/GPP-1-PROTECTED-LIVE-ADAPTER-PREREQUISITE-ATTESTATION.md`
+**Branch:** `codex/gpp1-live-adapter-prereq-attestation`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp1-live-adapter-prereq-attestation`
 **Mode:** written, trackable, fail-closed promotion program
 **Support impact:** none
 **Release impact:** none
@@ -47,6 +49,16 @@ Last live verification on current `origin/main` showed:
     guarded and not production-supported.
 12. Controlled local patch/test rehearsal passed in a disposable worktree with
     rollback, but `support_widening=false`.
+13. GPP-1 live attestation on 2026-04-25 still shows only GitHub environment
+    `pypi`; `ao-kernel-live-adapter-gate` is absent.
+14. `gh secret list --repo Halildeu/ao-kernel` returned no visible repository
+    secret handles.
+15. `gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel`
+    returned `HTTP 404`, because the required environment is absent.
+16. `.github/workflows/live-adapter-gate.yml` still has only
+    `workflow_dispatch` among live-gate trigger/secret/environment grep terms;
+    no `environment:`, `secrets.`, `pull_request`, or `pull_request_target`
+    binding is present.
 
 ## 3. Current Verdict
 
@@ -83,9 +95,9 @@ The final production claim stays closed until `GPP-9` passes.
 
 | WP | Status | Goal | Exit decision |
 |---|---|---|---|
-| `GPP-0` | Active | Create written tracker and acceptance model | `tracker_ready_no_support_widening` |
-| `GPP-1` | Not started | Protected live-adapter prerequisite attestation | `prerequisites_ready` / `blocked_attestation_missing` |
-| `GPP-2` | Not started | Protected live-adapter gate runtime binding | `live_gate_ready` / `blocked_gate_unready` |
+| `GPP-0` | Completed | Create written tracker and acceptance model | `tracker_ready_no_support_widening` |
+| `GPP-1` | Closeout candidate | Protected live-adapter prerequisite attestation | `blocked_attestation_missing` |
+| `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until `GPP-1` can exit `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -98,6 +110,9 @@ The final production claim stays closed until `GPP-9` passes.
 
 **Goal:** Make the remaining production promotion work written, discoverable,
 and executable step by step.
+
+**Status:** completed on `main` by PR
+[#471](https://github.com/Halildeu/ao-kernel/pull/471).
 
 **Entry criteria:**
 
@@ -132,6 +147,10 @@ and executable step by step.
 **Goal:** Establish project-owned protected live-adapter prerequisites before
 any workflow binding or support promotion.
 
+**Status:** closeout candidate.
+
+**Exit decision:** `blocked_attestation_missing`.
+
 **Entry criteria:**
 
 1. `GPP-0` merged.
@@ -146,11 +165,17 @@ any workflow binding or support promotion.
 
 **Acceptance criteria:**
 
-1. GitHub environment inventory contains `ao-kernel-live-adapter-gate`.
-2. Required secret handle is attested at repository or environment scope.
-3. Fork-triggered PR contexts cannot access protected credentials.
-4. Missing environment or secret produces `blocked_attestation_missing`.
-5. Status docs and support boundary still say no support widening.
+1. GitHub environment inventory contains `ao-kernel-live-adapter-gate`: not
+   met; only `pypi` is currently visible.
+2. Required secret handle is attested at repository or environment scope: not
+   met; repository secret list is empty and environment-scoped secret lookup
+   returns `HTTP 404`.
+3. Fork-triggered PR contexts cannot access protected credentials: met for the
+   current design-only workflow, because the workflow is `workflow_dispatch`
+   only and has no `environment:` or `secrets.` reference.
+4. Missing environment or secret produces `blocked_attestation_missing`: met by
+   this slice.
+5. Status docs and support boundary still say no support widening: met.
 
 **Validation:**
 
@@ -159,16 +184,23 @@ any workflow binding or support promotion.
 3. workflow file inspection for no accidental secret exposure
 4. schema-backed prerequisite report if implemented
 
+**Decision record:** `.claude/plans/GPP-1-PROTECTED-LIVE-ADAPTER-PREREQUISITE-ATTESTATION.md`
+
 ## 8. GPP-2 - Protected Live-Adapter Gate Runtime Binding
 
 **Goal:** Convert the current design-only `live-adapter-gate.yml` into a
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
+**Status:** blocked by GPP-1.
+
 **Entry criteria:**
 
 1. `GPP-1` exit decision is `prerequisites_ready`.
 2. Protected environment and credential handle are attested.
+
+Current GPP-1 exit decision is `blocked_attestation_missing`, so GPP-2 cannot
+start yet.
 
 **Acceptance criteria:**
 
@@ -412,16 +444,17 @@ accident.
 
 ## 16. Current Active Work
 
-The active work is `GPP-0`.
+The active work is `GPP-1` closeout.
 
-After `GPP-0` merges, the next active work is:
+GPP-1 currently exits as:
 
 ```text
-GPP-1 - Protected Live-Adapter Prerequisite
+blocked_attestation_missing
 ```
 
-No other runtime/support-widening work should start until `GPP-1` exits with
-`prerequisites_ready` or an explicit blocked decision.
+No runtime/support-widening work should start from `GPP-2` until a future
+attestation proves `ao-kernel-live-adapter-gate` and
+`AO_CLAUDE_CODE_CLI_AUTH` are present and fork-safe.
 
 ## 17. Risk Register
 
@@ -440,4 +473,6 @@ No other runtime/support-widening work should start until `GPP-1` exits with
 |---|---|---|
 | 2026-04-25 | GPP-0 issue opened | Issue [#470](https://github.com/Halildeu/ao-kernel/issues/470) created to track the written production-promotion program. |
 | 2026-04-25 | GPP-0 branch opened | Branch `codex/gpp0-production-promotion-tracker` and dedicated worktree opened from `origin/main` at `1b8078f`. |
-
+| 2026-04-25 | GPP-0 merged | PR [#471](https://github.com/Halildeu/ao-kernel/pull/471) merged at `f3823be`; tracker is live on `main`. |
+| 2026-04-25 | GPP-1 issue opened | Issue [#472](https://github.com/Halildeu/ao-kernel/issues/472) created for protected live-adapter prerequisite attestation. |
+| 2026-04-25 | GPP-1 attestation recorded | Live GitHub environment/secret evidence keeps GPP-1 at `blocked_attestation_missing`; GPP-2 remains blocked. |

--- a/.claude/plans/GPP-1-PROTECTED-LIVE-ADAPTER-PREREQUISITE-ATTESTATION.md
+++ b/.claude/plans/GPP-1-PROTECTED-LIVE-ADAPTER-PREREQUISITE-ATTESTATION.md
@@ -1,0 +1,209 @@
+# GPP-1 - Protected Live-Adapter Prerequisite Attestation
+
+**Status:** closeout candidate
+**Date:** 2026-04-25
+**Parent tracker:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
+**Slice issue:** [#472](https://github.com/Halildeu/ao-kernel/issues/472)
+**Branch:** `codex/gpp1-live-adapter-prereq-attestation`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp1-live-adapter-prereq-attestation`
+**Base authority:** `origin/main` at `f3823be`
+**Decision:** `blocked_attestation_missing`
+**Support impact:** none
+**Release impact:** none
+
+## 1. Purpose
+
+Attest whether the project-owned protected live-adapter prerequisites exist
+before `ao-kernel` binds the live adapter workflow to protected credentials or
+promotes `claude-code-cli` beyond `Beta (operator-managed)`.
+
+This slice is deliberately no-widening. It does not create GitHub secrets, read
+secret values, bind a workflow environment, run `claude`, or claim production
+real-adapter support.
+
+## 2. Required Prerequisites
+
+| Prerequisite | Required value | Status |
+|---|---|---|
+| Protected GitHub environment | `ao-kernel-live-adapter-gate` | Not attested |
+| Project-owned credential handle | `AO_CLAUDE_CODE_CLI_AUTH` | Not attested |
+| Fork-safe trigger path | no fork-triggered live secret access | Current design-only workflow remains safe |
+| Live workflow binding | only after prerequisite attestation | Blocked |
+
+## 3. Live Evidence
+
+Commands were run from `origin/main`/GPP-1 branch state on 2026-04-25.
+
+### GitHub Environments
+
+Command:
+
+```bash
+gh api repos/Halildeu/ao-kernel/environments \
+  --jq '.environments[]? | {name, protection_rules: (.protection_rules|length), deployment_branch_policy}'
+```
+
+Observed output:
+
+```json
+{"deployment_branch_policy":null,"name":"pypi","protection_rules":0}
+```
+
+Decision: the required environment `ao-kernel-live-adapter-gate` is not
+present.
+
+### Repository Secrets
+
+Command:
+
+```bash
+gh secret list --repo Halildeu/ao-kernel
+```
+
+Observed output: empty.
+
+Decision: the required repository secret handle `AO_CLAUDE_CODE_CLI_AUTH` is not
+attested.
+
+### Environment Secrets
+
+Command:
+
+```bash
+gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel
+```
+
+Observed output:
+
+```text
+failed to get secrets: HTTP 404: Not Found
+```
+
+Decision: the required environment does not exist, so environment-scoped secret
+attestation is also absent.
+
+### Workflow Safety Inspection
+
+Command:
+
+```bash
+rg -n "environment:|secrets\.|pull_request_target|pull_request|workflow_dispatch|AO_CLAUDE_CODE_CLI_AUTH|ao-kernel-live-adapter-gate" \
+  .github/workflows/live-adapter-gate.yml
+```
+
+Observed output:
+
+```text
+4:  workflow_dispatch:
+```
+
+Decision: the current workflow is still manual/design-only. It does not bind a
+GitHub environment, does not reference secrets, and does not run on pull request
+events.
+
+### Existing Schema-Backed Gate Contract
+
+Command:
+
+```bash
+python3 scripts/live_adapter_gate_contract.py \
+  --output json \
+  --report-path /tmp/gpp1-live-adapter-gate-contract.v1.json \
+  --evidence-path /tmp/gpp1-live-adapter-gate-evidence.v1.json \
+  --environment-contract-path /tmp/gpp1-live-adapter-gate-environment-contract.v1.json \
+  --rehearsal-decision-path /tmp/gpp1-live-adapter-gate-rehearsal-decision.v1.json \
+  --target-ref main \
+  --reason gpp1-prerequisite-attestation \
+  --requested-by codex \
+  --event-name local-attestation \
+  --head-sha f3823beb16cb7476312516e5c72140b06dca6965
+```
+
+Key observed fields:
+
+```text
+environment contract:
+overall_status=blocked
+finding_code=live_gate_protected_environment_not_attested
+live_execution_allowed=False
+support_widening=False
+protected_environment.name=ao-kernel-live-adapter-gate
+required_secrets=AO_CLAUDE_CODE_CLI_AUTH
+
+rehearsal decision:
+overall_status=blocked
+finding_code=live_gate_rehearsal_blocked_missing_protected_prerequisites
+live_execution_allowed=False
+live_rehearsal_attempted=False
+support_widening=False
+prerequisites=protected_environment_attestation:not_attested,project_owned_credential:not_attested,protected_live_preflight:blocked,governed_workflow_smoke:blocked
+```
+
+Decision: existing machine-readable contract already models the correct blocked
+state; GPP-1 records the current live attestation result rather than adding a
+new runtime helper.
+
+## 4. Exit Decision
+
+`GPP-1` exits as:
+
+```text
+blocked_attestation_missing
+```
+
+Reasons:
+
+1. Required protected environment `ao-kernel-live-adapter-gate` is absent.
+2. Required credential handle `AO_CLAUDE_CODE_CLI_AUTH` is not attested at
+   repository scope.
+3. Environment-scoped secret attestation cannot exist because the environment
+   itself returns `404`.
+4. The live-adapter workflow is still design-only and intentionally has no
+   secret or environment binding.
+
+## 5. Support Boundary
+
+No support widening.
+
+`ao-kernel` remains a narrow stable governed runtime. `claude-code-cli` remains
+`Beta (operator-managed)`. A green `live-adapter-gate` workflow still means
+blocked/design-only artifacts were emitted, not that a project-owned real
+adapter ran.
+
+## 6. What Unblocks GPP-2
+
+`GPP-2` must not start until a future operator/admin step provides fresh
+attestation that:
+
+1. GitHub environment `ao-kernel-live-adapter-gate` exists.
+2. Its protection settings match the protected gate contract.
+3. Credential handle `AO_CLAUDE_CODE_CLI_AUTH` or an explicitly approved
+   replacement exists at repository or environment scope.
+4. Fork-triggered contexts cannot read that credential.
+
+Only after those are true should a new slice bind
+`.github/workflows/live-adapter-gate.yml` to the protected environment and
+attempt a live protected adapter rehearsal.
+
+## 7. Non-Goals
+
+1. No GitHub environment creation.
+2. No repository or environment secret value creation.
+3. No secret value readback.
+4. No `environment:` workflow binding.
+5. No `claude` execution.
+6. No production adapter certification.
+7. No release, tag, or publish.
+
+## 8. Validation
+
+Local validation for this slice:
+
+1. `git diff --check`
+2. `python3 -m ao_kernel version`
+3. `python3 -m ao_kernel doctor`
+4. `pytest -q tests/test_live_adapter_gate_contract.py tests/test_gp5_platform_claim_decision.py`
+5. live GitHub environment inventory command
+6. live GitHub secret list command
+7. workflow safety grep
+

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -129,14 +129,16 @@ ayrı ayrı görünür kılmak.
 - **RI-5b implementation issue:** [#464](https://github.com/Halildeu/ao-kernel/issues/464) (`closed by PR #465`)
 - **RI-5b closeout issue:** [#466](https://github.com/Halildeu/ao-kernel/issues/466) (`closed by PR #467`)
 - **RI-5b post-closeout next-slice cleanup issue:** [#468](https://github.com/Halildeu/ao-kernel/issues/468) (`closes with this status cleanup PR`)
-- **GPP-0 production promotion tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470) (`open`)
+- **GPP-0 production promotion tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470) (`closed by PR #471`)
+- **GPP-1 protected live-adapter prerequisite attestation:** `.claude/plans/GPP-1-PROTECTED-LIVE-ADAPTER-PREREQUISITE-ATTESTATION.md`
+- **GPP-1 issue:** [#472](https://github.com/Halildeu/ao-kernel/issues/472) (`open`)
 - **Current mode:** stable maintenance + written general-purpose production
   promotion tracking. RI-5b is merged as Beta/operator-managed root export, not
-  a production platform claim. GPP-0 creates the trackable promotion program;
-  no support widening, release, runtime adapter promotion, or production claim is
-  made by GPP-0. Future stable widening still requires protected live-adapter
-  evidence, repo-intelligence integration gates, write-side rollback evidence,
-  and an explicit closeout decision.
+  a production platform claim. GPP-1 live attestation currently exits as
+  `blocked_attestation_missing`; no support widening, release, runtime adapter
+  promotion, or production claim is made by GPP-1. Future stable widening still
+  requires protected live-adapter evidence, repo-intelligence integration gates,
+  write-side rollback evidence, and an explicit closeout decision.
 
 ## 2. Başlangıç Gerçeği
 
@@ -232,6 +234,11 @@ maintenance baseline ve `SM-2` stable baseline evidence refresh geçerlidir.
 promotion gap'lerini `.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md`
 altında yazılı, sıralı ve kanıt-gated hale getirir. `GPP-0` merge olduktan
 sonraki tek aktif hat `GPP-1` protected live-adapter prerequisite olacaktır.
+
+`GPP-1` closeout adayı canlı attestation sonucu `blocked_attestation_missing`
+kararındadır: `ao-kernel-live-adapter-gate` environment yoktur,
+`AO_CLAUDE_CODE_CLI_AUTH` secret handle attested değildir ve GPP-2 runtime
+binding hattı bu prerequisite kapanmadan başlamaz.
 
 Mevcut yol:
 


### PR DESCRIPTION
## Summary
- Adds the GPP-1 protected live-adapter prerequisite attestation record.
- Records the live result as `blocked_attestation_missing`: required environment `ao-kernel-live-adapter-gate` is absent and `AO_CLAUDE_CODE_CLI_AUTH` is not attested.
- Updates the GPP tracker and post-beta status SSOT so GPP-2 remains blocked until protected prerequisites exist.

## Live evidence
- `gh api repos/Halildeu/ao-kernel/environments` -> only `pypi`
- `gh secret list --repo Halildeu/ao-kernel` -> empty visible repository secret list
- `gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel` -> `HTTP 404`
- workflow safety grep on `.github/workflows/live-adapter-gate.yml` -> only `workflow_dispatch`; no `environment:`, no `secrets.`, no PR trigger

## Validation
- `git diff --check`
- `python3 -m ao_kernel version` -> `ao-kernel 4.0.0`
- `python3 -m ao_kernel doctor` -> `8 OK, 1 WARN, 0 FAIL`
- `pytest -q tests/test_live_adapter_gate_contract.py tests/test_gp5_platform_claim_decision.py` -> `24 passed`

## Scope
- Docs/status/decision record only.
- No runtime code changes.
- No GitHub environment or secret creation.
- No live adapter execution.
- No support widening, release, tag, or publish.

Closes #472