### PR TITLE
[codex] add GPP agent operating program contract

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,14 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-1 prerequisite attestation closeout
+**Status:** GPP-1b agent operating program contract active
 **Date:** 2026-04-25
-**Authority:** `origin/main` at `f3823be`
+**Authority:** `origin/main` at `0ad7209`
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#472](https://github.com/Halildeu/ao-kernel/issues/472)
-**Current slice record:** `.claude/plans/GPP-1-PROTECTED-LIVE-ADAPTER-PREREQUISITE-ATTESTATION.md`
-**Branch:** `codex/gpp1-live-adapter-prereq-attestation`
-**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp1-live-adapter-prereq-attestation`
+**Current slice issue:** [#474](https://github.com/Halildeu/ao-kernel/issues/474)
+**Current slice record:** `.claude/plans/GPP-1b-AGENT-OPERATING-PROGRAM-CONTRACT.md`
+**Machine-readable status:** `.claude/plans/gpp_status.v1.json`
+**Branch:** `codex/gpp1b-agent-operating-program-contract`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp1b-agent-operating-program-contract`
 **Mode:** written, trackable, fail-closed promotion program
 **Support impact:** none
 **Release impact:** none
@@ -59,6 +60,9 @@ Last live verification on current `origin/main` showed:
     `workflow_dispatch` among live-gate trigger/secret/environment grep terms;
     no `environment:`, `secrets.`, `pull_request`, or `pull_request_target`
     binding is present.
+17. GPP-1b adds a machine-readable operator contract so Codex and Claude Code
+    read the same active work package and blocked gates from repo state instead
+    of chat memory.
 
 ## 3. Current Verdict
 
@@ -96,7 +100,8 @@ The final production claim stays closed until `GPP-9` passes.
 | WP | Status | Goal | Exit decision |
 |---|---|---|---|
 | `GPP-0` | Completed | Create written tracker and acceptance model | `tracker_ready_no_support_widening` |
-| `GPP-1` | Closeout candidate | Protected live-adapter prerequisite attestation | `blocked_attestation_missing` |
+| `GPP-1` | Completed | Protected live-adapter prerequisite attestation | `blocked_attestation_missing` |
+| `GPP-1b` | Active | Agent operating program contract | `agent_operating_contract_ready_no_support_widening` |
 | `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until `GPP-1` can exit `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -147,7 +152,8 @@ and executable step by step.
 **Goal:** Establish project-owned protected live-adapter prerequisites before
 any workflow binding or support promotion.
 
-**Status:** closeout candidate.
+**Status:** completed on `main` by PR
+[#473](https://github.com/Halildeu/ao-kernel/pull/473).
 
 **Exit decision:** `blocked_attestation_missing`.
 
@@ -186,7 +192,37 @@ any workflow binding or support promotion.
 
 **Decision record:** `.claude/plans/GPP-1-PROTECTED-LIVE-ADAPTER-PREREQUISITE-ATTESTATION.md`
 
-## 8. GPP-2 - Protected Live-Adapter Gate Runtime Binding
+## 8. GPP-1b - Agent Operating Program Contract
+
+**Goal:** Make Codex and Claude Code follow the repo-owned GPP program state
+before choosing or implementing the next work package.
+
+**Status:** active.
+
+**Exit decision target:** `agent_operating_contract_ready_no_support_widening`.
+
+**Scope:**
+
+1. Add `AGENTS.md` startup and execution contract.
+2. Add `.claude/plans/gpp_status.v1.json` as the machine-readable GPP status.
+3. Add `scripts/gpp_next.py` to print the active WP and blocked gates.
+4. Add tests that pin the active WP, blocked WP, and no-widening guards.
+5. Keep `GPP-2` blocked.
+
+**Acceptance criteria:**
+
+1. `python3 scripts/gpp_next.py` reports `GPP-1b` as active.
+2. `python3 scripts/gpp_next.py --output json` returns valid JSON.
+3. `support_widening_allowed`, `production_platform_claim_allowed`, and
+   `live_adapter_execution_allowed` are all `false`.
+4. `GPP-2` remains listed as blocked.
+5. `AGENTS.md` tells Codex and Claude Code to read repo state before acting.
+6. No live adapter execution, credential binding, support widening, release, or
+   production claim is introduced.
+
+**Decision record:** `.claude/plans/GPP-1b-AGENT-OPERATING-PROGRAM-CONTRACT.md`
+
+## 9. GPP-2 - Protected Live-Adapter Gate Runtime Binding
 
 **Goal:** Convert the current design-only `live-adapter-gate.yml` into a
 protected manual gate that can actually run a real adapter under project-owned
@@ -221,7 +257,7 @@ start yet.
 3. negative/fail-closed runs are recorded
 4. local tests for artifact schema and status mapping
 
-## 9. GPP-3 - Real-Adapter Usage and Cost Evidence
+## 10. GPP-3 - Real-Adapter Usage and Cost Evidence
 
 **Goal:** Close or explicitly decide the `BC-10` blocker from `GP-5.9`.
 
@@ -247,7 +283,7 @@ start yet.
 3. live or simulated unavailable-usage path
 4. support-boundary wording check
 
-## 10. GPP-4 - Production-Certified Read-Only Adapter Decision
+## 11. GPP-4 - Production-Certified Read-Only Adapter Decision
 
 **Goal:** Decide whether `claude-code-cli` can move from
 `Beta (operator-managed)` to production-certified read-only.
@@ -274,7 +310,7 @@ start yet.
 3. support-boundary grep for tier consistency
 4. no production write support is implied
 
-## 11. GPP-5 - Repo-Intelligence Workflow Integration
+## 12. GPP-5 - Repo-Intelligence Workflow Integration
 
 **Goal:** Move repo intelligence from explicit operator handoff toward
 governed workflow integration without hidden prompt injection.
@@ -304,7 +340,7 @@ governed workflow integration without hidden prompt injection.
 4. disabled-config test
 5. negative grep for hidden MCP/root export/context compiler wiring
 
-## 12. GPP-6 - Read-Only Production E2E
+## 13. GPP-6 - Read-Only Production E2E
 
 **Goal:** Prove the first complete read-only coding automation chain with real
 adapter and repo intelligence.
@@ -342,7 +378,7 @@ repo scan/index/query
 3. event-order assertions
 4. runbook reproduction check
 
-## 13. GPP-7 - Controlled Write-Side Production Candidate
+## 14. GPP-7 - Controlled Write-Side Production Candidate
 
 **Goal:** Promote local patch/test from rehearsal-only toward a production
 candidate under disposable/dedicated worktree controls.
@@ -371,7 +407,7 @@ candidate under disposable/dedicated worktree controls.
 3. rollback artifact verification
 4. path ownership event checks
 
-## 14. GPP-8 - Remote PR Live-Write Promotion Candidate
+## 15. GPP-8 - Remote PR Live-Write Promotion Candidate
 
 **Goal:** Move `gh-cli-pr` from preflight/disposable rehearsal toward a
 production candidate without granting arbitrary repository write support by
@@ -401,7 +437,7 @@ accident.
 3. no side effects remaining
 4. docs/runbook/known-bugs parity
 
-## 15. GPP-9 - Full Production Matrix and Claim Decision
+## 16. GPP-9 - Full Production Matrix and Claim Decision
 
 **Goal:** Decide the general-purpose production claim with complete evidence.
 
@@ -442,21 +478,21 @@ accident.
 4. wheel-installed packaging smoke
 5. protected live-adapter evidence artifacts
 
-## 16. Current Active Work
+## 17. Current Active Work
 
-The active work is `GPP-1` closeout.
+The active work is `GPP-1b`.
 
-GPP-1 currently exits as:
+GPP-1b target exit is:
 
 ```text
-blocked_attestation_missing
+agent_operating_contract_ready_no_support_widening
 ```
 
 No runtime/support-widening work should start from `GPP-2` until a future
 attestation proves `ao-kernel-live-adapter-gate` and
 `AO_CLAUDE_CODE_CLI_AUTH` are present and fork-safe.
 
-## 17. Risk Register
+## 18. Risk Register
 
 | Risk | Impact | Mitigation |
 |---|---|---|
@@ -467,7 +503,7 @@ attestation proves `ao-kernel-live-adapter-gate` and
 | Remote PR writes leak to arbitrary repos | Production side effect risk | Disposable guard + explicit allow flag + rollback evidence |
 | Full matrix becomes stale | Fake green promotion | Require fresh artifacts from current `origin/main` |
 
-## 18. Tracking Log
+## 19. Tracking Log
 
 | Date | Event | Notes |
 |---|---|---|
@@ -476,3 +512,6 @@ attestation proves `ao-kernel-live-adapter-gate` and
 | 2026-04-25 | GPP-0 merged | PR [#471](https://github.com/Halildeu/ao-kernel/pull/471) merged at `f3823be`; tracker is live on `main`. |
 | 2026-04-25 | GPP-1 issue opened | Issue [#472](https://github.com/Halildeu/ao-kernel/issues/472) created for protected live-adapter prerequisite attestation. |
 | 2026-04-25 | GPP-1 attestation recorded | Live GitHub environment/secret evidence keeps GPP-1 at `blocked_attestation_missing`; GPP-2 remains blocked. |
+| 2026-04-25 | GPP-1 merged | PR [#473](https://github.com/Halildeu/ao-kernel/pull/473) merged at `0ad7209`; protected live-adapter prerequisite remains blocked. |
+| 2026-04-25 | GPP-1b issue opened | Issue [#474](https://github.com/Halildeu/ao-kernel/issues/474) created for agent operating program contract. |
+| 2026-04-25 | GPP-1b contract added | `AGENTS.md`, `.claude/plans/gpp_status.v1.json`, and `scripts/gpp_next.py` make the active program state machine-readable for Codex/Claude operator sessions. |

--- a/.claude/plans/GPP-1b-AGENT-OPERATING-PROGRAM-CONTRACT.md
+++ b/.claude/plans/GPP-1b-AGENT-OPERATING-PROGRAM-CONTRACT.md
@@ -1,0 +1,88 @@
+# GPP-1b - Agent Operating Program Contract
+
+**Status:** active
+**Date:** 2026-04-25
+**Parent tracker:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
+**Slice issue:** [#474](https://github.com/Halildeu/ao-kernel/issues/474)
+**Branch:** `codex/gpp1b-agent-operating-program-contract`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp1b-agent-operating-program-contract`
+**Base authority:** `origin/main` at `0ad7209`
+**Target exit decision:** `agent_operating_contract_ready_no_support_widening`
+**Support impact:** none
+**Release impact:** none
+
+## 1. Purpose
+
+Make Codex and Claude Code follow the same repo-owned program state when they
+operate on `ao-kernel`.
+
+This slice is about operator discipline, not product live-adapter promotion.
+It does not run `claude`, does not bind protected GitHub environments, and does
+not widen support.
+
+## 2. Problem
+
+The GPP program now has a written tracker, but agents can still drift if they
+infer the next action from chat history instead of repo state.
+
+The required behavior is:
+
+1. Read `origin/main` as authority.
+2. Read the GPP status file.
+3. Identify the single active work package.
+4. Respect blocked runtime/support-widening gates.
+5. Use one issue, one worktree, one branch, one PR, one exit decision.
+
+## 3. Implemented Surface
+
+1. `AGENTS.md` records the startup and execution contract for Codex and Claude
+   Code.
+2. `.claude/plans/gpp_status.v1.json` exposes the current GPP state in a
+   machine-readable form.
+3. `scripts/gpp_next.py` prints the active work package, blocked work packages,
+   required startup checks, forbidden actions, and next allowed actions.
+4. `tests/test_gpp_next.py` pins the status contract and helper behavior.
+5. The human-readable GPP and post-beta status files point to this contract.
+
+## 4. Current Program Decision
+
+`GPP-1` remains closed as `blocked_attestation_missing`.
+
+`GPP-2` remains blocked because the required protected live-adapter environment
+and credential handle are not attested.
+
+`GPP-1b` does not solve that runtime prerequisite. It prevents Codex/Claude
+operator sessions from accidentally skipping it.
+
+## 5. Acceptance Criteria
+
+1. Agents have a short startup contract in `AGENTS.md`.
+2. `python3 scripts/gpp_next.py` reports `GPP-1b` as the active work package.
+3. `python3 scripts/gpp_next.py --output json` returns valid JSON.
+4. `.claude/plans/gpp_status.v1.json` keeps:
+   - `support_widening_allowed=false`
+   - `production_platform_claim_allowed=false`
+   - `live_adapter_execution_allowed=false`
+5. `GPP-2` is explicitly listed as blocked.
+6. Tests fail if the active WP, blocked WP, or support-widening guard drifts.
+7. No runtime adapter code changes are made.
+
+## 6. Non-Goals
+
+1. No live adapter execution.
+2. No GitHub environment creation.
+3. No secret or credential handling.
+4. No workflow `environment:` binding.
+5. No support-tier promotion.
+6. No release, tag, or publish.
+
+## 7. Validation
+
+Required local validation:
+
+1. `git diff --check`
+2. `python3 scripts/gpp_next.py`
+3. `python3 scripts/gpp_next.py --output json`
+4. `pytest -q tests/test_gpp_next.py`
+5. `python3 -m ao_kernel doctor`
+

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -131,14 +131,19 @@ ayrı ayrı görünür kılmak.
 - **RI-5b post-closeout next-slice cleanup issue:** [#468](https://github.com/Halildeu/ao-kernel/issues/468) (`closes with this status cleanup PR`)
 - **GPP-0 production promotion tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470) (`closed by PR #471`)
 - **GPP-1 protected live-adapter prerequisite attestation:** `.claude/plans/GPP-1-PROTECTED-LIVE-ADAPTER-PREREQUISITE-ATTESTATION.md`
-- **GPP-1 issue:** [#472](https://github.com/Halildeu/ao-kernel/issues/472) (`open`)
+- **GPP-1 issue:** [#472](https://github.com/Halildeu/ao-kernel/issues/472) (`closed by PR #473`)
+- **GPP-1b agent operating program contract:** `.claude/plans/GPP-1b-AGENT-OPERATING-PROGRAM-CONTRACT.md`
+- **GPP machine-readable status:** `.claude/plans/gpp_status.v1.json`
+- **GPP-1b issue:** [#474](https://github.com/Halildeu/ao-kernel/issues/474) (`open`)
 - **Current mode:** stable maintenance + written general-purpose production
   promotion tracking. RI-5b is merged as Beta/operator-managed root export, not
-  a production platform claim. GPP-1 live attestation currently exits as
-  `blocked_attestation_missing`; no support widening, release, runtime adapter
-  promotion, or production claim is made by GPP-1. Future stable widening still
-  requires protected live-adapter evidence, repo-intelligence integration gates,
-  write-side rollback evidence, and an explicit closeout decision.
+  a production platform claim. GPP-1 live attestation exited as
+  `blocked_attestation_missing`. GPP-1b makes Codex/Claude operator sessions
+  read that blocked state from repo-owned program status before acting. No
+  support widening, release, runtime adapter promotion, or production claim is
+  made by GPP-1b. Future stable widening still requires protected live-adapter
+  evidence, repo-intelligence integration gates, write-side rollback evidence,
+  and an explicit closeout decision.
 
 ## 2. Başlangıç Gerçeği
 
@@ -211,7 +216,7 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — stable maintenance + GPP-0 tracking
+### Current mode — stable maintenance + GPP-1b operator contract
 
 `GP-3` parent promotion programı `close_keep_operator_beta` kararıyla
 kapanmıştır. `GP-4.1` workflow skeleton, `GP-4.2` evidence artifact,
@@ -239,6 +244,11 @@ sonraki tek aktif hat `GPP-1` protected live-adapter prerequisite olacaktır.
 kararındadır: `ao-kernel-live-adapter-gate` environment yoktur,
 `AO_CLAUDE_CODE_CLI_AUTH` secret handle attested değildir ve GPP-2 runtime
 binding hattı bu prerequisite kapanmadan başlamaz.
+
+`GPP-1b`, bu blocked runtime sonucunu değiştirmez. Amacı Codex ve Claude Code
+operatör oturumlarının `.claude/plans/gpp_status.v1.json` ve
+`scripts/gpp_next.py` üzerinden aynı aktif work package ve blocked gate
+gerçeğini okumasıdır.
 
 Mevcut yol:
 

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1",
+  "program_id": "general-purpose-production-promotion",
+  "program_title": "General-Purpose Production Promotion",
+  "authority_ref": "origin/main",
+  "authority_head_at_last_update": "0ad7209",
+  "status_file": ".claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md",
+  "post_beta_status_file": ".claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md",
+  "current_wp": {
+    "id": "GPP-1b",
+    "title": "Agent Operating Program Contract",
+    "status": "active",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/474",
+    "branch": "codex/gpp1b-agent-operating-program-contract",
+    "worktree": "/Users/halilkocoglu/Documents/ao-kernel-gpp1b-agent-operating-program-contract",
+    "exit_decision": "agent_operating_contract_ready_no_support_widening",
+    "allowed_scope": [
+      "agent instructions",
+      "program status",
+      "small helper script",
+      "tests",
+      "docs"
+    ]
+  },
+  "completed_wps": [
+    {
+      "id": "GPP-0",
+      "decision": "tracker_ready_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/470",
+      "pr": "https://github.com/Halildeu/ao-kernel/pull/471"
+    },
+    {
+      "id": "GPP-1",
+      "decision": "blocked_attestation_missing",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/472",
+      "pr": "https://github.com/Halildeu/ao-kernel/pull/473"
+    }
+  ],
+  "blocked_wps": [
+    {
+      "id": "GPP-2",
+      "title": "Protected Live-Adapter Gate Runtime Binding",
+      "reason": "ao-kernel-live-adapter-gate environment and AO_CLAUDE_CODE_CLI_AUTH handle are not attested",
+      "blocked_until": "GPP-1 can exit prerequisites_ready in a future attestation slice"
+    }
+  ],
+  "support_widening_allowed": false,
+  "production_platform_claim_allowed": false,
+  "live_adapter_execution_allowed": false,
+  "required_startup_checks": [
+    {
+      "id": "git_status",
+      "command": "git status --short --branch"
+    },
+    {
+      "id": "origin_divergence",
+      "command": "git rev-list --left-right --count HEAD...origin/main"
+    },
+    {
+      "id": "branch_preflight",
+      "command": "bash .claude/scripts/ops.sh preflight"
+    },
+    {
+      "id": "program_status",
+      "command": "python3 scripts/gpp_next.py"
+    }
+  ],
+  "required_workflow": [
+    "read GPP status",
+    "open one issue",
+    "create one dedicated worktree",
+    "create one short-lived branch",
+    "change only the active work-package scope",
+    "run validation",
+    "commit and push",
+    "open one PR",
+    "wait for CI",
+    "merge only after checks are green",
+    "fast-forward main from origin/main",
+    "remove merged worktree and branch"
+  ],
+  "forbidden_actions": [
+    "work from stale local main",
+    "pull or rebase with uncommitted changes",
+    "edit feature/runtime scope in primary checkout",
+    "treat local operator auth as production evidence",
+    "start GPP-2 runtime binding while GPP-2 is blocked",
+    "set support_widening=true without explicit GPP-9 promotion decision",
+    "set production_platform_claim=true without explicit GPP-9 promotion decision"
+  ],
+  "next_allowed_actions": [
+    "complete GPP-1b docs/status/script/test PR",
+    "keep GPP-2 blocked",
+    "open a future admin/provisioning attestation slice only after protected prerequisites exist"
+  ],
+  "last_updated": "2026-04-25"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# Agent Operating Contract
+
+Bu repo'da Codex ve Claude Code aynı program kontratını takip eder. Ajanlar
+sohbet hafızasına veya tahmine göre sıradaki işi seçmez.
+
+## Zorunlu Başlangıç
+
+Her yeni oturumda, kod veya doküman değiştirmeden önce:
+
+```bash
+git status --short --branch
+git rev-list --left-right --count HEAD...origin/main
+bash .claude/scripts/ops.sh preflight
+python3 scripts/gpp_next.py
+```
+
+Son komut GPP programının aktif work package'ını, blocked hatları ve izinli
+sonraki adımı gösterir.
+
+## Çalışma Kuralı
+
+1. `origin/main` merge sonrası tek authority'dir.
+2. Her iş ayrı worktree ve short-lived `codex/*` branch üzerinde yürür; farklı
+   prefix yalnız açık onayla kullanılır, `claude/*` branch'leri kullanılmaz.
+3. Her work package tek issue, tek branch, tek PR ve tek exit decision üretir.
+4. Primary checkout sadece `main` sync ve doğrulama içindir; feature/runtime
+   editleri primary checkout üstünde yapılmaz.
+5. Aynı anda GPP status dosyasında izin verilen aktif iş dışında runtime veya
+   support-widening işi başlatılmaz.
+6. Merge sonrası `origin/main` fast-forward edilir, worktree ve branch
+   temizlenir.
+
+## Yasaklar
+
+1. Dirty worktree ile `pull`, `rebase`, `switch`, `checkout` veya worktree
+   remove yapılmaz.
+2. Local/operator smoke production evidence sayılmaz.
+3. Docs-only PR ile support tier genişletilmez.
+4. `support_widening=true` veya `production_platform_claim=true` yalnız GPP
+   full matrix ve explicit closeout kararı olmadan yazılmaz.
+5. GPP-2 live-adapter runtime binding, `GPP-1`/`GPP-1b` kararları aşılmadan
+   başlatılmaz.
+
+## Current Program
+
+Makine-okunur durum:
+
+```text
+.claude/plans/gpp_status.v1.json
+```
+
+İnsan-okur SSOT:
+
+```text
+.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+```
+
+Aktif kontrat:
+
+```text
+GPP-1b - Agent Operating Program Contract
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -628,3 +628,34 @@ Repo-side merge governance özeti:
    Runtime closure tamamlanmadan anlatı genişletilmez. Bir yüzey ancak
    code path + davranışsal test + packaging smoke + support matrix birlikte
    mevcutsa "destekli" kabul edilir.
+
+## 21. GPP Agent Operating Contract (2026-04-25)
+
+Codex ve Claude Code, general-purpose production promotion programında sıradaki
+işi sohbet hafızasından değil repo içi SSOT'lardan okur.
+
+Zorunlu başlangıç:
+
+```bash
+git status --short --branch
+git rev-list --left-right --count HEAD...origin/main
+bash .claude/scripts/ops.sh preflight
+python3 scripts/gpp_next.py
+```
+
+SSOT dosyaları:
+
+- İnsan-okur program status: `.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md`
+- Makine-okur program status: `.claude/plans/gpp_status.v1.json`
+- Ajan startup kontratı: `AGENTS.md`
+
+Kurallar:
+
+1. Aktif GPP work package dışında runtime/support-widening işi başlatılmaz.
+2. `scripts/gpp_next.py` `GPP-2` veya başka bir hattı blocked gösteriyorsa
+   ajan o hattı kodlamaz; önce blocked kararını değiştirecek kanıt gerekir.
+3. `support_widening_allowed=false` ve `production_platform_claim_allowed=false`
+   değerleri yalnız explicit GPP full-matrix promotion PR'ı ile değişebilir.
+4. Local/operator smoke, project-owned production evidence sayılmaz.
+5. Her GPP slice tek issue, tek dedicated worktree, tek short-lived branch, tek
+   PR ve tek exit decision ile kapanır.

--- a/scripts/gpp_next.py
+++ b/scripts/gpp_next.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Print the active GPP work package for Codex/Claude operator sessions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_STATUS_PATH = Path(".claude/plans/gpp_status.v1.json")
+
+
+class GppStatusError(RuntimeError):
+    """Raised when the GPP status file is missing or malformed."""
+
+
+def repo_root_from_script() -> Path:
+    """Return the repository root based on this script path."""
+
+    return Path(__file__).resolve().parents[1]
+
+
+def load_status(path: Path) -> dict[str, Any]:
+    """Load and minimally validate the GPP status payload."""
+
+    if not path.exists():
+        raise GppStatusError(f"GPP status file not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise GppStatusError("GPP status payload must be a JSON object")
+
+    required = (
+        "schema_version",
+        "program_id",
+        "authority_ref",
+        "current_wp",
+        "blocked_wps",
+        "support_widening_allowed",
+        "production_platform_claim_allowed",
+        "live_adapter_execution_allowed",
+        "required_startup_checks",
+        "required_workflow",
+        "forbidden_actions",
+        "next_allowed_actions",
+    )
+    missing = [key for key in required if key not in payload]
+    if missing:
+        raise GppStatusError(f"GPP status missing required keys: {', '.join(missing)}")
+
+    current_wp = payload["current_wp"]
+    if not isinstance(current_wp, dict) or not current_wp.get("id") or not current_wp.get("title"):
+        raise GppStatusError("GPP status current_wp must include id and title")
+
+    for guard in ("support_widening_allowed", "production_platform_claim_allowed", "live_adapter_execution_allowed"):
+        if payload[guard] is not False:
+            raise GppStatusError(f"{guard} must be false until an explicit promotion decision")
+
+    if not isinstance(payload["blocked_wps"], list):
+        raise GppStatusError("blocked_wps must be a list")
+
+    return payload
+
+
+def run_git_summary(repo_root: Path) -> dict[str, str]:
+    """Return non-fatal git status signals for operator startup."""
+
+    commands = {
+        "status": ["git", "status", "--short", "--branch"],
+        "divergence": ["git", "rev-list", "--left-right", "--count", "HEAD...origin/main"],
+        "origin_head": ["git", "rev-parse", "--short", "origin/main"],
+    }
+    summary: dict[str, str] = {}
+    for key, command in commands.items():
+        completed = subprocess.run(
+            command,
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode == 0:
+            summary[key] = completed.stdout.strip()
+        else:
+            summary[key] = f"unavailable: {completed.stderr.strip() or completed.returncode}"
+    return summary
+
+
+def render_text(payload: dict[str, Any], *, git_summary: dict[str, str] | None = None) -> str:
+    """Render a concise operator-facing status report."""
+
+    current_wp = payload["current_wp"]
+    blocked_wps = payload["blocked_wps"]
+    lines = [
+        f"Program: {payload.get('program_title', payload['program_id'])}",
+        f"Authority ref: {payload['authority_ref']}",
+        f"Authority head at last update: {payload.get('authority_head_at_last_update', 'unknown')}",
+        f"Active WP: {current_wp['id']} - {current_wp['title']}",
+        f"Active status: {current_wp.get('status', 'unknown')}",
+        f"Exit decision: {current_wp.get('exit_decision', 'unset')}",
+        f"Support widening allowed: {str(payload['support_widening_allowed']).lower()}",
+        f"Production platform claim allowed: {str(payload['production_platform_claim_allowed']).lower()}",
+        f"Live adapter execution allowed: {str(payload['live_adapter_execution_allowed']).lower()}",
+        "",
+        "Blocked work packages:",
+    ]
+
+    if blocked_wps:
+        for item in blocked_wps:
+            lines.append(f"- {item['id']}: {item['reason']}")
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "Required startup checks:"])
+    for item in payload["required_startup_checks"]:
+        lines.append(f"- {item['id']}: {item['command']}")
+
+    lines.extend(["", "Next allowed actions:"])
+    for action in payload["next_allowed_actions"]:
+        lines.append(f"- {action}")
+
+    lines.extend(["", "Forbidden actions:"])
+    for action in payload["forbidden_actions"]:
+        lines.append(f"- {action}")
+
+    if git_summary is not None:
+        lines.extend(["", "Current git signals:"])
+        lines.append(git_summary.get("status", "status unavailable"))
+        lines.append(f"divergence: {git_summary.get('divergence', 'unavailable')}")
+        lines.append(f"origin/main head: {git_summary.get('origin_head', 'unavailable')}")
+
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--status-path", type=Path, default=None, help="Path to gpp_status.v1.json")
+    parser.add_argument("--repo-root", type=Path, default=None, help="Repository root for git summary")
+    parser.add_argument("--output", choices=("text", "json"), default="text", help="Output format")
+    parser.add_argument("--skip-git", action="store_true", help="Do not collect git summary")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root.resolve() if args.repo_root else repo_root_from_script()
+    status_path = args.status_path.resolve() if args.status_path else repo_root / DEFAULT_STATUS_PATH
+
+    try:
+        payload = load_status(status_path)
+    except (GppStatusError, json.JSONDecodeError) as exc:
+        print(f"gpp_next: {exc}", file=sys.stderr)
+        return 2
+
+    if args.output == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    git_summary = None if args.skip_git else run_git_summary(repo_root)
+    print(render_text(payload, git_summary=git_summary), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _module() -> Any:
+    module_path = _repo_root() / "scripts" / "gpp_next.py"
+    spec = importlib.util.spec_from_file_location("gpp_next", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _status_path() -> Path:
+    return _repo_root() / ".claude" / "plans" / "gpp_status.v1.json"
+
+
+def test_gpp_status_contract_keeps_support_widening_closed() -> None:
+    payload = json.loads(_status_path().read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == "1"
+    assert payload["program_id"] == "general-purpose-production-promotion"
+    assert payload["current_wp"]["id"] == "GPP-1b"
+    assert payload["current_wp"]["status"] == "active"
+    assert payload["current_wp"]["exit_decision"] == "agent_operating_contract_ready_no_support_widening"
+    assert payload["support_widening_allowed"] is False
+    assert payload["production_platform_claim_allowed"] is False
+    assert payload["live_adapter_execution_allowed"] is False
+    assert {item["id"] for item in payload["blocked_wps"]} == {"GPP-2"}
+    assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
+
+
+def test_gpp_next_load_status_validates_required_guards() -> None:
+    mod = _module()
+
+    payload = mod.load_status(_status_path())
+
+    assert payload["current_wp"]["id"] == "GPP-1b"
+    assert payload["blocked_wps"][0]["id"] == "GPP-2"
+    assert payload["support_widening_allowed"] is False
+
+
+def test_gpp_next_rejects_fake_support_widening(tmp_path: Path) -> None:
+    mod = _module()
+    payload = json.loads(_status_path().read_text(encoding="utf-8"))
+    payload["support_widening_allowed"] = True
+    status_path = tmp_path / "gpp_status.v1.json"
+    status_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    try:
+        mod.load_status(status_path)
+    except mod.GppStatusError as exc:
+        assert "support_widening_allowed must be false" in str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("expected GppStatusError for fake support widening")
+
+
+def test_gpp_next_text_output_names_active_and_blocked_work() -> None:
+    mod = _module()
+    payload = mod.load_status(_status_path())
+
+    rendered = mod.render_text(payload, git_summary={"status": "## main...origin/main", "divergence": "0\t0"})
+
+    assert "Active WP: GPP-1b - Agent Operating Program Contract" in rendered
+    assert "Support widening allowed: false" in rendered
+    assert "Production platform claim allowed: false" in rendered
+    assert "Live adapter execution allowed: false" in rendered
+    assert "- GPP-2: ao-kernel-live-adapter-gate environment" in rendered
+    assert "divergence: 0\t0" in rendered
+
+
+def test_gpp_next_cli_json_output(capsys: Any) -> None:
+    mod = _module()
+
+    result = mod.main(["--status-path", str(_status_path()), "--output", "json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert result == 0
+    assert payload["current_wp"]["id"] == "GPP-1b"
+    assert payload["blocked_wps"][0]["id"] == "GPP-2"
+


### PR DESCRIPTION
## Summary
- add AGENTS.md startup contract for Codex and Claude Code operator sessions
- add machine-readable GPP status plus scripts/gpp_next.py helper
- update GPP/post-beta status docs and CLAUDE.md to keep GPP-2 blocked until protected prerequisites exist
- add tests that pin the active WP, blocked WP, and support-widening guards

## Validation
- git diff --check
- python3 scripts/gpp_next.py
- python3 scripts/gpp_next.py --output json
- pytest -q tests/test_gpp_next.py tests/test_gp5_platform_claim_decision.py
- python3 -m ao_kernel doctor

## Scope
- no runtime adapter changes
- no live adapter execution
- no GitHub environment or secret provisioning
- no support-tier widening
- no release/tag/publish

Closes #474