### PR TITLE
[codex] close out GPP agent contract status

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,14 +1,14 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-1b agent operating program contract active
+**Status:** GPP-2 blocked after GPP-1b contract merge
 **Date:** 2026-04-25
-**Authority:** `origin/main` at `0ad7209`
+**Authority:** `origin/main` at `c579089`
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#474](https://github.com/Halildeu/ao-kernel/issues/474)
-**Current slice record:** `.claude/plans/GPP-1b-AGENT-OPERATING-PROGRAM-CONTRACT.md`
+**Current slice issue:** none active; GPP-2 is blocked
+**Current slice record:** `.claude/plans/gpp_status.v1.json`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
-**Branch:** `codex/gpp1b-agent-operating-program-contract`
-**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp1b-agent-operating-program-contract`
+**Branch:** none active
+**Worktree:** none active
 **Mode:** written, trackable, fail-closed promotion program
 **Support impact:** none
 **Release impact:** none
@@ -60,8 +60,8 @@ Last live verification on current `origin/main` showed:
     `workflow_dispatch` among live-gate trigger/secret/environment grep terms;
     no `environment:`, `secrets.`, `pull_request`, or `pull_request_target`
     binding is present.
-17. GPP-1b adds a machine-readable operator contract so Codex and Claude Code
-    read the same active work package and blocked gates from repo state instead
+17. GPP-1b added a machine-readable operator contract so Codex and Claude Code
+    read the same current work package and blocked gates from repo state instead
     of chat memory.
 
 ## 3. Current Verdict
@@ -101,7 +101,7 @@ The final production claim stays closed until `GPP-9` passes.
 |---|---|---|---|
 | `GPP-0` | Completed | Create written tracker and acceptance model | `tracker_ready_no_support_widening` |
 | `GPP-1` | Completed | Protected live-adapter prerequisite attestation | `blocked_attestation_missing` |
-| `GPP-1b` | Active | Agent operating program contract | `agent_operating_contract_ready_no_support_widening` |
+| `GPP-1b` | Completed | Agent operating program contract | `agent_operating_contract_ready_no_support_widening` |
 | `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until `GPP-1` can exit `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -197,7 +197,7 @@ any workflow binding or support promotion.
 **Goal:** Make Codex and Claude Code follow the repo-owned GPP program state
 before choosing or implementing the next work package.
 
-**Status:** active.
+**Status:** completed by PR [#475](https://github.com/Halildeu/ao-kernel/pull/475).
 
 **Exit decision target:** `agent_operating_contract_ready_no_support_widening`.
 
@@ -205,13 +205,13 @@ before choosing or implementing the next work package.
 
 1. Add `AGENTS.md` startup and execution contract.
 2. Add `.claude/plans/gpp_status.v1.json` as the machine-readable GPP status.
-3. Add `scripts/gpp_next.py` to print the active WP and blocked gates.
-4. Add tests that pin the active WP, blocked WP, and no-widening guards.
+3. Add `scripts/gpp_next.py` to print the current/active WP and blocked gates.
+4. Add tests that pin the current WP, blocked WP, and no-widening guards.
 5. Keep `GPP-2` blocked.
 
 **Acceptance criteria:**
 
-1. `python3 scripts/gpp_next.py` reports `GPP-1b` as active.
+1. `python3 scripts/gpp_next.py` reports `GPP-2` as blocked after the merge.
 2. `python3 scripts/gpp_next.py --output json` returns valid JSON.
 3. `support_widening_allowed`, `production_platform_claim_allowed`, and
    `live_adapter_execution_allowed` are all `false`.
@@ -480,17 +480,10 @@ accident.
 
 ## 17. Current Active Work
 
-The active work is `GPP-1b`.
-
-GPP-1b target exit is:
-
-```text
-agent_operating_contract_ready_no_support_widening
-```
-
-No runtime/support-widening work should start from `GPP-2` until a future
-attestation proves `ao-kernel-live-adapter-gate` and
-`AO_CLAUDE_CODE_CLI_AUTH` are present and fork-safe.
+No runtime/support-widening work is active. `GPP-2` is the current blocked
+program head and must not start until a future attestation proves
+`ao-kernel-live-adapter-gate` and `AO_CLAUDE_CODE_CLI_AUTH` are present and
+fork-safe.
 
 ## 18. Risk Register
 
@@ -514,4 +507,6 @@ attestation proves `ao-kernel-live-adapter-gate` and
 | 2026-04-25 | GPP-1 attestation recorded | Live GitHub environment/secret evidence keeps GPP-1 at `blocked_attestation_missing`; GPP-2 remains blocked. |
 | 2026-04-25 | GPP-1 merged | PR [#473](https://github.com/Halildeu/ao-kernel/pull/473) merged at `0ad7209`; protected live-adapter prerequisite remains blocked. |
 | 2026-04-25 | GPP-1b issue opened | Issue [#474](https://github.com/Halildeu/ao-kernel/issues/474) created for agent operating program contract. |
-| 2026-04-25 | GPP-1b contract added | `AGENTS.md`, `.claude/plans/gpp_status.v1.json`, and `scripts/gpp_next.py` make the active program state machine-readable for Codex/Claude operator sessions. |
+| 2026-04-25 | GPP-1b contract added | `AGENTS.md`, `.claude/plans/gpp_status.v1.json`, and `scripts/gpp_next.py` make the current program state machine-readable for Codex/Claude operator sessions. |
+| 2026-04-25 | GPP-1b merged | PR [#475](https://github.com/Halildeu/ao-kernel/pull/475) merged at `c579089`; status now holds at `GPP-2` blocked. |
+| 2026-04-25 | GPP-1c issue opened | Issue [#476](https://github.com/Halildeu/ao-kernel/issues/476) tracks this status closeout so operator sessions do not see stale `GPP-1b active` state. |

--- a/.claude/plans/GPP-1b-AGENT-OPERATING-PROGRAM-CONTRACT.md
+++ b/.claude/plans/GPP-1b-AGENT-OPERATING-PROGRAM-CONTRACT.md
@@ -1,11 +1,11 @@
 # GPP-1b - Agent Operating Program Contract
 
-**Status:** active
+**Status:** completed by PR [#475](https://github.com/Halildeu/ao-kernel/pull/475)
 **Date:** 2026-04-25
 **Parent tracker:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
 **Slice issue:** [#474](https://github.com/Halildeu/ao-kernel/issues/474)
-**Branch:** `codex/gpp1b-agent-operating-program-contract`
-**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp1b-agent-operating-program-contract`
+**Branch:** `codex/gpp1b-agent-operating-program-contract` (merged)
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp1b-agent-operating-program-contract` (removed after merge)
 **Base authority:** `origin/main` at `0ad7209`
 **Target exit decision:** `agent_operating_contract_ready_no_support_widening`
 **Support impact:** none
@@ -85,4 +85,3 @@ Required local validation:
 3. `python3 scripts/gpp_next.py --output json`
 4. `pytest -q tests/test_gpp_next.py`
 5. `python3 -m ao_kernel doctor`
-

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -134,14 +134,16 @@ ayrı ayrı görünür kılmak.
 - **GPP-1 issue:** [#472](https://github.com/Halildeu/ao-kernel/issues/472) (`closed by PR #473`)
 - **GPP-1b agent operating program contract:** `.claude/plans/GPP-1b-AGENT-OPERATING-PROGRAM-CONTRACT.md`
 - **GPP machine-readable status:** `.claude/plans/gpp_status.v1.json`
-- **GPP-1b issue:** [#474](https://github.com/Halildeu/ao-kernel/issues/474) (`open`)
+- **GPP-1b issue:** [#474](https://github.com/Halildeu/ao-kernel/issues/474) (`closed by PR #475`)
+- **GPP-1c status closeout issue:** [#476](https://github.com/Halildeu/ao-kernel/issues/476) (`open`)
 - **Current mode:** stable maintenance + written general-purpose production
   promotion tracking. RI-5b is merged as Beta/operator-managed root export, not
   a production platform claim. GPP-1 live attestation exited as
-  `blocked_attestation_missing`. GPP-1b makes Codex/Claude operator sessions
-  read that blocked state from repo-owned program status before acting. No
-  support widening, release, runtime adapter promotion, or production claim is
-  made by GPP-1b. Future stable widening still requires protected live-adapter
+  `blocked_attestation_missing`. GPP-1b is merged and makes Codex/Claude
+  operator sessions read that blocked state from repo-owned program status
+  before acting. Current program status holds at `GPP-2` blocked. No support
+  widening, release, runtime adapter promotion, or production claim is made by
+  GPP-1b/GPP-1c. Future stable widening still requires protected live-adapter
   evidence, repo-intelligence integration gates, write-side rollback evidence,
   and an explicit closeout decision.
 
@@ -216,7 +218,7 @@ ayrı ayrı görünür kılmak.
 
 ## 5. Şimdi
 
-### Current mode — stable maintenance + GPP-1b operator contract
+### Current mode — stable maintenance + GPP-2 blocked
 
 `GP-3` parent promotion programı `close_keep_operator_beta` kararıyla
 kapanmıştır. `GP-4.1` workflow skeleton, `GP-4.2` evidence artifact,
@@ -247,7 +249,7 @@ binding hattı bu prerequisite kapanmadan başlamaz.
 
 `GPP-1b`, bu blocked runtime sonucunu değiştirmez. Amacı Codex ve Claude Code
 operatör oturumlarının `.claude/plans/gpp_status.v1.json` ve
-`scripts/gpp_next.py` üzerinden aynı aktif work package ve blocked gate
+`scripts/gpp_next.py` üzerinden aynı current work package ve blocked gate
 gerçeğini okumasıdır.
 
 Mevcut yol:

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -3,24 +3,17 @@
   "program_id": "general-purpose-production-promotion",
   "program_title": "General-Purpose Production Promotion",
   "authority_ref": "origin/main",
-  "authority_head_at_last_update": "0ad7209",
+  "authority_head_at_last_update": "c579089",
   "status_file": ".claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md",
   "post_beta_status_file": ".claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md",
   "current_wp": {
-    "id": "GPP-1b",
-    "title": "Agent Operating Program Contract",
-    "status": "active",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/474",
-    "branch": "codex/gpp1b-agent-operating-program-contract",
-    "worktree": "/Users/halilkocoglu/Documents/ao-kernel-gpp1b-agent-operating-program-contract",
-    "exit_decision": "agent_operating_contract_ready_no_support_widening",
-    "allowed_scope": [
-      "agent instructions",
-      "program status",
-      "small helper script",
-      "tests",
-      "docs"
-    ]
+    "id": "GPP-2",
+    "title": "Protected Live-Adapter Gate Runtime Binding",
+    "status": "blocked",
+    "issue": null,
+    "exit_decision": "blocked_attestation_missing",
+    "blocked_until": "a future prerequisite attestation proves the protected environment and credential handle exist",
+    "allowed_scope": []
   },
   "completed_wps": [
     {
@@ -34,6 +27,12 @@
       "decision": "blocked_attestation_missing",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/472",
       "pr": "https://github.com/Halildeu/ao-kernel/pull/473"
+    },
+    {
+      "id": "GPP-1b",
+      "decision": "agent_operating_contract_ready_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/474",
+      "pr": "https://github.com/Halildeu/ao-kernel/pull/475"
     }
   ],
   "blocked_wps": [
@@ -89,9 +88,9 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "complete GPP-1b docs/status/script/test PR",
     "keep GPP-2 blocked",
-    "open a future admin/provisioning attestation slice only after protected prerequisites exist"
+    "open a future admin/provisioning attestation slice only after protected prerequisites exist",
+    "do not widen support or claim production platform readiness"
   ],
   "last_updated": "2026-04-25"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@ bash .claude/scripts/ops.sh preflight
 python3 scripts/gpp_next.py
 ```
 
-Son komut GPP programının aktif work package'ını, blocked hatları ve izinli
-sonraki adımı gösterir.
+Son komut GPP programının current/active work package'ını, blocked hatları ve
+izinli sonraki adımı gösterir.
 
 ## Çalışma Kuralı
 
@@ -25,8 +25,8 @@ sonraki adımı gösterir.
 3. Her work package tek issue, tek branch, tek PR ve tek exit decision üretir.
 4. Primary checkout sadece `main` sync ve doğrulama içindir; feature/runtime
    editleri primary checkout üstünde yapılmaz.
-5. Aynı anda GPP status dosyasında izin verilen aktif iş dışında runtime veya
-   support-widening işi başlatılmaz.
+5. GPP status dosyası blocked durum gösteriyorsa runtime veya support-widening
+   işi başlatılmaz.
 6. Merge sonrası `origin/main` fast-forward edilir, worktree ve branch
    temizlenir.
 
@@ -38,8 +38,8 @@ sonraki adımı gösterir.
 3. Docs-only PR ile support tier genişletilmez.
 4. `support_widening=true` veya `production_platform_claim=true` yalnız GPP
    full matrix ve explicit closeout kararı olmadan yazılmaz.
-5. GPP-2 live-adapter runtime binding, `GPP-1`/`GPP-1b` kararları aşılmadan
-   başlatılmaz.
+5. GPP-2 live-adapter runtime binding, protected prerequisite attestation
+   `prerequisites_ready` olmadan başlatılmaz.
 
 ## Current Program
 
@@ -55,8 +55,8 @@ Makine-okunur durum:
 .claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
 ```
 
-Aktif kontrat:
+Current program head:
 
 ```text
-GPP-1b - Agent Operating Program Contract
+GPP-2 - Protected Live-Adapter Gate Runtime Binding (blocked)
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -651,7 +651,8 @@ SSOT dosyaları:
 
 Kurallar:
 
-1. Aktif GPP work package dışında runtime/support-widening işi başlatılmaz.
+1. GPP status dosyasında current/active work package okunmadan
+   runtime/support-widening işi başlatılmaz.
 2. `scripts/gpp_next.py` `GPP-2` veya başka bir hattı blocked gösteriyorsa
    ajan o hattı kodlamaz; önce blocked kararını değiştirecek kanıt gerekir.
 3. `support_widening_allowed=false` ve `production_platform_claim_allowed=false`

--- a/scripts/gpp_next.py
+++ b/scripts/gpp_next.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Print the active GPP work package for Codex/Claude operator sessions."""
+"""Print the current GPP work package for Codex/Claude operator sessions."""
 
 from __future__ import annotations
 
@@ -94,12 +94,14 @@ def render_text(payload: dict[str, Any], *, git_summary: dict[str, str] | None =
 
     current_wp = payload["current_wp"]
     blocked_wps = payload["blocked_wps"]
+    current_label = "Active WP" if current_wp.get("status") == "active" else "Current WP"
+    status_label = "Active status" if current_wp.get("status") == "active" else "Current status"
     lines = [
         f"Program: {payload.get('program_title', payload['program_id'])}",
         f"Authority ref: {payload['authority_ref']}",
         f"Authority head at last update: {payload.get('authority_head_at_last_update', 'unknown')}",
-        f"Active WP: {current_wp['id']} - {current_wp['title']}",
-        f"Active status: {current_wp.get('status', 'unknown')}",
+        f"{current_label}: {current_wp['id']} - {current_wp['title']}",
+        f"{status_label}: {current_wp.get('status', 'unknown')}",
         f"Exit decision: {current_wp.get('exit_decision', 'unset')}",
         f"Support widening allowed: {str(payload['support_widening_allowed']).lower()}",
         f"Production platform claim allowed: {str(payload['production_platform_claim_allowed']).lower()}",

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -28,9 +28,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
 
     assert payload["schema_version"] == "1"
     assert payload["program_id"] == "general-purpose-production-promotion"
-    assert payload["current_wp"]["id"] == "GPP-1b"
-    assert payload["current_wp"]["status"] == "active"
-    assert payload["current_wp"]["exit_decision"] == "agent_operating_contract_ready_no_support_widening"
+    assert payload["current_wp"]["id"] == "GPP-2"
+    assert payload["current_wp"]["status"] == "blocked"
+    assert payload["current_wp"]["exit_decision"] == "blocked_attestation_missing"
+    assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -43,7 +44,8 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     payload = mod.load_status(_status_path())
 
-    assert payload["current_wp"]["id"] == "GPP-1b"
+    assert payload["current_wp"]["id"] == "GPP-2"
+    assert payload["current_wp"]["status"] == "blocked"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
     assert payload["support_widening_allowed"] is False
 
@@ -63,13 +65,14 @@ def test_gpp_next_rejects_fake_support_widening(tmp_path: Path) -> None:
         raise AssertionError("expected GppStatusError for fake support widening")
 
 
-def test_gpp_next_text_output_names_active_and_blocked_work() -> None:
+def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     mod = _module()
     payload = mod.load_status(_status_path())
 
     rendered = mod.render_text(payload, git_summary={"status": "## main...origin/main", "divergence": "0\t0"})
 
-    assert "Active WP: GPP-1b - Agent Operating Program Contract" in rendered
+    assert "Current WP: GPP-2 - Protected Live-Adapter Gate Runtime Binding" in rendered
+    assert "Current status: blocked" in rendered
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
@@ -85,6 +88,6 @@ def test_gpp_next_cli_json_output(capsys: Any) -> None:
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert result == 0
-    assert payload["current_wp"]["id"] == "GPP-1b"
+    assert payload["current_wp"]["id"] == "GPP-2"
+    assert payload["current_wp"]["status"] == "blocked"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
-


### PR DESCRIPTION
## Summary
- mark GPP-1b completed after PR #475
- make gpp_status.v1.json and scripts/gpp_next.py report GPP-2 as blocked
- update AGENTS/CLAUDE/status docs so operator sessions do not see stale GPP-1b active state
- update tests to pin GPP-2 blocked and no support widening

## Validation
- git diff --check
- python3 scripts/gpp_next.py
- python3 scripts/gpp_next.py --output json | python3 -m json.tool
- pytest -q tests/test_gpp_next.py tests/test_gp5_platform_claim_decision.py
- python3 -m ao_kernel doctor

## Scope
- no runtime adapter changes
- no live adapter execution
- no protected environment or secret provisioning
- no support-tier widening
- no release/tag/publish

Closes #476