### PR TITLE
[codex] use live authority head in GPP status

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -2,7 +2,8 @@
 
 **Status:** GPP-2 blocked after GPP-1b contract merge
 **Date:** 2026-04-25
-**Authority:** `origin/main` at `c579089`
+**Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
+the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
 **Current slice issue:** none active; GPP-2 is blocked
 **Current slice record:** `.claude/plans/gpp_status.v1.json`
@@ -510,3 +511,4 @@ fork-safe.
 | 2026-04-25 | GPP-1b contract added | `AGENTS.md`, `.claude/plans/gpp_status.v1.json`, and `scripts/gpp_next.py` make the current program state machine-readable for Codex/Claude operator sessions. |
 | 2026-04-25 | GPP-1b merged | PR [#475](https://github.com/Halildeu/ao-kernel/pull/475) merged at `c579089`; status now holds at `GPP-2` blocked. |
 | 2026-04-25 | GPP-1c issue opened | Issue [#476](https://github.com/Halildeu/ao-kernel/issues/476) tracks this status closeout so operator sessions do not see stale `GPP-1b active` state. |
+| 2026-04-25 | GPP-1d issue opened | Issue [#478](https://github.com/Halildeu/ao-kernel/issues/478) tracks removal of moving authority SHAs from live status so merge commits do not create stale SSOT drift. |

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -135,7 +135,8 @@ ayrı ayrı görünür kılmak.
 - **GPP-1b agent operating program contract:** `.claude/plans/GPP-1b-AGENT-OPERATING-PROGRAM-CONTRACT.md`
 - **GPP machine-readable status:** `.claude/plans/gpp_status.v1.json`
 - **GPP-1b issue:** [#474](https://github.com/Halildeu/ao-kernel/issues/474) (`closed by PR #475`)
-- **GPP-1c status closeout issue:** [#476](https://github.com/Halildeu/ao-kernel/issues/476) (`open`)
+- **GPP-1c status closeout issue:** [#476](https://github.com/Halildeu/ao-kernel/issues/476) (`closed by PR #477`)
+- **GPP-1d authority-head cleanup issue:** [#478](https://github.com/Halildeu/ao-kernel/issues/478) (`open`)
 - **Current mode:** stable maintenance + written general-purpose production
   promotion tracking. RI-5b is merged as Beta/operator-managed root export, not
   a production platform claim. GPP-1 live attestation exited as

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -3,7 +3,6 @@
   "program_id": "general-purpose-production-promotion",
   "program_title": "General-Purpose Production Promotion",
   "authority_ref": "origin/main",
-  "authority_head_at_last_update": "c579089",
   "status_file": ".claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md",
   "post_beta_status_file": ".claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md",
   "current_wp": {

--- a/scripts/gpp_next.py
+++ b/scripts/gpp_next.py
@@ -99,7 +99,6 @@ def render_text(payload: dict[str, Any], *, git_summary: dict[str, str] | None =
     lines = [
         f"Program: {payload.get('program_title', payload['program_id'])}",
         f"Authority ref: {payload['authority_ref']}",
-        f"Authority head at last update: {payload.get('authority_head_at_last_update', 'unknown')}",
         f"{current_label}: {current_wp['id']} - {current_wp['title']}",
         f"{status_label}: {current_wp.get('status', 'unknown')}",
         f"Exit decision: {current_wp.get('exit_decision', 'unset')}",
@@ -133,6 +132,9 @@ def render_text(payload: dict[str, Any], *, git_summary: dict[str, str] | None =
         lines.append(git_summary.get("status", "status unavailable"))
         lines.append(f"divergence: {git_summary.get('divergence', 'unavailable')}")
         lines.append(f"origin/main head: {git_summary.get('origin_head', 'unavailable')}")
+
+    if payload.get("authority_head_at_last_update"):
+        lines.extend(["", f"Authority head at last status edit: {payload['authority_head_at_last_update']}"])
 
     return "\n".join(lines) + "\n"
 


### PR DESCRIPTION
## Summary
- remove moving authority SHA from live GPP status JSON/header
- keep origin/main as authority ref and rely on gpp_next live git summary for current head
- record GPP-1d tracking issue in status docs

## Validation
- git diff --check
- python3 scripts/gpp_next.py
- pytest -q tests/test_gpp_next.py tests/test_gp5_platform_claim_decision.py
- rg confirms no static authority SHA remains in live GPP status JSON/header

## Scope
- no runtime adapter changes
- no live adapter execution
- no protected environment or secret provisioning
- no support widening
- no release/tag/publish

Closes #478