### PR TITLE
[codex] re-attest GPP live-adapter prerequisites

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,6 +1,6 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 blocked after GPP-1b contract merge
+**Status:** GPP-2 blocked after GPP-2a prerequisite re-attestation
 **Date:** 2026-04-25
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
@@ -41,7 +41,7 @@ Last live verification on current `origin/main` showed:
    `support_widening=false`, and `production_platform_claim=false`.
 7. `live_adapter_gate_contract.py` returned `overall_status=blocked` because
    the protected live-adapter gate is still design-only.
-8. GitHub environment inventory showed only `pypi`; the required
+8. GitHub environment inventory still showed only `pypi`; the required
    `ao-kernel-live-adapter-gate` environment is not present.
 9. `AO_CLAUDE_CODE_CLI_AUTH` was not attested as a repository or environment
    secret handle.
@@ -64,6 +64,9 @@ Last live verification on current `origin/main` showed:
 17. GPP-1b added a machine-readable operator contract so Codex and Claude Code
     read the same current work package and blocked gates from repo state instead
     of chat memory.
+18. GPP-2a re-attestation on 2026-04-25 reconfirmed the same blocker:
+    `ao-kernel-live-adapter-gate` is absent, environment secret lookup returns
+    `HTTP 404`, and `AO_CLAUDE_CODE_CLI_AUTH` is not project-owned/attested.
 
 ## 3. Current Verdict
 
@@ -103,7 +106,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-0` | Completed | Create written tracker and acceptance model | `tracker_ready_no_support_widening` |
 | `GPP-1` | Completed | Protected live-adapter prerequisite attestation | `blocked_attestation_missing` |
 | `GPP-1b` | Completed | Agent operating program contract | `agent_operating_contract_ready_no_support_widening` |
-| `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until `GPP-1` can exit `prerequisites_ready` |
+| `GPP-2a` | Completed | Protected live-adapter prerequisite re-attestation | `still_blocked_protected_prerequisites_missing` |
+| `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until a future attestation exits `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -229,15 +233,15 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked by GPP-1.
+**Status:** blocked by GPP-2a re-attestation.
 
 **Entry criteria:**
 
 1. `GPP-1` exit decision is `prerequisites_ready`.
 2. Protected environment and credential handle are attested.
 
-Current GPP-1 exit decision is `blocked_attestation_missing`, so GPP-2 cannot
-start yet.
+Current GPP-2a exit decision is
+`still_blocked_protected_prerequisites_missing`, so GPP-2 cannot start yet.
 
 **Acceptance criteria:**
 
@@ -512,3 +516,6 @@ fork-safe.
 | 2026-04-25 | GPP-1b merged | PR [#475](https://github.com/Halildeu/ao-kernel/pull/475) merged at `c579089`; status now holds at `GPP-2` blocked. |
 | 2026-04-25 | GPP-1c issue opened | Issue [#476](https://github.com/Halildeu/ao-kernel/issues/476) tracks this status closeout so operator sessions do not see stale `GPP-1b active` state. |
 | 2026-04-25 | GPP-1d issue opened | Issue [#478](https://github.com/Halildeu/ao-kernel/issues/478) tracks removal of moving authority SHAs from live status so merge commits do not create stale SSOT drift. |
+| 2026-04-25 | GPP-1d merged | PR [#479](https://github.com/Halildeu/ao-kernel/pull/479) merged; live authority head is now read from git signals instead of static status text. |
+| 2026-04-25 | GPP-2a issue opened | Issue [#480](https://github.com/Halildeu/ao-kernel/issues/480) created to re-attest protected live-adapter prerequisites before any GPP-2 runtime binding. |
+| 2026-04-25 | GPP-2a re-attestation recorded | Live evidence still shows only `pypi` environment and `ao-kernel-live-adapter-gate` secret lookup returns `HTTP 404`; GPP-2 remains blocked. |

--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -518,4 +518,4 @@ fork-safe.
 | 2026-04-25 | GPP-1d issue opened | Issue [#478](https://github.com/Halildeu/ao-kernel/issues/478) tracks removal of moving authority SHAs from live status so merge commits do not create stale SSOT drift. |
 | 2026-04-25 | GPP-1d merged | PR [#479](https://github.com/Halildeu/ao-kernel/pull/479) merged; live authority head is now read from git signals instead of static status text. |
 | 2026-04-25 | GPP-2a issue opened | Issue [#480](https://github.com/Halildeu/ao-kernel/issues/480) created to re-attest protected live-adapter prerequisites before any GPP-2 runtime binding. |
-| 2026-04-25 | GPP-2a re-attestation recorded | Live evidence still shows only `pypi` environment and `ao-kernel-live-adapter-gate` secret lookup returns `HTTP 404`; GPP-2 remains blocked. |
+| 2026-04-25 | GPP-2a re-attestation recorded | PR [#481](https://github.com/Halildeu/ao-kernel/pull/481) records live evidence: only `pypi` environment exists and `ao-kernel-live-adapter-gate` secret lookup returns `HTTP 404`; GPP-2 remains blocked. |

--- a/.claude/plans/GPP-2a-PROTECTED-LIVE-ADAPTER-PREREQUISITE-RE-ATTESTATION.md
+++ b/.claude/plans/GPP-2a-PROTECTED-LIVE-ADAPTER-PREREQUISITE-RE-ATTESTATION.md
@@ -1,9 +1,10 @@
 # GPP-2a - Protected Live-Adapter Prerequisite Re-Attestation
 
-**Status:** completed by this PR
+**Status:** completed by PR [#481](https://github.com/Halildeu/ao-kernel/pull/481)
 **Date:** 2026-04-25
 **Parent tracker:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
 **Slice issue:** [#480](https://github.com/Halildeu/ao-kernel/issues/480)
+**Slice PR:** [#481](https://github.com/Halildeu/ao-kernel/pull/481)
 **Branch:** `codex/gpp2a-prereq-reattest`
 **Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp2a-prereq-reattest`
 **Target decision:** `still_blocked_protected_prerequisites_missing`

--- a/.claude/plans/GPP-2a-PROTECTED-LIVE-ADAPTER-PREREQUISITE-RE-ATTESTATION.md
+++ b/.claude/plans/GPP-2a-PROTECTED-LIVE-ADAPTER-PREREQUISITE-RE-ATTESTATION.md
@@ -1,0 +1,90 @@
+# GPP-2a - Protected Live-Adapter Prerequisite Re-Attestation
+
+**Status:** completed by this PR
+**Date:** 2026-04-25
+**Parent tracker:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
+**Slice issue:** [#480](https://github.com/Halildeu/ao-kernel/issues/480)
+**Branch:** `codex/gpp2a-prereq-reattest`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp2a-prereq-reattest`
+**Target decision:** `still_blocked_protected_prerequisites_missing`
+**Support impact:** none
+**Release impact:** none
+
+## 1. Purpose
+
+Re-attest the protected live-adapter prerequisites before any `GPP-2` runtime
+binding work starts.
+
+This slice is not runtime work. It records whether the project-owned protected
+GitHub environment and credential handle exist. If they do not exist, `GPP-2`
+must remain blocked.
+
+## 2. Live Evidence
+
+Commands run from clean `main` on 2026-04-25:
+
+```bash
+git status --short --branch
+git rev-list --left-right --count HEAD...origin/main
+bash .claude/scripts/ops.sh preflight
+python3 scripts/gpp_next.py
+gh api repos/Halildeu/ao-kernel/environments --jq '.environments[].name'
+gh secret list --repo Halildeu/ao-kernel
+gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel
+```
+
+Observed results:
+
+1. `main` was synchronized with `origin/main`; divergence was `0 0`.
+2. `scripts/gpp_next.py` reported `GPP-2` as blocked.
+3. GitHub environment inventory returned only `pypi`.
+4. Repository secret listing returned no visible secret handles.
+5. Environment secret listing for `ao-kernel-live-adapter-gate` returned
+   `HTTP 404` because the environment is absent.
+
+## 3. Decision
+
+`GPP-2a` exits with:
+
+```text
+still_blocked_protected_prerequisites_missing
+```
+
+`GPP-2` remains blocked because:
+
+1. Protected environment `ao-kernel-live-adapter-gate` is absent.
+2. Credential handle `AO_CLAUDE_CODE_CLI_AUTH` is not attested under that
+   environment.
+3. Project-owned live adapter execution evidence is still unavailable.
+
+## 4. What Unblocks GPP-2
+
+A future admin/provisioning step must provide fresh evidence that:
+
+1. GitHub environment `ao-kernel-live-adapter-gate` exists.
+2. The environment has the required protection policy.
+3. Secret handle `AO_CLAUDE_CODE_CLI_AUTH` exists under that environment.
+4. Fork-triggered workflows cannot access the credential.
+
+Only after that evidence exists may a new attestation slice change the
+precondition decision to `prerequisites_ready`.
+
+## 5. Non-Goals
+
+1. No runtime adapter code changes.
+2. No workflow `environment:` binding.
+3. No GitHub environment creation.
+4. No secret creation or secret value handling.
+5. No live adapter execution.
+6. No support-tier widening.
+7. No release, tag, or publish.
+
+## 6. Validation
+
+Required validation for this slice:
+
+1. `git diff --check`
+2. `python3 scripts/gpp_next.py`
+3. `python3 scripts/gpp_next.py --output json`
+4. `pytest -q tests/test_gpp_next.py tests/test_gp5_platform_claim_decision.py`
+5. `python3 -m ao_kernel doctor`

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -137,7 +137,7 @@ ayrı ayrı görünür kılmak.
 - **GPP-1b issue:** [#474](https://github.com/Halildeu/ao-kernel/issues/474) (`closed by PR #475`)
 - **GPP-1c status closeout issue:** [#476](https://github.com/Halildeu/ao-kernel/issues/476) (`closed by PR #477`)
 - **GPP-1d authority-head cleanup issue:** [#478](https://github.com/Halildeu/ao-kernel/issues/478) (`closed by PR #479`)
-- **GPP-2a protected prerequisite re-attestation issue:** [#480](https://github.com/Halildeu/ao-kernel/issues/480) (`open`)
+- **GPP-2a protected prerequisite re-attestation issue:** [#480](https://github.com/Halildeu/ao-kernel/issues/480) (`closes by PR #481`)
 - **Current mode:** stable maintenance + written general-purpose production
   promotion tracking. RI-5b is merged as Beta/operator-managed root export, not
   a production platform claim. GPP-1 live attestation exited as

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -136,17 +136,19 @@ ayrı ayrı görünür kılmak.
 - **GPP machine-readable status:** `.claude/plans/gpp_status.v1.json`
 - **GPP-1b issue:** [#474](https://github.com/Halildeu/ao-kernel/issues/474) (`closed by PR #475`)
 - **GPP-1c status closeout issue:** [#476](https://github.com/Halildeu/ao-kernel/issues/476) (`closed by PR #477`)
-- **GPP-1d authority-head cleanup issue:** [#478](https://github.com/Halildeu/ao-kernel/issues/478) (`open`)
+- **GPP-1d authority-head cleanup issue:** [#478](https://github.com/Halildeu/ao-kernel/issues/478) (`closed by PR #479`)
+- **GPP-2a protected prerequisite re-attestation issue:** [#480](https://github.com/Halildeu/ao-kernel/issues/480) (`open`)
 - **Current mode:** stable maintenance + written general-purpose production
   promotion tracking. RI-5b is merged as Beta/operator-managed root export, not
   a production platform claim. GPP-1 live attestation exited as
   `blocked_attestation_missing`. GPP-1b is merged and makes Codex/Claude
   operator sessions read that blocked state from repo-owned program status
-  before acting. Current program status holds at `GPP-2` blocked. No support
-  widening, release, runtime adapter promotion, or production claim is made by
-  GPP-1b/GPP-1c. Future stable widening still requires protected live-adapter
-  evidence, repo-intelligence integration gates, write-side rollback evidence,
-  and an explicit closeout decision.
+  before acting. Current program status holds at `GPP-2` blocked. GPP-2a
+  re-attestation reconfirmed the missing protected environment and credential
+  handle. No support widening, release, runtime adapter promotion, or production
+  claim is made by GPP-1b/GPP-1c/GPP-2a. Future stable widening still requires
+  protected live-adapter evidence, repo-intelligence integration gates,
+  write-side rollback evidence, and an explicit closeout decision.
 
 ## 2. Başlangıç Gerçeği
 
@@ -247,6 +249,10 @@ sonraki tek aktif hat `GPP-1` protected live-adapter prerequisite olacaktır.
 kararındadır: `ao-kernel-live-adapter-gate` environment yoktur,
 `AO_CLAUDE_CODE_CLI_AUTH` secret handle attested değildir ve GPP-2 runtime
 binding hattı bu prerequisite kapanmadan başlamaz.
+
+`GPP-2a` re-attestation bu sonucu tekrar doğrular: live environment inventory
+yalnız `pypi` döndürür, `ao-kernel-live-adapter-gate` environment secret lookup
+`HTTP 404` döndürür ve runtime binding hâlâ başlamaz.
 
 `GPP-1b`, bu blocked runtime sonucunu değiştirmez. Amacı Codex ve Claude Code
 operatör oturumlarının `.claude/plans/gpp_status.v1.json` ve

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -37,6 +37,7 @@
       "id": "GPP-2a",
       "decision": "still_blocked_protected_prerequisites_missing",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/480",
+      "pr": "https://github.com/Halildeu/ao-kernel/pull/481",
       "record": ".claude/plans/GPP-2a-PROTECTED-LIVE-ADAPTER-PREREQUISITE-RE-ATTESTATION.md"
     }
   ],

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -32,6 +32,12 @@
       "decision": "agent_operating_contract_ready_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/474",
       "pr": "https://github.com/Halildeu/ao-kernel/pull/475"
+    },
+    {
+      "id": "GPP-2a",
+      "decision": "still_blocked_protected_prerequisites_missing",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/480",
+      "record": ".claude/plans/GPP-2a-PROTECTED-LIVE-ADAPTER-PREREQUISITE-RE-ATTESTATION.md"
     }
   ],
   "blocked_wps": [
@@ -39,7 +45,7 @@
       "id": "GPP-2",
       "title": "Protected Live-Adapter Gate Runtime Binding",
       "reason": "ao-kernel-live-adapter-gate environment and AO_CLAUDE_CODE_CLI_AUTH handle are not attested",
-      "blocked_until": "GPP-1 can exit prerequisites_ready in a future attestation slice"
+      "blocked_until": "a future prerequisite attestation exits prerequisites_ready after the protected environment and credential handle exist"
     }
   ],
   "support_widening_allowed": false,
@@ -88,7 +94,7 @@
   ],
   "next_allowed_actions": [
     "keep GPP-2 blocked",
-    "open a future admin/provisioning attestation slice only after protected prerequisites exist",
+    "perform external admin provisioning for ao-kernel-live-adapter-gate and AO_CLAUDE_CODE_CLI_AUTH before another attestation slice",
     "do not widen support or claim production platform readiness"
   ],
   "last_updated": "2026-04-25"

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -32,6 +32,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["current_wp"]["status"] == "blocked"
     assert payload["current_wp"]["exit_decision"] == "blocked_attestation_missing"
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
+    assert any(
+        item["id"] == "GPP-2a" and item["decision"] == "still_blocked_protected_prerequisites_missing"
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -47,6 +51,7 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
+    assert "protected environment and credential handle exist" in payload["blocked_wps"][0]["blocked_until"]
     assert payload["support_widening_allowed"] is False
 
 


### PR DESCRIPTION
## Summary
- record GPP-2a protected live-adapter prerequisite re-attestation
- keep GPP-2 blocked because ao-kernel-live-adapter-gate is absent and AO_CLAUDE_CODE_CLI_AUTH is not attested
- update machine-readable GPP status, human status docs, and tests
- fix stale GPP-1d issue status in post-beta status

## Live evidence
- gh api repos/Halildeu/ao-kernel/environments --jq .environments[].name -> pypi only
- gh secret list --repo Halildeu/ao-kernel -> no visible repository secret handles
- gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel -> HTTP 404

## Validation
- git diff --check
- python3 scripts/gpp_next.py
- python3 scripts/gpp_next.py --output json | python3 -m json.tool
- pytest -q tests/test_gpp_next.py tests/test_gp5_platform_claim_decision.py
- python3 -m ao_kernel doctor

## Scope
- no runtime adapter code
- no workflow environment binding
- no GitHub environment or secret creation
- no live adapter execution
- no support widening
- no release/tag/publish

Closes #480