### PR TITLE
[codex] track GPP live-adapter admin provisioning

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,11 +1,12 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 blocked after GPP-2a prerequisite re-attestation
+**Status:** GPP-2 blocked; GPP-2b external/admin provisioning issue open
 **Date:** 2026-04-25
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** none active; GPP-2 is blocked
+**Current slice issue:** [#482](https://github.com/Halildeu/ao-kernel/issues/482)
+for external/admin provisioning
 **Current slice record:** `.claude/plans/gpp_status.v1.json`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
@@ -67,6 +68,11 @@ Last live verification on current `origin/main` showed:
 18. GPP-2a re-attestation on 2026-04-25 reconfirmed the same blocker:
     `ao-kernel-live-adapter-gate` is absent, environment secret lookup returns
     `HTTP 404`, and `AO_CLAUDE_CODE_CLI_AUTH` is not project-owned/attested.
+19. GPP-2b opened issue
+    [#482](https://github.com/Halildeu/ao-kernel/issues/482) to track the
+    external/admin provisioning work. Live collaborator inventory currently
+    shows only `Halildeu`, so the protected reviewer model still needs a
+    non-triggering reviewer/admin or an explicitly approved equivalent gate.
 
 ## 3. Current Verdict
 
@@ -107,6 +113,7 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-1` | Completed | Protected live-adapter prerequisite attestation | `blocked_attestation_missing` |
 | `GPP-1b` | Completed | Agent operating program contract | `agent_operating_contract_ready_no_support_widening` |
 | `GPP-2a` | Completed | Protected live-adapter prerequisite re-attestation | `still_blocked_protected_prerequisites_missing` |
+| `GPP-2b` | External/admin open | Protected live-adapter environment and credential provisioning | tracked in [#482](https://github.com/Halildeu/ao-kernel/issues/482); no runtime change |
 | `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until a future attestation exits `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -486,9 +493,10 @@ accident.
 ## 17. Current Active Work
 
 No runtime/support-widening work is active. `GPP-2` is the current blocked
-program head and must not start until a future attestation proves
-`ao-kernel-live-adapter-gate` and `AO_CLAUDE_CODE_CLI_AUTH` are present and
-fork-safe.
+program head. GPP-2b is tracked in
+[#482](https://github.com/Halildeu/ao-kernel/issues/482) as an external/admin
+provisioning action and must complete before another prerequisite attestation
+can attempt to unblock `GPP-2`.
 
 ## 18. Risk Register
 
@@ -519,3 +527,4 @@ fork-safe.
 | 2026-04-25 | GPP-1d merged | PR [#479](https://github.com/Halildeu/ao-kernel/pull/479) merged; live authority head is now read from git signals instead of static status text. |
 | 2026-04-25 | GPP-2a issue opened | Issue [#480](https://github.com/Halildeu/ao-kernel/issues/480) created to re-attest protected live-adapter prerequisites before any GPP-2 runtime binding. |
 | 2026-04-25 | GPP-2a re-attestation recorded | PR [#481](https://github.com/Halildeu/ao-kernel/pull/481) records live evidence: only `pypi` environment exists and `ao-kernel-live-adapter-gate` secret lookup returns `HTTP 404`; GPP-2 remains blocked. |
+| 2026-04-25 | GPP-2b external/admin issue opened | Issue [#482](https://github.com/Halildeu/ao-kernel/issues/482) tracks protected environment, reviewer, and credential provisioning required before `GPP-2` can start. |

--- a/.claude/plans/GPP-2b-EXTERNAL-ADMIN-PROVISIONING.md
+++ b/.claude/plans/GPP-2b-EXTERNAL-ADMIN-PROVISIONING.md
@@ -1,0 +1,104 @@
+# GPP-2b - External Admin Provisioning Tracker
+
+**Status:** open external/admin action
+**Date:** 2026-04-25
+**Issue:** [#482](https://github.com/Halildeu/ao-kernel/issues/482)
+**Program head:** `GPP-2` remains blocked
+**Support impact:** none
+**Runtime impact:** none
+
+## 1. Purpose
+
+Track the non-code prerequisite work required before `GPP-2` runtime binding can
+start.
+
+This tracker does not create a secret, does not read a secret value, does not
+bind the live-adapter workflow, and does not widen support. It records the
+external GitHub admin state that must be changed before a future prerequisite
+attestation can exit `prerequisites_ready`.
+
+## 2. Live Evidence
+
+Collected from `origin/main` on 2026-04-25 after PR
+[#481](https://github.com/Halildeu/ao-kernel/pull/481) merged:
+
+```bash
+git status --short --branch
+# ## main...origin/main
+
+git rev-list --left-right --count HEAD...origin/main
+# 0 0
+
+python3 scripts/gpp_next.py
+# Current WP: GPP-2 - Protected Live-Adapter Gate Runtime Binding
+# Current status: blocked
+# Live adapter execution allowed: false
+
+gh api repos/Halildeu/ao-kernel/environments --jq '.environments[].name'
+# pypi
+
+gh secret list --repo Halildeu/ao-kernel
+# empty
+
+gh api 'repos/Halildeu/ao-kernel/collaborators?per_page=100' \
+  --jq '.[] | {login:.login, role_name:.role_name}'
+# {"login":"Halildeu","role_name":"admin"}
+```
+
+## 3. Current Decision
+
+`GPP-2` stays blocked.
+
+The project-owned protected live-adapter gate is not ready because:
+
+1. `ao-kernel-live-adapter-gate` is not present in the GitHub environment
+   inventory.
+2. `AO_CLAUDE_CODE_CLI_AUTH` is not visible as a repository secret handle.
+3. Environment-scoped secret attestation cannot pass until the environment
+   exists.
+4. Only one repository collaborator is visible, so the protected reviewer model
+   needs a non-triggering reviewer/admin or an explicitly approved equivalent
+   release gate before self-review prevention can be meaningful.
+
+## 4. Required External/Admin Work
+
+Complete issue [#482](https://github.com/Halildeu/ao-kernel/issues/482):
+
+1. Create or designate GitHub environment `ao-kernel-live-adapter-gate`.
+2. Configure environment protection to match the existing contract:
+   - allowed deployment ref: `main`;
+   - required reviewers enabled;
+   - prevent self-review enabled;
+   - fork-triggered events cannot access protected credentials.
+3. Add at least one non-triggering maintainer reviewer, or record an explicitly
+   approved release-gate equivalent if the repository remains single-admin.
+4. Store project-owned Claude Code CLI credential material, or an explicitly
+   approved non-API-key equivalent, as environment secret handle
+   `AO_CLAUDE_CODE_CLI_AUTH`.
+5. Do not commit, print, or read back the secret value.
+
+## 5. Follow-Up Gate
+
+After #482 is complete, open a fresh prerequisite attestation slice. That slice
+must collect live evidence that:
+
+1. `gh api repos/Halildeu/ao-kernel/environments --jq '.environments[].name'`
+   includes `ao-kernel-live-adapter-gate`;
+2. `gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel`
+   lists `AO_CLAUDE_CODE_CLI_AUTH`;
+3. environment protection evidence is compatible with the protected gate
+   contract;
+4. fork-triggered contexts cannot read protected credentials.
+
+Only if the follow-up attestation exits `prerequisites_ready` can `GPP-2`
+runtime binding begin.
+
+## 6. Forbidden Until Then
+
+1. No runtime binding.
+2. No live adapter execution.
+3. No support widening.
+4. No production-platform claim.
+5. No secret value readback.
+6. No local operator auth treated as project-owned production evidence.
+

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -138,6 +138,7 @@ ayrı ayrı görünür kılmak.
 - **GPP-1c status closeout issue:** [#476](https://github.com/Halildeu/ao-kernel/issues/476) (`closed by PR #477`)
 - **GPP-1d authority-head cleanup issue:** [#478](https://github.com/Halildeu/ao-kernel/issues/478) (`closed by PR #479`)
 - **GPP-2a protected prerequisite re-attestation issue:** [#480](https://github.com/Halildeu/ao-kernel/issues/480) (`closes by PR #481`)
+- **GPP-2b external/admin provisioning issue:** [#482](https://github.com/Halildeu/ao-kernel/issues/482)
 - **Current mode:** stable maintenance + written general-purpose production
   promotion tracking. RI-5b is merged as Beta/operator-managed root export, not
   a production platform claim. GPP-1 live attestation exited as
@@ -145,10 +146,12 @@ ayrı ayrı görünür kılmak.
   operator sessions read that blocked state from repo-owned program status
   before acting. Current program status holds at `GPP-2` blocked. GPP-2a
   re-attestation reconfirmed the missing protected environment and credential
-  handle. No support widening, release, runtime adapter promotion, or production
-  claim is made by GPP-1b/GPP-1c/GPP-2a. Future stable widening still requires
-  protected live-adapter evidence, repo-intelligence integration gates,
-  write-side rollback evidence, and an explicit closeout decision.
+  handle. GPP-2b now tracks the external/admin provisioning work for the
+  protected environment, reviewer model, and credential handle. No support
+  widening, release, runtime adapter promotion, or production claim is made by
+  GPP-1b/GPP-1c/GPP-2a/GPP-2b. Future stable widening still requires protected
+  live-adapter evidence, repo-intelligence integration gates, write-side
+  rollback evidence, and an explicit closeout decision.
 
 ## 2. Başlangıç Gerçeği
 

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,7 +9,7 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": null,
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/482",
     "exit_decision": "blocked_attestation_missing",
     "blocked_until": "a future prerequisite attestation proves the protected environment and credential handle exist",
     "allowed_scope": []
@@ -47,6 +47,17 @@
       "title": "Protected Live-Adapter Gate Runtime Binding",
       "reason": "ao-kernel-live-adapter-gate environment and AO_CLAUDE_CODE_CLI_AUTH handle are not attested",
       "blocked_until": "a future prerequisite attestation exits prerequisites_ready after the protected environment and credential handle exist"
+    }
+  ],
+  "pending_external_actions": [
+    {
+      "id": "GPP-2b",
+      "title": "External admin provisioning for protected live-adapter gate",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/482",
+      "record": ".claude/plans/GPP-2b-EXTERNAL-ADMIN-PROVISIONING.md",
+      "status": "open",
+      "decision": "external_admin_prerequisites_required",
+      "required_before": "GPP-2 runtime binding"
     }
   ],
   "support_widening_allowed": false,
@@ -95,7 +106,9 @@
   ],
   "next_allowed_actions": [
     "keep GPP-2 blocked",
-    "perform external admin provisioning for ao-kernel-live-adapter-gate and AO_CLAUDE_CODE_CLI_AUTH before another attestation slice",
+    "track external admin provisioning in issue #482",
+    "provision ao-kernel-live-adapter-gate and AO_CLAUDE_CODE_CLI_AUTH outside the repo without reading secret values",
+    "run a follow-up prerequisite attestation slice only after issue #482 acceptance criteria are met",
     "do not widen support or claim production platform readiness"
   ],
   "last_updated": "2026-04-25"

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,6 +30,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/482"
     assert payload["current_wp"]["exit_decision"] == "blocked_attestation_missing"
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
@@ -39,6 +40,8 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
+    assert payload["pending_external_actions"][0]["id"] == "GPP-2b"
+    assert payload["pending_external_actions"][0]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/482"
     assert {item["id"] for item in payload["blocked_wps"]} == {"GPP-2"}
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
 
@@ -50,6 +53,7 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/482"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
     assert "protected environment and credential handle exist" in payload["blocked_wps"][0]["blocked_until"]
     assert payload["support_widening_allowed"] is False


### PR DESCRIPTION
## Summary

- opens the GPP-2b external/admin provisioning tracker for issue #482
- links `scripts/gpp_next.py` status to the active prerequisite issue while keeping `GPP-2` blocked
- records that protected environment, reviewer model, and `AO_CLAUDE_CODE_CLI_AUTH` provisioning must happen outside repo code before a new attestation slice can unblock runtime binding

## Non-goals

- no runtime binding
- no live adapter execution
- no support widening
- no production-platform claim
- no secret value creation or readback

## Validation

- `python3 scripts/gpp_next.py`
- `python3 scripts/gpp_next.py --output json | python3 -m json.tool`
- `pytest -q tests/test_gpp_next.py tests/test_gp5_platform_claim_decision.py`
- `git diff --check`
- `python3 -m ao_kernel doctor` (`8 OK, 1 WARN, 0 FAIL`; expected extension truth inventory warning)

Issue: #482
