### PR TITLE
[codex] record GPP live-gate partial provisioning

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -42,8 +42,9 @@ Last live verification on current `origin/main` showed:
    `support_widening=false`, and `production_platform_claim=false`.
 7. `live_adapter_gate_contract.py` returned `overall_status=blocked` because
    the protected live-adapter gate is still design-only.
-8. GitHub environment inventory still showed only `pypi`; the required
-   `ao-kernel-live-adapter-gate` environment is not present.
+8. GitHub environment inventory now includes `ao-kernel-live-adapter-gate`.
+   The environment has custom branch policy enabled for `main` and
+   `can_admins_bypass=false`.
 9. `AO_CLAUDE_CODE_CLI_AUTH` was not attested as a repository or environment
    secret handle.
 10. Local `claude-code-cli` operator smoke passed, but that is operator-managed
@@ -52,12 +53,13 @@ Last live verification on current `origin/main` showed:
     guarded and not production-supported.
 12. Controlled local patch/test rehearsal passed in a disposable worktree with
     rollback, but `support_widening=false`.
-13. GPP-1 live attestation on 2026-04-25 still shows only GitHub environment
-    `pypi`; `ao-kernel-live-adapter-gate` is absent.
+13. GPP-1 live attestation on 2026-04-25 showed only GitHub environment
+    `pypi`; at that point `ao-kernel-live-adapter-gate` was absent.
 14. `gh secret list --repo Halildeu/ao-kernel` returned no visible repository
     secret handles.
 15. `gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel`
-    returned `HTTP 404`, because the required environment is absent.
+    returns an empty list; the environment exists, but the required credential
+    handle is not present.
 16. `.github/workflows/live-adapter-gate.yml` still has only
     `workflow_dispatch` among live-gate trigger/secret/environment grep terms;
     no `environment:`, `secrets.`, `pull_request`, or `pull_request_target`
@@ -65,14 +67,19 @@ Last live verification on current `origin/main` showed:
 17. GPP-1b added a machine-readable operator contract so Codex and Claude Code
     read the same current work package and blocked gates from repo state instead
     of chat memory.
-18. GPP-2a re-attestation on 2026-04-25 reconfirmed the same blocker:
-    `ao-kernel-live-adapter-gate` is absent, environment secret lookup returns
-    `HTTP 404`, and `AO_CLAUDE_CODE_CLI_AUTH` is not project-owned/attested.
+18. GPP-2a re-attestation on 2026-04-25 reconfirmed the same then-current
+    blocker: `ao-kernel-live-adapter-gate` was absent, environment secret
+    lookup returned `HTTP 404`, and `AO_CLAUDE_CODE_CLI_AUTH` was not
+    project-owned/attested.
 19. GPP-2b opened issue
     [#482](https://github.com/Halildeu/ao-kernel/issues/482) to track the
     external/admin provisioning work. Live collaborator inventory currently
     shows only `Halildeu`, so the protected reviewer model still needs a
     non-triggering reviewer/admin or an explicitly approved equivalent gate.
+20. GPP-2b partially provisioned the GitHub environment: the environment exists,
+    deployment branch policy includes `main`, and admin bypass is disabled.
+    Required reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` are still
+    missing, so `GPP-2` remains blocked.
 
 ## 3. Current Verdict
 
@@ -113,7 +120,7 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-1` | Completed | Protected live-adapter prerequisite attestation | `blocked_attestation_missing` |
 | `GPP-1b` | Completed | Agent operating program contract | `agent_operating_contract_ready_no_support_widening` |
 | `GPP-2a` | Completed | Protected live-adapter prerequisite re-attestation | `still_blocked_protected_prerequisites_missing` |
-| `GPP-2b` | External/admin open | Protected live-adapter environment and credential provisioning | tracked in [#482](https://github.com/Halildeu/ao-kernel/issues/482); no runtime change |
+| `GPP-2b` | Partially provisioned / blocked | Protected live-adapter environment and credential provisioning | environment exists; `main` branch policy and admin-bypass-off are set; reviewer protection and credential handle still missing |
 | `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until a future attestation exits `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -183,17 +190,20 @@ any workflow binding or support promotion.
 
 **Acceptance criteria:**
 
-1. GitHub environment inventory contains `ao-kernel-live-adapter-gate`: not
-   met; only `pypi` is currently visible.
-2. Required secret handle is attested at repository or environment scope: not
-   met; repository secret list is empty and environment-scoped secret lookup
-   returns `HTTP 404`.
-3. Fork-triggered PR contexts cannot access protected credentials: met for the
+1. GitHub environment inventory contains `ao-kernel-live-adapter-gate`: met.
+2. Deployment branch policy is restricted through custom branch policies and
+   includes `main`: met.
+3. Admin bypass is disabled on `ao-kernel-live-adapter-gate`: met.
+4. Required secret handle is attested at repository or environment scope: not
+   met; environment-scoped secret lookup returns an empty list.
+5. Required reviewer protection is configured or an explicitly approved
+   equivalent release gate is documented: not met.
+6. Fork-triggered PR contexts cannot access protected credentials: met for the
    current design-only workflow, because the workflow is `workflow_dispatch`
    only and has no `environment:` or `secrets.` reference.
-4. Missing environment or secret produces `blocked_attestation_missing`: met by
+7. Missing secret or reviewer protection produces `blocked_attestation_missing`: met by
    this slice.
-5. Status docs and support boundary still say no support widening: met.
+8. Status docs and support boundary still say no support widening: met.
 
 **Validation:**
 
@@ -495,8 +505,9 @@ accident.
 No runtime/support-widening work is active. `GPP-2` is the current blocked
 program head. GPP-2b is tracked in
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) as an external/admin
-provisioning action and must complete before another prerequisite attestation
-can attempt to unblock `GPP-2`.
+provisioning action. The environment and `main` branch policy are present, but
+reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` must still be completed
+before another prerequisite attestation can attempt to unblock `GPP-2`.
 
 ## 18. Risk Register
 
@@ -526,5 +537,6 @@ can attempt to unblock `GPP-2`.
 | 2026-04-25 | GPP-1d issue opened | Issue [#478](https://github.com/Halildeu/ao-kernel/issues/478) tracks removal of moving authority SHAs from live status so merge commits do not create stale SSOT drift. |
 | 2026-04-25 | GPP-1d merged | PR [#479](https://github.com/Halildeu/ao-kernel/pull/479) merged; live authority head is now read from git signals instead of static status text. |
 | 2026-04-25 | GPP-2a issue opened | Issue [#480](https://github.com/Halildeu/ao-kernel/issues/480) created to re-attest protected live-adapter prerequisites before any GPP-2 runtime binding. |
-| 2026-04-25 | GPP-2a re-attestation recorded | PR [#481](https://github.com/Halildeu/ao-kernel/pull/481) records live evidence: only `pypi` environment exists and `ao-kernel-live-adapter-gate` secret lookup returns `HTTP 404`; GPP-2 remains blocked. |
+| 2026-04-25 | GPP-2a re-attestation recorded | PR [#481](https://github.com/Halildeu/ao-kernel/pull/481) recorded then-current evidence: only `pypi` environment existed and `ao-kernel-live-adapter-gate` secret lookup returned `HTTP 404`; GPP-2 remained blocked. |
 | 2026-04-25 | GPP-2b external/admin issue opened | Issue [#482](https://github.com/Halildeu/ao-kernel/issues/482) tracks protected environment, reviewer, and credential provisioning required before `GPP-2` can start. |
+| 2026-04-25 | GPP-2b partial provisioning recorded | `ao-kernel-live-adapter-gate` now exists, custom deployment branch policy includes `main`, and admin bypass is disabled. Reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` remain missing, so #482 stays open and `GPP-2` stays blocked. |

--- a/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
+++ b/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
@@ -165,12 +165,13 @@ an executable protected gate.
 
 **GP-5.1a audit result:** `blocked_unattested_keep_operator_beta`.
 
-`GP-5.1a` checked the current GitHub environment and secret-handle metadata
-without creating environments, reading secret values, binding workflow
-environments, or invoking `claude`. The only configured environment is `pypi`;
-the required `ao-kernel-live-adapter-gate` environment is absent, and
-`AO_CLAUDE_CODE_CLI_AUTH` is not attested as a repository or environment
-secret handle. Therefore `GP-5.1b` must not bind the workflow yet.
+`GP-5.1a` checked the GitHub environment and secret-handle metadata without
+creating environments, reading secret values, binding workflow environments, or
+invoking `claude`. At that time the required `ao-kernel-live-adapter-gate`
+environment was absent. GPP-2b later partially provisioned that environment
+with `main` deployment branch policy and `can_admins_bypass=false`, but
+`AO_CLAUDE_CODE_CLI_AUTH` and required reviewer protection are still not
+attested. Therefore `GP-5.1b` must not bind the workflow yet.
 
 The detailed decision record is
 `.claude/plans/GP-5.1a-PROTECTED-GATE-PREREQUISITE-AUDIT.md`.
@@ -604,7 +605,7 @@ verification only after gate closeout.
 | `R7` cost/secret exposure | Protected gate leaks credentials or runs too often | Protected environment, manual/scheduled trigger, timeout, cost guard, fork isolation. |
 | `R8` merge overwrite | Parallel sessions lose work | Dedicated worktrees, branch sync checks, overlap review, no destructive cleanup. |
 | `R9` RI-5 / GP-5.3 interface conflict | Root export and workflow context handoff evolve different artifact contracts | Keep ownership split explicit; GP-5.3a/3b use stdout Markdown first; `context_compiler` opt-in waits for RI-5a schema on `origin/main`. |
-| `R10` protected environment permanently absent | Live-adapter promotion stays blocked and local auth is mistaken for support | Keep `blocked` as non-pass; allow repo-intelligence read-only slices to proceed without support widening. |
+| `R10` protected gate partially provisioned but incomplete | Live-adapter promotion stays blocked and local auth is mistaken for support | Keep `blocked` as non-pass until environment secret and reviewer protection are attested; allow repo-intelligence read-only slices to proceed without support widening. |
 | `R11` workspace metadata drift | MCP/workspace status reports stale version or kind while runtime package is current | Add a small investigation/fix slice before using workspace metadata as a platform-readiness signal. |
 
 ## 7. First Backlog

--- a/.claude/plans/GPP-2b-EXTERNAL-ADMIN-PROVISIONING.md
+++ b/.claude/plans/GPP-2b-EXTERNAL-ADMIN-PROVISIONING.md
@@ -1,6 +1,6 @@
 # GPP-2b - External Admin Provisioning Tracker
 
-**Status:** open external/admin action
+**Status:** partially provisioned; still blocked
 **Date:** 2026-04-25
 **Issue:** [#482](https://github.com/Halildeu/ao-kernel/issues/482)
 **Program head:** `GPP-2` remains blocked
@@ -45,18 +45,34 @@ gh api 'repos/Halildeu/ao-kernel/collaborators?per_page=100' \
 # {"login":"Halildeu","role_name":"admin"}
 ```
 
+Additional partial provisioning completed on 2026-04-25:
+
+```bash
+gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate \
+  --jq '{name:.name, can_admins_bypass:.can_admins_bypass, protection_rules:.protection_rules, deployment_branch_policy:.deployment_branch_policy}'
+# {"can_admins_bypass":false,"deployment_branch_policy":{"custom_branch_policies":true,"protected_branches":false},"name":"ao-kernel-live-adapter-gate","protection_rules":[{"id":53201958,"node_id":"GA_kwDOSA13rs4DK8wm","type":"branch_policy"}]}
+
+gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate/deployment-branch-policies \
+  --jq '.branch_policies[] | {name:.name, type:.type}'
+# {"name":"main","type":"branch"}
+
+gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel
+# empty
+```
+
 ## 3. Current Decision
 
 `GPP-2` stays blocked.
 
 The project-owned protected live-adapter gate is not ready because:
 
-1. `ao-kernel-live-adapter-gate` is not present in the GitHub environment
-   inventory.
-2. `AO_CLAUDE_CODE_CLI_AUTH` is not visible as a repository secret handle.
-3. Environment-scoped secret attestation cannot pass until the environment
-   exists.
-4. Only one repository collaborator is visible, so the protected reviewer model
+1. `ao-kernel-live-adapter-gate` is now present, but only the branch-policy
+   protection rule is configured.
+2. Deployment branch policy is custom and currently includes `main`.
+3. Admin bypass is disabled.
+4. `AO_CLAUDE_CODE_CLI_AUTH` is not visible as an environment secret handle.
+5. Required reviewer protection is not configured.
+6. Only one repository collaborator is visible, so the protected reviewer model
    needs a non-triggering reviewer/admin or an explicitly approved equivalent
    release gate before self-review prevention can be meaningful.
 
@@ -64,18 +80,18 @@ The project-owned protected live-adapter gate is not ready because:
 
 Complete issue [#482](https://github.com/Halildeu/ao-kernel/issues/482):
 
-1. Create or designate GitHub environment `ao-kernel-live-adapter-gate`.
-2. Configure environment protection to match the existing contract:
-   - allowed deployment ref: `main`;
+1. Keep GitHub environment `ao-kernel-live-adapter-gate` present.
+2. Keep deployment branch policy restricted to `main`.
+3. Configure the remaining environment protection required by the contract:
    - required reviewers enabled;
    - prevent self-review enabled;
    - fork-triggered events cannot access protected credentials.
-3. Add at least one non-triggering maintainer reviewer, or record an explicitly
+4. Add at least one non-triggering maintainer reviewer, or record an explicitly
    approved release-gate equivalent if the repository remains single-admin.
-4. Store project-owned Claude Code CLI credential material, or an explicitly
+5. Store project-owned Claude Code CLI credential material, or an explicitly
    approved non-API-key equivalent, as environment secret handle
    `AO_CLAUDE_CODE_CLI_AUTH`.
-5. Do not commit, print, or read back the secret value.
+6. Do not commit, print, or read back the secret value.
 
 ## 5. Follow-Up Gate
 
@@ -83,12 +99,14 @@ After #482 is complete, open a fresh prerequisite attestation slice. That slice
 must collect live evidence that:
 
 1. `gh api repos/Halildeu/ao-kernel/environments --jq '.environments[].name'`
-   includes `ao-kernel-live-adapter-gate`;
-2. `gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel`
+   still includes `ao-kernel-live-adapter-gate`;
+2. `gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate/deployment-branch-policies`
+   still includes only the intended `main` policy;
+3. `gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel`
    lists `AO_CLAUDE_CODE_CLI_AUTH`;
-3. environment protection evidence is compatible with the protected gate
+4. environment protection evidence is compatible with the protected gate
    contract;
-4. fork-triggered contexts cannot read protected credentials.
+5. fork-triggered contexts cannot read protected credentials.
 
 Only if the follow-up attestation exits `prerequisites_ready` can `GPP-2`
 runtime binding begin.
@@ -101,4 +119,3 @@ runtime binding begin.
 4. No production-platform claim.
 5. No secret value readback.
 6. No local operator auth treated as project-owned production evidence.
-

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -147,7 +147,10 @@ ayrı ayrı görünür kılmak.
   before acting. Current program status holds at `GPP-2` blocked. GPP-2a
   re-attestation reconfirmed the missing protected environment and credential
   handle. GPP-2b now tracks the external/admin provisioning work for the
-  protected environment, reviewer model, and credential handle. No support
+  protected environment, reviewer model, and credential handle. The protected
+  environment has since been partially provisioned with `main` branch policy
+  and admin bypass disabled, but reviewer protection and
+  `AO_CLAUDE_CODE_CLI_AUTH` remain missing. No support
   widening, release, runtime adapter promotion, or production claim is made by
   GPP-1b/GPP-1c/GPP-2a/GPP-2b. Future stable widening still requires protected
   live-adapter evidence, repo-intelligence integration gates, write-side
@@ -249,13 +252,15 @@ altında yazılı, sıralı ve kanıt-gated hale getirir. `GPP-0` merge olduktan
 sonraki tek aktif hat `GPP-1` protected live-adapter prerequisite olacaktır.
 
 `GPP-1` closeout adayı canlı attestation sonucu `blocked_attestation_missing`
-kararındadır: `ao-kernel-live-adapter-gate` environment yoktur,
-`AO_CLAUDE_CODE_CLI_AUTH` secret handle attested değildir ve GPP-2 runtime
-binding hattı bu prerequisite kapanmadan başlamaz.
+kararındaydı: o anda `ao-kernel-live-adapter-gate` environment yoktu,
+`AO_CLAUDE_CODE_CLI_AUTH` secret handle attested değildi ve GPP-2 runtime
+binding hattı bu prerequisite kapanmadan başlayamazdı.
 
-`GPP-2a` re-attestation bu sonucu tekrar doğrular: live environment inventory
-yalnız `pypi` döndürür, `ao-kernel-live-adapter-gate` environment secret lookup
-`HTTP 404` döndürür ve runtime binding hâlâ başlamaz.
+`GPP-2a` re-attestation bu sonucu tekrar doğruladı. Sonraki GPP-2b admin
+adımında `ao-kernel-live-adapter-gate` environment oluşturuldu, `main` branch
+policy eklendi ve admin bypass kapatıldı. Buna rağmen
+`AO_CLAUDE_CODE_CLI_AUTH` environment secret handle yoktur, required reviewer
+protection yoktur ve runtime binding hâlâ başlamaz.
 
 `GPP-1b`, bu blocked runtime sonucunu değiştirmez. Amacı Codex ve Claude Code
 operatör oturumlarının `.claude/plans/gpp_status.v1.json` ve
@@ -334,7 +339,7 @@ retrieval evidence ve manual/stdout handoff protected real-adapter credential'a
 bağlı değildir. Buna rağmen support widening ancak GP-5 closeout kapıları
 tamamlanınca yapılır.
 
-`GP-5.1a` canlı audit sonucu:
+`GP-5.1a` canlı audit sonucu GPP-2b öncesinde:
 
 1. GitHub environments inventory yalnız `pypi` döndürdü.
 2. Required environment `ao-kernel-live-adapter-gate` yoktur.
@@ -344,6 +349,15 @@ tamamlanınca yapılır.
 5. `.github/workflows/live-adapter-gate.yml` hâlâ `workflow_dispatch` only,
    `environment:` binding yok, `secrets.` referansı yok ve live adapter
    çalıştırmıyor.
+
+GPP-2b sonrası canlı delta:
+
+1. `ao-kernel-live-adapter-gate` environment artık vardır.
+2. Custom deployment branch policy açıktır ve `main` policy kaydı vardır.
+3. `can_admins_bypass=false`.
+4. `AO_CLAUDE_CODE_CLI_AUTH` environment secret handle hâlâ yoktur.
+5. Required reviewer protection hâlâ yoktur.
+6. `GPP-2` hâlâ blocked durumdadır; support widening ve production claim yoktur.
 6. `scripts/live_adapter_gate_contract.py` blocked evidence üretmeye devam
    ediyor: `overall_status=blocked`, `decision=blocked_no_rehearsal`,
    `support_widening=false`.

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -55,8 +55,8 @@
       "title": "External admin provisioning for protected live-adapter gate",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/482",
       "record": ".claude/plans/GPP-2b-EXTERNAL-ADMIN-PROVISIONING.md",
-      "status": "open",
-      "decision": "external_admin_prerequisites_required",
+      "status": "partially_provisioned_blocked",
+      "decision": "environment_created_secret_and_reviewer_still_missing",
       "required_before": "GPP-2 runtime binding"
     }
   ],
@@ -107,7 +107,8 @@
   "next_allowed_actions": [
     "keep GPP-2 blocked",
     "track external admin provisioning in issue #482",
-    "provision ao-kernel-live-adapter-gate and AO_CLAUDE_CODE_CLI_AUTH outside the repo without reading secret values",
+    "provision AO_CLAUDE_CODE_CLI_AUTH under ao-kernel-live-adapter-gate without reading secret values",
+    "configure required reviewer protection or record an explicitly approved equivalent release gate",
     "run a follow-up prerequisite attestation slice only after issue #482 acceptance criteria are met",
     "do not widen support or claim production platform readiness"
   ],

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -42,6 +42,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"][0]["id"] == "GPP-2b"
     assert payload["pending_external_actions"][0]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/482"
+    assert payload["pending_external_actions"][0]["status"] == "partially_provisioned_blocked"
+    assert (
+        payload["pending_external_actions"][0]["decision"]
+        == "environment_created_secret_and_reviewer_still_missing"
+    )
     assert {item["id"] for item in payload["blocked_wps"]} == {"GPP-2"}
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
 


### PR DESCRIPTION
## Summary

- records the partial external/admin provisioning completed for #482
- updates GPP status to show `ao-kernel-live-adapter-gate` exists with `main` deployment branch policy and admin bypass disabled
- keeps `GPP-2` blocked because `AO_CLAUDE_CODE_CLI_AUTH` and required reviewer protection are still missing

## Live admin evidence

```bash
gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate \
  --jq '{name:.name, can_admins_bypass:.can_admins_bypass, protection_rules:.protection_rules, deployment_branch_policy:.deployment_branch_policy}'
# can_admins_bypass=false, branch_policy protection rule, custom_branch_policies=true

gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate/deployment-branch-policies \
  --jq '.branch_policies[] | {name:.name, type:.type}'
# {"name":"main","type":"branch"}

gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel
# empty
```

## Non-goals

- no runtime binding
- no live adapter execution
- no secret value creation or readback
- no support widening
- no production-platform claim

## Validation

- `python3 scripts/gpp_next.py`
- `python3 scripts/gpp_next.py --output json | python3 -m json.tool`
- `pytest -q tests/test_gpp_next.py tests/test_gp5_platform_claim_decision.py`
- `git diff --check`
- `python3 -m ao_kernel doctor` (`8 OK, 1 WARN, 0 FAIL`; expected extension truth inventory warning)

Issue: #482
