### PR TITLE
[codex] track GPP reviewer and credential gate

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -121,6 +121,7 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-1b` | Completed | Agent operating program contract | `agent_operating_contract_ready_no_support_widening` |
 | `GPP-2a` | Completed | Protected live-adapter prerequisite re-attestation | `still_blocked_protected_prerequisites_missing` |
 | `GPP-2b` | Partially provisioned / blocked | Protected live-adapter environment and credential provisioning | environment exists; `main` branch policy and admin-bypass-off are set; reviewer protection and credential handle still missing |
+| `GPP-2c` | Blocked external/admin decision | Reviewer and credential gate resolution | `AO_CLAUDE_CODE_CLI_AUTH` and non-self reviewer/equivalent gate still missing |
 | `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until a future attestation exits `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -508,6 +509,9 @@ program head. GPP-2b is tracked in
 provisioning action. The environment and `main` branch policy are present, but
 reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` must still be completed
 before another prerequisite attestation can attempt to unblock `GPP-2`.
+GPP-2c is tracked in
+[#485](https://github.com/Halildeu/ao-kernel/issues/485) to resolve the
+remaining reviewer and credential gate decision.
 
 ## 18. Risk Register
 
@@ -540,3 +544,4 @@ before another prerequisite attestation can attempt to unblock `GPP-2`.
 | 2026-04-25 | GPP-2a re-attestation recorded | PR [#481](https://github.com/Halildeu/ao-kernel/pull/481) recorded then-current evidence: only `pypi` environment existed and `ao-kernel-live-adapter-gate` secret lookup returned `HTTP 404`; GPP-2 remained blocked. |
 | 2026-04-25 | GPP-2b external/admin issue opened | Issue [#482](https://github.com/Halildeu/ao-kernel/issues/482) tracks protected environment, reviewer, and credential provisioning required before `GPP-2` can start. |
 | 2026-04-25 | GPP-2b partial provisioning recorded | `ao-kernel-live-adapter-gate` now exists, custom deployment branch policy includes `main`, and admin bypass is disabled. Reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` remain missing, so #482 stays open and `GPP-2` stays blocked. |
+| 2026-04-25 | GPP-2c issue opened | Issue [#485](https://github.com/Halildeu/ao-kernel/issues/485) tracks the remaining protected reviewer and credential gate: add/designate a non-self reviewer or explicitly approve an equivalent release gate, and set `AO_CLAUDE_CODE_CLI_AUTH` without secret readback. |

--- a/.claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md
+++ b/.claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md
@@ -1,0 +1,103 @@
+# GPP-2c - Reviewer and Credential Gate Decision
+
+**Status:** blocked; external/admin decision required
+**Date:** 2026-04-25
+**Issue:** [#485](https://github.com/Halildeu/ao-kernel/issues/485)
+**Parent issue:** [#482](https://github.com/Halildeu/ao-kernel/issues/482)
+**Program head:** `GPP-2` remains blocked
+**Support impact:** none
+**Runtime impact:** none
+
+## 1. Purpose
+
+Capture the remaining protected live-adapter gate blockers after GPP-2b partial
+provisioning.
+
+This is deliberately a governance/admin gate, not runtime implementation. It
+does not bind `.github/workflows/live-adapter-gate.yml`, does not create or read
+secret values, does not execute a live adapter, and does not widen support.
+
+## 2. Current Live Evidence
+
+```bash
+gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate \
+  --jq '{name:.name, can_admins_bypass:.can_admins_bypass, protection_rules:.protection_rules, deployment_branch_policy:.deployment_branch_policy}'
+# {"can_admins_bypass":false,"deployment_branch_policy":{"custom_branch_policies":true,"protected_branches":false},"name":"ao-kernel-live-adapter-gate","protection_rules":[{"id":53201958,"node_id":"GA_kwDOSA13rs4DK8wm","type":"branch_policy"}]}
+
+gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate/deployment-branch-policies \
+  --jq '.branch_policies[] | {name:.name, type:.type}'
+# {"name":"main","type":"branch"}
+
+gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel
+# empty
+
+gh api 'repos/Halildeu/ao-kernel/collaborators?per_page=100' \
+  --jq '.[] | {login:.login, id:.id, role_name:.role_name}'
+# {"login":"Halildeu","id":186576227,"role_name":"admin"}
+```
+
+## 3. Decision
+
+`GPP-2` remains blocked.
+
+The environment shell is now present and partially hardened:
+
+1. `ao-kernel-live-adapter-gate` exists.
+2. Deployment branch policy includes `main`.
+3. `can_admins_bypass=false`.
+
+The gate is still incomplete:
+
+1. `AO_CLAUDE_CODE_CLI_AUTH` is not present as an environment secret handle.
+2. Required reviewer protection is not configured.
+3. A true non-self reviewer gate is not currently possible while only one
+   collaborator is visible.
+
+## 4. Acceptable Resolution Paths
+
+### Preferred Path
+
+1. Add or designate a second maintainer reviewer.
+2. Configure `ao-kernel-live-adapter-gate` required reviewers with
+   prevent-self-review.
+3. Set `AO_CLAUDE_CODE_CLI_AUTH` under the environment without printing or
+   reading back the secret value.
+4. Open a follow-up attestation PR that proves the handle exists and the
+   reviewer gate is present.
+
+### Alternative Path
+
+1. Record an explicit single-admin equivalent release-gate decision.
+2. Explain why the equivalent gate is acceptable despite lacking a non-self
+   GitHub reviewer.
+3. Keep that exception scoped to this repository and this protected gate.
+4. Still require `AO_CLAUDE_CODE_CLI_AUTH` as an environment secret handle
+   before any runtime binding.
+
+The alternative path is not implied by this document. It requires an explicit
+operator decision in a follow-up issue/PR before it can unblock anything.
+
+## 5. Follow-Up Attestation Requirement
+
+After either acceptable path is complete, open a fresh prerequisite attestation
+slice. That slice must prove:
+
+1. the environment still exists;
+2. deployment branch policy still allows only the intended `main` path;
+3. `can_admins_bypass=false`;
+4. `AO_CLAUDE_CODE_CLI_AUTH` exists under the environment;
+5. reviewer protection or an explicitly approved equivalent release gate is
+   present;
+6. fork-triggered contexts cannot read protected credentials.
+
+Only then may `GPP-2` runtime binding start.
+
+## 6. Forbidden Until Then
+
+1. No `GPP-2` runtime binding.
+2. No live adapter execution.
+3. No support widening.
+4. No production-platform claim.
+5. No secret value readback.
+6. No local operator auth treated as project-owned evidence.
+

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -139,6 +139,7 @@ ayrı ayrı görünür kılmak.
 - **GPP-1d authority-head cleanup issue:** [#478](https://github.com/Halildeu/ao-kernel/issues/478) (`closed by PR #479`)
 - **GPP-2a protected prerequisite re-attestation issue:** [#480](https://github.com/Halildeu/ao-kernel/issues/480) (`closes by PR #481`)
 - **GPP-2b external/admin provisioning issue:** [#482](https://github.com/Halildeu/ao-kernel/issues/482)
+- **GPP-2c reviewer/credential gate issue:** [#485](https://github.com/Halildeu/ao-kernel/issues/485)
 - **Current mode:** stable maintenance + written general-purpose production
   promotion tracking. RI-5b is merged as Beta/operator-managed root export, not
   a production platform claim. GPP-1 live attestation exited as
@@ -150,11 +151,12 @@ ayrı ayrı görünür kılmak.
   protected environment, reviewer model, and credential handle. The protected
   environment has since been partially provisioned with `main` branch policy
   and admin bypass disabled, but reviewer protection and
-  `AO_CLAUDE_CODE_CLI_AUTH` remain missing. No support
+  `AO_CLAUDE_CODE_CLI_AUTH` remain missing. GPP-2c now tracks that final
+  reviewer/credential gate decision. No support
   widening, release, runtime adapter promotion, or production claim is made by
-  GPP-1b/GPP-1c/GPP-2a/GPP-2b. Future stable widening still requires protected
-  live-adapter evidence, repo-intelligence integration gates, write-side
-  rollback evidence, and an explicit closeout decision.
+  GPP-1b/GPP-1c/GPP-2a/GPP-2b/GPP-2c. Future stable widening still requires
+  protected live-adapter evidence, repo-intelligence integration gates,
+  write-side rollback evidence, and an explicit closeout decision.
 
 ## 2. Başlangıç Gerçeği
 

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -58,6 +58,15 @@
       "status": "partially_provisioned_blocked",
       "decision": "environment_created_secret_and_reviewer_still_missing",
       "required_before": "GPP-2 runtime binding"
+    },
+    {
+      "id": "GPP-2c",
+      "title": "Reviewer and credential gate resolution",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/485",
+      "record": ".claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md",
+      "status": "blocked_external_admin_decision_required",
+      "decision": "missing_environment_secret_and_non_self_reviewer_gate",
+      "required_before": "GPP-2 runtime binding"
     }
   ],
   "support_widening_allowed": false,
@@ -107,6 +116,7 @@
   "next_allowed_actions": [
     "keep GPP-2 blocked",
     "track external admin provisioning in issue #482",
+    "resolve reviewer and credential gate in issue #485",
     "provision AO_CLAUDE_CODE_CLI_AUTH under ao-kernel-live-adapter-gate without reading secret values",
     "configure required reviewer protection or record an explicitly approved equivalent release gate",
     "run a follow-up prerequisite attestation slice only after issue #482 acceptance criteria are met",

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -47,6 +47,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         payload["pending_external_actions"][0]["decision"]
         == "environment_created_secret_and_reviewer_still_missing"
     )
+    assert payload["pending_external_actions"][1]["id"] == "GPP-2c"
+    assert payload["pending_external_actions"][1]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/485"
+    assert payload["pending_external_actions"][1]["status"] == "blocked_external_admin_decision_required"
+    assert (
+        payload["pending_external_actions"][1]["decision"]
+        == "missing_environment_secret_and_non_self_reviewer_gate"
+    )
     assert {item["id"] for item in payload["blocked_wps"]} == {"GPP-2"}
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
 


### PR DESCRIPTION
## Summary

- opens GPP-2c as the explicit reviewer/credential gate decision record for issue #485
- records that `ao-kernel-live-adapter-gate` exists with `main` policy and admin bypass disabled, but `AO_CLAUDE_CODE_CLI_AUTH` and reviewer protection are still missing
- keeps `GPP-2` blocked with no runtime binding, live execution, support widening, or production-platform claim

## Decision boundary

Preferred path:

- add/designate a second maintainer reviewer
- configure required reviewers with prevent-self-review
- set `AO_CLAUDE_CODE_CLI_AUTH` under the environment without reading back the value

Alternative path:

- explicitly approve a single-admin equivalent release gate in a future issue/PR
- still require the environment secret handle before any runtime binding

## Validation

- `python3 scripts/gpp_next.py`
- `python3 scripts/gpp_next.py --output json | python3 -m json.tool`
- `pytest -q tests/test_gpp_next.py tests/test_gp5_platform_claim_decision.py`
- `git diff --check`
- `python3 -m ao_kernel doctor` (`8 OK, 1 WARN, 0 FAIL`; expected extension truth inventory warning)

Issue: #485
