### PR TITLE
[codex] add metadata-only live gate attestation

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -122,6 +122,7 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2a` | Completed | Protected live-adapter prerequisite re-attestation | `still_blocked_protected_prerequisites_missing` |
 | `GPP-2b` | Partially provisioned / blocked | Protected live-adapter environment and credential provisioning | environment exists; `main` branch policy and admin-bypass-off are set; reviewer protection and credential handle still missing |
 | `GPP-2c` | Blocked external/admin decision | Reviewer and credential gate resolution | `AO_CLAUDE_CODE_CLI_AUTH` and non-self reviewer/equivalent gate still missing |
+| `GPP-2d` | Implemented / no support widening | Metadata-only live gate attestation tool | repeatable attestation is available; current live gate still blocked |
 | `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until a future attestation exits `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -511,7 +512,9 @@ reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` must still be completed
 before another prerequisite attestation can attempt to unblock `GPP-2`.
 GPP-2c is tracked in
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) to resolve the
-remaining reviewer and credential gate decision.
+remaining reviewer and credential gate decision. GPP-2d adds
+`scripts/live_adapter_gate_attest.py` so the next prerequisite attestation uses
+repeatable metadata-only evidence instead of hand-written command snippets.
 
 ## 18. Risk Register
 
@@ -545,3 +548,4 @@ remaining reviewer and credential gate decision.
 | 2026-04-25 | GPP-2b external/admin issue opened | Issue [#482](https://github.com/Halildeu/ao-kernel/issues/482) tracks protected environment, reviewer, and credential provisioning required before `GPP-2` can start. |
 | 2026-04-25 | GPP-2b partial provisioning recorded | `ao-kernel-live-adapter-gate` now exists, custom deployment branch policy includes `main`, and admin bypass is disabled. Reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` remain missing, so #482 stays open and `GPP-2` stays blocked. |
 | 2026-04-25 | GPP-2c issue opened | Issue [#485](https://github.com/Halildeu/ao-kernel/issues/485) tracks the remaining protected reviewer and credential gate: add/designate a non-self reviewer or explicitly approve an equivalent release gate, and set `AO_CLAUDE_CODE_CLI_AUTH` without secret readback. |
+| 2026-04-25 | GPP-2d issue opened | Issue [#487](https://github.com/Halildeu/ao-kernel/issues/487) tracks a metadata-only attestation tool for repeatable protected gate evidence. |

--- a/.claude/plans/GPP-2d-METADATA-ONLY-LIVE-GATE-ATTESTATION.md
+++ b/.claude/plans/GPP-2d-METADATA-ONLY-LIVE-GATE-ATTESTATION.md
@@ -1,0 +1,74 @@
+# GPP-2d - Metadata-Only Live Gate Attestation Tool
+
+**Status:** implemented; no support widening
+**Date:** 2026-04-25
+**Issue:** [#487](https://github.com/Halildeu/ao-kernel/issues/487)
+**Program head:** `GPP-2` remains blocked
+**Support impact:** none
+**Runtime impact:** none
+
+## 1. Purpose
+
+Make protected live-adapter gate attestation repeatable.
+
+Earlier GPP-2b/GPP-2c slices used live `gh` commands and issue comments to
+record the gate state. This slice adds a metadata-only tool that emits a
+machine-readable attestation artifact without reading secret values, binding the
+workflow, running `claude`, or widening support.
+
+## 2. Implemented Surface
+
+1. Helper:
+   `ao_kernel.live_adapter_gate.build_live_adapter_gate_attestation()`.
+2. Writer:
+   `ao_kernel.live_adapter_gate.write_live_adapter_gate_attestation()`.
+3. Renderer:
+   `ao_kernel.live_adapter_gate.render_live_adapter_gate_attestation_text()`.
+4. CLI:
+   `python3 scripts/live_adapter_gate_attest.py`.
+5. Artifact:
+   `live-adapter-gate-attestation.v1.json`.
+
+## 3. Checks
+
+The attestation evaluates metadata only:
+
+1. environment `ao-kernel-live-adapter-gate` exists;
+2. admin bypass is disabled;
+3. deployment branch policy is restricted to `main`;
+4. environment secret handle `AO_CLAUDE_CODE_CLI_AUTH` exists by name;
+5. required reviewer gate exists, or an explicitly approved equivalent release
+   gate is supplied;
+6. support boundary remains closed.
+
+Secret values are never accepted, read, printed, or written.
+
+## 4. Current Expected Result
+
+With current live metadata, the artifact must be `blocked` because:
+
+1. `AO_CLAUDE_CODE_CLI_AUTH` is still missing under the environment;
+2. required reviewer protection is still missing;
+3. only one collaborator is visible, so a non-self reviewer gate is not yet
+   possible.
+
+`runtime_binding_allowed=false`, `live_execution_allowed=false`, and
+`support_widening=false` remain the expected result until a future attestation
+proves prerequisites ready.
+
+## 5. Non-Goals
+
+1. No runtime binding.
+2. No live adapter execution.
+3. No secret value readback.
+4. No single-admin equivalent gate approval.
+5. No support widening.
+6. No production-platform claim.
+
+## 6. Validation
+
+1. Unit tests cover the current partial-provisioning blocked state.
+2. Unit tests cover a synthetic metadata-ready state.
+3. CLI fixture test proves deterministic artifact writing without live GitHub.
+4. `python3 scripts/gpp_next.py` still reports `GPP-2` blocked.
+

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -140,6 +140,7 @@ ayrı ayrı görünür kılmak.
 - **GPP-2a protected prerequisite re-attestation issue:** [#480](https://github.com/Halildeu/ao-kernel/issues/480) (`closes by PR #481`)
 - **GPP-2b external/admin provisioning issue:** [#482](https://github.com/Halildeu/ao-kernel/issues/482)
 - **GPP-2c reviewer/credential gate issue:** [#485](https://github.com/Halildeu/ao-kernel/issues/485)
+- **GPP-2d metadata-only live gate attestation issue:** [#487](https://github.com/Halildeu/ao-kernel/issues/487)
 - **Current mode:** stable maintenance + written general-purpose production
   promotion tracking. RI-5b is merged as Beta/operator-managed root export, not
   a production platform claim. GPP-1 live attestation exited as
@@ -152,11 +153,13 @@ ayrı ayrı görünür kılmak.
   environment has since been partially provisioned with `main` branch policy
   and admin bypass disabled, but reviewer protection and
   `AO_CLAUDE_CODE_CLI_AUTH` remain missing. GPP-2c now tracks that final
-  reviewer/credential gate decision. No support
+  reviewer/credential gate decision. GPP-2d adds repeatable metadata-only
+  attestation tooling so future prerequisite checks do not rely on manual issue
+  comments. No support
   widening, release, runtime adapter promotion, or production claim is made by
-  GPP-1b/GPP-1c/GPP-2a/GPP-2b/GPP-2c. Future stable widening still requires
-  protected live-adapter evidence, repo-intelligence integration gates,
-  write-side rollback evidence, and an explicit closeout decision.
+  GPP-1b/GPP-1c/GPP-2a/GPP-2b/GPP-2c/GPP-2d. Future stable widening still
+  requires protected live-adapter evidence, repo-intelligence integration
+  gates, write-side rollback evidence, and an explicit closeout decision.
 
 ## 2. Başlangıç Gerçeği
 

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -67,6 +67,15 @@
       "status": "blocked_external_admin_decision_required",
       "decision": "missing_environment_secret_and_non_self_reviewer_gate",
       "required_before": "GPP-2 runtime binding"
+    },
+    {
+      "id": "GPP-2d",
+      "title": "Metadata-only live gate attestation tool",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/487",
+      "record": ".claude/plans/GPP-2d-METADATA-ONLY-LIVE-GATE-ATTESTATION.md",
+      "status": "implemented_no_support_widening",
+      "decision": "repeatable_attestation_available_current_gate_still_blocked",
+      "required_before": "future prerequisite attestation"
     }
   ],
   "support_widening_allowed": false,
@@ -117,6 +126,7 @@
     "keep GPP-2 blocked",
     "track external admin provisioning in issue #482",
     "resolve reviewer and credential gate in issue #485",
+    "use scripts/live_adapter_gate_attest.py for the next prerequisite attestation",
     "provision AO_CLAUDE_CODE_CLI_AUTH under ao-kernel-live-adapter-gate without reading secret values",
     "configure required reviewer protection or record an explicitly approved equivalent release gate",
     "run a follow-up prerequisite attestation slice only after issue #482 acceptance criteria are met",

--- a/ao_kernel/live_adapter_gate.py
+++ b/ao_kernel/live_adapter_gate.py
@@ -38,10 +38,15 @@ REHEARSAL_DECISION_ARTIFACT_KIND = "live_adapter_gate_rehearsal_decision"
 REHEARSAL_DECISION_SCHEMA_NAME = "live-adapter-gate-rehearsal-decision.schema.v1.json"
 REHEARSAL_DECISION_ARTIFACT = "live-adapter-gate-rehearsal-decision.v1.json"
 REHEARSAL_DECISION_FINDING = "live_gate_rehearsal_blocked_missing_protected_prerequisites"
+ATTESTATION_PROGRAM_ID = "GPP-2d"
+ATTESTATION_ARTIFACT_KIND = "live_adapter_gate_prerequisite_attestation"
+ATTESTATION_ARTIFACT = "live-adapter-gate-attestation.v1.json"
+REQUIRED_SECRET_ID = "AO_CLAUDE_CODE_CLI_AUTH"
 
 
 CheckStatus = Literal["pass", "blocked", "skipped"]
 OverallStatus = Literal["blocked"]
+AttestationStatus = Literal["ready", "blocked"]
 EvidenceRequirementStatus = Literal["present", "blocked"]
 PrerequisiteStatus = Literal["blocked", "not_attested"]
 
@@ -221,6 +226,37 @@ class LiveAdapterGateRehearsalDecision(TypedDict):
     support_widening: bool
     prerequisite_status: list[LiveAdapterGatePrerequisiteStatus]
     promotion_decision: LiveAdapterGateRehearsalPromotionDecision
+    findings: list[str]
+
+
+class LiveAdapterGateAttestationCheck(TypedDict):
+    """Single metadata-only prerequisite attestation check."""
+
+    name: str
+    status: CheckStatus
+    finding_code: str | None
+    detail: str
+
+
+class LiveAdapterGateAttestationArtifact(TypedDict):
+    """Metadata-only protected live-adapter prerequisite attestation."""
+
+    schema_version: str
+    artifact_kind: str
+    program_id: str
+    gate_id: str
+    adapter_id: str
+    support_tier: str
+    overall_status: AttestationStatus
+    finding_code: str | None
+    generated_at: str
+    environment_name: str
+    required_secret_id: str
+    equivalent_release_gate_approved: bool
+    runtime_binding_allowed: bool
+    live_execution_allowed: bool
+    support_widening: bool
+    checks: list[LiveAdapterGateAttestationCheck]
     findings: list[str]
 
 
@@ -532,6 +568,211 @@ def build_live_adapter_gate_rehearsal_decision(
     }
 
 
+def _status(
+    condition: bool,
+    *,
+    finding_code: str | None,
+    pass_detail: str,
+    blocked_detail: str,
+) -> LiveAdapterGateAttestationCheck:
+    """Build one fail-closed attestation check."""
+
+    if condition:
+        return {
+            "name": "",
+            "status": "pass",
+            "finding_code": None,
+            "detail": pass_detail,
+        }
+    return {
+        "name": "",
+        "status": "blocked",
+        "finding_code": finding_code,
+        "detail": blocked_detail,
+    }
+
+
+def _as_dict(payload: object) -> dict[str, Any]:
+    """Return ``payload`` as a dictionary or an empty dictionary."""
+
+    return payload if isinstance(payload, dict) else {}
+
+
+def _as_list(payload: object) -> list[Any]:
+    """Return ``payload`` as a list or an empty list."""
+
+    return payload if isinstance(payload, list) else []
+
+
+def _named_items(payload: object, *, container_key: str | None = None) -> list[dict[str, Any]]:
+    """Extract named dictionaries from a GitHub API payload."""
+
+    if container_key and isinstance(payload, dict):
+        payload = payload.get(container_key, [])
+    return [item for item in _as_list(payload) if isinstance(item, dict)]
+
+
+def _branch_policy_names(branch_policy_payload: object) -> list[str]:
+    """Return deployment branch policy names from GitHub API output."""
+
+    return sorted(
+        item["name"]
+        for item in _named_items(branch_policy_payload, container_key="branch_policies")
+        if isinstance(item.get("name"), str)
+    )
+
+
+def _secret_names(secret_payload: object) -> list[str]:
+    """Return secret names without reading secret values."""
+
+    return sorted(item["name"] for item in _named_items(secret_payload) if isinstance(item.get("name"), str))
+
+
+def _collaborator_logins(collaborator_payload: object) -> list[str]:
+    """Return visible collaborator logins from GitHub API output."""
+
+    return sorted(item["login"] for item in _named_items(collaborator_payload) if isinstance(item.get("login"), str))
+
+
+def _required_reviewer_rules(environment_payload: object) -> list[dict[str, Any]]:
+    """Return required-reviewer environment protection rules."""
+
+    environment = _as_dict(environment_payload)
+    return [
+        rule
+        for rule in _as_list(environment.get("protection_rules", []))
+        if isinstance(rule, dict) and rule.get("type") == "required_reviewers"
+    ]
+
+
+def _has_branch_policy_rule(environment_payload: object) -> bool:
+    """Return whether the environment has a branch-policy protection rule."""
+
+    environment = _as_dict(environment_payload)
+    return any(
+        isinstance(rule, dict) and rule.get("type") == "branch_policy"
+        for rule in _as_list(environment.get("protection_rules", []))
+    )
+
+
+def build_live_adapter_gate_attestation(
+    *,
+    environment_payload: object,
+    branch_policy_payload: object,
+    secret_payload: object,
+    collaborator_payload: object,
+    environment_name: str = PROTECTED_ENVIRONMENT_NAME,
+    required_secret_id: str = REQUIRED_SECRET_ID,
+    actor_login: str = "",
+    equivalent_release_gate_approved: bool = False,
+    generated_at: str | None = None,
+) -> LiveAdapterGateAttestationArtifact:
+    """Build a metadata-only protected live-adapter prerequisite attestation.
+
+    This helper consumes GitHub API metadata only. It never accepts or emits
+    secret values and it never grants support widening. ``runtime_binding`` can
+    only become allowed when all prerequisites are metadata-attested; live
+    execution remains a separate downstream gate.
+    """
+
+    environment = _as_dict(environment_payload)
+    environment_exists = environment.get("name") == environment_name
+    admin_bypass_disabled = environment_exists and environment.get("can_admins_bypass") is False
+    deployment_policy = _as_dict(environment.get("deployment_branch_policy"))
+    custom_branch_policy = deployment_policy.get("custom_branch_policies") is True
+    branch_policy_names = _branch_policy_names(branch_policy_payload)
+    main_only_branch_policy = branch_policy_names == ["main"]
+    branch_policy_ok = _has_branch_policy_rule(environment) and custom_branch_policy and main_only_branch_policy
+
+    secret_present = required_secret_id in _secret_names(secret_payload)
+    reviewer_rules = _required_reviewer_rules(environment)
+    reviewer_gate_configured = bool(reviewer_rules)
+    prevent_self_review = any(rule.get("prevent_self_review") is True for rule in reviewer_rules)
+    collaborators = _collaborator_logins(collaborator_payload)
+    non_self_collaborators = [login for login in collaborators if not actor_login or login != actor_login]
+    non_self_reviewer_possible = len(non_self_collaborators) >= 1
+    reviewer_gate_ok = (reviewer_gate_configured and prevent_self_review and non_self_reviewer_possible) or (
+        equivalent_release_gate_approved
+    )
+
+    check_specs = [
+        (
+            "protected_environment",
+            environment_exists,
+            "live_gate_environment_missing",
+            f"GitHub environment {environment_name!r} exists.",
+            f"GitHub environment {environment_name!r} is missing.",
+        ),
+        (
+            "admin_bypass",
+            admin_bypass_disabled,
+            "live_gate_admin_bypass_enabled",
+            "Environment admin bypass is disabled.",
+            "Environment admin bypass is not disabled.",
+        ),
+        (
+            "deployment_branch_policy",
+            branch_policy_ok,
+            "live_gate_branch_policy_not_main_only",
+            "Environment deployment branch policy is restricted to main.",
+            f"Environment deployment branch policy is not restricted to main; observed={branch_policy_names!r}.",
+        ),
+        (
+            "credential_handle",
+            secret_present,
+            "live_gate_credential_handle_missing",
+            f"Environment secret handle {required_secret_id!r} is present by name.",
+            f"Environment secret handle {required_secret_id!r} is missing.",
+        ),
+        (
+            "reviewer_gate",
+            reviewer_gate_ok,
+            "live_gate_reviewer_gate_missing",
+            "Reviewer protection or an explicitly approved equivalent release gate is present.",
+            "Required reviewer protection is missing and no equivalent release gate is approved.",
+        ),
+        (
+            "support_boundary",
+            True,
+            None,
+            "Attestation never widens support or certifies production.",
+            "",
+        ),
+    ]
+    checks: list[LiveAdapterGateAttestationCheck] = []
+    for name, condition, finding_code, pass_detail, blocked_detail in check_specs:
+        check = _status(
+            condition,
+            finding_code=finding_code,
+            pass_detail=pass_detail,
+            blocked_detail=blocked_detail,
+        )
+        check["name"] = name
+        checks.append(check)
+
+    findings = [check["finding_code"] for check in checks if check["finding_code"]]
+    overall_status: AttestationStatus = "ready" if not findings else "blocked"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_kind": ATTESTATION_ARTIFACT_KIND,
+        "program_id": ATTESTATION_PROGRAM_ID,
+        "gate_id": GATE_ID,
+        "adapter_id": ADAPTER_ID,
+        "support_tier": SUPPORT_TIER,
+        "overall_status": overall_status,
+        "finding_code": None if overall_status == "ready" else findings[0],
+        "generated_at": generated_at or utc_timestamp(),
+        "environment_name": environment_name,
+        "required_secret_id": required_secret_id,
+        "equivalent_release_gate_approved": equivalent_release_gate_approved,
+        "runtime_binding_allowed": overall_status == "ready",
+        "live_execution_allowed": False,
+        "support_widening": False,
+        "checks": checks,
+        "findings": findings,
+    }
+
+
 def load_live_adapter_gate_evidence_schema() -> dict[str, Any]:
     """Load the bundled GP-4.2 evidence artifact JSON Schema."""
 
@@ -602,6 +843,13 @@ def write_live_adapter_gate_rehearsal_decision(path: Path, decision: LiveAdapter
     path.write_text(json.dumps(decision, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def write_live_adapter_gate_attestation(path: Path, artifact: LiveAdapterGateAttestationArtifact) -> None:
+    """Write a metadata-only live-adapter prerequisite attestation."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
 def render_live_adapter_gate_text(report: LiveAdapterGateReport) -> str:
     """Render a concise operator-facing summary for logs."""
 
@@ -616,6 +864,26 @@ def render_live_adapter_gate_text(report: LiveAdapterGateReport) -> str:
         "checks:",
     ]
     for check in report["checks"]:
+        suffix = f" ({check['finding_code']})" if check["finding_code"] else ""
+        lines.append(f"- {check['name']}: {check['status']}{suffix}")
+    return "\n".join(lines)
+
+
+def render_live_adapter_gate_attestation_text(artifact: LiveAdapterGateAttestationArtifact) -> str:
+    """Render a concise operator-facing attestation summary."""
+
+    lines = [
+        f"program_id: {artifact['program_id']}",
+        f"gate_id: {artifact['gate_id']}",
+        f"adapter_id: {artifact['adapter_id']}",
+        f"overall_status: {artifact['overall_status']}",
+        f"finding_code: {artifact['finding_code'] or 'none'}",
+        f"runtime_binding_allowed: {str(artifact['runtime_binding_allowed']).lower()}",
+        f"live_execution_allowed: {str(artifact['live_execution_allowed']).lower()}",
+        f"support_widening: {str(artifact['support_widening']).lower()}",
+        "checks:",
+    ]
+    for check in artifact["checks"]:
         suffix = f" ({check['finding_code']})" if check["finding_code"] else ""
         lines.append(f"- {check['name']}: {check['status']}{suffix}")
     return "\n".join(lines)

--- a/scripts/live_adapter_gate_attest.py
+++ b/scripts/live_adapter_gate_attest.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Emit metadata-only protected live-adapter prerequisite attestation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel.live_adapter_gate import (  # noqa: E402
+    ATTESTATION_ARTIFACT,
+    PROTECTED_ENVIRONMENT_NAME,
+    REQUIRED_SECRET_ID,
+    build_live_adapter_gate_attestation,
+    render_live_adapter_gate_attestation_text,
+    write_live_adapter_gate_attestation,
+)
+
+
+def _load_json_file(path: Path | None) -> object | None:
+    """Load a JSON fixture if ``path`` is provided."""
+
+    if path is None:
+        return None
+    payload: object = json.loads(path.read_text(encoding="utf-8"))
+    return payload
+
+
+def _run_json(command: list[str]) -> object:
+    """Run a command that emits JSON and return the decoded payload."""
+
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    return json.loads(completed.stdout or "null")
+
+
+def _collect_live_payloads(repo: str, environment: str) -> tuple[object, object, object, object]:
+    """Collect GitHub metadata without reading secret values."""
+
+    environment_payload = _run_json(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/environments/{environment}",
+        ]
+    )
+    branch_policy_payload = _run_json(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/environments/{environment}/deployment-branch-policies",
+        ]
+    )
+    secret_payload = _run_json(
+        [
+            "gh",
+            "secret",
+            "list",
+            "--env",
+            environment,
+            "--repo",
+            repo,
+            "--json",
+            "name,updatedAt",
+        ]
+    )
+    collaborator_payload = _run_json(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/collaborators?per_page=100",
+        ]
+    )
+    return environment_payload, branch_policy_payload, secret_payload, collaborator_payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="Halildeu/ao-kernel", help="GitHub repository owner/name.")
+    parser.add_argument("--environment", default=PROTECTED_ENVIRONMENT_NAME, help="Protected environment name.")
+    parser.add_argument("--secret-id", default=REQUIRED_SECRET_ID, help="Required environment secret handle.")
+    parser.add_argument("--actor-login", default="", help="Current triggering actor login for non-self checks.")
+    parser.add_argument(
+        "--equivalent-release-gate-approved",
+        action="store_true",
+        help="Treat an explicitly approved equivalent release gate as satisfying reviewer protection.",
+    )
+    parser.add_argument(
+        "--artifact-path",
+        type=Path,
+        default=Path(ATTESTATION_ARTIFACT),
+        help="Path for the metadata-only attestation artifact.",
+    )
+    parser.add_argument("--output", choices=("json", "text"), default="json", help="Stdout render mode.")
+    parser.add_argument(
+        "--fail-on-blocked",
+        action="store_true",
+        help="Return exit code 1 when prerequisites are blocked.",
+    )
+    parser.add_argument("--environment-json", type=Path, default=None, help="Fixture JSON for environment metadata.")
+    parser.add_argument(
+        "--branch-policies-json",
+        type=Path,
+        default=None,
+        help="Fixture JSON for deployment branch policy metadata.",
+    )
+    parser.add_argument("--secrets-json", type=Path, default=None, help="Fixture JSON for secret names.")
+    parser.add_argument("--collaborators-json", type=Path, default=None, help="Fixture JSON for collaborators.")
+    return parser
+
+
+def _fixture_payloads(args: argparse.Namespace) -> tuple[object, object, object, object] | None:
+    """Return fixture payloads when all fixture inputs are provided."""
+
+    paths = (args.environment_json, args.branch_policies_json, args.secrets_json, args.collaborators_json)
+    if all(path is None for path in paths):
+        return None
+    if any(path is None for path in paths):
+        raise SystemExit("all fixture inputs must be provided together")
+    return (
+        _load_json_file(args.environment_json),
+        _load_json_file(args.branch_policies_json),
+        _load_json_file(args.secrets_json),
+        _load_json_file(args.collaborators_json),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    payloads = _fixture_payloads(args)
+    if payloads is None:
+        payloads = _collect_live_payloads(args.repo, args.environment)
+
+    environment_payload, branch_policy_payload, secret_payload, collaborator_payload = payloads
+    artifact = build_live_adapter_gate_attestation(
+        environment_payload=environment_payload,
+        branch_policy_payload=branch_policy_payload,
+        secret_payload=secret_payload,
+        collaborator_payload=collaborator_payload,
+        environment_name=args.environment,
+        required_secret_id=args.secret_id,
+        actor_login=args.actor_login,
+        equivalent_release_gate_approved=args.equivalent_release_gate_approved,
+    )
+    write_live_adapter_gate_attestation(args.artifact_path, artifact)
+
+    if args.output == "json":
+        print(json.dumps(artifact, indent=2, sort_keys=True))
+    else:
+        print(render_live_adapter_gate_attestation_text(artifact))
+
+    if args.fail_on_blocked and artifact["overall_status"] != "ready":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -54,6 +54,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         payload["pending_external_actions"][1]["decision"]
         == "missing_environment_secret_and_non_self_reviewer_gate"
     )
+    assert payload["pending_external_actions"][2]["id"] == "GPP-2d"
+    assert payload["pending_external_actions"][2]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/487"
+    assert payload["pending_external_actions"][2]["status"] == "implemented_no_support_widening"
+    assert (
+        payload["pending_external_actions"][2]["decision"]
+        == "repeatable_attestation_available_current_gate_still_blocked"
+    )
     assert {item["id"] for item in payload["blocked_wps"]} == {"GPP-2"}
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
 

--- a/tests/test_live_adapter_gate_contract.py
+++ b/tests/test_live_adapter_gate_contract.py
@@ -10,10 +10,12 @@ from jsonschema import Draft202012Validator
 from jsonschema.exceptions import ValidationError
 
 from ao_kernel.live_adapter_gate import (
+    ATTESTATION_ARTIFACT,
     BLOCKED_FINDING,
     EVIDENCE_ARTIFACT,
     ENVIRONMENT_CONTRACT_ARTIFACT,
     REHEARSAL_DECISION_ARTIFACT,
+    build_live_adapter_gate_attestation,
     build_live_adapter_gate_evidence_artifact,
     build_live_adapter_gate_environment_contract,
     build_live_adapter_gate_rehearsal_decision,
@@ -23,6 +25,7 @@ from ao_kernel.live_adapter_gate import (
     load_live_adapter_gate_environment_schema,
     load_live_adapter_gate_rehearsal_decision_schema,
     render_live_adapter_gate_text,
+    write_live_adapter_gate_attestation,
     validate_live_adapter_gate_evidence_artifact,
     validate_live_adapter_gate_environment_contract,
     validate_live_adapter_gate_rehearsal_decision,
@@ -205,6 +208,140 @@ def test_build_live_adapter_gate_rehearsal_decision_is_schema_valid_and_blocked(
     assert prerequisites["project_owned_credential"]["status"] == "not_attested"
     assert prerequisites["protected_live_preflight"]["status"] == "blocked"
     assert prerequisites["governed_workflow_smoke"]["status"] == "blocked"
+
+
+def test_build_live_adapter_gate_attestation_blocks_current_partial_gate() -> None:
+    artifact = build_live_adapter_gate_attestation(
+        environment_payload={
+            "name": "ao-kernel-live-adapter-gate",
+            "can_admins_bypass": False,
+            "deployment_branch_policy": {"custom_branch_policies": True, "protected_branches": False},
+            "protection_rules": [{"id": 53201958, "type": "branch_policy"}],
+        },
+        branch_policy_payload={"branch_policies": [{"name": "main", "type": "branch"}]},
+        secret_payload=[],
+        collaborator_payload=[{"login": "Halildeu", "role_name": "admin"}],
+        actor_login="Halildeu",
+        generated_at="2026-04-25T00:00:00Z",
+    )
+
+    assert artifact["artifact_kind"] == "live_adapter_gate_prerequisite_attestation"
+    assert artifact["program_id"] == "GPP-2d"
+    assert artifact["overall_status"] == "blocked"
+    assert artifact["finding_code"] == "live_gate_credential_handle_missing"
+    assert artifact["runtime_binding_allowed"] is False
+    assert artifact["live_execution_allowed"] is False
+    assert artifact["support_widening"] is False
+
+    checks = {check["name"]: check for check in artifact["checks"]}
+    assert checks["protected_environment"]["status"] == "pass"
+    assert checks["admin_bypass"]["status"] == "pass"
+    assert checks["deployment_branch_policy"]["status"] == "pass"
+    assert checks["credential_handle"]["status"] == "blocked"
+    assert checks["credential_handle"]["finding_code"] == "live_gate_credential_handle_missing"
+    assert checks["reviewer_gate"]["status"] == "blocked"
+    assert checks["reviewer_gate"]["finding_code"] == "live_gate_reviewer_gate_missing"
+
+
+def test_build_live_adapter_gate_attestation_allows_ready_metadata_only_state() -> None:
+    artifact = build_live_adapter_gate_attestation(
+        environment_payload={
+            "name": "ao-kernel-live-adapter-gate",
+            "can_admins_bypass": False,
+            "deployment_branch_policy": {"custom_branch_policies": True, "protected_branches": False},
+            "protection_rules": [
+                {"id": 1, "type": "branch_policy"},
+                {"id": 2, "type": "required_reviewers", "prevent_self_review": True},
+            ],
+        },
+        branch_policy_payload={"branch_policies": [{"name": "main", "type": "branch"}]},
+        secret_payload=[{"name": "AO_CLAUDE_CODE_CLI_AUTH", "updatedAt": "2026-04-25T00:00:00Z"}],
+        collaborator_payload=[
+            {"login": "Halildeu", "role_name": "admin"},
+            {"login": "release-reviewer", "role_name": "maintain"},
+        ],
+        actor_login="Halildeu",
+        generated_at="2026-04-25T00:00:00Z",
+    )
+
+    assert artifact["overall_status"] == "ready"
+    assert artifact["finding_code"] is None
+    assert artifact["runtime_binding_allowed"] is True
+    assert artifact["live_execution_allowed"] is False
+    assert artifact["support_widening"] is False
+    assert artifact["findings"] == []
+
+
+def test_write_live_adapter_gate_attestation_round_trips_json(tmp_path: Path) -> None:
+    artifact = build_live_adapter_gate_attestation(
+        environment_payload={},
+        branch_policy_payload={},
+        secret_payload=[],
+        collaborator_payload=[],
+        generated_at="2026-04-25T00:00:00Z",
+    )
+    path = tmp_path / ATTESTATION_ARTIFACT
+
+    write_live_adapter_gate_attestation(path, artifact)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload == artifact
+    assert path.read_text(encoding="utf-8").endswith("\n")
+
+
+def test_live_adapter_gate_attestation_cli_uses_fixture_metadata(tmp_path: Path) -> None:
+    environment_path = tmp_path / "environment.json"
+    branch_policies_path = tmp_path / "branch-policies.json"
+    secrets_path = tmp_path / "secrets.json"
+    collaborators_path = tmp_path / "collaborators.json"
+    artifact_path = tmp_path / ATTESTATION_ARTIFACT
+
+    environment_path.write_text(
+        json.dumps(
+            {
+                "name": "ao-kernel-live-adapter-gate",
+                "can_admins_bypass": False,
+                "deployment_branch_policy": {"custom_branch_policies": True, "protected_branches": False},
+                "protection_rules": [{"id": 53201958, "type": "branch_policy"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    branch_policies_path.write_text(
+        json.dumps({"branch_policies": [{"name": "main", "type": "branch"}]}),
+        encoding="utf-8",
+    )
+    secrets_path.write_text("[]", encoding="utf-8")
+    collaborators_path.write_text(json.dumps([{"login": "Halildeu", "role_name": "admin"}]), encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/live_adapter_gate_attest.py",
+            "--environment-json",
+            str(environment_path),
+            "--branch-policies-json",
+            str(branch_policies_path),
+            "--secrets-json",
+            str(secrets_path),
+            "--collaborators-json",
+            str(collaborators_path),
+            "--artifact-path",
+            str(artifact_path),
+            "--output",
+            "json",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    stdout_payload = json.loads(completed.stdout)
+    file_payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert stdout_payload == file_payload
+    assert stdout_payload["overall_status"] == "blocked"
+    assert stdout_payload["finding_code"] == "live_gate_credential_handle_missing"
 
 
 def test_live_adapter_gate_evidence_schema_rejects_support_widening() -> None:


### PR DESCRIPTION
## Summary

- adds `build_live_adapter_gate_attestation()` and `scripts/live_adapter_gate_attest.py`
- emits metadata-only JSON/text attestation for `ao-kernel-live-adapter-gate` without reading secret values
- covers current partial-provisioning blocked state plus a synthetic metadata-ready state
- updates GPP status so future prerequisite checks use repeatable attestation evidence

## Current live result

```text
program_id: GPP-2d
overall_status: blocked
finding_code: live_gate_credential_handle_missing
runtime_binding_allowed: false
live_execution_allowed: false
support_widening: false
checks:
- protected_environment: pass
- admin_bypass: pass
- deployment_branch_policy: pass
- credential_handle: blocked (live_gate_credential_handle_missing)
- reviewer_gate: blocked (live_gate_reviewer_gate_missing)
- support_boundary: pass
```

## Non-goals

- no runtime binding
- no live adapter execution
- no secret value readback
- no single-admin equivalent gate approval
- no support widening
- no production-platform claim

## Validation

- `pytest -q tests/test_live_adapter_gate_contract.py tests/test_gpp_next.py tests/test_gp5_platform_claim_decision.py`
- `python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/ao-kernel-live-adapter-gate-attestation.json --output text`
- `python3 scripts/gpp_next.py`
- `ruff check ao_kernel/live_adapter_gate.py scripts/live_adapter_gate_attest.py tests/test_live_adapter_gate_contract.py tests/test_gpp_next.py`
- `mypy ao_kernel/live_adapter_gate.py scripts/live_adapter_gate_attest.py`
- `git diff --check`
- `python3 -m ao_kernel doctor` (`8 OK, 1 WARN, 0 FAIL`; expected extension truth inventory warning)

Issue: #487
