### PR TITLE
[codex] record equivalent gate decision

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,12 +1,12 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 blocked; GPP-2b external/admin provisioning issue open
+**Status:** GPP-2 blocked; single-admin equivalent gate not approved
 **Date:** 2026-04-25
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#482](https://github.com/Halildeu/ao-kernel/issues/482)
-for external/admin provisioning
+**Current slice issue:** [#489](https://github.com/Halildeu/ao-kernel/issues/489)
+for single-admin equivalent gate decision tracking
 **Current slice record:** `.claude/plans/gpp_status.v1.json`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
@@ -80,6 +80,11 @@ Last live verification on current `origin/main` showed:
     deployment branch policy includes `main`, and admin bypass is disabled.
     Required reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` are still
     missing, so `GPP-2` remains blocked.
+21. GPP-2d merged metadata-only attestation tooling so the live gate can be
+    checked repeatably without reading secret values. GPP-2e records that the
+    single-admin equivalent release gate is not approved; the
+    `--equivalent-release-gate-approved` attestation option must not be used
+    until a future explicit approval supersedes this decision.
 
 ## 3. Current Verdict
 
@@ -123,6 +128,7 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2b` | Partially provisioned / blocked | Protected live-adapter environment and credential provisioning | environment exists; `main` branch policy and admin-bypass-off are set; reviewer protection and credential handle still missing |
 | `GPP-2c` | Blocked external/admin decision | Reviewer and credential gate resolution | `AO_CLAUDE_CODE_CLI_AUTH` and non-self reviewer/equivalent gate still missing |
 | `GPP-2d` | Implemented / no support widening | Metadata-only live gate attestation tool | repeatable attestation is available; current live gate still blocked |
+| `GPP-2e` | Completed / no support widening | Single-admin equivalent gate decision | `not_approved`; equivalent gate override cannot be used without a future explicit approval |
 | `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until a future attestation exits `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -515,6 +521,9 @@ GPP-2c is tracked in
 remaining reviewer and credential gate decision. GPP-2d adds
 `scripts/live_adapter_gate_attest.py` so the next prerequisite attestation uses
 repeatable metadata-only evidence instead of hand-written command snippets.
+GPP-2e records the single-admin equivalent gate as `not_approved`; the
+attestation override `--equivalent-release-gate-approved` is forbidden until a
+future explicit approval supersedes [#489](https://github.com/Halildeu/ao-kernel/issues/489).
 
 ## 18. Risk Register
 
@@ -549,3 +558,5 @@ repeatable metadata-only evidence instead of hand-written command snippets.
 | 2026-04-25 | GPP-2b partial provisioning recorded | `ao-kernel-live-adapter-gate` now exists, custom deployment branch policy includes `main`, and admin bypass is disabled. Reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` remain missing, so #482 stays open and `GPP-2` stays blocked. |
 | 2026-04-25 | GPP-2c issue opened | Issue [#485](https://github.com/Halildeu/ao-kernel/issues/485) tracks the remaining protected reviewer and credential gate: add/designate a non-self reviewer or explicitly approve an equivalent release gate, and set `AO_CLAUDE_CODE_CLI_AUTH` without secret readback. |
 | 2026-04-25 | GPP-2d issue opened | Issue [#487](https://github.com/Halildeu/ao-kernel/issues/487) tracks a metadata-only attestation tool for repeatable protected gate evidence. |
+| 2026-04-25 | GPP-2d merged | PR [#488](https://github.com/Halildeu/ao-kernel/pull/488) added `scripts/live_adapter_gate_attest.py`; live attestation remains blocked by missing credential handle and reviewer/equivalent gate. |
+| 2026-04-25 | GPP-2e issue opened | Issue [#489](https://github.com/Halildeu/ao-kernel/issues/489) tracks the single-admin equivalent gate decision; current repo decision is `not_approved`, so the attestation override remains forbidden. |

--- a/.claude/plans/GPP-2e-SINGLE-ADMIN-EQUIVALENT-GATE-DECISION.md
+++ b/.claude/plans/GPP-2e-SINGLE-ADMIN-EQUIVALENT-GATE-DECISION.md
@@ -1,0 +1,74 @@
+# GPP-2e - Single-Admin Equivalent Release-Gate Decision
+
+**Issue:** [#489](https://github.com/Halildeu/ao-kernel/issues/489)
+**Date:** 2026-04-25
+**Program head:** `GPP-2` remains blocked
+**Decision:** `not_approved`
+**Support impact:** none
+**Runtime impact:** none
+
+## Purpose
+
+This record defines the decision boundary for using a single-admin equivalent
+release gate instead of a true non-self GitHub environment reviewer for the
+protected live-adapter gate.
+
+It does not approve that equivalent gate. It prevents the
+`--equivalent-release-gate-approved` attestation option from being used as an
+implicit shortcut.
+
+## Current Evidence
+
+The live gate currently has these properties:
+
+1. GitHub environment `ao-kernel-live-adapter-gate` exists.
+2. Admin bypass is disabled.
+3. Deployment branch policy is restricted to `main`.
+4. Environment secret handle `AO_CLAUDE_CODE_CLI_AUTH` is absent.
+5. Required reviewer protection is absent.
+6. Only one collaborator, `Halildeu`, is visible through the GitHub
+   collaborators API.
+
+The repeatable attestation tool reports:
+
+```text
+overall_status: blocked
+finding_code: live_gate_credential_handle_missing
+runtime_binding_allowed: false
+live_execution_allowed: false
+support_widening: false
+```
+
+## Decision
+
+The single-admin equivalent release gate is **not approved**.
+
+The preferred resolution remains:
+
+1. Add or designate a second maintainer reviewer.
+2. Configure required reviewers on `ao-kernel-live-adapter-gate`.
+3. Enable prevent-self-review or an equivalent non-self approval mechanism.
+4. Add `AO_CLAUDE_CODE_CLI_AUTH` as an environment secret handle without
+   reading back, printing, or committing the secret value.
+5. Re-run metadata-only attestation and record the result in a follow-up PR.
+
+An equivalent single-admin release gate can only be used after a future explicit
+decision changes this record from `not_approved` to `approved`.
+
+## Contract
+
+Until a future explicit approval exists:
+
+1. `scripts/live_adapter_gate_attest.py --equivalent-release-gate-approved`
+   must not be used for production prerequisite attestation.
+2. `GPP-2` runtime binding must not start.
+3. Live adapter execution remains forbidden.
+4. Support widening remains forbidden.
+5. Production-platform claim remains forbidden.
+6. Local operator auth remains non-production evidence.
+
+## Exit State
+
+This slice closes as `decision_recorded_not_approved_no_support_widening`.
+
+It improves governance clarity only. It does not unblock `GPP-2`.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -140,7 +140,8 @@ ayrı ayrı görünür kılmak.
 - **GPP-2a protected prerequisite re-attestation issue:** [#480](https://github.com/Halildeu/ao-kernel/issues/480) (`closes by PR #481`)
 - **GPP-2b external/admin provisioning issue:** [#482](https://github.com/Halildeu/ao-kernel/issues/482)
 - **GPP-2c reviewer/credential gate issue:** [#485](https://github.com/Halildeu/ao-kernel/issues/485)
-- **GPP-2d metadata-only live gate attestation issue:** [#487](https://github.com/Halildeu/ao-kernel/issues/487)
+- **GPP-2d metadata-only live gate attestation issue:** [#487](https://github.com/Halildeu/ao-kernel/issues/487) (`closed by PR #488`)
+- **GPP-2e single-admin equivalent gate decision issue:** [#489](https://github.com/Halildeu/ao-kernel/issues/489)
 - **Current mode:** stable maintenance + written general-purpose production
   promotion tracking. RI-5b is merged as Beta/operator-managed root export, not
   a production platform claim. GPP-1 live attestation exited as
@@ -155,9 +156,11 @@ ayrı ayrı görünür kılmak.
   `AO_CLAUDE_CODE_CLI_AUTH` remain missing. GPP-2c now tracks that final
   reviewer/credential gate decision. GPP-2d adds repeatable metadata-only
   attestation tooling so future prerequisite checks do not rely on manual issue
-  comments. No support
+  comments. GPP-2e records that the single-admin equivalent release gate is
+  not approved, so `--equivalent-release-gate-approved` cannot be used for
+  production prerequisite attestation without a future explicit approval. No support
   widening, release, runtime adapter promotion, or production claim is made by
-  GPP-1b/GPP-1c/GPP-2a/GPP-2b/GPP-2c/GPP-2d. Future stable widening still
+  GPP-1b/GPP-1c/GPP-2a/GPP-2b/GPP-2c/GPP-2d/GPP-2e. Future stable widening still
   requires protected live-adapter evidence, repo-intelligence integration
   gates, write-side rollback evidence, and an explicit closeout decision.
 
@@ -266,6 +269,11 @@ adımında `ao-kernel-live-adapter-gate` environment oluşturuldu, `main` branch
 policy eklendi ve admin bypass kapatıldı. Buna rağmen
 `AO_CLAUDE_CODE_CLI_AUTH` environment secret handle yoktur, required reviewer
 protection yoktur ve runtime binding hâlâ başlamaz.
+
+`GPP-2d` metadata-only attestation tooling'i merge edildi. `GPP-2e` single-admin
+equivalent release gate kararını `not_approved` olarak kaydeder; bu nedenle
+`--equivalent-release-gate-approved` flag'i production prerequisite attestation
+için kullanılamaz.
 
 `GPP-1b`, bu blocked runtime sonucunu değiştirmez. Amacı Codex ve Claude Code
 operatör oturumlarının `.claude/plans/gpp_status.v1.json` ve

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -39,14 +39,27 @@
       "issue": "https://github.com/Halildeu/ao-kernel/issues/480",
       "pr": "https://github.com/Halildeu/ao-kernel/pull/481",
       "record": ".claude/plans/GPP-2a-PROTECTED-LIVE-ADAPTER-PREREQUISITE-RE-ATTESTATION.md"
+    },
+    {
+      "id": "GPP-2d",
+      "decision": "repeatable_attestation_available_current_gate_still_blocked",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/487",
+      "pr": "https://github.com/Halildeu/ao-kernel/pull/488",
+      "record": ".claude/plans/GPP-2d-METADATA-ONLY-LIVE-GATE-ATTESTATION.md"
+    },
+    {
+      "id": "GPP-2e",
+      "decision": "decision_recorded_not_approved_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/489",
+      "record": ".claude/plans/GPP-2e-SINGLE-ADMIN-EQUIVALENT-GATE-DECISION.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
       "title": "Protected Live-Adapter Gate Runtime Binding",
-      "reason": "ao-kernel-live-adapter-gate environment and AO_CLAUDE_CODE_CLI_AUTH handle are not attested",
-      "blocked_until": "a future prerequisite attestation exits prerequisites_ready after the protected environment and credential handle exist"
+      "reason": "AO_CLAUDE_CODE_CLI_AUTH handle and reviewer/equivalent gate are not attested",
+      "blocked_until": "a future prerequisite attestation exits prerequisites_ready after the credential handle and reviewer/equivalent gate exist"
     }
   ],
   "pending_external_actions": [
@@ -67,15 +80,6 @@
       "status": "blocked_external_admin_decision_required",
       "decision": "missing_environment_secret_and_non_self_reviewer_gate",
       "required_before": "GPP-2 runtime binding"
-    },
-    {
-      "id": "GPP-2d",
-      "title": "Metadata-only live gate attestation tool",
-      "issue": "https://github.com/Halildeu/ao-kernel/issues/487",
-      "record": ".claude/plans/GPP-2d-METADATA-ONLY-LIVE-GATE-ATTESTATION.md",
-      "status": "implemented_no_support_widening",
-      "decision": "repeatable_attestation_available_current_gate_still_blocked",
-      "required_before": "future prerequisite attestation"
     }
   ],
   "support_widening_allowed": false,
@@ -119,6 +123,7 @@
     "edit feature/runtime scope in primary checkout",
     "treat local operator auth as production evidence",
     "start GPP-2 runtime binding while GPP-2 is blocked",
+    "use --equivalent-release-gate-approved while GPP-2e remains not_approved",
     "set support_widening=true without explicit GPP-9 promotion decision",
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
@@ -126,6 +131,7 @@
     "keep GPP-2 blocked",
     "track external admin provisioning in issue #482",
     "resolve reviewer and credential gate in issue #485",
+    "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
     "use scripts/live_adapter_gate_attest.py for the next prerequisite attestation",
     "provision AO_CLAUDE_CODE_CLI_AUTH under ao-kernel-live-adapter-gate without reading secret values",
     "configure required reviewer protection or record an explicitly approved equivalent release gate",

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -37,6 +37,19 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         item["id"] == "GPP-2a" and item["decision"] == "still_blocked_protected_prerequisites_missing"
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2d"
+        and item["decision"] == "repeatable_attestation_available_current_gate_still_blocked"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/487"
+        for item in payload["completed_wps"]
+    )
+    assert any(
+        item["id"] == "GPP-2e"
+        and item["decision"] == "decision_recorded_not_approved_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/489"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -54,15 +67,28 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         payload["pending_external_actions"][1]["decision"]
         == "missing_environment_secret_and_non_self_reviewer_gate"
     )
-    assert payload["pending_external_actions"][2]["id"] == "GPP-2d"
-    assert payload["pending_external_actions"][2]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/487"
-    assert payload["pending_external_actions"][2]["status"] == "implemented_no_support_widening"
-    assert (
-        payload["pending_external_actions"][2]["decision"]
-        == "repeatable_attestation_available_current_gate_still_blocked"
-    )
+    assert {item["id"] for item in payload["pending_external_actions"]} == {"GPP-2b", "GPP-2c"}
     assert {item["id"] for item in payload["blocked_wps"]} == {"GPP-2"}
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
+    assert any(
+        action == "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action == "use --equivalent-release-gate-approved while GPP-2e remains not_approved"
+        for action in payload["forbidden_actions"]
+    )
+
+
+def test_gpp2e_equivalent_gate_decision_defaults_to_not_approved() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2e-SINGLE-ADMIN-EQUIVALENT-GATE-DECISION.md"
+    ).read_text(encoding="utf-8")
+
+    assert "**Decision:** `not_approved`" in decision
+    assert "does not approve that equivalent gate" in decision
+    assert "--equivalent-release-gate-approved" in decision
+    assert "must not be used for production prerequisite attestation" in decision
 
 
 def test_gpp_next_load_status_validates_required_guards() -> None:
@@ -74,7 +100,7 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
     assert payload["current_wp"]["status"] == "blocked"
     assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/482"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
-    assert "protected environment and credential handle exist" in payload["blocked_wps"][0]["blocked_until"]
+    assert "credential handle and reviewer/equivalent gate exist" in payload["blocked_wps"][0]["blocked_until"]
     assert payload["support_widening_allowed"] is False
 
 
@@ -104,7 +130,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "- GPP-2: ao-kernel-live-adapter-gate environment" in rendered
+    assert "- GPP-2: AO_CLAUDE_CODE_CLI_AUTH handle and reviewer/equivalent gate" in rendered
     assert "divergence: 0\t0" in rendered
 
 


### PR DESCRIPTION
## Summary

- Record GPP-2e single-admin equivalent release-gate decision as `not_approved`.
- Move GPP-2d metadata-only attestation tooling from pending external action to completed work in the machine-readable GPP status.
- Keep GPP-2 blocked on the missing credential handle and reviewer/equivalent gate.
- Add tests that pin the `not_approved` decision and forbid using `--equivalent-release-gate-approved` as an implicit shortcut.

Closes #489.

## Scope boundary

This PR does not:

- start GPP-2 runtime binding
- execute a live adapter
- read or print secret values
- widen support
- claim general-purpose production readiness
- approve the single-admin equivalent gate

## Validation

```bash
python3 -m json.tool .claude/plans/gpp_status.v1.json >/tmp/gpp_status.pretty.json
python3 scripts/gpp_next.py
pytest -q tests/test_gpp_next.py tests/test_live_adapter_gate_contract.py tests/test_gp5_platform_claim_decision.py
python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/ao-kernel-gpp2e-live-adapter-gate-attestation.json --output text
python3 -m ao_kernel doctor
bash .claude/scripts/ops.sh preflight
ruff check tests/test_gpp_next.py
git diff --check
```

Observed locally:

- targeted tests: `34 passed`
- live attestation: `overall_status: blocked`, `runtime_binding_allowed: false`, `live_execution_allowed: false`, `support_widening: false`
- doctor: `8 OK, 1 WARN, 0 FAIL` (known extension truth warning)
- ops preflight: branch fresh; dirty warning only before commit
