### PR TITLE
[codex] define independent release gate

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,12 +1,12 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 blocked; single-admin equivalent gate not approved
+**Status:** GPP-2 blocked; independent release gate required
 **Date:** 2026-04-25
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#489](https://github.com/Halildeu/ao-kernel/issues/489)
-for single-admin equivalent gate decision tracking
+**Current slice issue:** [#491](https://github.com/Halildeu/ao-kernel/issues/491)
+for independent release gate architecture decision tracking
 **Current slice record:** `.claude/plans/gpp_status.v1.json`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
@@ -73,9 +73,8 @@ Last live verification on current `origin/main` showed:
     project-owned/attested.
 19. GPP-2b opened issue
     [#482](https://github.com/Halildeu/ao-kernel/issues/482) to track the
-    external/admin provisioning work. Live collaborator inventory currently
-    shows only `Halildeu`, so the protected reviewer model still needs a
-    non-triggering reviewer/admin or an explicitly approved equivalent gate.
+    external/admin provisioning work. The protected gate requires an
+    independent release authority; this is not a product end-user account.
 20. GPP-2b partially provisioned the GitHub environment: the environment exists,
     deployment branch policy includes `main`, and admin bypass is disabled.
     Required reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` are still
@@ -85,6 +84,10 @@ Last live verification on current `origin/main` showed:
     single-admin equivalent release gate is not approved; the
     `--equivalent-release-gate-approved` attestation option must not be used
     until a future explicit approval supersedes this decision.
+22. GPP-2f records the required trust boundary as an independent release gate.
+    Acceptable future models are GitHub-native release authority, GitHub App
+    deployment protection, or OIDC-backed external secret broker. Product
+    end-user accounts are not release authority.
 
 ## 3. Current Verdict
 
@@ -129,6 +132,7 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2c` | Blocked external/admin decision | Reviewer and credential gate resolution | `AO_CLAUDE_CODE_CLI_AUTH` and non-self reviewer/equivalent gate still missing |
 | `GPP-2d` | Implemented / no support widening | Metadata-only live gate attestation tool | repeatable attestation is available; current live gate still blocked |
 | `GPP-2e` | Completed / no support widening | Single-admin equivalent gate decision | `not_approved`; equivalent gate override cannot be used without a future explicit approval |
+| `GPP-2f` | Completed / no support widening | Independent release gate architecture decision | independent release gate required; product end-user account is not release authority |
 | `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until a future attestation exits `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -518,12 +522,16 @@ reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` must still be completed
 before another prerequisite attestation can attempt to unblock `GPP-2`.
 GPP-2c is tracked in
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) to resolve the
-remaining reviewer and credential gate decision. GPP-2d adds
+remaining independent release gate and credential decision. GPP-2d adds
 `scripts/live_adapter_gate_attest.py` so the next prerequisite attestation uses
 repeatable metadata-only evidence instead of hand-written command snippets.
 GPP-2e records the single-admin equivalent gate as `not_approved`; the
 attestation override `--equivalent-release-gate-approved` is forbidden until a
 future explicit approval supersedes [#489](https://github.com/Halildeu/ao-kernel/issues/489).
+GPP-2f clarifies that the gate is an independent release authority, not a
+product end-user account. Acceptable future models are GitHub-native release
+authority, GitHub App deployment protection, or OIDC-backed external secret
+broker.
 
 ## 18. Risk Register
 
@@ -560,3 +568,4 @@ future explicit approval supersedes [#489](https://github.com/Halildeu/ao-kernel
 | 2026-04-25 | GPP-2d issue opened | Issue [#487](https://github.com/Halildeu/ao-kernel/issues/487) tracks a metadata-only attestation tool for repeatable protected gate evidence. |
 | 2026-04-25 | GPP-2d merged | PR [#488](https://github.com/Halildeu/ao-kernel/pull/488) added `scripts/live_adapter_gate_attest.py`; live attestation remains blocked by missing credential handle and reviewer/equivalent gate. |
 | 2026-04-25 | GPP-2e issue opened | Issue [#489](https://github.com/Halildeu/ao-kernel/issues/489) tracks the single-admin equivalent gate decision; current repo decision is `not_approved`, so the attestation override remains forbidden. |
+| 2026-04-26 | GPP-2f issue opened | Issue [#491](https://github.com/Halildeu/ao-kernel/issues/491) tracks the independent release gate architecture decision; product end-user accounts are explicitly not release authority. |

--- a/.claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md
+++ b/.claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md
@@ -1,4 +1,4 @@
-# GPP-2c - Reviewer and Credential Gate Decision
+# GPP-2c - Independent Release Gate and Credential Decision
 
 **Status:** blocked; external/admin decision required
 **Date:** 2026-04-25
@@ -16,6 +16,10 @@ provisioning.
 This is deliberately a governance/admin gate, not runtime implementation. It
 does not bind `.github/workflows/live-adapter-gate.yml`, does not create or read
 secret values, does not execute a live adapter, and does not widen support.
+
+`Reviewer` in the original slice title means GitHub-native release authority,
+not an application end-user account. `GPP-2f` supersedes the vocabulary with
+the broader independent release gate requirement.
 
 ## 2. Current Live Evidence
 
@@ -49,21 +53,22 @@ The environment shell is now present and partially hardened:
 The gate is still incomplete:
 
 1. `AO_CLAUDE_CODE_CLI_AUTH` is not present as an environment secret handle.
-2. Required reviewer protection is not configured.
-3. A true non-self reviewer gate is not currently possible while only one
-   collaborator is visible.
+2. No approved independent release gate is configured.
+3. The GitHub-native reviewer/team model is only one possible implementation;
+   a GitHub App deployment protection rule or OIDC-backed secret broker may
+   satisfy the same trust-boundary requirement in a future slice.
 
 ## 4. Acceptable Resolution Paths
 
 ### Preferred Path
 
-1. Add or designate a second maintainer reviewer.
+1. Add or designate a release authority reviewer or team.
 2. Configure `ao-kernel-live-adapter-gate` required reviewers with
    prevent-self-review.
 3. Set `AO_CLAUDE_CODE_CLI_AUTH` under the environment without printing or
    reading back the secret value.
 4. Open a follow-up attestation PR that proves the handle exists and the
-   reviewer gate is present.
+   independent release gate is present.
 
 ### Alternative Path
 
@@ -86,8 +91,7 @@ slice. That slice must prove:
 2. deployment branch policy still allows only the intended `main` path;
 3. `can_admins_bypass=false`;
 4. `AO_CLAUDE_CODE_CLI_AUTH` exists under the environment;
-5. reviewer protection or an explicitly approved equivalent release gate is
-   present;
+5. an approved independent release gate is present;
 6. fork-triggered contexts cannot read protected credentials.
 
 Only then may `GPP-2` runtime binding start.
@@ -100,4 +104,3 @@ Only then may `GPP-2` runtime binding start.
 4. No production-platform claim.
 5. No secret value readback.
 6. No local operator auth treated as project-owned evidence.
-

--- a/.claude/plans/GPP-2e-SINGLE-ADMIN-EQUIVALENT-GATE-DECISION.md
+++ b/.claude/plans/GPP-2e-SINGLE-ADMIN-EQUIVALENT-GATE-DECISION.md
@@ -13,6 +13,11 @@ This record defines the decision boundary for using a single-admin equivalent
 release gate instead of a true non-self GitHub environment reviewer for the
 protected live-adapter gate.
 
+The reviewer term here refers to a GitHub-native release authority model, not a
+product end-user account. `GPP-2f` broadens the accepted future architecture to
+an independent release gate: GitHub-native release authority, GitHub App
+deployment protection, or OIDC-backed external secret broker.
+
 It does not approve that equivalent gate. It prevents the
 `--equivalent-release-gate-approved` attestation option from being used as an
 implicit shortcut.
@@ -45,7 +50,7 @@ The single-admin equivalent release gate is **not approved**.
 
 The preferred resolution remains:
 
-1. Add or designate a second maintainer reviewer.
+1. Add or designate an independent release authority.
 2. Configure required reviewers on `ao-kernel-live-adapter-gate`.
 3. Enable prevent-self-review or an equivalent non-self approval mechanism.
 4. Add `AO_CLAUDE_CODE_CLI_AUTH` as an environment secret handle without

--- a/.claude/plans/GPP-2f-INDEPENDENT-RELEASE-GATE-ARCHITECTURE.md
+++ b/.claude/plans/GPP-2f-INDEPENDENT-RELEASE-GATE-ARCHITECTURE.md
@@ -1,0 +1,87 @@
+# GPP-2f - Independent Release Gate Architecture Decision
+
+**Issue:** [#491](https://github.com/Halildeu/ao-kernel/issues/491)
+**Date:** 2026-04-26
+**Program head:** `GPP-2` remains blocked
+**Decision:** `independent_release_gate_required`
+**Support impact:** none
+**Runtime impact:** none
+
+## Purpose
+
+This record replaces the ambiguous "real reviewer" wording with an explicit
+trust-boundary requirement for the protected live-adapter gate.
+
+The required control is not a product end-user account. The required control is
+an independent release authority that prevents the same automation/session from
+both creating or triggering a change and opening access to live adapter
+credentials.
+
+## Decision
+
+`GPP-2` requires an **independent release gate** before runtime binding can
+start.
+
+Acceptable models are:
+
+1. **GitHub-native release authority**
+   - A required GitHub environment reviewer or team.
+   - The reviewer/team represents release authority, not an application
+     end-user.
+   - Self-review must be prevented or equivalently controlled.
+2. **GitHub App deployment protection rule**
+   - A GitHub App or policy service evaluates repo-owned evidence.
+   - The app approves only after branch, CI, attestation, support-boundary, and
+     runtime-binding prerequisites pass.
+3. **OIDC-backed external secret broker**
+   - The workflow receives no long-lived live adapter secret directly.
+   - A broker releases credential material only after repository, ref,
+     workflow, and attestation checks pass.
+
+The previous single-admin equivalent gate remains **not approved**. It cannot
+be used as the independent release gate unless a future explicit decision
+supersedes `GPP-2e`.
+
+## Current Blocking State
+
+The protected environment is partially provisioned:
+
+1. `ao-kernel-live-adapter-gate` exists.
+2. Admin bypass is disabled.
+3. Deployment branch policy is restricted to `main`.
+
+The gate remains blocked because:
+
+1. `AO_CLAUDE_CODE_CLI_AUTH` is not present as an environment secret handle.
+2. No approved independent release gate model is implemented.
+3. The single-admin equivalent gate is `not_approved`.
+
+## Contract
+
+Until a future explicit approval and attestation exist:
+
+1. `GPP-2` runtime binding must not start.
+2. Live adapter execution remains forbidden.
+3. Support widening remains forbidden.
+4. Production-platform claim remains forbidden.
+5. `--equivalent-release-gate-approved` remains forbidden while `GPP-2e`
+   remains `not_approved`.
+6. Product end-user accounts must not be treated as release authority.
+
+## Future Implementation Slices
+
+The next implementation slice must choose one model:
+
+1. `GPP-2g-github-release-authority`
+2. `GPP-2g-deployment-protection-app`
+3. `GPP-2g-oidc-secret-broker`
+
+Only after a model is implemented and `AO_CLAUDE_CODE_CLI_AUTH` or the selected
+broker handle is attested may a follow-up prerequisite attestation attempt to
+unblock `GPP-2`.
+
+## Exit State
+
+This slice closes as `independent_release_gate_required_no_support_widening`.
+
+It improves the trust-boundary model only. It does not unblock `GPP-2`.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -142,6 +142,7 @@ ayrı ayrı görünür kılmak.
 - **GPP-2c reviewer/credential gate issue:** [#485](https://github.com/Halildeu/ao-kernel/issues/485)
 - **GPP-2d metadata-only live gate attestation issue:** [#487](https://github.com/Halildeu/ao-kernel/issues/487) (`closed by PR #488`)
 - **GPP-2e single-admin equivalent gate decision issue:** [#489](https://github.com/Halildeu/ao-kernel/issues/489)
+- **GPP-2f independent release gate architecture issue:** [#491](https://github.com/Halildeu/ao-kernel/issues/491)
 - **Current mode:** stable maintenance + written general-purpose production
   promotion tracking. RI-5b is merged as Beta/operator-managed root export, not
   a production platform claim. GPP-1 live attestation exited as
@@ -158,9 +159,13 @@ ayrı ayrı görünür kılmak.
   attestation tooling so future prerequisite checks do not rely on manual issue
   comments. GPP-2e records that the single-admin equivalent release gate is
   not approved, so `--equivalent-release-gate-approved` cannot be used for
-  production prerequisite attestation without a future explicit approval. No support
+  production prerequisite attestation without a future explicit approval.
+  GPP-2f clarifies the required control as an independent release gate, not a
+  product end-user account. Acceptable future models are GitHub-native release
+  authority, GitHub App deployment protection, or OIDC-backed external secret
+  broker. No support
   widening, release, runtime adapter promotion, or production claim is made by
-  GPP-1b/GPP-1c/GPP-2a/GPP-2b/GPP-2c/GPP-2d/GPP-2e. Future stable widening still
+  GPP-1b/GPP-1c/GPP-2a/GPP-2b/GPP-2c/GPP-2d/GPP-2e/GPP-2f. Future stable widening still
   requires protected live-adapter evidence, repo-intelligence integration
   gates, write-side rollback evidence, and an explicit closeout decision.
 
@@ -274,6 +279,10 @@ protection yoktur ve runtime binding hâlâ başlamaz.
 equivalent release gate kararını `not_approved` olarak kaydeder; bu nedenle
 `--equivalent-release-gate-approved` flag'i production prerequisite attestation
 için kullanılamaz.
+
+`GPP-2f`, bu gate'in son kullanıcı hesabı değil bağımsız release authority
+olduğunu kaydeder. Kabul edilebilir modeller GitHub-native release authority,
+GitHub App deployment protection veya OIDC-backed external secret broker'dır.
 
 `GPP-1b`, bu blocked runtime sonucunu değiştirmez. Amacı Codex ve Claude Code
 operatör oturumlarının `.claude/plans/gpp_status.v1.json` ve

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -52,14 +52,20 @@
       "decision": "decision_recorded_not_approved_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/489",
       "record": ".claude/plans/GPP-2e-SINGLE-ADMIN-EQUIVALENT-GATE-DECISION.md"
+    },
+    {
+      "id": "GPP-2f",
+      "decision": "independent_release_gate_required_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/491",
+      "record": ".claude/plans/GPP-2f-INDEPENDENT-RELEASE-GATE-ARCHITECTURE.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
       "title": "Protected Live-Adapter Gate Runtime Binding",
-      "reason": "AO_CLAUDE_CODE_CLI_AUTH handle and reviewer/equivalent gate are not attested",
-      "blocked_until": "a future prerequisite attestation exits prerequisites_ready after the credential handle and reviewer/equivalent gate exist"
+      "reason": "AO_CLAUDE_CODE_CLI_AUTH handle and an independent release gate are not attested",
+      "blocked_until": "a future prerequisite attestation exits prerequisites_ready after the credential handle and an approved independent release gate exist"
     }
   ],
   "pending_external_actions": [
@@ -74,11 +80,11 @@
     },
     {
       "id": "GPP-2c",
-      "title": "Reviewer and credential gate resolution",
+      "title": "Independent release gate and credential resolution",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/485",
       "record": ".claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md",
-      "status": "blocked_external_admin_decision_required",
-      "decision": "missing_environment_secret_and_non_self_reviewer_gate",
+      "status": "blocked_external_independent_gate_decision_required",
+      "decision": "missing_environment_secret_and_independent_release_gate",
       "required_before": "GPP-2 runtime binding"
     }
   ],
@@ -124,17 +130,19 @@
     "treat local operator auth as production evidence",
     "start GPP-2 runtime binding while GPP-2 is blocked",
     "use --equivalent-release-gate-approved while GPP-2e remains not_approved",
+    "treat a product end-user account as release authority",
     "set support_widening=true without explicit GPP-9 promotion decision",
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
     "keep GPP-2 blocked",
     "track external admin provisioning in issue #482",
-    "resolve reviewer and credential gate in issue #485",
+    "resolve independent release gate and credential handling in issue #485",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
+    "choose one independent release gate model before any GPP-2 runtime binding",
     "use scripts/live_adapter_gate_attest.py for the next prerequisite attestation",
     "provision AO_CLAUDE_CODE_CLI_AUTH under ao-kernel-live-adapter-gate without reading secret values",
-    "configure required reviewer protection or record an explicitly approved equivalent release gate",
+    "configure GitHub-native release authority, GitHub App deployment protection, or OIDC secret broker gate",
     "run a follow-up prerequisite attestation slice only after issue #482 acceptance criteria are met",
     "do not widen support or claim production platform readiness"
   ],

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -50,6 +50,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2f"
+        and item["decision"] == "independent_release_gate_required_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/491"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -62,10 +69,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert payload["pending_external_actions"][1]["id"] == "GPP-2c"
     assert payload["pending_external_actions"][1]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/485"
-    assert payload["pending_external_actions"][1]["status"] == "blocked_external_admin_decision_required"
+    assert payload["pending_external_actions"][1]["title"] == "Independent release gate and credential resolution"
+    assert payload["pending_external_actions"][1]["status"] == "blocked_external_independent_gate_decision_required"
     assert (
         payload["pending_external_actions"][1]["decision"]
-        == "missing_environment_secret_and_non_self_reviewer_gate"
+        == "missing_environment_secret_and_independent_release_gate"
     )
     assert {item["id"] for item in payload["pending_external_actions"]} == {"GPP-2b", "GPP-2c"}
     assert {item["id"] for item in payload["blocked_wps"]} == {"GPP-2"}
@@ -77,6 +85,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(
         action == "use --equivalent-release-gate-approved while GPP-2e remains not_approved"
         for action in payload["forbidden_actions"]
+    )
+    assert any(action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"])
+    assert any(
+        action == "choose one independent release gate model before any GPP-2 runtime binding"
+        for action in payload["next_allowed_actions"]
     )
 
 
@@ -91,6 +104,19 @@ def test_gpp2e_equivalent_gate_decision_defaults_to_not_approved() -> None:
     assert "must not be used for production prerequisite attestation" in decision
 
 
+def test_gpp2f_independent_release_gate_replaces_end_user_reviewer_model() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2f-INDEPENDENT-RELEASE-GATE-ARCHITECTURE.md"
+    ).read_text(encoding="utf-8")
+
+    assert "**Decision:** `independent_release_gate_required`" in decision
+    assert "not a product end-user account" in decision
+    assert "GitHub-native release authority" in decision
+    assert "GitHub App deployment protection rule" in decision
+    assert "OIDC-backed external secret broker" in decision
+    assert "Product end-user accounts must not be treated as release authority" in decision
+
+
 def test_gpp_next_load_status_validates_required_guards() -> None:
     mod = _module()
 
@@ -100,7 +126,7 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
     assert payload["current_wp"]["status"] == "blocked"
     assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/482"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
-    assert "credential handle and reviewer/equivalent gate exist" in payload["blocked_wps"][0]["blocked_until"]
+    assert "credential handle and an approved independent release gate exist" in payload["blocked_wps"][0]["blocked_until"]
     assert payload["support_widening_allowed"] is False
 
 
@@ -130,7 +156,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "- GPP-2: AO_CLAUDE_CODE_CLI_AUTH handle and reviewer/equivalent gate" in rendered
+    assert "- GPP-2: AO_CLAUDE_CODE_CLI_AUTH handle and an independent release gate" in rendered
     assert "divergence: 0\t0" in rendered
 
 


### PR DESCRIPTION
## Summary

- Add GPP-2f architecture decision: the protected live-adapter gate requires an independent release gate, not a product end-user account.
- Define acceptable future gate models: GitHub-native release authority, GitHub App deployment protection, or OIDC-backed external secret broker.
- Update machine-readable GPP status and GPP docs so GPP-2 remains blocked on credential handle + independent release gate evidence.
- Keep the single-admin equivalent gate explicitly not approved and keep `--equivalent-release-gate-approved` forbidden.
- Update tests to pin the new trust-boundary language and prevent fake unblock.

Closes #491.

## Scope boundary

This PR does not:

- start GPP-2 runtime binding
- execute a live adapter
- read or print secret values
- approve the single-admin equivalent gate
- widen support
- claim general-purpose production readiness

## Validation

```bash
python3 -m json.tool .claude/plans/gpp_status.v1.json >/tmp/gpp2f_status.pretty.json
python3 scripts/gpp_next.py
pytest -q tests/test_gpp_next.py tests/test_live_adapter_gate_contract.py tests/test_gp5_platform_claim_decision.py
python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/ao-kernel-gpp2f-attestation.json --output text
python3 -m ao_kernel doctor
bash .claude/scripts/ops.sh preflight
ruff check tests/test_gpp_next.py
git diff --check
```

Observed locally:

- targeted tests: `35 passed`
- live attestation: `overall_status: blocked`, `runtime_binding_allowed: false`, `live_execution_allowed: false`, `support_widening: false`
- doctor: `8 OK, 1 WARN, 0 FAIL` (known extension truth warning)
- ops preflight: branch fresh; dirty warning only before commit
