### PR TITLE
[codex] define Claude MCP consultation gate

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -5,8 +5,8 @@
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#491](https://github.com/Halildeu/ao-kernel/issues/491)
-for independent release gate architecture decision tracking
+**Current slice issue:** [#493](https://github.com/Halildeu/ao-kernel/issues/493)
+for GitHub-native release authority and Claude MCP consultation protocol
 **Current slice record:** `.claude/plans/gpp_status.v1.json`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
@@ -88,6 +88,10 @@ Last live verification on current `origin/main` showed:
     Acceptable future models are GitHub-native release authority, GitHub App
     deployment protection, or OIDC-backed external secret broker. Product
     end-user accounts are not release authority.
+23. GPP-2g selects GitHub-native release authority as the first GPP-2 gate
+    model and records Claude Code + ao-kernel MCP as advisory consultation
+    only. Claude/MCP consultation does not approve release gates, credentials,
+    support widening, or production-platform claims.
 
 ## 3. Current Verdict
 
@@ -133,6 +137,7 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2d` | Implemented / no support widening | Metadata-only live gate attestation tool | repeatable attestation is available; current live gate still blocked |
 | `GPP-2e` | Completed / no support widening | Single-admin equivalent gate decision | `not_approved`; equivalent gate override cannot be used without a future explicit approval |
 | `GPP-2f` | Completed / no support widening | Independent release gate architecture decision | independent release gate required; product end-user account is not release authority |
+| `GPP-2g` | Completed / no support widening | GitHub-native release authority selection and Claude MCP consultation protocol | GitHub-native release authority selected; Claude/MCP is advisory only |
 | `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until a future attestation exits `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -531,7 +536,12 @@ future explicit approval supersedes [#489](https://github.com/Halildeu/ao-kernel
 GPP-2f clarifies that the gate is an independent release authority, not a
 product end-user account. Acceptable future models are GitHub-native release
 authority, GitHub App deployment protection, or OIDC-backed external secret
-broker.
+broker. GPP-2g selects GitHub-native release authority as the first
+provisioning path and records Claude/MCP consultation as an advisory review
+protocol only. The next external/admin action is to configure a required
+reviewer or team on `ao-kernel-live-adapter-gate` and set
+`AO_CLAUDE_CODE_CLI_AUTH` without reading the secret value; only a fresh
+metadata attestation can unblock `GPP-2`.
 
 ## 18. Risk Register
 
@@ -543,6 +553,7 @@ broker.
 | Repo-intelligence hidden injection | Context trust boundary breaks | Explicit opt-in + metadata fail-closed tests |
 | Remote PR writes leak to arbitrary repos | Production side effect risk | Disposable guard + explicit allow flag + rollback evidence |
 | Full matrix becomes stale | Fake green promotion | Require fresh artifacts from current `origin/main` |
+| Advisory consultation mistaken for release authority | Protected gate can be falsely unblocked | Claude/MCP protocol is advisory only; GitHub-native reviewer/team or approved equivalent gate remains required |
 
 ## 19. Tracking Log
 
@@ -569,3 +580,4 @@ broker.
 | 2026-04-25 | GPP-2d merged | PR [#488](https://github.com/Halildeu/ao-kernel/pull/488) added `scripts/live_adapter_gate_attest.py`; live attestation remains blocked by missing credential handle and reviewer/equivalent gate. |
 | 2026-04-25 | GPP-2e issue opened | Issue [#489](https://github.com/Halildeu/ao-kernel/issues/489) tracks the single-admin equivalent gate decision; current repo decision is `not_approved`, so the attestation override remains forbidden. |
 | 2026-04-26 | GPP-2f issue opened | Issue [#491](https://github.com/Halildeu/ao-kernel/issues/491) tracks the independent release gate architecture decision; product end-user accounts are explicitly not release authority. |
+| 2026-04-26 | GPP-2g issue opened | Issue [#493](https://github.com/Halildeu/ao-kernel/issues/493) tracks GitHub-native release authority selection and Claude/MCP advisory consultation protocol. |

--- a/.claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md
+++ b/.claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md
@@ -54,13 +54,14 @@ The gate is still incomplete:
 
 1. `AO_CLAUDE_CODE_CLI_AUTH` is not present as an environment secret handle.
 2. No approved independent release gate is configured.
-3. The GitHub-native reviewer/team model is only one possible implementation;
-   a GitHub App deployment protection rule or OIDC-backed secret broker may
-   satisfy the same trust-boundary requirement in a future slice.
+3. GPP-2g selects the GitHub-native reviewer/team model as the first
+   provisioning path.
+4. A GitHub App deployment protection rule or OIDC-backed secret broker remains
+   an acceptable fallback if the selected path cannot be provisioned.
 
 ## 4. Acceptable Resolution Paths
 
-### Preferred Path
+### Selected First Path
 
 1. Add or designate a release authority reviewer or team.
 2. Configure `ao-kernel-live-adapter-gate` required reviewers with

--- a/.claude/plans/GPP-2f-INDEPENDENT-RELEASE-GATE-ARCHITECTURE.md
+++ b/.claude/plans/GPP-2f-INDEPENDENT-RELEASE-GATE-ARCHITECTURE.md
@@ -70,15 +70,18 @@ Until a future explicit approval and attestation exist:
 
 ## Future Implementation Slices
 
-The next implementation slice must choose one model:
+The next implementation slice selected the first model:
 
-1. `GPP-2g-github-release-authority`
-2. `GPP-2g-deployment-protection-app`
-3. `GPP-2g-oidc-secret-broker`
+1. `GPP-2g-github-release-authority`: selected as the first provisioning path
+   by `.claude/plans/GPP-2g-GITHUB-NATIVE-RELEASE-AUTHORITY-AND-CLAUDE-MCP-CONSULTATION.md`.
+2. `GPP-2g-deployment-protection-app`: remains an acceptable fallback if the
+   GitHub-native reviewer/team path cannot be provisioned.
+3. `GPP-2g-oidc-secret-broker`: remains an acceptable fallback if the project
+   chooses brokered credential release instead of environment secrets.
 
-Only after a model is implemented and `AO_CLAUDE_CODE_CLI_AUTH` or the selected
-broker handle is attested may a follow-up prerequisite attestation attempt to
-unblock `GPP-2`.
+Only after the selected model is provisioned and `AO_CLAUDE_CODE_CLI_AUTH` or
+the selected broker handle is attested may a follow-up prerequisite attestation
+attempt to unblock `GPP-2`.
 
 ## Exit State
 

--- a/.claude/plans/GPP-2g-GITHUB-NATIVE-RELEASE-AUTHORITY-AND-CLAUDE-MCP-CONSULTATION.md
+++ b/.claude/plans/GPP-2g-GITHUB-NATIVE-RELEASE-AUTHORITY-AND-CLAUDE-MCP-CONSULTATION.md
@@ -1,0 +1,148 @@
+# GPP-2g - GitHub-Native Release Authority and Claude MCP Consultation
+
+**Issue:** [#493](https://github.com/Halildeu/ao-kernel/issues/493)
+**Date:** 2026-04-26
+**Program head:** `GPP-2` remains blocked
+**Decision:** `github_native_release_authority_selected_claude_mcp_advisory`
+**Support impact:** none
+**Runtime impact:** none
+
+## Purpose
+
+This record closes the ambiguity between two separate controls:
+
+1. the independent release authority required to unlock protected live-adapter
+   credentials; and
+2. the advisory Claude Code + ao-kernel MCP consultation path used when a
+   roadmap-first-stage decision or review/fix loop needs an external
+   architecture reviewer.
+
+These controls are not interchangeable. Claude/MCP consultation can recommend
+or challenge a plan, but it cannot approve live adapter credentials, release
+gates, support widening, or production-platform claims.
+
+## Decision
+
+The first independent release gate model for `GPP-2` is:
+
+```text
+GitHub-native release authority
+```
+
+The required release authority is a GitHub environment required reviewer or
+team on `ao-kernel-live-adapter-gate`, with self-review prevented or controlled
+by an equivalent future mechanism. The reviewer/team represents release
+authority. It is not an application end-user account.
+
+The alternate models from `GPP-2f` stay valid fallback options:
+
+1. GitHub App deployment protection rule;
+2. OIDC-backed external secret broker.
+
+They are not selected for the first provisioning path because they add more
+infrastructure before the current blocked gate has even proven the basic
+environment reviewer and credential-handle contract.
+
+## Current Blocking State
+
+`GPP-2` remains blocked after this record.
+
+The protected environment is partially provisioned:
+
+1. `ao-kernel-live-adapter-gate` exists.
+2. Admin bypass is disabled.
+3. Deployment branch policy is restricted to `main`.
+
+The gate still lacks:
+
+1. required reviewer/team protection with self-review prevention or equivalent
+   control;
+2. `AO_CLAUDE_CODE_CLI_AUTH` as an environment secret handle;
+3. a fresh `scripts/live_adapter_gate_attest.py` artifact with all checks
+   passing.
+
+## Claude MCP Consultation Protocol
+
+Claude Code may be used as an advisory reviewer through the ao-kernel MCP
+server only under the following trigger conditions:
+
+1. roadmap first-stage plan validation before starting a new major GPP work
+   package;
+2. post-implementation review returns `RED` or a ship-blocking architecture
+   disagreement;
+3. the same review loop reaches three or more `REVISE` iterations without
+   convergence;
+4. a GPP governance, protected-gate, support-boundary, or production-claim
+   decision needs a second architecture opinion;
+5. a review fix would exceed the approved WP scope and needs an explicit
+   split/defer decision.
+
+The consultation path is advisory only. It must not:
+
+1. mutate repo state;
+2. write ao-kernel memory or canonical decisions;
+3. read, print, transform, or validate secret values;
+4. approve `AO_CLAUDE_CODE_CLI_AUTH` handling;
+5. approve `--equivalent-release-gate-approved`;
+6. widen support;
+7. authorize production-platform claims;
+8. replace GitHub required reviewers, deployment protection, or external secret
+   broker controls.
+
+## Allowed MCP Surface
+
+Default allowed tools for Claude/MCP consultation:
+
+1. `mcp__ao-kernel__ao_workspace_status`;
+2. `mcp__ao-kernel__ao_policy_check`;
+3. `mcp__ao-kernel__ao_quality_gate`;
+4. `mcp__ao-kernel__ao_memory_read`, only for read-only context retrieval;
+5. `mcp__ao-kernel__ao_llm_route`, only in dry-run or non-mutating analysis
+   mode if needed by a future explicit consultation contract.
+
+Forbidden tools and behaviors:
+
+1. `mcp__ao-kernel__ao_memory_write`;
+2. `mcp__ao-kernel__ao_llm_call`;
+3. any MCP or built-in tool invocation that writes files, opens PRs, changes
+   GitHub settings, writes secrets, or mutates canonical program state;
+4. any prompt or tool payload containing credential material.
+
+Claude Code built-in tools must be constrained by the operator command for
+consultation runs. A future helper may automate this, but until then the
+operator must not treat a broad Claude Code session as an MCP-only consultation.
+
+## Reference Command Shape
+
+The minimum safe command shape is:
+
+```bash
+claude -p \
+  --strict-mcp-config \
+  --allowedTools mcp__ao-kernel__ao_workspace_status,mcp__ao-kernel__ao_policy_check,mcp__ao-kernel__ao_quality_gate \
+  --mcp-config '{"mcpServers":{"ao-kernel":{"command":"python3","args":["-m","ao_kernel","mcp","serve"]}}}' \
+  -- '<read-only consultation prompt>'
+```
+
+If `ao_memory_read` is required, add it explicitly and record why in the issue
+or PR summary. Do not add `ao_memory_write` or `ao_llm_call`.
+
+## Next Provisioning Step
+
+The next admin/provisioning action stays external to this PR:
+
+1. configure GitHub-native required reviewer/team protection on
+   `ao-kernel-live-adapter-gate`;
+2. set `AO_CLAUDE_CODE_CLI_AUTH` under that environment without reading back
+   the secret value;
+3. run `scripts/live_adapter_gate_attest.py` and require all checks to pass
+   before `GPP-2` runtime binding starts.
+
+## Exit State
+
+This slice closes as
+`github_native_release_authority_selected_claude_mcp_advisory_no_support_widening`.
+
+It selects the first release-gate model and records the consultation protocol.
+It does not unblock `GPP-2`, does not run a live adapter, does not change
+secrets, and does not widen support.

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -58,6 +58,12 @@
       "decision": "independent_release_gate_required_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/491",
       "record": ".claude/plans/GPP-2f-INDEPENDENT-RELEASE-GATE-ARCHITECTURE.md"
+    },
+    {
+      "id": "GPP-2g",
+      "decision": "github_native_release_authority_selected_claude_mcp_advisory_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/493",
+      "record": ".claude/plans/GPP-2g-GITHUB-NATIVE-RELEASE-AUTHORITY-AND-CLAUDE-MCP-CONSULTATION.md"
     }
   ],
   "blocked_wps": [
@@ -83,8 +89,8 @@
       "title": "Independent release gate and credential resolution",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/485",
       "record": ".claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md",
-      "status": "blocked_external_independent_gate_decision_required",
-      "decision": "missing_environment_secret_and_independent_release_gate",
+      "status": "blocked_external_github_native_release_authority_provisioning_required",
+      "decision": "github_native_release_authority_selected_secret_and_reviewer_still_missing",
       "required_before": "GPP-2 runtime binding"
     }
   ],
@@ -131,6 +137,9 @@
     "start GPP-2 runtime binding while GPP-2 is blocked",
     "use --equivalent-release-gate-approved while GPP-2e remains not_approved",
     "treat a product end-user account as release authority",
+    "treat Claude MCP consultation as release authority",
+    "use ao_memory_write or ao_llm_call during Claude MCP consultation",
+    "include credential material in Claude MCP prompts or tool payloads",
     "set support_widening=true without explicit GPP-9 promotion decision",
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
@@ -139,12 +148,13 @@
     "track external admin provisioning in issue #482",
     "resolve independent release gate and credential handling in issue #485",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
-    "choose one independent release gate model before any GPP-2 runtime binding",
+    "provision the selected GitHub-native release authority before any GPP-2 runtime binding",
+    "use Claude MCP consultation only as advisory review, not release authority",
     "use scripts/live_adapter_gate_attest.py for the next prerequisite attestation",
     "provision AO_CLAUDE_CODE_CLI_AUTH under ao-kernel-live-adapter-gate without reading secret values",
-    "configure GitHub-native release authority, GitHub App deployment protection, or OIDC secret broker gate",
+    "configure GitHub-native required reviewer or team protection on ao-kernel-live-adapter-gate",
     "run a follow-up prerequisite attestation slice only after issue #482 acceptance criteria are met",
     "do not widen support or claim production platform readiness"
   ],
-  "last_updated": "2026-04-25"
+  "last_updated": "2026-04-26"
 }

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -57,6 +57,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2g"
+        and item["decision"] == "github_native_release_authority_selected_claude_mcp_advisory_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/493"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -70,10 +77,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["pending_external_actions"][1]["id"] == "GPP-2c"
     assert payload["pending_external_actions"][1]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/485"
     assert payload["pending_external_actions"][1]["title"] == "Independent release gate and credential resolution"
-    assert payload["pending_external_actions"][1]["status"] == "blocked_external_independent_gate_decision_required"
+    assert (
+        payload["pending_external_actions"][1]["status"]
+        == "blocked_external_github_native_release_authority_provisioning_required"
+    )
     assert (
         payload["pending_external_actions"][1]["decision"]
-        == "missing_environment_secret_and_independent_release_gate"
+        == "github_native_release_authority_selected_secret_and_reviewer_still_missing"
     )
     assert {item["id"] for item in payload["pending_external_actions"]} == {"GPP-2b", "GPP-2c"}
     assert {item["id"] for item in payload["blocked_wps"]} == {"GPP-2"}
@@ -88,7 +98,16 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"])
     assert any(
-        action == "choose one independent release gate model before any GPP-2 runtime binding"
+        action == "provision the selected GitHub-native release authority before any GPP-2 runtime binding"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(action == "treat Claude MCP consultation as release authority" for action in payload["forbidden_actions"])
+    assert any(
+        action == "use ao_memory_write or ao_llm_call during Claude MCP consultation"
+        for action in payload["forbidden_actions"]
+    )
+    assert any(
+        action == "use Claude MCP consultation only as advisory review, not release authority"
         for action in payload["next_allowed_actions"]
     )
 
@@ -115,6 +134,22 @@ def test_gpp2f_independent_release_gate_replaces_end_user_reviewer_model() -> No
     assert "GitHub App deployment protection rule" in decision
     assert "OIDC-backed external secret broker" in decision
     assert "Product end-user accounts must not be treated as release authority" in decision
+
+
+def test_gpp2g_claude_mcp_consultation_is_advisory_only() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2g-GITHUB-NATIVE-RELEASE-AUTHORITY-AND-CLAUDE-MCP-CONSULTATION.md"
+    ).read_text(encoding="utf-8")
+
+    assert "**Decision:** `github_native_release_authority_selected_claude_mcp_advisory`" in decision
+    assert "GitHub-native release authority" in decision
+    assert "It is not an application end-user account." in decision
+    assert "The consultation path is advisory only." in decision
+    assert "mcp__ao-kernel__ao_workspace_status" in decision
+    assert "mcp__ao-kernel__ao_quality_gate" in decision
+    assert "mcp__ao-kernel__ao_memory_write" in decision
+    assert "mcp__ao-kernel__ao_llm_call" in decision
+    assert "does not unblock `GPP-2`" in decision
 
 
 def test_gpp_next_load_status_validates_required_guards() -> None:


### PR DESCRIPTION
## Summary

- add `GPP-2g` decision record selecting GitHub-native release authority as the first independent GPP-2 gate model
- codify Claude Code + ao-kernel MCP consultation as advisory-only review escalation, not release authority
- keep GPP-2 blocked and pin the no-support-widening/no-live-execution guards in `gpp_status.v1.json` and tests

## Validation

- `python3 -m json.tool .claude/plans/gpp_status.v1.json >/tmp/gpp_status.pretty.json`
- `python3 scripts/gpp_next.py`
- `pytest -q tests/test_gpp_next.py`
- `ruff check tests/test_gpp_next.py`
- `pytest -q tests/test_live_adapter_gate_contract.py tests/test_gp5_platform_claim_decision.py`
- `python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/gpp2g-attestation.json --output text` (expected blocked: missing credential handle and reviewer gate)
- `python3 -m ao_kernel doctor` (8 OK, 1 WARN, 0 FAIL; existing extension truth warning)
- `git diff --check`

Closes #493.
