### PR TITLE
[codex] select deployment protection bot gate

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -5,8 +5,8 @@
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#493](https://github.com/Halildeu/ao-kernel/issues/493)
-for GitHub-native release authority and Claude MCP consultation protocol
+**Current slice issue:** [#495](https://github.com/Halildeu/ao-kernel/issues/495)
+for deployment protection bot gate decision
 **Current slice record:** `.claude/plans/gpp_status.v1.json`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
@@ -92,6 +92,10 @@ Last live verification on current `origin/main` showed:
     model and records Claude Code + ao-kernel MCP as advisory consultation
     only. Claude/MCP consultation does not approve release gates, credentials,
     support widening, or production-platform claims.
+24. GPP-2h supersedes the first provisioning path from required reviewer/team
+    to GitHub App deployment protection. A PAT-backed bot user is rejected;
+    the selected model is a policy bot connected to environment deployment
+    protection. GPP-2 remains blocked.
 
 ## 3. Current Verdict
 
@@ -137,7 +141,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2d` | Implemented / no support widening | Metadata-only live gate attestation tool | repeatable attestation is available; current live gate still blocked |
 | `GPP-2e` | Completed / no support widening | Single-admin equivalent gate decision | `not_approved`; equivalent gate override cannot be used without a future explicit approval |
 | `GPP-2f` | Completed / no support widening | Independent release gate architecture decision | independent release gate required; product end-user account is not release authority |
-| `GPP-2g` | Completed / no support widening | GitHub-native release authority selection and Claude MCP consultation protocol | GitHub-native release authority selected; Claude/MCP is advisory only |
+| `GPP-2g` | Completed / no support widening | GitHub-native release authority selection and Claude MCP consultation protocol | provisioning path superseded by GPP-2h; Claude/MCP advisory protocol remains active |
+| `GPP-2h` | Completed / no support widening | Deployment protection bot gate decision | GitHub App deployment protection selected; PAT-backed bot reviewer rejected |
 | `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until a future attestation exits `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -538,10 +543,12 @@ product end-user account. Acceptable future models are GitHub-native release
 authority, GitHub App deployment protection, or OIDC-backed external secret
 broker. GPP-2g selects GitHub-native release authority as the first
 provisioning path and records Claude/MCP consultation as an advisory review
-protocol only. The next external/admin action is to configure a required
-reviewer or team on `ao-kernel-live-adapter-gate` and set
-`AO_CLAUDE_CODE_CLI_AUTH` without reading the secret value; only a fresh
-metadata attestation can unblock `GPP-2`.
+protocol only. GPP-2h supersedes the GPP-2g provisioning path and selects a
+GitHub App deployment protection bot gate. The next repo-code action is to add
+metadata-only attestation support for the selected deployment protection model.
+Only after that support exists should an external/admin step configure the app
+gate and set `AO_CLAUDE_CODE_CLI_AUTH` without reading the secret value; only a
+fresh metadata attestation can unblock `GPP-2`.
 
 ## 18. Risk Register
 
@@ -553,7 +560,8 @@ metadata attestation can unblock `GPP-2`.
 | Repo-intelligence hidden injection | Context trust boundary breaks | Explicit opt-in + metadata fail-closed tests |
 | Remote PR writes leak to arbitrary repos | Production side effect risk | Disposable guard + explicit allow flag + rollback evidence |
 | Full matrix becomes stale | Fake green promotion | Require fresh artifacts from current `origin/main` |
-| Advisory consultation mistaken for release authority | Protected gate can be falsely unblocked | Claude/MCP protocol is advisory only; GitHub-native reviewer/team or approved equivalent gate remains required |
+| Advisory consultation mistaken for release authority | Protected gate can be falsely unblocked | Claude/MCP protocol is advisory only; deployment protection app or explicitly approved equivalent gate remains required |
+| Bot account mistaken for deployment protection | Same operator can rubber-stamp the gate | PAT-backed bot reviewer is rejected; use GitHub App deployment protection |
 
 ## 19. Tracking Log
 
@@ -581,3 +589,4 @@ metadata attestation can unblock `GPP-2`.
 | 2026-04-25 | GPP-2e issue opened | Issue [#489](https://github.com/Halildeu/ao-kernel/issues/489) tracks the single-admin equivalent gate decision; current repo decision is `not_approved`, so the attestation override remains forbidden. |
 | 2026-04-26 | GPP-2f issue opened | Issue [#491](https://github.com/Halildeu/ao-kernel/issues/491) tracks the independent release gate architecture decision; product end-user accounts are explicitly not release authority. |
 | 2026-04-26 | GPP-2g issue opened | Issue [#493](https://github.com/Halildeu/ao-kernel/issues/493) tracks GitHub-native release authority selection and Claude/MCP advisory consultation protocol. |
+| 2026-04-26 | GPP-2h issue opened | Issue [#495](https://github.com/Halildeu/ao-kernel/issues/495) tracks deployment protection bot gate selection; GitHub App deployment protection supersedes the required-reviewer provisioning path. |

--- a/.claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md
+++ b/.claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md
@@ -54,14 +54,16 @@ The gate is still incomplete:
 
 1. `AO_CLAUDE_CODE_CLI_AUTH` is not present as an environment secret handle.
 2. No approved independent release gate is configured.
-3. GPP-2g selects the GitHub-native reviewer/team model as the first
+3. GPP-2g selected the GitHub-native reviewer/team model as the first
    provisioning path.
-4. A GitHub App deployment protection rule or OIDC-backed secret broker remains
-   an acceptable fallback if the selected path cannot be provisioned.
+4. GPP-2h supersedes that path and selects a GitHub App deployment protection
+   rule as the active bot gate model.
+5. A human/team required reviewer or OIDC-backed secret broker remains an
+   acceptable fallback only through a future explicit decision.
 
 ## 4. Acceptable Resolution Paths
 
-### Selected First Path
+### Superseded Path
 
 1. Add or designate a release authority reviewer or team.
 2. Configure `ao-kernel-live-adapter-gate` required reviewers with
@@ -70,6 +72,17 @@ The gate is still incomplete:
    reading back the secret value.
 4. Open a follow-up attestation PR that proves the handle exists and the
    independent release gate is present.
+
+### Selected Active Path
+
+1. Implement metadata-only attestation support for GitHub App deployment
+   protection evidence.
+2. Configure a GitHub App or policy service as the deployment protection gate
+   for `ao-kernel-live-adapter-gate`.
+3. Set `AO_CLAUDE_CODE_CLI_AUTH` under the environment without printing or
+   reading back the secret value.
+4. Open a follow-up attestation PR that proves the handle exists and the
+   selected deployment protection bot gate is present.
 
 ### Alternative Path
 

--- a/.claude/plans/GPP-2f-INDEPENDENT-RELEASE-GATE-ARCHITECTURE.md
+++ b/.claude/plans/GPP-2f-INDEPENDENT-RELEASE-GATE-ARCHITECTURE.md
@@ -70,12 +70,15 @@ Until a future explicit approval and attestation exist:
 
 ## Future Implementation Slices
 
-The next implementation slice selected the first model:
+The first implementation slice selected GitHub-native reviewer/team, then the
+operator superseded that provisioning path with the deployment protection bot
+model:
 
 1. `GPP-2g-github-release-authority`: selected as the first provisioning path
    by `.claude/plans/GPP-2g-GITHUB-NATIVE-RELEASE-AUTHORITY-AND-CLAUDE-MCP-CONSULTATION.md`.
-2. `GPP-2g-deployment-protection-app`: remains an acceptable fallback if the
-   GitHub-native reviewer/team path cannot be provisioned.
+2. `GPP-2h-deployment-protection-bot-gate`: supersedes the GPP-2g provisioning
+   path and selects the GitHub App deployment protection rule as the active
+   release authority model.
 3. `GPP-2g-oidc-secret-broker`: remains an acceptable fallback if the project
    chooses brokered credential release instead of environment secrets.
 

--- a/.claude/plans/GPP-2g-GITHUB-NATIVE-RELEASE-AUTHORITY-AND-CLAUDE-MCP-CONSULTATION.md
+++ b/.claude/plans/GPP-2g-GITHUB-NATIVE-RELEASE-AUTHORITY-AND-CLAUDE-MCP-CONSULTATION.md
@@ -6,6 +6,7 @@
 **Decision:** `github_native_release_authority_selected_claude_mcp_advisory`
 **Support impact:** none
 **Runtime impact:** none
+**Provisioning path superseded by:** `GPP-2h`
 
 ## Purpose
 
@@ -129,7 +130,14 @@ or PR summary. Do not add `ao_memory_write` or `ao_llm_call`.
 
 ## Next Provisioning Step
 
-The next admin/provisioning action stays external to this PR:
+This provisioning path was superseded by
+`.claude/plans/GPP-2h-DEPLOYMENT-PROTECTION-BOT-GATE-DECISION.md`.
+
+The selected first path is now GitHub App deployment protection, not a
+human/team required-reviewer path. The Claude/MCP advisory consultation
+protocol in this record remains active.
+
+The previous admin/provisioning action was:
 
 1. configure GitHub-native required reviewer/team protection on
    `ao-kernel-live-adapter-gate`;

--- a/.claude/plans/GPP-2h-DEPLOYMENT-PROTECTION-BOT-GATE-DECISION.md
+++ b/.claude/plans/GPP-2h-DEPLOYMENT-PROTECTION-BOT-GATE-DECISION.md
@@ -1,0 +1,116 @@
+# GPP-2h - Deployment Protection Bot Gate Decision
+
+**Issue:** [#495](https://github.com/Halildeu/ao-kernel/issues/495)
+**Date:** 2026-04-26
+**Program head:** `GPP-2` remains blocked
+**Decision:** `github_app_deployment_protection_rule_selected`
+**Support impact:** none
+**Runtime impact:** none
+
+## Purpose
+
+This record supersedes the first provisioning path selected in `GPP-2g`.
+
+The intended release authority is not a second product user account and not a
+bot account that clicks approval through a PAT. The selected model is a GitHub
+App or policy service connected to GitHub environment deployment protection.
+That app evaluates repo-owned evidence and approves protected environment
+deployment only when the gate contract is satisfied.
+
+Claude/MCP consultation remains advisory only and is unchanged by this record.
+
+## Decision
+
+The selected independent release gate model for `GPP-2` is:
+
+```text
+GitHub App deployment protection rule
+```
+
+The model is a policy bot, not a user-like reviewer account.
+
+Rejected models for this lane:
+
+1. product end-user account as release authority;
+2. second GitHub user account controlled by the same operator as a rubber
+   stamp;
+3. PAT-backed bot account listed as required reviewer;
+4. Claude/MCP consultation as release authority;
+5. `--equivalent-release-gate-approved` while `GPP-2e` remains
+   `not_approved`.
+
+Fallback models remain valid only through a future explicit decision:
+
+1. human/team GitHub-native required reviewer;
+2. OIDC-backed external secret broker.
+
+## Deployment Protection Bot Contract
+
+The future GitHub App or policy service must approve the protected deployment
+only after checking repo-owned evidence. Minimum approval inputs:
+
+1. repository is `Halildeu/ao-kernel`;
+2. ref is protected `main`;
+3. workflow identity is the approved live-adapter gate workflow;
+4. default CI and required checks are green for the approved ref;
+5. `scripts/live_adapter_gate_attest.py` or its successor reports a passing
+   protected gate prerequisite attestation;
+6. `AO_CLAUDE_CODE_CLI_AUTH` exists as an environment secret handle or the
+   selected broker handle exists;
+7. `support_widening_allowed=false` remains true until a later GPP-9
+   production claim decision;
+8. `production_platform_claim_allowed=false` remains true until a later GPP-9
+   production claim decision;
+9. no secret value is read, logged, transformed, echoed, or sent through MCP;
+10. fork-triggered or untrusted contexts cannot access protected credentials.
+
+The bot must fail closed. Missing evidence, stale evidence, unrecognized
+workflow identity, non-main ref, missing credential handle, or support-boundary
+drift must block approval.
+
+## Current Blocking State
+
+`GPP-2` remains blocked after this record.
+
+Current live gate state:
+
+1. `ao-kernel-live-adapter-gate` exists;
+2. admin bypass is disabled;
+3. deployment branch policy is restricted to `main`;
+4. `AO_CLAUDE_CODE_CLI_AUTH` is still not attested as an environment secret
+   handle;
+5. no GitHub App deployment protection rule is implemented or attested;
+6. `scripts/live_adapter_gate_attest.py` currently checks required reviewer or
+   equivalent release gate metadata, not the selected deployment protection
+   bot metadata shape.
+
+## Next Implementation Slices
+
+The next repo-code slice should be narrow:
+
+```text
+GPP-2i - deployment protection attestation support
+```
+
+Scope for `GPP-2i`:
+
+1. extend the metadata-only live gate attestation model to represent GitHub App
+   deployment protection evidence;
+2. keep required reviewer metadata as historical/alternate evidence, not the
+   selected path;
+3. add tests for missing app, wrong app, stale app/evidence, and app-present
+   but credential-missing states;
+4. keep all support/runtime/production flags false;
+5. do not create the GitHub App, set secrets, or run a live adapter.
+
+The later external/admin provisioning step should configure the GitHub App
+deployment protection rule in `ao-kernel-live-adapter-gate`, then set
+`AO_CLAUDE_CODE_CLI_AUTH` without secret readback, then run a fresh attestation.
+
+## Exit State
+
+This slice closes as
+`github_app_deployment_protection_rule_selected_no_support_widening`.
+
+It selects the release authority model. It does not unblock `GPP-2`, does not
+run a live adapter, does not create or read secrets, and does not widen support.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -143,6 +143,8 @@ ayrı ayrı görünür kılmak.
 - **GPP-2d metadata-only live gate attestation issue:** [#487](https://github.com/Halildeu/ao-kernel/issues/487) (`closed by PR #488`)
 - **GPP-2e single-admin equivalent gate decision issue:** [#489](https://github.com/Halildeu/ao-kernel/issues/489)
 - **GPP-2f independent release gate architecture issue:** [#491](https://github.com/Halildeu/ao-kernel/issues/491)
+- **GPP-2g Claude MCP consultation protocol issue:** [#493](https://github.com/Halildeu/ao-kernel/issues/493)
+- **GPP-2h deployment protection bot gate issue:** [#495](https://github.com/Halildeu/ao-kernel/issues/495)
 - **Current mode:** stable maintenance + written general-purpose production
   promotion tracking. RI-5b is merged as Beta/operator-managed root export, not
   a production platform claim. GPP-1 live attestation exited as
@@ -163,11 +165,14 @@ ayrı ayrı görünür kılmak.
   GPP-2f clarifies the required control as an independent release gate, not a
   product end-user account. Acceptable future models are GitHub-native release
   authority, GitHub App deployment protection, or OIDC-backed external secret
-  broker. No support
+  broker. GPP-2g records Claude/MCP consultation as advisory only; GPP-2h
+  selects GitHub App deployment protection as the active bot gate model and
+  rejects PAT-backed bot reviewers. No support
   widening, release, runtime adapter promotion, or production claim is made by
-  GPP-1b/GPP-1c/GPP-2a/GPP-2b/GPP-2c/GPP-2d/GPP-2e/GPP-2f. Future stable widening still
-  requires protected live-adapter evidence, repo-intelligence integration
-  gates, write-side rollback evidence, and an explicit closeout decision.
+  GPP-1b/GPP-1c/GPP-2a/GPP-2b/GPP-2c/GPP-2d/GPP-2e/GPP-2f/GPP-2g/GPP-2h.
+  Future stable widening still requires protected live-adapter evidence,
+  repo-intelligence integration gates, write-side rollback evidence, and an
+  explicit closeout decision.
 
 ## 2. Başlangıç Gerçeği
 
@@ -283,6 +288,9 @@ için kullanılamaz.
 `GPP-2f`, bu gate'in son kullanıcı hesabı değil bağımsız release authority
 olduğunu kaydeder. Kabul edilebilir modeller GitHub-native release authority,
 GitHub App deployment protection veya OIDC-backed external secret broker'dır.
+`GPP-2g`, Claude/MCP danışmanlığını advisory-only olarak sınırlar. `GPP-2h`,
+aktif provisioning yolunu GitHub App deployment protection bot gate olarak
+seçer; PAT destekli bot kullanıcı reviewer modeli kabul edilmez.
 
 `GPP-1b`, bu blocked runtime sonucunu değiştirmez. Amacı Codex ve Claude Code
 operatör oturumlarının `.claude/plans/gpp_status.v1.json` ve

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -64,6 +64,12 @@
       "decision": "github_native_release_authority_selected_claude_mcp_advisory_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/493",
       "record": ".claude/plans/GPP-2g-GITHUB-NATIVE-RELEASE-AUTHORITY-AND-CLAUDE-MCP-CONSULTATION.md"
+    },
+    {
+      "id": "GPP-2h",
+      "decision": "github_app_deployment_protection_rule_selected_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/495",
+      "record": ".claude/plans/GPP-2h-DEPLOYMENT-PROTECTION-BOT-GATE-DECISION.md"
     }
   ],
   "blocked_wps": [
@@ -89,8 +95,8 @@
       "title": "Independent release gate and credential resolution",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/485",
       "record": ".claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md",
-      "status": "blocked_external_github_native_release_authority_provisioning_required",
-      "decision": "github_native_release_authority_selected_secret_and_reviewer_still_missing",
+      "status": "blocked_external_deployment_protection_bot_provisioning_required",
+      "decision": "github_app_deployment_protection_selected_secret_and_app_gate_still_missing",
       "required_before": "GPP-2 runtime binding"
     }
   ],
@@ -137,6 +143,7 @@
     "start GPP-2 runtime binding while GPP-2 is blocked",
     "use --equivalent-release-gate-approved while GPP-2e remains not_approved",
     "treat a product end-user account as release authority",
+    "treat a PAT-backed bot user as release authority",
     "treat Claude MCP consultation as release authority",
     "use ao_memory_write or ao_llm_call during Claude MCP consultation",
     "include credential material in Claude MCP prompts or tool payloads",
@@ -148,11 +155,12 @@
     "track external admin provisioning in issue #482",
     "resolve independent release gate and credential handling in issue #485",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
-    "provision the selected GitHub-native release authority before any GPP-2 runtime binding",
+    "implement deployment protection attestation support before any GPP-2 runtime binding",
+    "provision the selected GitHub App deployment protection rule before any GPP-2 runtime binding",
     "use Claude MCP consultation only as advisory review, not release authority",
     "use scripts/live_adapter_gate_attest.py for the next prerequisite attestation",
     "provision AO_CLAUDE_CODE_CLI_AUTH under ao-kernel-live-adapter-gate without reading secret values",
-    "configure GitHub-native required reviewer or team protection on ao-kernel-live-adapter-gate",
+    "configure GitHub App deployment protection on ao-kernel-live-adapter-gate after attestation support exists",
     "run a follow-up prerequisite attestation slice only after issue #482 acceptance criteria are met",
     "do not widen support or claim production platform readiness"
   ],

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -64,6 +64,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2h"
+        and item["decision"] == "github_app_deployment_protection_rule_selected_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/495"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -79,11 +86,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["pending_external_actions"][1]["title"] == "Independent release gate and credential resolution"
     assert (
         payload["pending_external_actions"][1]["status"]
-        == "blocked_external_github_native_release_authority_provisioning_required"
+        == "blocked_external_deployment_protection_bot_provisioning_required"
     )
     assert (
         payload["pending_external_actions"][1]["decision"]
-        == "github_native_release_authority_selected_secret_and_reviewer_still_missing"
+        == "github_app_deployment_protection_selected_secret_and_app_gate_still_missing"
     )
     assert {item["id"] for item in payload["pending_external_actions"]} == {"GPP-2b", "GPP-2c"}
     assert {item["id"] for item in payload["blocked_wps"]} == {"GPP-2"}
@@ -97,8 +104,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         for action in payload["forbidden_actions"]
     )
     assert any(action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"])
+    assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
     assert any(
-        action == "provision the selected GitHub-native release authority before any GPP-2 runtime binding"
+        action == "implement deployment protection attestation support before any GPP-2 runtime binding"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action == "provision the selected GitHub App deployment protection rule before any GPP-2 runtime binding"
         for action in payload["next_allowed_actions"]
     )
     assert any(action == "treat Claude MCP consultation as release authority" for action in payload["forbidden_actions"])
@@ -145,11 +157,27 @@ def test_gpp2g_claude_mcp_consultation_is_advisory_only() -> None:
     assert "GitHub-native release authority" in decision
     assert "It is not an application end-user account." in decision
     assert "The consultation path is advisory only." in decision
+    assert "**Provisioning path superseded by:** `GPP-2h`" in decision
     assert "mcp__ao-kernel__ao_workspace_status" in decision
     assert "mcp__ao-kernel__ao_quality_gate" in decision
     assert "mcp__ao-kernel__ao_memory_write" in decision
     assert "mcp__ao-kernel__ao_llm_call" in decision
     assert "does not unblock `GPP-2`" in decision
+
+
+def test_gpp2h_selects_deployment_protection_bot_not_bot_user() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2h-DEPLOYMENT-PROTECTION-BOT-GATE-DECISION.md"
+    ).read_text(encoding="utf-8")
+
+    assert "**Decision:** `github_app_deployment_protection_rule_selected`" in decision
+    assert "supersedes the first provisioning path selected in `GPP-2g`" in decision
+    assert "GitHub App deployment protection rule" in decision
+    assert "The model is a policy bot, not a user-like reviewer account." in decision
+    assert "PAT-backed bot account listed as required reviewer" in decision
+    assert "GPP-2i - deployment protection attestation support" in decision
+    assert "does not unblock `GPP-2`" in decision
+    assert "does not widen support" in decision
 
 
 def test_gpp_next_load_status_validates_required_guards() -> None:


### PR DESCRIPTION
## Summary

- add `GPP-2h` decision record selecting GitHub App deployment protection as the bot gate model
- supersede the GPP-2g human/team required-reviewer provisioning path while keeping Claude/MCP advisory-only
- update GPP status, post-beta status, and guard tests so GPP-2 remains blocked until deployment-protection attestation support and external provisioning exist

## Validation

- `python3 -m json.tool .claude/plans/gpp_status.v1.json >/tmp/gpp2h-status.pretty.json`
- `python3 scripts/gpp_next.py`
- `pytest -q tests/test_gpp_next.py`
- `ruff check tests/test_gpp_next.py`
- `pytest -q tests/test_live_adapter_gate_contract.py tests/test_gp5_platform_claim_decision.py`
- `python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/gpp2h-attestation.json --output text` (expected blocked: current attestation still lacks credential handle and selected bot gate support)
- `python3 -m ao_kernel doctor` (8 OK, 1 WARN, 0 FAIL; existing extension truth warning)
- `git diff --check`

Closes #495.
