### PR TITLE
[codex] support deployment protection attestation

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -5,8 +5,8 @@
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#495](https://github.com/Halildeu/ao-kernel/issues/495)
-for deployment protection bot gate decision
+**Current slice issue:** [#497](https://github.com/Halildeu/ao-kernel/issues/497)
+for deployment protection attestation support
 **Current slice record:** `.claude/plans/gpp_status.v1.json`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
@@ -77,8 +77,8 @@ Last live verification on current `origin/main` showed:
     independent release authority; this is not a product end-user account.
 20. GPP-2b partially provisioned the GitHub environment: the environment exists,
     deployment branch policy includes `main`, and admin bypass is disabled.
-    Required reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` are still
-    missing, so `GPP-2` remains blocked.
+    The selected GitHub App deployment protection rule and
+    `AO_CLAUDE_CODE_CLI_AUTH` are still missing, so `GPP-2` remains blocked.
 21. GPP-2d merged metadata-only attestation tooling so the live gate can be
     checked repeatably without reading secret values. GPP-2e records that the
     single-admin equivalent release gate is not approved; the
@@ -96,6 +96,9 @@ Last live verification on current `origin/main` showed:
     to GitHub App deployment protection. A PAT-backed bot user is rejected;
     the selected model is a policy bot connected to environment deployment
     protection. GPP-2 remains blocked.
+25. GPP-2i adds metadata-only attestation support for the selected GitHub App
+    deployment protection model. The current live gate remains blocked because
+    the app rule and `AO_CLAUDE_CODE_CLI_AUTH` handle are not yet attested.
 
 ## 3. Current Verdict
 
@@ -136,13 +139,14 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-1` | Completed | Protected live-adapter prerequisite attestation | `blocked_attestation_missing` |
 | `GPP-1b` | Completed | Agent operating program contract | `agent_operating_contract_ready_no_support_widening` |
 | `GPP-2a` | Completed | Protected live-adapter prerequisite re-attestation | `still_blocked_protected_prerequisites_missing` |
-| `GPP-2b` | Partially provisioned / blocked | Protected live-adapter environment and credential provisioning | environment exists; `main` branch policy and admin-bypass-off are set; reviewer protection and credential handle still missing |
-| `GPP-2c` | Blocked external/admin decision | Reviewer and credential gate resolution | `AO_CLAUDE_CODE_CLI_AUTH` and non-self reviewer/equivalent gate still missing |
+| `GPP-2b` | Partially provisioned / blocked | Protected live-adapter environment and credential provisioning | environment exists; `main` branch policy and admin-bypass-off are set; deployment protection app gate and credential handle still missing |
+| `GPP-2c` | Blocked external/admin decision | Deployment-protection and credential gate resolution | `AO_CLAUDE_CODE_CLI_AUTH` and selected deployment protection app gate still missing |
 | `GPP-2d` | Implemented / no support widening | Metadata-only live gate attestation tool | repeatable attestation is available; current live gate still blocked |
 | `GPP-2e` | Completed / no support widening | Single-admin equivalent gate decision | `not_approved`; equivalent gate override cannot be used without a future explicit approval |
 | `GPP-2f` | Completed / no support widening | Independent release gate architecture decision | independent release gate required; product end-user account is not release authority |
 | `GPP-2g` | Completed / no support widening | GitHub-native release authority selection and Claude MCP consultation protocol | provisioning path superseded by GPP-2h; Claude/MCP advisory protocol remains active |
 | `GPP-2h` | Completed / no support widening | Deployment protection bot gate decision | GitHub App deployment protection selected; PAT-backed bot reviewer rejected |
+| `GPP-2i` | Completed / no support widening | Deployment protection attestation support | selected app-gate metadata is recognized; current live gate still blocked |
 | `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until a future attestation exits `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -218,13 +222,13 @@ any workflow binding or support promotion.
 3. Admin bypass is disabled on `ao-kernel-live-adapter-gate`: met.
 4. Required secret handle is attested at repository or environment scope: not
    met; environment-scoped secret lookup returns an empty list.
-5. Required reviewer protection is configured or an explicitly approved
-   equivalent release gate is documented: not met.
+5. Independent release gate is configured: not met; GPP-2h/GPP-2i selected
+   GitHub App deployment protection, and the app rule is not yet attested.
 6. Fork-triggered PR contexts cannot access protected credentials: met for the
    current design-only workflow, because the workflow is `workflow_dispatch`
    only and has no `environment:` or `secrets.` reference.
-7. Missing secret or reviewer protection produces `blocked_attestation_missing`: met by
-   this slice.
+7. Missing secret or selected deployment-protection gate produces
+   `blocked_attestation_missing`: met by this slice.
 8. Status docs and support boundary still say no support widening: met.
 
 **Validation:**
@@ -528,8 +532,9 @@ No runtime/support-widening work is active. `GPP-2` is the current blocked
 program head. GPP-2b is tracked in
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) as an external/admin
 provisioning action. The environment and `main` branch policy are present, but
-reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` must still be completed
-before another prerequisite attestation can attempt to unblock `GPP-2`.
+the selected deployment-protection app gate and `AO_CLAUDE_CODE_CLI_AUTH` must
+still be completed before another prerequisite attestation can attempt to
+unblock `GPP-2`.
 GPP-2c is tracked in
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) to resolve the
 remaining independent release gate and credential decision. GPP-2d adds
@@ -544,11 +549,11 @@ authority, GitHub App deployment protection, or OIDC-backed external secret
 broker. GPP-2g selects GitHub-native release authority as the first
 provisioning path and records Claude/MCP consultation as an advisory review
 protocol only. GPP-2h supersedes the GPP-2g provisioning path and selects a
-GitHub App deployment protection bot gate. The next repo-code action is to add
-metadata-only attestation support for the selected deployment protection model.
-Only after that support exists should an external/admin step configure the app
-gate and set `AO_CLAUDE_CODE_CLI_AUTH` without reading the secret value; only a
-fresh metadata attestation can unblock `GPP-2`.
+GitHub App deployment protection bot gate. GPP-2i adds metadata-only
+attestation support for that selected model. The next external/admin step is to
+configure the app gate with slug `ao-kernel-live-adapter-gate` and set
+`AO_CLAUDE_CODE_CLI_AUTH` without reading the secret value; only a fresh
+metadata attestation can unblock `GPP-2`.
 
 ## 18. Risk Register
 
@@ -581,12 +586,13 @@ fresh metadata attestation can unblock `GPP-2`.
 | 2026-04-25 | GPP-1d merged | PR [#479](https://github.com/Halildeu/ao-kernel/pull/479) merged; live authority head is now read from git signals instead of static status text. |
 | 2026-04-25 | GPP-2a issue opened | Issue [#480](https://github.com/Halildeu/ao-kernel/issues/480) created to re-attest protected live-adapter prerequisites before any GPP-2 runtime binding. |
 | 2026-04-25 | GPP-2a re-attestation recorded | PR [#481](https://github.com/Halildeu/ao-kernel/pull/481) recorded then-current evidence: only `pypi` environment existed and `ao-kernel-live-adapter-gate` secret lookup returned `HTTP 404`; GPP-2 remained blocked. |
-| 2026-04-25 | GPP-2b external/admin issue opened | Issue [#482](https://github.com/Halildeu/ao-kernel/issues/482) tracks protected environment, reviewer, and credential provisioning required before `GPP-2` can start. |
-| 2026-04-25 | GPP-2b partial provisioning recorded | `ao-kernel-live-adapter-gate` now exists, custom deployment branch policy includes `main`, and admin bypass is disabled. Reviewer protection and `AO_CLAUDE_CODE_CLI_AUTH` remain missing, so #482 stays open and `GPP-2` stays blocked. |
-| 2026-04-25 | GPP-2c issue opened | Issue [#485](https://github.com/Halildeu/ao-kernel/issues/485) tracks the remaining protected reviewer and credential gate: add/designate a non-self reviewer or explicitly approve an equivalent release gate, and set `AO_CLAUDE_CODE_CLI_AUTH` without secret readback. |
+| 2026-04-25 | GPP-2b external/admin issue opened | Issue [#482](https://github.com/Halildeu/ao-kernel/issues/482) tracks protected environment, independent release gate, and credential provisioning required before `GPP-2` can start. |
+| 2026-04-25 | GPP-2b partial provisioning recorded | `ao-kernel-live-adapter-gate` now exists, custom deployment branch policy includes `main`, and admin bypass is disabled. The selected deployment-protection app gate and `AO_CLAUDE_CODE_CLI_AUTH` remain missing, so #482 stays open and `GPP-2` stays blocked. |
+| 2026-04-25 | GPP-2c issue opened | Issue [#485](https://github.com/Halildeu/ao-kernel/issues/485) tracks the remaining independent release gate and credential gate: configure the selected deployment-protection app gate and set `AO_CLAUDE_CODE_CLI_AUTH` without secret readback. |
 | 2026-04-25 | GPP-2d issue opened | Issue [#487](https://github.com/Halildeu/ao-kernel/issues/487) tracks a metadata-only attestation tool for repeatable protected gate evidence. |
-| 2026-04-25 | GPP-2d merged | PR [#488](https://github.com/Halildeu/ao-kernel/pull/488) added `scripts/live_adapter_gate_attest.py`; live attestation remains blocked by missing credential handle and reviewer/equivalent gate. |
+| 2026-04-25 | GPP-2d merged | PR [#488](https://github.com/Halildeu/ao-kernel/pull/488) added `scripts/live_adapter_gate_attest.py`; live attestation remains blocked by missing credential handle and, after GPP-2h/GPP-2i, the selected deployment-protection app gate. |
 | 2026-04-25 | GPP-2e issue opened | Issue [#489](https://github.com/Halildeu/ao-kernel/issues/489) tracks the single-admin equivalent gate decision; current repo decision is `not_approved`, so the attestation override remains forbidden. |
 | 2026-04-26 | GPP-2f issue opened | Issue [#491](https://github.com/Halildeu/ao-kernel/issues/491) tracks the independent release gate architecture decision; product end-user accounts are explicitly not release authority. |
 | 2026-04-26 | GPP-2g issue opened | Issue [#493](https://github.com/Halildeu/ao-kernel/issues/493) tracks GitHub-native release authority selection and Claude/MCP advisory consultation protocol. |
 | 2026-04-26 | GPP-2h issue opened | Issue [#495](https://github.com/Halildeu/ao-kernel/issues/495) tracks deployment protection bot gate selection; GitHub App deployment protection supersedes the required-reviewer provisioning path. |
+| 2026-04-26 | GPP-2i issue opened | Issue [#497](https://github.com/Halildeu/ao-kernel/issues/497) tracks metadata-only attestation support for the selected deployment protection bot gate. |

--- a/.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md
+++ b/.claude/plans/GP-4.3-PROTECTED-ENVIRONMENT-SECRET-CONTRACT.md
@@ -39,8 +39,10 @@ The required future environment is:
 |---|---|
 | Environment name | `ao-kernel-live-adapter-gate` |
 | Allowed refs | `main` |
-| Required reviewers | `true` |
-| Prevent self-review | `true` |
+| Release gate model | GitHub App deployment protection rule |
+| Deployment protection app slug | `ao-kernel-live-adapter-gate` |
+| Required reviewers | `false` |
+| Prevent self-review | `false` |
 | Fork secrets | `false` |
 | Forbidden events | `pull_request`, `pull_request_target`, `push` |
 
@@ -65,8 +67,9 @@ The new environment contract artifact is intentionally blocked:
 
 The current repository environment inventory does not include
 `ao-kernel-live-adapter-gate`; only `pypi` exists at implementation time. A
-later slice must either configure and attest that environment or record an
-explicit release-gate equivalent.
+later slice must either configure and attest that environment with the selected
+deployment-protection app gate or record an explicit superseding release-gate
+decision.
 
 ## Non-Goals
 

--- a/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
+++ b/.claude/plans/GP-5-GENERAL-PURPOSE-PRODUCTION-PLATFORM-INTEGRATION.md
@@ -170,8 +170,9 @@ creating environments, reading secret values, binding workflow environments, or
 invoking `claude`. At that time the required `ao-kernel-live-adapter-gate`
 environment was absent. GPP-2b later partially provisioned that environment
 with `main` deployment branch policy and `can_admins_bypass=false`, but
-`AO_CLAUDE_CODE_CLI_AUTH` and required reviewer protection are still not
-attested. Therefore `GP-5.1b` must not bind the workflow yet.
+`AO_CLAUDE_CODE_CLI_AUTH` and the selected GitHub App deployment protection
+rule are still not attested. Therefore `GP-5.1b` must not bind the workflow
+yet.
 
 The detailed decision record is
 `.claude/plans/GP-5.1a-PROTECTED-GATE-PREREQUISITE-AUDIT.md`.
@@ -605,7 +606,7 @@ verification only after gate closeout.
 | `R7` cost/secret exposure | Protected gate leaks credentials or runs too often | Protected environment, manual/scheduled trigger, timeout, cost guard, fork isolation. |
 | `R8` merge overwrite | Parallel sessions lose work | Dedicated worktrees, branch sync checks, overlap review, no destructive cleanup. |
 | `R9` RI-5 / GP-5.3 interface conflict | Root export and workflow context handoff evolve different artifact contracts | Keep ownership split explicit; GP-5.3a/3b use stdout Markdown first; `context_compiler` opt-in waits for RI-5a schema on `origin/main`. |
-| `R10` protected gate partially provisioned but incomplete | Live-adapter promotion stays blocked and local auth is mistaken for support | Keep `blocked` as non-pass until environment secret and reviewer protection are attested; allow repo-intelligence read-only slices to proceed without support widening. |
+| `R10` protected gate partially provisioned but incomplete | Live-adapter promotion stays blocked and local auth is mistaken for support | Keep `blocked` as non-pass until the environment secret and selected deployment-protection app gate are attested; allow repo-intelligence read-only slices to proceed without support widening. |
 | `R11` workspace metadata drift | MCP/workspace status reports stale version or kind while runtime package is current | Add a small investigation/fix slice before using workspace metadata as a platform-readiness signal. |
 
 ## 7. First Backlog

--- a/.claude/plans/GPP-2b-EXTERNAL-ADMIN-PROVISIONING.md
+++ b/.claude/plans/GPP-2b-EXTERNAL-ADMIN-PROVISIONING.md
@@ -71,10 +71,11 @@ The project-owned protected live-adapter gate is not ready because:
 2. Deployment branch policy is custom and currently includes `main`.
 3. Admin bypass is disabled.
 4. `AO_CLAUDE_CODE_CLI_AUTH` is not visible as an environment secret handle.
-5. Required reviewer protection is not configured.
-6. Only one repository collaborator is visible, so the protected reviewer model
-   needs a non-triggering reviewer/admin or an explicitly approved equivalent
-   release gate before self-review prevention can be meaningful.
+5. The current selected release-gate model, superseded by GPP-2h/GPP-2i, is a
+   GitHub App deployment protection rule; that app rule is not configured.
+6. Only one repository collaborator is visible, so the earlier protected
+   reviewer model remains unsuitable unless explicitly superseded by a real
+   independent release authority.
 
 ## 4. Required External/Admin Work
 
@@ -82,12 +83,10 @@ Complete issue [#482](https://github.com/Halildeu/ao-kernel/issues/482):
 
 1. Keep GitHub environment `ao-kernel-live-adapter-gate` present.
 2. Keep deployment branch policy restricted to `main`.
-3. Configure the remaining environment protection required by the contract:
-   - required reviewers enabled;
-   - prevent self-review enabled;
-   - fork-triggered events cannot access protected credentials.
-4. Add at least one non-triggering maintainer reviewer, or record an explicitly
-   approved release-gate equivalent if the repository remains single-admin.
+3. Configure the selected GitHub App deployment protection rule on
+   `ao-kernel-live-adapter-gate` with app slug
+   `ao-kernel-live-adapter-gate`.
+4. Fork-triggered events must not access protected credentials.
 5. Store project-owned Claude Code CLI credential material, or an explicitly
    approved non-API-key equivalent, as environment secret handle
    `AO_CLAUDE_CODE_CLI_AUTH`.
@@ -104,8 +103,8 @@ must collect live evidence that:
    still includes only the intended `main` policy;
 3. `gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel`
    lists `AO_CLAUDE_CODE_CLI_AUTH`;
-4. environment protection evidence is compatible with the protected gate
-   contract;
+4. deployment protection evidence includes the selected enabled GitHub App rule
+   with slug `ao-kernel-live-adapter-gate`;
 5. fork-triggered contexts cannot read protected credentials.
 
 Only if the follow-up attestation exits `prerequisites_ready` can `GPP-2`

--- a/.claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md
+++ b/.claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md
@@ -76,7 +76,7 @@ The gate is still incomplete:
 ### Selected Active Path
 
 1. Implement metadata-only attestation support for GitHub App deployment
-   protection evidence.
+   protection evidence. Completed by `GPP-2i`.
 2. Configure a GitHub App or policy service as the deployment protection gate
    for `ao-kernel-live-adapter-gate`.
 3. Set `AO_CLAUDE_CODE_CLI_AUTH` under the environment without printing or
@@ -105,7 +105,8 @@ slice. That slice must prove:
 2. deployment branch policy still allows only the intended `main` path;
 3. `can_admins_bypass=false`;
 4. `AO_CLAUDE_CODE_CLI_AUTH` exists under the environment;
-5. an approved independent release gate is present;
+5. the selected deployment protection app gate is present, or a future
+   explicit decision selects another independent release-gate model;
 6. fork-triggered contexts cannot read protected credentials.
 
 Only then may `GPP-2` runtime binding start.

--- a/.claude/plans/GPP-2d-METADATA-ONLY-LIVE-GATE-ATTESTATION.md
+++ b/.claude/plans/GPP-2d-METADATA-ONLY-LIVE-GATE-ATTESTATION.md
@@ -37,8 +37,9 @@ The attestation evaluates metadata only:
 2. admin bypass is disabled;
 3. deployment branch policy is restricted to `main`;
 4. environment secret handle `AO_CLAUDE_CODE_CLI_AUTH` exists by name;
-5. required reviewer gate exists, or an explicitly approved equivalent release
-   gate is supplied;
+5. the currently selected independent release gate is present. GPP-2h/GPP-2i
+   supersede the original required-reviewer path with a GitHub App deployment
+   protection rule named `ao-kernel-live-adapter-gate`;
 6. support boundary remains closed.
 
 Secret values are never accepted, read, printed, or written.
@@ -48,9 +49,11 @@ Secret values are never accepted, read, printed, or written.
 With current live metadata, the artifact must be `blocked` because:
 
 1. `AO_CLAUDE_CODE_CLI_AUTH` is still missing under the environment;
-2. required reviewer protection is still missing;
-3. only one collaborator is visible, so a non-self reviewer gate is not yet
-   possible.
+2. the selected GitHub App deployment protection rule is still missing.
+
+The earlier required-reviewer/equivalent-gate wording is historical. Current
+attestation treats `--equivalent-release-gate-approved` as recorded metadata
+only; it does not satisfy the selected deployment-protection bot gate.
 
 `runtime_binding_allowed=false`, `live_execution_allowed=false`, and
 `support_widening=false` remain the expected result until a future attestation
@@ -71,4 +74,3 @@ proves prerequisites ready.
 2. Unit tests cover a synthetic metadata-ready state.
 3. CLI fixture test proves deterministic artifact writing without live GitHub.
 4. `python3 scripts/gpp_next.py` still reports `GPP-2` blocked.
-

--- a/.claude/plans/GPP-2e-SINGLE-ADMIN-EQUIVALENT-GATE-DECISION.md
+++ b/.claude/plans/GPP-2e-SINGLE-ADMIN-EQUIVALENT-GATE-DECISION.md
@@ -30,7 +30,9 @@ The live gate currently has these properties:
 2. Admin bypass is disabled.
 3. Deployment branch policy is restricted to `main`.
 4. Environment secret handle `AO_CLAUDE_CODE_CLI_AUTH` is absent.
-5. Required reviewer protection is absent.
+5. Required reviewer protection was absent at the time of this decision; the
+   active path was later superseded by the selected GitHub App deployment
+   protection gate.
 6. Only one collaborator, `Halildeu`, is visible through the GitHub
    collaborators API.
 
@@ -48,7 +50,7 @@ support_widening: false
 
 The single-admin equivalent release gate is **not approved**.
 
-The preferred resolution remains:
+The preferred resolution at the time was:
 
 1. Add or designate an independent release authority.
 2. Configure required reviewers on `ao-kernel-live-adapter-gate`.
@@ -59,6 +61,10 @@ The preferred resolution remains:
 
 An equivalent single-admin release gate can only be used after a future explicit
 decision changes this record from `not_approved` to `approved`.
+
+GPP-2h/GPP-2i later supersede the reviewer provisioning path with a GitHub App
+deployment protection rule. This record still blocks the single-admin
+equivalent-gate override.
 
 ## Contract
 

--- a/.claude/plans/GPP-2g-GITHUB-NATIVE-RELEASE-AUTHORITY-AND-CLAUDE-MCP-CONSULTATION.md
+++ b/.claude/plans/GPP-2g-GITHUB-NATIVE-RELEASE-AUTHORITY-AND-CLAUDE-MCP-CONSULTATION.md
@@ -40,9 +40,10 @@ The alternate models from `GPP-2f` stay valid fallback options:
 1. GitHub App deployment protection rule;
 2. OIDC-backed external secret broker.
 
-They are not selected for the first provisioning path because they add more
-infrastructure before the current blocked gate has even proven the basic
-environment reviewer and credential-handle contract.
+They were not selected for the first provisioning path because they added more
+infrastructure before the current blocked gate had proven the basic environment
+reviewer and credential-handle contract. GPP-2h later superseded that first
+path and selected GitHub App deployment protection.
 
 ## Current Blocking State
 

--- a/.claude/plans/GPP-2h-DEPLOYMENT-PROTECTION-BOT-GATE-DECISION.md
+++ b/.claude/plans/GPP-2h-DEPLOYMENT-PROTECTION-BOT-GATE-DECISION.md
@@ -80,13 +80,13 @@ Current live gate state:
 4. `AO_CLAUDE_CODE_CLI_AUTH` is still not attested as an environment secret
    handle;
 5. no GitHub App deployment protection rule is implemented or attested;
-6. `scripts/live_adapter_gate_attest.py` currently checks required reviewer or
-   equivalent release gate metadata, not the selected deployment protection
-   bot metadata shape.
+6. before GPP-2i, `scripts/live_adapter_gate_attest.py` checked required
+   reviewer or equivalent release gate metadata, not the selected deployment
+   protection bot metadata shape.
 
 ## Next Implementation Slices
 
-The next repo-code slice should be narrow:
+The next repo-code slice has been implemented:
 
 ```text
 GPP-2i - deployment protection attestation support
@@ -102,6 +102,9 @@ Scope for `GPP-2i`:
    but credential-missing states;
 4. keep all support/runtime/production flags false;
 5. do not create the GitHub App, set secrets, or run a live adapter.
+
+`GPP-2i` closes with the live gate still blocked until external/admin
+provisioning supplies the selected app gate and credential handle.
 
 The later external/admin provisioning step should configure the GitHub App
 deployment protection rule in `ao-kernel-live-adapter-gate`, then set

--- a/.claude/plans/GPP-2i-DEPLOYMENT-PROTECTION-ATTESTATION-SUPPORT.md
+++ b/.claude/plans/GPP-2i-DEPLOYMENT-PROTECTION-ATTESTATION-SUPPORT.md
@@ -1,0 +1,87 @@
+# GPP-2i - Deployment Protection Attestation Support
+
+**Issue:** [#497](https://github.com/Halildeu/ao-kernel/issues/497)
+**Date:** 2026-04-26
+**Program head:** `GPP-2` remains blocked
+**Decision:** `deployment_protection_attestation_supported_gate_still_blocked`
+**Support impact:** none
+**Runtime impact:** metadata-only attestation support; no live execution
+
+## Purpose
+
+`GPP-2h` selected GitHub App deployment protection as the independent release
+gate model. This slice updates the repository's metadata-only attestation
+surface to understand that selected model before any external provisioning or
+runtime binding starts.
+
+The implementation does not create a GitHub App, does not configure
+environment protection, does not set or read secrets, and does not execute
+`claude-code-cli`.
+
+## Implemented Contract
+
+The live-adapter prerequisite attestation now carries:
+
+1. `release_gate_model = github_app_deployment_protection_rule`;
+2. `required_deployment_protection_app_slug = ao-kernel-live-adapter-gate`;
+3. a fail-closed `deployment_protection_gate` check;
+4. deployment protection metadata fixture support in
+   `scripts/live_adapter_gate_attest.py`;
+5. live metadata collection from GitHub's environment deployment protection
+   rules endpoint, with failure treated as an empty/missing app gate rather
+   than a pass.
+
+The selected gate is only satisfied when the required GitHub App slug is
+present and enabled in deployment protection metadata.
+
+## Preserved Guards
+
+1. `GPP-2` remains blocked.
+2. `runtime_binding_allowed` remains false on the current live repo because
+   the required credential handle and deployment protection app are still not
+   attested.
+3. `live_execution_allowed` remains false even for ready metadata-only
+   fixtures; live execution is a later runtime-binding gate.
+4. `support_widening` remains false.
+5. `--equivalent-release-gate-approved` does not satisfy the selected
+   deployment protection bot gate.
+6. A wrong GitHub App slug blocks.
+7. PAT-backed bot user reviewer remains forbidden.
+
+## Current Live Result
+
+Current live attestation remains blocked:
+
+```text
+credential_handle: blocked (live_gate_credential_handle_missing)
+deployment_protection_gate: blocked (live_gate_deployment_protection_missing)
+runtime_binding_allowed: false
+live_execution_allowed: false
+support_widening: false
+```
+
+This is the expected result until the external/admin provisioning step creates
+or installs the selected GitHub App deployment protection rule and sets
+`AO_CLAUDE_CODE_CLI_AUTH` as an environment secret handle.
+
+## Next Step
+
+The next action is external/admin provisioning:
+
+1. create or install the GitHub App/policy service with slug
+   `ao-kernel-live-adapter-gate`;
+2. attach it as a deployment protection rule to the
+   `ao-kernel-live-adapter-gate` environment;
+3. set `AO_CLAUDE_CODE_CLI_AUTH` under that environment without secret value
+   readback;
+4. run a fresh metadata-only prerequisite attestation.
+
+Only after that attestation exits `ready` may `GPP-2` runtime binding begin.
+
+## Exit State
+
+This slice closes as
+`deployment_protection_attestation_supported_gate_still_blocked`.
+
+It implements attestation support only. It does not unblock `GPP-2`, does not
+run a live adapter, does not configure GitHub, and does not widen support.

--- a/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
+++ b/.claude/plans/POST-BETA-CORRECTNESS-EXPANSION-STATUS.md
@@ -139,12 +139,13 @@ ayrı ayrı görünür kılmak.
 - **GPP-1d authority-head cleanup issue:** [#478](https://github.com/Halildeu/ao-kernel/issues/478) (`closed by PR #479`)
 - **GPP-2a protected prerequisite re-attestation issue:** [#480](https://github.com/Halildeu/ao-kernel/issues/480) (`closes by PR #481`)
 - **GPP-2b external/admin provisioning issue:** [#482](https://github.com/Halildeu/ao-kernel/issues/482)
-- **GPP-2c reviewer/credential gate issue:** [#485](https://github.com/Halildeu/ao-kernel/issues/485)
+- **GPP-2c release-gate/credential issue:** [#485](https://github.com/Halildeu/ao-kernel/issues/485)
 - **GPP-2d metadata-only live gate attestation issue:** [#487](https://github.com/Halildeu/ao-kernel/issues/487) (`closed by PR #488`)
 - **GPP-2e single-admin equivalent gate decision issue:** [#489](https://github.com/Halildeu/ao-kernel/issues/489)
 - **GPP-2f independent release gate architecture issue:** [#491](https://github.com/Halildeu/ao-kernel/issues/491)
 - **GPP-2g Claude MCP consultation protocol issue:** [#493](https://github.com/Halildeu/ao-kernel/issues/493)
 - **GPP-2h deployment protection bot gate issue:** [#495](https://github.com/Halildeu/ao-kernel/issues/495)
+- **GPP-2i deployment protection attestation support issue:** [#497](https://github.com/Halildeu/ao-kernel/issues/497)
 - **Current mode:** stable maintenance + written general-purpose production
   promotion tracking. RI-5b is merged as Beta/operator-managed root export, not
   a production platform claim. GPP-1 live attestation exited as
@@ -153,11 +154,11 @@ ayrı ayrı görünür kılmak.
   before acting. Current program status holds at `GPP-2` blocked. GPP-2a
   re-attestation reconfirmed the missing protected environment and credential
   handle. GPP-2b now tracks the external/admin provisioning work for the
-  protected environment, reviewer model, and credential handle. The protected
+  protected environment, independent release-gate model, and credential handle. The protected
   environment has since been partially provisioned with `main` branch policy
-  and admin bypass disabled, but reviewer protection and
+  and admin bypass disabled, but the selected deployment-protection app gate and
   `AO_CLAUDE_CODE_CLI_AUTH` remain missing. GPP-2c now tracks that final
-  reviewer/credential gate decision. GPP-2d adds repeatable metadata-only
+  release-gate/credential decision. GPP-2d adds repeatable metadata-only
   attestation tooling so future prerequisite checks do not rely on manual issue
   comments. GPP-2e records that the single-admin equivalent release gate is
   not approved, so `--equivalent-release-gate-approved` cannot be used for
@@ -167,9 +168,12 @@ ayrı ayrı görünür kılmak.
   authority, GitHub App deployment protection, or OIDC-backed external secret
   broker. GPP-2g records Claude/MCP consultation as advisory only; GPP-2h
   selects GitHub App deployment protection as the active bot gate model and
-  rejects PAT-backed bot reviewers. No support
+  rejects PAT-backed bot reviewers. GPP-2i adds metadata-only attestation
+  support for the selected app gate, but the live gate remains blocked until
+  the app rule and `AO_CLAUDE_CODE_CLI_AUTH` handle are actually provisioned.
+  No support
   widening, release, runtime adapter promotion, or production claim is made by
-  GPP-1b/GPP-1c/GPP-2a/GPP-2b/GPP-2c/GPP-2d/GPP-2e/GPP-2f/GPP-2g/GPP-2h.
+  GPP-1b/GPP-1c/GPP-2a/GPP-2b/GPP-2c/GPP-2d/GPP-2e/GPP-2f/GPP-2g/GPP-2h/GPP-2i.
   Future stable widening still requires protected live-adapter evidence,
   repo-intelligence integration gates, write-side rollback evidence, and an
   explicit closeout decision.
@@ -277,8 +281,8 @@ binding hattı bu prerequisite kapanmadan başlayamazdı.
 `GPP-2a` re-attestation bu sonucu tekrar doğruladı. Sonraki GPP-2b admin
 adımında `ao-kernel-live-adapter-gate` environment oluşturuldu, `main` branch
 policy eklendi ve admin bypass kapatıldı. Buna rağmen
-`AO_CLAUDE_CODE_CLI_AUTH` environment secret handle yoktur, required reviewer
-protection yoktur ve runtime binding hâlâ başlamaz.
+`AO_CLAUDE_CODE_CLI_AUTH` environment secret handle yoktur, selected deployment
+protection app rule yoktur ve runtime binding hâlâ başlamaz.
 
 `GPP-2d` metadata-only attestation tooling'i merge edildi. `GPP-2e` single-admin
 equivalent release gate kararını `not_approved` olarak kaydeder; bu nedenle
@@ -290,7 +294,9 @@ olduğunu kaydeder. Kabul edilebilir modeller GitHub-native release authority,
 GitHub App deployment protection veya OIDC-backed external secret broker'dır.
 `GPP-2g`, Claude/MCP danışmanlığını advisory-only olarak sınırlar. `GPP-2h`,
 aktif provisioning yolunu GitHub App deployment protection bot gate olarak
-seçer; PAT destekli bot kullanıcı reviewer modeli kabul edilmez.
+seçer; PAT destekli bot kullanıcı reviewer modeli kabul edilmez. `GPP-2i`,
+bu seçili bot gate için metadata-only attestation desteğini ekler; canlı gate
+app rule ve credential handle provision edilene kadar blocked kalır.
 
 `GPP-1b`, bu blocked runtime sonucunu değiştirmez. Amacı Codex ve Claude Code
 operatör oturumlarının `.claude/plans/gpp_status.v1.json` ve
@@ -386,7 +392,7 @@ GPP-2b sonrası canlı delta:
 2. Custom deployment branch policy açıktır ve `main` policy kaydı vardır.
 3. `can_admins_bypass=false`.
 4. `AO_CLAUDE_CODE_CLI_AUTH` environment secret handle hâlâ yoktur.
-5. Required reviewer protection hâlâ yoktur.
+5. Selected deployment-protection app rule hâlâ yoktur.
 6. `GPP-2` hâlâ blocked durumdadır; support widening ve production claim yoktur.
 6. `scripts/live_adapter_gate_contract.py` blocked evidence üretmeye devam
    ediyor: `overall_status=blocked`, `decision=blocked_no_rehearsal`,

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -70,6 +70,12 @@
       "decision": "github_app_deployment_protection_rule_selected_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/495",
       "record": ".claude/plans/GPP-2h-DEPLOYMENT-PROTECTION-BOT-GATE-DECISION.md"
+    },
+    {
+      "id": "GPP-2i",
+      "decision": "deployment_protection_attestation_supported_gate_still_blocked",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/497",
+      "record": ".claude/plans/GPP-2i-DEPLOYMENT-PROTECTION-ATTESTATION-SUPPORT.md"
     }
   ],
   "blocked_wps": [
@@ -87,7 +93,7 @@
       "issue": "https://github.com/Halildeu/ao-kernel/issues/482",
       "record": ".claude/plans/GPP-2b-EXTERNAL-ADMIN-PROVISIONING.md",
       "status": "partially_provisioned_blocked",
-      "decision": "environment_created_secret_and_reviewer_still_missing",
+      "decision": "environment_created_secret_and_app_gate_still_missing",
       "required_before": "GPP-2 runtime binding"
     },
     {
@@ -95,8 +101,8 @@
       "title": "Independent release gate and credential resolution",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/485",
       "record": ".claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md",
-      "status": "blocked_external_deployment_protection_bot_provisioning_required",
-      "decision": "github_app_deployment_protection_selected_secret_and_app_gate_still_missing",
+      "status": "blocked_external_deployment_protection_bot_and_secret_provisioning_required",
+      "decision": "attestation_support_ready_secret_and_app_gate_still_missing",
       "required_before": "GPP-2 runtime binding"
     }
   ],
@@ -155,12 +161,11 @@
     "track external admin provisioning in issue #482",
     "resolve independent release gate and credential handling in issue #485",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
-    "implement deployment protection attestation support before any GPP-2 runtime binding",
     "provision the selected GitHub App deployment protection rule before any GPP-2 runtime binding",
     "use Claude MCP consultation only as advisory review, not release authority",
     "use scripts/live_adapter_gate_attest.py for the next prerequisite attestation",
     "provision AO_CLAUDE_CODE_CLI_AUTH under ao-kernel-live-adapter-gate without reading secret values",
-    "configure GitHub App deployment protection on ao-kernel-live-adapter-gate after attestation support exists",
+    "configure GitHub App deployment protection on ao-kernel-live-adapter-gate with app slug ao-kernel-live-adapter-gate",
     "run a follow-up prerequisite attestation slice only after issue #482 acceptance criteria are met",
     "do not widen support or claim production platform readiness"
   ],

--- a/ao_kernel/defaults/schemas/live-adapter-gate-environment.schema.v1.json
+++ b/ao_kernel/defaults/schemas/live-adapter-gate-environment.schema.v1.json
@@ -94,6 +94,9 @@
       "required": [
         "name",
         "required",
+        "release_gate_model",
+        "deployment_protection_app_required",
+        "deployment_protection_app_slug",
         "required_reviewers",
         "prevent_self_review",
         "allowed_refs",
@@ -106,11 +109,20 @@
         "required": {
           "const": true
         },
-        "required_reviewers": {
+        "release_gate_model": {
+          "const": "github_app_deployment_protection_rule"
+        },
+        "deployment_protection_app_required": {
           "const": true
         },
+        "deployment_protection_app_slug": {
+          "const": "ao-kernel-live-adapter-gate"
+        },
+        "required_reviewers": {
+          "const": false
+        },
         "prevent_self_review": {
-          "const": true
+          "const": false
         },
         "allowed_refs": {
           "type": "array",

--- a/ao_kernel/live_adapter_gate.py
+++ b/ao_kernel/live_adapter_gate.py
@@ -42,6 +42,8 @@ ATTESTATION_PROGRAM_ID = "GPP-2d"
 ATTESTATION_ARTIFACT_KIND = "live_adapter_gate_prerequisite_attestation"
 ATTESTATION_ARTIFACT = "live-adapter-gate-attestation.v1.json"
 REQUIRED_SECRET_ID = "AO_CLAUDE_CODE_CLI_AUTH"
+SELECTED_RELEASE_GATE_MODEL = "github_app_deployment_protection_rule"
+REQUIRED_DEPLOYMENT_PROTECTION_APP_SLUG = "ao-kernel-live-adapter-gate"
 
 
 CheckStatus = Literal["pass", "blocked", "skipped"]
@@ -142,6 +144,9 @@ class LiveAdapterGateProtectedEnvironment(TypedDict):
 
     name: str
     required: bool
+    release_gate_model: str
+    deployment_protection_app_required: bool
+    deployment_protection_app_slug: str
     required_reviewers: bool
     prevent_self_review: bool
     allowed_refs: list[str]
@@ -253,6 +258,8 @@ class LiveAdapterGateAttestationArtifact(TypedDict):
     environment_name: str
     required_secret_id: str
     equivalent_release_gate_approved: bool
+    release_gate_model: str
+    required_deployment_protection_app_slug: str
     runtime_binding_allowed: bool
     live_execution_allowed: bool
     support_widening: bool
@@ -455,12 +462,15 @@ def build_live_adapter_gate_environment_contract(
         "protected_environment": {
             "name": PROTECTED_ENVIRONMENT_NAME,
             "required": True,
-            "required_reviewers": True,
-            "prevent_self_review": True,
+            "release_gate_model": SELECTED_RELEASE_GATE_MODEL,
+            "deployment_protection_app_required": True,
+            "deployment_protection_app_slug": REQUIRED_DEPLOYMENT_PROTECTION_APP_SLUG,
+            "required_reviewers": False,
+            "prevent_self_review": False,
             "allowed_refs": ["main"],
             "detail": (
                 "Future live execution must run through this protected GitHub "
-                "environment or an explicitly approved release-gate equivalent."
+                "environment and the selected GitHub App deployment protection gate."
             ),
         },
         "trigger_policy": {
@@ -645,6 +655,75 @@ def _required_reviewer_rules(environment_payload: object) -> list[dict[str, Any]
     ]
 
 
+def _deployment_protection_rules(deployment_protection_payload: object) -> list[dict[str, Any]]:
+    """Return GitHub App deployment protection rules from supported payload shapes."""
+
+    if isinstance(deployment_protection_payload, list):
+        return [item for item in deployment_protection_payload if isinstance(item, dict)]
+    if not isinstance(deployment_protection_payload, dict):
+        return []
+    candidates: list[dict[str, Any]] = []
+    for key in (
+        "custom_deployment_protection_rules",
+        "deployment_protection_rules",
+        "protection_rules",
+    ):
+        candidates.extend(_named_items(deployment_protection_payload, container_key=key))
+    if not candidates and any(key in deployment_protection_payload for key in ("app", "name", "slug")):
+        candidates.append(deployment_protection_payload)
+    return candidates
+
+
+def _deployment_protection_rule_names(deployment_protection_payload: object) -> list[str]:
+    """Return readable deployment-protection rule app identities."""
+
+    names: list[str] = []
+    for rule in _deployment_protection_rules(deployment_protection_payload):
+        app = _as_dict(rule.get("app"))
+        for candidate in (
+            app.get("slug"),
+            app.get("name"),
+            rule.get("app_slug"),
+            rule.get("app_name"),
+            rule.get("slug"),
+            rule.get("name"),
+        ):
+            if isinstance(candidate, str) and candidate:
+                names.append(candidate)
+                break
+    return sorted(set(names))
+
+
+def _deployment_protection_gate_ok(
+    deployment_protection_payload: object,
+    *,
+    required_app_slug: str,
+) -> bool:
+    """Return whether the selected GitHub App deployment protection gate exists."""
+
+    if not required_app_slug:
+        return False
+    for rule in _deployment_protection_rules(deployment_protection_payload):
+        if rule.get("enabled") is False:
+            continue
+        app = _as_dict(rule.get("app"))
+        identities = {
+            value
+            for value in (
+                app.get("slug"),
+                app.get("name"),
+                rule.get("app_slug"),
+                rule.get("app_name"),
+                rule.get("slug"),
+                rule.get("name"),
+            )
+            if isinstance(value, str) and value
+        }
+        if required_app_slug in identities:
+            return True
+    return False
+
+
 def _has_branch_policy_rule(environment_payload: object) -> bool:
     """Return whether the environment has a branch-policy protection rule."""
 
@@ -661,8 +740,10 @@ def build_live_adapter_gate_attestation(
     branch_policy_payload: object,
     secret_payload: object,
     collaborator_payload: object,
+    deployment_protection_payload: object | None = None,
     environment_name: str = PROTECTED_ENVIRONMENT_NAME,
     required_secret_id: str = REQUIRED_SECRET_ID,
+    required_deployment_protection_app_slug: str = REQUIRED_DEPLOYMENT_PROTECTION_APP_SLUG,
     actor_login: str = "",
     equivalent_release_gate_approved: bool = False,
     generated_at: str | None = None,
@@ -685,14 +766,11 @@ def build_live_adapter_gate_attestation(
     branch_policy_ok = _has_branch_policy_rule(environment) and custom_branch_policy and main_only_branch_policy
 
     secret_present = required_secret_id in _secret_names(secret_payload)
-    reviewer_rules = _required_reviewer_rules(environment)
-    reviewer_gate_configured = bool(reviewer_rules)
-    prevent_self_review = any(rule.get("prevent_self_review") is True for rule in reviewer_rules)
-    collaborators = _collaborator_logins(collaborator_payload)
-    non_self_collaborators = [login for login in collaborators if not actor_login or login != actor_login]
-    non_self_reviewer_possible = len(non_self_collaborators) >= 1
-    reviewer_gate_ok = (reviewer_gate_configured and prevent_self_review and non_self_reviewer_possible) or (
-        equivalent_release_gate_approved
+    deployment_protection_payload = deployment_protection_payload or {}
+    deployment_rule_names = _deployment_protection_rule_names(deployment_protection_payload)
+    deployment_protection_gate_ok = _deployment_protection_gate_ok(
+        deployment_protection_payload,
+        required_app_slug=required_deployment_protection_app_slug,
     )
 
     check_specs = [
@@ -725,11 +803,17 @@ def build_live_adapter_gate_attestation(
             f"Environment secret handle {required_secret_id!r} is missing.",
         ),
         (
-            "reviewer_gate",
-            reviewer_gate_ok,
-            "live_gate_reviewer_gate_missing",
-            "Reviewer protection or an explicitly approved equivalent release gate is present.",
-            "Required reviewer protection is missing and no equivalent release gate is approved.",
+            "deployment_protection_gate",
+            deployment_protection_gate_ok,
+            "live_gate_deployment_protection_missing",
+            (
+                "Selected GitHub App deployment protection gate "
+                f"{required_deployment_protection_app_slug!r} is present."
+            ),
+            (
+                "Selected GitHub App deployment protection gate "
+                f"{required_deployment_protection_app_slug!r} is missing; observed={deployment_rule_names!r}."
+            ),
         ),
         (
             "support_boundary",
@@ -765,6 +849,8 @@ def build_live_adapter_gate_attestation(
         "environment_name": environment_name,
         "required_secret_id": required_secret_id,
         "equivalent_release_gate_approved": equivalent_release_gate_approved,
+        "release_gate_model": SELECTED_RELEASE_GATE_MODEL,
+        "required_deployment_protection_app_slug": required_deployment_protection_app_slug,
         "runtime_binding_allowed": overall_status == "ready",
         "live_execution_allowed": False,
         "support_widening": False,

--- a/scripts/live_adapter_gate_attest.py
+++ b/scripts/live_adapter_gate_attest.py
@@ -16,6 +16,7 @@ if str(_REPO_ROOT) not in sys.path:
 from ao_kernel.live_adapter_gate import (  # noqa: E402
     ATTESTATION_ARTIFACT,
     PROTECTED_ENVIRONMENT_NAME,
+    REQUIRED_DEPLOYMENT_PROTECTION_APP_SLUG,
     REQUIRED_SECRET_ID,
     build_live_adapter_gate_attestation,
     render_live_adapter_gate_attestation_text,
@@ -32,14 +33,19 @@ def _load_json_file(path: Path | None) -> object | None:
     return payload
 
 
-def _run_json(command: list[str]) -> object:
+def _run_json(command: list[str], *, allow_failure: bool = False) -> object:
     """Run a command that emits JSON and return the decoded payload."""
 
-    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    completed = subprocess.run(command, check=not allow_failure, capture_output=True, text=True)
+    if completed.returncode != 0 and allow_failure:
+        return {
+            "custom_deployment_protection_rules": [],
+            "collection_error": completed.stderr.strip() or str(completed.returncode),
+        }
     return json.loads(completed.stdout or "null")
 
 
-def _collect_live_payloads(repo: str, environment: str) -> tuple[object, object, object, object]:
+def _collect_live_payloads(repo: str, environment: str) -> tuple[object, object, object, object, object]:
     """Collect GitHub metadata without reading secret values."""
 
     environment_payload = _run_json(
@@ -76,7 +82,21 @@ def _collect_live_payloads(repo: str, environment: str) -> tuple[object, object,
             f"repos/{repo}/collaborators?per_page=100",
         ]
     )
-    return environment_payload, branch_policy_payload, secret_payload, collaborator_payload
+    deployment_protection_payload = _run_json(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/environments/{environment}/deployment_protection_rules",
+        ],
+        allow_failure=True,
+    )
+    return (
+        environment_payload,
+        branch_policy_payload,
+        secret_payload,
+        collaborator_payload,
+        deployment_protection_payload,
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -86,11 +106,19 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--repo", default="Halildeu/ao-kernel", help="GitHub repository owner/name.")
     parser.add_argument("--environment", default=PROTECTED_ENVIRONMENT_NAME, help="Protected environment name.")
     parser.add_argument("--secret-id", default=REQUIRED_SECRET_ID, help="Required environment secret handle.")
+    parser.add_argument(
+        "--deployment-protection-app-slug",
+        default=REQUIRED_DEPLOYMENT_PROTECTION_APP_SLUG,
+        help="Required GitHub App deployment protection slug.",
+    )
     parser.add_argument("--actor-login", default="", help="Current triggering actor login for non-self checks.")
     parser.add_argument(
         "--equivalent-release-gate-approved",
         action="store_true",
-        help="Treat an explicitly approved equivalent release gate as satisfying reviewer protection.",
+        help=(
+            "Record a historical equivalent release gate flag; it does not satisfy "
+            "the selected GitHub App deployment protection gate."
+        ),
     )
     parser.add_argument(
         "--artifact-path",
@@ -113,22 +141,31 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--secrets-json", type=Path, default=None, help="Fixture JSON for secret names.")
     parser.add_argument("--collaborators-json", type=Path, default=None, help="Fixture JSON for collaborators.")
+    parser.add_argument(
+        "--deployment-protection-json",
+        type=Path,
+        default=None,
+        help="Fixture JSON for deployment protection rules.",
+    )
     return parser
 
 
-def _fixture_payloads(args: argparse.Namespace) -> tuple[object, object, object, object] | None:
+def _fixture_payloads(args: argparse.Namespace) -> tuple[object, object, object, object, object] | None:
     """Return fixture payloads when all fixture inputs are provided."""
 
-    paths = (args.environment_json, args.branch_policies_json, args.secrets_json, args.collaborators_json)
-    if all(path is None for path in paths):
+    core_paths = (args.environment_json, args.branch_policies_json, args.secrets_json, args.collaborators_json)
+    if all(path is None for path in core_paths):
+        if args.deployment_protection_json is not None:
+            raise SystemExit("deployment protection fixture requires the core fixture inputs")
         return None
-    if any(path is None for path in paths):
-        raise SystemExit("all fixture inputs must be provided together")
+    if any(path is None for path in core_paths):
+        raise SystemExit("all core fixture inputs must be provided together")
     return (
         _load_json_file(args.environment_json),
         _load_json_file(args.branch_policies_json),
         _load_json_file(args.secrets_json),
         _load_json_file(args.collaborators_json),
+        _load_json_file(args.deployment_protection_json) if args.deployment_protection_json else {},
     )
 
 
@@ -141,14 +178,22 @@ def main(argv: list[str] | None = None) -> int:
     if payloads is None:
         payloads = _collect_live_payloads(args.repo, args.environment)
 
-    environment_payload, branch_policy_payload, secret_payload, collaborator_payload = payloads
+    (
+        environment_payload,
+        branch_policy_payload,
+        secret_payload,
+        collaborator_payload,
+        deployment_protection_payload,
+    ) = payloads
     artifact = build_live_adapter_gate_attestation(
         environment_payload=environment_payload,
         branch_policy_payload=branch_policy_payload,
         secret_payload=secret_payload,
         collaborator_payload=collaborator_payload,
+        deployment_protection_payload=deployment_protection_payload,
         environment_name=args.environment,
         required_secret_id=args.secret_id,
+        required_deployment_protection_app_slug=args.deployment_protection_app_slug,
         actor_login=args.actor_login,
         equivalent_release_gate_approved=args.equivalent_release_gate_approved,
     )

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -71,6 +71,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2i"
+        and item["decision"] == "deployment_protection_attestation_supported_gate_still_blocked"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/497"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -79,18 +86,18 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["pending_external_actions"][0]["status"] == "partially_provisioned_blocked"
     assert (
         payload["pending_external_actions"][0]["decision"]
-        == "environment_created_secret_and_reviewer_still_missing"
+        == "environment_created_secret_and_app_gate_still_missing"
     )
     assert payload["pending_external_actions"][1]["id"] == "GPP-2c"
     assert payload["pending_external_actions"][1]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/485"
     assert payload["pending_external_actions"][1]["title"] == "Independent release gate and credential resolution"
     assert (
         payload["pending_external_actions"][1]["status"]
-        == "blocked_external_deployment_protection_bot_provisioning_required"
+        == "blocked_external_deployment_protection_bot_and_secret_provisioning_required"
     )
     assert (
         payload["pending_external_actions"][1]["decision"]
-        == "github_app_deployment_protection_selected_secret_and_app_gate_still_missing"
+        == "attestation_support_ready_secret_and_app_gate_still_missing"
     )
     assert {item["id"] for item in payload["pending_external_actions"]} == {"GPP-2b", "GPP-2c"}
     assert {item["id"] for item in payload["blocked_wps"]} == {"GPP-2"}
@@ -106,11 +113,12 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"])
     assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
     assert any(
-        action == "implement deployment protection attestation support before any GPP-2 runtime binding"
+        action == "provision the selected GitHub App deployment protection rule before any GPP-2 runtime binding"
         for action in payload["next_allowed_actions"]
     )
     assert any(
-        action == "provision the selected GitHub App deployment protection rule before any GPP-2 runtime binding"
+        action
+        == "configure GitHub App deployment protection on ao-kernel-live-adapter-gate with app slug ao-kernel-live-adapter-gate"
         for action in payload["next_allowed_actions"]
     )
     assert any(action == "treat Claude MCP consultation as release authority" for action in payload["forbidden_actions"])
@@ -176,6 +184,20 @@ def test_gpp2h_selects_deployment_protection_bot_not_bot_user() -> None:
     assert "The model is a policy bot, not a user-like reviewer account." in decision
     assert "PAT-backed bot account listed as required reviewer" in decision
     assert "GPP-2i - deployment protection attestation support" in decision
+    assert "does not unblock `GPP-2`" in decision
+    assert "does not widen support" in decision
+
+
+def test_gpp2i_attestation_support_keeps_gate_blocked() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2i-DEPLOYMENT-PROTECTION-ATTESTATION-SUPPORT.md"
+    ).read_text(encoding="utf-8")
+
+    assert "**Decision:** `deployment_protection_attestation_supported_gate_still_blocked`" in decision
+    assert "`release_gate_model = github_app_deployment_protection_rule`" in decision
+    assert "`required_deployment_protection_app_slug = ao-kernel-live-adapter-gate`" in decision
+    assert "deployment_protection_gate: blocked (live_gate_deployment_protection_missing)" in decision
+    assert "`--equivalent-release-gate-approved` does not satisfy" in decision
     assert "does not unblock `GPP-2`" in decision
     assert "does not widen support" in decision
 

--- a/tests/test_live_adapter_gate_contract.py
+++ b/tests/test_live_adapter_gate_contract.py
@@ -15,6 +15,7 @@ from ao_kernel.live_adapter_gate import (
     EVIDENCE_ARTIFACT,
     ENVIRONMENT_CONTRACT_ARTIFACT,
     REHEARSAL_DECISION_ARTIFACT,
+    REQUIRED_DEPLOYMENT_PROTECTION_APP_SLUG,
     build_live_adapter_gate_attestation,
     build_live_adapter_gate_evidence_artifact,
     build_live_adapter_gate_environment_contract,
@@ -153,12 +154,15 @@ def test_build_live_adapter_gate_environment_contract_is_schema_valid_and_blocke
     assert contract["protected_environment"] == {
         "name": "ao-kernel-live-adapter-gate",
         "required": True,
-        "required_reviewers": True,
-        "prevent_self_review": True,
+        "release_gate_model": "github_app_deployment_protection_rule",
+        "deployment_protection_app_required": True,
+        "deployment_protection_app_slug": REQUIRED_DEPLOYMENT_PROTECTION_APP_SLUG,
+        "required_reviewers": False,
+        "prevent_self_review": False,
         "allowed_refs": ["main"],
         "detail": (
             "Future live execution must run through this protected GitHub "
-            "environment or an explicitly approved release-gate equivalent."
+            "environment and the selected GitHub App deployment protection gate."
         ),
     }
     assert contract["trigger_policy"]["forks_allowed"] is False
@@ -239,8 +243,8 @@ def test_build_live_adapter_gate_attestation_blocks_current_partial_gate() -> No
     assert checks["deployment_branch_policy"]["status"] == "pass"
     assert checks["credential_handle"]["status"] == "blocked"
     assert checks["credential_handle"]["finding_code"] == "live_gate_credential_handle_missing"
-    assert checks["reviewer_gate"]["status"] == "blocked"
-    assert checks["reviewer_gate"]["finding_code"] == "live_gate_reviewer_gate_missing"
+    assert checks["deployment_protection_gate"]["status"] == "blocked"
+    assert checks["deployment_protection_gate"]["finding_code"] == "live_gate_deployment_protection_missing"
 
 
 def test_build_live_adapter_gate_attestation_allows_ready_metadata_only_state() -> None:
@@ -260,16 +264,77 @@ def test_build_live_adapter_gate_attestation_allows_ready_metadata_only_state() 
             {"login": "Halildeu", "role_name": "admin"},
             {"login": "release-reviewer", "role_name": "maintain"},
         ],
+        deployment_protection_payload={
+            "custom_deployment_protection_rules": [
+                {
+                    "id": 10,
+                    "enabled": True,
+                    "app": {"slug": REQUIRED_DEPLOYMENT_PROTECTION_APP_SLUG},
+                }
+            ]
+        },
         actor_login="Halildeu",
         generated_at="2026-04-25T00:00:00Z",
     )
 
+    assert artifact["release_gate_model"] == "github_app_deployment_protection_rule"
+    assert artifact["required_deployment_protection_app_slug"] == REQUIRED_DEPLOYMENT_PROTECTION_APP_SLUG
     assert artifact["overall_status"] == "ready"
     assert artifact["finding_code"] is None
     assert artifact["runtime_binding_allowed"] is True
     assert artifact["live_execution_allowed"] is False
     assert artifact["support_widening"] is False
     assert artifact["findings"] == []
+
+
+def test_build_live_adapter_gate_attestation_rejects_wrong_deployment_protection_app() -> None:
+    artifact = build_live_adapter_gate_attestation(
+        environment_payload={
+            "name": "ao-kernel-live-adapter-gate",
+            "can_admins_bypass": False,
+            "deployment_branch_policy": {"custom_branch_policies": True, "protected_branches": False},
+            "protection_rules": [{"id": 1, "type": "branch_policy"}],
+        },
+        branch_policy_payload={"branch_policies": [{"name": "main", "type": "branch"}]},
+        secret_payload=[{"name": "AO_CLAUDE_CODE_CLI_AUTH", "updatedAt": "2026-04-25T00:00:00Z"}],
+        collaborator_payload=[],
+        deployment_protection_payload={
+            "custom_deployment_protection_rules": [
+                {"id": 10, "enabled": True, "app": {"slug": "some-other-app"}}
+            ]
+        },
+        generated_at="2026-04-25T00:00:00Z",
+    )
+
+    checks = {check["name"]: check for check in artifact["checks"]}
+    assert artifact["overall_status"] == "blocked"
+    assert artifact["finding_code"] == "live_gate_deployment_protection_missing"
+    assert checks["credential_handle"]["status"] == "pass"
+    assert checks["deployment_protection_gate"]["status"] == "blocked"
+    assert "some-other-app" in checks["deployment_protection_gate"]["detail"]
+
+
+def test_equivalent_release_gate_flag_does_not_bypass_selected_bot_gate() -> None:
+    artifact = build_live_adapter_gate_attestation(
+        environment_payload={
+            "name": "ao-kernel-live-adapter-gate",
+            "can_admins_bypass": False,
+            "deployment_branch_policy": {"custom_branch_policies": True, "protected_branches": False},
+            "protection_rules": [{"id": 1, "type": "branch_policy"}],
+        },
+        branch_policy_payload={"branch_policies": [{"name": "main", "type": "branch"}]},
+        secret_payload=[{"name": "AO_CLAUDE_CODE_CLI_AUTH", "updatedAt": "2026-04-25T00:00:00Z"}],
+        collaborator_payload=[],
+        deployment_protection_payload={},
+        equivalent_release_gate_approved=True,
+        generated_at="2026-04-25T00:00:00Z",
+    )
+
+    checks = {check["name"]: check for check in artifact["checks"]}
+    assert artifact["equivalent_release_gate_approved"] is True
+    assert artifact["overall_status"] == "blocked"
+    assert artifact["finding_code"] == "live_gate_deployment_protection_missing"
+    assert checks["deployment_protection_gate"]["status"] == "blocked"
 
 
 def test_write_live_adapter_gate_attestation_round_trips_json(tmp_path: Path) -> None:
@@ -294,6 +359,7 @@ def test_live_adapter_gate_attestation_cli_uses_fixture_metadata(tmp_path: Path)
     branch_policies_path = tmp_path / "branch-policies.json"
     secrets_path = tmp_path / "secrets.json"
     collaborators_path = tmp_path / "collaborators.json"
+    deployment_protection_path = tmp_path / "deployment-protection.json"
     artifact_path = tmp_path / ATTESTATION_ARTIFACT
 
     environment_path.write_text(
@@ -313,6 +379,10 @@ def test_live_adapter_gate_attestation_cli_uses_fixture_metadata(tmp_path: Path)
     )
     secrets_path.write_text("[]", encoding="utf-8")
     collaborators_path.write_text(json.dumps([{"login": "Halildeu", "role_name": "admin"}]), encoding="utf-8")
+    deployment_protection_path.write_text(
+        json.dumps({"custom_deployment_protection_rules": []}),
+        encoding="utf-8",
+    )
 
     completed = subprocess.run(
         [
@@ -326,6 +396,8 @@ def test_live_adapter_gate_attestation_cli_uses_fixture_metadata(tmp_path: Path)
             str(secrets_path),
             "--collaborators-json",
             str(collaborators_path),
+            "--deployment-protection-json",
+            str(deployment_protection_path),
             "--artifact-path",
             str(artifact_path),
             "--output",


### PR DESCRIPTION
## Summary
- Adds GPP-2i metadata-only attestation support for the selected GitHub App deployment protection gate.
- Extends the live-adapter gate artifact/schema with `release_gate_model`, selected app slug, and `deployment_protection_gate` checks.
- Updates `scripts/live_adapter_gate_attest.py` to collect/fixture deployment protection metadata while keeping secret values unread.
- Updates GPP status/decision records so the current blocker is credential handle + selected deployment-protection app gate, not the superseded reviewer path.

## Guardrails
- No live adapter execution.
- No runtime binding.
- No secret value readback.
- No support widening or production-platform claim.
- `--equivalent-release-gate-approved` remains historical metadata and does not satisfy the selected app gate.

## Validation
- `python3 -m json.tool .claude/plans/gpp_status.v1.json >/tmp/gpp2i-status.pretty.json && python3 scripts/gpp_next.py`
- `pytest -q tests/test_live_adapter_gate_contract.py tests/test_gpp_next.py tests/test_gp5_platform_claim_decision.py`
- `ruff check ao_kernel/live_adapter_gate.py scripts/live_adapter_gate_attest.py tests/test_live_adapter_gate_contract.py tests/test_gpp_next.py`
- `python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/gpp2i-current-attestation.json --output text`
- `python3 -m ao_kernel doctor` (8 OK, 1 known extension inventory WARN, 0 FAIL)
- `git diff --check`
- `bash .claude/scripts/ops.sh preflight`

Closes #497.
