### PR TITLE
docs(gpp): refresh live gate metadata

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,12 +1,12 @@
 # General-Purpose Production Promotion Status
 
 **Status:** GPP-2 blocked; independent release gate required
-**Date:** 2026-04-25
+**Date:** 2026-04-27
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#497](https://github.com/Halildeu/ao-kernel/issues/497)
-for deployment protection attestation support
+**Current slice issue:** [#515](https://github.com/Halildeu/ao-kernel/issues/515)
+for protected live gate metadata refresh
 **Current slice record:** `.claude/plans/gpp_status.v1.json`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
@@ -99,6 +99,11 @@ Last live verification on current `origin/main` showed:
 25. GPP-2i adds metadata-only attestation support for the selected GitHub App
     deployment protection model. The current live gate remains blocked because
     the app rule and `AO_CLAUDE_CODE_CLI_AUTH` handle are not yet attested.
+26. GPP-2j refreshed live metadata on 2026-04-27 after RI-6 closeout. The
+    protected environment, admin-bypass-off setting, and branch policy still
+    pass; the selected GitHub App slug returns `HTTP 404`, deployment
+    protection rules are empty, and `AO_CLAUDE_CODE_CLI_AUTH` is not listed as
+    an environment secret handle. `GPP-2` remains blocked.
 
 ## 3. Current Verdict
 
@@ -147,6 +152,7 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2g` | Completed / no support widening | GitHub-native release authority selection and Claude MCP consultation protocol | provisioning path superseded by GPP-2h; Claude/MCP advisory protocol remains active |
 | `GPP-2h` | Completed / no support widening | Deployment protection bot gate decision | GitHub App deployment protection selected; PAT-backed bot reviewer rejected |
 | `GPP-2i` | Completed / no support widening | Deployment protection attestation support | selected app-gate metadata is recognized; current live gate still blocked |
+| `GPP-2j` | Completed / no support widening | Protected live gate metadata refresh after RI-6 closeout | current live gate still blocked; selected app gate and credential handle missing |
 | `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until a future attestation exits `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -550,7 +556,10 @@ broker. GPP-2g selects GitHub-native release authority as the first
 provisioning path and records Claude/MCP consultation as an advisory review
 protocol only. GPP-2h supersedes the GPP-2g provisioning path and selects a
 GitHub App deployment protection bot gate. GPP-2i adds metadata-only
-attestation support for that selected model. The next external/admin step is to
+attestation support for that selected model. GPP-2j refreshed the live metadata
+after RI-6 closeout and reconfirmed the same blocked state: app slug lookup
+returns `HTTP 404`, deployment protection rules are empty, and
+`AO_CLAUDE_CODE_CLI_AUTH` is not listed. The next external/admin step is to
 configure the app gate with slug `ao-kernel-live-adapter-gate` and set
 `AO_CLAUDE_CODE_CLI_AUTH` without reading the secret value; only a fresh
 metadata attestation can unblock `GPP-2`.
@@ -596,3 +605,5 @@ metadata attestation can unblock `GPP-2`.
 | 2026-04-26 | GPP-2g issue opened | Issue [#493](https://github.com/Halildeu/ao-kernel/issues/493) tracks GitHub-native release authority selection and Claude/MCP advisory consultation protocol. |
 | 2026-04-26 | GPP-2h issue opened | Issue [#495](https://github.com/Halildeu/ao-kernel/issues/495) tracks deployment protection bot gate selection; GitHub App deployment protection supersedes the required-reviewer provisioning path. |
 | 2026-04-26 | GPP-2i issue opened | Issue [#497](https://github.com/Halildeu/ao-kernel/issues/497) tracks metadata-only attestation support for the selected deployment protection bot gate. |
+| 2026-04-27 | GPP-2j issue opened | Issue [#515](https://github.com/Halildeu/ao-kernel/issues/515) tracks the post-RI-6 metadata refresh for the protected live gate. |
+| 2026-04-27 | GPP-2j live metadata refreshed | `scripts/live_adapter_gate_attest.py` still reports `overall_status=blocked`; protected environment/admin bypass/branch policy pass, but `AO_CLAUDE_CODE_CLI_AUTH` and the selected deployment protection app gate remain missing. |

--- a/.claude/plans/GPP-2b-EXTERNAL-ADMIN-PROVISIONING.md
+++ b/.claude/plans/GPP-2b-EXTERNAL-ADMIN-PROVISIONING.md
@@ -60,6 +60,34 @@ gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel
 # empty
 ```
 
+Fresh post-RI-6 metadata refresh on 2026-04-27 after PR
+[#514](https://github.com/Halildeu/ao-kernel/pull/514) merged:
+
+```bash
+python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/gpp-2-post-ri6-attestation.json --output text
+# overall_status: blocked
+# finding_code: live_gate_credential_handle_missing
+# runtime_binding_allowed: false
+# live_execution_allowed: false
+# support_widening: false
+# checks:
+# - protected_environment: pass
+# - admin_bypass: pass
+# - deployment_branch_policy: pass
+# - credential_handle: blocked (live_gate_credential_handle_missing)
+# - deployment_protection_gate: blocked (live_gate_deployment_protection_missing)
+# - support_boundary: pass
+
+gh api /apps/ao-kernel-live-adapter-gate --jq '{slug:.slug,id:.id,name:.name}'
+# HTTP 404 Not Found
+
+gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate/deployment_protection_rules
+# {"total_count":0,"custom_deployment_protection_rules":[]}
+
+gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel --json name,updatedAt
+# []
+```
+
 ## 3. Current Decision
 
 `GPP-2` stays blocked.

--- a/.claude/plans/GPP-2j-PROTECTED-LIVE-GATE-METADATA-REFRESH.md
+++ b/.claude/plans/GPP-2j-PROTECTED-LIVE-GATE-METADATA-REFRESH.md
@@ -1,0 +1,171 @@
+# GPP-2j - Protected Live Gate Metadata Refresh
+
+**Status:** closeout candidate
+**Date:** 2026-04-27
+**Authority:** `origin/main` at `0135c63`
+**Issue:** [#515](https://github.com/Halildeu/ao-kernel/issues/515)
+**Branch:** `codex/gpp-2j-live-gate-refresh`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2j-live-gate-refresh`
+**Program head:** `GPP-2` remains blocked
+**Support impact:** none
+**Runtime impact:** metadata-only refresh; no live execution
+
+## 1. Purpose
+
+Refresh the protected live-adapter gate metadata after RI-6 closeout and record
+whether `GPP-2` can proceed.
+
+Decision:
+
+```text
+protected_live_gate_metadata_refreshed_still_blocked_no_support_widening
+```
+
+This slice does not create a GitHub App, does not configure environment
+protection, does not set or read secrets, does not bind runtime workflows, does
+not run a live adapter, and does not widen support.
+
+## 2. Live Metadata Evidence
+
+Collected from `origin/main` on 2026-04-27 after PR
+[#514](https://github.com/Halildeu/ao-kernel/pull/514) merged.
+
+Startup checks:
+
+```bash
+git status --short --branch
+# ## main...origin/main
+
+git rev-list --left-right --count HEAD...origin/main
+# 0 0
+
+bash .claude/scripts/ops.sh preflight
+# Preflight clean
+
+python3 scripts/gpp_next.py
+# Current WP: GPP-2 - Protected Live-Adapter Gate Runtime Binding
+# Current status: blocked
+# Support widening allowed: false
+# Production platform claim allowed: false
+# Live adapter execution allowed: false
+```
+
+Metadata-only live-adapter gate attestation:
+
+```bash
+python3 scripts/live_adapter_gate_attest.py \
+  --artifact-path /tmp/gpp-2-post-ri6-attestation.json \
+  --output text
+# program_id: GPP-2d
+# gate_id: ci-managed-live-adapter-gate
+# adapter_id: claude-code-cli
+# overall_status: blocked
+# finding_code: live_gate_credential_handle_missing
+# runtime_binding_allowed: false
+# live_execution_allowed: false
+# support_widening: false
+# checks:
+# - protected_environment: pass
+# - admin_bypass: pass
+# - deployment_branch_policy: pass
+# - credential_handle: blocked (live_gate_credential_handle_missing)
+# - deployment_protection_gate: blocked (live_gate_deployment_protection_missing)
+# - support_boundary: pass
+```
+
+Environment metadata:
+
+```bash
+gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate \
+  --jq '{name:.name, can_admins_bypass:.can_admins_bypass, protection_rules:.protection_rules, deployment_branch_policy:.deployment_branch_policy}'
+# {"can_admins_bypass":false,"deployment_branch_policy":{"custom_branch_policies":true,"protected_branches":false},"name":"ao-kernel-live-adapter-gate","protection_rules":[{"id":53201958,"node_id":"GA_kwDOSA13rs4DK8wm","type":"branch_policy"}]}
+```
+
+Selected deployment protection app lookup:
+
+```bash
+gh api /apps/ao-kernel-live-adapter-gate --jq '{slug:.slug,id:.id,name:.name}'
+# HTTP 404 Not Found
+```
+
+Deployment protection rules:
+
+```bash
+gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate/deployment_protection_rules
+# {"total_count":0,"custom_deployment_protection_rules":[]}
+```
+
+Environment secret handles:
+
+```bash
+gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel --json name,updatedAt
+# []
+```
+
+## 3. Current Decision
+
+`GPP-2` remains blocked.
+
+Passing checks:
+
+1. protected environment exists;
+2. admin bypass is disabled;
+3. custom deployment branch policy is present for the protected environment.
+
+Still blocking:
+
+1. `AO_CLAUDE_CODE_CLI_AUTH` is not visible as an environment secret handle;
+2. selected GitHub App slug `ao-kernel-live-adapter-gate` is not visible;
+3. no deployment protection rule is attached to
+   `ao-kernel-live-adapter-gate`.
+
+## 4. Required External/Admin Work
+
+The next action remains external/admin provisioning, tracked in
+[#482](https://github.com/Halildeu/ao-kernel/issues/482) and
+[#485](https://github.com/Halildeu/ao-kernel/issues/485):
+
+1. create or install the GitHub App/policy service with slug
+   `ao-kernel-live-adapter-gate`, or open an explicit decision PR to change the
+   selected model;
+2. attach that app as a deployment protection rule to environment
+   `ao-kernel-live-adapter-gate`;
+3. set `AO_CLAUDE_CODE_CLI_AUTH` under that environment without printing or
+   reading back the secret value;
+4. re-run metadata-only prerequisite attestation only after both the app rule
+   and secret handle are visible by metadata.
+
+## 5. Forbidden Until Then
+
+1. No `GPP-2` runtime binding.
+2. No live adapter execution.
+3. No support widening.
+4. No production platform claim.
+5. No secret value readback.
+6. No local operator auth treated as project-owned production evidence.
+7. No Claude/MCP advisory response treated as release authority.
+8. No product end-user account or PAT-backed bot user treated as release
+   authority.
+
+## 6. Validation
+
+```bash
+git status --short --branch
+git rev-list --left-right --count HEAD...origin/main
+bash .claude/scripts/ops.sh preflight
+python3 scripts/gpp_next.py
+python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/gpp-2-post-ri6-attestation.json --output text
+git diff --check
+```
+
+Expected closeout decision:
+
+```text
+protected_live_gate_metadata_refreshed_still_blocked_no_support_widening
+```
+
+Recorded closeout decision:
+
+```text
+protected_live_gate_metadata_refreshed_still_blocked_no_support_widening
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -76,6 +76,12 @@
       "decision": "deployment_protection_attestation_supported_gate_still_blocked",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/497",
       "record": ".claude/plans/GPP-2i-DEPLOYMENT-PROTECTION-ATTESTATION-SUPPORT.md"
+    },
+    {
+      "id": "GPP-2j",
+      "decision": "protected_live_gate_metadata_refreshed_still_blocked_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/515",
+      "record": ".claude/plans/GPP-2j-PROTECTED-LIVE-GATE-METADATA-REFRESH.md"
     }
   ],
   "blocked_wps": [
@@ -169,5 +175,5 @@
     "run a follow-up prerequisite attestation slice only after issue #482 acceptance criteria are met",
     "do not widen support or claim production platform readiness"
   ],
-  "last_updated": "2026-04-26"
+  "last_updated": "2026-04-27"
 }


### PR DESCRIPTION
Closes #515.

## Summary
- record a fresh metadata-only protected live gate refresh after RI-6 closeout
- add GPP-2j closeout note with current live evidence
- update GPP human-readable and machine-readable status to 2026-04-27
- refresh GPP-2b external/admin tracker with current blocked metadata

## Current result
- protected environment exists
- admin bypass is disabled
- deployment branch policy is present
- selected GitHub App slug `ao-kernel-live-adapter-gate` returns HTTP 404
- deployment protection rules are empty
- `AO_CLAUDE_CODE_CLI_AUTH` is not listed as an environment secret handle
- `GPP-2` remains blocked

## Guardrails
- no runtime binding
- no live adapter execution
- no support widening
- no production platform claim
- no secret value readback
- no local operator auth / Claude MCP / product account / PAT-backed bot treated as release authority

## Validation
- startup checks passed on primary main before branch work
- `python3 -m json.tool .claude/plans/gpp_status.v1.json` -> passed
- `python3 scripts/gpp_next.py` -> GPP-2 blocked, support widening false, production platform claim false, live adapter execution false
- `python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/gpp-2-post-ri6-attestation.json --output text` -> blocked; credential handle and deployment protection gate missing
- `git diff --check` -> passed
- `bash .claude/scripts/ops.sh preflight` -> branch fresh; dirty warning only before commit