### PR TITLE
docs(gpp): add live gate provisioning runbook

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -5,8 +5,8 @@
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#515](https://github.com/Halildeu/ao-kernel/issues/515)
-for protected live gate metadata refresh
+**Current slice issue:** [#517](https://github.com/Halildeu/ao-kernel/issues/517)
+for protected live gate provisioning runbook
 **Current slice record:** `.claude/plans/gpp_status.v1.json`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
@@ -104,6 +104,11 @@ Last live verification on current `origin/main` showed:
     pass; the selected GitHub App slug returns `HTTP 404`, deployment
     protection rules are empty, and `AO_CLAUDE_CODE_CLI_AUTH` is not listed as
     an environment secret handle. `GPP-2` remains blocked.
+27. GPP-2k adds an operator/admin provisioning runbook for #482/#485 so the
+    selected GitHub App deployment protection rule and
+    `AO_CLAUDE_CODE_CLI_AUTH` handle can be provisioned without secret
+    readback. `GPP-2` remains blocked until a future metadata attestation exits
+    `prerequisites_ready`.
 
 ## 3. Current Verdict
 
@@ -153,6 +158,7 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2h` | Completed / no support widening | Deployment protection bot gate decision | GitHub App deployment protection selected; PAT-backed bot reviewer rejected |
 | `GPP-2i` | Completed / no support widening | Deployment protection attestation support | selected app-gate metadata is recognized; current live gate still blocked |
 | `GPP-2j` | Completed / no support widening | Protected live gate metadata refresh after RI-6 closeout | current live gate still blocked; selected app gate and credential handle missing |
+| `GPP-2k` | Completed / no support widening | Protected live gate provisioning runbook | operator/admin checklist ready; current live gate still blocked |
 | `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until a future attestation exits `prerequisites_ready` |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -559,10 +565,13 @@ GitHub App deployment protection bot gate. GPP-2i adds metadata-only
 attestation support for that selected model. GPP-2j refreshed the live metadata
 after RI-6 closeout and reconfirmed the same blocked state: app slug lookup
 returns `HTTP 404`, deployment protection rules are empty, and
-`AO_CLAUDE_CODE_CLI_AUTH` is not listed. The next external/admin step is to
-configure the app gate with slug `ao-kernel-live-adapter-gate` and set
-`AO_CLAUDE_CODE_CLI_AUTH` without reading the secret value; only a fresh
-metadata attestation can unblock `GPP-2`.
+`AO_CLAUDE_CODE_CLI_AUTH` is not listed. GPP-2k adds
+[`docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md`](../../docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md)
+as the operator/admin checklist for completing #482/#485 without secret
+readback. The next external/admin step is to configure the app gate with slug
+`ao-kernel-live-adapter-gate` and set `AO_CLAUDE_CODE_CLI_AUTH` without
+reading the secret value; only a fresh metadata attestation can unblock
+`GPP-2`.
 
 ## 18. Risk Register
 
@@ -607,3 +616,5 @@ metadata attestation can unblock `GPP-2`.
 | 2026-04-26 | GPP-2i issue opened | Issue [#497](https://github.com/Halildeu/ao-kernel/issues/497) tracks metadata-only attestation support for the selected deployment protection bot gate. |
 | 2026-04-27 | GPP-2j issue opened | Issue [#515](https://github.com/Halildeu/ao-kernel/issues/515) tracks the post-RI-6 metadata refresh for the protected live gate. |
 | 2026-04-27 | GPP-2j live metadata refreshed | `scripts/live_adapter_gate_attest.py` still reports `overall_status=blocked`; protected environment/admin bypass/branch policy pass, but `AO_CLAUDE_CODE_CLI_AUTH` and the selected deployment protection app gate remain missing. |
+| 2026-04-27 | GPP-2k issue opened | Issue [#517](https://github.com/Halildeu/ao-kernel/issues/517) tracks the protected live gate provisioning runbook for #482/#485. |
+| 2026-04-27 | GPP-2k provisioning runbook added | `docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md` records the no-secret-readback checklist, metadata verification commands, and evidence template for the selected deployment protection app gate. |

--- a/.claude/plans/GPP-2k-PROTECTED-LIVE-GATE-PROVISIONING-RUNBOOK.md
+++ b/.claude/plans/GPP-2k-PROTECTED-LIVE-GATE-PROVISIONING-RUNBOOK.md
@@ -1,0 +1,114 @@
+# GPP-2k - Protected Live Gate Provisioning Runbook
+
+**Status:** closeout candidate
+**Date:** 2026-04-27
+**Authority:** `origin/main` at `1a3bf8c`
+**Issue:** [#517](https://github.com/Halildeu/ao-kernel/issues/517)
+**Branch:** `codex/gpp-2k-live-gate-runbook`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2k-live-gate-runbook`
+**Program head:** `GPP-2` remains blocked
+**Support impact:** none
+**Runtime impact:** docs/status only; no live execution
+
+## 1. Purpose
+
+Add an operator-facing runbook for the external/admin provisioning steps that
+still block `GPP-2`.
+
+Decision:
+
+```text
+protected_live_gate_provisioning_runbook_ready_no_support_widening
+```
+
+This slice does not create a GitHub App, does not configure GitHub environment
+protection, does not set or read secrets, does not bind runtime workflows, does
+not run a live adapter, and does not widen support.
+
+## 2. Added Runbook
+
+The new runbook is:
+
+```text
+docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+```
+
+It records:
+
+1. selected gate model:
+   `github_app_deployment_protection_rule`;
+2. required app slug:
+   `ao-kernel-live-adapter-gate`;
+3. protected environment:
+   `ao-kernel-live-adapter-gate`;
+4. required environment secret handle:
+   `AO_CLAUDE_CODE_CLI_AUTH`;
+5. metadata-only verification commands;
+6. evidence comment template for #482/#485 or a follow-up attestation PR;
+7. rollback/remediation steps for wrong app or wrong secret handle;
+8. forbidden actions that keep runtime binding and support widening closed.
+
+## 3. Current Decision
+
+`GPP-2` remains blocked.
+
+This runbook reduces operator ambiguity only. The current blockers are still:
+
+1. `AO_CLAUDE_CODE_CLI_AUTH` is not visible as an environment secret handle;
+2. selected GitHub App slug `ao-kernel-live-adapter-gate` is not visible;
+3. no deployment protection rule is attached to
+   `ao-kernel-live-adapter-gate`.
+
+## 4. Required External/Admin Work
+
+Follow
+[`docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md`](../../docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md)
+to complete #482/#485 without secret readback.
+
+Only after the selected app gate and credential handle are visible by metadata
+should a follow-up prerequisite attestation slice run:
+
+```bash
+python3 scripts/live_adapter_gate_attest.py \
+  --artifact-path /tmp/gpp-2-post-provisioning-attestation.json \
+  --output text
+```
+
+Only if that future slice exits `prerequisites_ready` may `GPP-2` runtime
+binding begin.
+
+## 5. Forbidden Until Then
+
+1. No `GPP-2` runtime binding.
+2. No live adapter execution.
+3. No support widening.
+4. No production platform claim.
+5. No secret value readback.
+6. No local operator auth treated as project-owned production evidence.
+7. No Claude/MCP advisory response treated as release authority.
+8. No product end-user account or PAT-backed bot user treated as release
+   authority.
+9. No `--equivalent-release-gate-approved` while #489 remains not approved.
+
+## 6. Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_gpp_next.py
+pytest -q tests/test_gp5_platform_claim_decision.py
+pytest -q tests/test_gp5_operations_support_package.py
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Expected closeout decision:
+
+```text
+protected_live_gate_provisioning_runbook_ready_no_support_widening
+```
+
+Recorded closeout decision:
+
+```text
+protected_live_gate_provisioning_runbook_ready_no_support_widening
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -82,6 +82,12 @@
       "decision": "protected_live_gate_metadata_refreshed_still_blocked_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/515",
       "record": ".claude/plans/GPP-2j-PROTECTED-LIVE-GATE-METADATA-REFRESH.md"
+    },
+    {
+      "id": "GPP-2k",
+      "decision": "protected_live_gate_provisioning_runbook_ready_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/517",
+      "record": ".claude/plans/GPP-2k-PROTECTED-LIVE-GATE-PROVISIONING-RUNBOOK.md"
     }
   ],
   "blocked_wps": [
@@ -172,6 +178,7 @@
     "use scripts/live_adapter_gate_attest.py for the next prerequisite attestation",
     "provision AO_CLAUDE_CODE_CLI_AUTH under ao-kernel-live-adapter-gate without reading secret values",
     "configure GitHub App deployment protection on ao-kernel-live-adapter-gate with app slug ao-kernel-live-adapter-gate",
+    "follow docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md for external/admin provisioning before the next prerequisite attestation",
     "run a follow-up prerequisite attestation slice only after issue #482 acceptance criteria are met",
     "do not widen support or claim production platform readiness"
   ],

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -1,0 +1,250 @@
+# Protected Live-Adapter Gate Provisioning Runbook
+
+This runbook is the operator/admin checklist for unblocking the protected
+live-adapter prerequisite gate tracked in
+[#482](https://github.com/Halildeu/ao-kernel/issues/482) and
+[#485](https://github.com/Halildeu/ao-kernel/issues/485).
+
+It is not a runtime-binding guide. Completing the checklist only prepares the
+metadata-only attestation that may later decide whether `GPP-2` can start.
+
+Current selected model:
+
+| Field | Value |
+|---|---|
+| Protected environment | `ao-kernel-live-adapter-gate` |
+| Deployment protection model | GitHub App deployment protection rule |
+| Required app slug | `ao-kernel-live-adapter-gate` |
+| Required credential handle | `AO_CLAUDE_CODE_CLI_AUTH` |
+| Current program head | `GPP-2` blocked |
+
+## Preconditions
+
+Before changing GitHub admin state:
+
+1. `main` must be clean and synchronized with `origin/main`.
+2. `python3 scripts/gpp_next.py` must still report `GPP-2` as blocked.
+3. The operator must have GitHub admin permission for `Halildeu/ao-kernel`.
+4. The operator must know the GitHub App or policy service that owns slug
+   `ao-kernel-live-adapter-gate`, or open a decision PR before changing the
+   selected slug/model.
+5. Credential material must be available through the operator's approved
+   secret handoff path. Do not paste it into issues, PRs, logs, MCP prompts, or
+   chat.
+
+Current known provisioned state:
+
+1. GitHub environment `ao-kernel-live-adapter-gate` exists.
+2. Admin bypass is disabled.
+3. The environment uses a custom branch policy that includes `main`.
+
+Current known missing state:
+
+1. GitHub App slug `ao-kernel-live-adapter-gate` is not visible.
+2. No custom deployment protection rule is attached to the environment.
+3. `AO_CLAUDE_CODE_CLI_AUTH` is not visible as an environment secret handle.
+
+## Admin Checklist
+
+### 1. Confirm the Selected Gate
+
+Use the selected model from `GPP-2h`/`GPP-2i`:
+
+```text
+release_gate_model = github_app_deployment_protection_rule
+required_deployment_protection_app_slug = ao-kernel-live-adapter-gate
+```
+
+If the app slug or release-gate model must change, stop here and open a new
+decision PR first. Do not silently replace the selected model in GitHub admin
+state.
+
+### 2. Create or Install the GitHub App
+
+Create or install the GitHub App/policy service with slug:
+
+```text
+ao-kernel-live-adapter-gate
+```
+
+The app must behave as an independent release authority. It must fail closed
+when evidence is missing, stale, from the wrong ref, from the wrong workflow, or
+when support-boundary guards drift.
+
+Minimum approval inputs for the app:
+
+1. repository is `Halildeu/ao-kernel`;
+2. ref is protected `main`;
+3. workflow identity is the approved live-adapter gate workflow;
+4. required CI checks are green for the approved ref;
+5. `scripts/live_adapter_gate_attest.py` or a successor reports protected
+   prerequisites ready;
+6. credential handle metadata exists without reading the credential value;
+7. `support_widening_allowed=false` remains true until a later explicit
+   promotion decision;
+8. `production_platform_claim_allowed=false` remains true until a later
+   explicit promotion decision.
+
+### 3. Attach the Deployment Protection Rule
+
+Attach the GitHub App as a custom deployment protection rule on environment:
+
+```text
+ao-kernel-live-adapter-gate
+```
+
+Keep the existing environment hardening in place:
+
+1. admin bypass disabled;
+2. branch policy restricted to `main`;
+3. no fork-triggered path with access to protected credentials.
+
+### 4. Store the Credential Handle
+
+Store the project-owned Claude Code CLI credential material, or an explicitly
+approved non-API-key equivalent, as an environment secret handle:
+
+```text
+AO_CLAUDE_CODE_CLI_AUTH
+```
+
+Allowed command shape:
+
+```bash
+gh secret set AO_CLAUDE_CODE_CLI_AUTH \
+  --env ao-kernel-live-adapter-gate \
+  --repo Halildeu/ao-kernel
+```
+
+This command may prompt for the secret value. Do not echo the value, commit it,
+print it, copy it into issue/PR comments, or read it back. The only acceptable
+evidence is secret-handle metadata such as the handle name and `updatedAt`.
+
+## Metadata Verification
+
+Run these commands after provisioning. They are metadata-only and must not print
+secret values.
+
+```bash
+gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate \
+  --jq '{name:.name, can_admins_bypass:.can_admins_bypass, protection_rules:.protection_rules, deployment_branch_policy:.deployment_branch_policy}'
+```
+
+Expected interpretation:
+
+1. `name` is `ao-kernel-live-adapter-gate`;
+2. `can_admins_bypass` is `false`;
+3. deployment branch policy is custom and includes `main`;
+4. protection rules include the expected branch policy metadata.
+
+```bash
+gh api /apps/ao-kernel-live-adapter-gate --jq '{slug:.slug,id:.id,name:.name}'
+```
+
+Expected interpretation:
+
+1. the command returns app metadata, not `HTTP 404`;
+2. `slug` is `ao-kernel-live-adapter-gate`.
+
+```bash
+gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate/deployment_protection_rules
+```
+
+Expected interpretation:
+
+1. `total_count` is greater than zero;
+2. `custom_deployment_protection_rules` includes the selected app slug;
+3. the rule is enabled for the protected environment.
+
+```bash
+gh secret list \
+  --env ao-kernel-live-adapter-gate \
+  --repo Halildeu/ao-kernel \
+  --json name,updatedAt
+```
+
+Expected interpretation:
+
+1. `AO_CLAUDE_CODE_CLI_AUTH` is listed;
+2. no secret value is shown or requested.
+
+After metadata is visible, run the prerequisite attestation:
+
+```bash
+python3 scripts/live_adapter_gate_attest.py \
+  --artifact-path /tmp/gpp-2-post-provisioning-attestation.json \
+  --output text
+```
+
+Ready metadata means the next prerequisite slice may record
+`prerequisites_ready`. It still does not authorize runtime binding inside this
+admin checklist, live adapter execution, support widening, or a production
+platform claim.
+
+## Evidence Comment Template
+
+Use this shape when commenting on #482, #485, or a follow-up attestation PR:
+
+```markdown
+## Protected live-adapter gate provisioning evidence
+
+- Environment: `ao-kernel-live-adapter-gate`
+- Admin bypass: `<false>`
+- Branch policy: `<main custom policy present>`
+- GitHub App slug: `ao-kernel-live-adapter-gate`
+- Deployment protection rule: `<present/enabled>`
+- Secret handle: `AO_CLAUDE_CODE_CLI_AUTH` listed by metadata only
+- Secret value readback: `not performed`
+- Attestation artifact: `<path or uploaded artifact URL>`
+- Attestation status: `<blocked|ready>`
+- Support widening: `false`
+- Production platform claim: `false`
+```
+
+Do not include the credential value, local auth output, MCP payloads, or
+operator-only secret handoff details.
+
+## Blocked Interpretations
+
+Keep `GPP-2` blocked when any of these remain true:
+
+1. app lookup returns `HTTP 404`;
+2. deployment protection rule list is empty or missing the selected app;
+3. `AO_CLAUDE_CODE_CLI_AUTH` is absent from environment secret metadata;
+4. admin bypass is enabled;
+5. branch policy is not restricted to `main`;
+6. attestation reports `overall_status=blocked`;
+7. the evidence came from local operator auth rather than project-owned
+   protected gate metadata.
+
+## Rollback and Remediation
+
+If the wrong app slug or wrong protection rule is attached:
+
+1. remove or disable the incorrect deployment protection rule through GitHub
+   admin UI/API;
+2. attach the selected app slug, or open a decision PR before selecting a new
+   slug/model;
+3. rerun metadata verification;
+4. rerun `scripts/live_adapter_gate_attest.py`;
+5. record the corrected metadata only.
+
+If the wrong credential handle is set:
+
+1. do not print or inspect its value;
+2. remove or supersede the incorrect handle through GitHub secret management;
+3. set `AO_CLAUDE_CODE_CLI_AUTH` through the approved secret handoff path;
+4. verify only with `gh secret list --env ... --json name,updatedAt`.
+
+## Forbidden Actions
+
+1. No secret value readback.
+2. No local `claude` auth output treated as project-owned production evidence.
+3. No Claude/MCP response treated as release authority.
+4. No product end-user account treated as release authority.
+5. No PAT-backed bot user treated as release authority.
+6. No `--equivalent-release-gate-approved` while #489 remains not approved.
+7. No `GPP-2` runtime binding until a follow-up attestation permits it.
+8. No live adapter execution.
+9. No support widening.
+10. No production platform claim.

--- a/docs/OPERATIONS-RUNBOOK.md
+++ b/docs/OPERATIONS-RUNBOOK.md
@@ -62,6 +62,11 @@ semantiğindedir. Workflow'un yeşil olması production-certified
 `claude-code-cli` support anlamına gelmez.
 `GP-4.5` closeout kararı `close_no_widening_keep_operator_beta` olduğu için bu
 yüzey artık aktif widening gate değil, blocked/no-widening operasyon kaydıdır.
+Protected live-adapter admin provisioning is covered by
+[`LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md`](LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md).
+Use that checklist for #482/#485 before any follow-up prerequisite attestation;
+it is metadata-only guidance and does not authorize runtime binding, secret
+readback, live adapter execution, support widening, or a production claim.
 
 Prerequisite contract (operator-managed lanes):
 
@@ -507,6 +512,7 @@ and the public package install path is verified.
 
 - [`PUBLIC-BETA.md`](PUBLIC-BETA.md) — release support matrix
 - [`SUPPORT-BOUNDARY.md`](SUPPORT-BOUNDARY.md) — narrative support tiers
+- [`LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md`](LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md) — protected live-adapter gate admin checklist
 - [`UPGRADE-NOTES.md`](UPGRADE-NOTES.md) — upgrade checklist
 - [`ROLLBACK.md`](ROLLBACK.md) — rollback procedures
 - [`KNOWN-BUGS.md`](KNOWN-BUGS.md) — active known-bugs registry

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -78,6 +78,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2k"
+        and item["decision"] == "protected_live_gate_provisioning_runbook_ready_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/517"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -119,6 +126,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(
         action
         == "configure GitHub App deployment protection on ao-kernel-live-adapter-gate with app slug ao-kernel-live-adapter-gate"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "follow docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md for external/admin provisioning before the next prerequisite attestation"
         for action in payload["next_allowed_actions"]
     )
     assert any(action == "treat Claude MCP consultation as release authority" for action in payload["forbidden_actions"])


### PR DESCRIPTION
## Summary

- add a protected live-adapter gate provisioning runbook for #482/#485
- link it from the operations runbook and record GPP-2k in GPP status
- keep `GPP-2` blocked with support/runtime/production guards false

## Validation

- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `pytest -q tests/test_gpp_next.py`
- `pytest -q tests/test_gp5_platform_claim_decision.py`
- `pytest -q tests/test_gp5_operations_support_package.py`
- `python3 scripts/gpp_next.py`
- `git diff --check`

Closes #517.
