### PR TITLE
docs(gpp): record live gate prerequisites ready

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,12 +1,12 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 blocked; independent release gate required
+**Status:** GPP-2 prerequisites ready; runtime binding not started
 **Date:** 2026-04-27
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#517](https://github.com/Halildeu/ao-kernel/issues/517)
-for protected live gate provisioning runbook
+**Current slice issue:** [#519](https://github.com/Halildeu/ao-kernel/issues/519)
+for protected live gate prerequisites-ready attestation
 **Current slice record:** `.claude/plans/gpp_status.v1.json`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
@@ -109,6 +109,13 @@ Last live verification on current `origin/main` showed:
     `AO_CLAUDE_CODE_CLI_AUTH` handle can be provisioned without secret
     readback. `GPP-2` remains blocked until a future metadata attestation exits
     `prerequisites_ready`.
+28. GPP-2l records the post-provisioning metadata attestation on 2026-04-27.
+    `scripts/live_adapter_gate_attest.py` now reports `overall_status=ready`,
+    the selected deployment protection app rule passes, and
+    `AO_CLAUDE_CODE_CLI_AUTH` is listed as an environment secret handle.
+    Runtime binding has not started; `live_execution_allowed=false`,
+    `support_widening=false`, and `production_platform_claim=false` remain
+    closed.
 
 ## 3. Current Verdict
 
@@ -159,7 +166,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2i` | Completed / no support widening | Deployment protection attestation support | selected app-gate metadata is recognized; current live gate still blocked |
 | `GPP-2j` | Completed / no support widening | Protected live gate metadata refresh after RI-6 closeout | current live gate still blocked; selected app gate and credential handle missing |
 | `GPP-2k` | Completed / no support widening | Protected live gate provisioning runbook | operator/admin checklist ready; current live gate still blocked |
-| `GPP-2` | Blocked | Protected live-adapter gate runtime binding | blocked until a future attestation exits `prerequisites_ready` |
+| `GPP-2l` | Completed / no support widening | Protected live gate prerequisites-ready attestation | protected prerequisites ready; runtime binding not started |
+| `GPP-2` | Ready / not started | Protected live-adapter gate runtime binding | prerequisites ready; next slice may bind the workflow fail-closed |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -540,38 +548,35 @@ accident.
 
 ## 17. Current Active Work
 
-No runtime/support-widening work is active. `GPP-2` is the current blocked
-program head. GPP-2b is tracked in
-[#482](https://github.com/Halildeu/ao-kernel/issues/482) as an external/admin
-provisioning action. The environment and `main` branch policy are present, but
-the selected deployment-protection app gate and `AO_CLAUDE_CODE_CLI_AUTH` must
-still be completed before another prerequisite attestation can attempt to
-unblock `GPP-2`.
-GPP-2c is tracked in
-[#485](https://github.com/Halildeu/ao-kernel/issues/485) to resolve the
-remaining independent release gate and credential decision. GPP-2d adds
-`scripts/live_adapter_gate_attest.py` so the next prerequisite attestation uses
-repeatable metadata-only evidence instead of hand-written command snippets.
-GPP-2e records the single-admin equivalent gate as `not_approved`; the
-attestation override `--equivalent-release-gate-approved` is forbidden until a
-future explicit approval supersedes [#489](https://github.com/Halildeu/ao-kernel/issues/489).
+No live execution/support-widening work is active. `GPP-2` is now ready to
+start a controlled runtime-binding slice because GPP-2l records a
+metadata-only `overall_status=ready` prerequisite attestation. GPP-2b
+[#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
+[#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
+metadata prerequisite level: the protected environment exists, admin bypass is
+disabled, `main` branch policy is present, the selected GitHub App deployment
+protection rule is enabled, and `AO_CLAUDE_CODE_CLI_AUTH` is listed as an
+environment secret handle.
+
+GPP-2d provides `scripts/live_adapter_gate_attest.py` for repeatable
+metadata-only evidence. GPP-2e still records the single-admin equivalent gate
+as `not_approved`; the attestation override
+`--equivalent-release-gate-approved` remains forbidden until a future explicit
+approval supersedes [#489](https://github.com/Halildeu/ao-kernel/issues/489).
 GPP-2f clarifies that the gate is an independent release authority, not a
-product end-user account. Acceptable future models are GitHub-native release
-authority, GitHub App deployment protection, or OIDC-backed external secret
-broker. GPP-2g selects GitHub-native release authority as the first
-provisioning path and records Claude/MCP consultation as an advisory review
-protocol only. GPP-2h supersedes the GPP-2g provisioning path and selects a
-GitHub App deployment protection bot gate. GPP-2i adds metadata-only
-attestation support for that selected model. GPP-2j refreshed the live metadata
-after RI-6 closeout and reconfirmed the same blocked state: app slug lookup
-returns `HTTP 404`, deployment protection rules are empty, and
-`AO_CLAUDE_CODE_CLI_AUTH` is not listed. GPP-2k adds
-[`docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md`](../../docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md)
-as the operator/admin checklist for completing #482/#485 without secret
-readback. The next external/admin step is to configure the app gate with slug
-`ao-kernel-live-adapter-gate` and set `AO_CLAUDE_CODE_CLI_AUTH` without
-reading the secret value; only a fresh metadata attestation can unblock
-`GPP-2`.
+product end-user account. GPP-2g records Claude/MCP consultation as advisory
+only. GPP-2h selects GitHub App deployment protection, GPP-2i adds attestation
+support for that model, GPP-2j refreshes blocked metadata, and GPP-2k adds the
+operator provisioning runbook.
+
+The next GPP-2 slice may bind `.github/workflows/live-adapter-gate.yml` to
+`environment: ao-kernel-live-adapter-gate` and reference
+`AO_CLAUDE_CODE_CLI_AUTH` only by protected secret handle. That slice must keep
+fork and pull-request contexts away from protected credentials and must keep
+`live_execution_allowed=false`, `support_widening=false`, and
+`production_platform_claim=false` unless a later explicit evidence slice
+changes those guards. If the deployment protection app webhook/policy endpoint
+is inactive or fails, the protected deployment must remain blocked.
 
 ## 18. Risk Register
 
@@ -618,3 +623,5 @@ reading the secret value; only a fresh metadata attestation can unblock
 | 2026-04-27 | GPP-2j live metadata refreshed | `scripts/live_adapter_gate_attest.py` still reports `overall_status=blocked`; protected environment/admin bypass/branch policy pass, but `AO_CLAUDE_CODE_CLI_AUTH` and the selected deployment protection app gate remain missing. |
 | 2026-04-27 | GPP-2k issue opened | Issue [#517](https://github.com/Halildeu/ao-kernel/issues/517) tracks the protected live gate provisioning runbook for #482/#485. |
 | 2026-04-27 | GPP-2k provisioning runbook added | `docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md` records the no-secret-readback checklist, metadata verification commands, and evidence template for the selected deployment protection app gate. |
+| 2026-04-27 | GPP-2l issue opened | Issue [#519](https://github.com/Halildeu/ao-kernel/issues/519) tracks the post-provisioning prerequisites-ready attestation. |
+| 2026-04-27 | GPP-2l prerequisites ready | `scripts/live_adapter_gate_attest.py` reports `overall_status=ready`; protected environment/admin bypass/branch policy, `AO_CLAUDE_CODE_CLI_AUTH`, and the selected deployment protection app gate pass. Runtime binding has not started and live execution/support widening remain false. |

--- a/.claude/plans/GPP-2l-PROTECTED-LIVE-GATE-PREREQUISITES-READY.md
+++ b/.claude/plans/GPP-2l-PROTECTED-LIVE-GATE-PREREQUISITES-READY.md
@@ -1,0 +1,176 @@
+# GPP-2l - Protected Live Gate Prerequisites Ready
+
+**Status:** closeout candidate
+**Date:** 2026-04-27
+**Authority:** `origin/main` at `b1bf64a`
+**Issue:** [#519](https://github.com/Halildeu/ao-kernel/issues/519)
+**Branch:** `codex/gpp-2l-prereq-ready`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2l-prereq-ready`
+**Program head:** `GPP-2` prerequisites ready; runtime binding not started
+**Support impact:** none
+**Runtime impact:** metadata-only attestation; no live execution
+
+## 1. Purpose
+
+Record the metadata-only prerequisite attestation after external/admin
+provisioning supplied the selected GitHub App deployment protection rule and
+the required environment secret handle.
+
+Decision:
+
+```text
+protected_live_gate_prerequisites_ready_runtime_binding_not_started
+```
+
+This slice does not bind `.github/workflows/live-adapter-gate.yml` to the
+protected environment, does not execute a live adapter, does not read secret
+values, does not widen support, and does not claim production-platform
+readiness.
+
+## 2. Live Metadata Evidence
+
+Collected from `origin/main` on 2026-04-27 after PR
+[#518](https://github.com/Halildeu/ao-kernel/pull/518) merged and external
+admin provisioning completed.
+
+Startup checks:
+
+```bash
+git status --short --branch
+# ## main...origin/main
+
+git rev-list --left-right --count HEAD...origin/main
+# 0 0
+
+bash .claude/scripts/ops.sh preflight
+# Preflight clean
+
+python3 scripts/gpp_next.py
+# Current WP: GPP-2 - Protected Live-Adapter Gate Runtime Binding
+# Current status: blocked
+# Support widening allowed: false
+# Production platform claim allowed: false
+# Live adapter execution allowed: false
+```
+
+Environment metadata:
+
+```bash
+gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate \
+  --jq '{name:.name, can_admins_bypass:.can_admins_bypass, protection_rules:.protection_rules, deployment_branch_policy:.deployment_branch_policy}'
+# {"can_admins_bypass":false,"deployment_branch_policy":{"custom_branch_policies":true,"protected_branches":false},"name":"ao-kernel-live-adapter-gate","protection_rules":[{"id":53201958,"node_id":"GA_kwDOSA13rs4DK8wm","type":"branch_policy"}]}
+```
+
+Deployment protection rule metadata:
+
+```bash
+gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate/deployment_protection_rules
+# {"total_count":1,"custom_deployment_protection_rules":[{"id":53336469,"node_id":"GA_kwDOSA13rs4DLdmV","app":{"id":3522435,"node_id":"A_kwDOCx7tY84ANb-D","slug":"ao-kernel-live-adapter-gate","integration_url":"https://api.github.com/apps/ao-kernel-live-adapter-gate"},"enabled":true}]}
+```
+
+Environment secret handle metadata:
+
+```bash
+gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel --json name,updatedAt
+# [{"name":"AO_CLAUDE_CODE_CLI_AUTH","updatedAt":"2026-04-27T17:17:12Z"}]
+```
+
+Metadata-only live-adapter gate attestation:
+
+```bash
+python3 scripts/live_adapter_gate_attest.py \
+  --artifact-path /tmp/gpp-2-post-provisioning-attestation.json \
+  --output text
+# program_id: GPP-2d
+# gate_id: ci-managed-live-adapter-gate
+# adapter_id: claude-code-cli
+# overall_status: ready
+# finding_code: none
+# runtime_binding_allowed: true
+# live_execution_allowed: false
+# support_widening: false
+# checks:
+# - protected_environment: pass
+# - admin_bypass: pass
+# - deployment_branch_policy: pass
+# - credential_handle: pass
+# - deployment_protection_gate: pass
+# - support_boundary: pass
+```
+
+## 3. Current Decision
+
+`GPP-2` is no longer blocked by missing protected prerequisites.
+
+Passing checks:
+
+1. protected environment exists;
+2. admin bypass is disabled;
+3. custom deployment branch policy includes `main`;
+4. selected GitHub App deployment protection rule is enabled with slug
+   `ao-kernel-live-adapter-gate`;
+5. `AO_CLAUDE_CODE_CLI_AUTH` exists as an environment secret handle by
+   metadata;
+6. attestation reports `overall_status=ready`.
+
+Still closed:
+
+1. no runtime workflow binding has been applied;
+2. no live adapter has been executed;
+3. `live_execution_allowed=false`;
+4. `support_widening=false`;
+5. `production_platform_claim=false`.
+
+## 4. Next Runtime Binding Slice
+
+The next controlled slice may start `GPP-2` runtime binding from the ready
+prerequisite state. That slice must remain fail-closed and should not treat
+this metadata-ready state as live service certification.
+
+Minimum scope for the next slice:
+
+1. bind `.github/workflows/live-adapter-gate.yml` to
+   `environment: ao-kernel-live-adapter-gate`;
+2. reference `AO_CLAUDE_CODE_CLI_AUTH` only by handle;
+3. keep fork and pull-request contexts away from protected credentials;
+4. keep live execution disabled until protected workflow evidence is recorded;
+5. preserve `support_widening=false` and `production_platform_claim=false`.
+
+If the deployment protection app webhook/policy endpoint is not active when
+that slice runs, the protected deployment must remain blocked. That is a
+correct fail-closed result, not permission to bypass the gate.
+
+## 5. Forbidden After This Slice
+
+1. No secret value readback.
+2. No local operator auth treated as project-owned production evidence.
+3. No Claude/MCP advisory response treated as release authority.
+4. No product end-user account or PAT-backed bot user treated as release
+   authority.
+5. No `--equivalent-release-gate-approved` while #489 remains not approved.
+6. No live adapter execution until a later protected runtime evidence slice
+   explicitly permits it.
+7. No support widening.
+8. No production platform claim.
+
+## 6. Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_gpp_next.py
+python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/gpp-2-post-provisioning-attestation.json --output text
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Expected closeout decision:
+
+```text
+protected_live_gate_prerequisites_ready_runtime_binding_not_started
+```
+
+Recorded closeout decision:
+
+```text
+protected_live_gate_prerequisites_ready_runtime_binding_not_started
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -8,11 +8,16 @@
   "current_wp": {
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
-    "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/482",
-    "exit_decision": "blocked_attestation_missing",
-    "blocked_until": "a future prerequisite attestation proves the protected environment and credential handle exist",
-    "allowed_scope": []
+    "status": "ready",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/519",
+    "exit_decision": "prerequisites_ready_runtime_binding_not_started",
+    "ready_after": "protected live gate attestation reports overall_status=ready with live_execution_allowed=false",
+    "allowed_scope": [
+      "open a dedicated GPP-2 runtime binding issue, branch, and PR",
+      "bind the live-adapter gate workflow to ao-kernel-live-adapter-gate",
+      "reference AO_CLAUDE_CODE_CLI_AUTH only by protected environment secret handle",
+      "keep live execution disabled until protected workflow evidence is recorded"
+    ]
   },
   "completed_wps": [
     {
@@ -88,36 +93,16 @@
       "decision": "protected_live_gate_provisioning_runbook_ready_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/517",
       "record": ".claude/plans/GPP-2k-PROTECTED-LIVE-GATE-PROVISIONING-RUNBOOK.md"
-    }
-  ],
-  "blocked_wps": [
-    {
-      "id": "GPP-2",
-      "title": "Protected Live-Adapter Gate Runtime Binding",
-      "reason": "AO_CLAUDE_CODE_CLI_AUTH handle and an independent release gate are not attested",
-      "blocked_until": "a future prerequisite attestation exits prerequisites_ready after the credential handle and an approved independent release gate exist"
-    }
-  ],
-  "pending_external_actions": [
-    {
-      "id": "GPP-2b",
-      "title": "External admin provisioning for protected live-adapter gate",
-      "issue": "https://github.com/Halildeu/ao-kernel/issues/482",
-      "record": ".claude/plans/GPP-2b-EXTERNAL-ADMIN-PROVISIONING.md",
-      "status": "partially_provisioned_blocked",
-      "decision": "environment_created_secret_and_app_gate_still_missing",
-      "required_before": "GPP-2 runtime binding"
     },
     {
-      "id": "GPP-2c",
-      "title": "Independent release gate and credential resolution",
-      "issue": "https://github.com/Halildeu/ao-kernel/issues/485",
-      "record": ".claude/plans/GPP-2c-REVIEWER-AND-CREDENTIAL-GATE.md",
-      "status": "blocked_external_deployment_protection_bot_and_secret_provisioning_required",
-      "decision": "attestation_support_ready_secret_and_app_gate_still_missing",
-      "required_before": "GPP-2 runtime binding"
+      "id": "GPP-2l",
+      "decision": "protected_live_gate_prerequisites_ready_runtime_binding_not_started",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/519",
+      "record": ".claude/plans/GPP-2l-PROTECTED-LIVE-GATE-PREREQUISITES-READY.md"
     }
   ],
+  "blocked_wps": [],
+  "pending_external_actions": [],
   "support_widening_allowed": false,
   "production_platform_claim_allowed": false,
   "live_adapter_execution_allowed": false,
@@ -158,7 +143,8 @@
     "pull or rebase with uncommitted changes",
     "edit feature/runtime scope in primary checkout",
     "treat local operator auth as production evidence",
-    "start GPP-2 runtime binding while GPP-2 is blocked",
+    "treat metadata-ready prerequisites as live adapter execution approval",
+    "run a live adapter before a later protected runtime evidence slice permits it",
     "use --equivalent-release-gate-approved while GPP-2e remains not_approved",
     "treat a product end-user account as release authority",
     "treat a PAT-backed bot user as release authority",
@@ -169,17 +155,14 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "keep GPP-2 blocked",
-    "track external admin provisioning in issue #482",
-    "resolve independent release gate and credential handling in issue #485",
+    "start the next controlled GPP-2 runtime-binding slice from ready prerequisites",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
-    "provision the selected GitHub App deployment protection rule before any GPP-2 runtime binding",
     "use Claude MCP consultation only as advisory review, not release authority",
-    "use scripts/live_adapter_gate_attest.py for the next prerequisite attestation",
-    "provision AO_CLAUDE_CODE_CLI_AUTH under ao-kernel-live-adapter-gate without reading secret values",
-    "configure GitHub App deployment protection on ao-kernel-live-adapter-gate with app slug ao-kernel-live-adapter-gate",
-    "follow docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md for external/admin provisioning before the next prerequisite attestation",
-    "run a follow-up prerequisite attestation slice only after issue #482 acceptance criteria are met",
+    "bind .github/workflows/live-adapter-gate.yml to ao-kernel-live-adapter-gate only in a dedicated issue/branch/PR",
+    "reference AO_CLAUDE_CODE_CLI_AUTH only as a protected environment secret handle",
+    "keep fork and pull_request contexts away from protected credentials",
+    "preserve live_execution_allowed=false until protected runtime evidence permits a later live run",
+    "do not treat an inactive or failing deployment protection webhook as approval; fail closed instead",
     "do not widen support or claim production platform readiness"
   ],
   "last_updated": "2026-04-27"

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -32,13 +32,17 @@ Before changing GitHub admin state:
    secret handoff path. Do not paste it into issues, PRs, logs, MCP prompts, or
    chat.
 
-Current known provisioned state:
+Provisioned state after GPP-2l:
 
 1. GitHub environment `ao-kernel-live-adapter-gate` exists.
 2. Admin bypass is disabled.
 3. The environment uses a custom branch policy that includes `main`.
+4. GitHub App deployment protection rule
+   `ao-kernel-live-adapter-gate` is attached and enabled.
+5. `AO_CLAUDE_CODE_CLI_AUTH` exists as an environment secret handle by
+   metadata.
 
-Current known missing state:
+Blocked interpretation for a fresh or drifted setup:
 
 1. GitHub App slug `ao-kernel-live-adapter-gate` is not visible.
 2. No custom deployment protection rule is attached to the environment.

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -29,9 +29,9 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["schema_version"] == "1"
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
-    assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/482"
-    assert payload["current_wp"]["exit_decision"] == "blocked_attestation_missing"
+    assert payload["current_wp"]["status"] == "ready"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/519"
+    assert payload["current_wp"]["exit_decision"] == "prerequisites_ready_runtime_binding_not_started"
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
         item["id"] == "GPP-2a" and item["decision"] == "still_blocked_protected_prerequisites_missing"
@@ -85,29 +85,18 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2l"
+        and item["decision"] == "protected_live_gate_prerequisites_ready_runtime_binding_not_started"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/519"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
-    assert payload["pending_external_actions"][0]["id"] == "GPP-2b"
-    assert payload["pending_external_actions"][0]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/482"
-    assert payload["pending_external_actions"][0]["status"] == "partially_provisioned_blocked"
-    assert (
-        payload["pending_external_actions"][0]["decision"]
-        == "environment_created_secret_and_app_gate_still_missing"
-    )
-    assert payload["pending_external_actions"][1]["id"] == "GPP-2c"
-    assert payload["pending_external_actions"][1]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/485"
-    assert payload["pending_external_actions"][1]["title"] == "Independent release gate and credential resolution"
-    assert (
-        payload["pending_external_actions"][1]["status"]
-        == "blocked_external_deployment_protection_bot_and_secret_provisioning_required"
-    )
-    assert (
-        payload["pending_external_actions"][1]["decision"]
-        == "attestation_support_ready_secret_and_app_gate_still_missing"
-    )
-    assert {item["id"] for item in payload["pending_external_actions"]} == {"GPP-2b", "GPP-2c"}
-    assert {item["id"] for item in payload["blocked_wps"]} == {"GPP-2"}
+    assert payload["pending_external_actions"] == []
+    assert payload["blocked_wps"] == []
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
     assert any(
         action == "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded"
@@ -120,17 +109,17 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"])
     assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
     assert any(
-        action == "provision the selected GitHub App deployment protection rule before any GPP-2 runtime binding"
+        action == "start the next controlled GPP-2 runtime-binding slice from ready prerequisites"
         for action in payload["next_allowed_actions"]
     )
     assert any(
         action
-        == "configure GitHub App deployment protection on ao-kernel-live-adapter-gate with app slug ao-kernel-live-adapter-gate"
+        == "bind .github/workflows/live-adapter-gate.yml to ao-kernel-live-adapter-gate only in a dedicated issue/branch/PR"
         for action in payload["next_allowed_actions"]
     )
     assert any(
         action
-        == "follow docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md for external/admin provisioning before the next prerequisite attestation"
+        == "reference AO_CLAUDE_CODE_CLI_AUTH only as a protected environment secret handle"
         for action in payload["next_allowed_actions"]
     )
     assert any(action == "treat Claude MCP consultation as release authority" for action in payload["forbidden_actions"])
@@ -220,10 +209,10 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
     payload = mod.load_status(_status_path())
 
     assert payload["current_wp"]["id"] == "GPP-2"
-    assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/482"
-    assert payload["blocked_wps"][0]["id"] == "GPP-2"
-    assert "credential handle and an approved independent release gate exist" in payload["blocked_wps"][0]["blocked_until"]
+    assert payload["current_wp"]["status"] == "ready"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/519"
+    assert payload["blocked_wps"] == []
+    assert "runtime_binding_not_started" in payload["current_wp"]["exit_decision"]
     assert payload["support_widening_allowed"] is False
 
 
@@ -249,11 +238,11 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     rendered = mod.render_text(payload, git_summary={"status": "## main...origin/main", "divergence": "0\t0"})
 
     assert "Current WP: GPP-2 - Protected Live-Adapter Gate Runtime Binding" in rendered
-    assert "Current status: blocked" in rendered
+    assert "Current status: ready" in rendered
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "- GPP-2: AO_CLAUDE_CODE_CLI_AUTH handle and an independent release gate" in rendered
+    assert "Blocked work packages:\n- none" in rendered
     assert "divergence: 0\t0" in rendered
 
 
@@ -266,5 +255,5 @@ def test_gpp_next_cli_json_output(capsys: Any) -> None:
     payload = json.loads(captured.out)
     assert result == 0
     assert payload["current_wp"]["id"] == "GPP-2"
-    assert payload["current_wp"]["status"] == "blocked"
-    assert payload["blocked_wps"][0]["id"] == "GPP-2"
+    assert payload["current_wp"]["status"] == "ready"
+    assert payload["blocked_wps"] == []


### PR DESCRIPTION
## Summary

- record the post-provisioning metadata-only live gate attestation as `GPP-2l`
- move GPP status from blocked prerequisites to `GPP-2` ready / runtime binding not started
- keep `live_execution_allowed=false`, `support_widening=false`, and `production_platform_claim=false`

## Evidence

- `gh secret list --env ao-kernel-live-adapter-gate --repo Halildeu/ao-kernel --json name,updatedAt` lists `AO_CLAUDE_CODE_CLI_AUTH`
- `gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate/deployment_protection_rules` lists enabled app slug `ao-kernel-live-adapter-gate`
- `python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/gpp-2-post-provisioning-attestation.json --output text` reports `overall_status: ready`, `runtime_binding_allowed: true`, `live_execution_allowed: false`, `support_widening: false`

## Validation

- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `pytest -q tests/test_gpp_next.py`
- `pytest -q tests/test_live_adapter_gate_contract.py`
- `pytest -q tests/test_gp5_platform_claim_decision.py tests/test_gp5_operations_support_package.py`
- `python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/gpp-2-post-provisioning-attestation.json --output text`
- `python3 scripts/gpp_next.py`
- `git diff --check`

Closes #519.
