### PR TITLE
GPP-2m: bind live adapter gate to protected environment

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 prerequisites ready; runtime binding not started
+**Status:** GPP-2 protected workflow bound; live execution not started
 **Date:** 2026-04-27
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#519](https://github.com/Halildeu/ao-kernel/issues/519)
-for protected live gate prerequisites-ready attestation
-**Current slice record:** `.claude/plans/gpp_status.v1.json`
+**Current slice issue:** [#521](https://github.com/Halildeu/ao-kernel/issues/521)
+for protected live gate runtime binding
+**Current slice record:** `.claude/plans/GPP-2m-PROTECTED-LIVE-GATE-RUNTIME-BINDING.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -116,6 +116,11 @@ Last live verification on current `origin/main` showed:
     Runtime binding has not started; `live_execution_allowed=false`,
     `support_widening=false`, and `production_platform_claim=false` remain
     closed.
+29. GPP-2m binds `.github/workflows/live-adapter-gate.yml` to protected
+    environment `ao-kernel-live-adapter-gate`. The workflow remains
+    `workflow_dispatch` only, contains no `secrets.` expression, and still
+    does not invoke a live adapter. Deployment protection inactivity, denial,
+    timeout, or failure is fail-closed evidence, not approval.
 
 ## 3. Current Verdict
 
@@ -167,7 +172,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2j` | Completed / no support widening | Protected live gate metadata refresh after RI-6 closeout | current live gate still blocked; selected app gate and credential handle missing |
 | `GPP-2k` | Completed / no support widening | Protected live gate provisioning runbook | operator/admin checklist ready; current live gate still blocked |
 | `GPP-2l` | Completed / no support widening | Protected live gate prerequisites-ready attestation | protected prerequisites ready; runtime binding not started |
-| `GPP-2` | Ready / not started | Protected live-adapter gate runtime binding | prerequisites ready; next slice may bind the workflow fail-closed |
+| `GPP-2m` | Completed / no support widening | Protected live gate runtime binding | workflow bound to protected environment; live execution still disabled |
+| `GPP-2` | Bound / no live execution | Protected live-adapter gate runtime binding | protected workflow binding is present; next slice may collect protected workflow evidence fail-closed |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -296,20 +302,23 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked by GPP-2a re-attestation.
+**Status:** partially bound by GPP-2m; live execution still disabled.
 
 **Entry criteria:**
 
 1. `GPP-1` exit decision is `prerequisites_ready`.
 2. Protected environment and credential handle are attested.
 
-Current GPP-2a exit decision is
-`still_blocked_protected_prerequisites_missing`, so GPP-2 cannot start yet.
+GPP-2l records ready protected prerequisite metadata. GPP-2m binds the manual
+workflow to `ao-kernel-live-adapter-gate` without invoking a live adapter or
+using the protected credential value.
 
 **Acceptance criteria:**
 
-1. Workflow binds to `environment: ao-kernel-live-adapter-gate`.
-2. Manual dispatch can run `claude-code-cli` preflight.
+1. Workflow binds to `environment: ao-kernel-live-adapter-gate`: met by
+   GPP-2m.
+2. Manual dispatch can run `claude-code-cli` preflight: not yet met; live
+   execution remains disabled.
 3. A governed workflow smoke runs through the protected gate.
 4. Evidence artifact records adapter identity, workflow identity, event order,
    timeout, redaction status, artifact paths, and failure mode.
@@ -548,9 +557,11 @@ accident.
 
 ## 17. Current Active Work
 
-No live execution/support-widening work is active. `GPP-2` is now ready to
-start a controlled runtime-binding slice because GPP-2l records a
-metadata-only `overall_status=ready` prerequisite attestation. GPP-2b
+No live execution/support-widening work is active. `GPP-2` is now bound to the
+protected environment, but it is not yet live-execution capable. GPP-2l records
+a metadata-only `overall_status=ready` prerequisite attestation, and GPP-2m
+binds `.github/workflows/live-adapter-gate.yml` to
+`ao-kernel-live-adapter-gate` without using secret values. GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
 metadata prerequisite level: the protected environment exists, admin bypass is
@@ -569,14 +580,14 @@ only. GPP-2h selects GitHub App deployment protection, GPP-2i adds attestation
 support for that model, GPP-2j refreshes blocked metadata, and GPP-2k adds the
 operator provisioning runbook.
 
-The next GPP-2 slice may bind `.github/workflows/live-adapter-gate.yml` to
-`environment: ao-kernel-live-adapter-gate` and reference
-`AO_CLAUDE_CODE_CLI_AUTH` only by protected secret handle. That slice must keep
-fork and pull-request contexts away from protected credentials and must keep
+The next GPP-2 slice may collect protected workflow evidence from `main`.
+It must keep fork and pull-request contexts away from protected credentials,
+must not use `AO_CLAUDE_CODE_CLI_AUTH` through a `secrets.` expression until a
+later live-execution slice explicitly permits it, and must keep
 `live_execution_allowed=false`, `support_widening=false`, and
-`production_platform_claim=false` unless a later explicit evidence slice
-changes those guards. If the deployment protection app webhook/policy endpoint
-is inactive or fails, the protected deployment must remain blocked.
+`production_platform_claim=false`. If the deployment protection app webhook or
+policy endpoint is inactive, denies, times out, or fails, the protected
+deployment must remain blocked or failed.
 
 ## 18. Risk Register
 
@@ -625,3 +636,5 @@ is inactive or fails, the protected deployment must remain blocked.
 | 2026-04-27 | GPP-2k provisioning runbook added | `docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md` records the no-secret-readback checklist, metadata verification commands, and evidence template for the selected deployment protection app gate. |
 | 2026-04-27 | GPP-2l issue opened | Issue [#519](https://github.com/Halildeu/ao-kernel/issues/519) tracks the post-provisioning prerequisites-ready attestation. |
 | 2026-04-27 | GPP-2l prerequisites ready | `scripts/live_adapter_gate_attest.py` reports `overall_status=ready`; protected environment/admin bypass/branch policy, `AO_CLAUDE_CODE_CLI_AUTH`, and the selected deployment protection app gate pass. Runtime binding has not started and live execution/support widening remain false. |
+| 2026-04-27 | GPP-2m issue opened | Issue [#521](https://github.com/Halildeu/ao-kernel/issues/521) tracks protected live gate workflow binding. |
+| 2026-04-27 | GPP-2m workflow bound | `.github/workflows/live-adapter-gate.yml` is bound to `ao-kernel-live-adapter-gate`; triggers remain manual-only, no `secrets.` expression is present, and live execution/support widening remain false. |

--- a/.claude/plans/GPP-2m-PROTECTED-LIVE-GATE-RUNTIME-BINDING.md
+++ b/.claude/plans/GPP-2m-PROTECTED-LIVE-GATE-RUNTIME-BINDING.md
@@ -1,0 +1,126 @@
+# GPP-2m - Protected Live Gate Runtime Binding
+
+**Status:** closeout candidate
+**Date:** 2026-04-27
+**Authority:** `origin/main` at `fe8b61c`
+**Issue:** [#521](https://github.com/Halildeu/ao-kernel/issues/521)
+**Branch:** `codex/gpp-2m-runtime-binding`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2m-runtime-binding`
+**Program head:** `GPP-2` protected workflow bound; live execution not started
+**Support impact:** none
+**Runtime impact:** protected environment binding only; no live adapter call
+
+## 1. Purpose
+
+Bind the manual live-adapter gate workflow to the protected GitHub environment
+after GPP-2l recorded ready prerequisite metadata.
+
+Decision:
+
+```text
+protected_workflow_bound_live_execution_still_disabled
+```
+
+This slice does not invoke `claude`, does not read or reference secret values,
+does not add `push`, `pull_request`, or `pull_request_target` triggers, does
+not widen support, and does not claim production-platform readiness.
+
+## 2. Scope
+
+Changed workflow:
+
+```text
+.github/workflows/live-adapter-gate.yml
+```
+
+The `live-adapter-gate-contract` job now has a job-level binding:
+
+```yaml
+environment:
+  name: ao-kernel-live-adapter-gate
+```
+
+The workflow remains `workflow_dispatch` only and keeps `permissions:
+contents: read`. It still emits blocked design/evidence artifacts through
+`scripts/live_adapter_gate_contract.py`; it does not run the live adapter.
+
+## 3. Fail-Closed Interpretation
+
+GitHub environment deployment protection is now on the execution path for the
+manual gate job. If the GitHub App deployment protection webhook or policy
+service is inactive, denies the deployment, times out, or fails, the workflow
+must remain blocked or failed.
+
+That is the expected fail-closed result. It is not approval to bypass the
+environment, use a PAT-backed bot reviewer, use `--equivalent-release-gate-approved`,
+or treat local operator auth as project-owned production evidence.
+
+## 4. Secret Boundary
+
+`AO_CLAUDE_CODE_CLI_AUTH` remains only an environment secret handle attested by
+metadata. This slice intentionally does not use `secrets.AO_CLAUDE_CODE_CLI_AUTH`
+or any other `secrets.` expression.
+
+Future live execution requires a separate issue, branch, PR, and evidence
+slice that explicitly permits the live adapter run while preserving redaction
+and support-boundary guards.
+
+## 5. Current Decision
+
+Passing checks after this slice:
+
+1. protected environment prerequisites are ready by GPP-2l;
+2. `.github/workflows/live-adapter-gate.yml` is bound to
+   `ao-kernel-live-adapter-gate`;
+3. workflow triggers remain manual-only;
+4. workflow has no `secrets.` expression;
+5. workflow has no live adapter invocation;
+6. `live_execution_allowed=false`;
+7. `support_widening=false`;
+8. `production_platform_claim=false`.
+
+Still closed:
+
+1. no protected workflow dispatch evidence has been collected in this slice;
+2. no live adapter has executed;
+3. no production support claim is made.
+
+## 6. Next Slice
+
+The next controlled slice may collect protected workflow evidence from `main`.
+It must treat deployment protection inactivity, denial, timeout, or failure as
+fail-closed evidence, not approval.
+
+Minimum scope for the next slice:
+
+1. dispatch `.github/workflows/live-adapter-gate.yml` from `main`;
+2. record whether the environment deployment protection app approves, denies,
+   blocks, times out, or fails;
+3. download and validate artifacts only if the protected job reaches its
+   artifact-producing steps;
+4. keep `live_execution_allowed=false` unless a later explicit live-execution
+   slice changes that guard;
+5. keep `support_widening=false` and `production_platform_claim=false`.
+
+## 7. Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_live_adapter_gate_contract.py
+pytest -q tests/test_gpp_next.py
+python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/gpp-2m-attestation.json --output text
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Expected closeout decision:
+
+```text
+protected_workflow_bound_live_execution_still_disabled
+```
+
+Recorded closeout decision:
+
+```text
+protected_workflow_bound_live_execution_still_disabled
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -8,15 +8,15 @@
   "current_wp": {
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
-    "status": "ready",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/519",
-    "exit_decision": "prerequisites_ready_runtime_binding_not_started",
-    "ready_after": "protected live gate attestation reports overall_status=ready with live_execution_allowed=false",
+    "status": "bound",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/521",
+    "exit_decision": "protected_workflow_bound_live_execution_still_disabled",
+    "ready_after": "protected live gate workflow is bound to ao-kernel-live-adapter-gate with live_execution_allowed=false",
     "allowed_scope": [
-      "open a dedicated GPP-2 runtime binding issue, branch, and PR",
-      "bind the live-adapter gate workflow to ao-kernel-live-adapter-gate",
-      "reference AO_CLAUDE_CODE_CLI_AUTH only by protected environment secret handle",
-      "keep live execution disabled until protected workflow evidence is recorded"
+      "open a dedicated GPP-2 protected workflow evidence issue, branch, and PR",
+      "dispatch the live-adapter gate workflow only from main through ao-kernel-live-adapter-gate",
+      "observe deployment protection app inactivity, denial, or timeout as fail-closed evidence",
+      "keep live execution disabled until protected workflow evidence explicitly permits a later live run"
     ]
   },
   "completed_wps": [
@@ -99,6 +99,12 @@
       "decision": "protected_live_gate_prerequisites_ready_runtime_binding_not_started",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/519",
       "record": ".claude/plans/GPP-2l-PROTECTED-LIVE-GATE-PREREQUISITES-READY.md"
+    },
+    {
+      "id": "GPP-2m",
+      "decision": "protected_workflow_bound_live_execution_still_disabled",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/521",
+      "record": ".claude/plans/GPP-2m-PROTECTED-LIVE-GATE-RUNTIME-BINDING.md"
     }
   ],
   "blocked_wps": [],
@@ -155,14 +161,14 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "start the next controlled GPP-2 runtime-binding slice from ready prerequisites",
+    "start the next controlled GPP-2 protected workflow evidence slice from the bound workflow",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
     "use Claude MCP consultation only as advisory review, not release authority",
-    "bind .github/workflows/live-adapter-gate.yml to ao-kernel-live-adapter-gate only in a dedicated issue/branch/PR",
-    "reference AO_CLAUDE_CODE_CLI_AUTH only as a protected environment secret handle",
+    "dispatch .github/workflows/live-adapter-gate.yml only from main through ao-kernel-live-adapter-gate",
+    "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it",
     "keep fork and pull_request contexts away from protected credentials",
     "preserve live_execution_allowed=false until protected runtime evidence permits a later live run",
-    "do not treat an inactive or failing deployment protection webhook as approval; fail closed instead",
+    "treat inactive, denied, timed out, or failing deployment protection as fail-closed evidence, not approval",
     "do not widen support or claim production platform readiness"
   ],
   "last_updated": "2026-04-27"

--- a/.github/workflows/live-adapter-gate.yml
+++ b/.github/workflows/live-adapter-gate.yml
@@ -27,6 +27,8 @@ jobs:
   live-adapter-gate-contract:
     name: live-adapter-gate-contract
     runs-on: ubuntu-latest
+    environment:
+      name: ao-kernel-live-adapter-gate
     timeout-minutes: 5
     steps:
       - name: Validate GP-4.1 dispatch scope

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -5,8 +5,8 @@ live-adapter prerequisite gate tracked in
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and
 [#485](https://github.com/Halildeu/ao-kernel/issues/485).
 
-It is not a runtime-binding guide. Completing the checklist only prepares the
-metadata-only attestation that may later decide whether `GPP-2` can start.
+It is not a live-execution guide. Completing the checklist prepares or repairs
+the metadata-only attestation that the protected workflow binding depends on.
 
 Current selected model:
 
@@ -16,14 +16,15 @@ Current selected model:
 | Deployment protection model | GitHub App deployment protection rule |
 | Required app slug | `ao-kernel-live-adapter-gate` |
 | Required credential handle | `AO_CLAUDE_CODE_CLI_AUTH` |
-| Current program head | `GPP-2` blocked |
+| Current program head | `GPP-2` workflow bound; live execution disabled |
 
 ## Preconditions
 
 Before changing GitHub admin state:
 
 1. `main` must be clean and synchronized with `origin/main`.
-2. `python3 scripts/gpp_next.py` must still report `GPP-2` as blocked.
+2. `python3 scripts/gpp_next.py` must still report `support_widening=false`,
+   `production_platform_claim=false`, and `live_adapter_execution_allowed=false`.
 3. The operator must have GitHub admin permission for `Halildeu/ao-kernel`.
 4. The operator must know the GitHub App or policy service that owns slug
    `ao-kernel-live-adapter-gate`, or open a decision PR before changing the
@@ -41,6 +42,14 @@ Provisioned state after GPP-2l:
    `ao-kernel-live-adapter-gate` is attached and enabled.
 5. `AO_CLAUDE_CODE_CLI_AUTH` exists as an environment secret handle by
    metadata.
+
+Runtime-binding state after GPP-2m:
+
+1. `.github/workflows/live-adapter-gate.yml` is bound to
+   `ao-kernel-live-adapter-gate`.
+2. The workflow remains `workflow_dispatch` only.
+3. The workflow contains no `secrets.` expression.
+4. The workflow does not invoke a live adapter.
 
 Blocked interpretation for a fresh or drifted setup:
 
@@ -180,10 +189,10 @@ python3 scripts/live_adapter_gate_attest.py \
   --output text
 ```
 
-Ready metadata means the next prerequisite slice may record
-`prerequisites_ready`. It still does not authorize runtime binding inside this
-admin checklist, live adapter execution, support widening, or a production
-platform claim.
+Ready metadata plus the GPP-2m workflow binding means a later controlled slice
+may collect protected workflow evidence from `main`. It still does not
+authorize live adapter execution, support widening, or a production platform
+claim.
 
 ## Evidence Comment Template
 
@@ -210,7 +219,8 @@ operator-only secret handoff details.
 
 ## Blocked Interpretations
 
-Keep `GPP-2` blocked when any of these remain true:
+Keep protected workflow evidence blocked or failed when any of these remain
+true:
 
 1. app lookup returns `HTTP 404`;
 2. deployment protection rule list is empty or missing the selected app;
@@ -248,7 +258,7 @@ If the wrong credential handle is set:
 4. No product end-user account treated as release authority.
 5. No PAT-backed bot user treated as release authority.
 6. No `--equivalent-release-gate-approved` while #489 remains not approved.
-7. No `GPP-2` runtime binding until a follow-up attestation permits it.
+7. No bypass of the protected workflow binding.
 8. No live adapter execution.
 9. No support widening.
 10. No production platform claim.

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -29,9 +29,9 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["schema_version"] == "1"
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
-    assert payload["current_wp"]["status"] == "ready"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/519"
-    assert payload["current_wp"]["exit_decision"] == "prerequisites_ready_runtime_binding_not_started"
+    assert payload["current_wp"]["status"] == "bound"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/521"
+    assert payload["current_wp"]["exit_decision"] == "protected_workflow_bound_live_execution_still_disabled"
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
         item["id"] == "GPP-2a" and item["decision"] == "still_blocked_protected_prerequisites_missing"
@@ -92,6 +92,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2m"
+        and item["decision"] == "protected_workflow_bound_live_execution_still_disabled"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/521"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -109,17 +116,16 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"])
     assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
     assert any(
-        action == "start the next controlled GPP-2 runtime-binding slice from ready prerequisites"
+        action == "start the next controlled GPP-2 protected workflow evidence slice from the bound workflow"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action == "dispatch .github/workflows/live-adapter-gate.yml only from main through ao-kernel-live-adapter-gate"
         for action in payload["next_allowed_actions"]
     )
     assert any(
         action
-        == "bind .github/workflows/live-adapter-gate.yml to ao-kernel-live-adapter-gate only in a dedicated issue/branch/PR"
-        for action in payload["next_allowed_actions"]
-    )
-    assert any(
-        action
-        == "reference AO_CLAUDE_CODE_CLI_AUTH only as a protected environment secret handle"
+        == "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it"
         for action in payload["next_allowed_actions"]
     )
     assert any(action == "treat Claude MCP consultation as release authority" for action in payload["forbidden_actions"])
@@ -209,10 +215,10 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
     payload = mod.load_status(_status_path())
 
     assert payload["current_wp"]["id"] == "GPP-2"
-    assert payload["current_wp"]["status"] == "ready"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/519"
+    assert payload["current_wp"]["status"] == "bound"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/521"
     assert payload["blocked_wps"] == []
-    assert "runtime_binding_not_started" in payload["current_wp"]["exit_decision"]
+    assert "live_execution_still_disabled" in payload["current_wp"]["exit_decision"]
     assert payload["support_widening_allowed"] is False
 
 
@@ -238,7 +244,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     rendered = mod.render_text(payload, git_summary={"status": "## main...origin/main", "divergence": "0\t0"})
 
     assert "Current WP: GPP-2 - Protected Live-Adapter Gate Runtime Binding" in rendered
-    assert "Current status: ready" in rendered
+    assert "Current status: bound" in rendered
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
@@ -255,5 +261,5 @@ def test_gpp_next_cli_json_output(capsys: Any) -> None:
     payload = json.loads(captured.out)
     assert result == 0
     assert payload["current_wp"]["id"] == "GPP-2"
-    assert payload["current_wp"]["status"] == "ready"
+    assert payload["current_wp"]["status"] == "bound"
     assert payload["blocked_wps"] == []

--- a/tests/test_live_adapter_gate_contract.py
+++ b/tests/test_live_adapter_gate_contract.py
@@ -554,13 +554,14 @@ def test_script_emits_json_and_report_file(tmp_path: Path) -> None:
     assert rehearsal_decision_payload["live_rehearsal_attempted"] is False
 
 
-def test_live_adapter_gate_workflow_is_manual_contract_only() -> None:
+def test_live_adapter_gate_workflow_is_protected_manual_contract_only() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     workflow = (repo_root / ".github/workflows/live-adapter-gate.yml").read_text(encoding="utf-8")
 
     assert "workflow_dispatch:" in workflow
     assert "\n  push:" not in workflow
     assert "\n  pull_request:" not in workflow
+    assert "\n  pull_request_target:" not in workflow
     assert "live_adapter_gate_contract.py" in workflow
     assert "live-adapter-gate-contract.v1.json" in workflow
     assert "live-adapter-gate-evidence.v1.json" in workflow
@@ -569,7 +570,7 @@ def test_live_adapter_gate_workflow_is_manual_contract_only() -> None:
     assert "claude_code_cli_smoke.py" not in workflow
     assert "claude_code_cli_workflow_smoke.py" not in workflow
     assert "secrets." not in workflow
-    assert "\n    environment:" not in workflow
+    assert "\n    environment:\n      name: ao-kernel-live-adapter-gate\n" in workflow
     assert "contents: read" in workflow
 
 


### PR DESCRIPTION
## Summary
- Bind `live-adapter-gate-contract` to protected environment `ao-kernel-live-adapter-gate`.
- Keep the workflow manual-only with no `secrets.` expression and no live adapter invocation.
- Record GPP-2m closeout state: workflow bound, live execution still disabled, no support widening, no production platform claim.

## Validation
- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `pytest -q tests/test_live_adapter_gate_contract.py`
- `pytest -q tests/test_gpp_next.py`
- `python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/gpp-2m-attestation.json --output text`
- `python3 scripts/gpp_next.py`
- `pytest -q tests/test_gp5_platform_claim_decision.py tests/test_gp5_operations_support_package.py`
- `git diff --check`
- `actionlint .github/workflows/live-adapter-gate.yml`
- `pytest -q` (`3105 passed, 2 skipped`)

Closes #521