### PR TITLE
GPP-2n: record protected workflow fail-closed evidence

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 protected workflow bound; live execution not started
-**Date:** 2026-04-27
+**Status:** GPP-2 protected workflow evidence fail-closed; policy response missing
+**Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#521](https://github.com/Halildeu/ao-kernel/issues/521)
-for protected live gate runtime binding
-**Current slice record:** `.claude/plans/GPP-2m-PROTECTED-LIVE-GATE-RUNTIME-BINDING.md`
+**Current slice issue:** [#523](https://github.com/Halildeu/ao-kernel/issues/523)
+for protected live gate workflow evidence
+**Current slice record:** `.claude/plans/GPP-2n-PROTECTED-WORKFLOW-EVIDENCE.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -121,6 +121,13 @@ Last live verification on current `origin/main` showed:
     `workflow_dispatch` only, contains no `secrets.` expression, and still
     does not invoke a live adapter. Deployment protection inactivity, denial,
     timeout, or failure is fail-closed evidence, not approval.
+30. GPP-2n dispatched `Live Adapter Gate` from `main` on run
+    `25020015357`. GitHub created deployment `4503862042` for
+    `ao-kernel-live-adapter-gate`, held job `73277880393` in `waiting`, exposed
+    `current_user_can_approve=false`, produced no artifacts, and after bounded
+    observation the run was cancelled. This is fail-closed evidence that the
+    protected environment is on the execution path, but the deployment
+    protection app/policy service did not return a decision.
 
 ## 3. Current Verdict
 
@@ -173,7 +180,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2k` | Completed / no support widening | Protected live gate provisioning runbook | operator/admin checklist ready; current live gate still blocked |
 | `GPP-2l` | Completed / no support widening | Protected live gate prerequisites-ready attestation | protected prerequisites ready; runtime binding not started |
 | `GPP-2m` | Completed / no support widening | Protected live gate runtime binding | workflow bound to protected environment; live execution still disabled |
-| `GPP-2` | Bound / no live execution | Protected live-adapter gate runtime binding | protected workflow binding is present; next slice may collect protected workflow evidence fail-closed |
+| `GPP-2n` | Completed / no support widening | Protected live gate workflow evidence | protected workflow reached environment gate and failed closed because policy response is missing |
+| `GPP-2` | Blocked / policy response missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must respond before further runtime work |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -302,7 +310,7 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** partially bound by GPP-2m; live execution still disabled.
+**Status:** blocked by GPP-2n fail-closed protected workflow evidence.
 
 **Entry criteria:**
 
@@ -311,7 +319,9 @@ evidence.
 
 GPP-2l records ready protected prerequisite metadata. GPP-2m binds the manual
 workflow to `ao-kernel-live-adapter-gate` without invoking a live adapter or
-using the protected credential value.
+using the protected credential value. GPP-2n proves the bound workflow reaches
+the protected environment gate, but the deployment protection app/policy
+service does not yet return an approval, denial, timeout, or failure decision.
 
 **Acceptance criteria:**
 
@@ -319,7 +329,8 @@ using the protected credential value.
    GPP-2m.
 2. Manual dispatch can run `claude-code-cli` preflight: not yet met; live
    execution remains disabled.
-3. A governed workflow smoke runs through the protected gate.
+3. A governed workflow smoke runs through the protected gate: not yet met; the
+   protected job remained waiting before any steps ran.
 4. Evidence artifact records adapter identity, workflow identity, event order,
    timeout, redaction status, artifact paths, and failure mode.
 5. Missing auth, missing binary, timeout, prompt denial, malformed output, and
@@ -557,11 +568,13 @@ accident.
 
 ## 17. Current Active Work
 
-No live execution/support-widening work is active. `GPP-2` is now bound to the
-protected environment, but it is not yet live-execution capable. GPP-2l records
-a metadata-only `overall_status=ready` prerequisite attestation, and GPP-2m
-binds `.github/workflows/live-adapter-gate.yml` to
-`ao-kernel-live-adapter-gate` without using secret values. GPP-2b
+No live execution/support-widening work is active. `GPP-2` is blocked on the
+deployment protection app/policy service response path. GPP-2l records a
+metadata-only `overall_status=ready` prerequisite attestation, GPP-2m binds
+`.github/workflows/live-adapter-gate.yml` to
+`ao-kernel-live-adapter-gate` without using secret values, and GPP-2n proves
+the bound workflow reaches that protected environment but stays waiting without
+a policy decision. GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
 metadata prerequisite level: the protected environment exists, admin bypass is
@@ -580,14 +593,15 @@ only. GPP-2h selects GitHub App deployment protection, GPP-2i adds attestation
 support for that model, GPP-2j refreshes blocked metadata, and GPP-2k adds the
 operator provisioning runbook.
 
-The next GPP-2 slice may collect protected workflow evidence from `main`.
-It must keep fork and pull-request contexts away from protected credentials,
-must not use `AO_CLAUDE_CODE_CLI_AUTH` through a `secrets.` expression until a
-later live-execution slice explicitly permits it, and must keep
-`live_execution_allowed=false`, `support_widening=false`, and
-`production_platform_claim=false`. If the deployment protection app webhook or
-policy endpoint is inactive, denies, times out, or fails, the protected
-deployment must remain blocked or failed.
+The next GPP-2 action is to activate or configure the
+`ao-kernel-live-adapter-gate` deployment protection app/policy service so it
+responds to protected deployment callbacks. Do not repeatedly dispatch
+`.github/workflows/live-adapter-gate.yml` until that service is expected to
+respond. Any follow-up must keep fork and pull-request contexts away from
+protected credentials, must not use `AO_CLAUDE_CODE_CLI_AUTH` through a
+`secrets.` expression until a later live-execution slice explicitly permits it,
+and must keep `live_execution_allowed=false`, `support_widening=false`, and
+`production_platform_claim=false`.
 
 ## 18. Risk Register
 
@@ -601,6 +615,7 @@ deployment must remain blocked or failed.
 | Full matrix becomes stale | Fake green promotion | Require fresh artifacts from current `origin/main` |
 | Advisory consultation mistaken for release authority | Protected gate can be falsely unblocked | Claude/MCP protocol is advisory only; deployment protection app or explicitly approved equivalent gate remains required |
 | Bot account mistaken for deployment protection | Same operator can rubber-stamp the gate | PAT-backed bot reviewer is rejected; use GitHub App deployment protection |
+| Deployment protection app installed but inactive | Protected workflow waits forever and produces no artifacts | Treat waiting/cancelled runs as fail-closed; activate policy service before repeating evidence dispatch |
 
 ## 19. Tracking Log
 
@@ -638,3 +653,5 @@ deployment must remain blocked or failed.
 | 2026-04-27 | GPP-2l prerequisites ready | `scripts/live_adapter_gate_attest.py` reports `overall_status=ready`; protected environment/admin bypass/branch policy, `AO_CLAUDE_CODE_CLI_AUTH`, and the selected deployment protection app gate pass. Runtime binding has not started and live execution/support widening remain false. |
 | 2026-04-27 | GPP-2m issue opened | Issue [#521](https://github.com/Halildeu/ao-kernel/issues/521) tracks protected live gate workflow binding. |
 | 2026-04-27 | GPP-2m workflow bound | `.github/workflows/live-adapter-gate.yml` is bound to `ao-kernel-live-adapter-gate`; triggers remain manual-only, no `secrets.` expression is present, and live execution/support widening remain false. |
+| 2026-04-28 | GPP-2n issue opened | Issue [#523](https://github.com/Halildeu/ao-kernel/issues/523) tracks protected workflow evidence collection after the environment binding. |
+| 2026-04-28 | GPP-2n evidence fail-closed | Workflow run `25020015357` reached `ao-kernel-live-adapter-gate` and stayed waiting for deployment protection app response; no steps or artifacts ran, `current_user_can_approve=false`, and the run was cancelled after bounded observation. |

--- a/.claude/plans/GPP-2n-PROTECTED-WORKFLOW-EVIDENCE.md
+++ b/.claude/plans/GPP-2n-PROTECTED-WORKFLOW-EVIDENCE.md
@@ -1,0 +1,198 @@
+# GPP-2n - Protected Workflow Evidence
+
+**Status:** closeout candidate
+**Date:** 2026-04-28
+**Authority:** `origin/main` at `ac5a128`
+**Issue:** [#523](https://github.com/Halildeu/ao-kernel/issues/523)
+**Branch:** `codex/gpp-2n-protected-workflow-evidence`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2n-protected-workflow-evidence`
+**Program head:** `GPP-2` protected workflow evidence collected fail-closed
+**Support impact:** none
+**Runtime impact:** protected workflow dispatch only; no live adapter call
+
+## 1. Purpose
+
+Collect the first protected workflow evidence after GPP-2m bound
+`.github/workflows/live-adapter-gate.yml` to `ao-kernel-live-adapter-gate`.
+
+Decision:
+
+```text
+protected_workflow_evidence_fail_closed_policy_response_missing
+```
+
+This slice dispatches the manual workflow from `main`, observes the protected
+environment gate, and records the result. It does not invoke `claude`, does not
+reference `secrets.AO_CLAUDE_CODE_CLI_AUTH`, does not read secret values, does
+not widen support, and does not claim production-platform readiness.
+
+## 2. Dispatch Evidence
+
+Startup checks:
+
+```bash
+git status --short --branch
+# ## main...origin/main
+
+git rev-list --left-right --count HEAD...origin/main
+# 0 0
+
+bash .claude/scripts/ops.sh preflight
+# Preflight clean
+
+python3 scripts/gpp_next.py
+# Current WP: GPP-2 - Protected Live-Adapter Gate Runtime Binding
+# Current status: bound
+# Support widening allowed: false
+# Production platform claim allowed: false
+# Live adapter execution allowed: false
+```
+
+Workflow dispatch:
+
+```bash
+gh workflow run 'Live Adapter Gate' \
+  --repo Halildeu/ao-kernel \
+  --ref main \
+  -f reason='GPP-2n protected workflow evidence collection; no live adapter execution' \
+  -f target_ref=main \
+  -f adapter_lane=claude-code-cli
+```
+
+Run metadata:
+
+```text
+run_id: 25020015357
+run_url: https://github.com/Halildeu/ao-kernel/actions/runs/25020015357
+workflow_name: Live Adapter Gate
+event: workflow_dispatch
+head_sha: ac5a1282348cfa2d1a7cfedba3a3f48a5f3f178d
+created_at: 2026-04-27T21:16:59Z
+environment: ao-kernel-live-adapter-gate
+job_id: 73277880393
+job_name: live-adapter-gate-contract
+```
+
+Initial protected-gate observation:
+
+```text
+run_status: waiting
+run_conclusion: none
+job_status: waiting
+job_conclusion: none
+job_steps: []
+deployment_id: 4503862042
+deployment_statuses: waiting, waiting
+pending_deployment_environment: ao-kernel-live-adapter-gate
+pending_deployment_current_user_can_approve: false
+pending_deployment_reviewers: []
+artifact_download: no valid artifacts found to download
+```
+
+Bounded observation after roughly two minutes:
+
+```text
+run_status: waiting
+job_status: waiting
+job_steps: []
+updated_at: 2026-04-27T21:17:02Z
+```
+
+Cleanup:
+
+```bash
+gh run cancel 25020015357 --repo Halildeu/ao-kernel
+```
+
+Final run state after cancellation:
+
+```text
+run_status: completed
+run_conclusion: cancelled
+job_status: completed
+job_conclusion: cancelled
+job_completed_at: 2026-04-27T21:19:59Z
+run_updated_at: 2026-04-27T21:20:04Z
+deployment_statuses: error, waiting, waiting
+```
+
+## 3. Interpretation
+
+The protected workflow binding is active: GitHub created a deployment for
+`ao-kernel-live-adapter-gate` and held the job before any workflow step ran.
+Because no deployment protection app approval arrived, the job remained
+`waiting`, no artifacts were produced, and the current user could not manually
+approve it through the pending deployment API.
+
+This is correct fail-closed behavior. It proves the protected environment is
+on the execution path and that the workflow does not fall through to unguarded
+execution.
+
+It is not sufficient runtime evidence for GPP-2 completion because:
+
+1. no app approval, denial, or policy explanation was returned;
+2. no workflow step executed;
+3. no `live-adapter-gate-*.json` artifacts were produced;
+4. no `claude-code-cli` preflight ran;
+5. no live adapter ran.
+
+## 4. Current Decision
+
+`GPP-2` is blocked again, but for a narrower reason than before.
+
+Resolved:
+
+1. protected environment exists;
+2. admin bypass is disabled;
+3. branch policy includes `main`;
+4. deployment protection app rule is attached and enabled;
+5. `AO_CLAUDE_CODE_CLI_AUTH` exists as an environment secret handle;
+6. workflow is bound to `ao-kernel-live-adapter-gate`;
+7. workflow dispatch reaches the protected environment gate.
+
+Blocked:
+
+1. the deployment protection app/policy service did not return a decision;
+2. protected workflow artifacts were not produced;
+3. live adapter execution remains disabled.
+
+Still closed:
+
+1. `live_execution_allowed=false`;
+2. `support_widening=false`;
+3. `production_platform_claim=false`.
+
+## 5. Next Required Action
+
+Activate or configure the `ao-kernel-live-adapter-gate` GitHub App deployment
+protection policy service so it handles protected deployment callbacks and
+returns an explicit approve, deny, timeout, or failure result.
+
+If that service is repo-owned, it must be implemented through a dedicated
+issue, branch, PR, and evidence record. If it is external/admin-owned, record
+the external action and rerun protected workflow evidence after it is active.
+
+Do not repeatedly dispatch the protected workflow until the policy service is
+expected to respond. Repeated waiting runs add noise but no new evidence.
+
+## 6. Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_gpp_next.py
+python3 scripts/gpp_next.py
+python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/gpp-2n-attestation.json --output text
+git diff --check
+```
+
+Expected closeout decision:
+
+```text
+protected_workflow_evidence_fail_closed_policy_response_missing
+```
+
+Recorded closeout decision:
+
+```text
+protected_workflow_evidence_fail_closed_policy_response_missing
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -8,14 +8,14 @@
   "current_wp": {
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
-    "status": "bound",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/521",
-    "exit_decision": "protected_workflow_bound_live_execution_still_disabled",
-    "ready_after": "protected live gate workflow is bound to ao-kernel-live-adapter-gate with live_execution_allowed=false",
+    "status": "blocked",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/523",
+    "exit_decision": "protected_workflow_evidence_fail_closed_policy_response_missing",
+    "ready_after": "deployment protection policy service approves the bound workflow and produces protected workflow evidence with live_execution_allowed=false",
     "allowed_scope": [
-      "open a dedicated GPP-2 protected workflow evidence issue, branch, and PR",
-      "dispatch the live-adapter gate workflow only from main through ao-kernel-live-adapter-gate",
-      "observe deployment protection app inactivity, denial, or timeout as fail-closed evidence",
+      "open a dedicated GPP-2 deployment-protection policy-service remediation issue, branch, and PR if the fix is repo-owned",
+      "activate or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
+      "repeat protected workflow evidence collection from main after the policy service responds",
       "keep live execution disabled until protected workflow evidence explicitly permits a later live run"
     ]
   },
@@ -105,10 +105,24 @@
       "decision": "protected_workflow_bound_live_execution_still_disabled",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/521",
       "record": ".claude/plans/GPP-2m-PROTECTED-LIVE-GATE-RUNTIME-BINDING.md"
+    },
+    {
+      "id": "GPP-2n",
+      "decision": "protected_workflow_evidence_fail_closed_policy_response_missing",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/523",
+      "record": ".claude/plans/GPP-2n-PROTECTED-WORKFLOW-EVIDENCE.md"
     }
   ],
-  "blocked_wps": [],
-  "pending_external_actions": [],
+  "blocked_wps": [
+    {
+      "id": "GPP-2",
+      "reason": "protected workflow dispatch reached ao-kernel-live-adapter-gate but no deployment protection app approval arrived; the job stayed waiting, produced no artifacts, and was cancelled after bounded observation"
+    }
+  ],
+  "pending_external_actions": [
+    "activate or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook so it responds to protected deployment callbacks",
+    "rerun the protected workflow evidence slice from main after the policy service can approve, deny, or fail explicitly"
+  ],
   "support_widening_allowed": false,
   "production_platform_claim_allowed": false,
   "live_adapter_execution_allowed": false,
@@ -161,15 +175,15 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "start the next controlled GPP-2 protected workflow evidence slice from the bound workflow",
+    "resolve the deployment-protection policy service response gap before any further live-adapter runtime work",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
     "use Claude MCP consultation only as advisory review, not release authority",
-    "dispatch .github/workflows/live-adapter-gate.yml only from main through ao-kernel-live-adapter-gate",
+    "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active",
     "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it",
     "keep fork and pull_request contexts away from protected credentials",
     "preserve live_execution_allowed=false until protected runtime evidence permits a later live run",
-    "treat inactive, denied, timed out, or failing deployment protection as fail-closed evidence, not approval",
+    "treat inactive, denied, timed out, cancelled, or failing deployment protection as fail-closed evidence, not approval",
     "do not widen support or claim production platform readiness"
   ],
-  "last_updated": "2026-04-27"
+  "last_updated": "2026-04-28"
 }

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -16,7 +16,7 @@ Current selected model:
 | Deployment protection model | GitHub App deployment protection rule |
 | Required app slug | `ao-kernel-live-adapter-gate` |
 | Required credential handle | `AO_CLAUDE_CODE_CLI_AUTH` |
-| Current program head | `GPP-2` workflow bound; live execution disabled |
+| Current program head | `GPP-2` blocked on deployment protection policy response |
 
 ## Preconditions
 
@@ -50,6 +50,18 @@ Runtime-binding state after GPP-2m:
 2. The workflow remains `workflow_dispatch` only.
 3. The workflow contains no `secrets.` expression.
 4. The workflow does not invoke a live adapter.
+
+Protected workflow evidence after GPP-2n:
+
+1. Workflow run `25020015357` was dispatched from `main`.
+2. GitHub created deployment `4503862042` for
+   `ao-kernel-live-adapter-gate`.
+3. Job `73277880393` stayed `waiting` before any workflow step ran.
+4. Pending deployment metadata reported `current_user_can_approve=false` and
+   no reviewers.
+5. No `live-adapter-gate-*.json` artifacts were produced.
+6. The run was cancelled after bounded observation and is fail-closed
+   evidence, not approval.
 
 Blocked interpretation for a fresh or drifted setup:
 
@@ -97,6 +109,10 @@ Minimum approval inputs for the app:
    promotion decision;
 8. `production_platform_claim_allowed=false` remains true until a later
    explicit promotion decision.
+
+The GPP-2n evidence shows that merely attaching the app is not enough. The app
+or backing policy service must actively respond to deployment protection
+callbacks. A waiting run with no app decision must be treated as blocked.
 
 ### 3. Attach the Deployment Protection Rule
 
@@ -189,10 +205,11 @@ python3 scripts/live_adapter_gate_attest.py \
   --output text
 ```
 
-Ready metadata plus the GPP-2m workflow binding means a later controlled slice
-may collect protected workflow evidence from `main`. It still does not
-authorize live adapter execution, support widening, or a production platform
-claim.
+Ready metadata plus the GPP-2m workflow binding allowed GPP-2n to collect
+protected workflow evidence from `main`. That evidence failed closed because
+the deployment protection app/policy service did not return a decision. It
+still does not authorize live adapter execution, support widening, or a
+production platform claim.
 
 ## Evidence Comment Template
 
@@ -229,7 +246,11 @@ true:
 5. branch policy is not restricted to `main`;
 6. attestation reports `overall_status=blocked`;
 7. the evidence came from local operator auth rather than project-owned
-   protected gate metadata.
+   protected gate metadata;
+8. a protected workflow run remains `waiting` for the deployment protection app
+   and produces no artifacts;
+9. pending deployment metadata reports `current_user_can_approve=false` and no
+   app decision.
 
 ## Rollback and Remediation
 
@@ -250,6 +271,15 @@ If the wrong credential handle is set:
 3. set `AO_CLAUDE_CODE_CLI_AUTH` through the approved secret handoff path;
 4. verify only with `gh secret list --env ... --json name,updatedAt`.
 
+If the selected deployment protection app is attached but does not respond:
+
+1. do not bypass the environment gate;
+2. do not repeatedly dispatch waiting workflow runs;
+3. activate or configure the app webhook/policy service so it returns an
+   explicit approve, deny, timeout, or failure decision;
+4. rerun protected workflow evidence from `main` only after the service is
+   expected to respond.
+
 ## Forbidden Actions
 
 1. No secret value readback.
@@ -259,6 +289,8 @@ If the wrong credential handle is set:
 5. No PAT-backed bot user treated as release authority.
 6. No `--equivalent-release-gate-approved` while #489 remains not approved.
 7. No bypass of the protected workflow binding.
-8. No live adapter execution.
-9. No support widening.
-10. No production platform claim.
+8. No repeated protected workflow dispatch while the policy service is known
+   not to respond.
+9. No live adapter execution.
+10. No support widening.
+11. No production platform claim.

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -29,9 +29,9 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["schema_version"] == "1"
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
-    assert payload["current_wp"]["status"] == "bound"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/521"
-    assert payload["current_wp"]["exit_decision"] == "protected_workflow_bound_live_execution_still_disabled"
+    assert payload["current_wp"]["status"] == "blocked"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/523"
+    assert payload["current_wp"]["exit_decision"] == "protected_workflow_evidence_fail_closed_policy_response_missing"
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
         item["id"] == "GPP-2a" and item["decision"] == "still_blocked_protected_prerequisites_missing"
@@ -99,11 +99,30 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2n"
+        and item["decision"] == "protected_workflow_evidence_fail_closed_policy_response_missing"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/523"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
-    assert payload["pending_external_actions"] == []
-    assert payload["blocked_wps"] == []
+    assert payload["pending_external_actions"] == [
+        "activate or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook so it responds to protected deployment callbacks",
+        "rerun the protected workflow evidence slice from main after the policy service can approve, deny, or fail explicitly",
+    ]
+    assert payload["blocked_wps"] == [
+        {
+            "id": "GPP-2",
+            "reason": (
+                "protected workflow dispatch reached ao-kernel-live-adapter-gate but no deployment "
+                "protection app approval arrived; the job stayed waiting, produced no artifacts, and "
+                "was cancelled after bounded observation"
+            ),
+        }
+    ]
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
     assert any(
         action == "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded"
@@ -116,11 +135,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"])
     assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
     assert any(
-        action == "start the next controlled GPP-2 protected workflow evidence slice from the bound workflow"
+        action == "resolve the deployment-protection policy service response gap before any further live-adapter runtime work"
         for action in payload["next_allowed_actions"]
     )
     assert any(
-        action == "dispatch .github/workflows/live-adapter-gate.yml only from main through ao-kernel-live-adapter-gate"
+        action == "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -215,10 +234,10 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
     payload = mod.load_status(_status_path())
 
     assert payload["current_wp"]["id"] == "GPP-2"
-    assert payload["current_wp"]["status"] == "bound"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/521"
-    assert payload["blocked_wps"] == []
-    assert "live_execution_still_disabled" in payload["current_wp"]["exit_decision"]
+    assert payload["current_wp"]["status"] == "blocked"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/523"
+    assert payload["blocked_wps"][0]["id"] == "GPP-2"
+    assert "policy_response_missing" in payload["current_wp"]["exit_decision"]
     assert payload["support_widening_allowed"] is False
 
 
@@ -244,11 +263,11 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     rendered = mod.render_text(payload, git_summary={"status": "## main...origin/main", "divergence": "0\t0"})
 
     assert "Current WP: GPP-2 - Protected Live-Adapter Gate Runtime Binding" in rendered
-    assert "Current status: bound" in rendered
+    assert "Current status: blocked" in rendered
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "Blocked work packages:\n- none" in rendered
+    assert "Blocked work packages:\n- GPP-2: protected workflow dispatch reached" in rendered
     assert "divergence: 0\t0" in rendered
 
 
@@ -261,5 +280,5 @@ def test_gpp_next_cli_json_output(capsys: Any) -> None:
     payload = json.loads(captured.out)
     assert result == 0
     assert payload["current_wp"]["id"] == "GPP-2"
-    assert payload["current_wp"]["status"] == "bound"
-    assert payload["blocked_wps"] == []
+    assert payload["current_wp"]["status"] == "blocked"
+    assert payload["blocked_wps"][0]["id"] == "GPP-2"


### PR DESCRIPTION
## Summary
- Dispatch `Live Adapter Gate` from `main` and record run `25020015357` as protected workflow evidence.
- Classify the run as fail-closed: job reached `ao-kernel-live-adapter-gate`, stayed `waiting`, produced no artifacts, and was cancelled after bounded observation.
- Move GPP-2 back to blocked on missing deployment-protection policy-service response while preserving `live_execution_allowed=false`, `support_widening=false`, and `production_platform_claim=false`.

## Evidence
- Run: https://github.com/Halildeu/ao-kernel/actions/runs/25020015357
- Deployment: `4503862042`
- Job: `73277880393`
- Pending deployment: `current_user_can_approve=false`, no reviewers
- Artifact download: no valid artifacts found
- Final run conclusion: `cancelled`
- Final deployment status includes `error` after cancellation

## Validation
- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `pytest -q tests/test_gpp_next.py`
- `python3 scripts/gpp_next.py`
- `python3 scripts/live_adapter_gate_attest.py --artifact-path /tmp/gpp-2n-attestation.json --output text`
- `git diff --check`
- `pytest -q tests/test_live_adapter_gate_contract.py tests/test_gp5_platform_claim_decision.py tests/test_gp5_operations_support_package.py`
- `pytest -q` (`3105 passed, 2 skipped`)

Closes #523