### PR TITLE
GPP-2o: add live gate policy decision core

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 protected workflow evidence fail-closed; policy response missing
+**Status:** GPP-2 policy decision core ready; service deployment/config still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#523](https://github.com/Halildeu/ao-kernel/issues/523)
-for protected live gate workflow evidence
-**Current slice record:** `.claude/plans/GPP-2n-PROTECTED-WORKFLOW-EVIDENCE.md`
+**Current slice issue:** [#525](https://github.com/Halildeu/ao-kernel/issues/525)
+for deployment protection policy decision core
+**Current slice record:** `.claude/plans/GPP-2o-POLICY-DECISION-CORE.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -128,6 +128,13 @@ Last live verification on current `origin/main` showed:
     observation the run was cancelled. This is fail-closed evidence that the
     protected environment is on the execution path, but the deployment
     protection app/policy service did not return a decision.
+31. GPP-2o adds a repo-owned, side-effect-free deployment protection policy
+    decision core and local CLI. Raw/unverified callbacks reject fail-closed;
+    contract-only approval requires verified workflow identity, ready protected
+    prerequisites, `main`, no pull-request context, and closed
+    live-execution/support/production-claim boundaries. GPP-2 remains blocked
+    until this policy is deployed or configured behind the GitHub App webhook
+    and new protected workflow evidence is collected.
 
 ## 3. Current Verdict
 
@@ -181,7 +188,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2l` | Completed / no support widening | Protected live gate prerequisites-ready attestation | protected prerequisites ready; runtime binding not started |
 | `GPP-2m` | Completed / no support widening | Protected live gate runtime binding | workflow bound to protected environment; live execution still disabled |
 | `GPP-2n` | Completed / no support widening | Protected live gate workflow evidence | protected workflow reached environment gate and failed closed because policy response is missing |
-| `GPP-2` | Blocked / policy response missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must respond before further runtime work |
+| `GPP-2o` | Completed / no support widening | Deployment protection policy decision core | repo-owned decision core and CLI ready; service is not yet deployed/configured |
+| `GPP-2` | Blocked / service deployment/config missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be deployed/configured before further runtime work |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -310,7 +318,8 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked by GPP-2n fail-closed protected workflow evidence.
+**Status:** blocked after GPP-2o; policy decision core exists, but service
+deployment/configuration is still missing.
 
 **Entry criteria:**
 
@@ -321,7 +330,10 @@ GPP-2l records ready protected prerequisite metadata. GPP-2m binds the manual
 workflow to `ao-kernel-live-adapter-gate` without invoking a live adapter or
 using the protected credential value. GPP-2n proves the bound workflow reaches
 the protected environment gate, but the deployment protection app/policy
-service does not yet return an approval, denial, timeout, or failure decision.
+service did not return an approval, denial, timeout, or failure decision.
+GPP-2o adds the repo-owned policy decision core and CLI that the service can
+use, but no webhook/service deployment or GitHub callback review evidence has
+been recorded.
 
 **Acceptance criteria:**
 
@@ -572,9 +584,11 @@ No live execution/support-widening work is active. `GPP-2` is blocked on the
 deployment protection app/policy service response path. GPP-2l records a
 metadata-only `overall_status=ready` prerequisite attestation, GPP-2m binds
 `.github/workflows/live-adapter-gate.yml` to
-`ao-kernel-live-adapter-gate` without using secret values, and GPP-2n proves
+`ao-kernel-live-adapter-gate` without using secret values, GPP-2n proves
 the bound workflow reaches that protected environment but stays waiting without
-a policy decision. GPP-2b
+a policy decision, and GPP-2o adds the repo-owned decision core that can return
+`approve_contract_gate` or `reject` once it is placed behind the GitHub App
+webhook. GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
 metadata prerequisite level: the protected environment exists, admin bypass is
@@ -593,9 +607,11 @@ only. GPP-2h selects GitHub App deployment protection, GPP-2i adds attestation
 support for that model, GPP-2j refreshes blocked metadata, and GPP-2k adds the
 operator provisioning runbook.
 
-The next GPP-2 action is to activate or configure the
+The next GPP-2 action is to deploy or configure the
 `ao-kernel-live-adapter-gate` deployment protection app/policy service so it
-responds to protected deployment callbacks. Do not repeatedly dispatch
+receives protected deployment callbacks, enriches them with trusted context,
+evaluates `ao_kernel.live_adapter_gate_policy` or an equivalent fail-closed
+policy, and posts an explicit GitHub deployment review callback. Do not repeatedly dispatch
 `.github/workflows/live-adapter-gate.yml` until that service is expected to
 respond. Any follow-up must keep fork and pull-request contexts away from
 protected credentials, must not use `AO_CLAUDE_CODE_CLI_AUTH` through a
@@ -616,6 +632,7 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | Advisory consultation mistaken for release authority | Protected gate can be falsely unblocked | Claude/MCP protocol is advisory only; deployment protection app or explicitly approved equivalent gate remains required |
 | Bot account mistaken for deployment protection | Same operator can rubber-stamp the gate | PAT-backed bot reviewer is rejected; use GitHub App deployment protection |
 | Deployment protection app installed but inactive | Protected workflow waits forever and produces no artifacts | Treat waiting/cancelled runs as fail-closed; activate policy service before repeating evidence dispatch |
+| Policy decision core exists but is not deployed | Protected workflow still receives no app response | Treat GPP-2o as implementation readiness only; deploy/configure webhook before rerunning evidence |
 
 ## 19. Tracking Log
 
@@ -655,3 +672,5 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-27 | GPP-2m workflow bound | `.github/workflows/live-adapter-gate.yml` is bound to `ao-kernel-live-adapter-gate`; triggers remain manual-only, no `secrets.` expression is present, and live execution/support widening remain false. |
 | 2026-04-28 | GPP-2n issue opened | Issue [#523](https://github.com/Halildeu/ao-kernel/issues/523) tracks protected workflow evidence collection after the environment binding. |
 | 2026-04-28 | GPP-2n evidence fail-closed | Workflow run `25020015357` reached `ao-kernel-live-adapter-gate` and stayed waiting for deployment protection app response; no steps or artifacts ran, `current_user_can_approve=false`, and the run was cancelled after bounded observation. |
+| 2026-04-28 | GPP-2o issue opened | Issue [#525](https://github.com/Halildeu/ao-kernel/issues/525) tracks the repo-owned deployment protection policy decision core. |
+| 2026-04-28 | GPP-2o decision core added | `ao_kernel/live_adapter_gate_policy.py` and `scripts/live_adapter_gate_policy_decision.py` add fail-closed policy evaluation; service deployment/configuration remains required before rerunning protected workflow evidence. |

--- a/.claude/plans/GPP-2o-POLICY-DECISION-CORE.md
+++ b/.claude/plans/GPP-2o-POLICY-DECISION-CORE.md
@@ -1,0 +1,146 @@
+# GPP-2o - Deployment Protection Policy Decision Core
+
+**Status:** closeout candidate
+**Date:** 2026-04-28
+**Authority:** `origin/main` at `3297cc2`
+**Issue:** [#525](https://github.com/Halildeu/ao-kernel/issues/525)
+**Branch:** `codex/gpp-2o-policy-decision-core`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2o-policy-decision-core`
+**Program head:** `GPP-2` blocked on policy service deployment/configuration
+**Support impact:** none
+**Runtime impact:** no live adapter call; no secret context use
+
+## 1. Purpose
+
+GPP-2n proved that the protected workflow reaches
+`ao-kernel-live-adapter-gate`, but the GitHub App deployment-protection service
+did not return a decision. This slice adds the repo-owned decision core that a
+GitHub App webhook or equivalent policy service can call before reviewing the
+deployment callback.
+
+Decision:
+
+```text
+policy_decision_core_ready_service_not_deployed
+```
+
+This slice does not deploy a webhook, does not call GitHub's deployment review
+API, does not invoke `claude`, does not reference
+`secrets.AO_CLAUDE_CODE_CLI_AUTH`, does not read secret values, does not widen
+support, and does not claim production-platform readiness.
+
+## 2. Implemented Surface
+
+Code:
+
+1. `ao_kernel/live_adapter_gate_policy.py`
+   - extracts GitHub `deployment_protection_rule` webhook-shaped fields;
+   - requires service-enriched verified context before approval;
+   - rejects missing, malformed, wrong repository, wrong environment, wrong
+     event, wrong ref, missing SHA, missing callback URL, missing workflow
+     identity, pull-request context, missing prerequisite attestation, live
+     execution signals, support widening signals, or production-claim signals;
+   - emits `approve_contract_gate` only for the design-only protected gate path;
+   - always emits `live_execution_allowed=false`,
+     `support_widening_allowed=false`, and
+     `production_platform_claim_allowed=false`.
+2. `scripts/live_adapter_gate_policy_decision.py`
+   - reads a webhook/enriched payload JSON;
+   - writes `live-adapter-gate-policy-decision.v1.json`;
+   - renders JSON or text for local validation;
+   - optionally exits non-zero on reject with `--fail-on-reject`.
+3. `tests/test_live_adapter_gate_policy.py`
+   - covers the contract-only approval path;
+   - covers raw webhook fail-closed behavior;
+   - covers wrong repo/ref, missing callback, live execution signal, and
+     pull-request context rejection;
+   - covers CLI artifact writing.
+
+## 3. Policy Interpretation
+
+Raw GitHub webhook fields are intentionally not enough for approval. The
+deployment-protection service must enrich the payload with verified context
+from trusted sources before it can produce `approve_contract_gate`.
+
+Required approved context:
+
+1. repository is `Halildeu/ao-kernel`;
+2. environment is `ao-kernel-live-adapter-gate`;
+3. event is `workflow_dispatch`;
+4. ref normalizes to `main`;
+5. SHA is present;
+6. deployment callback URL is present and usable;
+7. workflow identity is `Live Adapter Gate` or
+   `.github/workflows/live-adapter-gate.yml`;
+8. no pull-request context is present;
+9. protected prerequisite attestation is ready;
+10. `live_execution_allowed=false`;
+11. `support_widening_allowed=false`;
+12. `production_platform_claim_allowed=false`.
+
+Any missing or non-matching input produces `reject`. That rejection is a valid
+fail-closed policy response, but it does not complete GPP-2. GPP-2 still needs
+a deployed/configured GitHub App webhook that posts the decision to GitHub's
+deployment-protection review callback and then new protected workflow evidence
+from `main`.
+
+## 4. Current Decision
+
+Resolved by this slice:
+
+1. repo-owned deterministic policy decision core exists;
+2. local CLI can evaluate webhook/enriched payloads;
+3. raw/unverified deployment-protection payloads reject fail-closed;
+4. contract-only approval remains explicitly separate from live adapter
+   execution.
+
+Still blocked:
+
+1. no repo-owned webhook server is deployed or configured behind the installed
+   GitHub App;
+2. no GitHub deployment callback review has been posted by the policy service;
+3. no new protected workflow evidence artifacts exist after policy response;
+4. live adapter execution remains disabled.
+
+Still closed:
+
+1. `live_execution_allowed=false`;
+2. `support_widening=false`;
+3. `production_platform_claim=false`.
+
+## 5. Next Required Action
+
+Deploy or configure the `ao-kernel-live-adapter-gate` GitHub App
+deployment-protection policy service so it:
+
+1. receives `deployment_protection_rule` callbacks;
+2. enriches the payload with trusted workflow/prerequisite context;
+3. evaluates that context with `ao_kernel.live_adapter_gate_policy` or an
+   equivalent fail-closed policy;
+4. posts an explicit approved/rejected result to the deployment callback URL;
+5. records response evidence without secret value exposure.
+
+Only after that service is expected to respond should the protected workflow
+evidence slice be rerun from `main`.
+
+## 6. Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_live_adapter_gate_policy.py
+pytest -q tests/test_gpp_next.py
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Expected closeout decision:
+
+```text
+policy_decision_core_ready_service_not_deployed
+```
+
+Recorded closeout decision:
+
+```text
+policy_decision_core_ready_service_not_deployed
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,12 +9,11 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/523",
-    "exit_decision": "protected_workflow_evidence_fail_closed_policy_response_missing",
-    "ready_after": "deployment protection policy service approves the bound workflow and produces protected workflow evidence with live_execution_allowed=false",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/525",
+    "exit_decision": "policy_decision_core_ready_service_not_deployed",
+    "ready_after": "deployment protection policy service is deployed/configured behind the GitHub App and produces protected workflow evidence with live_execution_allowed=false",
     "allowed_scope": [
-      "open a dedicated GPP-2 deployment-protection policy-service remediation issue, branch, and PR if the fix is repo-owned",
-      "activate or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
+      "use the repo-owned policy decision core to implement or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
       "repeat protected workflow evidence collection from main after the policy service responds",
       "keep live execution disabled until protected workflow evidence explicitly permits a later live run"
     ]
@@ -111,17 +110,23 @@
       "decision": "protected_workflow_evidence_fail_closed_policy_response_missing",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/523",
       "record": ".claude/plans/GPP-2n-PROTECTED-WORKFLOW-EVIDENCE.md"
+    },
+    {
+      "id": "GPP-2o",
+      "decision": "policy_decision_core_ready_service_not_deployed",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/525",
+      "record": ".claude/plans/GPP-2o-POLICY-DECISION-CORE.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "protected workflow dispatch reached ao-kernel-live-adapter-gate but no deployment protection app approval arrived; the job stayed waiting, produced no artifacts, and was cancelled after bounded observation"
+      "reason": "repo-owned deployment-protection policy decision core is ready, but the GitHub App webhook/policy service is not yet deployed or configured to respond to protected deployment callbacks"
     }
   ],
   "pending_external_actions": [
-    "activate or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook so it responds to protected deployment callbacks",
-    "rerun the protected workflow evidence slice from main after the policy service can approve, deny, or fail explicitly"
+    "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook so it calls the repo-owned policy decision core or an equivalent fail-closed policy",
+    "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly"
   ],
   "support_widening_allowed": false,
   "production_platform_claim_allowed": false,
@@ -175,10 +180,11 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "resolve the deployment-protection policy service response gap before any further live-adapter runtime work",
+    "deploy or configure the deployment-protection policy service response path before any further live-adapter runtime work",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
     "use Claude MCP consultation only as advisory review, not release authority",
     "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active",
+    "use scripts/live_adapter_gate_policy_decision.py only for policy callback decision evaluation, not live adapter execution",
     "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it",
     "keep fork and pull_request contexts away from protected credentials",
     "preserve live_execution_allowed=false until protected runtime evidence permits a later live run",

--- a/ao_kernel/live_adapter_gate_policy.py
+++ b/ao_kernel/live_adapter_gate_policy.py
@@ -1,0 +1,462 @@
+"""Fail-closed deployment protection policy decision helpers.
+
+This module is intentionally side-effect free. It evaluates a GitHub
+``deployment_protection_rule`` webhook payload plus service-enriched verified
+context and returns the decision a deployment-protection service can use when
+calling GitHub's review callback.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal, TypedDict, cast
+from urllib.parse import urlparse
+
+from ao_kernel.live_adapter_gate import (
+    ADAPTER_ID,
+    GATE_ID,
+    PROTECTED_ENVIRONMENT_NAME,
+    REQUIRED_DEPLOYMENT_PROTECTION_APP_SLUG,
+    SUPPORT_TIER,
+    utc_timestamp,
+)
+
+POLICY_DECISION_SCHEMA_VERSION = "1"
+POLICY_DECISION_PROGRAM_ID = "GPP-2o"
+POLICY_DECISION_ARTIFACT_KIND = "live_adapter_gate_policy_decision"
+POLICY_DECISION_ARTIFACT = "live-adapter-gate-policy-decision.v1.json"
+EXPECTED_REPOSITORY = "Halildeu/ao-kernel"
+EXPECTED_REF = "main"
+EXPECTED_TRIGGER_EVENT = "workflow_dispatch"
+EXPECTED_WORKFLOW_NAME = "Live Adapter Gate"
+EXPECTED_WORKFLOW_PATH = ".github/workflows/live-adapter-gate.yml"
+APPROVE_CONTRACT_GATE_DECISION = "approve_contract_gate"
+REJECT_DECISION = "reject"
+POLICY_REJECT_FINDING = "live_gate_policy_rejected"
+
+PolicyCheckStatus = Literal["pass", "blocked"]
+PolicyDecisionValue = Literal["approve_contract_gate", "reject"]
+GithubReviewState = Literal["approved", "rejected"]
+
+
+class LiveAdapterGatePolicyCheck(TypedDict):
+    """Single deterministic policy-service input check."""
+
+    name: str
+    status: PolicyCheckStatus
+    finding_code: str | None
+    detail: str
+
+
+class LiveAdapterGatePolicyContext(TypedDict):
+    """Extracted deployment-protection policy context."""
+
+    repository: str | None
+    environment: str | None
+    event: str | None
+    ref: str | None
+    sha: str | None
+    deployment_callback_url: str | None
+    workflow_name: str | None
+    workflow_path: str | None
+    prerequisites_ready: bool | None
+    attestation_overall_status: str | None
+    live_execution_allowed: bool | None
+    support_widening_allowed: bool | None
+    production_platform_claim_allowed: bool | None
+    pull_request_count: int | None
+
+
+class LiveAdapterGatePolicyDecision(TypedDict):
+    """Machine-readable deployment-protection policy decision."""
+
+    schema_version: str
+    artifact_kind: str
+    program_id: str
+    gate_id: str
+    adapter_id: str
+    support_tier: str
+    generated_at: str
+    app_slug: str
+    decision: PolicyDecisionValue
+    github_review_state: GithubReviewState
+    approval_allowed: bool
+    live_execution_allowed: bool
+    support_widening_allowed: bool
+    production_platform_claim_allowed: bool
+    finding_code: str | None
+    reason: str
+    context: LiveAdapterGatePolicyContext
+    checks: list[LiveAdapterGatePolicyCheck]
+    findings: list[str]
+
+
+def _as_dict(payload: object) -> dict[str, Any]:
+    """Return ``payload`` as a dictionary or an empty dictionary."""
+
+    if isinstance(payload, dict):
+        return cast(dict[str, Any], payload)
+    return {}
+
+
+def _as_list(payload: object) -> list[Any]:
+    """Return ``payload`` as a list or an empty list."""
+
+    if isinstance(payload, list):
+        return payload
+    return []
+
+
+def _string(value: object) -> str | None:
+    """Return a non-empty string value."""
+
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _bool(value: object) -> bool | None:
+    """Return a boolean value without coercing strings."""
+
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _normalize_ref(value: str | None) -> str | None:
+    """Normalize refs/heads/main to main."""
+
+    if value is None:
+        return None
+    if value.startswith("refs/heads/"):
+        return value.removeprefix("refs/heads/")
+    return value
+
+
+def _first_string(*values: object) -> str | None:
+    """Return the first non-empty string."""
+
+    for value in values:
+        candidate = _string(value)
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def _first_bool(*values: object) -> bool | None:
+    """Return the first explicit boolean."""
+
+    for value in values:
+        candidate = _bool(value)
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def _callback_url_is_usable(url: str | None) -> bool:
+    """Return whether GitHub supplied a plausible review callback URL."""
+
+    if url is None:
+        return False
+    parsed = urlparse(url)
+    return parsed.scheme == "https" and bool(parsed.netloc) and bool(parsed.path)
+
+
+def _workflow_matches(name: str | None, path: str | None) -> bool:
+    """Return whether the enriched context identifies the approved workflow."""
+
+    return name == EXPECTED_WORKFLOW_NAME or path == EXPECTED_WORKFLOW_PATH
+
+
+def _pass(
+    name: str,
+    *,
+    detail: str,
+) -> LiveAdapterGatePolicyCheck:
+    """Build a passing policy check."""
+
+    return {
+        "name": name,
+        "status": "pass",
+        "finding_code": None,
+        "detail": detail,
+    }
+
+
+def _blocked(
+    name: str,
+    *,
+    finding_code: str,
+    detail: str,
+) -> LiveAdapterGatePolicyCheck:
+    """Build a blocked policy check."""
+
+    return {
+        "name": name,
+        "status": "blocked",
+        "finding_code": finding_code,
+        "detail": detail,
+    }
+
+
+def _check(
+    name: str,
+    condition: bool,
+    *,
+    finding_code: str,
+    pass_detail: str,
+    blocked_detail: str,
+) -> LiveAdapterGatePolicyCheck:
+    """Build one fail-closed check."""
+
+    if condition:
+        return _pass(name, detail=pass_detail)
+    return _blocked(name, finding_code=finding_code, detail=blocked_detail)
+
+
+def _verified_context(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return service-enriched verified context if present."""
+
+    candidates = (
+        payload.get("verified_context"),
+        payload.get("ao_kernel_policy_context"),
+        payload.get("gpp"),
+        _as_dict(payload.get("ao_kernel")).get("policy_context"),
+    )
+    for candidate in candidates:
+        context = _as_dict(candidate)
+        if context:
+            return context
+    return {}
+
+
+def extract_live_adapter_gate_policy_context(payload: object) -> LiveAdapterGatePolicyContext:
+    """Extract the policy decision context from a webhook-shaped payload."""
+
+    root = _as_dict(payload)
+    repository = _as_dict(root.get("repository"))
+    deployment = _as_dict(root.get("deployment"))
+    workflow = _as_dict(root.get("workflow"))
+    workflow_run = _as_dict(root.get("workflow_run"))
+    verified = _verified_context(root)
+    environment_value = root.get("environment")
+    environment = _first_string(
+        environment_value if isinstance(environment_value, str) else None,
+        _as_dict(environment_value).get("name"),
+        deployment.get("environment"),
+        verified.get("environment"),
+    )
+    ref = _normalize_ref(
+        _first_string(
+            root.get("ref"),
+            deployment.get("ref"),
+            workflow_run.get("head_branch"),
+            verified.get("ref"),
+        )
+    )
+    pull_requests = _as_list(root.get("pull_requests"))
+    return {
+        "repository": _first_string(repository.get("full_name"), root.get("repository_full_name"), verified.get("repository")),
+        "environment": environment,
+        "event": _first_string(root.get("event"), workflow_run.get("event"), verified.get("event")),
+        "ref": ref,
+        "sha": _first_string(root.get("sha"), deployment.get("sha"), workflow_run.get("head_sha"), verified.get("sha")),
+        "deployment_callback_url": _first_string(
+            root.get("deployment_callback_url"),
+            root.get("callback_url"),
+            _as_dict(root.get("deployment_protection_rule")).get("url"),
+            verified.get("deployment_callback_url"),
+        ),
+        "workflow_name": _first_string(workflow.get("name"), workflow_run.get("name"), verified.get("workflow_name")),
+        "workflow_path": _first_string(workflow.get("path"), workflow_run.get("path"), verified.get("workflow_path")),
+        "prerequisites_ready": _first_bool(
+            verified.get("prerequisites_ready"),
+            verified.get("protected_prerequisites_ready"),
+        ),
+        "attestation_overall_status": _first_string(
+            verified.get("attestation_overall_status"),
+            _as_dict(verified.get("attestation")).get("overall_status"),
+        ),
+        "live_execution_allowed": _first_bool(
+            verified.get("live_execution_allowed"),
+            verified.get("live_adapter_execution_allowed"),
+        ),
+        "support_widening_allowed": _first_bool(
+            verified.get("support_widening_allowed"),
+            verified.get("support_widening"),
+        ),
+        "production_platform_claim_allowed": _first_bool(
+            verified.get("production_platform_claim_allowed"),
+            verified.get("production_platform_claim"),
+        ),
+        "pull_request_count": len(pull_requests) if "pull_requests" in root else None,
+    }
+
+
+def build_live_adapter_gate_policy_decision(
+    payload: object,
+    *,
+    generated_at: str | None = None,
+) -> LiveAdapterGatePolicyDecision:
+    """Build a fail-closed deployment-protection policy decision.
+
+    Raw GitHub webhook fields are not enough for approval. The service must
+    enrich the payload with verified GPP context proving the workflow identity,
+    ready prerequisite attestation, and closed support/live-execution boundary.
+    """
+
+    context = extract_live_adapter_gate_policy_context(payload)
+    prerequisites_ready = (
+        context["prerequisites_ready"] is True or context["attestation_overall_status"] == "ready"
+    )
+    live_execution_closed = context["live_execution_allowed"] is False
+    support_boundary_closed = (
+        context["support_widening_allowed"] is False
+        and context["production_platform_claim_allowed"] is False
+    )
+    checks = [
+        _check(
+            "repository",
+            context["repository"] == EXPECTED_REPOSITORY,
+            finding_code="live_gate_policy_wrong_repository",
+            pass_detail=f"Repository is {EXPECTED_REPOSITORY}.",
+            blocked_detail="Repository is missing or is not the approved repository.",
+        ),
+        _check(
+            "environment",
+            context["environment"] == PROTECTED_ENVIRONMENT_NAME,
+            finding_code="live_gate_policy_wrong_environment",
+            pass_detail=f"Environment is {PROTECTED_ENVIRONMENT_NAME}.",
+            blocked_detail="Environment is missing or is not the protected live-adapter gate environment.",
+        ),
+        _check(
+            "trigger_event",
+            context["event"] == EXPECTED_TRIGGER_EVENT,
+            finding_code="live_gate_policy_wrong_event",
+            pass_detail=f"Trigger event is {EXPECTED_TRIGGER_EVENT}.",
+            blocked_detail="Trigger event is missing or is not workflow_dispatch.",
+        ),
+        _check(
+            "ref",
+            context["ref"] == EXPECTED_REF,
+            finding_code="live_gate_policy_wrong_ref",
+            pass_detail=f"Ref is {EXPECTED_REF}.",
+            blocked_detail="Ref is missing or is not the protected main ref.",
+        ),
+        _check(
+            "sha",
+            context["sha"] is not None,
+            finding_code="live_gate_policy_missing_sha",
+            pass_detail="Commit SHA is present.",
+            blocked_detail="Commit SHA is missing.",
+        ),
+        _check(
+            "deployment_callback_url",
+            _callback_url_is_usable(context["deployment_callback_url"]),
+            finding_code="live_gate_policy_missing_callback_url",
+            pass_detail="Deployment protection review callback URL is present.",
+            blocked_detail="Deployment protection review callback URL is missing or unusable.",
+        ),
+        _check(
+            "workflow_identity",
+            _workflow_matches(context["workflow_name"], context["workflow_path"]),
+            finding_code="live_gate_policy_missing_workflow_identity",
+            pass_detail="Verified context identifies the approved live-adapter gate workflow.",
+            blocked_detail="Verified context does not identify the approved live-adapter gate workflow.",
+        ),
+        _check(
+            "pull_request_boundary",
+            context["pull_request_count"] in (0, None),
+            finding_code="live_gate_policy_pull_request_context",
+            pass_detail="No pull_request context is attached to the deployment-protection payload.",
+            blocked_detail="Pull request context is attached; protected live credentials must stay away from PR paths.",
+        ),
+        _check(
+            "protected_prerequisites",
+            prerequisites_ready,
+            finding_code="live_gate_policy_prerequisites_not_ready",
+            pass_detail="Verified protected prerequisite attestation is ready.",
+            blocked_detail="Verified protected prerequisite attestation is missing or not ready.",
+        ),
+        _check(
+            "live_execution_boundary",
+            live_execution_closed,
+            finding_code="live_gate_policy_live_execution_open",
+            pass_detail="Verified context keeps live adapter execution disabled.",
+            blocked_detail="Verified context does not explicitly keep live adapter execution disabled.",
+        ),
+        _check(
+            "support_boundary",
+            support_boundary_closed,
+            finding_code="live_gate_policy_support_boundary_open",
+            pass_detail="Verified context keeps support widening and production platform claim closed.",
+            blocked_detail="Verified context does not explicitly keep support widening and production platform claim closed.",
+        ),
+    ]
+    findings = [check["finding_code"] for check in checks if check["finding_code"] is not None]
+    approval_allowed = not findings
+    decision = cast(PolicyDecisionValue, APPROVE_CONTRACT_GATE_DECISION if approval_allowed else REJECT_DECISION)
+    review_state: GithubReviewState = "approved" if approval_allowed else "rejected"
+    return {
+        "schema_version": POLICY_DECISION_SCHEMA_VERSION,
+        "artifact_kind": POLICY_DECISION_ARTIFACT_KIND,
+        "program_id": POLICY_DECISION_PROGRAM_ID,
+        "gate_id": GATE_ID,
+        "adapter_id": ADAPTER_ID,
+        "support_tier": SUPPORT_TIER,
+        "generated_at": generated_at or utc_timestamp(),
+        "app_slug": REQUIRED_DEPLOYMENT_PROTECTION_APP_SLUG,
+        "decision": decision,
+        "github_review_state": review_state,
+        "approval_allowed": approval_allowed,
+        "live_execution_allowed": False,
+        "support_widening_allowed": False,
+        "production_platform_claim_allowed": False,
+        "finding_code": None if approval_allowed else POLICY_REJECT_FINDING,
+        "reason": (
+            "Contract-only protected gate may proceed; live adapter execution, support widening, "
+            "and production platform claim remain disabled."
+            if approval_allowed
+            else "Deployment-protection policy rejected the request fail-closed."
+        ),
+        "context": context,
+        "checks": checks,
+        "findings": findings,
+    }
+
+
+def render_live_adapter_gate_policy_decision_text(decision: LiveAdapterGatePolicyDecision) -> str:
+    """Render a compact human-readable policy decision."""
+
+    context = decision["context"]
+    lines = [
+        f"decision: {decision['decision']}",
+        f"github_review_state: {decision['github_review_state']}",
+        f"approval_allowed: {str(decision['approval_allowed']).lower()}",
+        f"live_execution_allowed: {str(decision['live_execution_allowed']).lower()}",
+        f"support_widening_allowed: {str(decision['support_widening_allowed']).lower()}",
+        f"production_platform_claim_allowed: {str(decision['production_platform_claim_allowed']).lower()}",
+        f"repository: {context['repository'] or '<missing>'}",
+        f"environment: {context['environment'] or '<missing>'}",
+        f"ref: {context['ref'] or '<missing>'}",
+        f"sha: {context['sha'] or '<missing>'}",
+        f"workflow: {context['workflow_name'] or context['workflow_path'] or '<missing>'}",
+        "checks:",
+    ]
+    for check in decision["checks"]:
+        finding = f" ({check['finding_code']})" if check["finding_code"] else ""
+        lines.append(f"- {check['name']}: {check['status']}{finding}")
+    if decision["findings"]:
+        lines.append("findings:")
+        lines.extend(f"- {finding}" for finding in decision["findings"])
+    return "\n".join(lines)
+
+
+def write_live_adapter_gate_policy_decision(
+    path: Path,
+    decision: LiveAdapterGatePolicyDecision,
+) -> None:
+    """Write a policy decision artifact as canonical pretty JSON."""
+
+    path.write_text(json.dumps(decision, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -16,7 +16,7 @@ Current selected model:
 | Deployment protection model | GitHub App deployment protection rule |
 | Required app slug | `ao-kernel-live-adapter-gate` |
 | Required credential handle | `AO_CLAUDE_CODE_CLI_AUTH` |
-| Current program head | `GPP-2` blocked on deployment protection policy response |
+| Current program head | `GPP-2` blocked on policy service deployment/configuration |
 
 ## Preconditions
 
@@ -62,6 +62,20 @@ Protected workflow evidence after GPP-2n:
 5. No `live-adapter-gate-*.json` artifacts were produced.
 6. The run was cancelled after bounded observation and is fail-closed
    evidence, not approval.
+
+Policy decision core after GPP-2o:
+
+1. `ao_kernel/live_adapter_gate_policy.py` evaluates deployment-protection
+   callback payloads plus service-enriched verified context.
+2. `scripts/live_adapter_gate_policy_decision.py` can render a local policy
+   decision artifact for validation.
+3. Raw/unverified webhook payloads reject fail-closed.
+4. `approve_contract_gate` is only for the design-only protected gate and still
+   records `live_execution_allowed=false`, `support_widening_allowed=false`,
+   and `production_platform_claim_allowed=false`.
+5. The policy core is not a deployed webhook. GPP-2 remains blocked until the
+   GitHub App service calls it or an equivalent fail-closed policy and posts a
+   deployment callback review.
 
 Blocked interpretation for a fresh or drifted setup:
 
@@ -113,6 +127,13 @@ Minimum approval inputs for the app:
 The GPP-2n evidence shows that merely attaching the app is not enough. The app
 or backing policy service must actively respond to deployment protection
 callbacks. A waiting run with no app decision must be treated as blocked.
+
+The GPP-2o decision core gives that backing service a deterministic local
+policy surface. Before approving a callback, the service must enrich the raw
+GitHub payload with trusted context proving the approved workflow identity,
+ready protected prerequisite attestation, `main`, no pull-request context, and
+closed live-execution/support/production-claim boundaries. Missing enriched
+context must produce `reject`, not approval.
 
 ### 3. Attach the Deployment Protection Rule
 
@@ -275,8 +296,9 @@ If the selected deployment protection app is attached but does not respond:
 
 1. do not bypass the environment gate;
 2. do not repeatedly dispatch waiting workflow runs;
-3. activate or configure the app webhook/policy service so it returns an
-   explicit approve, deny, timeout, or failure decision;
+3. deploy or configure the app webhook/policy service so it evaluates
+   `ao_kernel.live_adapter_gate_policy` or an equivalent fail-closed policy and
+   returns an explicit approve, deny, timeout, or failure decision;
 4. rerun protected workflow evidence from `main` only after the service is
    expected to respond.
 

--- a/scripts/live_adapter_gate_policy_decision.py
+++ b/scripts/live_adapter_gate_policy_decision.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Evaluate a protected live-adapter deployment-protection policy payload."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel.live_adapter_gate_policy import (  # noqa: E402
+    POLICY_DECISION_ARTIFACT,
+    build_live_adapter_gate_policy_decision,
+    render_live_adapter_gate_policy_decision_text,
+    write_live_adapter_gate_policy_decision,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--payload",
+        type=Path,
+        required=True,
+        help="Path to a deployment_protection_rule webhook or enriched policy payload JSON.",
+    )
+    parser.add_argument(
+        "--decision-path",
+        type=Path,
+        default=Path(POLICY_DECISION_ARTIFACT),
+        help="Path for the policy decision artifact.",
+    )
+    parser.add_argument("--output", choices=("json", "text"), default="json", help="Stdout render mode.")
+    parser.add_argument(
+        "--fail-on-reject",
+        action="store_true",
+        help="Return exit code 1 when the policy decision is reject.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    payload: object = json.loads(args.payload.read_text(encoding="utf-8"))
+    decision = build_live_adapter_gate_policy_decision(payload)
+    write_live_adapter_gate_policy_decision(args.decision_path, decision)
+
+    if args.output == "json":
+        print(json.dumps(decision, indent=2, sort_keys=True))
+    else:
+        print(render_live_adapter_gate_policy_decision_text(decision))
+
+    if args.fail_on_reject and decision["decision"] == "reject":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,8 +30,8 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/523"
-    assert payload["current_wp"]["exit_decision"] == "protected_workflow_evidence_fail_closed_policy_response_missing"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/525"
+    assert payload["current_wp"]["exit_decision"] == "policy_decision_core_ready_service_not_deployed"
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
         item["id"] == "GPP-2a" and item["decision"] == "still_blocked_protected_prerequisites_missing"
@@ -106,20 +106,27 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2o"
+        and item["decision"] == "policy_decision_core_ready_service_not_deployed"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/525"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
-        "activate or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook so it responds to protected deployment callbacks",
-        "rerun the protected workflow evidence slice from main after the policy service can approve, deny, or fail explicitly",
+        "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook so it calls the repo-owned policy decision core or an equivalent fail-closed policy",
+        "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
     ]
     assert payload["blocked_wps"] == [
         {
             "id": "GPP-2",
             "reason": (
-                "protected workflow dispatch reached ao-kernel-live-adapter-gate but no deployment "
-                "protection app approval arrived; the job stayed waiting, produced no artifacts, and "
-                "was cancelled after bounded observation"
+                "repo-owned deployment-protection policy decision core is ready, but the GitHub App "
+                "webhook/policy service is not yet deployed or configured to respond to protected "
+                "deployment callbacks"
             ),
         }
     ]
@@ -135,11 +142,16 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"])
     assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
     assert any(
-        action == "resolve the deployment-protection policy service response gap before any further live-adapter runtime work"
+        action == "deploy or configure the deployment-protection policy service response path before any further live-adapter runtime work"
         for action in payload["next_allowed_actions"]
     )
     assert any(
         action == "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "use scripts/live_adapter_gate_policy_decision.py only for policy callback decision evaluation, not live adapter execution"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -235,9 +247,9 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/523"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/525"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
-    assert "policy_response_missing" in payload["current_wp"]["exit_decision"]
+    assert payload["current_wp"]["exit_decision"] == "policy_decision_core_ready_service_not_deployed"
     assert payload["support_widening_allowed"] is False
 
 
@@ -267,7 +279,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "Blocked work packages:\n- GPP-2: protected workflow dispatch reached" in rendered
+    assert "Blocked work packages:\n- GPP-2: repo-owned deployment-protection policy decision core is ready" in rendered
     assert "divergence: 0\t0" in rendered
 
 

--- a/tests/test_live_adapter_gate_policy.py
+++ b/tests/test_live_adapter_gate_policy.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from ao_kernel.live_adapter_gate_policy import (
+    APPROVE_CONTRACT_GATE_DECISION,
+    EXPECTED_WORKFLOW_NAME,
+    EXPECTED_WORKFLOW_PATH,
+    REJECT_DECISION,
+    build_live_adapter_gate_policy_decision,
+    render_live_adapter_gate_policy_decision_text,
+    write_live_adapter_gate_policy_decision,
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _approved_payload() -> dict[str, object]:
+    return {
+        "environment": "ao-kernel-live-adapter-gate",
+        "event": "workflow_dispatch",
+        "sha": "abc123",
+        "ref": "refs/heads/main",
+        "deployment_callback_url": (
+            "https://api.github.com/repos/Halildeu/ao-kernel/actions/runs/25020015357/"
+            "deployment_protection_rule"
+        ),
+        "repository": {"full_name": "Halildeu/ao-kernel"},
+        "pull_requests": [],
+        "verified_context": {
+            "workflow_name": EXPECTED_WORKFLOW_NAME,
+            "workflow_path": EXPECTED_WORKFLOW_PATH,
+            "prerequisites_ready": True,
+            "attestation_overall_status": "ready",
+            "live_execution_allowed": False,
+            "support_widening_allowed": False,
+            "production_platform_claim_allowed": False,
+        },
+    }
+
+
+def _find_check(decision: dict[str, object], name: str) -> dict[str, object]:
+    checks = decision["checks"]
+    assert isinstance(checks, list)
+    for check in checks:
+        assert isinstance(check, dict)
+        if check["name"] == name:
+            return check
+    raise AssertionError(f"missing check: {name}")
+
+
+def test_policy_decision_approves_contract_only_when_verified_context_is_closed() -> None:
+    decision = build_live_adapter_gate_policy_decision(
+        _approved_payload(),
+        generated_at="2026-04-28T00:00:00Z",
+    )
+
+    assert decision["schema_version"] == "1"
+    assert decision["program_id"] == "GPP-2o"
+    assert decision["decision"] == APPROVE_CONTRACT_GATE_DECISION
+    assert decision["github_review_state"] == "approved"
+    assert decision["approval_allowed"] is True
+    assert decision["live_execution_allowed"] is False
+    assert decision["support_widening_allowed"] is False
+    assert decision["production_platform_claim_allowed"] is False
+    assert decision["finding_code"] is None
+    assert decision["findings"] == []
+    assert decision["context"]["ref"] == "main"
+    assert all(check["status"] == "pass" for check in decision["checks"])
+
+
+def test_policy_decision_rejects_raw_webhook_payload_without_verified_context() -> None:
+    payload = _approved_payload()
+    payload.pop("verified_context")
+
+    decision = build_live_adapter_gate_policy_decision(payload)
+
+    assert decision["decision"] == REJECT_DECISION
+    assert decision["github_review_state"] == "rejected"
+    assert decision["approval_allowed"] is False
+    assert "live_gate_policy_missing_workflow_identity" in decision["findings"]
+    assert "live_gate_policy_prerequisites_not_ready" in decision["findings"]
+    assert "live_gate_policy_live_execution_open" in decision["findings"]
+    assert "live_gate_policy_support_boundary_open" in decision["findings"]
+
+
+def test_policy_decision_rejects_wrong_repository() -> None:
+    payload = _approved_payload()
+    payload["repository"] = {"full_name": "Other/repo"}
+
+    decision = build_live_adapter_gate_policy_decision(payload)
+
+    assert decision["decision"] == REJECT_DECISION
+    assert _find_check(decision, "repository")["finding_code"] == "live_gate_policy_wrong_repository"
+
+
+def test_policy_decision_rejects_wrong_ref() -> None:
+    payload = _approved_payload()
+    payload["ref"] = "refs/heads/feature"
+
+    decision = build_live_adapter_gate_policy_decision(payload)
+
+    assert decision["decision"] == REJECT_DECISION
+    assert _find_check(decision, "ref")["finding_code"] == "live_gate_policy_wrong_ref"
+
+
+def test_policy_decision_rejects_missing_callback_url() -> None:
+    payload = _approved_payload()
+    payload.pop("deployment_callback_url")
+
+    decision = build_live_adapter_gate_policy_decision(payload)
+
+    assert decision["decision"] == REJECT_DECISION
+    assert (
+        _find_check(decision, "deployment_callback_url")["finding_code"]
+        == "live_gate_policy_missing_callback_url"
+    )
+
+
+def test_policy_decision_rejects_live_execution_signal() -> None:
+    payload = _approved_payload()
+    verified_context = payload["verified_context"]
+    assert isinstance(verified_context, dict)
+    verified_context["live_execution_allowed"] = True
+
+    decision = build_live_adapter_gate_policy_decision(payload)
+
+    assert decision["decision"] == REJECT_DECISION
+    assert _find_check(decision, "live_execution_boundary")["finding_code"] == "live_gate_policy_live_execution_open"
+
+
+def test_policy_decision_rejects_pull_request_context() -> None:
+    payload = _approved_payload()
+    payload["pull_requests"] = [{"number": 1}]
+
+    decision = build_live_adapter_gate_policy_decision(payload)
+
+    assert decision["decision"] == REJECT_DECISION
+    assert _find_check(decision, "pull_request_boundary")["finding_code"] == "live_gate_policy_pull_request_context"
+
+
+def test_render_and_write_policy_decision(tmp_path: Path) -> None:
+    decision = build_live_adapter_gate_policy_decision(
+        _approved_payload(),
+        generated_at="2026-04-28T00:00:00Z",
+    )
+    path = tmp_path / "decision.json"
+
+    write_live_adapter_gate_policy_decision(path, decision)
+
+    assert json.loads(path.read_text(encoding="utf-8")) == decision
+    assert path.read_text(encoding="utf-8").endswith("\n")
+    rendered = render_live_adapter_gate_policy_decision_text(decision)
+    assert "decision: approve_contract_gate" in rendered
+    assert "approval_allowed: true" in rendered
+
+
+def test_policy_decision_cli_writes_artifact(tmp_path: Path) -> None:
+    payload_path = tmp_path / "payload.json"
+    decision_path = tmp_path / "decision.json"
+    payload_path.write_text(json.dumps(_approved_payload()), encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/live_adapter_gate_policy_decision.py",
+            "--payload",
+            str(payload_path),
+            "--decision-path",
+            str(decision_path),
+            "--output",
+            "text",
+        ],
+        cwd=_repo_root(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "decision: approve_contract_gate" in completed.stdout
+    assert json.loads(decision_path.read_text(encoding="utf-8"))["decision"] == APPROVE_CONTRACT_GATE_DECISION


### PR DESCRIPTION
## Summary
- Add a side-effect-free deployment protection policy decision core for the ao-kernel live-adapter gate.
- Add a local CLI that writes live-adapter-gate-policy-decision.v1.json from webhook/enriched policy payloads.
- Update GPP status/runbook records to mark the decision core ready while keeping GPP-2 blocked until the GitHub App webhook/service is deployed or configured.

## Safety boundaries
- No live adapter execution.
- No secrets.AO_CLAUDE_CODE_CLI_AUTH usage or secret value readback.
- No support widening.
- No production platform claim.
- Raw/unverified webhook payloads reject fail-closed.

## Validation
- python3 -m json.tool .claude/plans/gpp_status.v1.json >/tmp/gpp_status_check.json
- pytest -q tests/test_live_adapter_gate_policy.py tests/test_gpp_next.py
- pytest -q tests/test_live_adapter_gate_contract.py tests/test_live_adapter_gate_policy.py tests/test_gpp_next.py
- python3 -m ruff check ao_kernel/live_adapter_gate_policy.py scripts/live_adapter_gate_policy_decision.py tests/test_live_adapter_gate_policy.py tests/test_gpp_next.py
- python3 -m mypy ao_kernel/live_adapter_gate_policy.py scripts/live_adapter_gate_policy_decision.py
- python3 scripts/gpp_next.py >/tmp/gpp_next_check.txt
- git diff --check
- pytest -q (3114 passed, 2 skipped)

Closes #525