### PR TITLE
GPP-2p: add live gate policy webhook service scaffold

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 policy decision core ready; service deployment/config still blocked
+**Status:** GPP-2 policy webhook service scaffold ready; service deployment/config still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#525](https://github.com/Halildeu/ao-kernel/issues/525)
-for deployment protection policy decision core
-**Current slice record:** `.claude/plans/GPP-2o-POLICY-DECISION-CORE.md`
+**Current slice issue:** [#527](https://github.com/Halildeu/ao-kernel/issues/527)
+for deployment protection policy webhook service scaffold
+**Current slice record:** `.claude/plans/GPP-2p-POLICY-WEBHOOK-SERVICE-SCAFFOLD.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -135,6 +135,13 @@ Last live verification on current `origin/main` showed:
     live-execution/support/production-claim boundaries. GPP-2 remains blocked
     until this policy is deployed or configured behind the GitHub App webhook
     and new protected workflow evidence is collected.
+32. GPP-2p adds the repo-owned webhook service boundary for that policy. It
+    verifies GitHub `X-Hub-Signature-256`, accepts only
+    `deployment_protection_rule`, builds the GitHub callback request body
+    (`environment_name`, `state`, `comment`), and emits a local artifact
+    without posting to GitHub. GPP-2 remains blocked until a hosted service is
+    configured with webhook secret and GitHub App auth and new protected
+    workflow evidence is collected.
 
 ## 3. Current Verdict
 
@@ -189,7 +196,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2m` | Completed / no support widening | Protected live gate runtime binding | workflow bound to protected environment; live execution still disabled |
 | `GPP-2n` | Completed / no support widening | Protected live gate workflow evidence | protected workflow reached environment gate and failed closed because policy response is missing |
 | `GPP-2o` | Completed / no support widening | Deployment protection policy decision core | repo-owned decision core and CLI ready; service is not yet deployed/configured |
-| `GPP-2` | Blocked / service deployment/config missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be deployed/configured before further runtime work |
+| `GPP-2p` | Completed / no support widening | Deployment protection policy webhook service scaffold | repo-owned webhook/callback request scaffold ready; service is not yet deployed/configured |
+| `GPP-2` | Blocked / service deployment/config missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be deployed/configured with webhook secret and GitHub App auth before further runtime work |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -318,8 +326,8 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2o; policy decision core exists, but service
-deployment/configuration is still missing.
+**Status:** blocked after GPP-2p; policy decision core and webhook scaffold
+exist, but service deployment/configuration is still missing.
 
 **Entry criteria:**
 
@@ -333,7 +341,9 @@ the protected environment gate, but the deployment protection app/policy
 service did not return an approval, denial, timeout, or failure decision.
 GPP-2o adds the repo-owned policy decision core and CLI that the service can
 use, but no webhook/service deployment or GitHub callback review evidence has
-been recorded.
+been recorded. GPP-2p adds the repo-owned webhook service boundary and callback
+request artifact, but no hosted endpoint, webhook secret, GitHub App auth, or
+actual callback POST evidence has been recorded.
 
 **Acceptance criteria:**
 
@@ -588,7 +598,9 @@ metadata-only `overall_status=ready` prerequisite attestation, GPP-2m binds
 the bound workflow reaches that protected environment but stays waiting without
 a policy decision, and GPP-2o adds the repo-owned decision core that can return
 `approve_contract_gate` or `reject` once it is placed behind the GitHub App
-webhook. GPP-2b
+webhook. GPP-2p adds the repo-owned webhook service scaffold that verifies
+GitHub signatures, constrains the event, and builds the deployment callback
+request without posting it. GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
 metadata prerequisite level: the protected environment exists, admin bypass is
@@ -610,8 +622,9 @@ operator provisioning runbook.
 The next GPP-2 action is to deploy or configure the
 `ao-kernel-live-adapter-gate` deployment protection app/policy service so it
 receives protected deployment callbacks, enriches them with trusted context,
-evaluates `ao_kernel.live_adapter_gate_policy` or an equivalent fail-closed
-policy, and posts an explicit GitHub deployment review callback. Do not repeatedly dispatch
+evaluates the repo-owned policy modules or an equivalent fail-closed policy,
+attaches GitHub App auth outside the repo, and posts an explicit GitHub
+deployment review callback. Do not repeatedly dispatch
 `.github/workflows/live-adapter-gate.yml` until that service is expected to
 respond. Any follow-up must keep fork and pull-request contexts away from
 protected credentials, must not use `AO_CLAUDE_CODE_CLI_AUTH` through a
@@ -633,6 +646,7 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | Bot account mistaken for deployment protection | Same operator can rubber-stamp the gate | PAT-backed bot reviewer is rejected; use GitHub App deployment protection |
 | Deployment protection app installed but inactive | Protected workflow waits forever and produces no artifacts | Treat waiting/cancelled runs as fail-closed; activate policy service before repeating evidence dispatch |
 | Policy decision core exists but is not deployed | Protected workflow still receives no app response | Treat GPP-2o as implementation readiness only; deploy/configure webhook before rerunning evidence |
+| Webhook scaffold exists but has no runtime auth | Callback artifact exists but GitHub still receives no review | Treat GPP-2p as implementation readiness only; deploy with webhook secret and GitHub App auth before rerunning evidence |
 
 ## 19. Tracking Log
 
@@ -674,3 +688,5 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-28 | GPP-2n evidence fail-closed | Workflow run `25020015357` reached `ao-kernel-live-adapter-gate` and stayed waiting for deployment protection app response; no steps or artifacts ran, `current_user_can_approve=false`, and the run was cancelled after bounded observation. |
 | 2026-04-28 | GPP-2o issue opened | Issue [#525](https://github.com/Halildeu/ao-kernel/issues/525) tracks the repo-owned deployment protection policy decision core. |
 | 2026-04-28 | GPP-2o decision core added | `ao_kernel/live_adapter_gate_policy.py` and `scripts/live_adapter_gate_policy_decision.py` add fail-closed policy evaluation; service deployment/configuration remains required before rerunning protected workflow evidence. |
+| 2026-04-28 | GPP-2p issue opened | Issue [#527](https://github.com/Halildeu/ao-kernel/issues/527) tracks the repo-owned deployment protection policy webhook service scaffold. |
+| 2026-04-28 | GPP-2p webhook scaffold added | `ao_kernel/live_adapter_gate_policy_service.py` and `scripts/live_adapter_gate_policy_service_smoke.py` add webhook signature/event checks and callback request artifact generation; hosted service deployment/configuration remains required before rerunning protected workflow evidence. |

--- a/.claude/plans/GPP-2p-POLICY-WEBHOOK-SERVICE-SCAFFOLD.md
+++ b/.claude/plans/GPP-2p-POLICY-WEBHOOK-SERVICE-SCAFFOLD.md
@@ -1,0 +1,143 @@
+# GPP-2p - Deployment Protection Policy Webhook Service Scaffold
+
+**Status:** closeout candidate
+**Date:** 2026-04-28
+**Authority:** `origin/main` at `c762523`
+**Issue:** [#527](https://github.com/Halildeu/ao-kernel/issues/527)
+**Branch:** `codex/gpp-2p-policy-webhook-service`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2p-policy-webhook-service`
+**Program head:** `GPP-2` blocked on policy service deployment/configuration
+**Support impact:** none
+**Runtime impact:** no live adapter call; no secret context use; no GitHub
+callback POST from tests or default CLI
+
+## 1. Purpose
+
+GPP-2o added a deterministic deployment-protection policy decision core.
+GPP-2 still needs a service boundary that can receive GitHub App webhooks,
+verify the delivery, restrict the event type, evaluate the policy, and prepare
+the GitHub custom deployment protection review callback.
+
+Decision:
+
+```text
+policy_webhook_service_scaffold_ready_service_not_deployed
+```
+
+This slice does not deploy a webhook, does not call GitHub's deployment review
+API, does not invoke `claude`, does not reference
+`secrets.AO_CLAUDE_CODE_CLI_AUTH`, does not read secret values, does not widen
+support, and does not claim production-platform readiness.
+
+## 2. Implemented Surface
+
+Code:
+
+1. `ao_kernel/live_adapter_gate_policy_service.py`
+   - verifies GitHub webhook `X-Hub-Signature-256` values using HMAC-SHA256;
+   - accepts only `X-GitHub-Event: deployment_protection_rule`;
+   - rejects malformed JSON before policy evaluation;
+   - calls `ao_kernel.live_adapter_gate_policy` for the decision;
+   - builds the GitHub callback request shape:
+     `POST {deployment_callback_url}` with `environment_name`, `state`, and
+     `comment`;
+   - never performs the network POST itself.
+2. `scripts/live_adapter_gate_policy_service_smoke.py`
+   - reads a local webhook/enriched payload fixture;
+   - verifies or locally signs fixture delivery headers;
+   - writes `live-adapter-gate-policy-service-callback-request.v1.json`;
+   - supports unsigned fixture evaluation only behind
+     `--allow-unsigned-fixture`.
+3. `tests/test_live_adapter_gate_policy_service.py`
+   - pins the official GitHub HMAC-SHA256 example vector;
+   - covers missing signature, wrong event, malformed JSON, raw webhook reject,
+     verified-context approval, and CLI artifact writing.
+
+## 3. Policy Interpretation
+
+The service scaffold deliberately separates these concerns:
+
+1. webhook authenticity;
+2. GitHub App event scope;
+3. JSON payload shape;
+4. policy decision;
+5. callback request construction;
+6. runtime callback posting.
+
+Only the first five are implemented by this repo slice. Runtime deployment
+must attach the webhook secret and GitHub App authentication outside the repo
+and execute the returned callback request. That external deployment remains the
+current GPP-2 blocker.
+
+The scaffold can produce a rejected callback request for a valid, signed
+`deployment_protection_rule` payload even when policy context is missing. That
+is intentional: a service should respond explicitly with `rejected` instead of
+leaving GitHub Actions waiting indefinitely.
+
+## 4. Current Decision
+
+Resolved by this slice:
+
+1. webhook signature verification is deterministic and fail-closed;
+2. non-`deployment_protection_rule` events fail before policy evaluation;
+3. malformed JSON fails before policy evaluation;
+4. valid raw callbacks can produce an explicit rejected callback request;
+5. verified closed context can produce an approved contract-gate callback
+   request;
+6. local smoke tooling emits a callback artifact without network side effects.
+
+Still blocked:
+
+1. no hosted webhook endpoint is deployed;
+2. no webhook secret is configured in a runtime service;
+3. no GitHub App installation token or equivalent app auth is configured in a
+   runtime service;
+4. no deployment callback review has been posted by the service;
+5. no new protected workflow evidence artifacts exist after policy response;
+6. live adapter execution remains disabled.
+
+Still closed:
+
+1. `live_execution_allowed=false`;
+2. `support_widening=false`;
+3. `production_platform_claim=false`.
+
+## 5. Next Required Action
+
+Deploy or configure the `ao-kernel-live-adapter-gate` GitHub App
+deployment-protection policy service so it:
+
+1. receives `deployment_protection_rule` callbacks;
+2. verifies `X-Hub-Signature-256` with a runtime webhook secret;
+3. enriches the payload with trusted workflow/prerequisite context;
+4. evaluates that context with the repo-owned policy modules;
+5. attaches GitHub App authentication outside the repo;
+6. posts the callback request to `deployment_callback_url`;
+7. records response evidence without secret value exposure.
+
+Only after that service is expected to respond should the protected workflow
+evidence slice be rerun from `main`.
+
+## 6. Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_live_adapter_gate_policy_service.py
+pytest -q tests/test_live_adapter_gate_policy.py tests/test_live_adapter_gate_policy_service.py tests/test_gpp_next.py
+python3 -m ruff check ao_kernel/live_adapter_gate_policy_service.py scripts/live_adapter_gate_policy_service_smoke.py tests/test_live_adapter_gate_policy_service.py tests/test_gpp_next.py
+python3 -m mypy ao_kernel/live_adapter_gate_policy_service.py scripts/live_adapter_gate_policy_service_smoke.py
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Expected closeout decision:
+
+```text
+policy_webhook_service_scaffold_ready_service_not_deployed
+```
+
+Recorded closeout decision:
+
+```text
+policy_webhook_service_scaffold_ready_service_not_deployed
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,11 +9,11 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/525",
-    "exit_decision": "policy_decision_core_ready_service_not_deployed",
-    "ready_after": "deployment protection policy service is deployed/configured behind the GitHub App and produces protected workflow evidence with live_execution_allowed=false",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/527",
+    "exit_decision": "policy_webhook_service_scaffold_ready_service_not_deployed",
+    "ready_after": "deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, posts callback reviews, and produces protected workflow evidence with live_execution_allowed=false",
     "allowed_scope": [
-      "use the repo-owned policy decision core to implement or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
+      "use the repo-owned policy service scaffold to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
       "repeat protected workflow evidence collection from main after the policy service responds",
       "keep live execution disabled until protected workflow evidence explicitly permits a later live run"
     ]
@@ -116,16 +116,22 @@
       "decision": "policy_decision_core_ready_service_not_deployed",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/525",
       "record": ".claude/plans/GPP-2o-POLICY-DECISION-CORE.md"
+    },
+    {
+      "id": "GPP-2p",
+      "decision": "policy_webhook_service_scaffold_ready_service_not_deployed",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/527",
+      "record": ".claude/plans/GPP-2p-POLICY-WEBHOOK-SERVICE-SCAFFOLD.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned deployment-protection policy decision core is ready, but the GitHub App webhook/policy service is not yet deployed or configured to respond to protected deployment callbacks"
+      "reason": "repo-owned policy webhook service scaffold is ready, but the GitHub App service is not yet deployed/configured with webhook secret and GitHub App auth to post deployment callback reviews"
     }
   ],
   "pending_external_actions": [
-    "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook so it calls the repo-owned policy decision core or an equivalent fail-closed policy",
+    "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
     "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly"
   ],
   "support_widening_allowed": false,
@@ -180,10 +186,11 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "deploy or configure the deployment-protection policy service response path before any further live-adapter runtime work",
+    "deploy or configure the deployment-protection policy service using the repo-owned service scaffold before any further live-adapter runtime work",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
     "use Claude MCP consultation only as advisory review, not release authority",
     "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active",
+    "use scripts/live_adapter_gate_policy_service_smoke.py only for local webhook/callback artifact validation, not live callback posting",
     "use scripts/live_adapter_gate_policy_decision.py only for policy callback decision evaluation, not live adapter execution",
     "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it",
     "keep fork and pull_request contexts away from protected credentials",

--- a/ao_kernel/live_adapter_gate_policy_service.py
+++ b/ao_kernel/live_adapter_gate_policy_service.py
@@ -1,0 +1,357 @@
+"""Webhook service boundary for the protected live-adapter gate policy."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any, Literal, Mapping, TypedDict, cast
+
+from ao_kernel.live_adapter_gate import PROTECTED_ENVIRONMENT_NAME, utc_timestamp
+from ao_kernel.live_adapter_gate_policy import (
+    GithubReviewState,
+    LiveAdapterGatePolicyDecision,
+    build_live_adapter_gate_policy_decision,
+    render_live_adapter_gate_policy_decision_text,
+)
+
+POLICY_SERVICE_SCHEMA_VERSION = "1"
+POLICY_SERVICE_PROGRAM_ID = "GPP-2p"
+POLICY_SERVICE_ARTIFACT_KIND = "live_adapter_gate_policy_service_callback_request"
+POLICY_SERVICE_ARTIFACT = "live-adapter-gate-policy-service-callback-request.v1.json"
+GITHUB_DEPLOYMENT_PROTECTION_EVENT = "deployment_protection_rule"
+GITHUB_SIGNATURE_HEADER = "x-hub-signature-256"
+GITHUB_EVENT_HEADER = "x-github-event"
+GITHUB_DELIVERY_HEADER = "x-github-delivery"
+
+PolicyServiceStatus = Literal["callback_ready", "blocked"]
+PolicyServiceCheckStatus = Literal["pass", "blocked", "skipped"]
+
+
+class LiveAdapterGatePolicyServiceCheck(TypedDict):
+    """Single service-boundary check."""
+
+    name: str
+    status: PolicyServiceCheckStatus
+    finding_code: str | None
+    detail: str
+
+
+class LiveAdapterGateDeploymentReviewPayload(TypedDict):
+    """GitHub custom deployment protection review request body."""
+
+    environment_name: str
+    state: GithubReviewState
+    comment: str
+
+
+class LiveAdapterGateDeploymentReviewRequest(TypedDict):
+    """Network request shape for the GitHub deployment protection callback."""
+
+    method: str
+    url: str | None
+    headers: dict[str, str]
+    json: LiveAdapterGateDeploymentReviewPayload | None
+    authorization_required: bool
+
+
+class LiveAdapterGatePolicyServiceResult(TypedDict):
+    """Machine-readable policy service callback artifact."""
+
+    schema_version: str
+    artifact_kind: str
+    program_id: str
+    generated_at: str
+    status: PolicyServiceStatus
+    finding_code: str | None
+    reason: str
+    event_name: str | None
+    delivery_id: str | None
+    signature_verified: bool | None
+    should_post_callback: bool
+    decision: LiveAdapterGatePolicyDecision | None
+    callback_request: LiveAdapterGateDeploymentReviewRequest
+    checks: list[LiveAdapterGatePolicyServiceCheck]
+    findings: list[str]
+
+
+def github_webhook_signature(secret: str, body: bytes) -> str:
+    """Return the GitHub ``X-Hub-Signature-256`` value for ``body``."""
+
+    digest = hmac.new(secret.encode("utf-8"), msg=body, digestmod=hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def verify_github_webhook_signature(body: bytes, secret: str, signature_header: str | None) -> bool:
+    """Verify a GitHub webhook HMAC-SHA256 signature in constant time."""
+
+    if not secret or not signature_header:
+        return False
+    expected = github_webhook_signature(secret, body)
+    return hmac.compare_digest(expected, signature_header)
+
+
+def _header(headers: Mapping[str, str], name: str) -> str | None:
+    """Return a case-insensitive header value."""
+
+    target = name.lower()
+    for key, value in headers.items():
+        if key.lower() == target and value.strip():
+            return value.strip()
+    return None
+
+
+def _pass(name: str, *, detail: str) -> LiveAdapterGatePolicyServiceCheck:
+    """Build a passing service check."""
+
+    return {"name": name, "status": "pass", "finding_code": None, "detail": detail}
+
+
+def _blocked(name: str, *, finding_code: str, detail: str) -> LiveAdapterGatePolicyServiceCheck:
+    """Build a blocked service check."""
+
+    return {"name": name, "status": "blocked", "finding_code": finding_code, "detail": detail}
+
+
+def _skipped(name: str, *, finding_code: str | None, detail: str) -> LiveAdapterGatePolicyServiceCheck:
+    """Build a skipped service check."""
+
+    return {"name": name, "status": "skipped", "finding_code": finding_code, "detail": detail}
+
+
+def build_deployment_protection_review_payload(
+    decision: LiveAdapterGatePolicyDecision,
+) -> LiveAdapterGateDeploymentReviewPayload:
+    """Build the GitHub custom deployment protection review JSON body."""
+
+    environment_name = decision["context"]["environment"] or PROTECTED_ENVIRONMENT_NAME
+    finding_suffix = ""
+    if decision["findings"]:
+        finding_suffix = " Findings: " + ", ".join(decision["findings"])
+    comment = (
+        f"ao-kernel live-adapter gate policy decision: {decision['decision']}. "
+        f"{decision['reason']}{finding_suffix}"
+    )
+    return {
+        "environment_name": environment_name,
+        "state": decision["github_review_state"],
+        "comment": comment,
+    }
+
+
+def build_deployment_protection_review_request(
+    decision: LiveAdapterGatePolicyDecision,
+) -> LiveAdapterGateDeploymentReviewRequest:
+    """Build the GitHub callback request shape without executing it."""
+
+    return {
+        "method": "POST",
+        "url": decision["context"]["deployment_callback_url"],
+        "headers": {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        "json": build_deployment_protection_review_payload(decision),
+        "authorization_required": True,
+    }
+
+
+def _empty_callback_request() -> LiveAdapterGateDeploymentReviewRequest:
+    """Return an empty callback request for blocked pre-policy states."""
+
+    return {
+        "method": "POST",
+        "url": None,
+        "headers": {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        "json": None,
+        "authorization_required": True,
+    }
+
+
+def _decode_json_body(body: bytes) -> tuple[dict[str, Any] | None, str | None]:
+    """Decode a JSON object body."""
+
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return None, str(exc)
+    if not isinstance(payload, dict):
+        return None, "webhook JSON body must be an object"
+    return cast(dict[str, Any], payload), None
+
+
+def build_live_adapter_gate_policy_service_result(
+    body: bytes,
+    headers: Mapping[str, str],
+    *,
+    webhook_secret: str | None = None,
+    require_signature: bool = True,
+    generated_at: str | None = None,
+) -> LiveAdapterGatePolicyServiceResult:
+    """Evaluate a webhook delivery and build a callback request artifact.
+
+    The function never posts to GitHub. Runtime deployment must attach a GitHub
+    App token outside this repository and execute the returned request shape.
+    """
+
+    checks: list[LiveAdapterGatePolicyServiceCheck] = []
+    event_name = _header(headers, GITHUB_EVENT_HEADER)
+    delivery_id = _header(headers, GITHUB_DELIVERY_HEADER)
+    signature_header = _header(headers, GITHUB_SIGNATURE_HEADER)
+
+    if require_signature:
+        if webhook_secret is None:
+            signature_verified: bool | None = False
+            checks.append(
+                _blocked(
+                    "webhook_signature",
+                    finding_code="live_gate_policy_service_signature_secret_missing",
+                    detail="Webhook signature verification is required, but no webhook secret was provided.",
+                )
+            )
+        elif verify_github_webhook_signature(body, webhook_secret, signature_header):
+            signature_verified = True
+            checks.append(_pass("webhook_signature", detail="GitHub webhook signature verified."))
+        else:
+            signature_verified = False
+            checks.append(
+                _blocked(
+                    "webhook_signature",
+                    finding_code="live_gate_policy_service_signature_invalid",
+                    detail="GitHub webhook signature is missing or does not match the body.",
+                )
+            )
+    else:
+        signature_verified = None
+        checks.append(
+            _skipped(
+                "webhook_signature",
+                finding_code="live_gate_policy_service_signature_not_required",
+                detail="Signature verification skipped for local fixture evaluation only.",
+            )
+        )
+
+    event_ok = event_name == GITHUB_DEPLOYMENT_PROTECTION_EVENT
+    if event_ok:
+        checks.append(_pass("webhook_event", detail=f"Webhook event is {GITHUB_DEPLOYMENT_PROTECTION_EVENT}."))
+    else:
+        checks.append(
+            _blocked(
+                "webhook_event",
+                finding_code="live_gate_policy_service_wrong_event",
+                detail="Webhook event is missing or is not deployment_protection_rule.",
+            )
+        )
+
+    payload, json_error = _decode_json_body(body)
+    if payload is None:
+        checks.append(
+            _blocked(
+                "webhook_json",
+                finding_code="live_gate_policy_service_invalid_json",
+                detail=f"Webhook body is not a JSON object: {json_error}",
+            )
+        )
+    else:
+        checks.append(_pass("webhook_json", detail="Webhook body decoded as a JSON object."))
+
+    pre_policy_blockers = [
+        check["finding_code"]
+        for check in checks
+        if check["status"] == "blocked" and check["finding_code"] is not None
+    ]
+    if payload is None or pre_policy_blockers:
+        return {
+            "schema_version": POLICY_SERVICE_SCHEMA_VERSION,
+            "artifact_kind": POLICY_SERVICE_ARTIFACT_KIND,
+            "program_id": POLICY_SERVICE_PROGRAM_ID,
+            "generated_at": generated_at or utc_timestamp(),
+            "status": "blocked",
+            "finding_code": "live_gate_policy_service_blocked",
+            "reason": "Deployment-protection webhook service rejected the delivery before policy evaluation.",
+            "event_name": event_name,
+            "delivery_id": delivery_id,
+            "signature_verified": signature_verified,
+            "should_post_callback": False,
+            "decision": None,
+            "callback_request": _empty_callback_request(),
+            "checks": checks,
+            "findings": pre_policy_blockers,
+        }
+
+    decision = build_live_adapter_gate_policy_decision(payload, generated_at=generated_at)
+    callback_request = build_deployment_protection_review_request(decision)
+    callback_ready = callback_request["url"] is not None
+    if callback_ready:
+        checks.append(_pass("callback_request", detail="GitHub deployment protection callback request is ready."))
+    else:
+        checks.append(
+            _blocked(
+                "callback_request",
+                finding_code="live_gate_policy_service_missing_callback_url",
+                detail="Policy decision did not include a usable deployment callback URL.",
+            )
+        )
+
+    findings = [
+        check["finding_code"]
+        for check in checks
+        if check["status"] == "blocked" and check["finding_code"] is not None
+    ]
+    return {
+        "schema_version": POLICY_SERVICE_SCHEMA_VERSION,
+        "artifact_kind": POLICY_SERVICE_ARTIFACT_KIND,
+        "program_id": POLICY_SERVICE_PROGRAM_ID,
+        "generated_at": generated_at or utc_timestamp(),
+        "status": "callback_ready" if callback_ready else "blocked",
+        "finding_code": None if callback_ready else "live_gate_policy_service_blocked",
+        "reason": (
+            "Deployment-protection callback request is ready; caller must attach GitHub App auth and POST it."
+            if callback_ready
+            else "Deployment-protection callback request is not ready."
+        ),
+        "event_name": event_name,
+        "delivery_id": delivery_id,
+        "signature_verified": signature_verified,
+        "should_post_callback": callback_ready,
+        "decision": decision,
+        "callback_request": callback_request,
+        "checks": checks,
+        "findings": findings,
+    }
+
+
+def render_live_adapter_gate_policy_service_text(result: LiveAdapterGatePolicyServiceResult) -> str:
+    """Render a compact human-readable policy service result."""
+
+    lines = [
+        f"status: {result['status']}",
+        f"event_name: {result['event_name'] or '<missing>'}",
+        f"delivery_id: {result['delivery_id'] or '<missing>'}",
+        f"signature_verified: {result['signature_verified']}",
+        f"should_post_callback: {str(result['should_post_callback']).lower()}",
+        f"callback_url: {result['callback_request']['url'] or '<missing>'}",
+    ]
+    if result["decision"] is not None:
+        lines.append(render_live_adapter_gate_policy_decision_text(result["decision"]))
+    lines.append("service_checks:")
+    for check in result["checks"]:
+        finding = f" ({check['finding_code']})" if check["finding_code"] else ""
+        lines.append(f"- {check['name']}: {check['status']}{finding}")
+    if result["findings"]:
+        lines.append("service_findings:")
+        lines.extend(f"- {finding}" for finding in result["findings"])
+    return "\n".join(lines)
+
+
+def write_live_adapter_gate_policy_service_result(
+    path: Path,
+    result: LiveAdapterGatePolicyServiceResult,
+) -> None:
+    """Write a policy service callback artifact as canonical pretty JSON."""
+
+    path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -77,6 +77,19 @@ Policy decision core after GPP-2o:
    GitHub App service calls it or an equivalent fail-closed policy and posts a
    deployment callback review.
 
+Policy webhook service scaffold after GPP-2p:
+
+1. `ao_kernel/live_adapter_gate_policy_service.py` verifies
+   `X-Hub-Signature-256` with HMAC-SHA256.
+2. The service boundary accepts only `deployment_protection_rule` events.
+3. It builds the GitHub callback request body with `environment_name`, `state`,
+   and `comment`.
+4. `scripts/live_adapter_gate_policy_service_smoke.py` writes a local callback
+   request artifact for fixture validation.
+5. The scaffold does not perform the network POST. GPP-2 remains blocked until
+   a hosted service is configured with webhook secret and GitHub App auth and
+   posts the deployment callback review.
+
 Blocked interpretation for a fresh or drifted setup:
 
 1. GitHub App slug `ao-kernel-live-adapter-gate` is not visible.
@@ -134,6 +147,29 @@ GitHub payload with trusted context proving the approved workflow identity,
 ready protected prerequisite attestation, `main`, no pull-request context, and
 closed live-execution/support/production-claim boundaries. Missing enriched
 context must produce `reject`, not approval.
+
+The GPP-2p service scaffold defines the webhook/callback boundary that a hosted
+service can wrap:
+
+1. verify `X-Hub-Signature-256` with a runtime webhook secret;
+2. reject non-`deployment_protection_rule` events before policy evaluation;
+3. evaluate the policy decision;
+4. build the callback request for GitHub's custom deployment protection review
+   endpoint;
+5. attach GitHub App authentication outside the repository and POST the
+   callback request.
+
+Local smoke validation is allowed with fixtures:
+
+```bash
+python3 scripts/live_adapter_gate_policy_service_smoke.py \
+  --payload <deployment-protection-payload.json> \
+  --allow-unsigned-fixture \
+  --artifact-path /tmp/live-adapter-gate-policy-service-callback-request.v1.json \
+  --output text
+```
+
+Do not use `--allow-unsigned-fixture` in the hosted service.
 
 ### 3. Attach the Deployment Protection Rule
 
@@ -296,9 +332,10 @@ If the selected deployment protection app is attached but does not respond:
 
 1. do not bypass the environment gate;
 2. do not repeatedly dispatch waiting workflow runs;
-3. deploy or configure the app webhook/policy service so it evaluates
-   `ao_kernel.live_adapter_gate_policy` or an equivalent fail-closed policy and
-   returns an explicit approve, deny, timeout, or failure decision;
+3. deploy or configure the app webhook/policy service so it verifies GitHub
+   webhook signatures, evaluates the repo-owned policy modules or an
+   equivalent fail-closed policy, attaches GitHub App auth outside the repo,
+   and returns an explicit approve, deny, timeout, or failure decision;
 4. rerun protected workflow evidence from `main` only after the service is
    expected to respond.
 

--- a/scripts/live_adapter_gate_policy_service_smoke.py
+++ b/scripts/live_adapter_gate_policy_service_smoke.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Build a protected live-adapter policy service callback artifact locally."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel.live_adapter_gate_policy_service import (  # noqa: E402
+    GITHUB_DEPLOYMENT_PROTECTION_EVENT,
+    POLICY_SERVICE_ARTIFACT,
+    build_live_adapter_gate_policy_service_result,
+    github_webhook_signature,
+    render_live_adapter_gate_policy_service_text,
+    write_live_adapter_gate_policy_service_result,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--payload",
+        type=Path,
+        required=True,
+        help="Path to a deployment_protection_rule webhook or enriched policy payload JSON.",
+    )
+    parser.add_argument(
+        "--artifact-path",
+        type=Path,
+        default=Path(POLICY_SERVICE_ARTIFACT),
+        help="Path for the service callback artifact.",
+    )
+    parser.add_argument("--output", choices=("json", "text"), default="json", help="Stdout render mode.")
+    parser.add_argument("--event", default=GITHUB_DEPLOYMENT_PROTECTION_EVENT, help="X-GitHub-Event header value.")
+    parser.add_argument("--delivery-id", default="local-fixture", help="X-GitHub-Delivery header value.")
+    parser.add_argument("--signature", default=None, help="X-Hub-Signature-256 header value.")
+    parser.add_argument(
+        "--webhook-secret-env",
+        default=None,
+        help="Environment variable that contains the webhook secret for signature verification.",
+    )
+    parser.add_argument(
+        "--sign-fixture-with-secret-env",
+        default=None,
+        help="Environment variable used to sign the local fixture before verification.",
+    )
+    parser.add_argument(
+        "--allow-unsigned-fixture",
+        action="store_true",
+        help="Skip signature verification for local fixture evaluation only.",
+    )
+    parser.add_argument(
+        "--fail-on-blocked",
+        action="store_true",
+        help="Return exit code 1 when the service result is blocked.",
+    )
+    return parser
+
+
+def _env_secret(name: str | None) -> str | None:
+    """Return an environment secret by name without printing it."""
+
+    if name is None:
+        return None
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"environment variable {name} is not set")
+    return value
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    body = args.payload.read_bytes()
+    webhook_secret = _env_secret(args.webhook_secret_env)
+    signature = args.signature
+    signing_secret = _env_secret(args.sign_fixture_with_secret_env)
+    if signing_secret is not None:
+        signature = github_webhook_signature(signing_secret, body)
+        if webhook_secret is None:
+            webhook_secret = signing_secret
+
+    require_signature = not args.allow_unsigned_fixture
+    headers = {
+        "X-GitHub-Event": args.event,
+        "X-GitHub-Delivery": args.delivery_id,
+    }
+    if signature is not None:
+        headers["X-Hub-Signature-256"] = signature
+
+    result = build_live_adapter_gate_policy_service_result(
+        body,
+        headers,
+        webhook_secret=webhook_secret,
+        require_signature=require_signature,
+    )
+    write_live_adapter_gate_policy_service_result(args.artifact_path, result)
+
+    if args.output == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(render_live_adapter_gate_policy_service_text(result))
+
+    if args.fail_on_blocked and result["status"] == "blocked":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,8 +30,8 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/525"
-    assert payload["current_wp"]["exit_decision"] == "policy_decision_core_ready_service_not_deployed"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/527"
+    assert payload["current_wp"]["exit_decision"] == "policy_webhook_service_scaffold_ready_service_not_deployed"
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
         item["id"] == "GPP-2a" and item["decision"] == "still_blocked_protected_prerequisites_missing"
@@ -113,20 +113,26 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2p"
+        and item["decision"] == "policy_webhook_service_scaffold_ready_service_not_deployed"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/527"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
-        "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook so it calls the repo-owned policy decision core or an equivalent fail-closed policy",
+        "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
         "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
     ]
     assert payload["blocked_wps"] == [
         {
             "id": "GPP-2",
             "reason": (
-                "repo-owned deployment-protection policy decision core is ready, but the GitHub App "
-                "webhook/policy service is not yet deployed or configured to respond to protected "
-                "deployment callbacks"
+                "repo-owned policy webhook service scaffold is ready, but the GitHub App service is not yet "
+                "deployed/configured with webhook secret and GitHub App auth to post deployment callback reviews"
             ),
         }
     ]
@@ -142,11 +148,17 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"])
     assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
     assert any(
-        action == "deploy or configure the deployment-protection policy service response path before any further live-adapter runtime work"
+        action
+        == "deploy or configure the deployment-protection policy service using the repo-owned service scaffold before any further live-adapter runtime work"
         for action in payload["next_allowed_actions"]
     )
     assert any(
         action == "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "use scripts/live_adapter_gate_policy_service_smoke.py only for local webhook/callback artifact validation, not live callback posting"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -247,9 +259,9 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/525"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/527"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
-    assert payload["current_wp"]["exit_decision"] == "policy_decision_core_ready_service_not_deployed"
+    assert payload["current_wp"]["exit_decision"] == "policy_webhook_service_scaffold_ready_service_not_deployed"
     assert payload["support_widening_allowed"] is False
 
 
@@ -279,7 +291,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "Blocked work packages:\n- GPP-2: repo-owned deployment-protection policy decision core is ready" in rendered
+    assert "Blocked work packages:\n- GPP-2: repo-owned policy webhook service scaffold is ready" in rendered
     assert "divergence: 0\t0" in rendered
 
 

--- a/tests/test_live_adapter_gate_policy_service.py
+++ b/tests/test_live_adapter_gate_policy_service.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from ao_kernel.live_adapter_gate_policy import EXPECTED_WORKFLOW_NAME, EXPECTED_WORKFLOW_PATH
+from ao_kernel.live_adapter_gate_policy_service import (
+    GITHUB_DEPLOYMENT_PROTECTION_EVENT,
+    build_live_adapter_gate_policy_service_result,
+    github_webhook_signature,
+    verify_github_webhook_signature,
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _approved_payload() -> dict[str, object]:
+    return {
+        "environment": "ao-kernel-live-adapter-gate",
+        "event": "workflow_dispatch",
+        "sha": "abc123",
+        "ref": "refs/heads/main",
+        "deployment_callback_url": (
+            "https://api.github.com/repos/Halildeu/ao-kernel/actions/runs/25020015357/"
+            "deployment_protection_rule"
+        ),
+        "repository": {"full_name": "Halildeu/ao-kernel"},
+        "pull_requests": [],
+        "verified_context": {
+            "workflow_name": EXPECTED_WORKFLOW_NAME,
+            "workflow_path": EXPECTED_WORKFLOW_PATH,
+            "prerequisites_ready": True,
+            "attestation_overall_status": "ready",
+            "live_execution_allowed": False,
+            "support_widening_allowed": False,
+            "production_platform_claim_allowed": False,
+        },
+    }
+
+
+def _body(payload: dict[str, object]) -> bytes:
+    return json.dumps(payload, sort_keys=True).encode("utf-8")
+
+
+def _headers(body: bytes, *, secret: str = "secret", event: str = GITHUB_DEPLOYMENT_PROTECTION_EVENT) -> dict[str, str]:
+    return {
+        "X-GitHub-Event": event,
+        "X-GitHub-Delivery": "delivery-1",
+        "X-Hub-Signature-256": github_webhook_signature(secret, body),
+    }
+
+
+def test_signature_matches_github_docs_vector() -> None:
+    body = b"Hello, World!"
+    secret = "It's a Secret to Everybody"
+    expected = "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17"
+
+    assert github_webhook_signature(secret, body) == expected
+    assert verify_github_webhook_signature(body, secret, expected) is True
+    assert verify_github_webhook_signature(body, "wrong", expected) is False
+
+
+def test_service_blocks_missing_required_signature() -> None:
+    body = _body(_approved_payload())
+
+    result = build_live_adapter_gate_policy_service_result(
+        body,
+        {"X-GitHub-Event": GITHUB_DEPLOYMENT_PROTECTION_EVENT},
+        webhook_secret="secret",
+    )
+
+    assert result["status"] == "blocked"
+    assert result["should_post_callback"] is False
+    assert result["decision"] is None
+    assert "live_gate_policy_service_signature_invalid" in result["findings"]
+
+
+def test_service_blocks_wrong_event_before_policy_evaluation() -> None:
+    body = _body(_approved_payload())
+
+    result = build_live_adapter_gate_policy_service_result(
+        body,
+        _headers(body, event="push"),
+        webhook_secret="secret",
+    )
+
+    assert result["status"] == "blocked"
+    assert result["should_post_callback"] is False
+    assert result["decision"] is None
+    assert "live_gate_policy_service_wrong_event" in result["findings"]
+
+
+def test_service_blocks_malformed_json_before_policy_evaluation() -> None:
+    body = b"{not-json"
+
+    result = build_live_adapter_gate_policy_service_result(
+        body,
+        _headers(body),
+        webhook_secret="secret",
+    )
+
+    assert result["status"] == "blocked"
+    assert result["should_post_callback"] is False
+    assert result["decision"] is None
+    assert "live_gate_policy_service_invalid_json" in result["findings"]
+
+
+def test_service_builds_rejected_callback_for_raw_webhook_payload() -> None:
+    payload = _approved_payload()
+    payload.pop("verified_context")
+    body = _body(payload)
+
+    result = build_live_adapter_gate_policy_service_result(
+        body,
+        _headers(body),
+        webhook_secret="secret",
+        generated_at="2026-04-28T00:00:00Z",
+    )
+
+    assert result["status"] == "callback_ready"
+    assert result["should_post_callback"] is True
+    assert result["signature_verified"] is True
+    assert result["decision"] is not None
+    assert result["decision"]["decision"] == "reject"
+    assert result["callback_request"]["method"] == "POST"
+    assert result["callback_request"]["url"] == payload["deployment_callback_url"]
+    assert result["callback_request"]["json"] == {
+        "environment_name": "ao-kernel-live-adapter-gate",
+        "state": "rejected",
+        "comment": (
+            "ao-kernel live-adapter gate policy decision: reject. "
+            "Deployment-protection policy rejected the request fail-closed. "
+            "Findings: live_gate_policy_missing_workflow_identity, "
+            "live_gate_policy_prerequisites_not_ready, live_gate_policy_live_execution_open, "
+            "live_gate_policy_support_boundary_open"
+        ),
+    }
+    assert result["callback_request"]["authorization_required"] is True
+
+
+def test_service_builds_approved_callback_for_verified_closed_context() -> None:
+    payload = _approved_payload()
+    body = _body(payload)
+
+    result = build_live_adapter_gate_policy_service_result(
+        body,
+        _headers(body),
+        webhook_secret="secret",
+        generated_at="2026-04-28T00:00:00Z",
+    )
+
+    assert result["status"] == "callback_ready"
+    assert result["should_post_callback"] is True
+    assert result["decision"] is not None
+    assert result["decision"]["decision"] == "approve_contract_gate"
+    assert result["decision"]["live_execution_allowed"] is False
+    assert result["decision"]["support_widening_allowed"] is False
+    assert result["decision"]["production_platform_claim_allowed"] is False
+    assert result["callback_request"]["json"] is not None
+    assert result["callback_request"]["json"]["state"] == "approved"
+    assert result["callback_request"]["json"]["environment_name"] == "ao-kernel-live-adapter-gate"
+
+
+def test_service_cli_writes_callback_artifact_for_unsigned_fixture(tmp_path: Path) -> None:
+    payload_path = tmp_path / "payload.json"
+    artifact_path = tmp_path / "service.json"
+    payload_path.write_text(json.dumps(_approved_payload(), sort_keys=True), encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/live_adapter_gate_policy_service_smoke.py",
+            "--payload",
+            str(payload_path),
+            "--artifact-path",
+            str(artifact_path),
+            "--allow-unsigned-fixture",
+            "--output",
+            "text",
+        ],
+        cwd=_repo_root(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert "status: callback_ready" in completed.stdout
+    assert artifact["status"] == "callback_ready"
+    assert artifact["signature_verified"] is None
+    assert artifact["callback_request"]["json"]["state"] == "approved"


### PR DESCRIPTION
## Summary
- Add a fail-closed webhook service boundary for the ao-kernel live-adapter deployment protection gate.
- Verify GitHub X-Hub-Signature-256 payload signatures and accept only deployment_protection_rule events.
- Build the GitHub deployment protection callback request artifact without performing network POSTs.
- Update GPP status/runbook records to mark the webhook scaffold ready while keeping GPP-2 blocked until hosted service deploy/config.

## Safety boundaries
- No live adapter execution.
- No secrets.AO_CLAUDE_CODE_CLI_AUTH usage or secret value readback.
- No GitHub callback POST from tests or default CLI.
- No support widening.
- No production platform claim.
- Protected workflow is not redispatched.

## Validation
- python3 -m json.tool .claude/plans/gpp_status.v1.json >/tmp/gpp_status_check.json
- pytest -q tests/test_live_adapter_gate_policy_service.py
- pytest -q tests/test_live_adapter_gate_policy_service.py tests/test_live_adapter_gate_policy.py tests/test_gpp_next.py
- pytest -q tests/test_live_adapter_gate_contract.py tests/test_live_adapter_gate_policy.py tests/test_live_adapter_gate_policy_service.py tests/test_gpp_next.py
- python3 -m ruff check ao_kernel/live_adapter_gate_policy.py ao_kernel/live_adapter_gate_policy_service.py scripts/live_adapter_gate_policy_decision.py scripts/live_adapter_gate_policy_service_smoke.py tests/test_live_adapter_gate_policy.py tests/test_live_adapter_gate_policy_service.py tests/test_gpp_next.py
- python3 -m mypy ao_kernel/live_adapter_gate_policy.py ao_kernel/live_adapter_gate_policy_service.py scripts/live_adapter_gate_policy_decision.py scripts/live_adapter_gate_policy_service_smoke.py
- python3 scripts/gpp_next.py
- git diff --check
- pytest -q (3121 passed, 2 skipped)

Closes #527