### PR TITLE
GPP-2q: add live gate policy webhook runtime

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 policy webhook service scaffold ready; service deployment/config still blocked
+**Status:** GPP-2 deployable policy webhook runtime ready; hosted service deployment/config still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#527](https://github.com/Halildeu/ao-kernel/issues/527)
-for deployment protection policy webhook service scaffold
-**Current slice record:** `.claude/plans/GPP-2p-POLICY-WEBHOOK-SERVICE-SCAFFOLD.md`
+**Current slice issue:** [#529](https://github.com/Halildeu/ao-kernel/issues/529)
+for deployable deployment protection policy webhook runtime
+**Current slice record:** `.claude/plans/GPP-2q-POLICY-WEBHOOK-RUNTIME.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -142,6 +142,14 @@ Last live verification on current `origin/main` showed:
     without posting to GitHub. GPP-2 remains blocked until a hosted service is
     configured with webhook secret and GitHub App auth and new protected
     workflow evidence is collected.
+33. GPP-2q adds a deployable WSGI runtime around that service boundary. It
+    exposes `ao_kernel.live_adapter_gate_policy_runtime:application`, accepts
+    `POST /github/deployment-protection`, reads webhook/GitHub App auth only
+    from runtime environment or secret-file paths, mints installation tokens,
+    and posts redacted deployment protection callback review results. GPP-2
+    remains blocked until this runtime or an equivalent service is publicly
+    hosted, configured in the GitHub App webhook settings, and protected
+    workflow evidence confirms an explicit app response.
 
 ## 3. Current Verdict
 
@@ -197,7 +205,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2n` | Completed / no support widening | Protected live gate workflow evidence | protected workflow reached environment gate and failed closed because policy response is missing |
 | `GPP-2o` | Completed / no support widening | Deployment protection policy decision core | repo-owned decision core and CLI ready; service is not yet deployed/configured |
 | `GPP-2p` | Completed / no support widening | Deployment protection policy webhook service scaffold | repo-owned webhook/callback request scaffold ready; service is not yet deployed/configured |
-| `GPP-2` | Blocked / service deployment/config missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be deployed/configured with webhook secret and GitHub App auth before further runtime work |
+| `GPP-2q` | Completed / no support widening | Deployable policy webhook runtime | repo-owned WSGI runtime and GitHub App callback POST path ready; hosted service is not yet deployed/configured |
+| `GPP-2` | Blocked / hosted service deployment/config missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be hosted/configured with webhook URL, webhook secret, and GitHub App auth before further runtime work |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -326,8 +335,9 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2p; policy decision core and webhook scaffold
-exist, but service deployment/configuration is still missing.
+**Status:** blocked after GPP-2q; policy decision core, webhook scaffold, and
+deployable WSGI runtime exist, but hosted service deployment/configuration is
+still missing.
 
 **Entry criteria:**
 
@@ -343,7 +353,9 @@ GPP-2o adds the repo-owned policy decision core and CLI that the service can
 use, but no webhook/service deployment or GitHub callback review evidence has
 been recorded. GPP-2p adds the repo-owned webhook service boundary and callback
 request artifact, but no hosted endpoint, webhook secret, GitHub App auth, or
-actual callback POST evidence has been recorded.
+actual callback POST evidence has been recorded. GPP-2q adds a deployable WSGI
+runtime plus GitHub App installation-token callback POST path, but no public
+endpoint has been hosted or configured in the GitHub App webhook settings.
 
 **Acceptance criteria:**
 
@@ -600,7 +612,9 @@ a policy decision, and GPP-2o adds the repo-owned decision core that can return
 `approve_contract_gate` or `reject` once it is placed behind the GitHub App
 webhook. GPP-2p adds the repo-owned webhook service scaffold that verifies
 GitHub signatures, constrains the event, and builds the deployment callback
-request without posting it. GPP-2b
+request without posting it. GPP-2q adds the deployable WSGI runtime and GitHub
+App callback POST path, but that runtime has not yet been hosted or configured
+as the GitHub App webhook URL. GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
 metadata prerequisite level: the protected environment exists, admin bypass is
@@ -620,9 +634,10 @@ support for that model, GPP-2j refreshes blocked metadata, and GPP-2k adds the
 operator provisioning runbook.
 
 The next GPP-2 action is to deploy or configure the
-`ao-kernel-live-adapter-gate` deployment protection app/policy service so it
-receives protected deployment callbacks, enriches them with trusted context,
-evaluates the repo-owned policy modules or an equivalent fail-closed policy,
+`ao-kernel-live-adapter-gate` deployment protection app/policy service using
+`ao_kernel.live_adapter_gate_policy_runtime:application` or an equivalent
+fail-closed implementation so it receives protected deployment callbacks,
+enriches them with trusted context, evaluates the repo-owned policy modules,
 attaches GitHub App auth outside the repo, and posts an explicit GitHub
 deployment review callback. Do not repeatedly dispatch
 `.github/workflows/live-adapter-gate.yml` until that service is expected to
@@ -647,6 +662,7 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | Deployment protection app installed but inactive | Protected workflow waits forever and produces no artifacts | Treat waiting/cancelled runs as fail-closed; activate policy service before repeating evidence dispatch |
 | Policy decision core exists but is not deployed | Protected workflow still receives no app response | Treat GPP-2o as implementation readiness only; deploy/configure webhook before rerunning evidence |
 | Webhook scaffold exists but has no runtime auth | Callback artifact exists but GitHub still receives no review | Treat GPP-2p as implementation readiness only; deploy with webhook secret and GitHub App auth before rerunning evidence |
+| Webhook runtime exists but is not hosted | GitHub App still cannot receive or answer deployment callbacks | Treat GPP-2q as deployability readiness only; configure the hosted endpoint and GitHub App webhook before rerunning evidence |
 
 ## 19. Tracking Log
 
@@ -690,3 +706,5 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-28 | GPP-2o decision core added | `ao_kernel/live_adapter_gate_policy.py` and `scripts/live_adapter_gate_policy_decision.py` add fail-closed policy evaluation; service deployment/configuration remains required before rerunning protected workflow evidence. |
 | 2026-04-28 | GPP-2p issue opened | Issue [#527](https://github.com/Halildeu/ao-kernel/issues/527) tracks the repo-owned deployment protection policy webhook service scaffold. |
 | 2026-04-28 | GPP-2p webhook scaffold added | `ao_kernel/live_adapter_gate_policy_service.py` and `scripts/live_adapter_gate_policy_service_smoke.py` add webhook signature/event checks and callback request artifact generation; hosted service deployment/configuration remains required before rerunning protected workflow evidence. |
+| 2026-04-28 | GPP-2q issue opened | Issue [#529](https://github.com/Halildeu/ao-kernel/issues/529) tracks the deployable deployment protection policy webhook runtime. |
+| 2026-04-28 | GPP-2q webhook runtime added | `ao_kernel/live_adapter_gate_policy_runtime.py` exposes a WSGI service entrypoint and GitHub App installation-token callback POST path; public hosting and GitHub App webhook configuration remain required before rerunning protected workflow evidence. |

--- a/.claude/plans/GPP-2q-POLICY-WEBHOOK-RUNTIME.md
+++ b/.claude/plans/GPP-2q-POLICY-WEBHOOK-RUNTIME.md
@@ -1,0 +1,172 @@
+# GPP-2q - Deployable Policy Webhook Runtime
+
+**Status:** closeout candidate
+**Date:** 2026-04-28
+**Authority:** `origin/main` at `963b210`
+**Issue:** [#529](https://github.com/Halildeu/ao-kernel/issues/529)
+**Branch:** `codex/gpp-2q-policy-webhook-runtime`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2q-policy-webhook-runtime`
+**Program head:** `GPP-2` blocked on hosted policy service deployment/configuration
+**Support impact:** none
+**Runtime impact:** no live adapter call; no `AO_CLAUDE_CODE_CLI_AUTH`
+reference; no protected workflow dispatch
+
+## 1. Purpose
+
+GPP-2p added the webhook service boundary, but intentionally stopped before a
+hosted runtime could receive GitHub deliveries and post deployment protection
+reviews. GPP-2 still needs a deployable service wrapper that can run behind the
+`ao-kernel-live-adapter-gate` GitHub App webhook.
+
+Decision:
+
+```text
+policy_webhook_runtime_ready_service_not_deployed
+```
+
+This slice makes the repo-owned policy service deployable. It does not deploy a
+public endpoint, configure a webhook URL, read secret values back, dispatch the
+protected workflow, invoke `claude`, widen support, or claim production-platform
+readiness.
+
+## 2. Implemented Surface
+
+Code:
+
+1. `ao_kernel/live_adapter_gate_policy_runtime.py`
+   - exposes `policy_runtime_wsgi_app` / `application` as a WSGI entrypoint;
+   - serves `GET /healthz`;
+   - accepts `POST /github/deployment-protection`;
+   - reads the webhook secret from `AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET`;
+   - reads GitHub App auth config from `AO_GITHUB_APP_ID` plus either
+     `AO_GITHUB_APP_PRIVATE_KEY_PEM` or `AO_GITHUB_APP_PRIVATE_KEY_PATH`;
+   - verifies signed GitHub deliveries through the existing GPP-2p service;
+   - extracts the GitHub App installation id from the webhook payload;
+   - mints an installation access token with a GitHub App JWT;
+   - posts the approved or rejected deployment protection callback review;
+   - returns only redacted runtime status, never token/private key/secret
+     material.
+2. `pyproject.toml`
+   - adds optional extra `ao-kernel[policy-service]` for `PyJWT[crypto]`.
+3. `tests/test_live_adapter_gate_policy_runtime.py`
+   - covers approved callback posting for verified closed context;
+   - covers rejected callback posting for raw fail-closed webhook payloads;
+   - covers missing installation id;
+   - covers GitHub App token/callback POST flow without secret echo;
+   - covers missing optional dependency reporting;
+   - covers WSGI health and bad-signature responses.
+
+## 3. Runtime Contract
+
+Hosted service configuration must provide these environment variables:
+
+```text
+AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+or:
+
+```text
+AO_GITHUB_APP_PRIVATE_KEY_PATH
+```
+
+Optional:
+
+```text
+AO_GITHUB_API_URL
+AO_POLICY_SERVICE_MAX_BODY_BYTES
+```
+
+The deployment target must install:
+
+```bash
+pip install "ao-kernel[policy-service]"
+```
+
+Then run a WSGI server against:
+
+```text
+ao_kernel.live_adapter_gate_policy_runtime:application
+```
+
+The GitHub App webhook URL should point to:
+
+```text
+https://<host>/github/deployment-protection
+```
+
+The service remains fail-closed:
+
+1. invalid or missing webhook signatures return blocked status;
+2. non-`deployment_protection_rule` events return blocked status;
+3. malformed JSON returns blocked status;
+4. missing installation id blocks callback posting;
+5. GitHub token or callback POST failures block the runtime result;
+6. policy rejection still posts an explicit `rejected` review when GitHub auth
+   is available.
+
+## 4. Current Decision
+
+Resolved by this slice:
+
+1. repo-owned WSGI entrypoint exists for the GitHub App webhook;
+2. callback POST execution is implemented with GitHub App installation auth;
+3. runtime responses are redacted and do not echo secrets;
+4. optional dependency requirements are explicit;
+5. fail-closed runtime behavior is covered by tests.
+
+Still blocked:
+
+1. no public hosted endpoint is deployed;
+2. GitHub App webhook URL has not been configured to the hosted endpoint;
+3. hosted runtime secrets have not been configured by an approved secret path;
+4. no live GitHub deployment callback review has been posted by the hosted
+   service;
+5. no new protected workflow evidence artifacts exist after policy response;
+6. live adapter execution remains disabled.
+
+Still closed:
+
+1. `live_execution_allowed=false`;
+2. `support_widening=false`;
+3. `production_platform_claim=false`.
+
+## 5. Next Required Action
+
+Deploy the WSGI runtime behind the `ao-kernel-live-adapter-gate` GitHub App
+webhook and configure the app with:
+
+1. webhook URL `/github/deployment-protection`;
+2. webhook secret matching `AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET`;
+3. GitHub App id and private key material stored only in the hosting platform's
+   secret manager;
+4. `ao-kernel[policy-service]` installed so JWT signing works.
+
+Only after that service is expected to respond should the protected workflow
+evidence slice be rerun from `main`.
+
+## 6. Validation
+
+```bash
+pytest -q tests/test_live_adapter_gate_policy_runtime.py tests/test_live_adapter_gate_policy_service.py
+python3 -m ruff check ao_kernel/live_adapter_gate_policy_runtime.py tests/test_live_adapter_gate_policy_runtime.py pyproject.toml
+python3 -m mypy ao_kernel/live_adapter_gate_policy_runtime.py
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_live_adapter_gate_policy_runtime.py tests/test_live_adapter_gate_policy_service.py tests/test_gpp_next.py
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Expected closeout decision:
+
+```text
+policy_webhook_runtime_ready_service_not_deployed
+```
+
+Recorded closeout decision:
+
+```text
+policy_webhook_runtime_ready_service_not_deployed
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,11 +9,11 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/527",
-    "exit_decision": "policy_webhook_service_scaffold_ready_service_not_deployed",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/529",
+    "exit_decision": "policy_webhook_runtime_ready_service_not_deployed",
     "ready_after": "deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, posts callback reviews, and produces protected workflow evidence with live_execution_allowed=false",
     "allowed_scope": [
-      "use the repo-owned policy service scaffold to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
+      "use the repo-owned policy service runtime to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
       "repeat protected workflow evidence collection from main after the policy service responds",
       "keep live execution disabled until protected workflow evidence explicitly permits a later live run"
     ]
@@ -122,16 +122,22 @@
       "decision": "policy_webhook_service_scaffold_ready_service_not_deployed",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/527",
       "record": ".claude/plans/GPP-2p-POLICY-WEBHOOK-SERVICE-SCAFFOLD.md"
+    },
+    {
+      "id": "GPP-2q",
+      "decision": "policy_webhook_runtime_ready_service_not_deployed",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/529",
+      "record": ".claude/plans/GPP-2q-POLICY-WEBHOOK-RUNTIME.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned policy webhook service scaffold is ready, but the GitHub App service is not yet deployed/configured with webhook secret and GitHub App auth to post deployment callback reviews"
+      "reason": "repo-owned policy webhook runtime is ready, but the GitHub App service is not yet hosted/configured with webhook URL, webhook secret, and GitHub App auth to post deployment callback reviews"
     }
   ],
   "pending_external_actions": [
-    "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
+    "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned runtime with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
     "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly"
   ],
   "support_widening_allowed": false,
@@ -186,12 +192,13 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "deploy or configure the deployment-protection policy service using the repo-owned service scaffold before any further live-adapter runtime work",
+    "deploy or configure the deployment-protection policy service using the repo-owned WSGI runtime before any further live-adapter runtime work",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
     "use Claude MCP consultation only as advisory review, not release authority",
     "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active",
     "use scripts/live_adapter_gate_policy_service_smoke.py only for local webhook/callback artifact validation, not live callback posting",
     "use scripts/live_adapter_gate_policy_decision.py only for policy callback decision evaluation, not live adapter execution",
+    "configure ao_kernel.live_adapter_gate_policy_runtime:application only with runtime secret manager values, never committed or echoed secret material",
     "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it",
     "keep fork and pull_request contexts away from protected credentials",
     "preserve live_execution_allowed=false until protected runtime evidence permits a later live run",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,3 +271,4 @@ jobs:
           pip_install -e ".[mcp]"      && python -c "import mcp; print('mcp OK')"
           pip_install -e ".[mcp-http]" && python -c "import starlette, uvicorn; print('mcp-http OK')"
           pip_install -e ".[metrics]"  && python -c "import prometheus_client; print('metrics OK')"
+          pip_install -e ".[policy-service]" && python -c "import jwt; print('policy-service OK')"

--- a/ao_kernel/live_adapter_gate_policy_runtime.py
+++ b/ao_kernel/live_adapter_gate_policy_runtime.py
@@ -1,0 +1,581 @@
+"""Deployable runtime wrapper for the protected live-adapter gate policy service."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Protocol, TypedDict, cast
+
+from ao_kernel.live_adapter_gate_policy_service import (
+    LiveAdapterGateDeploymentReviewRequest,
+    LiveAdapterGatePolicyServiceResult,
+    build_live_adapter_gate_policy_service_result,
+)
+
+POLICY_RUNTIME_PROGRAM_ID = "GPP-2q"
+DEFAULT_WEBHOOK_PATH = "/github/deployment-protection"
+DEFAULT_HEALTH_PATH = "/healthz"
+DEFAULT_GITHUB_API_URL = "https://api.github.com"
+DEFAULT_MAX_BODY_BYTES = 1024 * 1024
+DEFAULT_HTTP_TIMEOUT_SECONDS = 10.0
+DEFAULT_GITHUB_APP_JWT_TTL_SECONDS = 540
+
+WEBHOOK_SECRET_ENV = "AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET"
+GITHUB_APP_ID_ENV = "AO_GITHUB_APP_ID"
+GITHUB_APP_PRIVATE_KEY_ENV = "AO_GITHUB_APP_PRIVATE_KEY_PEM"
+GITHUB_APP_PRIVATE_KEY_PATH_ENV = "AO_GITHUB_APP_PRIVATE_KEY_PATH"
+GITHUB_API_URL_ENV = "AO_GITHUB_API_URL"
+MAX_BODY_BYTES_ENV = "AO_POLICY_SERVICE_MAX_BODY_BYTES"
+
+
+class PolicyRuntimeError(RuntimeError):
+    """Base runtime error with a stable finding code."""
+
+    def __init__(self, finding_code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.finding_code = finding_code
+        self.detail = detail
+
+
+class PolicyRuntimeConfigError(PolicyRuntimeError):
+    """Runtime configuration is incomplete or invalid."""
+
+
+class PolicyRuntimeCallbackError(PolicyRuntimeError):
+    """GitHub callback POST failed."""
+
+    def __init__(self, finding_code: str, detail: str, *, status_code: int | None = None) -> None:
+        super().__init__(finding_code, detail)
+        self.status_code = status_code
+
+
+class CallbackPostResult(TypedDict):
+    """Sanitized callback POST outcome."""
+
+    status: str
+    status_code: int | None
+    finding_code: str | None
+    detail: str
+
+
+class PolicyRuntimeResult(TypedDict):
+    """Combined webhook policy and callback-post result."""
+
+    schema_version: str
+    program_id: str
+    status: str
+    finding_code: str | None
+    reason: str
+    service_result: LiveAdapterGatePolicyServiceResult
+    callback_post: CallbackPostResult | None
+
+
+HttpTransport = Callable[[str, str, Mapping[str, str], bytes | None, float], tuple[int, bytes]]
+
+
+class GithubCallbackClient(Protocol):
+    """Minimal client interface used by the webhook runtime."""
+
+    def post_deployment_protection_review(
+        self,
+        *,
+        installation_id: int,
+        callback_request: LiveAdapterGateDeploymentReviewRequest,
+    ) -> CallbackPostResult:
+        """Post a deployment protection review to GitHub."""
+
+
+@dataclass(frozen=True)
+class GithubAppConfig:
+    """GitHub App authentication config loaded from runtime-only secrets."""
+
+    app_id: str
+    private_key_pem: str
+    api_url: str = DEFAULT_GITHUB_API_URL
+
+
+@dataclass(frozen=True)
+class GithubAppDeploymentReviewClient:
+    """GitHub App client for posting custom deployment protection reviews."""
+
+    config: GithubAppConfig
+    transport: HttpTransport | None = None
+    timeout_seconds: float = DEFAULT_HTTP_TIMEOUT_SECONDS
+    now_seconds: Callable[[], int] = lambda: int(time.time())
+
+    def _transport(self) -> HttpTransport:
+        return self.transport or urllib_http_transport
+
+    def _installation_token(self, installation_id: int) -> str:
+        app_jwt = build_github_app_jwt(
+            app_id=self.config.app_id,
+            private_key_pem=self.config.private_key_pem,
+            now_seconds=self.now_seconds(),
+        )
+        url = f"{self.config.api_url.rstrip('/')}/app/installations/{installation_id}/access_tokens"
+        status_code, body = self._transport()(
+            "POST",
+            url,
+            {
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {app_jwt}",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            b"{}",
+            self.timeout_seconds,
+        )
+        if status_code < 200 or status_code >= 300:
+            raise PolicyRuntimeCallbackError(
+                "live_gate_policy_runtime_installation_token_failed",
+                f"GitHub installation token request failed with HTTP {status_code}.",
+                status_code=status_code,
+            )
+        payload = _decode_json_object(body)
+        token = payload.get("token")
+        if not isinstance(token, str) or not token:
+            raise PolicyRuntimeCallbackError(
+                "live_gate_policy_runtime_installation_token_missing",
+                "GitHub installation token response did not contain a token.",
+                status_code=status_code,
+            )
+        return token
+
+    def post_deployment_protection_review(
+        self,
+        *,
+        installation_id: int,
+        callback_request: LiveAdapterGateDeploymentReviewRequest,
+    ) -> CallbackPostResult:
+        """POST the callback request with a GitHub App installation token."""
+
+        callback_url = callback_request["url"]
+        callback_json = callback_request["json"]
+        if callback_url is None or callback_json is None:
+            raise PolicyRuntimeCallbackError(
+                "live_gate_policy_runtime_callback_request_missing",
+                "Policy service did not produce a callback URL and JSON body.",
+            )
+        installation_token = self._installation_token(installation_id)
+        request_body = json.dumps(callback_json, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        headers = {
+            **callback_request["headers"],
+            "Authorization": f"Bearer {installation_token}",
+            "Content-Type": "application/json",
+        }
+        status_code, _body = self._transport()("POST", callback_url, headers, request_body, self.timeout_seconds)
+        if status_code < 200 or status_code >= 300:
+            raise PolicyRuntimeCallbackError(
+                "live_gate_policy_runtime_callback_post_failed",
+                f"GitHub deployment protection callback failed with HTTP {status_code}.",
+                status_code=status_code,
+            )
+        return {
+            "status": "posted",
+            "status_code": status_code,
+            "finding_code": None,
+            "detail": "GitHub deployment protection callback review was posted.",
+        }
+
+
+def urllib_http_transport(
+    method: str,
+    url: str,
+    headers: Mapping[str, str],
+    body: bytes | None,
+    timeout_seconds: float,
+) -> tuple[int, bytes]:
+    """Perform one HTTP request with stdlib urllib."""
+
+    request = urllib.request.Request(url=url, data=body, headers=dict(headers), method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            return int(response.status), response.read()
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), exc.read()
+
+
+def build_github_app_jwt(
+    *,
+    app_id: str,
+    private_key_pem: str,
+    now_seconds: int | None = None,
+    ttl_seconds: int = DEFAULT_GITHUB_APP_JWT_TTL_SECONDS,
+) -> str:
+    """Build a GitHub App JWT using a runtime-provided private key."""
+
+    try:
+        jwt_module = cast(Any, __import__("jwt"))
+    except ImportError as exc:
+        raise PolicyRuntimeConfigError(
+            "live_gate_policy_runtime_pyjwt_missing",
+            "Install the policy-service extra so the hosted service can sign GitHub App JWTs.",
+        ) from exc
+
+    issued_at = int(time.time()) if now_seconds is None else now_seconds
+    payload = {
+        "iat": issued_at - 60,
+        "exp": issued_at + ttl_seconds,
+        "iss": app_id,
+    }
+    token = jwt_module.encode(payload, private_key_pem, algorithm="RS256")
+    return cast(str, token)
+
+
+def load_github_app_config(env: Mapping[str, str] | None = None) -> GithubAppConfig:
+    """Load GitHub App auth config from runtime environment variables."""
+
+    source = os.environ if env is None else env
+    app_id = _required_env(source, GITHUB_APP_ID_ENV)
+    private_key_pem = source.get(GITHUB_APP_PRIVATE_KEY_ENV)
+    private_key_path = source.get(GITHUB_APP_PRIVATE_KEY_PATH_ENV)
+    if private_key_pem is None and private_key_path:
+        try:
+            private_key_pem = Path(private_key_path).read_text(encoding="utf-8")
+        except OSError as exc:
+            raise PolicyRuntimeConfigError(
+                "live_gate_policy_runtime_private_key_read_failed",
+                f"Could not read GitHub App private key from {GITHUB_APP_PRIVATE_KEY_PATH_ENV}.",
+            ) from exc
+    if not private_key_pem:
+        raise PolicyRuntimeConfigError(
+            "live_gate_policy_runtime_private_key_missing",
+            f"Set {GITHUB_APP_PRIVATE_KEY_ENV} or {GITHUB_APP_PRIVATE_KEY_PATH_ENV} in the hosted service.",
+        )
+    return GithubAppConfig(
+        app_id=app_id,
+        private_key_pem=private_key_pem,
+        api_url=source.get(GITHUB_API_URL_ENV, DEFAULT_GITHUB_API_URL),
+    )
+
+
+def handle_live_adapter_gate_policy_webhook(
+    body: bytes,
+    headers: Mapping[str, str],
+    *,
+    webhook_secret: str,
+    github_client: GithubCallbackClient,
+    generated_at: str | None = None,
+) -> PolicyRuntimeResult:
+    """Evaluate one GitHub webhook delivery and post the callback review when ready."""
+
+    service_result = build_live_adapter_gate_policy_service_result(
+        body,
+        headers,
+        webhook_secret=webhook_secret,
+        require_signature=True,
+        generated_at=generated_at,
+    )
+    if not service_result["should_post_callback"]:
+        finding_code = service_result["finding_code"] or "live_gate_policy_runtime_service_blocked"
+        return _runtime_result(
+            status="blocked",
+            finding_code=finding_code,
+            reason="Policy service did not produce a callback request.",
+            service_result=service_result,
+            callback_post=None,
+        )
+
+    payload = _decode_json_object(body)
+    installation_id = extract_installation_id(payload)
+    if installation_id is None:
+        callback_post: CallbackPostResult = {
+            "status": "blocked",
+            "status_code": None,
+            "finding_code": "live_gate_policy_runtime_installation_id_missing",
+            "detail": "Webhook payload did not include a GitHub App installation id.",
+        }
+        return _runtime_result(
+            status="blocked",
+            finding_code=callback_post["finding_code"],
+            reason="Policy service could not authenticate a callback without an installation id.",
+            service_result=service_result,
+            callback_post=callback_post,
+        )
+
+    try:
+        callback_post = github_client.post_deployment_protection_review(
+            installation_id=installation_id,
+            callback_request=service_result["callback_request"],
+        )
+    except PolicyRuntimeCallbackError as exc:
+        callback_post = {
+            "status": "blocked",
+            "status_code": exc.status_code,
+            "finding_code": exc.finding_code,
+            "detail": exc.detail,
+        }
+        return _runtime_result(
+            status="blocked",
+            finding_code=exc.finding_code,
+            reason="Policy service could not post the GitHub deployment protection callback.",
+            service_result=service_result,
+            callback_post=callback_post,
+        )
+
+    return _runtime_result(
+        status="callback_posted",
+        finding_code=None,
+        reason="Policy service evaluated the webhook and posted a GitHub deployment protection callback.",
+        service_result=service_result,
+        callback_post=callback_post,
+    )
+
+
+def extract_installation_id(payload: Mapping[str, Any]) -> int | None:
+    """Extract the GitHub App installation id from a webhook payload."""
+
+    installation = payload.get("installation")
+    candidate: object
+    if isinstance(installation, Mapping):
+        candidate = installation.get("id")
+    else:
+        candidate = None
+    if candidate is None:
+        candidate = payload.get("installation_id")
+    if isinstance(candidate, bool):
+        return None
+    if isinstance(candidate, int) and candidate > 0:
+        return candidate
+    if isinstance(candidate, str) and candidate.isdigit():
+        parsed = int(candidate)
+        return parsed if parsed > 0 else None
+    return None
+
+
+def policy_runtime_wsgi_app(environ: Mapping[str, Any], start_response: Callable[[str, list[tuple[str, str]]], None]) -> Iterable[bytes]:
+    """WSGI entrypoint for hosted deployment-protection webhook services."""
+
+    method = str(environ.get("REQUEST_METHOD", "GET")).upper()
+    path = str(environ.get("PATH_INFO", "/"))
+    if method == "GET" and path == DEFAULT_HEALTH_PATH:
+        return _wsgi_json(start_response, 200, {"status": "ok", "program_id": POLICY_RUNTIME_PROGRAM_ID})
+    if method != "POST" or path != DEFAULT_WEBHOOK_PATH:
+        return _wsgi_json(start_response, 404, {"status": "not_found", "program_id": POLICY_RUNTIME_PROGRAM_ID})
+
+    try:
+        body = _read_wsgi_body(environ)
+        webhook_secret = _required_env(os.environ, WEBHOOK_SECRET_ENV)
+        config = load_github_app_config(os.environ)
+        result = handle_live_adapter_gate_policy_webhook(
+            body,
+            _wsgi_headers(environ),
+            webhook_secret=webhook_secret,
+            github_client=GithubAppDeploymentReviewClient(config),
+        )
+        return _wsgi_json(start_response, _status_code_for_runtime_result(result), _redacted_runtime_payload(result))
+    except PolicyRuntimeConfigError as exc:
+        return _wsgi_json(
+            start_response,
+            503,
+            {
+                "status": "blocked",
+                "program_id": POLICY_RUNTIME_PROGRAM_ID,
+                "finding_code": exc.finding_code,
+                "reason": exc.detail,
+            },
+        )
+    except PolicyRuntimeError as exc:
+        status_code = 413 if exc.finding_code == "live_gate_policy_runtime_body_too_large" else 500
+        return _wsgi_json(
+            start_response,
+            status_code,
+            {
+                "status": "blocked",
+                "program_id": POLICY_RUNTIME_PROGRAM_ID,
+                "finding_code": exc.finding_code,
+                "reason": exc.detail,
+            },
+        )
+
+
+application = policy_runtime_wsgi_app
+
+
+def _decode_json_object(body: bytes) -> dict[str, Any]:
+    payload = json.loads(body.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise PolicyRuntimeCallbackError(
+            "live_gate_policy_runtime_invalid_json",
+            "JSON body was not an object.",
+        )
+    return cast(dict[str, Any], payload)
+
+
+def _required_env(env: Mapping[str, str], name: str) -> str:
+    value = env.get(name)
+    if value:
+        return value
+    raise PolicyRuntimeConfigError(
+        "live_gate_policy_runtime_env_missing",
+        f"Set {name} in the hosted service runtime.",
+    )
+
+
+def _runtime_result(
+    *,
+    status: str,
+    finding_code: str | None,
+    reason: str,
+    service_result: LiveAdapterGatePolicyServiceResult,
+    callback_post: CallbackPostResult | None,
+) -> PolicyRuntimeResult:
+    return {
+        "schema_version": "1",
+        "program_id": POLICY_RUNTIME_PROGRAM_ID,
+        "status": status,
+        "finding_code": finding_code,
+        "reason": reason,
+        "service_result": service_result,
+        "callback_post": callback_post,
+    }
+
+
+def _status_code_for_runtime_result(result: PolicyRuntimeResult) -> int:
+    finding_code = result["finding_code"]
+    service_findings = set(result["service_result"]["findings"])
+    if result["status"] == "callback_posted":
+        return 202
+    if finding_code in {
+        "live_gate_policy_service_signature_invalid",
+        "live_gate_policy_service_signature_secret_missing",
+    } or service_findings.intersection(
+        {
+            "live_gate_policy_service_signature_invalid",
+            "live_gate_policy_service_signature_secret_missing",
+        }
+    ):
+        return 401
+    if finding_code in {
+        "live_gate_policy_service_wrong_event",
+        "live_gate_policy_service_invalid_json",
+        "live_gate_policy_runtime_installation_id_missing",
+    } or service_findings.intersection(
+        {
+            "live_gate_policy_service_wrong_event",
+            "live_gate_policy_service_invalid_json",
+        }
+    ):
+        return 400
+    return 502
+
+
+def _redacted_runtime_payload(result: PolicyRuntimeResult) -> dict[str, object]:
+    service_result = result["service_result"]
+    decision = service_result["decision"]
+    return {
+        "schema_version": result["schema_version"],
+        "program_id": result["program_id"],
+        "status": result["status"],
+        "finding_code": result["finding_code"],
+        "reason": result["reason"],
+        "event_name": service_result["event_name"],
+        "delivery_id": service_result["delivery_id"],
+        "signature_verified": service_result["signature_verified"],
+        "should_post_callback": service_result["should_post_callback"],
+        "policy_decision": decision["decision"] if decision is not None else None,
+        "github_review_state": decision["github_review_state"] if decision is not None else None,
+        "callback_post": result["callback_post"],
+        "findings": service_result["findings"],
+    }
+
+
+def _wsgi_headers(environ: Mapping[str, Any]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for key, value in environ.items():
+        if not key.startswith("HTTP_") or not isinstance(value, str):
+            continue
+        header_name = key.removeprefix("HTTP_").replace("_", "-")
+        headers[header_name] = value
+    if isinstance(environ.get("CONTENT_TYPE"), str):
+        headers["Content-Type"] = cast(str, environ["CONTENT_TYPE"])
+    return headers
+
+
+def _read_wsgi_body(environ: Mapping[str, Any]) -> bytes:
+    max_body_bytes = _positive_int_env(os.environ, MAX_BODY_BYTES_ENV, DEFAULT_MAX_BODY_BYTES)
+    content_length = _content_length(environ)
+    if content_length > max_body_bytes:
+        raise PolicyRuntimeError(
+            "live_gate_policy_runtime_body_too_large",
+            f"Webhook body exceeds configured limit of {max_body_bytes} bytes.",
+        )
+    body_stream = environ.get("wsgi.input")
+    read = getattr(body_stream, "read", None)
+    if not callable(read):
+        raise PolicyRuntimeError(
+            "live_gate_policy_runtime_body_stream_missing",
+            "WSGI input stream is missing.",
+        )
+    reader = cast(Callable[[int], bytes], read)
+    return reader(content_length)
+
+
+def _content_length(environ: Mapping[str, Any]) -> int:
+    value = environ.get("CONTENT_LENGTH")
+    if not isinstance(value, str) or not value:
+        return 0
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise PolicyRuntimeError(
+            "live_gate_policy_runtime_invalid_content_length",
+            "CONTENT_LENGTH is not an integer.",
+        ) from exc
+    if parsed < 0:
+        raise PolicyRuntimeError(
+            "live_gate_policy_runtime_invalid_content_length",
+            "CONTENT_LENGTH cannot be negative.",
+        )
+    return parsed
+
+
+def _positive_int_env(env: Mapping[str, str], name: str, default: int) -> int:
+    value = env.get(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise PolicyRuntimeConfigError(
+            "live_gate_policy_runtime_invalid_integer_env",
+            f"{name} must be an integer.",
+        ) from exc
+    if parsed <= 0:
+        raise PolicyRuntimeConfigError(
+            "live_gate_policy_runtime_invalid_integer_env",
+            f"{name} must be positive.",
+        )
+    return parsed
+
+
+def _wsgi_json(
+    start_response: Callable[[str, list[tuple[str, str]]], None],
+    status_code: int,
+    payload: Mapping[str, object],
+) -> Iterable[bytes]:
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    reason = {
+        200: "OK",
+        202: "Accepted",
+        400: "Bad Request",
+        401: "Unauthorized",
+        404: "Not Found",
+        413: "Payload Too Large",
+        500: "Internal Server Error",
+        502: "Bad Gateway",
+        503: "Service Unavailable",
+    }.get(status_code, "Status")
+    start_response(
+        f"{status_code} {reason}",
+        [
+            ("Content-Type", "application/json"),
+            ("Content-Length", str(len(body))),
+        ],
+    )
+    return [body]

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -90,6 +90,25 @@ Policy webhook service scaffold after GPP-2p:
    a hosted service is configured with webhook secret and GitHub App auth and
    posts the deployment callback review.
 
+Deployable policy webhook runtime after GPP-2q:
+
+1. `ao_kernel/live_adapter_gate_policy_runtime.py` exposes a WSGI entrypoint:
+   `ao_kernel.live_adapter_gate_policy_runtime:application`.
+2. The hosted runtime accepts `POST /github/deployment-protection` and serves
+   `GET /healthz`.
+3. It reads webhook and GitHub App auth material only from runtime
+   environment variables or private-key file paths:
+   `AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET`, `AO_GITHUB_APP_ID`, and either
+   `AO_GITHUB_APP_PRIVATE_KEY_PEM` or `AO_GITHUB_APP_PRIVATE_KEY_PATH`.
+4. It uses the GPP-2p service boundary for signature/event/policy evaluation,
+   extracts the GitHub App installation id, mints an installation token, and
+   posts the deployment protection review callback.
+5. Runtime responses are redacted and do not echo webhook secrets, private
+   keys, installation tokens, or `AO_CLAUDE_CODE_CLI_AUTH`.
+6. The runtime is deployable, but GPP-2 remains blocked until a public hosted
+   endpoint is configured in the GitHub App and live callback response evidence
+   exists.
+
 Blocked interpretation for a fresh or drifted setup:
 
 1. GitHub App slug `ao-kernel-live-adapter-gate` is not visible.
@@ -170,6 +189,35 @@ python3 scripts/live_adapter_gate_policy_service_smoke.py \
 ```
 
 Do not use `--allow-unsigned-fixture` in the hosted service.
+
+The GPP-2q runtime can be deployed by installing the policy-service optional
+extra and pointing a WSGI server at the repo-owned entrypoint:
+
+```bash
+pip install "ao-kernel[policy-service]"
+```
+
+```text
+ao_kernel.live_adapter_gate_policy_runtime:application
+```
+
+The GitHub App webhook URL should point at the hosted path:
+
+```text
+https://<host>/github/deployment-protection
+```
+
+Configure these runtime secrets through the hosting provider's secret manager:
+
+```text
+AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+or use `AO_GITHUB_APP_PRIVATE_KEY_PATH` when the hosting provider mounts the
+private key as a secret file. Do not commit, print, echo, read back, or paste
+these values into issues, PRs, MCP prompts, logs, or chat.
 
 ### 3. Attach the Deployment Protection Rule
 
@@ -332,10 +380,11 @@ If the selected deployment protection app is attached but does not respond:
 
 1. do not bypass the environment gate;
 2. do not repeatedly dispatch waiting workflow runs;
-3. deploy or configure the app webhook/policy service so it verifies GitHub
-   webhook signatures, evaluates the repo-owned policy modules or an
-   equivalent fail-closed policy, attaches GitHub App auth outside the repo,
-   and returns an explicit approve, deny, timeout, or failure decision;
+3. deploy or configure the app webhook/policy service using the GPP-2q WSGI
+   runtime or an equivalent fail-closed implementation so it verifies GitHub
+   webhook signatures, evaluates the repo-owned policy modules, attaches
+   GitHub App auth outside the repo, and returns an explicit approve, deny,
+   timeout, or failure decision;
 4. rerun protected workflow evidence from `main` only after the service is
    expected to respond.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ pgvector = [
 metrics = [
     "prometheus-client>=0.20.0",
 ]
+policy-service = [
+    "PyJWT[crypto]>=2.8.0",
+]
 # Meta-extras (PR-A6, widened in PR-B5 for metrics)
 coding = [
     "ao-kernel[llm]",

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,8 +30,8 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/527"
-    assert payload["current_wp"]["exit_decision"] == "policy_webhook_service_scaffold_ready_service_not_deployed"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/529"
+    assert payload["current_wp"]["exit_decision"] == "policy_webhook_runtime_ready_service_not_deployed"
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
         item["id"] == "GPP-2a" and item["decision"] == "still_blocked_protected_prerequisites_missing"
@@ -120,19 +120,27 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2q"
+        and item["decision"] == "policy_webhook_runtime_ready_service_not_deployed"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/529"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
-        "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
+        "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned runtime with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
         "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
     ]
     assert payload["blocked_wps"] == [
         {
             "id": "GPP-2",
             "reason": (
-                "repo-owned policy webhook service scaffold is ready, but the GitHub App service is not yet "
-                "deployed/configured with webhook secret and GitHub App auth to post deployment callback reviews"
+                "repo-owned policy webhook runtime is ready, but the GitHub App service is not yet "
+                "hosted/configured with webhook URL, webhook secret, and GitHub App auth to post deployment "
+                "callback reviews"
             ),
         }
     ]
@@ -149,7 +157,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
     assert any(
         action
-        == "deploy or configure the deployment-protection policy service using the repo-owned service scaffold before any further live-adapter runtime work"
+        == "deploy or configure the deployment-protection policy service using the repo-owned WSGI runtime before any further live-adapter runtime work"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -164,6 +172,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(
         action
         == "use scripts/live_adapter_gate_policy_decision.py only for policy callback decision evaluation, not live adapter execution"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "configure ao_kernel.live_adapter_gate_policy_runtime:application only with runtime secret manager values, never committed or echoed secret material"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -259,9 +272,9 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/527"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/529"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
-    assert payload["current_wp"]["exit_decision"] == "policy_webhook_service_scaffold_ready_service_not_deployed"
+    assert payload["current_wp"]["exit_decision"] == "policy_webhook_runtime_ready_service_not_deployed"
     assert payload["support_widening_allowed"] is False
 
 
@@ -291,7 +304,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "Blocked work packages:\n- GPP-2: repo-owned policy webhook service scaffold is ready" in rendered
+    assert "Blocked work packages:\n- GPP-2: repo-owned policy webhook runtime is ready" in rendered
     assert "divergence: 0\t0" in rendered
 
 

--- a/tests/test_live_adapter_gate_policy_runtime.py
+++ b/tests/test_live_adapter_gate_policy_runtime.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import builtins
+import json
+import sys
+import types
+from io import BytesIO
+from typing import Any, Mapping
+
+import pytest
+
+from ao_kernel.live_adapter_gate_policy import EXPECTED_WORKFLOW_NAME, EXPECTED_WORKFLOW_PATH
+from ao_kernel.live_adapter_gate_policy_runtime import (
+    DEFAULT_HEALTH_PATH,
+    DEFAULT_WEBHOOK_PATH,
+    GITHUB_APP_ID_ENV,
+    GITHUB_APP_PRIVATE_KEY_ENV,
+    WEBHOOK_SECRET_ENV,
+    CallbackPostResult,
+    GithubAppConfig,
+    GithubAppDeploymentReviewClient,
+    PolicyRuntimeConfigError,
+    build_github_app_jwt,
+    handle_live_adapter_gate_policy_webhook,
+    policy_runtime_wsgi_app,
+)
+from ao_kernel.live_adapter_gate_policy_service import (
+    GITHUB_DEPLOYMENT_PROTECTION_EVENT,
+    LiveAdapterGateDeploymentReviewRequest,
+    github_webhook_signature,
+)
+
+
+def _approved_payload() -> dict[str, object]:
+    return {
+        "environment": "ao-kernel-live-adapter-gate",
+        "event": "workflow_dispatch",
+        "sha": "abc123",
+        "ref": "refs/heads/main",
+        "deployment_callback_url": (
+            "https://api.github.com/repos/Halildeu/ao-kernel/actions/runs/25020015357/"
+            "deployment_protection_rule"
+        ),
+        "repository": {"full_name": "Halildeu/ao-kernel"},
+        "installation": {"id": 12345},
+        "pull_requests": [],
+        "verified_context": {
+            "workflow_name": EXPECTED_WORKFLOW_NAME,
+            "workflow_path": EXPECTED_WORKFLOW_PATH,
+            "prerequisites_ready": True,
+            "attestation_overall_status": "ready",
+            "live_execution_allowed": False,
+            "support_widening_allowed": False,
+            "production_platform_claim_allowed": False,
+        },
+    }
+
+
+def _body(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(payload, sort_keys=True).encode("utf-8")
+
+
+def _headers(body: bytes, *, secret: str = "secret") -> dict[str, str]:
+    return {
+        "X-GitHub-Event": GITHUB_DEPLOYMENT_PROTECTION_EVENT,
+        "X-GitHub-Delivery": "delivery-1",
+        "X-Hub-Signature-256": github_webhook_signature(secret, body),
+    }
+
+
+class FakeGithubClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, LiveAdapterGateDeploymentReviewRequest]] = []
+
+    def post_deployment_protection_review(
+        self,
+        *,
+        installation_id: int,
+        callback_request: LiveAdapterGateDeploymentReviewRequest,
+    ) -> CallbackPostResult:
+        self.calls.append((installation_id, callback_request))
+        return {
+            "status": "posted",
+            "status_code": 204,
+            "finding_code": None,
+            "detail": "posted in test",
+        }
+
+
+def test_runtime_posts_approved_callback_for_verified_context() -> None:
+    payload = _approved_payload()
+    body = _body(payload)
+    github_client = FakeGithubClient()
+
+    result = handle_live_adapter_gate_policy_webhook(
+        body,
+        _headers(body),
+        webhook_secret="secret",
+        github_client=github_client,
+        generated_at="2026-04-28T00:00:00Z",
+    )
+
+    assert result["status"] == "callback_posted"
+    assert result["finding_code"] is None
+    assert result["service_result"]["decision"] is not None
+    assert result["service_result"]["decision"]["decision"] == "approve_contract_gate"
+    assert result["service_result"]["decision"]["live_execution_allowed"] is False
+    assert github_client.calls == [(12345, result["service_result"]["callback_request"])]
+    callback_json = result["service_result"]["callback_request"]["json"]
+    assert callback_json is not None
+    assert callback_json["state"] == "approved"
+
+
+def test_runtime_posts_rejected_callback_for_raw_webhook_payload() -> None:
+    payload = _approved_payload()
+    payload.pop("verified_context")
+    body = _body(payload)
+    github_client = FakeGithubClient()
+
+    result = handle_live_adapter_gate_policy_webhook(
+        body,
+        _headers(body),
+        webhook_secret="secret",
+        github_client=github_client,
+        generated_at="2026-04-28T00:00:00Z",
+    )
+
+    assert result["status"] == "callback_posted"
+    assert result["service_result"]["decision"] is not None
+    assert result["service_result"]["decision"]["decision"] == "reject"
+    assert github_client.calls[0][0] == 12345
+    callback_json = github_client.calls[0][1]["json"]
+    assert callback_json is not None
+    assert callback_json["state"] == "rejected"
+
+
+def test_runtime_blocks_when_installation_id_is_missing() -> None:
+    payload = _approved_payload()
+    payload.pop("installation")
+    body = _body(payload)
+    github_client = FakeGithubClient()
+
+    result = handle_live_adapter_gate_policy_webhook(
+        body,
+        _headers(body),
+        webhook_secret="secret",
+        github_client=github_client,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["finding_code"] == "live_gate_policy_runtime_installation_id_missing"
+    assert result["callback_post"] is not None
+    assert result["callback_post"]["status"] == "blocked"
+    assert github_client.calls == []
+
+
+def test_github_app_client_posts_callback_without_returning_secret_material(monkeypatch: pytest.MonkeyPatch) -> None:
+    jwt_module = types.ModuleType("jwt")
+    jwt_payloads: list[dict[str, object]] = []
+
+    def encode(payload: dict[str, object], private_key: str, *, algorithm: str) -> str:
+        jwt_payloads.append(payload)
+        assert private_key == "private-key"
+        assert algorithm == "RS256"
+        return "app-jwt"
+
+    jwt_module.encode = encode  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "jwt", jwt_module)
+    calls: list[tuple[str, str, dict[str, str], bytes | None, float]] = []
+
+    def transport(
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        body: bytes | None,
+        timeout_seconds: float,
+    ) -> tuple[int, bytes]:
+        calls.append((method, url, dict(headers), body, timeout_seconds))
+        if url.endswith("/access_tokens"):
+            return 201, b'{"token":"installation-token"}'
+        return 204, b""
+
+    client = GithubAppDeploymentReviewClient(
+        GithubAppConfig(app_id="3522435", private_key_pem="private-key"),
+        transport=transport,
+        now_seconds=lambda: 1000,
+    )
+    callback_request: LiveAdapterGateDeploymentReviewRequest = {
+        "method": "POST",
+        "url": "https://api.github.com/repos/Halildeu/ao-kernel/actions/runs/1/deployment_protection_rule",
+        "headers": {"Accept": "application/vnd.github+json"},
+        "json": {
+            "environment_name": "ao-kernel-live-adapter-gate",
+            "state": "rejected",
+            "comment": "reject",
+        },
+        "authorization_required": True,
+    }
+
+    result = client.post_deployment_protection_review(installation_id=12345, callback_request=callback_request)
+
+    assert jwt_payloads == [{"iat": 940, "exp": 1540, "iss": "3522435"}]
+    assert calls[0][0] == "POST"
+    assert calls[0][2]["Authorization"] == "Bearer app-jwt"
+    assert calls[1][0] == "POST"
+    assert calls[1][1] == callback_request["url"]
+    assert calls[1][2]["Authorization"] == "Bearer installation-token"
+    assert result == {
+        "status": "posted",
+        "status_code": 204,
+        "finding_code": None,
+        "detail": "GitHub deployment protection callback review was posted.",
+    }
+    assert "installation-token" not in json.dumps(result)
+    assert "private-key" not in json.dumps(result)
+
+
+def test_build_github_app_jwt_reports_missing_optional_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(sys.modules, "jwt", raising=False)
+    original_import = builtins.__import__
+
+    def missing_jwt_import(name: str, *args: Any, **kwargs: Any) -> object:
+        if name == "jwt":
+            raise ImportError("missing jwt")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", missing_jwt_import)
+
+    with pytest.raises(PolicyRuntimeConfigError) as exc_info:
+        build_github_app_jwt(app_id="1", private_key_pem="private-key", now_seconds=1000)
+
+    assert "policy-service extra" in str(exc_info.value)
+
+
+def test_wsgi_health_endpoint() -> None:
+    status, payload = _call_wsgi("GET", DEFAULT_HEALTH_PATH, b"", {})
+
+    assert status == "200 OK"
+    assert payload == {"program_id": "GPP-2q", "status": "ok"}
+
+
+def test_wsgi_rejects_bad_signature_without_secret_echo(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(WEBHOOK_SECRET_ENV, "secret")
+    monkeypatch.setenv(GITHUB_APP_ID_ENV, "3522435")
+    monkeypatch.setenv(GITHUB_APP_PRIVATE_KEY_ENV, "private-key")
+    body = _body(_approved_payload())
+    headers = _headers(body)
+    headers["X-Hub-Signature-256"] = "sha256=bad"
+
+    status, payload = _call_wsgi("POST", DEFAULT_WEBHOOK_PATH, body, headers)
+
+    assert status == "401 Unauthorized"
+    assert payload["status"] == "blocked"
+    assert payload["signature_verified"] is False
+    assert "secret" not in json.dumps(payload)
+    assert "private-key" not in json.dumps(payload)
+
+
+def _call_wsgi(
+    method: str,
+    path: str,
+    body: bytes,
+    headers: Mapping[str, str],
+) -> tuple[str, dict[str, object]]:
+    environ: dict[str, object] = {
+        "REQUEST_METHOD": method,
+        "PATH_INFO": path,
+        "wsgi.input": BytesIO(body),
+        "CONTENT_LENGTH": str(len(body)),
+    }
+    for key, value in headers.items():
+        environ[f"HTTP_{key.upper().replace('-', '_')}"] = value
+    captured: dict[str, object] = {}
+
+    def start_response(status: str, response_headers: list[tuple[str, str]]) -> None:
+        captured["status"] = status
+        captured["headers"] = response_headers
+
+    chunks = list(policy_runtime_wsgi_app(environ, start_response))
+    response_body = b"".join(chunks)
+    return str(captured["status"]), json.loads(response_body.decode("utf-8"))


### PR DESCRIPTION
## Summary

- add a deployable WSGI runtime for the live-adapter deployment protection policy service
- add GitHub App JWT and installation-token callback POST handling with redacted runtime responses
- add `ao-kernel[policy-service]` optional dependency and CI extra smoke import
- update GPP status/runbook/docs for `policy_webhook_runtime_ready_service_not_deployed`

## Validation

- `python3 -m json.tool .claude/plans/gpp_status.v1.json >/tmp/gpp_status_check.json`
- `pytest -q tests/test_live_adapter_gate_policy_runtime.py tests/test_live_adapter_gate_policy_service.py tests/test_live_adapter_gate_policy.py tests/test_gpp_next.py`
- `python3 -m ruff check ao_kernel/ tests/`
- `python3 -m mypy ao_kernel/`
- `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/test.yml\"); puts \"workflow yaml OK\""`
- `python3 scripts/gpp_next.py`
- `git diff --check`
- `pytest -q` -> `3128 passed, 2 skipped`

## Guardrails

- no live adapter execution
- no protected workflow redispatch
- no secret value readback
- no `AO_CLAUDE_CODE_CLI_AUTH` through `secrets.` context
- no support widening
- no production platform claim

Closes #529