### PR TITLE
GPP-2r: add policy webhook container package

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 deployable policy webhook runtime ready; hosted service deployment/config still blocked
+**Status:** GPP-2 policy webhook container ready; hosted service deployment/config still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#529](https://github.com/Halildeu/ao-kernel/issues/529)
-for deployable deployment protection policy webhook runtime
-**Current slice record:** `.claude/plans/GPP-2q-POLICY-WEBHOOK-RUNTIME.md`
+**Current slice issue:** [#531](https://github.com/Halildeu/ao-kernel/issues/531)
+for deployment protection policy webhook container deploy package
+**Current slice record:** `.claude/plans/GPP-2r-POLICY-WEBHOOK-CONTAINER.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -150,6 +150,13 @@ Last live verification on current `origin/main` showed:
     remains blocked until this runtime or an equivalent service is publicly
     hosted, configured in the GitHub App webhook settings, and protected
     workflow evidence confirms an explicit app response.
+34. GPP-2r adds a container deploy package for the policy webhook service. It
+    builds the GPP-2q runtime into a `python:3.13-slim` image, runs `gunicorn`,
+    exposes `/healthz`, adds bounded no-secret container smoke tooling plus CI
+    validation, and keeps `AO_CLAUDE_CODE_CLI_AUTH` out of the service. GPP-2
+    remains blocked until the image is deployed to a public host, the GitHub App
+    webhook URL is configured, runtime secrets are supplied through a secret
+    manager, and protected workflow evidence confirms an explicit app response.
 
 ## 3. Current Verdict
 
@@ -206,7 +213,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2o` | Completed / no support widening | Deployment protection policy decision core | repo-owned decision core and CLI ready; service is not yet deployed/configured |
 | `GPP-2p` | Completed / no support widening | Deployment protection policy webhook service scaffold | repo-owned webhook/callback request scaffold ready; service is not yet deployed/configured |
 | `GPP-2q` | Completed / no support widening | Deployable policy webhook runtime | repo-owned WSGI runtime and GitHub App callback POST path ready; hosted service is not yet deployed/configured |
-| `GPP-2` | Blocked / hosted service deployment/config missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be hosted/configured with webhook URL, webhook secret, and GitHub App auth before further runtime work |
+| `GPP-2r` | Completed / no support widening | Policy webhook container deploy package | repo-owned container image package and bounded no-secret health smoke/CI job ready; hosted service is not yet deployed/configured |
+| `GPP-2` | Blocked / hosted service deployment/config missing | Protected live-adapter gate runtime binding | deployment protection app/policy service container must be hosted/configured with webhook URL, webhook secret, and GitHub App auth before further runtime work |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -335,9 +343,9 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2q; policy decision core, webhook scaffold, and
-deployable WSGI runtime exist, but hosted service deployment/configuration is
-still missing.
+**Status:** blocked after GPP-2r; policy decision core, webhook scaffold,
+deployable WSGI runtime, and container package exist, but hosted service
+deployment/configuration is still missing.
 
 **Entry criteria:**
 
@@ -356,6 +364,9 @@ request artifact, but no hosted endpoint, webhook secret, GitHub App auth, or
 actual callback POST evidence has been recorded. GPP-2q adds a deployable WSGI
 runtime plus GitHub App installation-token callback POST path, but no public
 endpoint has been hosted or configured in the GitHub App webhook settings.
+GPP-2r adds a container deployment package plus bounded no-secret health smoke
+tooling with CI validation, but no public hosted endpoint, webhook URL, runtime
+secret manager configuration, or live callback evidence has been recorded.
 
 **Acceptance criteria:**
 
@@ -614,7 +625,10 @@ webhook. GPP-2p adds the repo-owned webhook service scaffold that verifies
 GitHub signatures, constrains the event, and builds the deployment callback
 request without posting it. GPP-2q adds the deployable WSGI runtime and GitHub
 App callback POST path, but that runtime has not yet been hosted or configured
-as the GitHub App webhook URL. GPP-2b
+as the GitHub App webhook URL. GPP-2r adds the container deploy package and
+bounded no-secret health smoke/CI job, but the container has not yet been
+deployed to a public host or configured in the GitHub App webhook settings.
+GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
 metadata prerequisite level: the protected environment exists, admin bypass is
@@ -635,7 +649,7 @@ operator provisioning runbook.
 
 The next GPP-2 action is to deploy or configure the
 `ao-kernel-live-adapter-gate` deployment protection app/policy service using
-`ao_kernel.live_adapter_gate_policy_runtime:application` or an equivalent
+the GPP-2r container package, the GPP-2q WSGI runtime, or an equivalent
 fail-closed implementation so it receives protected deployment callbacks,
 enriches them with trusted context, evaluates the repo-owned policy modules,
 attaches GitHub App auth outside the repo, and posts an explicit GitHub
@@ -663,6 +677,7 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | Policy decision core exists but is not deployed | Protected workflow still receives no app response | Treat GPP-2o as implementation readiness only; deploy/configure webhook before rerunning evidence |
 | Webhook scaffold exists but has no runtime auth | Callback artifact exists but GitHub still receives no review | Treat GPP-2p as implementation readiness only; deploy with webhook secret and GitHub App auth before rerunning evidence |
 | Webhook runtime exists but is not hosted | GitHub App still cannot receive or answer deployment callbacks | Treat GPP-2q as deployability readiness only; configure the hosted endpoint and GitHub App webhook before rerunning evidence |
+| Container package exists but is not hosted | Local image health does not prove GitHub can call the app | Treat GPP-2r as packaging readiness only; deploy to a public host and configure GitHub App webhook before rerunning evidence |
 
 ## 19. Tracking Log
 
@@ -708,3 +723,5 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-28 | GPP-2p webhook scaffold added | `ao_kernel/live_adapter_gate_policy_service.py` and `scripts/live_adapter_gate_policy_service_smoke.py` add webhook signature/event checks and callback request artifact generation; hosted service deployment/configuration remains required before rerunning protected workflow evidence. |
 | 2026-04-28 | GPP-2q issue opened | Issue [#529](https://github.com/Halildeu/ao-kernel/issues/529) tracks the deployable deployment protection policy webhook runtime. |
 | 2026-04-28 | GPP-2q webhook runtime added | `ao_kernel/live_adapter_gate_policy_runtime.py` exposes a WSGI service entrypoint and GitHub App installation-token callback POST path; public hosting and GitHub App webhook configuration remain required before rerunning protected workflow evidence. |
+| 2026-04-28 | GPP-2r issue opened | Issue [#531](https://github.com/Halildeu/ao-kernel/issues/531) tracks the deployment protection policy webhook container package. |
+| 2026-04-28 | GPP-2r container package added | `deploy/live-adapter-gate-policy-service/Dockerfile`, `scripts/live_adapter_gate_policy_container_smoke.py`, and the `policy-container-smoke` CI job package the WSGI runtime as a no-secret health-checkable container; public hosting and GitHub App webhook configuration remain required before rerunning protected workflow evidence. |

--- a/.claude/plans/GPP-2r-POLICY-WEBHOOK-CONTAINER.md
+++ b/.claude/plans/GPP-2r-POLICY-WEBHOOK-CONTAINER.md
@@ -1,0 +1,180 @@
+# GPP-2r - Policy Webhook Container Deploy Package
+
+**Status:** closeout candidate
+**Date:** 2026-04-28
+**Authority:** `origin/main` at `132ad14`
+**Issue:** [#531](https://github.com/Halildeu/ao-kernel/issues/531)
+**Branch:** `codex/gpp-2r-policy-container`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2r-policy-container`
+**Program head:** `GPP-2` blocked on hosted policy service deployment/configuration
+**Support impact:** none
+**Runtime impact:** no live adapter call; no GitHub App webhook URL
+configuration; no secret value readback
+
+## 1. Purpose
+
+GPP-2q added a deployable WSGI runtime, but the repo still lacked a concrete
+container deployment package that a hosting platform can run without inventing
+local packaging steps. GPP-2 remains blocked because there is still no public
+hosted endpoint configured behind the GitHub App webhook.
+
+Decision:
+
+```text
+policy_webhook_container_ready_service_not_hosted
+```
+
+This slice makes the service container-buildable and locally health-checkable.
+It does not deploy to a public host, configure the GitHub App webhook URL, read
+secret values back, dispatch the protected workflow, invoke a live adapter,
+widen support, or claim production-platform readiness.
+
+## 2. Implemented Surface
+
+Code and deploy assets:
+
+1. `deploy/live-adapter-gate-policy-service/Dockerfile`
+   - builds from `python:3.13-slim`;
+   - installs `ao-kernel[policy-service]`;
+   - runs `gunicorn` against
+     `ao_kernel.live_adapter_gate_policy_runtime:application`;
+   - exposes port `8000`;
+   - adds a container health check for `/healthz`;
+   - runs as a non-root user.
+2. `.dockerignore`
+   - keeps git metadata, caches, build artifacts, coverage, and logs out of
+     the build context.
+3. `pyproject.toml`
+   - adds `gunicorn` to the `policy-service` optional extra.
+4. `scripts/live_adapter_gate_policy_container_smoke.py`
+   - builds the container image;
+   - runs it on a loopback-only random host port;
+   - checks `GET /healthz`;
+   - bounds Docker build/run waits with explicit timeouts;
+   - reports no secret readback, no GitHub callback POST, and no live adapter
+     execution.
+5. `tests/test_live_adapter_gate_policy_container.py`
+   - pins the Dockerfile runtime entrypoint and no-live-secret boundary;
+   - pins container smoke defaults.
+6. `.github/workflows/test.yml`
+   - runs the no-secret container build and `/healthz` smoke in CI.
+
+## 3. Container Contract
+
+Build:
+
+```bash
+docker build \
+  -f deploy/live-adapter-gate-policy-service/Dockerfile \
+  -t ao-kernel-live-adapter-gate-policy-service:local \
+  .
+```
+
+No-secret local health smoke:
+
+```bash
+python3 scripts/live_adapter_gate_policy_container_smoke.py \
+  --image ao-kernel-live-adapter-gate-policy-service:smoke \
+  --build-timeout-seconds 600
+```
+
+Hosted service configuration still must provide:
+
+```text
+AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+or:
+
+```text
+AO_GITHUB_APP_PRIVATE_KEY_PATH
+```
+
+The public GitHub App webhook URL must route to:
+
+```text
+POST /github/deployment-protection
+```
+
+Do not pass `AO_CLAUDE_CODE_CLI_AUTH` to this container. The policy service is
+not a live-adapter runner.
+
+## 4. Current Decision
+
+Resolved by this slice:
+
+1. repo-owned container build package exists;
+2. hosted WSGI command is explicit and repeatable;
+3. no-secret container health smoke exists with bounded Docker waits and CI
+   execution;
+4. optional server dependency is explicit;
+5. deploy runbook documents container usage.
+
+Still blocked:
+
+1. no public hosted endpoint is deployed;
+2. GitHub App webhook URL has not been configured to a hosted endpoint;
+3. hosted runtime secrets have not been configured by an approved secret path;
+4. no live GitHub deployment callback review has been posted by the hosted
+   service;
+5. no new protected workflow evidence artifacts exist after policy response;
+6. live adapter execution remains disabled.
+
+Still closed:
+
+1. `live_execution_allowed=false`;
+2. `support_widening=false`;
+3. `production_platform_claim=false`.
+
+## 5. Next Required Action
+
+Deploy the container to a public hosting platform and configure the
+`ao-kernel-live-adapter-gate` GitHub App webhook URL to the hosted
+`/github/deployment-protection` endpoint. Runtime secrets must be supplied only
+through the hosting provider's secret manager or secret-file mount.
+
+Only after that service is expected to respond should the protected workflow
+evidence slice be rerun from `main`.
+
+## 6. Validation
+
+Local validation passed:
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_live_adapter_gate_policy_container.py tests/test_gpp_next.py
+python3 -m ruff check ao_kernel/ tests/ scripts/live_adapter_gate_policy_container_smoke.py
+python3 -m mypy ao_kernel/ scripts/live_adapter_gate_policy_container_smoke.py
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Container build/health validation is wired into GitHub Actions as
+`policy-container-smoke`:
+
+```bash
+python3 scripts/live_adapter_gate_policy_container_smoke.py \
+  --image ao-kernel-live-adapter-gate-policy-service:ci \
+  --build-timeout-seconds 600 \
+  --timeout-seconds 90
+```
+
+Local Docker Desktop validation on this workstation was attempted with a short
+timeout and failed while resolving Docker Hub metadata for `python:3.13-slim`;
+the bounded timeout behavior is now explicit. This local Docker pull failure is
+not protected workflow evidence and does not post GitHub deployment callback
+reviews.
+
+Expected closeout decision:
+
+```text
+policy_webhook_container_ready_service_not_hosted
+```
+
+Recorded closeout decision:
+
+```text
+policy_webhook_container_ready_service_not_hosted
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,11 +9,11 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/529",
-    "exit_decision": "policy_webhook_runtime_ready_service_not_deployed",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/531",
+    "exit_decision": "policy_webhook_container_ready_service_not_hosted",
     "ready_after": "deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, posts callback reviews, and produces protected workflow evidence with live_execution_allowed=false",
     "allowed_scope": [
-      "use the repo-owned policy service runtime to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
+      "use the repo-owned policy service container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
       "repeat protected workflow evidence collection from main after the policy service responds",
       "keep live execution disabled until protected workflow evidence explicitly permits a later live run"
     ]
@@ -128,16 +128,22 @@
       "decision": "policy_webhook_runtime_ready_service_not_deployed",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/529",
       "record": ".claude/plans/GPP-2q-POLICY-WEBHOOK-RUNTIME.md"
+    },
+    {
+      "id": "GPP-2r",
+      "decision": "policy_webhook_container_ready_service_not_hosted",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/531",
+      "record": ".claude/plans/GPP-2r-POLICY-WEBHOOK-CONTAINER.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned policy webhook runtime is ready, but the GitHub App service is not yet hosted/configured with webhook URL, webhook secret, and GitHub App auth to post deployment callback reviews"
+      "reason": "repo-owned policy webhook container is ready, but the GitHub App service is not yet publicly hosted/configured with webhook URL, webhook secret, and GitHub App auth to post deployment callback reviews"
     }
   ],
   "pending_external_actions": [
-    "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned runtime with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
+    "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned container with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
     "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly"
   ],
   "support_widening_allowed": false,
@@ -192,12 +198,13 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "deploy or configure the deployment-protection policy service using the repo-owned WSGI runtime before any further live-adapter runtime work",
+    "deploy or configure the deployment-protection policy service using the repo-owned container package before any further live-adapter runtime work",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
     "use Claude MCP consultation only as advisory review, not release authority",
     "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active",
     "use scripts/live_adapter_gate_policy_service_smoke.py only for local webhook/callback artifact validation, not live callback posting",
     "use scripts/live_adapter_gate_policy_decision.py only for policy callback decision evaluation, not live adapter execution",
+    "use scripts/live_adapter_gate_policy_container_smoke.py only for no-secret local container health validation, not live callback posting",
     "configure ao_kernel.live_adapter_gate_policy_runtime:application only with runtime secret manager values, never committed or echoed secret material",
     "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it",
     "keep fork and pull_request contexts away from protected credentials",

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.venv
+__pycache__
+*.py[cod]
+*.egg-info
+build
+dist
+.archive
+.coverage
+coverage.xml
+htmlcov
+.DS_Store
+*.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,6 +147,23 @@ jobs:
       - name: Build wheel and run packaging smoke
         run: python scripts/packaging_smoke.py
 
+  policy-container-smoke:
+    name: policy-container-smoke
+    runs-on: ubuntu-latest
+    needs: [event-gate]
+    if: needs.event-gate.outputs.should_run == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Build and health-check policy service container
+        run: |
+          python scripts/live_adapter_gate_policy_container_smoke.py \
+            --image ao-kernel-live-adapter-gate-policy-service:ci \
+            --build-timeout-seconds 600 \
+            --timeout-seconds 90
+
   typecheck:
     name: typecheck
     runs-on: ubuntu-latest
@@ -271,4 +288,4 @@ jobs:
           pip_install -e ".[mcp]"      && python -c "import mcp; print('mcp OK')"
           pip_install -e ".[mcp-http]" && python -c "import starlette, uvicorn; print('mcp-http OK')"
           pip_install -e ".[metrics]"  && python -c "import prometheus_client; print('metrics OK')"
-          pip_install -e ".[policy-service]" && python -c "import jwt; print('policy-service OK')"
+          pip_install -e ".[policy-service]" && python -c "import gunicorn, jwt; print('policy-service OK')"

--- a/deploy/live-adapter-gate-policy-service/Dockerfile
+++ b/deploy/live-adapter-gate-policy-service/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8000 \
+    WEB_CONCURRENCY=1 \
+    WEB_THREADS=4 \
+    WEB_TIMEOUT=30
+
+WORKDIR /app
+
+COPY README.md pyproject.toml ./
+COPY ao_kernel ./ao_kernel
+
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && python -m pip install --no-cache-dir ".[policy-service]" \
+    && useradd --create-home --uid 10001 --shell /usr/sbin/nologin ao-kernel
+
+USER 10001
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import os, urllib.request; urllib.request.urlopen('http://127.0.0.1:%s/healthz' % os.environ.get('PORT', '8000'), timeout=3).read()"
+
+CMD ["sh", "-c", "exec gunicorn --bind 0.0.0.0:${PORT:-8000} --workers ${WEB_CONCURRENCY:-1} --threads ${WEB_THREADS:-4} --timeout ${WEB_TIMEOUT:-30} ao_kernel.live_adapter_gate_policy_runtime:application"]

--- a/deploy/live-adapter-gate-policy-service/README.md
+++ b/deploy/live-adapter-gate-policy-service/README.md
@@ -1,0 +1,74 @@
+# Live Adapter Gate Policy Service Container
+
+This container packages the GPP-2q WSGI runtime for the GitHub App deployment
+protection policy service.
+
+It is not a live-adapter runner. It only hosts:
+
+```text
+ao_kernel.live_adapter_gate_policy_runtime:application
+```
+
+## Build
+
+```bash
+docker build \
+  -f deploy/live-adapter-gate-policy-service/Dockerfile \
+  -t ao-kernel-live-adapter-gate-policy-service:local \
+  .
+```
+
+## Runtime
+
+Required hosting secrets:
+
+```text
+AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+or:
+
+```text
+AO_GITHUB_APP_PRIVATE_KEY_PATH
+```
+
+Optional runtime settings:
+
+```text
+PORT
+WEB_CONCURRENCY
+WEB_THREADS
+WEB_TIMEOUT
+AO_GITHUB_API_URL
+AO_POLICY_SERVICE_MAX_BODY_BYTES
+```
+
+The public GitHub App webhook URL must route to:
+
+```text
+POST /github/deployment-protection
+```
+
+The container health endpoint is:
+
+```text
+GET /healthz
+```
+
+Do not pass `AO_CLAUDE_CODE_CLI_AUTH` to this service. The protected live
+adapter credential remains unavailable to the policy service until a later GPP
+slice explicitly permits live execution.
+
+## Local No-Secret Smoke
+
+The local container smoke only builds the image and checks `/healthz`. It does
+not configure GitHub App secrets, receive GitHub webhooks, post callback
+reviews, dispatch the protected workflow, or execute a live adapter.
+
+```bash
+python3 scripts/live_adapter_gate_policy_container_smoke.py \
+  --image ao-kernel-live-adapter-gate-policy-service:smoke \
+  --build-timeout-seconds 600
+```

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -109,6 +109,23 @@ Deployable policy webhook runtime after GPP-2q:
    endpoint is configured in the GitHub App and live callback response evidence
    exists.
 
+Container deployment package after GPP-2r:
+
+1. `deploy/live-adapter-gate-policy-service/Dockerfile` packages the GPP-2q
+   WSGI runtime with `gunicorn`.
+2. The image exposes `8000`, serves `GET /healthz`, and runs
+   `ao_kernel.live_adapter_gate_policy_runtime:application`.
+3. `.dockerignore` keeps local caches, build artifacts, and git metadata out
+   of the build context.
+4. `scripts/live_adapter_gate_policy_container_smoke.py` builds the image,
+   runs it on loopback, and checks `/healthz` without runtime secrets or
+   unbounded Docker waits.
+5. GitHub Actions job `policy-container-smoke` runs the same no-secret
+   container build and `/healthz` check in CI.
+6. The container package is ready for an external host, but GPP-2 remains
+   blocked until that host is public, the GitHub App webhook URL is configured,
+   and callback response evidence exists.
+
 Blocked interpretation for a fresh or drifted setup:
 
 1. GitHub App slug `ao-kernel-live-adapter-gate` is not visible.
@@ -218,6 +235,27 @@ AO_GITHUB_APP_PRIVATE_KEY_PEM
 or use `AO_GITHUB_APP_PRIVATE_KEY_PATH` when the hosting provider mounts the
 private key as a secret file. Do not commit, print, echo, read back, or paste
 these values into issues, PRs, MCP prompts, logs, or chat.
+
+The GPP-2r container package can be built from the repository root:
+
+```bash
+docker build \
+  -f deploy/live-adapter-gate-policy-service/Dockerfile \
+  -t ao-kernel-live-adapter-gate-policy-service:local \
+  .
+```
+
+Local container health smoke is metadata/deployability evidence only:
+
+```bash
+python3 scripts/live_adapter_gate_policy_container_smoke.py \
+  --image ao-kernel-live-adapter-gate-policy-service:smoke \
+  --build-timeout-seconds 600
+```
+
+That smoke must not be treated as GitHub callback evidence. It does not
+configure runtime secrets, receive GitHub webhooks, post callback reviews,
+dispatch the protected workflow, or execute a live adapter.
 
 ### 3. Attach the Deployment Protection Rule
 
@@ -380,11 +418,11 @@ If the selected deployment protection app is attached but does not respond:
 
 1. do not bypass the environment gate;
 2. do not repeatedly dispatch waiting workflow runs;
-3. deploy or configure the app webhook/policy service using the GPP-2q WSGI
-   runtime or an equivalent fail-closed implementation so it verifies GitHub
-   webhook signatures, evaluates the repo-owned policy modules, attaches
-   GitHub App auth outside the repo, and returns an explicit approve, deny,
-   timeout, or failure decision;
+3. deploy or configure the app webhook/policy service using the GPP-2r
+   container package, the GPP-2q WSGI runtime, or an equivalent fail-closed
+   implementation so it verifies GitHub webhook signatures, evaluates the
+   repo-owned policy modules, attaches GitHub App auth outside the repo, and
+   returns an explicit approve, deny, timeout, or failure decision;
 4. rerun protected workflow evidence from `main` only after the service is
    expected to respond.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ metrics = [
     "prometheus-client>=0.20.0",
 ]
 policy-service = [
+    "gunicorn>=22.0.0",
     "PyJWT[crypto]>=2.8.0",
 ]
 # Meta-extras (PR-A6, widened in PR-B5 for metrics)

--- a/scripts/live_adapter_gate_policy_container_smoke.py
+++ b/scripts/live_adapter_gate_policy_container_smoke.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Build and health-check the live-adapter gate policy service container."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+DEFAULT_DOCKERFILE = Path("deploy/live-adapter-gate-policy-service/Dockerfile")
+DEFAULT_IMAGE = "ao-kernel-live-adapter-gate-policy-service:smoke"
+DEFAULT_TIMEOUT_SECONDS = 60.0
+DEFAULT_BUILD_TIMEOUT_SECONDS = 300.0
+DEFAULT_RUN_TIMEOUT_SECONDS = 30.0
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _run(
+    command: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    timeout_seconds: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+    )
+
+
+def _health_url(port: int) -> str:
+    return f"http://127.0.0.1:{port}/healthz"
+
+
+def _wait_for_health(url: str, *, timeout_seconds: float) -> dict[str, object]:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+                if isinstance(payload, dict):
+                    return payload
+        except Exception as exc:  # noqa: BLE001 - report final health failure compactly
+            last_error = exc
+        time.sleep(1)
+    detail = f": {last_error}" if last_error else ""
+    raise RuntimeError(f"container health endpoint did not become ready{detail}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", default=DEFAULT_IMAGE, help="Container image tag to build.")
+    parser.add_argument("--dockerfile", type=Path, default=DEFAULT_DOCKERFILE, help="Path to the policy service Dockerfile.")
+    parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS, help="Health wait timeout.")
+    parser.add_argument(
+        "--build-timeout-seconds",
+        type=float,
+        default=DEFAULT_BUILD_TIMEOUT_SECONDS,
+        help="Docker build timeout.",
+    )
+    parser.add_argument(
+        "--run-timeout-seconds",
+        type=float,
+        default=DEFAULT_RUN_TIMEOUT_SECONDS,
+        help="Docker run command timeout.",
+    )
+    parser.add_argument("--skip-build", action="store_true", help="Run an already-built image.")
+    return parser
+
+
+def _print_process_output(stdout: str | bytes | None, stderr: str | bytes | None) -> None:
+    for output in (stdout, stderr):
+        if not output:
+            continue
+        if isinstance(output, bytes):
+            output = output.decode("utf-8", errors="replace")
+        print(output, file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = _repo_root()
+    port = _free_port()
+    container_id: str | None = None
+    try:
+        if not args.skip_build:
+            _run(
+                [
+                    "docker",
+                    "build",
+                    "-f",
+                    str(args.dockerfile),
+                    "-t",
+                    args.image,
+                    ".",
+                ],
+                cwd=repo_root,
+                timeout_seconds=args.build_timeout_seconds,
+            )
+        run = _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--detach",
+                "--publish",
+                f"127.0.0.1:{port}:8000",
+                args.image,
+            ],
+            cwd=repo_root,
+            timeout_seconds=args.run_timeout_seconds,
+        )
+        container_id = run.stdout.strip()
+        payload = _wait_for_health(_health_url(port), timeout_seconds=args.timeout_seconds)
+        print(
+            json.dumps(
+                {
+                    "status": "pass",
+                    "image": args.image,
+                    "health_url": _health_url(port),
+                    "health_payload": payload,
+                    "secret_value_readback": False,
+                    "live_adapter_execution": False,
+                    "github_callback_post": False,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (OSError, RuntimeError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        print(f"container_smoke: {exc}", file=sys.stderr)
+        if isinstance(exc, subprocess.CalledProcessError):
+            _print_process_output(exc.stdout, exc.stderr)
+        if isinstance(exc, subprocess.TimeoutExpired):
+            _print_process_output(exc.stdout, exc.stderr)
+        return 2
+    finally:
+        if container_id:
+            try:
+                subprocess.run(["docker", "rm", "-f", container_id], cwd=repo_root, check=False, capture_output=True, timeout=15)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,8 +30,8 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/529"
-    assert payload["current_wp"]["exit_decision"] == "policy_webhook_runtime_ready_service_not_deployed"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/531"
+    assert payload["current_wp"]["exit_decision"] == "policy_webhook_container_ready_service_not_hosted"
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
         item["id"] == "GPP-2a" and item["decision"] == "still_blocked_protected_prerequisites_missing"
@@ -127,18 +127,25 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2r"
+        and item["decision"] == "policy_webhook_container_ready_service_not_hosted"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/531"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
-        "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned runtime with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
+        "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned container with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
         "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
     ]
     assert payload["blocked_wps"] == [
         {
             "id": "GPP-2",
             "reason": (
-                "repo-owned policy webhook runtime is ready, but the GitHub App service is not yet "
+                "repo-owned policy webhook container is ready, but the GitHub App service is not yet publicly "
                 "hosted/configured with webhook URL, webhook secret, and GitHub App auth to post deployment "
                 "callback reviews"
             ),
@@ -157,7 +164,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
     assert any(
         action
-        == "deploy or configure the deployment-protection policy service using the repo-owned WSGI runtime before any further live-adapter runtime work"
+        == "deploy or configure the deployment-protection policy service using the repo-owned container package before any further live-adapter runtime work"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -172,6 +179,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(
         action
         == "use scripts/live_adapter_gate_policy_decision.py only for policy callback decision evaluation, not live adapter execution"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "use scripts/live_adapter_gate_policy_container_smoke.py only for no-secret local container health validation, not live callback posting"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -272,9 +284,9 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/529"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/531"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
-    assert payload["current_wp"]["exit_decision"] == "policy_webhook_runtime_ready_service_not_deployed"
+    assert payload["current_wp"]["exit_decision"] == "policy_webhook_container_ready_service_not_hosted"
     assert payload["support_widening_allowed"] is False
 
 
@@ -304,7 +316,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "Blocked work packages:\n- GPP-2: repo-owned policy webhook runtime is ready" in rendered
+    assert "Blocked work packages:\n- GPP-2: repo-owned policy webhook container is ready" in rendered
     assert "divergence: 0\t0" in rendered
 
 

--- a/tests/test_live_adapter_gate_policy_container.py
+++ b/tests/test_live_adapter_gate_policy_container.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _container_smoke_module() -> Any:
+    module_path = _repo_root() / "scripts" / "live_adapter_gate_policy_container_smoke.py"
+    spec = importlib.util.spec_from_file_location("live_adapter_gate_policy_container_smoke", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_policy_service_dockerfile_hosts_wsgi_runtime_without_live_secret() -> None:
+    dockerfile = _repo_root() / "deploy" / "live-adapter-gate-policy-service" / "Dockerfile"
+    text = dockerfile.read_text(encoding="utf-8")
+
+    assert "python:3.13-slim" in text
+    assert ".[policy-service]" in text
+    assert "gunicorn" in text
+    assert "ao_kernel.live_adapter_gate_policy_runtime:application" in text
+    assert "/healthz" in text
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in text
+
+
+def test_container_smoke_defaults_to_no_secret_health_check_only() -> None:
+    module = _container_smoke_module()
+    parser = module.build_parser()
+    args = parser.parse_args([])
+
+    assert args.image == "ao-kernel-live-adapter-gate-policy-service:smoke"
+    assert args.dockerfile == Path("deploy/live-adapter-gate-policy-service/Dockerfile")
+    assert args.build_timeout_seconds == 300.0
+    assert args.run_timeout_seconds == 30.0
+    assert module._health_url(18080) == "http://127.0.0.1:18080/healthz"
+    smoke_source = Path(module.__file__).read_text(encoding="utf-8")
+    assert "timeout_seconds=args.build_timeout_seconds" in smoke_source
+    assert '"secret_value_readback": False' in smoke_source
+    assert '"live_adapter_execution": False' in smoke_source
+    assert '"github_callback_post": False' in smoke_source


### PR DESCRIPTION
Closes #531.

## Summary
- add a Docker package for `ao_kernel.live_adapter_gate_policy_runtime:application` with gunicorn and `/healthz`
- add a no-secret container smoke script with bounded Docker build/run timeouts
- wire `policy-container-smoke` into CI and update GPP/runbook status for the still-blocked hosted service gate

## Validation
- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `pytest -q tests/test_live_adapter_gate_policy_container.py tests/test_gpp_next.py`
- `python3 -m ruff check ao_kernel/ tests/ scripts/live_adapter_gate_policy_container_smoke.py`
- `python3 -m mypy ao_kernel/ scripts/live_adapter_gate_policy_container_smoke.py`
- `python3 scripts/gpp_next.py`
- `git diff --check`

Local Docker Desktop still times out resolving Docker Hub metadata for `python:3.13-slim`; the new CI `policy-container-smoke` job performs the full no-secret container build and health check on GitHub Actions.