### PR TITLE
GPP-2s: add policy container image publish path

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 policy webhook container ready; hosted service deployment/config still blocked
+**Status:** GPP-2 policy container image publish path ready; hosted service deployment/config still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#531](https://github.com/Halildeu/ao-kernel/issues/531)
-for deployment protection policy webhook container deploy package
-**Current slice record:** `.claude/plans/GPP-2r-POLICY-WEBHOOK-CONTAINER.md`
+**Current slice issue:** [#533](https://github.com/Halildeu/ao-kernel/issues/533)
+for deployment protection policy container image publication
+**Current slice record:** `.claude/plans/GPP-2s-POLICY-CONTAINER-IMAGE-PUBLISH.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -157,6 +157,14 @@ Last live verification on current `origin/main` showed:
     remains blocked until the image is deployed to a public host, the GitHub App
     webhook URL is configured, runtime secrets are supplied through a secret
     manager, and protected workflow evidence confirms an explicit app response.
+35. GPP-2s adds a GHCR image publication path for the policy webhook
+    container. Pull requests build and no-secret smoke the image without
+    pushing; trusted non-PR events can publish
+    `ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service:sha-<commit>`
+    and `:main` without referencing protected live credentials. GPP-2 remains
+    blocked until that image is deployed to a public host, the GitHub App
+    webhook URL is configured, runtime secrets are supplied through a secret
+    manager, and protected workflow evidence confirms an explicit app response.
 
 ## 3. Current Verdict
 
@@ -214,7 +222,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2p` | Completed / no support widening | Deployment protection policy webhook service scaffold | repo-owned webhook/callback request scaffold ready; service is not yet deployed/configured |
 | `GPP-2q` | Completed / no support widening | Deployable policy webhook runtime | repo-owned WSGI runtime and GitHub App callback POST path ready; hosted service is not yet deployed/configured |
 | `GPP-2r` | Completed / no support widening | Policy webhook container deploy package | repo-owned container image package and bounded no-secret health smoke/CI job ready; hosted service is not yet deployed/configured |
-| `GPP-2` | Blocked / hosted service deployment/config missing | Protected live-adapter gate runtime binding | deployment protection app/policy service container must be hosted/configured with webhook URL, webhook secret, and GitHub App auth before further runtime work |
+| `GPP-2s` | Completed / no support widening | Policy container image publication | repo-owned GHCR image publish path ready; hosted service is not yet deployed/configured |
+| `GPP-2` | Blocked / hosted service deployment/config missing | Protected live-adapter gate runtime binding | deployment protection app/policy service image/container must be hosted/configured with webhook URL, webhook secret, and GitHub App auth before further runtime work |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -343,9 +352,9 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2r; policy decision core, webhook scaffold,
-deployable WSGI runtime, and container package exist, but hosted service
-deployment/configuration is still missing.
+**Status:** blocked after GPP-2s; policy decision core, webhook scaffold,
+deployable WSGI runtime, container package, and GHCR image publication path
+exist, but hosted service deployment/configuration is still missing.
 
 **Entry criteria:**
 
@@ -367,6 +376,9 @@ endpoint has been hosted or configured in the GitHub App webhook settings.
 GPP-2r adds a container deployment package plus bounded no-secret health smoke
 tooling with CI validation, but no public hosted endpoint, webhook URL, runtime
 secret manager configuration, or live callback evidence has been recorded.
+GPP-2s adds a GHCR image publication path for trusted non-PR builds, but no
+public hosted endpoint, webhook URL, runtime secret manager configuration, or
+live callback evidence has been recorded.
 
 **Acceptance criteria:**
 
@@ -628,6 +640,9 @@ App callback POST path, but that runtime has not yet been hosted or configured
 as the GitHub App webhook URL. GPP-2r adds the container deploy package and
 bounded no-secret health smoke/CI job, but the container has not yet been
 deployed to a public host or configured in the GitHub App webhook settings.
+GPP-2s adds the GHCR image publication path for that container, but the image
+has not yet been deployed to a public host or configured in the GitHub App
+webhook settings.
 GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
@@ -649,11 +664,11 @@ operator provisioning runbook.
 
 The next GPP-2 action is to deploy or configure the
 `ao-kernel-live-adapter-gate` deployment protection app/policy service using
-the GPP-2r container package, the GPP-2q WSGI runtime, or an equivalent
-fail-closed implementation so it receives protected deployment callbacks,
-enriches them with trusted context, evaluates the repo-owned policy modules,
-attaches GitHub App auth outside the repo, and posts an explicit GitHub
-deployment review callback. Do not repeatedly dispatch
+the GPP-2s GHCR image, the GPP-2r container package, the GPP-2q WSGI runtime,
+or an equivalent fail-closed implementation so it receives protected deployment
+callbacks, enriches them with trusted context, evaluates the repo-owned policy
+modules, attaches GitHub App auth outside the repo, and posts an explicit
+GitHub deployment review callback. Do not repeatedly dispatch
 `.github/workflows/live-adapter-gate.yml` until that service is expected to
 respond. Any follow-up must keep fork and pull-request contexts away from
 protected credentials, must not use `AO_CLAUDE_CODE_CLI_AUTH` through a
@@ -678,6 +693,7 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | Webhook scaffold exists but has no runtime auth | Callback artifact exists but GitHub still receives no review | Treat GPP-2p as implementation readiness only; deploy with webhook secret and GitHub App auth before rerunning evidence |
 | Webhook runtime exists but is not hosted | GitHub App still cannot receive or answer deployment callbacks | Treat GPP-2q as deployability readiness only; configure the hosted endpoint and GitHub App webhook before rerunning evidence |
 | Container package exists but is not hosted | Local image health does not prove GitHub can call the app | Treat GPP-2r as packaging readiness only; deploy to a public host and configure GitHub App webhook before rerunning evidence |
+| Container image exists but service is not hosted | GHCR image publication does not prove GitHub can call the app | Treat GPP-2s as deploy artifact readiness only; deploy the image to a public host and configure GitHub App webhook before rerunning evidence |
 
 ## 19. Tracking Log
 
@@ -725,3 +741,5 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-28 | GPP-2q webhook runtime added | `ao_kernel/live_adapter_gate_policy_runtime.py` exposes a WSGI service entrypoint and GitHub App installation-token callback POST path; public hosting and GitHub App webhook configuration remain required before rerunning protected workflow evidence. |
 | 2026-04-28 | GPP-2r issue opened | Issue [#531](https://github.com/Halildeu/ao-kernel/issues/531) tracks the deployment protection policy webhook container package. |
 | 2026-04-28 | GPP-2r container package added | `deploy/live-adapter-gate-policy-service/Dockerfile`, `scripts/live_adapter_gate_policy_container_smoke.py`, and the `policy-container-smoke` CI job package the WSGI runtime as a no-secret health-checkable container; public hosting and GitHub App webhook configuration remain required before rerunning protected workflow evidence. |
+| 2026-04-28 | GPP-2s issue opened | Issue [#533](https://github.com/Halildeu/ao-kernel/issues/533) tracks the deployment protection policy container image publication path. |
+| 2026-04-28 | GPP-2s image publish path added | `.github/workflows/policy-container-publish.yml` builds, no-secret smokes, and publishes trusted non-PR images to `ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service`; public hosting and GitHub App webhook configuration remain required before rerunning protected workflow evidence. |

--- a/.claude/plans/GPP-2s-POLICY-CONTAINER-IMAGE-PUBLISH.md
+++ b/.claude/plans/GPP-2s-POLICY-CONTAINER-IMAGE-PUBLISH.md
@@ -1,0 +1,148 @@
+# GPP-2s - Policy Container Image Publish Path
+
+**Status:** closeout candidate
+**Date:** 2026-04-28
+**Authority:** `origin/main` at `27b2b3f`
+**Issue:** [#533](https://github.com/Halildeu/ao-kernel/issues/533)
+**Branch:** `codex/gpp-2s-policy-image-publish`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2s-policy-image-publish`
+**Program head:** `GPP-2` blocked on hosted policy service deployment/configuration
+**Support impact:** none
+**Runtime impact:** no live adapter call; no GitHub App webhook URL
+configuration; no runtime secret value readback
+
+## 1. Purpose
+
+GPP-2r made the policy service container-buildable, but a hosting provider
+still needed either local build steps or a repo-owned published image artifact.
+This slice adds a no-secret GHCR publication path for the policy service image
+without deploying it or configuring the GitHub App webhook URL.
+
+Decision:
+
+```text
+policy_container_publish_path_ready_service_not_hosted
+```
+
+This slice creates a deploy artifact path only. It does not run a public
+service, set webhook URLs, read runtime secrets back, dispatch the protected
+workflow, invoke a live adapter, widen support, or claim production-platform
+readiness.
+
+## 2. Implemented Surface
+
+Code and deploy assets:
+
+1. `.github/workflows/policy-container-publish.yml`
+   - builds `deploy/live-adapter-gate-policy-service/Dockerfile`;
+   - tags the image as
+     `ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service:sha-<commit>`;
+   - runs the existing no-secret container `/healthz` smoke with
+     `--skip-build`;
+   - pushes only for trusted non-PR events;
+   - adds the moving `:main` tag only for `refs/heads/main`;
+   - uses `github.token` with `packages: write`, not `secrets.*`;
+   - does not reference `AO_CLAUDE_CODE_CLI_AUTH`, webhook secrets, GitHub App
+     private keys, or live adapter credentials.
+2. `tests/test_policy_container_publish_workflow.py`
+   - pins GHCR image naming, no-secret smoke execution, PR no-push gating, and
+     live credential exclusions.
+3. `deploy/live-adapter-gate-policy-service/README.md`
+   - documents the GHCR image tags and registry-token boundary.
+4. `docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md`
+   - records the image publication step and hosted-deploy pull guidance.
+
+## 3. Image Contract
+
+Trusted main/manual builds publish:
+
+```text
+ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service:sha-<commit>
+ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service:main
+```
+
+Hosted deployments should prefer the immutable `sha-<commit>` tag. If the
+hosting platform cannot pull the package anonymously, the host must receive a
+GHCR read token through its secret manager. Registry credentials must not be
+committed or baked into the image.
+
+The image still requires runtime host configuration for:
+
+```text
+AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+or:
+
+```text
+AO_GITHUB_APP_PRIVATE_KEY_PATH
+```
+
+Do not pass `AO_CLAUDE_CODE_CLI_AUTH` to this container. The policy service is
+not a live-adapter runner.
+
+## 4. Current Decision
+
+Resolved by this slice:
+
+1. repo-owned GHCR image publication path exists;
+2. PRs build and smoke the image without pushing;
+3. trusted non-PR events can push an immutable image tag;
+4. `main` builds can push a moving `main` tag;
+5. image publication stays separate from runtime secret handling.
+
+Still blocked:
+
+1. no public hosted endpoint is deployed;
+2. GitHub App webhook URL has not been configured to a hosted endpoint;
+3. hosted runtime secrets have not been configured by an approved secret path;
+4. no live GitHub deployment callback review has been posted by the hosted
+   service;
+5. no new protected workflow evidence artifacts exist after policy response;
+6. live adapter execution remains disabled.
+
+Still closed:
+
+1. `live_execution_allowed=false`;
+2. `support_widening=false`;
+3. `production_platform_claim=false`.
+
+## 5. Next Required Action
+
+Deploy the GHCR image or equivalent container package to a public hosting
+platform and configure the `ao-kernel-live-adapter-gate` GitHub App webhook URL
+to the hosted `/github/deployment-protection` endpoint. Runtime secrets must be
+supplied only through the hosting provider's secret manager or secret-file
+mount.
+
+Only after that service is expected to respond should the protected workflow
+evidence slice be rerun from `main`.
+
+## 6. Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_policy_container_publish_workflow.py tests/test_gpp_next.py
+python3 -m ruff check tests/test_policy_container_publish_workflow.py
+actionlint .github/workflows/policy-container-publish.yml
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+The image publication workflow itself is validated by PR CI as a build and
+no-secret smoke. Publishing happens only after merge or manual trusted
+dispatch.
+
+Expected closeout decision:
+
+```text
+policy_container_publish_path_ready_service_not_hosted
+```
+
+Recorded closeout decision:
+
+```text
+policy_container_publish_path_ready_service_not_hosted
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,11 +9,11 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/531",
-    "exit_decision": "policy_webhook_container_ready_service_not_hosted",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/533",
+    "exit_decision": "policy_container_publish_path_ready_service_not_hosted",
     "ready_after": "deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, posts callback reviews, and produces protected workflow evidence with live_execution_allowed=false",
     "allowed_scope": [
-      "use the repo-owned policy service container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
+      "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
       "repeat protected workflow evidence collection from main after the policy service responds",
       "keep live execution disabled until protected workflow evidence explicitly permits a later live run"
     ]
@@ -134,16 +134,22 @@
       "decision": "policy_webhook_container_ready_service_not_hosted",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/531",
       "record": ".claude/plans/GPP-2r-POLICY-WEBHOOK-CONTAINER.md"
+    },
+    {
+      "id": "GPP-2s",
+      "decision": "policy_container_publish_path_ready_service_not_hosted",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/533",
+      "record": ".claude/plans/GPP-2s-POLICY-CONTAINER-IMAGE-PUBLISH.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned policy webhook container is ready, but the GitHub App service is not yet publicly hosted/configured with webhook URL, webhook secret, and GitHub App auth to post deployment callback reviews"
+      "reason": "repo-owned policy webhook container image publish path is ready, but the GitHub App service is not yet publicly hosted/configured with webhook URL, webhook secret, and GitHub App auth to post deployment callback reviews"
     }
   ],
   "pending_external_actions": [
-    "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned container with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
+    "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
     "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly"
   ],
   "support_widening_allowed": false,
@@ -198,13 +204,14 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "deploy or configure the deployment-protection policy service using the repo-owned container package before any further live-adapter runtime work",
+    "deploy or configure the deployment-protection policy service using the repo-owned GHCR image or container package before any further live-adapter runtime work",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
     "use Claude MCP consultation only as advisory review, not release authority",
     "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active",
     "use scripts/live_adapter_gate_policy_service_smoke.py only for local webhook/callback artifact validation, not live callback posting",
     "use scripts/live_adapter_gate_policy_decision.py only for policy callback decision evaluation, not live adapter execution",
     "use scripts/live_adapter_gate_policy_container_smoke.py only for no-secret local container health validation, not live callback posting",
+    "publish or pull ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service only as a deploy artifact, not hosted service evidence",
     "configure ao_kernel.live_adapter_gate_policy_runtime:application only with runtime secret manager values, never committed or echoed secret material",
     "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it",
     "keep fork and pull_request contexts away from protected credentials",

--- a/.github/workflows/policy-container-publish.yml
+++ b/.github/workflows/policy-container-publish.yml
@@ -1,0 +1,87 @@
+name: Publish Policy Container
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "ao_kernel/**"
+      - "deploy/live-adapter-gate-policy-service/**"
+      - "pyproject.toml"
+      - ".github/workflows/policy-container-publish.yml"
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - edited
+    paths:
+      - "ao_kernel/**"
+      - "deploy/live-adapter-gate-policy-service/**"
+      - "pyproject.toml"
+      - ".github/workflows/policy-container-publish.yml"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Manual policy container publication reason"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  DOCKERFILE: deploy/live-adapter-gate-policy-service/Dockerfile
+  IMAGE_NAME: ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service
+
+jobs:
+  publish-policy-container:
+    name: publish-policy-container
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Build policy service image
+        id: build
+        run: |
+          image_sha="${IMAGE_NAME}:sha-${GITHUB_SHA}"
+          docker build -f "$DOCKERFILE" -t "$image_sha" .
+          echo "image_sha=$image_sha" >> "$GITHUB_OUTPUT"
+
+      - name: No-secret container health smoke
+        run: |
+          python scripts/live_adapter_gate_policy_container_smoke.py \
+            --skip-build \
+            --image "${{ steps.build.outputs.image_sha }}" \
+            --timeout-seconds 90
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      - name: Publish policy service image
+        if: github.event_name != 'pull_request'
+        run: |
+          image_sha="${{ steps.build.outputs.image_sha }}"
+          docker push "$image_sha"
+
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            image_main="${IMAGE_NAME}:main"
+            docker tag "$image_sha" "$image_main"
+            docker push "$image_main"
+            {
+              echo "Published policy service image:"
+              echo "- \`$image_sha\`"
+              echo "- \`$image_main\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Published policy service image: \`$image_sha\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/deploy/live-adapter-gate-policy-service/README.md
+++ b/deploy/live-adapter-gate-policy-service/README.md
@@ -18,6 +18,21 @@ docker build \
   .
 ```
 
+## Published Image
+
+The repository publication workflow builds this same Dockerfile, runs the
+no-secret `/healthz` smoke, and publishes trusted non-PR builds to GHCR:
+
+```text
+ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service:sha-<commit>
+ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service:main
+```
+
+Use the immutable `sha-<commit>` tag for hosted deployments whenever possible.
+If the hosting provider cannot pull the package anonymously, configure a GHCR
+read token through that provider's secret manager. Do not bake registry tokens
+or runtime secrets into the image.
+
 ## Runtime
 
 Required hosting secrets:

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -126,6 +126,24 @@ Container deployment package after GPP-2r:
    blocked until that host is public, the GitHub App webhook URL is configured,
    and callback response evidence exists.
 
+Container image publication after GPP-2s:
+
+1. `.github/workflows/policy-container-publish.yml` builds the same GPP-2r
+   container image for PR validation and trusted main/manual publication.
+2. The workflow runs
+   `scripts/live_adapter_gate_policy_container_smoke.py --skip-build` before
+   any image push.
+3. Pull request events build and smoke the image but do not push to GHCR.
+4. Trusted non-PR events publish to:
+   `ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service`.
+5. Published tags include immutable `sha-<commit>` tags and the moving `main`
+   tag for the current main image.
+6. The publication workflow does not reference `AO_CLAUDE_CODE_CLI_AUTH`,
+   webhook secrets, GitHub App private keys, or any live adapter credential.
+7. A published image is deployable input, not hosted-service evidence. GPP-2
+   remains blocked until the image is actually running behind a public URL and
+   posts deployment protection callback reviews.
+
 Blocked interpretation for a fresh or drifted setup:
 
 1. GitHub App slug `ao-kernel-live-adapter-gate` is not visible.
@@ -256,6 +274,20 @@ python3 scripts/live_adapter_gate_policy_container_smoke.py \
 That smoke must not be treated as GitHub callback evidence. It does not
 configure runtime secrets, receive GitHub webhooks, post callback reviews,
 dispatch the protected workflow, or execute a live adapter.
+
+After GPP-2s, trusted main builds publish a GHCR image that hosting providers
+can pull:
+
+```text
+ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service:sha-<commit>
+ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service:main
+```
+
+Prefer the immutable `sha-<commit>` tag for hosted deployments. If a hosting
+provider cannot pull the package anonymously, give that provider a GHCR read
+token through its secret manager. Do not put registry credentials, webhook
+secrets, GitHub App private keys, or live adapter credentials in the container
+image.
 
 ### 3. Attach the Deployment Protection Rule
 
@@ -418,11 +450,12 @@ If the selected deployment protection app is attached but does not respond:
 
 1. do not bypass the environment gate;
 2. do not repeatedly dispatch waiting workflow runs;
-3. deploy or configure the app webhook/policy service using the GPP-2r
-   container package, the GPP-2q WSGI runtime, or an equivalent fail-closed
-   implementation so it verifies GitHub webhook signatures, evaluates the
-   repo-owned policy modules, attaches GitHub App auth outside the repo, and
-   returns an explicit approve, deny, timeout, or failure decision;
+3. deploy or configure the app webhook/policy service using the GPP-2s GHCR
+   image, the GPP-2r container package, the GPP-2q WSGI runtime, or an
+   equivalent fail-closed implementation so it verifies GitHub webhook
+   signatures, evaluates the repo-owned policy modules, attaches GitHub App
+   auth outside the repo, and returns an explicit approve, deny, timeout, or
+   failure decision;
 4. rerun protected workflow evidence from `main` only after the service is
    expected to respond.
 

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,8 +30,8 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/531"
-    assert payload["current_wp"]["exit_decision"] == "policy_webhook_container_ready_service_not_hosted"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/533"
+    assert payload["current_wp"]["exit_decision"] == "policy_container_publish_path_ready_service_not_hosted"
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
         item["id"] == "GPP-2a" and item["decision"] == "still_blocked_protected_prerequisites_missing"
@@ -134,20 +134,27 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2s"
+        and item["decision"] == "policy_container_publish_path_ready_service_not_hosted"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/533"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
-        "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned container with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
+        "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
         "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
     ]
     assert payload["blocked_wps"] == [
         {
             "id": "GPP-2",
             "reason": (
-                "repo-owned policy webhook container is ready, but the GitHub App service is not yet publicly "
-                "hosted/configured with webhook URL, webhook secret, and GitHub App auth to post deployment "
-                "callback reviews"
+                "repo-owned policy webhook container image publish path is ready, but the GitHub App service is "
+                "not yet publicly hosted/configured with webhook URL, webhook secret, and GitHub App auth to "
+                "post deployment callback reviews"
             ),
         }
     ]
@@ -164,7 +171,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
     assert any(
         action
-        == "deploy or configure the deployment-protection policy service using the repo-owned container package before any further live-adapter runtime work"
+        == "deploy or configure the deployment-protection policy service using the repo-owned GHCR image or container package before any further live-adapter runtime work"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -184,6 +191,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(
         action
         == "use scripts/live_adapter_gate_policy_container_smoke.py only for no-secret local container health validation, not live callback posting"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "publish or pull ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service only as a deploy artifact, not hosted service evidence"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -284,9 +296,9 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/531"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/533"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
-    assert payload["current_wp"]["exit_decision"] == "policy_webhook_container_ready_service_not_hosted"
+    assert payload["current_wp"]["exit_decision"] == "policy_container_publish_path_ready_service_not_hosted"
     assert payload["support_widening_allowed"] is False
 
 
@@ -316,7 +328,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "Blocked work packages:\n- GPP-2: repo-owned policy webhook container is ready" in rendered
+    assert "Blocked work packages:\n- GPP-2: repo-owned policy webhook container image publish path is ready" in rendered
     assert "divergence: 0\t0" in rendered
 
 

--- a/tests/test_policy_container_publish_workflow.py
+++ b/tests/test_policy_container_publish_workflow.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def test_policy_container_publish_workflow_builds_smokes_and_publishes_ghcr() -> None:
+    workflow = _repo_root() / ".github" / "workflows" / "policy-container-publish.yml"
+    text = workflow.read_text(encoding="utf-8")
+
+    assert "ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service" in text
+    assert "deploy/live-adapter-gate-policy-service/Dockerfile" in text
+    assert "docker build -f \"$DOCKERFILE\"" in text
+    assert "scripts/live_adapter_gate_policy_container_smoke.py" in text
+    assert "--skip-build" in text
+    assert "docker push \"$image_sha\"" in text
+    assert "docker push \"$image_main\"" in text
+
+
+def test_policy_container_publish_workflow_keeps_prs_and_live_credentials_closed() -> None:
+    workflow = _repo_root() / ".github" / "workflows" / "policy-container-publish.yml"
+    text = workflow.read_text(encoding="utf-8")
+
+    assert "contents: read" in text
+    assert "packages: write" in text
+    assert "github.event_name != 'pull_request'" in text
+    assert "GHCR_TOKEN: ${{ github.token }}" in text
+    assert "secrets." not in text
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in text
+    assert "AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET" not in text
+    assert "AO_GITHUB_APP_PRIVATE_KEY" not in text
+    assert "workflow_dispatch" in text
+    assert "pull_request" in text


### PR DESCRIPTION
Closes #533.

## Summary
- add a no-secret GitHub Actions workflow that builds the live gate policy service container, runs the existing `/healthz` smoke with `--skip-build`, and publishes trusted non-PR images to GHCR
- document the GHCR image contract and update the live gate provisioning runbook
- record the GPP-2s decision while keeping GPP-2 blocked until a public hosted service and GitHub App webhook callback evidence exist

## Validation
- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `pytest -q tests/test_policy_container_publish_workflow.py tests/test_gpp_next.py`
- `python3 -m ruff check ao_kernel/ tests/ scripts/live_adapter_gate_policy_container_smoke.py`
- `actionlint .github/workflows/policy-container-publish.yml`
- `python3 scripts/gpp_next.py`
- `git diff --check`

## Guardrails
- no `secrets.*` context in the publish workflow
- no `AO_CLAUDE_CODE_CLI_AUTH`, webhook secret, GitHub App private key, or live adapter credential reference
- pull requests build and smoke only; image push is gated to non-PR events