### PR TITLE
GPP-2t: add autonomous policy service deploy path

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 policy container image publish path ready; hosted service deployment/config still blocked
+**Status:** GPP-2 autonomous policy service deploy path ready; cloud/bootstrap and callback evidence still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#533](https://github.com/Halildeu/ao-kernel/issues/533)
-for deployment protection policy container image publication
-**Current slice record:** `.claude/plans/GPP-2s-POLICY-CONTAINER-IMAGE-PUBLISH.md`
+**Current slice issue:** [#535](https://github.com/Halildeu/ao-kernel/issues/535)
+for autonomous deployment protection policy service deployment
+**Current slice record:** `.claude/plans/GPP-2t-AUTONOMOUS-POLICY-SERVICE-DEPLOYMENT.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -165,6 +165,15 @@ Last live verification on current `origin/main` showed:
     blocked until that image is deployed to a public host, the GitHub App
     webhook URL is configured, runtime secrets are supplied through a secret
     manager, and protected workflow evidence confirms an explicit app response.
+36. GPP-2t adds an autonomous Cloud Run deployment path for the policy service.
+    A trusted `main` image can be mirrored from GHCR to Artifact Registry,
+    deployed with GitHub OIDC, bound to Secret Manager object names, and
+    health-checked with `secret_value_readback=false`,
+    `live_adapter_execution=false`, and `github_callback_post=false`. GPP-2
+    remains blocked until cloud bootstrap is attested, a hosted service
+    deployment produces evidence from `main`, the GitHub App webhook URL is
+    configured to the deployed endpoint, and protected workflow evidence
+    confirms an explicit callback response.
 
 ## 3. Current Verdict
 
@@ -223,7 +232,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2q` | Completed / no support widening | Deployable policy webhook runtime | repo-owned WSGI runtime and GitHub App callback POST path ready; hosted service is not yet deployed/configured |
 | `GPP-2r` | Completed / no support widening | Policy webhook container deploy package | repo-owned container image package and bounded no-secret health smoke/CI job ready; hosted service is not yet deployed/configured |
 | `GPP-2s` | Completed / no support widening | Policy container image publication | repo-owned GHCR image publish path ready; hosted service is not yet deployed/configured |
-| `GPP-2` | Blocked / hosted service deployment/config missing | Protected live-adapter gate runtime binding | deployment protection app/policy service image/container must be hosted/configured with webhook URL, webhook secret, and GitHub App auth before further runtime work |
+| `GPP-2t` | Completed / no support widening | Autonomous policy service deployment path | repo-owned Cloud Run OIDC deploy path ready; cloud bootstrap, hosted health evidence, GitHub App webhook config, and callback evidence are not yet attested |
+| `GPP-2` | Blocked / hosted service bootstrap/config/evidence missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be hosted/configured with webhook URL, webhook secret, and GitHub App auth and must post callback evidence before further runtime work |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -642,7 +652,10 @@ bounded no-secret health smoke/CI job, but the container has not yet been
 deployed to a public host or configured in the GitHub App webhook settings.
 GPP-2s adds the GHCR image publication path for that container, but the image
 has not yet been deployed to a public host or configured in the GitHub App
-webhook settings.
+webhook settings. GPP-2t adds the autonomous Cloud Run deploy path for the
+policy service, but cloud OIDC/Secret Manager bootstrap, hosted health evidence
+from `main`, GitHub App webhook URL configuration, and live callback evidence
+are not yet attested.
 GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
@@ -662,13 +675,16 @@ only. GPP-2h selects GitHub App deployment protection, GPP-2i adds attestation
 support for that model, GPP-2j refreshes blocked metadata, and GPP-2k adds the
 operator provisioning runbook.
 
-The next GPP-2 action is to deploy or configure the
-`ao-kernel-live-adapter-gate` deployment protection app/policy service using
-the GPP-2s GHCR image, the GPP-2r container package, the GPP-2q WSGI runtime,
-or an equivalent fail-closed implementation so it receives protected deployment
-callbacks, enriches them with trusted context, evaluates the repo-owned policy
-modules, attaches GitHub App auth outside the repo, and posts an explicit
-GitHub deployment review callback. Do not repeatedly dispatch
+The next GPP-2 action is to bootstrap or run the autonomous policy service
+deployment path: GitHub OIDC trust, Google service-account permissions,
+Artifact Registry, Cloud Run, and Secret Manager object handles must exist
+without secret value readback, then the deploy workflow must produce hosted
+`/healthz` evidence from a trusted `main` image. After that, configure or verify
+the `ao-kernel-live-adapter-gate` GitHub App webhook URL points to the deployed
+`/github/deployment-protection` endpoint so the service can receive protected
+deployment callbacks, enrich them with trusted context, evaluate the repo-owned
+policy modules, attach GitHub App auth at runtime, and post an explicit GitHub
+deployment review callback. Do not repeatedly dispatch
 `.github/workflows/live-adapter-gate.yml` until that service is expected to
 respond. Any follow-up must keep fork and pull-request contexts away from
 protected credentials, must not use `AO_CLAUDE_CODE_CLI_AUTH` through a
@@ -694,6 +710,7 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | Webhook runtime exists but is not hosted | GitHub App still cannot receive or answer deployment callbacks | Treat GPP-2q as deployability readiness only; configure the hosted endpoint and GitHub App webhook before rerunning evidence |
 | Container package exists but is not hosted | Local image health does not prove GitHub can call the app | Treat GPP-2r as packaging readiness only; deploy to a public host and configure GitHub App webhook before rerunning evidence |
 | Container image exists but service is not hosted | GHCR image publication does not prove GitHub can call the app | Treat GPP-2s as deploy artifact readiness only; deploy the image to a public host and configure GitHub App webhook before rerunning evidence |
+| Deploy workflow exists but cloud bootstrap is missing | Automation path cannot produce hosted evidence | Treat GPP-2t as deploy automation readiness only; bootstrap OIDC/Secret Manager/Cloud Run and verify hosted health before rerunning protected workflow evidence |
 
 ## 19. Tracking Log
 
@@ -743,3 +760,5 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-28 | GPP-2r container package added | `deploy/live-adapter-gate-policy-service/Dockerfile`, `scripts/live_adapter_gate_policy_container_smoke.py`, and the `policy-container-smoke` CI job package the WSGI runtime as a no-secret health-checkable container; public hosting and GitHub App webhook configuration remain required before rerunning protected workflow evidence. |
 | 2026-04-28 | GPP-2s issue opened | Issue [#533](https://github.com/Halildeu/ao-kernel/issues/533) tracks the deployment protection policy container image publication path. |
 | 2026-04-28 | GPP-2s image publish path added | `.github/workflows/policy-container-publish.yml` builds, no-secret smokes, and publishes trusted non-PR images to `ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service`; public hosting and GitHub App webhook configuration remain required before rerunning protected workflow evidence. |
+| 2026-04-28 | GPP-2t issue opened | Issue [#535](https://github.com/Halildeu/ao-kernel/issues/535) tracks the autonomous policy service deployment path. |
+| 2026-04-28 | GPP-2t deploy path added | `.github/workflows/policy-service-deploy-cloud-run.yml` can mirror trusted GHCR images to Artifact Registry, deploy Cloud Run with OIDC and Secret Manager references, health-check `/healthz`, and upload no-secret deployment evidence; cloud bootstrap, GitHub App webhook URL configuration, and callback evidence remain required before rerunning protected workflow evidence. |

--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 autonomous policy service deploy path ready; cloud/bootstrap and callback evidence still blocked
+**Status:** GPP-2 Cloud Run bootstrap attestation tool ready; repository variables, GCP trust, hosting, and callback evidence still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#535](https://github.com/Halildeu/ao-kernel/issues/535)
-for autonomous deployment protection policy service deployment
-**Current slice record:** `.claude/plans/GPP-2t-AUTONOMOUS-POLICY-SERVICE-DEPLOYMENT.md`
+**Current slice issue:** [#549](https://github.com/Halildeu/ao-kernel/issues/549)
+for policy service Cloud Run bootstrap attestation
+**Current slice record:** `.claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -174,6 +174,14 @@ Last live verification on current `origin/main` showed:
     deployment produces evidence from `main`, the GitHub App webhook URL is
     configured to the deployed endpoint, and protected workflow evidence
     confirms an explicit callback response.
+37. GPP-2ab adds a metadata-only bootstrap attestation tool for the GitHub
+    repository variable handles required by the Cloud Run deployment workflow.
+    The current live metadata check reports all required handles missing.
+    `metadata_ready` would mean only that the variable handles are present by
+    name/timestamp. It would not prove Google Cloud OIDC trust,
+    service-account permissions, Secret Manager objects, Cloud Run hosting,
+    GitHub App webhook configuration, callback posting, live adapter execution,
+    support widening, or production-platform readiness.
 
 ## 3. Current Verdict
 
@@ -233,6 +241,7 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2r` | Completed / no support widening | Policy webhook container deploy package | repo-owned container image package and bounded no-secret health smoke/CI job ready; hosted service is not yet deployed/configured |
 | `GPP-2s` | Completed / no support widening | Policy container image publication | repo-owned GHCR image publish path ready; hosted service is not yet deployed/configured |
 | `GPP-2t` | Completed / no support widening | Autonomous policy service deployment path | repo-owned Cloud Run OIDC deploy path ready; cloud bootstrap, hosted health evidence, GitHub App webhook config, and callback evidence are not yet attested |
+| `GPP-2ab` | Completed / no support widening | Policy Cloud Run bootstrap attestation | metadata-only attestation tool ready; required repository variable handles are currently missing; GCP trust, Secret Manager objects, hosted service evidence, GitHub App webhook config, and callback evidence are not yet attested |
 | `GPP-2` | Blocked / hosted service bootstrap/config/evidence missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be hosted/configured with webhook URL, webhook secret, and GitHub App auth and must post callback evidence before further runtime work |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -362,9 +371,11 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2s; policy decision core, webhook scaffold,
-deployable WSGI runtime, container package, and GHCR image publication path
-exist, but hosted service deployment/configuration is still missing.
+**Status:** blocked after GPP-2ab; policy decision core, webhook scaffold,
+deployable WSGI runtime, container package, GHCR image publication path,
+Cloud Run deploy automation, and metadata-only bootstrap attestation tooling
+exist, but required repository variables, GCP trust, hosted service
+deployment/configuration, and callback evidence are still missing.
 
 **Entry criteria:**
 
@@ -388,7 +399,13 @@ tooling with CI validation, but no public hosted endpoint, webhook URL, runtime
 secret manager configuration, or live callback evidence has been recorded.
 GPP-2s adds a GHCR image publication path for trusted non-PR builds, but no
 public hosted endpoint, webhook URL, runtime secret manager configuration, or
-live callback evidence has been recorded.
+live callback evidence has been recorded. GPP-2t adds an autonomous Cloud Run
+deploy path, but no GCP trust bootstrap, hosted health evidence, webhook URL
+configuration, or callback evidence has been recorded. GPP-2ab adds a
+metadata-only repository variable bootstrap attestation tool for that deploy
+path, and the current live metadata check reports required handles missing.
+Even after a future `metadata_ready`, that status is not Google Cloud OIDC,
+Secret Manager, Cloud Run, webhook, or callback evidence.
 
 **Acceptance criteria:**
 
@@ -655,7 +672,12 @@ has not yet been deployed to a public host or configured in the GitHub App
 webhook settings. GPP-2t adds the autonomous Cloud Run deploy path for the
 policy service, but cloud OIDC/Secret Manager bootstrap, hosted health evidence
 from `main`, GitHub App webhook URL configuration, and live callback evidence
-are not yet attested.
+are not yet attested. GPP-2ab adds a metadata-only bootstrap attestation tool
+for the Cloud Run deploy workflow's required GitHub repository variable
+handles, and the current live metadata check reports required handles missing.
+A future `metadata_ready` must be treated only as repository-variable evidence,
+not GCP trust, hosted service, webhook configuration, callback, or live
+execution evidence.
 GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
@@ -675,8 +697,10 @@ only. GPP-2h selects GitHub App deployment protection, GPP-2i adds attestation
 support for that model, GPP-2j refreshes blocked metadata, and GPP-2k adds the
 operator provisioning runbook.
 
-The next GPP-2 action is to bootstrap or run the autonomous policy service
-deployment path: GitHub OIDC trust, Google service-account permissions,
+The next GPP-2 action is to run
+`scripts/policy_service_cloud_run_bootstrap_attest.py`, provision any missing
+repository variable handles, then bootstrap or run the autonomous policy
+service deployment path: GitHub OIDC trust, Google service-account permissions,
 Artifact Registry, Cloud Run, and Secret Manager object handles must exist
 without secret value readback, then the deploy workflow must produce hosted
 `/healthz` evidence from a trusted `main` image. After that, configure or verify
@@ -711,6 +735,8 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | Container package exists but is not hosted | Local image health does not prove GitHub can call the app | Treat GPP-2r as packaging readiness only; deploy to a public host and configure GitHub App webhook before rerunning evidence |
 | Container image exists but service is not hosted | GHCR image publication does not prove GitHub can call the app | Treat GPP-2s as deploy artifact readiness only; deploy the image to a public host and configure GitHub App webhook before rerunning evidence |
 | Deploy workflow exists but cloud bootstrap is missing | Automation path cannot produce hosted evidence | Treat GPP-2t as deploy automation readiness only; bootstrap OIDC/Secret Manager/Cloud Run and verify hosted health before rerunning protected workflow evidence |
+| Missing repository variables bypassed | Deploy workflow could be dispatched before non-secret handles exist | Run GPP-2ab attestation with `--fail-on-blocked` and provision missing GitHub repository variables before deploy dispatch |
+| `metadata_ready` mistaken for cloud readiness | Deployment could be treated as unblocked without GCP trust or hosting proof | Treat GPP-2ab as repository-variable metadata only; separately prove OIDC, service account permissions, Secret Manager objects, Cloud Run health, webhook URL, and callback evidence |
 
 ## 19. Tracking Log
 
@@ -762,3 +788,5 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-28 | GPP-2s image publish path added | `.github/workflows/policy-container-publish.yml` builds, no-secret smokes, and publishes trusted non-PR images to `ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service`; public hosting and GitHub App webhook configuration remain required before rerunning protected workflow evidence. |
 | 2026-04-28 | GPP-2t issue opened | Issue [#535](https://github.com/Halildeu/ao-kernel/issues/535) tracks the autonomous policy service deployment path. |
 | 2026-04-28 | GPP-2t deploy path added | `.github/workflows/policy-service-deploy-cloud-run.yml` can mirror trusted GHCR images to Artifact Registry, deploy Cloud Run with OIDC and Secret Manager references, health-check `/healthz`, and upload no-secret deployment evidence; cloud bootstrap, GitHub App webhook URL configuration, and callback evidence remain required before rerunning protected workflow evidence. |
+| 2026-04-28 | GPP-2ab issue opened | Issue [#549](https://github.com/Halildeu/ao-kernel/issues/549) tracks metadata-only Cloud Run bootstrap attestation for the policy service deploy path. |
+| 2026-04-28 | GPP-2ab bootstrap attestation added | `scripts/policy_service_cloud_run_bootstrap_attest.py` checks required GitHub repository variable handles with `gh variable list --json name,updatedAt`, ignores values, and records that current live metadata is `overall_status=blocked` because all required handles are missing; GCP trust, Secret Manager objects, Cloud Run hosting, webhook URL configuration, callback posting, live execution, support widening, and production-platform claims remain unproven. |

--- a/.claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md
+++ b/.claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md
@@ -1,0 +1,161 @@
+# GPP-2ab - Policy Cloud Run Bootstrap Attestation
+
+**Status:** closeout candidate
+**Date:** 2026-04-28
+**Authority:** `origin/main` at `02a4b7e`
+**Issue:** [#549](https://github.com/Halildeu/ao-kernel/issues/549)
+**Branch:** `codex/gpp-2ab-policy-cloud-run-bootstrap-attest`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2ab-policy-cloud-run-bootstrap-attest`
+**Program head:** `GPP-2` blocked on hosted policy service bootstrap/configuration
+**Support impact:** none
+**Runtime impact:** no Cloud Run deployment, no GitHub callback post, no
+protected workflow dispatch, no live adapter call
+
+## 1. Purpose
+
+GPP-2t added the autonomous Cloud Run deployment path for the policy service,
+but the next repeatable question was whether the repository has the non-secret
+variable handles required before dispatching that workflow. This slice adds a
+metadata-only bootstrap attestation for those handles.
+
+Decision:
+
+```text
+policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing
+```
+
+This slice creates the bootstrap attestation tool. It does not prove Google
+Cloud Workload Identity, service-account permissions, Artifact Registry,
+Secret Manager objects, Cloud Run hosting, GitHub App webhook configuration, a
+deployment protection callback post, live adapter execution, support widening,
+or production-platform readiness.
+
+## 2. Implemented Surface
+
+Code and docs:
+
+1. `scripts/policy_service_cloud_run_bootstrap_attest.py`
+   - collects GitHub repository variable metadata with
+     `gh variable list --json name,updatedAt`;
+   - records only variable names, presence, and update timestamps;
+   - ignores any variable `value` fields present in fixtures;
+   - writes `policy-service-cloud-run-bootstrap-attestation.v1.json`;
+   - exits non-zero with `--fail-on-blocked` when required handles are missing.
+2. `tests/test_policy_service_cloud_run_bootstrap_attest.py`
+   - pins metadata-only behavior, missing-variable blocking, CLI rendering, and
+     no-secret/no-live-operation guardrails.
+3. `deploy/live-adapter-gate-policy-service/README.md`
+   - documents the bootstrap attestation before Cloud Run deployment.
+4. `docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md`
+   - records how to run and interpret the attestation.
+
+## 3. Metadata Contract
+
+Required repository variables:
+
+```text
+GCP_PROJECT_ID
+GCP_WORKLOAD_IDENTITY_PROVIDER
+GCP_SERVICE_ACCOUNT
+GCP_CLOUD_RUN_REGION
+GCP_ARTIFACT_REGISTRY_LOCATION
+GCP_ARTIFACT_REGISTRY_REPOSITORY
+POLICY_SERVICE_NAME
+AO_GITHUB_APP_ID
+AO_POLICY_SERVICE_WEBHOOK_SECRET_NAME
+AO_GITHUB_APP_PRIVATE_KEY_SECRET_NAME
+```
+
+Optional repository variables:
+
+```text
+AO_POLICY_SERVICE_WEBHOOK_SECRET_VERSION
+AO_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION
+```
+
+The two `*_SECRET_NAME` variables are Secret Manager object names, not secret
+values. A `metadata_ready` attestation means only that these repository
+variable handles are visible by metadata. It is not cloud trust evidence.
+
+Current live metadata observation on 2026-04-28:
+
+```text
+overall_status=blocked
+finding_code=policy_cloud_run_bootstrap_missing_repository_variables
+```
+
+The live repository metadata check reported all required handles missing. Do
+not dispatch the Cloud Run deploy workflow until those handles are provisioned
+and a new attestation reports `overall_status=metadata_ready`.
+
+## 4. Trust Boundary
+
+The attestation intentionally does not use:
+
+```text
+gcloud secrets versions access
+secrets.*
+AO_CLAUDE_CODE_CLI_AUTH
+```
+
+It also does not deploy, dispatch, or post:
+
+```text
+Cloud Run deployment
+GitHub deployment protection callback
+.github/workflows/live-adapter-gate.yml
+live adapter execution
+```
+
+## 5. Current Decision
+
+Resolved by this slice:
+
+1. a repo-owned metadata-only attestation exists for the Cloud Run deploy
+   workflow's required repository variable handles;
+2. missing required handles produce `overall_status=blocked`;
+3. present required handles produce `overall_status=metadata_ready`;
+4. fixture values are ignored and are not serialized into evidence;
+5. the artifact records no secret value readback, no Cloud Run deployment, no
+   GitHub callback post, no live adapter execution, no support widening, and
+   no production-platform claim.
+
+Still blocked:
+
+1. required GitHub repository variable handles are currently missing;
+2. Google Cloud OIDC trust is not proven;
+3. Google service-account permissions are not proven;
+4. Artifact Registry and Secret Manager objects are not proven;
+5. Cloud Run hosting evidence is not present;
+6. the GitHub App webhook URL is not proven configured to a hosted endpoint;
+7. no real GitHub deployment callback review has been posted by the hosted
+   service;
+8. no new protected workflow evidence artifacts exist after policy response.
+
+Still closed:
+
+1. `live_execution_allowed=false`;
+2. `support_widening=false`;
+3. `production_platform_claim=false`.
+
+## 6. Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_policy_service_cloud_run_bootstrap_attest.py tests/test_policy_service_deploy_workflow.py tests/test_gpp_next.py
+python3 -m ruff check scripts/policy_service_cloud_run_bootstrap_attest.py tests/test_policy_service_cloud_run_bootstrap_attest.py tests/test_policy_service_deploy_workflow.py tests/test_gpp_next.py
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Expected closeout decision:
+
+```text
+policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing
+```
+
+Recorded closeout decision:
+
+```text
+policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing
+```

--- a/.claude/plans/GPP-2t-AUTONOMOUS-POLICY-SERVICE-DEPLOYMENT.md
+++ b/.claude/plans/GPP-2t-AUTONOMOUS-POLICY-SERVICE-DEPLOYMENT.md
@@ -1,0 +1,183 @@
+# GPP-2t - Autonomous Policy Service Deployment Path
+
+**Status:** closeout candidate
+**Date:** 2026-04-28
+**Authority:** `origin/main` at `02a4b7e`
+**Issue:** [#535](https://github.com/Halildeu/ao-kernel/issues/535)
+**Branch:** `codex/gpp-2t-autonomous-policy-deploy`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2t-autonomous-policy-deploy`
+**Program head:** `GPP-2` blocked on hosted policy service bootstrap/configuration
+**Support impact:** none
+**Runtime impact:** no live adapter call; no protected workflow dispatch; no
+GitHub deployment callback post in this slice
+
+## 1. Purpose
+
+GPP-2s made the policy service image publishable to GHCR. The next blocker was
+manual/public hosting. This slice adds a repo-owned autonomous deploy path for
+the policy service so a trusted `main` image can be deployed, health-checked,
+and evidenced without treating a manual UI host as the operating model.
+
+Decision:
+
+```text
+policy_service_autonomous_deploy_path_ready_service_not_bootstrapped
+```
+
+This slice creates the deploy automation path. It does not prove that the cloud
+trust bootstrap exists, does not configure the GitHub App webhook URL by reading
+GitHub App secrets in Actions, does not post a live deployment protection
+callback, does not run the live adapter, and does not widen support.
+
+## 2. Implemented Surface
+
+Deploy assets:
+
+1. `.github/workflows/policy-service-deploy-cloud-run.yml`
+   - triggers from successful trusted `Publish Policy Container` workflow runs
+     on `main` or trusted manual dispatch;
+   - uses GitHub OIDC (`id-token: write`) to authenticate to Google Cloud;
+   - reads only repository variables for cloud resource names and secret object
+     names;
+   - pulls the immutable GHCR image tag for the source SHA;
+   - mirrors that immutable image to Google Artifact Registry;
+   - deploys the image to Cloud Run with public ingress for GitHub webhook
+     delivery;
+   - binds runtime secrets by Secret Manager name/version, not by secret value;
+   - checks `GET /healthz`;
+   - uploads `policy-service-deploy.v1.json` evidence.
+2. `tests/test_policy_service_deploy_workflow.py`
+   - pins the OIDC/Cloud Run path, immutable image flow, health evidence, and
+     security guardrails.
+3. `deploy/live-adapter-gate-policy-service/README.md`
+   - documents required repository variables and secret-manager name contract.
+4. `docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md`
+   - records the autonomous deploy path and the evidence interpretation.
+
+## 3. Trust Boundary
+
+The workflow intentionally does not use:
+
+```text
+secrets.*
+AO_CLAUDE_CODE_CLI_AUTH
+gcloud secrets versions access
+pull_request
+pull_request_target
+```
+
+It also does not dispatch:
+
+```text
+.github/workflows/live-adapter-gate.yml
+```
+
+The policy service gets only the GitHub App runtime materials that Cloud Run
+resolves from Secret Manager at runtime:
+
+```text
+AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+Repository variables such as `AO_POLICY_SERVICE_WEBHOOK_SECRET_NAME` and
+`AO_GITHUB_APP_PRIVATE_KEY_SECRET_NAME` are secret object names, not secret
+values.
+
+## 4. Bootstrap Contract
+
+The automation is autonomous after the following machine-trust bootstrap exists:
+
+1. Google Cloud Workload Identity Provider trusts this repository's GitHub OIDC
+   identity for the deploy workflow.
+2. The configured Google service account can push to the selected Artifact
+   Registry repository and deploy the selected Cloud Run service.
+3. Google Secret Manager contains the webhook secret and GitHub App private key
+   under the configured secret object names.
+4. The Cloud Run service can access those secrets at runtime.
+5. The GitHub App webhook URL points at:
+
+```text
+https://<cloud-run-service-url>/github/deployment-protection
+```
+
+The bootstrap can be performed by infrastructure automation outside this repo,
+but the secret values must not be pasted into issues, PRs, logs, chat, MCP
+prompts, or repository files.
+
+## 5. Evidence Contract
+
+A successful deploy workflow uploads:
+
+```text
+policy-service-deploy.v1.json
+healthz.json
+```
+
+The deployment evidence records:
+
+```text
+status=policy_service_deployed_health_checked
+secret_value_readback=false
+live_adapter_execution=false
+github_callback_post=false
+support_widening=false
+production_platform_claim=false
+```
+
+This evidence proves a hosted health endpoint for the policy service revision.
+It is not enough to unblock live adapter execution. GPP-2 remains blocked until
+a later protected workflow evidence slice confirms that the GitHub App service
+receives a real `deployment_protection_rule` delivery and posts an explicit
+deployment protection callback review.
+
+## 6. Current Decision
+
+Resolved by this slice:
+
+1. repo-owned autonomous deploy workflow exists;
+2. deploy authentication is OIDC-based, not a committed cloud key;
+3. PR/fork contexts cannot run the deploy job;
+4. immutable GHCR image tags remain the source of deployed revisions;
+5. runtime secrets are passed by Secret Manager reference only;
+6. deploy evidence records no secret readback and no live adapter execution.
+
+Still blocked:
+
+1. cloud OIDC/service-account/Secret Manager bootstrap is not attested by this
+   PR;
+2. no Cloud Run deployment run has completed from `main` in this slice;
+3. GitHub App webhook URL is not proven configured to the Cloud Run endpoint;
+4. no real GitHub deployment callback review has been posted by the hosted
+   service;
+5. no new protected workflow evidence artifacts exist after policy response.
+
+Still closed:
+
+1. `live_execution_allowed=false`;
+2. `support_widening=false`;
+3. `production_platform_claim=false`.
+
+## 7. Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_policy_service_deploy_workflow.py tests/test_policy_container_publish_workflow.py tests/test_gpp_next.py
+python3 -m ruff check tests/test_policy_service_deploy_workflow.py tests/test_policy_container_publish_workflow.py tests/test_gpp_next.py
+actionlint .github/workflows/policy-service-deploy-cloud-run.yml .github/workflows/policy-container-publish.yml
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Expected closeout decision:
+
+```text
+policy_service_autonomous_deploy_path_ready_service_not_bootstrapped
+```
+
+Recorded closeout decision:
+
+```text
+policy_service_autonomous_deploy_path_ready_service_not_bootstrapped
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,9 +9,9 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/535",
-    "exit_decision": "policy_service_autonomous_deploy_path_ready_service_not_bootstrapped",
-    "ready_after": "deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, posts callback reviews, and produces protected workflow evidence with live_execution_allowed=false",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/549",
+    "exit_decision": "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing",
+    "ready_after": "policy service deploy workflow has completed from trusted main, hosted endpoint is configured as the GitHub App webhook URL, callback review evidence exists, and protected workflow evidence confirms live_execution_allowed=false",
     "allowed_scope": [
       "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
       "repeat protected workflow evidence collection from main after the policy service responds",
@@ -146,15 +146,22 @@
       "decision": "policy_service_autonomous_deploy_path_ready_service_not_bootstrapped",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/535",
       "record": ".claude/plans/GPP-2t-AUTONOMOUS-POLICY-SERVICE-DEPLOYMENT.md"
+    },
+    {
+      "id": "GPP-2ab",
+      "decision": "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/549",
+      "record": ".claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned autonomous Cloud Run deployment path is ready, but cloud OIDC/secret-manager bootstrap, hosted service evidence, GitHub App webhook URL configuration, and live deployment callback review evidence are not yet attested"
+      "reason": "repo-owned autonomous Cloud Run deployment path is ready, and metadata-only bootstrap attestation tool is ready, but the required GitHub repository variable handles are currently missing; Google Cloud OIDC trust, Secret Manager objects, hosted service evidence, GitHub App webhook URL configuration, and live deployment callback review evidence are not yet attested"
     }
   ],
   "pending_external_actions": [
+    "run scripts/policy_service_cloud_run_bootstrap_attest.py and provision any missing GitHub repository variable handles before dispatching the Cloud Run deploy workflow, while treating metadata_ready as repository-variable evidence only",
     "bootstrap the policy service deploy trust path with GitHub OIDC, Google service-account permissions, Artifact Registry, Cloud Run, and Secret Manager object handles without secret value readback",
     "run or observe the autonomous Cloud Run deployment workflow from a trusted main image until it produces health evidence for the policy service endpoint",
     "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the deployed /github/deployment-protection endpoint and can post deployment callback reviews",
@@ -212,6 +219,7 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
+    "run scripts/policy_service_cloud_run_bootstrap_attest.py to verify required GitHub repository variable handles before dispatching the Cloud Run deploy workflow, and treat metadata_ready as repository-variable evidence only",
     "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work",
     "configure or verify the GitHub App webhook URL only after the deployed policy service endpoint is health-checked",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,8 +9,8 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/533",
-    "exit_decision": "policy_container_publish_path_ready_service_not_hosted",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/535",
+    "exit_decision": "policy_service_autonomous_deploy_path_ready_service_not_bootstrapped",
     "ready_after": "deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, posts callback reviews, and produces protected workflow evidence with live_execution_allowed=false",
     "allowed_scope": [
       "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
@@ -140,16 +140,24 @@
       "decision": "policy_container_publish_path_ready_service_not_hosted",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/533",
       "record": ".claude/plans/GPP-2s-POLICY-CONTAINER-IMAGE-PUBLISH.md"
+    },
+    {
+      "id": "GPP-2t",
+      "decision": "policy_service_autonomous_deploy_path_ready_service_not_bootstrapped",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/535",
+      "record": ".claude/plans/GPP-2t-AUTONOMOUS-POLICY-SERVICE-DEPLOYMENT.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned policy webhook container image publish path is ready, but the GitHub App service is not yet publicly hosted/configured with webhook URL, webhook secret, and GitHub App auth to post deployment callback reviews"
+      "reason": "repo-owned autonomous Cloud Run deployment path is ready, but cloud OIDC/secret-manager bootstrap, hosted service evidence, GitHub App webhook URL configuration, and live deployment callback review evidence are not yet attested"
     }
   ],
   "pending_external_actions": [
-    "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
+    "bootstrap the policy service deploy trust path with GitHub OIDC, Google service-account permissions, Artifact Registry, Cloud Run, and Secret Manager object handles without secret value readback",
+    "run or observe the autonomous Cloud Run deployment workflow from a trusted main image until it produces health evidence for the policy service endpoint",
+    "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the deployed /github/deployment-protection endpoint and can post deployment callback reviews",
     "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly"
   ],
   "support_widening_allowed": false,
@@ -204,7 +212,8 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "deploy or configure the deployment-protection policy service using the repo-owned GHCR image or container package before any further live-adapter runtime work",
+    "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work",
+    "configure or verify the GitHub App webhook URL only after the deployed policy service endpoint is health-checked",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
     "use Claude MCP consultation only as advisory review, not release authority",
     "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active",

--- a/.github/workflows/policy-service-deploy-cloud-run.yml
+++ b/.github/workflows/policy-service-deploy-cloud-run.yml
@@ -1,0 +1,218 @@
+name: Deploy Policy Service to Cloud Run
+
+on:
+  workflow_run:
+    workflows: ["Publish Policy Container"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Trusted policy service deployment reason"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+  id-token: write
+
+env:
+  GHCR_IMAGE_NAME: ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+  GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+  GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+  GCP_CLOUD_RUN_REGION: ${{ vars.GCP_CLOUD_RUN_REGION }}
+  GCP_ARTIFACT_REGISTRY_LOCATION: ${{ vars.GCP_ARTIFACT_REGISTRY_LOCATION }}
+  GCP_ARTIFACT_REGISTRY_REPOSITORY: ${{ vars.GCP_ARTIFACT_REGISTRY_REPOSITORY }}
+  POLICY_SERVICE_NAME: ${{ vars.POLICY_SERVICE_NAME }}
+  AO_GITHUB_APP_ID: ${{ vars.AO_GITHUB_APP_ID }}
+  AO_POLICY_SERVICE_WEBHOOK_SECRET_NAME: ${{ vars.AO_POLICY_SERVICE_WEBHOOK_SECRET_NAME }}
+  AO_POLICY_SERVICE_WEBHOOK_SECRET_VERSION: ${{ vars.AO_POLICY_SERVICE_WEBHOOK_SECRET_VERSION || 'latest' }}
+  AO_GITHUB_APP_PRIVATE_KEY_SECRET_NAME: ${{ vars.AO_GITHUB_APP_PRIVATE_KEY_SECRET_NAME }}
+  AO_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION: ${{ vars.AO_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION || 'latest' }}
+
+jobs:
+  deploy-policy-service:
+    name: deploy-policy-service
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.event != 'pull_request'
+      )
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate trusted deploy configuration
+        env:
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+        run: |
+          set -euo pipefail
+
+          required_vars=(
+            GCP_PROJECT_ID
+            GCP_WORKLOAD_IDENTITY_PROVIDER
+            GCP_SERVICE_ACCOUNT
+            GCP_CLOUD_RUN_REGION
+            GCP_ARTIFACT_REGISTRY_LOCATION
+            GCP_ARTIFACT_REGISTRY_REPOSITORY
+            POLICY_SERVICE_NAME
+            AO_GITHUB_APP_ID
+            AO_POLICY_SERVICE_WEBHOOK_SECRET_NAME
+            AO_GITHUB_APP_PRIVATE_KEY_SECRET_NAME
+          )
+
+          missing=0
+          for name in "${required_vars[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Required repository variable $name is not configured."
+              missing=1
+            fi
+          done
+
+          source_sha="${WORKFLOW_RUN_HEAD_SHA:-$GITHUB_SHA}"
+          if [ -z "$source_sha" ]; then
+            echo "::error::Could not determine source SHA for policy image deployment."
+            missing=1
+          fi
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - id: images
+        name: Resolve immutable source and deployment images
+        env:
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+        run: |
+          set -euo pipefail
+
+          source_sha="${WORKFLOW_RUN_HEAD_SHA:-$GITHUB_SHA}"
+          ghcr_image="${GHCR_IMAGE_NAME}:sha-${source_sha}"
+          gar_host="${GCP_ARTIFACT_REGISTRY_LOCATION}-docker.pkg.dev"
+          gar_image="${gar_host}/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REGISTRY_REPOSITORY}/${POLICY_SERVICE_NAME}:sha-${source_sha}"
+
+          {
+            echo "source_sha=$source_sha"
+            echo "ghcr_image=$ghcr_image"
+            echo "gar_host=$gar_host"
+            echo "gar_image=$gar_image"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud with OIDC
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Log in to GHCR for source image pull
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      - name: Configure Artifact Registry Docker auth
+        run: gcloud auth configure-docker "${{ steps.images.outputs.gar_host }}" --quiet
+
+      - name: Mirror immutable GHCR image to Artifact Registry
+        run: |
+          set -euo pipefail
+
+          docker pull "${{ steps.images.outputs.ghcr_image }}"
+          docker tag "${{ steps.images.outputs.ghcr_image }}" "${{ steps.images.outputs.gar_image }}"
+          docker push "${{ steps.images.outputs.gar_image }}"
+
+      - id: deploy
+        name: Deploy policy service revision
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.POLICY_SERVICE_NAME }}
+          region: ${{ env.GCP_CLOUD_RUN_REGION }}
+          image: ${{ steps.images.outputs.gar_image }}
+          flags: "--allow-unauthenticated --ingress=all --port=8000"
+          env_vars: |
+            AO_GITHUB_APP_ID=${{ env.AO_GITHUB_APP_ID }}
+            PORT=8000
+          secrets: |
+            AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET=${{ env.AO_POLICY_SERVICE_WEBHOOK_SECRET_NAME }}:${{ env.AO_POLICY_SERVICE_WEBHOOK_SECRET_VERSION }}
+            AO_GITHUB_APP_PRIVATE_KEY_PEM=${{ env.AO_GITHUB_APP_PRIVATE_KEY_SECRET_NAME }}:${{ env.AO_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION }}
+
+      - name: Health-check deployed policy service
+        run: |
+          set -euo pipefail
+
+          mkdir -p policy-service-deploy-evidence
+          service_url="${{ steps.deploy.outputs.url }}"
+          curl -fsS --retry 5 --retry-delay 5 --retry-connrefused \
+            "$service_url/healthz" \
+            > policy-service-deploy-evidence/healthz.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("policy-service-deploy-evidence/healthz.json").read_text(encoding="utf-8"))
+          if payload.get("status") != "ok":
+              raise SystemExit(f"unexpected policy service health status: {payload!r}")
+          PY
+
+      - name: Write deployment evidence
+        env:
+          SERVICE_URL: ${{ steps.deploy.outputs.url }}
+          SOURCE_SHA: ${{ steps.images.outputs.source_sha }}
+          GHCR_IMAGE: ${{ steps.images.outputs.ghcr_image }}
+          GAR_IMAGE: ${{ steps.images.outputs.gar_image }}
+        run: |
+          set -euo pipefail
+
+          jq -n \
+            --arg schema_version "1" \
+            --arg program_id "GPP-2t" \
+            --arg service_name "$POLICY_SERVICE_NAME" \
+            --arg cloud_run_region "$GCP_CLOUD_RUN_REGION" \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg source_image "$GHCR_IMAGE" \
+            --arg deployed_image "$GAR_IMAGE" \
+            --arg service_url "$SERVICE_URL" \
+            --arg webhook_url "$SERVICE_URL/github/deployment-protection" \
+            --arg health_url "$SERVICE_URL/healthz" \
+            '{
+              schema_version: $schema_version,
+              program_id: $program_id,
+              status: "policy_service_deployed_health_checked",
+              service_name: $service_name,
+              cloud_run_region: $cloud_run_region,
+              source_sha: $source_sha,
+              source_image: $source_image,
+              deployed_image: $deployed_image,
+              service_url: $service_url,
+              webhook_url: $webhook_url,
+              health_url: $health_url,
+              health_checked: true,
+              secret_value_readback: false,
+              live_adapter_execution: false,
+              github_callback_post: false,
+              production_platform_claim: false,
+              support_widening: false
+            }' > policy-service-deploy-evidence/policy-service-deploy.v1.json
+
+          {
+            echo "Policy service deployment evidence"
+            echo
+            echo "- Source image: \`$GHCR_IMAGE\`"
+            echo "- Deployed image: \`$GAR_IMAGE\`"
+            echo "- Health URL: \`$SERVICE_URL/healthz\`"
+            echo "- GitHub App webhook URL: \`$SERVICE_URL/github/deployment-protection\`"
+            echo "- Secret value readback: \`false\`"
+            echo "- Live adapter execution: \`false\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload deployment evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: policy-service-deploy-${{ steps.images.outputs.source_sha }}
+          path: policy-service-deploy-evidence/

--- a/deploy/live-adapter-gate-policy-service/README.md
+++ b/deploy/live-adapter-gate-policy-service/README.md
@@ -83,6 +83,23 @@ The deploy workflow does not dispatch the protected live-adapter workflow, post
 GitHub deployment protection callbacks itself, or run a live adapter. It only
 deploys and health-checks the webhook service.
 
+Before dispatching or relying on this deploy path, run the metadata-only
+bootstrap attestation:
+
+```bash
+python3 scripts/policy_service_cloud_run_bootstrap_attest.py \
+  --artifact-path /tmp/policy-service-cloud-run-bootstrap-attestation.v1.json \
+  --output text \
+  --fail-on-blocked
+```
+
+That attestation checks only GitHub repository variable handles with
+`gh variable list --json name,updatedAt`. It does not read variable values,
+does not access Secret Manager, does not prove Google Cloud Workload Identity
+or Cloud Run permissions, does not deploy the service, and does not post a
+GitHub deployment protection callback. Missing repository variables mean the
+Cloud Run deployment must stay blocked.
+
 ## Runtime
 
 Required hosting secrets:

--- a/deploy/live-adapter-gate-policy-service/README.md
+++ b/deploy/live-adapter-gate-policy-service/README.md
@@ -33,6 +33,56 @@ If the hosting provider cannot pull the package anonymously, configure a GHCR
 read token through that provider's secret manager. Do not bake registry tokens
 or runtime secrets into the image.
 
+## Autonomous Cloud Run Deployment
+
+The repository also contains a trusted, non-PR deployment workflow:
+
+```text
+.github/workflows/policy-service-deploy-cloud-run.yml
+```
+
+That workflow is designed to run after the policy container publish workflow
+completes successfully on `main`, or by trusted manual dispatch. It uses
+GitHub OIDC to authenticate to Google Cloud, mirrors the immutable GHCR image
+to Artifact Registry, deploys the policy service to Cloud Run, verifies
+`GET /healthz`, and uploads a deployment evidence artifact.
+
+Required repository variables for that workflow:
+
+```text
+GCP_PROJECT_ID
+GCP_WORKLOAD_IDENTITY_PROVIDER
+GCP_SERVICE_ACCOUNT
+GCP_CLOUD_RUN_REGION
+GCP_ARTIFACT_REGISTRY_LOCATION
+GCP_ARTIFACT_REGISTRY_REPOSITORY
+POLICY_SERVICE_NAME
+AO_GITHUB_APP_ID
+AO_POLICY_SERVICE_WEBHOOK_SECRET_NAME
+AO_GITHUB_APP_PRIVATE_KEY_SECRET_NAME
+```
+
+Optional repository variables:
+
+```text
+AO_POLICY_SERVICE_WEBHOOK_SECRET_VERSION
+AO_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION
+```
+
+The two `*_SECRET_NAME` variables are secret-manager object names, not secret
+values. The workflow must not read back secret values. It passes those names to
+Cloud Run so the hosted service receives runtime secrets from Secret Manager.
+
+The deployed public GitHub App webhook URL has this shape:
+
+```text
+https://<cloud-run-service-url>/github/deployment-protection
+```
+
+The deploy workflow does not dispatch the protected live-adapter workflow, post
+GitHub deployment protection callbacks itself, or run a live adapter. It only
+deploys and health-checks the webhook service.
+
 ## Runtime
 
 Required hosting secrets:

--- a/deploy/live-adapter-gate-policy-service/README.md
+++ b/deploy/live-adapter-gate-policy-service/README.md
@@ -73,6 +73,33 @@ The two `*_SECRET_NAME` variables are secret-manager object names, not secret
 values. The workflow must not read back secret values. It passes those names to
 Cloud Run so the hosted service receives runtime secrets from Secret Manager.
 
+To provision those repository variables without using the GitHub UI, generate a
+local template, fill it with non-secret values, dry-run it, then apply it:
+
+```bash
+python3 scripts/policy_service_cloud_run_repo_variables.py \
+  --write-template /tmp/policy-service-cloud-run-repo-variables.json
+```
+
+```bash
+python3 scripts/policy_service_cloud_run_repo_variables.py \
+  --config-json /tmp/policy-service-cloud-run-repo-variables.json \
+  --dry-run \
+  --output text
+```
+
+```bash
+python3 scripts/policy_service_cloud_run_repo_variables.py \
+  --config-json /tmp/policy-service-cloud-run-repo-variables.json \
+  --output text
+```
+
+The tool validates required handles, rejects unknown variables, refuses common
+credential-shaped values, and sends values to `gh variable set` through stdin so
+they are not placed in the command line or rendered in stdout. Do not put
+webhook secrets, private keys, tokens, or `AO_CLAUDE_CODE_CLI_AUTH` in that
+JSON file.
+
 The deployed public GitHub App webhook URL has this shape:
 
 ```text

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -289,6 +289,44 @@ token through its secret manager. Do not put registry credentials, webhook
 secrets, GitHub App private keys, or live adapter credentials in the container
 image.
 
+Autonomous Cloud Run deployment path after GPP-2t:
+
+1. `.github/workflows/policy-service-deploy-cloud-run.yml` runs only from a
+   successful trusted `Publish Policy Container` workflow on `main`, or by
+   trusted `workflow_dispatch`.
+2. The workflow authenticates to Google Cloud with GitHub OIDC, not a committed
+   cloud key.
+3. It mirrors the immutable GHCR image tag to Google Artifact Registry and
+   deploys that immutable image to Cloud Run.
+4. Runtime secrets are supplied to Cloud Run by Secret Manager object name and
+   version. The workflow must not run `gcloud secrets versions access`, print
+   secret values, or use `secrets.*`.
+5. The public Cloud Run URL must route:
+
+```text
+GET  /healthz
+POST /github/deployment-protection
+```
+
+6. The workflow health-checks `/healthz` and uploads
+   `policy-service-deploy.v1.json` evidence with:
+
+```text
+secret_value_readback=false
+live_adapter_execution=false
+github_callback_post=false
+support_widening=false
+production_platform_claim=false
+```
+
+7. The GitHub App webhook URL should be the deployed Cloud Run URL plus
+   `/github/deployment-protection`. The deploy workflow exposes that URL in
+   its summary and evidence, but does not treat a health check as callback
+   evidence.
+8. Do not rerun protected workflow evidence until the deployed URL is configured
+   in the GitHub App and the service is expected to answer real
+   `deployment_protection_rule` deliveries.
+
 ### 3. Attach the Deployment Protection Rule
 
 Attach the GitHub App as a custom deployment protection rule on environment:

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -327,6 +327,29 @@ production_platform_claim=false
    in the GitHub App and the service is expected to answer real
    `deployment_protection_rule` deliveries.
 
+Bootstrap attestation after GPP-2ab:
+
+```bash
+python3 scripts/policy_service_cloud_run_bootstrap_attest.py \
+  --artifact-path /tmp/policy-service-cloud-run-bootstrap-attestation.v1.json \
+  --output text \
+  --fail-on-blocked
+```
+
+Interpretation:
+
+1. `overall_status=metadata_ready` means only that the required GitHub
+   repository variable handles are present by name/timestamp.
+2. Missing required variables block deployment workflow dispatch until the
+   handles are provisioned.
+3. The attestation does not read variable values, read Secret Manager values,
+   prove Workload Identity trust, prove Google service-account permissions,
+   prove Artifact Registry, deploy Cloud Run, configure the GitHub App webhook
+   URL, post a callback, dispatch the protected live-adapter workflow, or run a
+   live adapter.
+4. Treat the attestation artifact as bootstrap metadata only. Hosted health
+   evidence and protected callback evidence still require later steps.
+
 ### 3. Attach the Deployment Protection Rule
 
 Attach the GitHub App as a custom deployment protection rule on environment:

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -402,14 +402,21 @@ Expected interpretation:
 3. deployment branch policy is custom and includes `main`;
 4. protection rules include the expected branch policy metadata.
 
+Optional public app lookup:
+
 ```bash
 gh api /apps/ao-kernel-live-adapter-gate --jq '{slug:.slug,id:.id,name:.name}'
 ```
 
-Expected interpretation:
+Interpretation:
 
-1. the command returns app metadata, not `HTTP 404`;
-2. `slug` is `ao-kernel-live-adapter-gate`.
+1. If the command returns metadata, `slug` must be
+   `ao-kernel-live-adapter-gate`.
+2. If the command returns `HTTP 404`, do not treat that response alone as a
+   blocker. User-owned or otherwise non-public GitHub Apps can still appear in
+   the environment's custom deployment protection rule inventory below.
+3. For this runbook, the authoritative GitHub App metadata is the enabled
+   deployment protection rule attached to `ao-kernel-live-adapter-gate`.
 
 ```bash
 gh api repos/Halildeu/ao-kernel/environments/ao-kernel-live-adapter-gate/deployment_protection_rules
@@ -475,8 +482,9 @@ operator-only secret handoff details.
 Keep protected workflow evidence blocked or failed when any of these remain
 true:
 
-1. app lookup returns `HTTP 404`;
-2. deployment protection rule list is empty or missing the selected app;
+1. deployment protection rule list is empty or missing the selected app;
+2. public app lookup returns `HTTP 404` and the environment deployment
+   protection rule inventory also fails to show the selected app;
 3. `AO_CLAUDE_CODE_CLI_AUTH` is absent from environment secret metadata;
 4. admin bypass is enabled;
 5. branch policy is not restricted to `main`;

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -350,6 +350,63 @@ Interpretation:
 4. Treat the attestation artifact as bootstrap metadata only. Hosted health
    evidence and protected callback evidence still require later steps.
 
+Repository-variable bootstrap helper:
+
+```bash
+python3 scripts/policy_service_cloud_run_repo_variables.py \
+  --write-template /tmp/policy-service-cloud-run-repo-variables.json
+```
+
+Fill the template only with non-secret repository variable values:
+
+```text
+GCP_PROJECT_ID
+GCP_WORKLOAD_IDENTITY_PROVIDER
+GCP_SERVICE_ACCOUNT
+GCP_CLOUD_RUN_REGION
+GCP_ARTIFACT_REGISTRY_LOCATION
+GCP_ARTIFACT_REGISTRY_REPOSITORY
+POLICY_SERVICE_NAME
+AO_GITHUB_APP_ID
+AO_POLICY_SERVICE_WEBHOOK_SECRET_NAME
+AO_GITHUB_APP_PRIVATE_KEY_SECRET_NAME
+```
+
+The two `*_SECRET_NAME` values are Secret Manager object names, not secret
+values. Webhook secrets, GitHub App private keys, tokens, passwords, and
+`AO_CLAUDE_CODE_CLI_AUTH` must stay outside this JSON file.
+
+Validate without writing:
+
+```bash
+python3 scripts/policy_service_cloud_run_repo_variables.py \
+  --config-json /tmp/policy-service-cloud-run-repo-variables.json \
+  --dry-run \
+  --output text
+```
+
+Apply through the GitHub CLI:
+
+```bash
+python3 scripts/policy_service_cloud_run_repo_variables.py \
+  --config-json /tmp/policy-service-cloud-run-repo-variables.json \
+  --output text
+```
+
+Interpretation:
+
+1. The helper only writes GitHub repository variables with `gh variable set`.
+2. Variable values are supplied to `gh` through stdin and are not rendered in
+   stdout.
+3. The helper rejects unknown variables, missing required handles, runtime
+   secret variable names, and common credential-shaped values.
+4. It does not read back variable values, read Secret Manager values, deploy
+   Cloud Run, configure the GitHub App webhook URL, post a callback, dispatch
+   the protected live-adapter workflow, or run a live adapter.
+5. After applying, rerun
+   `scripts/policy_service_cloud_run_bootstrap_attest.py --fail-on-blocked` to
+   prove only that the required repository variable handles exist.
+
 ### 3. Attach the Deployment Protection Rule
 
 Attach the GitHub App as a custom deployment protection rule on environment:

--- a/scripts/policy_service_cloud_run_bootstrap_attest.py
+++ b/scripts/policy_service_cloud_run_bootstrap_attest.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Emit metadata-only policy service Cloud Run deploy bootstrap attestation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Literal, TypedDict
+
+ARTIFACT_KIND = "policy_service_cloud_run_bootstrap_attestation"
+ARTIFACT_NAME = "policy-service-cloud-run-bootstrap-attestation.v1.json"
+PROGRAM_ID = "GPP-2ab"
+SERVICE_ID = "ao-kernel-live-adapter-gate-policy-service"
+
+REQUIRED_REPOSITORY_VARIABLES: tuple[str, ...] = (
+    "GCP_PROJECT_ID",
+    "GCP_WORKLOAD_IDENTITY_PROVIDER",
+    "GCP_SERVICE_ACCOUNT",
+    "GCP_CLOUD_RUN_REGION",
+    "GCP_ARTIFACT_REGISTRY_LOCATION",
+    "GCP_ARTIFACT_REGISTRY_REPOSITORY",
+    "POLICY_SERVICE_NAME",
+    "AO_GITHUB_APP_ID",
+    "AO_POLICY_SERVICE_WEBHOOK_SECRET_NAME",
+    "AO_GITHUB_APP_PRIVATE_KEY_SECRET_NAME",
+)
+
+OPTIONAL_REPOSITORY_VARIABLES: tuple[str, ...] = (
+    "AO_POLICY_SERVICE_WEBHOOK_SECRET_VERSION",
+    "AO_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION",
+)
+
+
+class VariableStatus(TypedDict):
+    """Sanitized repository variable metadata."""
+
+    name: str
+    present: bool
+    updated_at: str | None
+
+
+class BootstrapCheck(TypedDict):
+    """One attestation check row."""
+
+    id: str
+    status: Literal["pass", "blocked"]
+    detail: str
+
+
+class BootstrapAttestation(TypedDict):
+    """Policy service Cloud Run bootstrap attestation artifact."""
+
+    schema_version: str
+    artifact_kind: str
+    program_id: str
+    service_id: str
+    overall_status: Literal["metadata_ready", "blocked"]
+    finding_code: str | None
+    reason: str
+    required_repository_variables: list[VariableStatus]
+    optional_repository_variables: list[VariableStatus]
+    missing_repository_variables: list[str]
+    checks: list[BootstrapCheck]
+    github_repository_variable_metadata_checked: bool
+    cloud_oidc_bootstrap_attested: bool
+    cloud_run_deploy_executed: bool
+    secret_value_readback: bool
+    github_callback_post: bool
+    live_adapter_execution: bool
+    support_widening: bool
+    production_platform_claim: bool
+
+
+def _variable_index(variable_payload: object) -> dict[str, str | None]:
+    """Return variable name -> updatedAt without preserving values."""
+
+    if not isinstance(variable_payload, list):
+        raise ValueError("repository variable payload must be a JSON list")
+    variables: dict[str, str | None] = {}
+    for item in variable_payload:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        updated_at = item.get("updatedAt")
+        variables[name] = updated_at if isinstance(updated_at, str) else None
+    return variables
+
+
+def _statuses(names: tuple[str, ...], variables: dict[str, str | None]) -> list[VariableStatus]:
+    return [{"name": name, "present": name in variables, "updated_at": variables.get(name)} for name in names]
+
+
+def _check(check_id: str, *, ok: bool, detail: str) -> BootstrapCheck:
+    return {"id": check_id, "status": "pass" if ok else "blocked", "detail": detail}
+
+
+def build_policy_service_cloud_run_bootstrap_attestation(variable_payload: object) -> BootstrapAttestation:
+    """Build a metadata-only deploy bootstrap attestation.
+
+    This intentionally validates repository variable handles only. It does not
+    prove Google Cloud Workload Identity, Artifact Registry, Secret Manager, or
+    Cloud Run are configured correctly.
+    """
+
+    variables = _variable_index(variable_payload)
+    missing = [name for name in REQUIRED_REPOSITORY_VARIABLES if name not in variables]
+    metadata_ready = not missing
+    checks = [
+        _check(
+            "required_repository_variables",
+            ok=metadata_ready,
+            detail=(
+                "All required repository variable handles are present."
+                if metadata_ready
+                else f"Missing required repository variable handles: {', '.join(missing)}."
+            ),
+        ),
+        _check(
+            "secret_value_readback",
+            ok=True,
+            detail="Only repository variable names and update timestamps were inspected.",
+        ),
+        _check(
+            "cloud_bootstrap_scope",
+            ok=True,
+            detail="Google Cloud OIDC, Artifact Registry, Secret Manager, and Cloud Run were not contacted.",
+        ),
+        _check(
+            "runtime_side_effects",
+            ok=True,
+            detail="No deploy, GitHub callback post, protected workflow dispatch, or live adapter execution was performed.",
+        ),
+    ]
+    return {
+        "schema_version": "1",
+        "artifact_kind": ARTIFACT_KIND,
+        "program_id": PROGRAM_ID,
+        "service_id": SERVICE_ID,
+        "overall_status": "metadata_ready" if metadata_ready else "blocked",
+        "finding_code": None if metadata_ready else "policy_cloud_run_bootstrap_missing_repository_variables",
+        "reason": (
+            "Required GitHub repository variable handles are present; Google Cloud bootstrap remains unproven."
+            if metadata_ready
+            else "Required GitHub repository variable handles are missing; do not dispatch deployment."
+        ),
+        "required_repository_variables": _statuses(REQUIRED_REPOSITORY_VARIABLES, variables),
+        "optional_repository_variables": _statuses(OPTIONAL_REPOSITORY_VARIABLES, variables),
+        "missing_repository_variables": missing,
+        "checks": checks,
+        "github_repository_variable_metadata_checked": True,
+        "cloud_oidc_bootstrap_attested": False,
+        "cloud_run_deploy_executed": False,
+        "secret_value_readback": False,
+        "github_callback_post": False,
+        "live_adapter_execution": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+    }
+
+
+def write_attestation(path: Path, attestation: BootstrapAttestation) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(attestation, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def render_attestation_text(attestation: BootstrapAttestation) -> str:
+    missing = attestation["missing_repository_variables"]
+    lines = [
+        "Policy Service Cloud Run Bootstrap Attestation",
+        f"overall_status: {attestation['overall_status']}",
+        f"finding_code: {attestation['finding_code'] or '<none>'}",
+        f"reason: {attestation['reason']}",
+        f"missing_repository_variables: {', '.join(missing) if missing else '<none>'}",
+        f"cloud_oidc_bootstrap_attested: {str(attestation['cloud_oidc_bootstrap_attested']).lower()}",
+        f"cloud_run_deploy_executed: {str(attestation['cloud_run_deploy_executed']).lower()}",
+        f"secret_value_readback: {str(attestation['secret_value_readback']).lower()}",
+        f"github_callback_post: {str(attestation['github_callback_post']).lower()}",
+        f"live_adapter_execution: {str(attestation['live_adapter_execution']).lower()}",
+        f"support_widening: {str(attestation['support_widening']).lower()}",
+        f"production_platform_claim: {str(attestation['production_platform_claim']).lower()}",
+        "",
+        "Required repository variables:",
+    ]
+    for item in attestation["required_repository_variables"]:
+        status = "present" if item["present"] else "missing"
+        lines.append(f"- {item['name']}: {status}")
+    lines.append("")
+    lines.append("Checks:")
+    for check in attestation["checks"]:
+        lines.append(f"- {check['id']}: {check['status']} - {check['detail']}")
+    return "\n".join(lines) + "\n"
+
+
+def _load_json(path: Path | None) -> object | None:
+    if path is None:
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _collect_repository_variables(repo: str) -> object:
+    completed = subprocess.run(
+        ["gh", "variable", "list", "--repo", repo, "--json", "name,updatedAt"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout or "[]")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="Halildeu/ao-kernel", help="GitHub repository owner/name.")
+    parser.add_argument("--variables-json", type=Path, default=None, help="Fixture JSON from gh variable list.")
+    parser.add_argument(
+        "--artifact-path",
+        type=Path,
+        default=Path(ARTIFACT_NAME),
+        help="Path for the metadata-only bootstrap attestation artifact.",
+    )
+    parser.add_argument("--output", choices=("json", "text"), default="json", help="Stdout render mode.")
+    parser.add_argument("--fail-on-blocked", action="store_true", help="Return exit code 1 when metadata is blocked.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    variable_payload = _load_json(args.variables_json)
+    if variable_payload is None:
+        variable_payload = _collect_repository_variables(args.repo)
+
+    attestation = build_policy_service_cloud_run_bootstrap_attestation(variable_payload)
+    write_attestation(args.artifact_path, attestation)
+
+    if args.output == "json":
+        print(json.dumps(attestation, indent=2, sort_keys=True))
+    else:
+        print(render_attestation_text(attestation), end="")
+
+    if args.fail_on_blocked and attestation["overall_status"] != "metadata_ready":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/policy_service_cloud_run_repo_variables.py
+++ b/scripts/policy_service_cloud_run_repo_variables.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Set non-secret Cloud Run deploy repository variables for the policy service."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, NoReturn
+
+try:
+    from policy_service_cloud_run_bootstrap_attest import (
+        OPTIONAL_REPOSITORY_VARIABLES,
+        REQUIRED_REPOSITORY_VARIABLES,
+    )
+except ModuleNotFoundError:  # pragma: no cover - supports importlib-based tests
+    import importlib.util
+
+    _ATTEST_PATH = Path(__file__).with_name("policy_service_cloud_run_bootstrap_attest.py")
+    _ATTEST_SPEC = importlib.util.spec_from_file_location("policy_service_cloud_run_bootstrap_attest", _ATTEST_PATH)
+    if _ATTEST_SPEC is None or _ATTEST_SPEC.loader is None:
+        raise
+    _ATTEST_MODULE = importlib.util.module_from_spec(_ATTEST_SPEC)
+    _ATTEST_SPEC.loader.exec_module(_ATTEST_MODULE)
+    REQUIRED_REPOSITORY_VARIABLES = _ATTEST_MODULE.REQUIRED_REPOSITORY_VARIABLES
+    OPTIONAL_REPOSITORY_VARIABLES = _ATTEST_MODULE.OPTIONAL_REPOSITORY_VARIABLES
+
+
+DEFAULT_REPOSITORY = "Halildeu/ao-kernel"
+DENIED_VARIABLE_NAMES = frozenset(
+    {
+        "AO_CLAUDE_CODE_CLI_AUTH",
+        "AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET",
+        "AO_GITHUB_APP_PRIVATE_KEY_PEM",
+        "AO_GITHUB_APP_PRIVATE_KEY_PATH",
+    }
+)
+DENIED_VALUE_MARKERS = (
+    "-----BEGIN ",
+    "github_pat_",
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "glpat-",
+    "xoxb-",
+    "xoxp-",
+    "sk-ant-",
+    "sk-",
+)
+ALLOWED_REPOSITORY_VARIABLES = REQUIRED_REPOSITORY_VARIABLES + OPTIONAL_REPOSITORY_VARIABLES
+
+
+@dataclass(frozen=True)
+class RepositoryVariableOperation:
+    """A validated GitHub repository variable write operation."""
+
+    name: str
+    value: str
+
+
+class ConfigError(ValueError):
+    """Raised when the local variable config is unsafe or incomplete."""
+
+
+RunGh = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _fail(message: str) -> NoReturn:
+    raise ConfigError(message)
+
+
+def empty_template() -> dict[str, str]:
+    return {name: "" for name in ALLOWED_REPOSITORY_VARIABLES}
+
+
+def write_template(path: Path, *, force: bool = False) -> None:
+    if path.exists() and not force:
+        _fail(f"refusing to overwrite existing template: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(empty_template(), indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def load_config(path: Path) -> dict[str, str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        _fail("configuration must be a JSON object of repository variable names to values")
+
+    config: dict[str, str] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str) or not key:
+            _fail("all repository variable names must be non-empty strings")
+        if not isinstance(value, str):
+            _fail(f"repository variable {key} must have a string value")
+        config[key] = value
+    return config
+
+
+def _looks_like_secret_value(value: str) -> bool:
+    stripped = value.strip()
+    return any(marker in stripped for marker in DENIED_VALUE_MARKERS)
+
+
+def build_operations(config: dict[str, str]) -> list[RepositoryVariableOperation]:
+    unknown = sorted(set(config) - set(ALLOWED_REPOSITORY_VARIABLES) - DENIED_VARIABLE_NAMES)
+    denied = sorted(set(config) & DENIED_VARIABLE_NAMES)
+    missing_required = [name for name in REQUIRED_REPOSITORY_VARIABLES if not config.get(name, "").strip()]
+    suspicious_values = [name for name, value in config.items() if value and _looks_like_secret_value(value)]
+
+    errors: list[str] = []
+    if unknown:
+        errors.append(f"unknown repository variables: {', '.join(unknown)}")
+    if denied:
+        errors.append(f"secret/runtime credential names are not repository variables: {', '.join(denied)}")
+    if missing_required:
+        errors.append(f"missing required repository variables: {', '.join(missing_required)}")
+    if suspicious_values:
+        errors.append(
+            "values look like credential material and must be stored in the cloud secret manager instead: "
+            + ", ".join(sorted(suspicious_values))
+        )
+    if errors:
+        _fail("\n".join(errors))
+
+    operations: list[RepositoryVariableOperation] = []
+    for name in ALLOWED_REPOSITORY_VARIABLES:
+        value = config.get(name, "").strip()
+        if value:
+            operations.append(RepositoryVariableOperation(name=name, value=value))
+    return operations
+
+
+def apply_operations(
+    operations: list[RepositoryVariableOperation],
+    *,
+    repo: str,
+    runner: RunGh = subprocess.run,
+) -> None:
+    for operation in operations:
+        runner(
+            ["gh", "variable", "set", operation.name, "--repo", repo],
+            check=True,
+            capture_output=True,
+            input=operation.value,
+            text=True,
+        )
+
+
+def render_summary(operations: list[RepositoryVariableOperation], *, repo: str, dry_run: bool) -> dict[str, Any]:
+    return {
+        "repo": repo,
+        "mode": "dry_run" if dry_run else "applied",
+        "variable_count": len(operations),
+        "variables": [operation.name for operation in operations],
+        "secret_value_readback": False,
+        "cloud_run_deploy_executed": False,
+        "github_callback_post": False,
+        "live_adapter_execution": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+    }
+
+
+def render_text(summary: dict[str, Any]) -> str:
+    lines = [
+        "Policy Service Cloud Run Repository Variables",
+        f"repo: {summary['repo']}",
+        f"mode: {summary['mode']}",
+        f"variable_count: {summary['variable_count']}",
+        f"secret_value_readback: {str(summary['secret_value_readback']).lower()}",
+        f"cloud_run_deploy_executed: {str(summary['cloud_run_deploy_executed']).lower()}",
+        f"github_callback_post: {str(summary['github_callback_post']).lower()}",
+        f"live_adapter_execution: {str(summary['live_adapter_execution']).lower()}",
+        f"support_widening: {str(summary['support_widening']).lower()}",
+        f"production_platform_claim: {str(summary['production_platform_claim']).lower()}",
+        "",
+        "Variables:",
+    ]
+    lines.extend(f"- {name}" for name in summary["variables"])
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPOSITORY, help="GitHub repository owner/name.")
+    parser.add_argument(
+        "--config-json",
+        type=Path,
+        default=None,
+        help="JSON object containing non-secret repository variable values.",
+    )
+    parser.add_argument(
+        "--write-template",
+        type=Path,
+        default=None,
+        help="Write an empty JSON config template containing required and optional variable names.",
+    )
+    parser.add_argument(
+        "--force-template-overwrite",
+        action="store_true",
+        help="Allow --write-template to overwrite an existing file.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Validate and print variable names without writing.")
+    parser.add_argument("--output", choices=("json", "text"), default="text", help="Stdout render mode.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.write_template is not None:
+            write_template(args.write_template, force=args.force_template_overwrite)
+            print(f"Wrote repository variable template: {args.write_template}")
+            if args.config_json is None:
+                return 0
+
+        if args.config_json is None:
+            parser.error("--config-json is required unless --write-template is used")
+
+        operations = build_operations(load_config(args.config_json))
+        if not args.dry_run:
+            apply_operations(operations, repo=args.repo)
+
+        summary = render_summary(operations, repo=args.repo, dry_run=args.dry_run)
+        if args.output == "json":
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        else:
+            print(render_text(summary), end="")
+    except ConfigError as exc:
+        parser.exit(2, f"error: {exc}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,8 +30,8 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/533"
-    assert payload["current_wp"]["exit_decision"] == "policy_container_publish_path_ready_service_not_hosted"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/535"
+    assert payload["current_wp"]["exit_decision"] == "policy_service_autonomous_deploy_path_ready_service_not_bootstrapped"
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
         item["id"] == "GPP-2a" and item["decision"] == "still_blocked_protected_prerequisites_missing"
@@ -141,20 +141,29 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2t"
+        and item["decision"] == "policy_service_autonomous_deploy_path_ready_service_not_bootstrapped"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/535"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
-        "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
+        "bootstrap the policy service deploy trust path with GitHub OIDC, Google service-account permissions, Artifact Registry, Cloud Run, and Secret Manager object handles without secret value readback",
+        "run or observe the autonomous Cloud Run deployment workflow from a trusted main image until it produces health evidence for the policy service endpoint",
+        "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the deployed /github/deployment-protection endpoint and can post deployment callback reviews",
         "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
     ]
     assert payload["blocked_wps"] == [
         {
             "id": "GPP-2",
             "reason": (
-                "repo-owned policy webhook container image publish path is ready, but the GitHub App service is "
-                "not yet publicly hosted/configured with webhook URL, webhook secret, and GitHub App auth to "
-                "post deployment callback reviews"
+                "repo-owned autonomous Cloud Run deployment path is ready, but cloud OIDC/secret-manager "
+                "bootstrap, hosted service evidence, GitHub App webhook URL configuration, and live deployment "
+                "callback review evidence are not yet attested"
             ),
         }
     ]
@@ -171,7 +180,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
     assert any(
         action
-        == "deploy or configure the deployment-protection policy service using the repo-owned GHCR image or container package before any further live-adapter runtime work"
+        == "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action == "configure or verify the GitHub App webhook URL only after the deployed policy service endpoint is health-checked"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -296,9 +309,9 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/533"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/535"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
-    assert payload["current_wp"]["exit_decision"] == "policy_container_publish_path_ready_service_not_hosted"
+    assert payload["current_wp"]["exit_decision"] == "policy_service_autonomous_deploy_path_ready_service_not_bootstrapped"
     assert payload["support_widening_allowed"] is False
 
 
@@ -328,7 +341,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "Blocked work packages:\n- GPP-2: repo-owned policy webhook container image publish path is ready" in rendered
+    assert "Blocked work packages:\n- GPP-2: repo-owned autonomous Cloud Run deployment path is ready" in rendered
     assert "divergence: 0\t0" in rendered
 
 

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,8 +30,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/535"
-    assert payload["current_wp"]["exit_decision"] == "policy_service_autonomous_deploy_path_ready_service_not_bootstrapped"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/549"
+    assert (
+        payload["current_wp"]["exit_decision"]
+        == "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing"
+    )
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
         item["id"] == "GPP-2a" and item["decision"] == "still_blocked_protected_prerequisites_missing"
@@ -148,10 +151,22 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2ab"
+        and item["decision"] == "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/549"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
+        (
+            "run scripts/policy_service_cloud_run_bootstrap_attest.py and provision any missing GitHub repository "
+            "variable handles before dispatching the Cloud Run deploy workflow, while treating metadata_ready as "
+            "repository-variable evidence only"
+        ),
         "bootstrap the policy service deploy trust path with GitHub OIDC, Google service-account permissions, Artifact Registry, Cloud Run, and Secret Manager object handles without secret value readback",
         "run or observe the autonomous Cloud Run deployment workflow from a trusted main image until it produces health evidence for the policy service endpoint",
         "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the deployed /github/deployment-protection endpoint and can post deployment callback reviews",
@@ -161,9 +176,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         {
             "id": "GPP-2",
             "reason": (
-                "repo-owned autonomous Cloud Run deployment path is ready, but cloud OIDC/secret-manager "
-                "bootstrap, hosted service evidence, GitHub App webhook URL configuration, and live deployment "
-                "callback review evidence are not yet attested"
+                "repo-owned autonomous Cloud Run deployment path is ready, and metadata-only bootstrap attestation "
+                "tool is ready, but the required GitHub repository variable handles are currently missing; Google "
+                "Cloud OIDC trust, Secret Manager objects, hosted service evidence, GitHub App webhook URL "
+                "configuration, and live deployment callback review evidence are not yet attested"
             ),
         }
     ]
@@ -178,6 +194,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"])
     assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
+    assert any(
+        action
+        == "run scripts/policy_service_cloud_run_bootstrap_attest.py to verify required GitHub repository variable handles before dispatching the Cloud Run deploy workflow, and treat metadata_ready as repository-variable evidence only"
+        for action in payload["next_allowed_actions"]
+    )
     assert any(
         action
         == "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work"
@@ -302,6 +323,22 @@ def test_gpp2i_attestation_support_keeps_gate_blocked() -> None:
     assert "does not widen support" in decision
 
 
+def test_gpp2ab_policy_cloud_run_bootstrap_attestation_is_metadata_only() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md"
+    ).read_text(encoding="utf-8")
+
+    assert "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing" in decision
+    assert "gh variable list --json name,updatedAt" in decision
+    assert "A `metadata_ready` attestation means only" in decision
+    assert "Google Cloud OIDC trust is not proven" in decision
+    assert "Cloud Run deployment" in decision
+    assert "AO_CLAUDE_CODE_CLI_AUTH" in decision
+    assert "`live_execution_allowed=false`" in decision
+    assert "`support_widening=false`" in decision
+    assert "`production_platform_claim=false`" in decision
+
+
 def test_gpp_next_load_status_validates_required_guards() -> None:
     mod = _module()
 
@@ -309,9 +346,12 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/535"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/549"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
-    assert payload["current_wp"]["exit_decision"] == "policy_service_autonomous_deploy_path_ready_service_not_bootstrapped"
+    assert (
+        payload["current_wp"]["exit_decision"]
+        == "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing"
+    )
     assert payload["support_widening_allowed"] is False
 
 
@@ -341,7 +381,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "Blocked work packages:\n- GPP-2: repo-owned autonomous Cloud Run deployment path is ready" in rendered
+    assert "metadata-only bootstrap attestation tool is ready" in rendered
     assert "divergence: 0\t0" in rendered
 
 

--- a/tests/test_policy_service_cloud_run_bootstrap_attest.py
+++ b/tests/test_policy_service_cloud_run_bootstrap_attest.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _module() -> Any:
+    module_path = _repo_root() / "scripts" / "policy_service_cloud_run_bootstrap_attest.py"
+    spec = importlib.util.spec_from_file_location("policy_service_cloud_run_bootstrap_attest", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ready_variables() -> list[dict[str, str]]:
+    mod = _module()
+    return [
+        {"name": name, "updatedAt": "2026-04-28T00:00:00Z", "value": f"hidden-{name}"}
+        for name in mod.REQUIRED_REPOSITORY_VARIABLES
+    ]
+
+
+def test_policy_cloud_run_bootstrap_attestation_records_metadata_ready_without_values() -> None:
+    mod = _module()
+
+    attestation = mod.build_policy_service_cloud_run_bootstrap_attestation(_ready_variables())
+    serialized = json.dumps(attestation, sort_keys=True)
+
+    assert attestation["artifact_kind"] == "policy_service_cloud_run_bootstrap_attestation"
+    assert attestation["program_id"] == "GPP-2ab"
+    assert attestation["service_id"] == "ao-kernel-live-adapter-gate-policy-service"
+    assert attestation["overall_status"] == "metadata_ready"
+    assert attestation["missing_repository_variables"] == []
+    assert all(item["present"] for item in attestation["required_repository_variables"])
+    assert attestation["github_repository_variable_metadata_checked"] is True
+    assert attestation["cloud_oidc_bootstrap_attested"] is False
+    assert attestation["cloud_run_deploy_executed"] is False
+    assert attestation["secret_value_readback"] is False
+    assert attestation["github_callback_post"] is False
+    assert attestation["live_adapter_execution"] is False
+    assert attestation["support_widening"] is False
+    assert attestation["production_platform_claim"] is False
+    assert "hidden-" not in serialized
+
+
+def test_policy_cloud_run_bootstrap_attestation_blocks_missing_required_variables() -> None:
+    mod = _module()
+    payload = [item for item in _ready_variables() if item["name"] != "GCP_SERVICE_ACCOUNT"]
+
+    attestation = mod.build_policy_service_cloud_run_bootstrap_attestation(payload)
+
+    assert attestation["overall_status"] == "blocked"
+    assert attestation["finding_code"] == "policy_cloud_run_bootstrap_missing_repository_variables"
+    assert attestation["missing_repository_variables"] == ["GCP_SERVICE_ACCOUNT"]
+    account = next(item for item in attestation["required_repository_variables"] if item["name"] == "GCP_SERVICE_ACCOUNT")
+    assert account == {"name": "GCP_SERVICE_ACCOUNT", "present": False, "updated_at": None}
+
+
+def test_policy_cloud_run_bootstrap_attestation_cli_uses_fixture_without_secret_readback(
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    mod = _module()
+    fixture_path = tmp_path / "variables.json"
+    artifact_path = tmp_path / "attestation.json"
+    fixture_path.write_text(json.dumps(_ready_variables()), encoding="utf-8")
+
+    exit_code = mod.main(
+        [
+            "--variables-json",
+            str(fixture_path),
+            "--artifact-path",
+            str(artifact_path),
+            "--output",
+            "text",
+            "--fail-on-blocked",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert "overall_status: metadata_ready" in captured.out
+    assert "secret_value_readback: false" in captured.out
+    assert artifact["overall_status"] == "metadata_ready"
+    assert artifact["secret_value_readback"] is False
+    assert "hidden-" not in artifact_path.read_text(encoding="utf-8")
+
+
+def test_policy_cloud_run_bootstrap_attestation_cli_can_fail_on_blocked(tmp_path: Path) -> None:
+    mod = _module()
+    fixture_path = tmp_path / "variables.json"
+    artifact_path = tmp_path / "attestation.json"
+    fixture_path.write_text(json.dumps([]), encoding="utf-8")
+
+    exit_code = mod.main(
+        [
+            "--variables-json",
+            str(fixture_path),
+            "--artifact-path",
+            str(artifact_path),
+            "--fail-on-blocked",
+        ]
+    )
+
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert exit_code == 1
+    assert artifact["overall_status"] == "blocked"
+    assert artifact["secret_value_readback"] is False
+    assert len(artifact["missing_repository_variables"]) == len(mod.REQUIRED_REPOSITORY_VARIABLES)
+
+
+def test_policy_cloud_run_bootstrap_live_collection_does_not_request_values() -> None:
+    source = (_repo_root() / "scripts" / "policy_service_cloud_run_bootstrap_attest.py").read_text(encoding="utf-8")
+
+    assert "--json\", \"name,updatedAt\"" in source
+    assert "gcloud secrets versions access" not in source
+    assert "secrets." not in source
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in source

--- a/tests/test_policy_service_cloud_run_repo_variables.py
+++ b/tests/test_policy_service_cloud_run_repo_variables.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _module() -> Any:
+    module_path = _repo_root() / "scripts" / "policy_service_cloud_run_repo_variables.py"
+    spec = importlib.util.spec_from_file_location("policy_service_cloud_run_repo_variables", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _complete_config() -> dict[str, str]:
+    mod = _module()
+    return {name: f"value-for-{name}" for name in mod.REQUIRED_REPOSITORY_VARIABLES}
+
+
+def test_repo_variable_template_contains_required_and_optional_names(tmp_path: Path) -> None:
+    mod = _module()
+    template_path = tmp_path / "cloud-run-variables.json"
+
+    mod.write_template(template_path)
+
+    template = json.loads(template_path.read_text(encoding="utf-8"))
+    assert set(mod.REQUIRED_REPOSITORY_VARIABLES).issubset(template)
+    assert set(mod.OPTIONAL_REPOSITORY_VARIABLES).issubset(template)
+    assert all(value == "" for value in template.values())
+
+
+def test_repo_variable_operations_require_all_required_handles() -> None:
+    mod = _module()
+    config = _complete_config()
+    del config["GCP_SERVICE_ACCOUNT"]
+
+    with pytest.raises(mod.ConfigError, match="missing required repository variables: GCP_SERVICE_ACCOUNT"):
+        mod.build_operations(config)
+
+
+def test_repo_variable_operations_reject_unknown_and_runtime_secret_names() -> None:
+    mod = _module()
+    config = _complete_config()
+    config["AO_CLAUDE_CODE_CLI_AUTH"] = "should-not-be-here"
+    config["NOT_A_DEPLOY_VARIABLE"] = "nope"
+
+    with pytest.raises(mod.ConfigError) as excinfo:
+        mod.build_operations(config)
+
+    message = str(excinfo.value)
+    assert "unknown repository variables: NOT_A_DEPLOY_VARIABLE" in message
+    assert "secret/runtime credential names are not repository variables: AO_CLAUDE_CODE_CLI_AUTH" in message
+
+
+def test_repo_variable_operations_reject_secret_looking_values() -> None:
+    mod = _module()
+    config = _complete_config()
+    config["GCP_PROJECT_ID"] = "github_pat_example"
+
+    with pytest.raises(mod.ConfigError, match="values look like credential material"):
+        mod.build_operations(config)
+
+
+def test_repo_variable_apply_uses_stdin_and_does_not_put_values_in_command() -> None:
+    mod = _module()
+    operations = [
+        mod.RepositoryVariableOperation(name="GCP_PROJECT_ID", value="actual-project-id"),
+        mod.RepositoryVariableOperation(name="POLICY_SERVICE_NAME", value="policy-service"),
+    ]
+    calls: list[dict[str, Any]] = []
+
+    def fake_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append({"args": args, "kwargs": kwargs})
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mod.apply_operations(operations, repo="Halildeu/ao-kernel", runner=fake_run)
+
+    assert [call["args"] for call in calls] == [
+        ["gh", "variable", "set", "GCP_PROJECT_ID", "--repo", "Halildeu/ao-kernel"],
+        ["gh", "variable", "set", "POLICY_SERVICE_NAME", "--repo", "Halildeu/ao-kernel"],
+    ]
+    assert [call["kwargs"]["input"] for call in calls] == ["actual-project-id", "policy-service"]
+    assert all("actual-project-id" not in " ".join(call["args"]) for call in calls)
+    assert all(call["kwargs"]["capture_output"] is True for call in calls)
+
+
+def test_repo_variable_dry_run_output_lists_names_not_values(tmp_path: Path, capsys: Any) -> None:
+    mod = _module()
+    config_path = tmp_path / "variables.json"
+    config = _complete_config()
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    exit_code = mod.main(["--config-json", str(config_path), "--dry-run", "--output", "text"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "mode: dry_run" in captured.out
+    assert "GCP_PROJECT_ID" in captured.out
+    assert "value-for-GCP_PROJECT_ID" not in captured.out
+    assert "cloud_run_deploy_executed: false" in captured.out
+    assert "github_callback_post: false" in captured.out
+    assert "live_adapter_execution: false" in captured.out

--- a/tests/test_policy_service_deploy_workflow.py
+++ b/tests/test_policy_service_deploy_workflow.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _workflow_text() -> str:
+    workflow = _repo_root() / ".github" / "workflows" / "policy-service-deploy-cloud-run.yml"
+    return workflow.read_text(encoding="utf-8")
+
+
+def test_policy_service_deploy_workflow_is_trusted_oidc_cloud_run_path() -> None:
+    text = _workflow_text()
+
+    assert "name: Deploy Policy Service to Cloud Run" in text
+    assert "workflow_run:" in text
+    assert 'workflows: ["Publish Policy Container"]' in text
+    assert "workflow_dispatch:" in text
+    assert "id-token: write" in text
+    assert "packages: read" in text
+    assert "google-github-actions/auth@v2" in text
+    assert "workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}" in text
+    assert "google-github-actions/deploy-cloudrun@v2" in text
+    assert "--allow-unauthenticated --ingress=all --port=8000" in text
+
+
+def test_policy_service_deploy_workflow_uses_published_image_and_health_evidence() -> None:
+    text = _workflow_text()
+
+    assert "ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service" in text
+    assert "sha-${source_sha}" in text
+    assert "docker pull \"${{ steps.images.outputs.ghcr_image }}\"" in text
+    assert "docker push \"${{ steps.images.outputs.gar_image }}\"" in text
+    assert "$service_url/healthz" in text
+    assert "policy-service-deploy-evidence/healthz.json" in text
+    assert "policy-service-deploy-evidence/policy-service-deploy.v1.json" in text
+    assert "policy_service_deployed_health_checked" in text
+    assert "$SERVICE_URL/github/deployment-protection" in text
+    assert "secret_value_readback: false" in text
+    assert "live_adapter_execution: false" in text
+    assert "github_callback_post: false" in text
+
+
+def test_policy_service_deploy_workflow_keeps_prs_and_live_credentials_closed() -> None:
+    text = _workflow_text()
+
+    assert "github.event.workflow_run.head_branch == 'main'" in text
+    assert "github.event.workflow_run.event != 'pull_request'" in text
+    assert "pull_request:" not in text
+    assert "pull_request_target" not in text
+    assert "secrets." not in text
+    assert "GHCR_TOKEN: ${{ github.token }}" in text
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in text
+    assert "gh workflow run live-adapter-gate" not in text
+    assert "gh api repos/Halildeu/ao-kernel/actions/workflows/live-adapter-gate.yml/dispatches" not in text
+    assert "gcloud secrets versions access" not in text
+    assert "AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET=${{ env.AO_POLICY_SERVICE_WEBHOOK_SECRET_NAME }}" in text
+    assert "AO_GITHUB_APP_PRIVATE_KEY_PEM=${{ env.AO_GITHUB_APP_PRIVATE_KEY_SECRET_NAME }}" in text


### PR DESCRIPTION
## Summary
- add a trusted Cloud Run deployment workflow for the policy service using GitHub OIDC
- mirror immutable GHCR images to Artifact Registry, deploy Cloud Run, health-check /healthz, and upload no-secret evidence
- document the bootstrap/secret-manager contract and update GPP status for #535

## Guardrails
- no pull_request or pull_request_target deploy trigger
- no secrets.* context or secret value readback
- no AO_CLAUDE_CODE_CLI_AUTH usage
- no protected live-adapter workflow dispatch or live adapter execution
- support_widening=false and production_platform_claim=false remain closed

## Validation
- python3 -m json.tool .claude/plans/gpp_status.v1.json
- pytest -q tests/test_policy_service_deploy_workflow.py tests/test_policy_container_publish_workflow.py tests/test_gpp_next.py
- python3 -m ruff check tests/test_policy_service_deploy_workflow.py tests/test_policy_container_publish_workflow.py tests/test_gpp_next.py
- actionlint .github/workflows/policy-service-deploy-cloud-run.yml .github/workflows/policy-container-publish.yml
- python3 scripts/gpp_next.py
- git diff --check

Closes #535