### PR TITLE
GPP-2v: scaffold ao-release-gate dry-run check

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 autonomous GitHub App release-gate model selected; hosted service deployment/config and release-gate implementation still blocked
+**Status:** GPP-2 `ao-release-gate` dry-run scaffold ready; hosted service deployment/config and GitHub App wiring still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#537](https://github.com/Halildeu/ao-kernel/issues/537)
-for autonomous GitHub App release-gate selection
-**Current slice record:** `.claude/plans/GPP-2u-AUTONOMOUS-GITHUB-APP-RELEASE-GATE.md`
+**Current slice issue:** [#539](https://github.com/Halildeu/ao-kernel/issues/539)
+for `ao-release-gate` dry-run scaffold
+**Current slice record:** `.claude/plans/GPP-2v-AO-RELEASE-GATE-DRY-RUN-SCAFFOLD.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -172,6 +172,13 @@ Last live verification on current `origin/main` showed:
     rejected. This does not unblock GPP-2; the deployment-protection service is
     still not hosted and `ao-release-gate` is not yet implemented, dry-run
     validated, installed, or required by branch protection.
+37. GPP-2v adds the repo-owned dry-run `ao-release-gate` decision scaffold.
+    `ao_kernel/ao_release_gate.py` and `scripts/ao_release_gate_decision.py`
+    evaluate PR-shaped evidence, GPP status, CI status, branch freshness, diff
+    scope, and forbidden authority signals without posting to GitHub or merging
+    anything. GPP-2 remains blocked until the GitHub App is installed/wired to
+    post the required check-run, branch protection is cut over after dry-run
+    evidence, and the deployment-protection policy service is hosted.
 
 ## 3. Current Verdict
 
@@ -231,7 +238,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2r` | Completed / no support widening | Policy webhook container deploy package | repo-owned container image package and bounded no-secret health smoke/CI job ready; hosted service is not yet deployed/configured |
 | `GPP-2s` | Completed / no support widening | Policy container image publication | repo-owned GHCR image publish path ready; hosted service is not yet deployed/configured |
 | `GPP-2u` | Completed / no support widening | Autonomous GitHub App release-gate decision | `ao-release-gate` required status-check model selected; app implementation/cutover still required |
-| `GPP-2` | Blocked / hosted service and release-gate implementation missing | Protected live-adapter gate runtime binding | deployment protection app/policy service image/container must be hosted/configured, and `ao-release-gate` must be implemented/cut over before human-free program merges |
+| `GPP-2v` | Completed / no support widening | `ao-release-gate` dry-run scaffold | side-effect-free decision core and CLI ready; GitHub App wiring/cutover still required |
+| `GPP-2` | Blocked / hosted service and release-gate wiring missing | Protected live-adapter gate runtime binding | deployment protection app/policy service image/container must be hosted/configured, and `ao-release-gate` must be installed/wired/cut over before human-free program merges |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -360,11 +368,12 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2u; policy decision core, webhook scaffold,
+**Status:** blocked after GPP-2v; policy decision core, webhook scaffold,
 deployable WSGI runtime, container package, and GHCR image publication path
-exist, and the autonomous GitHub App release-gate model is selected. Hosted
-service deployment/configuration and release-gate implementation/cutover are
-still missing.
+exist. The autonomous GitHub App release-gate model is selected, and the
+repo-owned dry-run decision scaffold now exists. Hosted service
+deployment/configuration, GitHub App check-run posting, and branch-protection
+cutover are still missing.
 
 **Entry criteria:**
 
@@ -394,6 +403,10 @@ emit a required status check/check-run for human-free PR merges. That app has
 not yet been implemented, installed, dry-run validated, or required by branch
 protection; GitHub App PR-review counting remains a spike only, not the durable
 enforcement path.
+GPP-2v adds the side-effect-free evaluator and CLI that a future GitHub App can
+call to produce an `ao-release-gate` check-run decision. It produces dry-run
+artifacts only; it does not post to GitHub, grant merge authority, or change
+branch protection.
 
 **Acceptance criteria:**
 
@@ -641,8 +654,8 @@ accident.
 ## 17. Current Active Work
 
 No live execution/support-widening work is active. `GPP-2` is blocked on the
-deployment protection app/policy service response path and the newly selected
-autonomous release-gate implementation path. GPP-2l records a metadata-only
+deployment protection app/policy service response path and the autonomous
+release-gate wiring/cutover path. GPP-2l records a metadata-only
 `overall_status=ready` prerequisite attestation, GPP-2m binds
 `.github/workflows/live-adapter-gate.yml` to
 `ao-kernel-live-adapter-gate` without using secret values, GPP-2n proves the
@@ -659,9 +672,11 @@ deployed to a public host or configured in the GitHub App webhook settings.
 GPP-2s adds the GHCR image publication path for that container, but the image
 has not yet been deployed to a public host or configured in the GitHub App
 webhook settings. GPP-2u selects `ao-release-gate`, a GitHub App required
-status-check authority for no-human-approval program PR merges, but that app is
-not yet implemented, installed, dry-run validated, or required by branch
-protection.
+status-check authority for no-human-approval program PR merges. GPP-2v adds
+`ao_kernel/ao_release_gate.py` and `scripts/ao_release_gate_decision.py` as the
+dry-run decision core and CLI that can produce future `ao-release-gate`
+check-run output, but the GitHub App is not yet installed/wired to post that
+check-run and branch protection does not yet require it.
 GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
@@ -680,14 +695,18 @@ product end-user account. GPP-2g records Claude/MCP consultation as advisory
 only. GPP-2h selects GitHub App deployment protection, GPP-2i adds attestation
 support for that model, GPP-2j refreshes blocked metadata, GPP-2k adds the
 operator provisioning runbook, and GPP-2u selects a separate GitHub App release
-gate for PR merge automation. Existing PR
-[#536](https://github.com/Halildeu/ao-kernel/pull/536) can stay blocked by
-review-required branch protection until an independent approval or the future
+gate for PR merge automation. GPP-2v provides the dry-run evaluator for that
+release gate while keeping `merge_authority_enabled=false`. Existing PRs
+[#536](https://github.com/Halildeu/ao-kernel/pull/536) and
+[#538](https://github.com/Halildeu/ao-kernel/pull/538) can stay blocked by
+review-required branch protection until independent approval or the future
 `ao-release-gate` required-check cutover exists; admin bypass remains
 forbidden.
 
-The next GPP-2 action is to implement a dry-run `ao-release-gate` GitHub App
-required status check, then deploy or configure the
+The next GPP-2 action is to wire the dry-run `ao-release-gate` evaluator into a
+GitHub App webhook/check-run posting path without merge authority, collect
+dry-run evidence on real PRs, and only then cut branch protection/rulesets over
+to require `ao-release-gate`. In parallel, deploy or configure the
 `ao-kernel-live-adapter-gate` deployment protection app/policy service using
 the GPP-2s GHCR image, the GPP-2r container package, the GPP-2q WSGI runtime,
 or an equivalent fail-closed implementation so it receives protected deployment
@@ -721,6 +740,7 @@ keep `live_execution_allowed=false`, `support_widening=false`, and
 | Container package exists but is not hosted | Local image health does not prove GitHub can call the app | Treat GPP-2r as packaging readiness only; deploy to a public host and configure GitHub App webhook before rerunning evidence |
 | Container image exists but service is not hosted | GHCR image publication does not prove GitHub can call the app | Treat GPP-2s as deploy artifact readiness only; deploy the image to a public host and configure GitHub App webhook before rerunning evidence |
 | Human review requirement blocks autonomous program PRs | Green CI still cannot merge without manual approval | Implement `ao-release-gate` as a GitHub App required status check; reject admin bypass, PAT-backed bots, and Claude/Codex release authority |
+| Dry-run release gate mistaken for merge authority | A scaffold could be overclaimed as production release control | GPP-2v sets `dry_run=true` and `merge_authority_enabled=false`; require GitHub App wiring and real PR evidence before branch-protection cutover |
 
 ## 19. Tracking Log
 
@@ -772,3 +792,5 @@ keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-28 | GPP-2s image publish path added | `.github/workflows/policy-container-publish.yml` builds, no-secret smokes, and publishes trusted non-PR images to `ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service`; public hosting and GitHub App webhook configuration remain required before rerunning protected workflow evidence. |
 | 2026-04-28 | GPP-2u issue opened | Issue [#537](https://github.com/Halildeu/ao-kernel/issues/537) tracks the autonomous GitHub App release-gate decision for no-human-approval program PR merges. |
 | 2026-04-28 | GPP-2u release-gate model selected | `ao-release-gate` required status-check model is selected; GitHub App review counting remains a spike, and admin bypass/PAT-backed bot/Codex-Claude release authority remains rejected. |
+| 2026-04-28 | GPP-2v issue opened | Issue [#539](https://github.com/Halildeu/ao-kernel/issues/539) tracks the `ao-release-gate` dry-run decision scaffold. |
+| 2026-04-28 | GPP-2v dry-run scaffold added | `ao_kernel/ao_release_gate.py` and `scripts/ao_release_gate_decision.py` produce side-effect-free future check-run decisions; GitHub App wiring, dry-run evidence, and branch-protection cutover remain required. |

--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 `ao-release-gate` dry-run scaffold ready; hosted service deployment/config and GitHub App wiring still blocked
+**Status:** GPP-2 `ao-release-gate` autonomous deploy path ready; hosting bootstrap/config, dry-run evidence, and cutover still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#539](https://github.com/Halildeu/ao-kernel/issues/539)
-for `ao-release-gate` dry-run scaffold
-**Current slice record:** `.claude/plans/GPP-2v-AO-RELEASE-GATE-DRY-RUN-SCAFFOLD.md`
+**Current slice issue:** [#547](https://github.com/Halildeu/ao-kernel/issues/547)
+for `ao-release-gate` autonomous Cloud Run deploy path
+**Current slice record:** `.claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -179,6 +179,39 @@ Last live verification on current `origin/main` showed:
     anything. GPP-2 remains blocked until the GitHub App is installed/wired to
     post the required check-run, branch protection is cut over after dry-run
     evidence, and the deployment-protection policy service is hosted.
+38. GPP-2w wires that dry-run evaluator into a GitHub App webhook/check-run
+    service surface. `ao_kernel/ao_release_gate_service.py` verifies webhook
+    signature/event/body inputs and builds the check-run request;
+    `ao_kernel/ao_release_gate_runtime.py` exposes WSGI health/webhook paths
+    and can post the check-run with GitHub App installation auth when hosted.
+    GPP-2 remains blocked until the service is publicly hosted/configured, real
+    PR dry-run check-run evidence is collected, branch protection is cut over,
+    and the deployment-protection policy service is hosted.
+39. GPP-2x packages the `ao-release-gate` check-run service as a repo-owned
+    container with a no-secret `/healthz` smoke path. The Dockerfile runs
+    `ao_kernel.ao_release_gate_runtime:application`, the smoke script verifies
+    health without webhook secrets or GitHub writes, and CI builds the
+    container. GPP-2 remains blocked until the container is published or
+    deployed, the hosted service is configured, real PR dry-run check-run
+    evidence is collected, branch protection is cut over, and the
+    deployment-protection policy service is hosted.
+40. GPP-2y adds a GHCR publication path for the `ao-release-gate` container.
+    PRs and codex branches build and no-secret smoke the image without pushing;
+    trusted `main` or manual dispatch can publish
+    `ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>` and the
+    moving `:main` tag. GPP-2 remains blocked until the image is actually
+    deployed to a public host, the GitHub App webhook/runtime secrets are
+    configured, real PR dry-run check-run evidence is collected, branch
+    protection is cut over, and the deployment-protection policy service is
+    hosted.
+41. GPP-2aa adds an autonomous Cloud Run deploy path for the `ao-release-gate`
+    image. Trusted `main` publication or explicit manual dispatch can mirror
+    the immutable GHCR image to Artifact Registry, deploy Cloud Run with
+    Secret Manager references, health-check `/healthz`, and upload deploy
+    evidence. GPP-2 remains blocked until the deploy trust bootstrap exists,
+    the GitHub App webhook URL is configured, real PR dry-run check-run
+    evidence is collected, branch protection is cut over, and the
+    deployment-protection policy service is hosted.
 
 ## 3. Current Verdict
 
@@ -239,7 +272,11 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2s` | Completed / no support widening | Policy container image publication | repo-owned GHCR image publish path ready; hosted service is not yet deployed/configured |
 | `GPP-2u` | Completed / no support widening | Autonomous GitHub App release-gate decision | `ao-release-gate` required status-check model selected; app implementation/cutover still required |
 | `GPP-2v` | Completed / no support widening | `ao-release-gate` dry-run scaffold | side-effect-free decision core and CLI ready; GitHub App wiring/cutover still required |
-| `GPP-2` | Blocked / hosted service and release-gate wiring missing | Protected live-adapter gate runtime binding | deployment protection app/policy service image/container must be hosted/configured, and `ao-release-gate` must be installed/wired/cut over before human-free program merges |
+| `GPP-2w` | Completed / no support widening | `ao-release-gate` check-run service wiring | webhook/check-run request service and WSGI GitHub App POST runtime ready; hosting, real PR evidence, and branch-protection cutover still required |
+| `GPP-2x` | Completed / no support widening | `ao-release-gate` container package | container build target, no-secret health smoke, and CI job ready; publish/hosting, real PR evidence, and branch-protection cutover still required |
+| `GPP-2y` | Completed / no support widening | `ao-release-gate` container image publication | GHCR publish workflow ready; public hosting, real PR evidence, and branch-protection cutover still required |
+| `GPP-2aa` | Completed / no support widening | `ao-release-gate` autonomous deploy path | Cloud Run deploy workflow ready; cloud bootstrap, webhook config, real PR evidence, and branch-protection cutover still required |
+| `GPP-2` | Blocked / hosted services and release-gate cutover missing | Protected live-adapter gate runtime binding | deployment protection app/policy service image/container must be hosted/configured, and `ao-release-gate` must be deployed/hosted/evidenced/cut over before human-free program merges |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -368,12 +405,14 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2v; policy decision core, webhook scaffold,
+**Status:** blocked after GPP-2aa; policy decision core, webhook scaffold,
 deployable WSGI runtime, container package, and GHCR image publication path
-exist. The autonomous GitHub App release-gate model is selected, and the
-repo-owned dry-run decision scaffold now exists. Hosted service
-deployment/configuration, GitHub App check-run posting, and branch-protection
-cutover are still missing.
+exist. The autonomous GitHub App release-gate model, dry-run decision
+scaffold, check-run service/runtime surface, and release-gate container package
+image publication path, and autonomous Cloud Run deploy workflow now exist.
+Hosted service bootstrap/configuration, real PR dry-run evidence,
+branch-protection cutover, and deployment-protection callback evidence are
+still missing.
 
 **Entry criteria:**
 
@@ -406,6 +445,20 @@ enforcement path.
 GPP-2v adds the side-effect-free evaluator and CLI that a future GitHub App can
 call to produce an `ao-release-gate` check-run decision. It produces dry-run
 artifacts only; it does not post to GitHub, grant merge authority, or change
+branch protection.
+GPP-2w adds the webhook service boundary and WSGI runtime that can post the
+dry-run `ao-release-gate` check-run with GitHub App installation auth when
+hosted. It still does not merge PRs, grant merge authority, change branch
+protection, or prove real PR check-run evidence.
+GPP-2x adds the container build target and no-secret health smoke for that WSGI
+runtime. It still does not publish the image, host the service, post check-runs
+to GitHub, grant merge authority, or change branch protection.
+GPP-2y adds the GHCR image publication path for that release-gate container.
+It still does not host the service, configure a webhook URL, post check-runs to
+GitHub, grant merge authority, or change branch protection.
+GPP-2aa adds the autonomous Cloud Run deploy workflow for that release-gate
+image. It still does not prove cloud bootstrap, configure the GitHub App webhook
+URL, post check-runs, collect real PR evidence, grant merge authority, or change
 branch protection.
 
 **Acceptance criteria:**
@@ -675,8 +728,24 @@ webhook settings. GPP-2u selects `ao-release-gate`, a GitHub App required
 status-check authority for no-human-approval program PR merges. GPP-2v adds
 `ao_kernel/ao_release_gate.py` and `scripts/ao_release_gate_decision.py` as the
 dry-run decision core and CLI that can produce future `ao-release-gate`
-check-run output, but the GitHub App is not yet installed/wired to post that
-check-run and branch protection does not yet require it.
+check-run output. GPP-2w adds `ao_kernel/ao_release_gate_service.py` and
+`ao_kernel/ao_release_gate_runtime.py` so a hosted GitHub App can verify
+webhooks, evaluate the dry-run release-gate decision, and post the check-run
+with installation auth. The service is still not publicly hosted/configured,
+real PR dry-run check-run evidence is not collected, and branch protection does
+not yet require it. GPP-2x adds `deploy/ao-release-gate-service/Dockerfile`
+and `scripts/ao_release_gate_container_smoke.py` so the same runtime has a
+repo-owned no-secret container health smoke path. GPP-2y adds
+`.github/workflows/ao-release-gate-container-publish.yml`, which builds and
+smokes the image on PR/codex branch changes and publishes only on trusted
+`main` or manual dispatch events. The image may now be published as a deploy
+artifact, but it is still not hosted and no GitHub delivery evidence exists.
+GPP-2aa adds `.github/workflows/ao-release-gate-deploy-cloud-run.yml`, which can
+mirror the immutable release-gate image to Artifact Registry, deploy Cloud Run
+with Secret Manager references, health-check `/healthz`, and upload deploy
+evidence after trusted `main` publication or manual dispatch. The deploy path
+is not itself GitHub App webhook configuration, check-run evidence, branch
+protection cutover, or merge authority.
 GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
@@ -696,17 +765,28 @@ only. GPP-2h selects GitHub App deployment protection, GPP-2i adds attestation
 support for that model, GPP-2j refreshes blocked metadata, GPP-2k adds the
 operator provisioning runbook, and GPP-2u selects a separate GitHub App release
 gate for PR merge automation. GPP-2v provides the dry-run evaluator for that
-release gate while keeping `merge_authority_enabled=false`. Existing PRs
+release gate while keeping `merge_authority_enabled=false`. GPP-2w provides the
+check-run service/runtime surface while still keeping merge authority disabled.
+GPP-2x provides the container package while still avoiding secret value
+readback, GitHub check-run POSTs, branch-protection cutover, and live adapter
+execution. GPP-2y provides the release-gate container publish path while still
+avoiding public hosting, webhook configuration, GitHub check-run POSTs,
+branch-protection cutover, and live adapter execution. GPP-2aa provides the
+release-gate Cloud Run deploy workflow while still avoiding secret value
+readback, GitHub check-run POST evidence, branch-protection cutover, merge
+authority, and live adapter execution.
+Existing PRs
 [#536](https://github.com/Halildeu/ao-kernel/pull/536) and
 [#538](https://github.com/Halildeu/ao-kernel/pull/538) can stay blocked by
 review-required branch protection until independent approval or the future
 `ao-release-gate` required-check cutover exists; admin bypass remains
 forbidden.
 
-The next GPP-2 action is to wire the dry-run `ao-release-gate` evaluator into a
-GitHub App webhook/check-run posting path without merge authority, collect
-dry-run evidence on real PRs, and only then cut branch protection/rulesets over
-to require `ao-release-gate`. In parallel, deploy or configure the
+The next GPP-2 action is to bootstrap/run the trusted dry-run `ao-release-gate`
+deploy path from `main`, configure that check-run service's GitHub App webhook
+URL, collect real PR check-run evidence, and only then cut branch
+protection/rulesets over to require `ao-release-gate`. In parallel, deploy or
+configure the
 `ao-kernel-live-adapter-gate` deployment protection app/policy service using
 the GPP-2s GHCR image, the GPP-2r container package, the GPP-2q WSGI runtime,
 or an equivalent fail-closed implementation so it receives protected deployment
@@ -741,6 +821,10 @@ keep `live_execution_allowed=false`, `support_widening=false`, and
 | Container image exists but service is not hosted | GHCR image publication does not prove GitHub can call the app | Treat GPP-2s as deploy artifact readiness only; deploy the image to a public host and configure GitHub App webhook before rerunning evidence |
 | Human review requirement blocks autonomous program PRs | Green CI still cannot merge without manual approval | Implement `ao-release-gate` as a GitHub App required status check; reject admin bypass, PAT-backed bots, and Claude/Codex release authority |
 | Dry-run release gate mistaken for merge authority | A scaffold could be overclaimed as production release control | GPP-2v sets `dry_run=true` and `merge_authority_enabled=false`; require GitHub App wiring and real PR evidence before branch-protection cutover |
+| Check-run service mistaken for cutover evidence | A hosted-capable runtime could be overclaimed as active enforcement | GPP-2w still requires public hosting, real PR dry-run check-run evidence, and explicit branch-protection cutover before release authority is active |
+| Release-gate container mistaken for hosted evidence | A local/CI image health pass could be overclaimed as active GitHub enforcement | GPP-2x treats the container as deploy artifact readiness only; require public hosting, webhook configuration, real PR dry-run evidence, and branch-protection cutover |
+| Release-gate image publish mistaken for hosted evidence | A GHCR image tag could be overclaimed as an active GitHub App | GPP-2y treats GHCR publication as deploy artifact readiness only; require public hosting, webhook configuration, real PR dry-run evidence, and branch-protection cutover |
+| Release-gate deploy health mistaken for release authority | A hosted `/healthz` response could be overclaimed as required-check enforcement | GPP-2aa records `check_run_post=false`, `real_pr_evidence=false`, `branch_protection_cutover=false`, and `merge_authority_enabled=false`; require real PR evidence and explicit cutover |
 
 ## 19. Tracking Log
 
@@ -794,3 +878,11 @@ keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-28 | GPP-2u release-gate model selected | `ao-release-gate` required status-check model is selected; GitHub App review counting remains a spike, and admin bypass/PAT-backed bot/Codex-Claude release authority remains rejected. |
 | 2026-04-28 | GPP-2v issue opened | Issue [#539](https://github.com/Halildeu/ao-kernel/issues/539) tracks the `ao-release-gate` dry-run decision scaffold. |
 | 2026-04-28 | GPP-2v dry-run scaffold added | `ao_kernel/ao_release_gate.py` and `scripts/ao_release_gate_decision.py` produce side-effect-free future check-run decisions; GitHub App wiring, dry-run evidence, and branch-protection cutover remain required. |
+| 2026-04-28 | GPP-2w issue opened | Issue [#541](https://github.com/Halildeu/ao-kernel/issues/541) tracks the `ao-release-gate` webhook/check-run service wiring. |
+| 2026-04-28 | GPP-2w check-run service added | `ao_kernel/ao_release_gate_service.py` and `ao_kernel/ao_release_gate_runtime.py` verify webhook input, evaluate the dry-run release gate, and can post the GitHub App check-run when hosted; public hosting, real PR dry-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |
+| 2026-04-28 | GPP-2x issue opened | Issue [#543](https://github.com/Halildeu/ao-kernel/issues/543) tracks the `ao-release-gate` container package and no-secret health smoke path. |
+| 2026-04-28 | GPP-2x container package added | `deploy/ao-release-gate-service/Dockerfile`, `scripts/ao_release_gate_container_smoke.py`, and the `release-gate-container-smoke` CI job package the WSGI runtime as a no-secret health-checkable container; publish/hosting, real PR dry-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |
+| 2026-04-28 | GPP-2y issue opened | Issue [#545](https://github.com/Halildeu/ao-kernel/issues/545) tracks the `ao-release-gate` container image publication path. |
+| 2026-04-28 | GPP-2y publish path added | `.github/workflows/ao-release-gate-container-publish.yml` builds, no-secret smokes, and publishes trusted `main` or manual images to `ghcr.io/halildeu/ao-kernel-ao-release-gate-service`; public hosting, real PR dry-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |
+| 2026-04-28 | GPP-2aa issue opened | Issue [#547](https://github.com/Halildeu/ao-kernel/issues/547) tracks the `ao-release-gate` autonomous Cloud Run deploy path. |
+| 2026-04-28 | GPP-2aa deploy path added | `.github/workflows/ao-release-gate-deploy-cloud-run.yml` can mirror the trusted immutable release-gate image to Artifact Registry, deploy Cloud Run with Secret Manager references, health-check `/healthz`, and upload deploy evidence; webhook configuration, real PR check-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |

--- a/.claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md
+++ b/.claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md
@@ -1,0 +1,170 @@
+# GPP-2aa - AO Release Gate Autonomous Deploy Path
+
+**Issue:** [#547](https://github.com/Halildeu/ao-kernel/issues/547)
+**Decision:** `ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped`
+**Date:** 2026-04-28
+**Support widening:** false
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## Decision
+
+GPP-2aa adds a repo-owned autonomous Cloud Run deploy path for the
+`ao-release-gate` check-run service image. The workflow can deploy a trusted
+immutable image tag after the `Publish AO Release Gate Container` workflow
+succeeds on `main`, or by explicit trusted `workflow_dispatch`.
+
+This is a deploy automation path only. It does not prove that Google Cloud OIDC
+bootstrap exists, it does not configure the GitHub App webhook URL, it does not
+post check-runs, it does not collect real PR evidence, it does not change branch
+protection, it does not merge pull requests, it does not run a live adapter, it
+does not widen support, and it does not claim production readiness.
+
+## Added Surface
+
+1. `.github/workflows/ao-release-gate-deploy-cloud-run.yml`
+   - runs only after trusted `main` publication or explicit
+     `workflow_dispatch`;
+   - uses GitHub OIDC (`id-token: write`) for Google Cloud auth;
+   - reads cloud resource names and secret object names from repository
+     variables;
+   - pulls the immutable GHCR image tag
+     `ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>`;
+   - mirrors that immutable image to Google Artifact Registry;
+   - deploys Cloud Run with public ingress for GitHub webhook delivery;
+   - binds runtime secrets by Secret Manager name/version, not by secret value;
+   - health-checks `GET /healthz`;
+   - uploads `ao-release-gate-deploy.v1.json` and `healthz.json` evidence.
+
+2. `tests/test_ao_release_gate_deploy_workflow.py`
+   - pins trusted trigger scope, OIDC auth, immutable image flow, health
+     evidence, and security guardrails.
+
+3. `deploy/ao-release-gate-service/README.md`
+   - records the Cloud Run variable and Secret Manager contract.
+
+## Trust Boundary
+
+The workflow intentionally does not use:
+
+```text
+secrets.*
+AO_CLAUDE_CODE_CLI_AUTH
+gcloud secrets versions access
+pull_request
+pull_request_target
+gh pr merge
+branch protection update APIs
+```
+
+The hosted service receives only runtime GitHub App materials that Cloud Run
+resolves from Secret Manager:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+Repository variables such as `AO_RELEASE_GATE_WEBHOOK_SECRET_NAME` and
+`AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME` are secret object names,
+not secret values.
+
+## Bootstrap Contract
+
+The deploy workflow is autonomous only after this external machine-trust
+bootstrap exists:
+
+1. Google Cloud Workload Identity Provider trusts this repository's GitHub OIDC
+   identity for the deploy workflow.
+2. The configured Google service account can push to the selected Artifact
+   Registry repository and deploy the selected Cloud Run service.
+3. Google Secret Manager contains the release-gate webhook secret and GitHub
+   App private key under the configured secret object names.
+4. The Cloud Run service can access those secrets at runtime.
+5. The `ao-release-gate` GitHub App webhook URL points at:
+
+```text
+https://<cloud-run-service-url>/github/ao-release-gate
+```
+
+Secret values must not be pasted into issues, PRs, logs, chat, MCP prompts, or
+repository files.
+
+## Evidence Contract
+
+A successful deploy workflow uploads:
+
+```text
+ao-release-gate-deploy.v1.json
+healthz.json
+```
+
+The deployment evidence records:
+
+```text
+status=ao_release_gate_deployed_health_checked
+secret_value_readback=false
+check_run_post=false
+real_pr_evidence=false
+branch_protection_cutover=false
+merge_authority_enabled=false
+live_adapter_execution=false
+support_widening=false
+production_platform_claim=false
+```
+
+This evidence proves a hosted health endpoint for the `ao-release-gate`
+revision. It is not enough to grant release authority. GPP-2 remains blocked
+until the GitHub App webhook is configured to this URL, real PR dry-run
+check-run evidence is collected, branch protection or rulesets require
+`ao-release-gate`, and the deployment-protection policy service is also
+hosted/configured with protected callback evidence.
+
+## Current Decision
+
+Resolved by this slice:
+
+1. repo-owned autonomous deploy workflow exists for `ao-release-gate`;
+2. deploy authentication is OIDC-based, not a committed cloud key;
+3. PR/fork contexts cannot run the deploy job;
+4. immutable GHCR image tags remain the source of deployed revisions;
+5. runtime secrets are passed by Secret Manager reference only;
+6. deploy evidence records no secret readback, no check-run POST, no branch
+   protection cutover, no merge authority, and no live adapter execution.
+
+Still blocked:
+
+1. cloud OIDC/service-account/Secret Manager bootstrap is not attested by this
+   PR;
+2. no Cloud Run deployment run has completed from `main` in this slice;
+3. the `ao-release-gate` GitHub App webhook URL is not proven configured to the
+   Cloud Run endpoint;
+4. no real PR dry-run check-run has been posted by the hosted service;
+5. branch protection/rulesets do not yet require `ao-release-gate`;
+6. the deployment-protection policy service still needs hosted callback
+   evidence before live-adapter runtime work can continue.
+
+Still closed:
+
+1. `merge_authority_enabled=false`;
+2. `live_execution_allowed=false`;
+3. `support_widening=false`;
+4. `production_platform_claim=false`.
+
+## Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_ao_release_gate_deploy_workflow.py tests/test_ao_release_gate_container_publish_workflow.py tests/test_gpp_next.py
+python3 -m ruff check tests/test_ao_release_gate_deploy_workflow.py tests/test_ao_release_gate_container_publish_workflow.py tests/test_gpp_next.py
+actionlint .github/workflows/ao-release-gate-deploy-cloud-run.yml .github/workflows/ao-release-gate-container-publish.yml
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Recorded closeout decision:
+
+```text
+ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped
+```

--- a/.claude/plans/GPP-2v-AO-RELEASE-GATE-DRY-RUN-SCAFFOLD.md
+++ b/.claude/plans/GPP-2v-AO-RELEASE-GATE-DRY-RUN-SCAFFOLD.md
@@ -1,0 +1,107 @@
+# GPP-2v - ao-release-gate Dry-Run Scaffold
+
+**Status:** closeout candidate
+**Date:** 2026-04-28
+**Issue:** [#539](https://github.com/Halildeu/ao-kernel/issues/539)
+**Depends on:** [#538](https://github.com/Halildeu/ao-kernel/pull/538)
+**Branch:** `codex/gpp-2v-release-gate-dry-run`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2v-release-gate-dry-run`
+**Decision:** `ao_release_gate_dry_run_scaffold_ready_no_support_widening`
+
+## Context
+
+GPP-2u selected `ao-release-gate`, a GitHub App release gate with a required
+status check/check-run, as the durable model for no-human-approval program PR
+merges. That decision intentionally left implementation and branch-protection
+cutover for later slices.
+
+This slice implements the first repo-owned, side-effect-free evaluator that a
+future `ao-release-gate` GitHub App can call before posting a check-run. It
+does not create the GitHub App, does not post to GitHub, does not change branch
+protection, and does not grant merge authority.
+
+## Added Surface
+
+1. `ao_kernel/ao_release_gate.py`
+   - Evaluates a PR-shaped release-gate payload and GPP status.
+   - Produces a deterministic dry-run decision artifact.
+   - Builds a future GitHub check-run shape named `ao-release-gate`.
+   - Keeps `merge_authority_enabled=false`.
+2. `scripts/ao_release_gate_decision.py`
+   - CLI wrapper for local/dry-run artifact generation.
+   - Supports `--fail-on-deny` for future CI or App adapter wiring.
+3. `tests/test_ao_release_gate.py`
+   - Covers allow, stale branch, untrusted fork, missing CI evidence, admin
+     bypass, GPP issue mismatch, render/write, and CLI paths.
+
+## Policy Behavior
+
+The evaluator allows only when all required evidence is present:
+
+1. Repository is `Halildeu/ao-kernel`.
+2. Base branch is `main`.
+3. PR number and head SHA are present.
+4. Work-package issue URL is present and matches current GPP status.
+5. Branch freshness is explicitly `true`.
+6. PR is not from a fork.
+7. Event is not `pull_request_target`.
+8. Supplied required checks are completed with `success`.
+9. Changed paths are inside an explicit work-package allowlist.
+10. GPP status keeps support widening, production platform claim, and live
+    adapter execution closed.
+11. Forbidden secret context, admin bypass, PAT-backed bot actor,
+    Codex/Claude release authority, and live adapter execution are explicitly
+    false.
+
+Terminal decisions:
+
+1. `allow_autonomous_merge`
+2. `deny_policy_violation`
+3. `deny_missing_evidence`
+4. `deny_stale_branch`
+5. `deny_untrusted_context`
+6. `error_fail_closed`
+
+The dry-run check-run conclusion is `success` only for
+`allow_autonomous_merge`; all deny/error decisions produce `failure`.
+
+## Non-Goals
+
+1. No GitHub App registration or private key handling.
+2. No webhook endpoint.
+3. No check-run POST to GitHub.
+4. No branch protection/ruleset change.
+5. No PR auto-merge.
+6. No admin bypass.
+7. No PAT-backed bot.
+8. No Claude/Codex release authority.
+9. No live adapter execution.
+10. No support widening or production platform claim.
+
+## Remaining Blockers
+
+GPP-2 remains blocked because:
+
+1. `ao-release-gate` is not yet installed as a GitHub App.
+2. The dry-run evaluator is not yet wired to a webhook/check-run posting path.
+3. Branch protection/rulesets do not yet require `ao-release-gate`.
+4. The deployment-protection policy service is still not publicly hosted or
+   configured with webhook URL, webhook secret, and GitHub App auth.
+
+## Validation
+
+```bash
+python3 -m ruff check ao_kernel/ao_release_gate.py scripts/ao_release_gate_decision.py tests/test_ao_release_gate.py
+pytest -q tests/test_ao_release_gate.py
+pytest -q tests/test_gpp_next.py
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+## Closeout
+
+`ao-release-gate` now has a repo-owned dry-run decision core and CLI artifact
+surface. This is implementation readiness only. It does not unblock GPP-2, does
+not authorize human-free merges yet, does not widen support, and does not
+permit production platform claims or live adapter execution.

--- a/.claude/plans/GPP-2w-AO-RELEASE-GATE-CHECK-RUN-SERVICE.md
+++ b/.claude/plans/GPP-2w-AO-RELEASE-GATE-CHECK-RUN-SERVICE.md
@@ -1,0 +1,104 @@
+# GPP-2w - AO Release Gate Check-Run Service
+
+**Issue:** [#541](https://github.com/Halildeu/ao-kernel/issues/541)
+**Decision:** `ao_release_gate_check_run_service_ready_no_support_widening`
+**Date:** 2026-04-28
+**Support widening:** false
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## Decision
+
+GPP-2w wires the dry-run `ao-release-gate` evaluator into a GitHub App webhook
+and check-run posting surface without granting merge authority. The service can
+verify a GitHub webhook delivery, evaluate the repo-owned release-gate policy,
+build an `ao-release-gate` check-run request, and the runtime can post that
+check-run using GitHub App installation authentication when hosted with runtime
+secrets.
+
+This is still a dry-run release gate. It does not merge PRs, does not change
+branch protection or rulesets, does not approve deployment protection reviews,
+does not run a live adapter, and does not widen support.
+It does not unblock GPP-2 and does not authorize human-free merges yet.
+
+## Added Surface
+
+1. `ao_kernel/ao_release_gate_service.py`
+   - verifies webhook signature when required;
+   - restricts supported events to PR/check/workflow delivery contexts;
+   - decodes a JSON object payload fail-closed;
+   - calls `ao_kernel.ao_release_gate.build_ao_release_gate_decision`;
+   - builds a GitHub check-run POST request for `ao-release-gate`;
+   - returns a machine-readable artifact without performing network I/O.
+
+2. `ao_kernel/ao_release_gate_runtime.py`
+   - exposes WSGI paths `/healthz` and `/github/ao-release-gate`;
+   - loads webhook secret, GitHub App id/private key, API URL, and GPP status
+     from runtime configuration;
+   - mints a GitHub App JWT and installation token;
+   - posts the check-run returned by the service boundary;
+   - redacts runtime responses so token, private key, and webhook secret
+     material are not echoed.
+
+3. Tests cover:
+   - missing or invalid signatures blocking before policy evaluation;
+   - unsupported events and malformed JSON blocking before policy evaluation;
+   - successful dry-run check-run request generation;
+   - denied-policy check-run generation with `failure` conclusion;
+   - runtime check-run POST path using a fake GitHub client;
+   - missing installation id blocking before POST;
+   - GitHub App client token/check-run POST behavior without returning secret
+     material;
+   - WSGI health and bad-signature responses.
+
+## Guardrails
+
+- `dry_run=true` remains true in the release-gate decision.
+- `merge_authority_enabled=false` remains false.
+- No branch protection/ruleset change.
+- No admin bypass.
+- No PAT-backed bot user.
+- No product end-user release authority.
+- No Claude/Codex release authority.
+- No `AO_CLAUDE_CODE_CLI_AUTH` reference.
+- No live adapter execution.
+- No support widening and no production platform claim.
+
+## Runtime Configuration Required Outside The Repo
+
+A hosted service must provide these values through a runtime secret manager or
+equivalent secret store:
+
+- `AO_RELEASE_GATE_WEBHOOK_SECRET`
+- `AO_GITHUB_APP_ID`
+- `AO_GITHUB_APP_PRIVATE_KEY_PEM` or `AO_GITHUB_APP_PRIVATE_KEY_PATH`
+
+Optional runtime values:
+
+- `AO_GITHUB_API_URL`
+- `AO_RELEASE_GATE_GPP_STATUS_PATH`
+- `AO_RELEASE_GATE_MAX_BODY_BYTES`
+
+Secret values must not be committed, echoed in logs, or sent to Claude MCP or
+other advisory systems.
+
+## Remaining Blockers
+
+GPP-2 remains blocked after this work because:
+
+1. The `ao-release-gate` service is not yet publicly hosted.
+2. The GitHub App webhook URL/runtime secret configuration is not yet proven on
+   a real delivery.
+3. No real PR dry-run check-run evidence has been collected.
+4. Branch protection/rulesets do not yet require `ao-release-gate`.
+5. The deployment-protection policy service for
+   `ao-kernel-live-adapter-gate` is still not publicly hosted/configured and
+   still has no protected workflow callback evidence.
+
+## Next Allowed Action
+
+Deploy or host the `ao-release-gate` check-run service in dry-run mode, collect
+real PR evidence that it posts the expected required check-run, and only then
+consider a branch-protection/ruleset cutover to require `ao-release-gate`.
+The deployment-protection policy service must also still be hosted/configured
+before protected live-adapter workflow evidence is rerun.

--- a/.claude/plans/GPP-2x-AO-RELEASE-GATE-CONTAINER.md
+++ b/.claude/plans/GPP-2x-AO-RELEASE-GATE-CONTAINER.md
@@ -1,0 +1,118 @@
+# GPP-2x - AO Release Gate Container Package
+
+**Issue:** [#543](https://github.com/Halildeu/ao-kernel/issues/543)
+**Decision:** `ao_release_gate_container_ready_no_support_widening`
+**Date:** 2026-04-28
+**Support widening:** false
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## Decision
+
+GPP-2x packages the `ao-release-gate` check-run service runtime as a
+repo-owned container image build target with a bounded no-secret health smoke.
+This makes the GPP-2w WSGI runtime deployable by a hosting platform without
+inventing packaging steps outside the repo.
+
+This slice does not publish the image, host the service, configure the GitHub
+App webhook URL, post a check-run to GitHub, change branch protection, merge
+PRs, run a live adapter, widen support, or claim production readiness.
+It does not unblock GPP-2 and does not authorize human-free merges.
+
+## Added Surface
+
+1. `deploy/ao-release-gate-service/Dockerfile`
+   - builds from `python:3.13-slim`;
+   - installs `ao-kernel[release-gate-service]`;
+   - runs `gunicorn` against `ao_kernel.ao_release_gate_runtime:application`;
+   - exposes port `8000`;
+   - adds a container health check for `/healthz`;
+   - runs as a non-root user.
+
+2. `scripts/ao_release_gate_container_smoke.py`
+   - builds the container image;
+   - runs it on a loopback-only random host port;
+   - checks `GET /healthz`;
+   - bounds Docker build/run waits with explicit timeouts;
+   - reports no secret readback, no GitHub check-run POST, no merge authority,
+     no branch-protection cutover, and no live adapter execution.
+
+3. `.github/workflows/test.yml`
+   - adds `release-gate-container-smoke` to build and health-check the
+     container in CI without secret context.
+
+4. `pyproject.toml`
+   - adds a `release-gate-service` optional extra for hosted service runtime
+     dependencies.
+
+5. `tests/test_ao_release_gate_container.py`
+   - pins the Dockerfile runtime entrypoint and no-secret boundary;
+   - pins smoke-script defaults;
+   - pins CI wiring without secret context.
+
+## Container Contract
+
+Build:
+
+```bash
+docker build \
+  -f deploy/ao-release-gate-service/Dockerfile \
+  -t ao-kernel-ao-release-gate-service:local \
+  .
+```
+
+No-secret local health smoke:
+
+```bash
+python3 scripts/ao_release_gate_container_smoke.py \
+  --image ao-kernel-ao-release-gate-service:smoke \
+  --build-timeout-seconds 600
+```
+
+Hosted service configuration still must provide runtime-only values outside
+the repo:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+or:
+
+```text
+AO_GITHUB_APP_PRIVATE_KEY_PATH
+```
+
+The public GitHub App webhook URL must route to:
+
+```text
+POST /github/ao-release-gate
+```
+
+Do not pass `AO_CLAUDE_CODE_CLI_AUTH` to this container. The release-gate
+service posts dry-run check-runs only after it is explicitly hosted and
+configured with GitHub App runtime secrets.
+
+## Remaining Blockers
+
+GPP-2 remains blocked after this work because:
+
+1. The `ao-release-gate` container image is not yet published to GHCR or
+   deployed to a public host.
+2. The `ao-release-gate` GitHub App webhook URL/runtime secret configuration is
+   not yet proven on a real delivery.
+3. No real PR dry-run check-run evidence has been collected.
+4. Branch protection/rulesets do not yet require `ao-release-gate`.
+5. The deployment-protection policy service for
+   `ao-kernel-live-adapter-gate` is still not publicly hosted/configured and
+   still has no protected workflow callback evidence.
+
+## Next Allowed Action
+
+Publish or otherwise deploy the `ao-release-gate` container as a deploy
+artifact, configure the hosted dry-run service with runtime secret-manager
+values, collect real PR check-run evidence, and only then consider a branch
+protection/ruleset cutover. The deployment-protection policy service must also
+still be hosted/configured before protected live-adapter workflow evidence is
+rerun.

--- a/.claude/plans/GPP-2y-AO-RELEASE-GATE-CONTAINER-PUBLISH.md
+++ b/.claude/plans/GPP-2y-AO-RELEASE-GATE-CONTAINER-PUBLISH.md
@@ -1,0 +1,101 @@
+# GPP-2y - AO Release Gate Container Publish Path
+
+**Issue:** [#545](https://github.com/Halildeu/ao-kernel/issues/545)
+**Decision:** `ao_release_gate_publish_path_ready_no_support_widening`
+**Date:** 2026-04-28
+**Support widening:** false
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## Decision
+
+GPP-2y adds a repo-owned GHCR publication path for the `ao-release-gate`
+check-run service container. Pull requests and codex branches build and run the
+no-secret `/healthz` smoke without pushing. Trusted `main` or manual
+`workflow_dispatch` runs can publish immutable `sha-<commit>` tags and the
+moving `main` tag for hosted deployments.
+
+This is a deploy artifact path only. It does not host the service, configure
+the GitHub App webhook URL, post check-runs, change branch protection, merge
+PRs, run a live adapter, widen support, or claim production readiness.
+It does not unblock GPP-2 and does not authorize human-free merges.
+
+## Added Surface
+
+1. `.github/workflows/ao-release-gate-container-publish.yml`
+   - builds `deploy/ao-release-gate-service/Dockerfile`;
+   - tags the image as
+     `ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>`;
+   - runs `scripts/ao_release_gate_container_smoke.py --skip-build` before
+     any image push;
+   - builds and smokes PR/codex branch changes without pushing;
+   - pushes only for `refs/heads/main` or explicit `workflow_dispatch`;
+   - adds the moving `:main` tag only for `refs/heads/main`;
+   - uses `github.token` with `packages: write`, not `secrets.*`;
+   - does not reference `AO_CLAUDE_CODE_CLI_AUTH`, webhook secrets, GitHub App
+     private keys, or live adapter credentials.
+
+2. `deploy/ao-release-gate-service/README.md`
+   - records GHCR image tags;
+   - records runtime-only GitHub App secret names;
+   - records `POST /github/ao-release-gate`;
+   - states that the package does not change branch protection or grant
+     release authority.
+
+3. `tests/test_ao_release_gate_container_publish_workflow.py`
+   - pins GHCR image naming, no-secret smoke execution, trusted-event publish
+     gating, and live credential exclusions.
+
+## Image Contract
+
+Trusted `main` or manual publication can produce:
+
+```text
+ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>
+ghcr.io/halildeu/ao-kernel-ao-release-gate-service:main
+```
+
+Hosted deployments should prefer immutable `sha-<commit>` tags. If the hosting
+platform cannot pull the package anonymously, the host must receive a GHCR read
+token through its secret manager. Registry credentials must not be committed or
+baked into the image.
+
+The image still requires runtime host configuration for:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+or:
+
+```text
+AO_GITHUB_APP_PRIVATE_KEY_PATH
+```
+
+Do not pass `AO_CLAUDE_CODE_CLI_AUTH` to this container. The release-gate
+service is not a live-adapter runner and is not merge authority until a later
+explicit branch-protection/ruleset cutover is approved after real PR evidence.
+
+## Remaining Blockers
+
+GPP-2 remains blocked after this work because:
+
+1. The `ao-release-gate` image publication path exists, but no public hosted
+   endpoint is deployed.
+2. The `ao-release-gate` GitHub App webhook URL/runtime secret configuration is
+   not yet proven on a real delivery.
+3. No real PR dry-run check-run evidence has been collected.
+4. Branch protection/rulesets do not yet require `ao-release-gate`.
+5. The deployment-protection policy service for
+   `ao-kernel-live-adapter-gate` is still not publicly hosted/configured and
+   still has no protected workflow callback evidence.
+
+## Next Allowed Action
+
+Deploy the published `ao-release-gate` image or equivalent container package to
+a public hosting platform, configure runtime secret-manager values, collect real
+PR dry-run check-run evidence, and only then consider a branch-protection or
+ruleset cutover. The deployment-protection policy service must also still be
+hosted/configured before protected live-adapter workflow evidence is rerun.

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,9 +9,9 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/539",
-    "exit_decision": "ao_release_gate_dry_run_scaffold_ready_policy_service_still_not_hosted",
-    "ready_after": "deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, ao-release-gate GitHub App check-run posting is wired and required by branch protection, callback reviews are posted, and protected workflow evidence is produced with live_execution_allowed=false",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/547",
+    "exit_decision": "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped",
+    "ready_after": "ao-release-gate deploy workflow has completed from main, hosted GitHub App check-run service is configured with runtime secrets and webhook URL, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, callback reviews are posted, and protected workflow evidence is produced with live_execution_allowed=false",
     "allowed_scope": [
       "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
       "repeat protected workflow evidence collection from main after the policy service responds",
@@ -152,17 +152,42 @@
       "decision": "ao_release_gate_dry_run_scaffold_ready_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/539",
       "record": ".claude/plans/GPP-2v-AO-RELEASE-GATE-DRY-RUN-SCAFFOLD.md"
+    },
+    {
+      "id": "GPP-2w",
+      "decision": "ao_release_gate_check_run_service_ready_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/541",
+      "record": ".claude/plans/GPP-2w-AO-RELEASE-GATE-CHECK-RUN-SERVICE.md"
+    },
+    {
+      "id": "GPP-2x",
+      "decision": "ao_release_gate_container_ready_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/543",
+      "record": ".claude/plans/GPP-2x-AO-RELEASE-GATE-CONTAINER.md"
+    },
+    {
+      "id": "GPP-2y",
+      "decision": "ao_release_gate_publish_path_ready_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/545",
+      "record": ".claude/plans/GPP-2y-AO-RELEASE-GATE-CONTAINER-PUBLISH.md"
+    },
+    {
+      "id": "GPP-2aa",
+      "decision": "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/547",
+      "record": ".claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned policy webhook container image publish path and ao-release-gate dry-run decision scaffold are ready, but the deployment-protection service is not yet publicly hosted/configured and ao-release-gate is not yet installed/wired to post a required GitHub App check-run"
+      "reason": "repo-owned policy webhook container image publish path, ao-release-gate dry-run decision scaffold, check-run service surface, release-gate container package, release-gate image publish path, and release-gate autonomous deploy path are ready, but neither the release-gate service nor the deployment-protection service is publicly hosted/configured with webhook evidence or cut over with protected evidence"
     }
   ],
   "pending_external_actions": [
-    "install and wire the ao-release-gate GitHub App or equivalent GitHub App required-check authority to call ao_kernel.ao_release_gate without PAT-backed bot users, admin bypass, or Codex/Claude release authority",
-    "collect dry-run ao-release-gate evidence on real PRs before granting merge authority or changing branch protection",
+    "bootstrap the ao-release-gate Cloud Run deploy trust path and run the trusted deploy workflow from main without treating health evidence as check-run evidence",
+    "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with runtime webhook secret and GitHub App authentication outside the repo",
+    "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
     "validate whether GitHub App pull request approvals count for the current branch protection; if not, cut over to a required ao-release-gate status check",
     "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
     "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly"
@@ -221,7 +246,8 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "wire the ao-release-gate dry-run evaluator into a GitHub App webhook/check-run posting path without merge authority",
+    "bootstrap and run the ao-release-gate Cloud Run deploy workflow from main before collecting real PR evidence",
+    "deploy or host the ao-release-gate check-run service in dry-run mode and collect real PR evidence before any branch protection cutover",
     "collect ao-release-gate dry-run check-run evidence on real PRs before any branch protection cutover",
     "validate GitHub App review-counting only as a spike; use required status check as the durable enforcement path unless proven otherwise",
     "deploy or configure the deployment-protection policy service using the repo-owned GHCR image or container package before any further live-adapter runtime work",
@@ -231,7 +257,10 @@
     "use scripts/live_adapter_gate_policy_service_smoke.py only for local webhook/callback artifact validation, not live callback posting",
     "use scripts/live_adapter_gate_policy_decision.py only for policy callback decision evaluation, not live adapter execution",
     "use scripts/live_adapter_gate_policy_container_smoke.py only for no-secret local container health validation, not live callback posting",
+    "use scripts/ao_release_gate_container_smoke.py only for no-secret local container health validation, not check-run posting",
+    "publish or pull ghcr.io/halildeu/ao-kernel-ao-release-gate-service only as a deploy artifact, not hosted service evidence",
     "publish or pull ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service only as a deploy artifact, not hosted service evidence",
+    "configure ao_kernel.ao_release_gate_runtime:application only with runtime secret manager values, never committed or echoed secret material",
     "configure ao_kernel.live_adapter_gate_policy_runtime:application only with runtime secret manager values, never committed or echoed secret material",
     "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it",
     "keep fork and pull_request contexts away from protected credentials",

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,9 +9,9 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/537",
-    "exit_decision": "autonomous_release_gate_selected_policy_service_still_not_hosted",
-    "ready_after": "deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, ao-release-gate required status-check authority is implemented/cut over, callback reviews are posted, and protected workflow evidence is produced with live_execution_allowed=false",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/539",
+    "exit_decision": "ao_release_gate_dry_run_scaffold_ready_policy_service_still_not_hosted",
+    "ready_after": "deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, ao-release-gate GitHub App check-run posting is wired and required by branch protection, callback reviews are posted, and protected workflow evidence is produced with live_execution_allowed=false",
     "allowed_scope": [
       "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
       "repeat protected workflow evidence collection from main after the policy service responds",
@@ -146,16 +146,23 @@
       "decision": "autonomous_github_app_release_gate_selected_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/537",
       "record": ".claude/plans/GPP-2u-AUTONOMOUS-GITHUB-APP-RELEASE-GATE.md"
+    },
+    {
+      "id": "GPP-2v",
+      "decision": "ao_release_gate_dry_run_scaffold_ready_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/539",
+      "record": ".claude/plans/GPP-2v-AO-RELEASE-GATE-DRY-RUN-SCAFFOLD.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned policy webhook container image publish path is ready and the autonomous GitHub App release-gate model is selected, but the deployment-protection service is not yet publicly hosted/configured and the ao-release-gate required status-check authority is not yet implemented/cut over"
+      "reason": "repo-owned policy webhook container image publish path and ao-release-gate dry-run decision scaffold are ready, but the deployment-protection service is not yet publicly hosted/configured and ao-release-gate is not yet installed/wired to post a required GitHub App check-run"
     }
   ],
   "pending_external_actions": [
-    "implement and install the ao-release-gate GitHub App or equivalent GitHub App required-check authority without PAT-backed bot users, admin bypass, or Codex/Claude release authority",
+    "install and wire the ao-release-gate GitHub App or equivalent GitHub App required-check authority to call ao_kernel.ao_release_gate without PAT-backed bot users, admin bypass, or Codex/Claude release authority",
+    "collect dry-run ao-release-gate evidence on real PRs before granting merge authority or changing branch protection",
     "validate whether GitHub App pull request approvals count for the current branch protection; if not, cut over to a required ao-release-gate status check",
     "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
     "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly"
@@ -214,7 +221,8 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "implement a dry-run ao-release-gate GitHub App required status check before any human-free merge automation",
+    "wire the ao-release-gate dry-run evaluator into a GitHub App webhook/check-run posting path without merge authority",
+    "collect ao-release-gate dry-run check-run evidence on real PRs before any branch protection cutover",
     "validate GitHub App review-counting only as a spike; use required status check as the durable enforcement path unless proven otherwise",
     "deploy or configure the deployment-protection policy service using the repo-owned GHCR image or container package before any further live-adapter runtime work",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",

--- a/.github/workflows/ao-release-gate-container-publish.yml
+++ b/.github/workflows/ao-release-gate-container-publish.yml
@@ -1,0 +1,91 @@
+name: Publish AO Release Gate Container
+
+on:
+  push:
+    branches:
+      - main
+      - "codex/**"
+    paths:
+      - "ao_kernel/**"
+      - "deploy/ao-release-gate-service/**"
+      - "scripts/ao_release_gate_container_smoke.py"
+      - "pyproject.toml"
+      - ".github/workflows/ao-release-gate-container-publish.yml"
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - edited
+    paths:
+      - "ao_kernel/**"
+      - "deploy/ao-release-gate-service/**"
+      - "scripts/ao_release_gate_container_smoke.py"
+      - "pyproject.toml"
+      - ".github/workflows/ao-release-gate-container-publish.yml"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Manual ao-release-gate container publication reason"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  DOCKERFILE: deploy/ao-release-gate-service/Dockerfile
+  IMAGE_NAME: ghcr.io/halildeu/ao-kernel-ao-release-gate-service
+
+jobs:
+  publish-ao-release-gate-container:
+    name: publish-ao-release-gate-container
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Build ao-release-gate service image
+        id: build
+        run: |
+          image_sha="${IMAGE_NAME}:sha-${GITHUB_SHA}"
+          docker build -f "$DOCKERFILE" -t "$image_sha" .
+          echo "image_sha=$image_sha" >> "$GITHUB_OUTPUT"
+
+      - name: No-secret container health smoke
+        run: |
+          python scripts/ao_release_gate_container_smoke.py \
+            --skip-build \
+            --image "${{ steps.build.outputs.image_sha }}" \
+            --timeout-seconds 90
+
+      - name: Log in to GHCR
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      - name: Publish ao-release-gate service image
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+        run: |
+          image_sha="${{ steps.build.outputs.image_sha }}"
+          docker push "$image_sha"
+
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            image_main="${IMAGE_NAME}:main"
+            docker tag "$image_sha" "$image_main"
+            docker push "$image_main"
+            {
+              echo "Published ao-release-gate service image:"
+              echo "- \`$image_sha\`"
+              echo "- \`$image_main\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Published ao-release-gate service image: \`$image_sha\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/ao-release-gate-deploy-cloud-run.yml
+++ b/.github/workflows/ao-release-gate-deploy-cloud-run.yml
@@ -1,0 +1,224 @@
+name: Deploy AO Release Gate to Cloud Run
+
+on:
+  workflow_run:
+    workflows: ["Publish AO Release Gate Container"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Trusted ao-release-gate deployment reason"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+  id-token: write
+
+env:
+  GHCR_IMAGE_NAME: ghcr.io/halildeu/ao-kernel-ao-release-gate-service
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+  GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+  GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+  GCP_CLOUD_RUN_REGION: ${{ vars.GCP_CLOUD_RUN_REGION }}
+  GCP_ARTIFACT_REGISTRY_LOCATION: ${{ vars.GCP_ARTIFACT_REGISTRY_LOCATION }}
+  GCP_ARTIFACT_REGISTRY_REPOSITORY: ${{ vars.GCP_ARTIFACT_REGISTRY_REPOSITORY }}
+  RELEASE_GATE_SERVICE_NAME: ${{ vars.RELEASE_GATE_SERVICE_NAME }}
+  AO_RELEASE_GATE_GITHUB_APP_ID: ${{ vars.AO_RELEASE_GATE_GITHUB_APP_ID }}
+  AO_RELEASE_GATE_WEBHOOK_SECRET_NAME: ${{ vars.AO_RELEASE_GATE_WEBHOOK_SECRET_NAME }}
+  AO_RELEASE_GATE_WEBHOOK_SECRET_VERSION: ${{ vars.AO_RELEASE_GATE_WEBHOOK_SECRET_VERSION || 'latest' }}
+  AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME: ${{ vars.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME }}
+  AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION: ${{ vars.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION || 'latest' }}
+
+jobs:
+  deploy-ao-release-gate:
+    name: deploy-ao-release-gate
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.event != 'pull_request'
+      )
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate trusted deploy configuration
+        env:
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+        run: |
+          set -euo pipefail
+
+          required_vars=(
+            GCP_PROJECT_ID
+            GCP_WORKLOAD_IDENTITY_PROVIDER
+            GCP_SERVICE_ACCOUNT
+            GCP_CLOUD_RUN_REGION
+            GCP_ARTIFACT_REGISTRY_LOCATION
+            GCP_ARTIFACT_REGISTRY_REPOSITORY
+            RELEASE_GATE_SERVICE_NAME
+            AO_RELEASE_GATE_GITHUB_APP_ID
+            AO_RELEASE_GATE_WEBHOOK_SECRET_NAME
+            AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME
+          )
+
+          missing=0
+          for name in "${required_vars[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Required repository variable $name is not configured."
+              missing=1
+            fi
+          done
+
+          source_sha="${WORKFLOW_RUN_HEAD_SHA:-$GITHUB_SHA}"
+          if [ -z "$source_sha" ]; then
+            echo "::error::Could not determine source SHA for ao-release-gate deployment."
+            missing=1
+          fi
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - id: images
+        name: Resolve immutable source and deployment images
+        env:
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+        run: |
+          set -euo pipefail
+
+          source_sha="${WORKFLOW_RUN_HEAD_SHA:-$GITHUB_SHA}"
+          ghcr_image="${GHCR_IMAGE_NAME}:sha-${source_sha}"
+          gar_host="${GCP_ARTIFACT_REGISTRY_LOCATION}-docker.pkg.dev"
+          gar_image="${gar_host}/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REGISTRY_REPOSITORY}/${RELEASE_GATE_SERVICE_NAME}:sha-${source_sha}"
+
+          {
+            echo "source_sha=$source_sha"
+            echo "ghcr_image=$ghcr_image"
+            echo "gar_host=$gar_host"
+            echo "gar_image=$gar_image"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud with OIDC
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Log in to GHCR for source image pull
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      - name: Configure Artifact Registry Docker auth
+        run: gcloud auth configure-docker "${{ steps.images.outputs.gar_host }}" --quiet
+
+      - name: Mirror immutable GHCR image to Artifact Registry
+        run: |
+          set -euo pipefail
+
+          docker pull "${{ steps.images.outputs.ghcr_image }}"
+          docker tag "${{ steps.images.outputs.ghcr_image }}" "${{ steps.images.outputs.gar_image }}"
+          docker push "${{ steps.images.outputs.gar_image }}"
+
+      - id: deploy
+        name: Deploy ao-release-gate revision
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.RELEASE_GATE_SERVICE_NAME }}
+          region: ${{ env.GCP_CLOUD_RUN_REGION }}
+          image: ${{ steps.images.outputs.gar_image }}
+          flags: "--allow-unauthenticated --ingress=all --port=8000"
+          env_vars: |
+            AO_GITHUB_APP_ID=${{ env.AO_RELEASE_GATE_GITHUB_APP_ID }}
+            PORT=8000
+          secrets: |
+            AO_RELEASE_GATE_WEBHOOK_SECRET=${{ env.AO_RELEASE_GATE_WEBHOOK_SECRET_NAME }}:${{ env.AO_RELEASE_GATE_WEBHOOK_SECRET_VERSION }}
+            AO_GITHUB_APP_PRIVATE_KEY_PEM=${{ env.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME }}:${{ env.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION }}
+
+      - name: Health-check deployed ao-release-gate
+        run: |
+          set -euo pipefail
+
+          mkdir -p ao-release-gate-deploy-evidence
+          service_url="${{ steps.deploy.outputs.url }}"
+          curl -fsS --retry 5 --retry-delay 5 --retry-connrefused \
+            "$service_url/healthz" \
+            > ao-release-gate-deploy-evidence/healthz.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("ao-release-gate-deploy-evidence/healthz.json").read_text(encoding="utf-8"))
+          if payload.get("status") != "ok":
+              raise SystemExit(f"unexpected ao-release-gate health status: {payload!r}")
+          PY
+
+      - name: Write deployment evidence
+        env:
+          SERVICE_URL: ${{ steps.deploy.outputs.url }}
+          SOURCE_SHA: ${{ steps.images.outputs.source_sha }}
+          GHCR_IMAGE: ${{ steps.images.outputs.ghcr_image }}
+          GAR_IMAGE: ${{ steps.images.outputs.gar_image }}
+        run: |
+          set -euo pipefail
+
+          jq -n \
+            --arg schema_version "1" \
+            --arg program_id "GPP-2aa" \
+            --arg service_name "$RELEASE_GATE_SERVICE_NAME" \
+            --arg cloud_run_region "$GCP_CLOUD_RUN_REGION" \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg source_image "$GHCR_IMAGE" \
+            --arg deployed_image "$GAR_IMAGE" \
+            --arg service_url "$SERVICE_URL" \
+            --arg webhook_url "$SERVICE_URL/github/ao-release-gate" \
+            --arg health_url "$SERVICE_URL/healthz" \
+            '{
+              schema_version: $schema_version,
+              program_id: $program_id,
+              status: "ao_release_gate_deployed_health_checked",
+              service_name: $service_name,
+              cloud_run_region: $cloud_run_region,
+              source_sha: $source_sha,
+              source_image: $source_image,
+              deployed_image: $deployed_image,
+              service_url: $service_url,
+              webhook_url: $webhook_url,
+              health_url: $health_url,
+              health_checked: true,
+              secret_value_readback: false,
+              check_run_post: false,
+              real_pr_evidence: false,
+              branch_protection_cutover: false,
+              merge_authority_enabled: false,
+              live_adapter_execution: false,
+              production_platform_claim: false,
+              support_widening: false
+            }' > ao-release-gate-deploy-evidence/ao-release-gate-deploy.v1.json
+
+          {
+            echo "AO release gate deployment evidence"
+            echo
+            echo "- Source image: \`$GHCR_IMAGE\`"
+            echo "- Deployed image: \`$GAR_IMAGE\`"
+            echo "- Health URL: \`$SERVICE_URL/healthz\`"
+            echo "- GitHub App webhook URL: \`$SERVICE_URL/github/ao-release-gate\`"
+            echo "- Secret value readback: \`false\`"
+            echo "- Check-run POST evidence: \`false\`"
+            echo "- Branch-protection cutover: \`false\`"
+            echo "- Merge authority enabled: \`false\`"
+            echo "- Live adapter execution: \`false\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload deployment evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: ao-release-gate-deploy-${{ steps.images.outputs.source_sha }}
+          path: ao-release-gate-deploy-evidence/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,6 +164,23 @@ jobs:
             --build-timeout-seconds 600 \
             --timeout-seconds 90
 
+  release-gate-container-smoke:
+    name: release-gate-container-smoke
+    runs-on: ubuntu-latest
+    needs: [event-gate]
+    if: needs.event-gate.outputs.should_run == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Build and health-check ao-release-gate service container
+        run: |
+          python scripts/ao_release_gate_container_smoke.py \
+            --image ao-kernel-ao-release-gate-service:ci \
+            --build-timeout-seconds 600 \
+            --timeout-seconds 90
+
   typecheck:
     name: typecheck
     runs-on: ubuntu-latest

--- a/ao_kernel/ao_release_gate.py
+++ b/ao_kernel/ao_release_gate.py
@@ -1,0 +1,625 @@
+"""Dry-run autonomous GitHub App release-gate decision helpers.
+
+This module is intentionally side-effect free. It evaluates a PR-shaped,
+service-enriched payload plus repo-owned GPP status and returns the check-run
+decision a future ``ao-release-gate`` GitHub App can post.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal, TypedDict, cast
+
+from ao_kernel.live_adapter_gate import utc_timestamp
+
+RELEASE_GATE_SCHEMA_VERSION = "1"
+RELEASE_GATE_PROGRAM_ID = "GPP-2v"
+RELEASE_GATE_ARTIFACT_KIND = "ao_release_gate_decision"
+RELEASE_GATE_ARTIFACT = "ao-release-gate-decision.v1.json"
+RELEASE_GATE_CHECK_NAME = "ao-release-gate"
+EXPECTED_REPOSITORY = "Halildeu/ao-kernel"
+EXPECTED_BASE_REF = "main"
+
+ALLOW_AUTONOMOUS_MERGE_DECISION = "allow_autonomous_merge"
+DENY_POLICY_VIOLATION_DECISION = "deny_policy_violation"
+DENY_MISSING_EVIDENCE_DECISION = "deny_missing_evidence"
+DENY_STALE_BRANCH_DECISION = "deny_stale_branch"
+DENY_UNTRUSTED_CONTEXT_DECISION = "deny_untrusted_context"
+ERROR_FAIL_CLOSED_DECISION = "error_fail_closed"
+
+ReleaseGateDecisionValue = Literal[
+    "allow_autonomous_merge",
+    "deny_policy_violation",
+    "deny_missing_evidence",
+    "deny_stale_branch",
+    "deny_untrusted_context",
+    "error_fail_closed",
+]
+ReleaseGateCheckStatus = Literal["pass", "blocked"]
+GithubCheckConclusion = Literal["success", "failure"]
+
+
+class AoReleaseGateInputCheck(TypedDict):
+    """Normalized upstream check status used by the release gate."""
+
+    name: str
+    status: str | None
+    conclusion: str | None
+
+
+class AoReleaseGateCheck(TypedDict):
+    """Single deterministic release-gate input check."""
+
+    name: str
+    status: ReleaseGateCheckStatus
+    finding_code: str | None
+    detail: str
+
+
+class AoReleaseGateContext(TypedDict):
+    """Extracted PR and GPP context for the dry-run release gate."""
+
+    repository: str | None
+    pull_request_number: int | None
+    issue_url: str | None
+    base_ref: str | None
+    head_ref: str | None
+    head_sha: str | None
+    branch_up_to_date: bool | None
+    from_fork: bool | None
+    event_name: str | None
+    changed_paths: list[str]
+    allowed_path_prefixes: list[str]
+    required_checks: list[AoReleaseGateInputCheck]
+    forbidden_secret_context_detected: bool | None
+    admin_bypass_requested: bool | None
+    pat_backed_bot_actor: bool | None
+    codex_or_claude_release_authority: bool | None
+    live_adapter_execution_requested: bool | None
+    gpp_current_wp_id: str | None
+    gpp_current_wp_issue: str | None
+    gpp_current_wp_status: str | None
+    gpp_support_widening_allowed: bool | None
+    gpp_production_platform_claim_allowed: bool | None
+    gpp_live_adapter_execution_allowed: bool | None
+
+
+class AoReleaseGateCheckRun(TypedDict):
+    """Future GitHub check-run shape, without posting it."""
+
+    name: str
+    status: str
+    conclusion: GithubCheckConclusion
+    title: str
+    summary: str
+    text: str
+
+
+class AoReleaseGateDecision(TypedDict):
+    """Machine-readable dry-run release-gate decision."""
+
+    schema_version: str
+    artifact_kind: str
+    program_id: str
+    generated_at: str
+    app_slug: str
+    dry_run: bool
+    merge_authority_enabled: bool
+    decision: ReleaseGateDecisionValue
+    allow: bool
+    finding_code: str | None
+    reason: str
+    context: AoReleaseGateContext
+    checks: list[AoReleaseGateCheck]
+    findings: list[str]
+    github_check_run: AoReleaseGateCheckRun
+
+
+def _as_dict(payload: object) -> dict[str, Any]:
+    """Return ``payload`` as a dictionary or an empty dictionary."""
+
+    if isinstance(payload, dict):
+        return cast(dict[str, Any], payload)
+    return {}
+
+
+def _as_list(payload: object) -> list[Any]:
+    """Return ``payload`` as a list or an empty list."""
+
+    if isinstance(payload, list):
+        return payload
+    return []
+
+
+def _string(value: object) -> str | None:
+    """Return a non-empty string value."""
+
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _bool(value: object) -> bool | None:
+    """Return a boolean value without coercing strings."""
+
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _int(value: object) -> int | None:
+    """Return an integer value without coercing strings."""
+
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _first_string(*values: object) -> str | None:
+    """Return the first non-empty string."""
+
+    for value in values:
+        candidate = _string(value)
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def _first_bool(*values: object) -> bool | None:
+    """Return the first explicit boolean."""
+
+    for value in values:
+        candidate = _bool(value)
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def _first_int(*values: object) -> int | None:
+    """Return the first explicit integer."""
+
+    for value in values:
+        candidate = _int(value)
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def _strings(payload: object) -> list[str]:
+    """Return a list containing only non-empty strings."""
+
+    result: list[str] = []
+    for item in _as_list(payload):
+        value = _string(item)
+        if value is not None:
+            result.append(value)
+    return result
+
+
+def _normalize_ref(value: str | None) -> str | None:
+    """Normalize refs/heads/main to main."""
+
+    if value is None:
+        return None
+    if value.startswith("refs/heads/"):
+        return value.removeprefix("refs/heads/")
+    return value
+
+
+def _service_context(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return service-enriched release-gate context if present."""
+
+    candidates = (
+        payload.get("release_gate_context"),
+        payload.get("ao_release_gate"),
+        payload.get("verified_context"),
+        _as_dict(payload.get("ao_kernel")).get("release_gate_context"),
+    )
+    for candidate in candidates:
+        context = _as_dict(candidate)
+        if context:
+            return context
+    return {}
+
+
+def _normalized_checks(payload: object) -> list[AoReleaseGateInputCheck]:
+    """Normalize check/status-rollup input objects."""
+
+    checks: list[AoReleaseGateInputCheck] = []
+    for item in _as_list(payload):
+        raw = _as_dict(item)
+        name = _first_string(raw.get("name"), raw.get("context"))
+        if name is None:
+            continue
+        checks.append(
+            {
+                "name": name,
+                "status": _first_string(raw.get("status")),
+                "conclusion": _first_string(raw.get("conclusion"), raw.get("state")),
+            }
+        )
+    return checks
+
+
+def _path_allowed(path: str, prefixes: list[str]) -> bool:
+    """Return whether ``path`` is inside one explicit allowed path prefix."""
+
+    for raw_prefix in prefixes:
+        prefix = raw_prefix.strip()
+        if not prefix:
+            continue
+        if prefix.endswith("/"):
+            if path.startswith(prefix):
+                return True
+        elif path == prefix or path.startswith(f"{prefix}/"):
+            return True
+    return False
+
+
+def _required_checks_are_green(checks: list[AoReleaseGateInputCheck]) -> bool:
+    """Return whether all non-self required checks are completed successfully."""
+
+    relevant = [check for check in checks if check["name"] != RELEASE_GATE_CHECK_NAME]
+    if not relevant:
+        return False
+    for check in relevant:
+        status = (check["status"] or "").lower()
+        conclusion = (check["conclusion"] or "").lower()
+        if status not in {"completed", "success"}:
+            return False
+        if conclusion != "success":
+            return False
+    return True
+
+
+def _pass(name: str, *, detail: str) -> AoReleaseGateCheck:
+    """Build a passing release-gate check."""
+
+    return {"name": name, "status": "pass", "finding_code": None, "detail": detail}
+
+
+def _blocked(name: str, *, finding_code: str, detail: str) -> AoReleaseGateCheck:
+    """Build a blocked release-gate check."""
+
+    return {"name": name, "status": "blocked", "finding_code": finding_code, "detail": detail}
+
+
+def _check(name: str, condition: bool, *, finding_code: str, pass_detail: str, blocked_detail: str) -> AoReleaseGateCheck:
+    """Build one fail-closed check."""
+
+    if condition:
+        return _pass(name, detail=pass_detail)
+    return _blocked(name, finding_code=finding_code, detail=blocked_detail)
+
+
+def extract_ao_release_gate_context(payload: object, gpp_status: object) -> AoReleaseGateContext:
+    """Extract normalized release-gate context from dry-run inputs."""
+
+    root = _as_dict(payload)
+    service = _service_context(root)
+    status = _as_dict(gpp_status)
+    current_wp = _as_dict(status.get("current_wp"))
+    repository = _as_dict(root.get("repository"))
+    pull_request = _as_dict(root.get("pull_request"))
+    base = _as_dict(pull_request.get("base"))
+    head = _as_dict(pull_request.get("head"))
+    head_repo = _as_dict(head.get("repo"))
+    changed_paths = _strings(root.get("changed_paths")) or _strings(service.get("changed_paths"))
+    allowed_path_prefixes = _strings(root.get("allowed_path_prefixes")) or _strings(
+        service.get("allowed_path_prefixes")
+    )
+    return {
+        "repository": _first_string(
+            repository.get("full_name"),
+            root.get("repository_full_name"),
+            service.get("repository"),
+        ),
+        "pull_request_number": _first_int(pull_request.get("number"), root.get("pull_request_number")),
+        "issue_url": _first_string(root.get("issue_url"), service.get("issue_url")),
+        "base_ref": _normalize_ref(_first_string(base.get("ref"), root.get("base_ref"), service.get("base_ref"))),
+        "head_ref": _normalize_ref(_first_string(head.get("ref"), root.get("head_ref"), service.get("head_ref"))),
+        "head_sha": _first_string(head.get("sha"), root.get("head_sha"), service.get("head_sha")),
+        "branch_up_to_date": _first_bool(root.get("branch_up_to_date"), service.get("branch_up_to_date")),
+        "from_fork": _first_bool(root.get("from_fork"), service.get("from_fork"), head_repo.get("fork")),
+        "event_name": _first_string(root.get("event_name"), service.get("event_name")),
+        "changed_paths": changed_paths,
+        "allowed_path_prefixes": allowed_path_prefixes,
+        "required_checks": _normalized_checks(root.get("required_checks") or root.get("checks")),
+        "forbidden_secret_context_detected": _first_bool(
+            root.get("forbidden_secret_context_detected"),
+            service.get("forbidden_secret_context_detected"),
+        ),
+        "admin_bypass_requested": _first_bool(root.get("admin_bypass_requested"), service.get("admin_bypass_requested")),
+        "pat_backed_bot_actor": _first_bool(root.get("pat_backed_bot_actor"), service.get("pat_backed_bot_actor")),
+        "codex_or_claude_release_authority": _first_bool(
+            root.get("codex_or_claude_release_authority"),
+            service.get("codex_or_claude_release_authority"),
+        ),
+        "live_adapter_execution_requested": _first_bool(
+            root.get("live_adapter_execution_requested"),
+            service.get("live_adapter_execution_requested"),
+        ),
+        "gpp_current_wp_id": _first_string(current_wp.get("id")),
+        "gpp_current_wp_issue": _first_string(current_wp.get("issue")),
+        "gpp_current_wp_status": _first_string(current_wp.get("status")),
+        "gpp_support_widening_allowed": _bool(status.get("support_widening_allowed")),
+        "gpp_production_platform_claim_allowed": _bool(status.get("production_platform_claim_allowed")),
+        "gpp_live_adapter_execution_allowed": _bool(status.get("live_adapter_execution_allowed")),
+    }
+
+
+def _decision_from_findings(findings: list[str]) -> ReleaseGateDecisionValue:
+    """Return the terminal release-gate decision for ordered findings."""
+
+    if "ao_release_gate_payload_not_object" in findings:
+        return cast(ReleaseGateDecisionValue, ERROR_FAIL_CLOSED_DECISION)
+    if "ao_release_gate_branch_not_up_to_date" in findings:
+        return cast(ReleaseGateDecisionValue, DENY_STALE_BRANCH_DECISION)
+    if any(
+        finding
+        in {
+            "ao_release_gate_wrong_repository",
+            "ao_release_gate_untrusted_fork",
+            "ao_release_gate_pull_request_target_context",
+        }
+        for finding in findings
+    ):
+        return cast(ReleaseGateDecisionValue, DENY_UNTRUSTED_CONTEXT_DECISION)
+    if any(
+        finding
+        in {
+            "ao_release_gate_missing_pull_request",
+            "ao_release_gate_missing_issue",
+            "ao_release_gate_branch_freshness_unknown",
+            "ao_release_gate_required_checks_missing",
+            "ao_release_gate_required_checks_not_green",
+            "ao_release_gate_diff_scope_missing",
+            "ao_release_gate_gpp_status_missing",
+            "ao_release_gate_gpp_issue_mismatch",
+        }
+        for finding in findings
+    ):
+        return cast(ReleaseGateDecisionValue, DENY_MISSING_EVIDENCE_DECISION)
+    if findings:
+        return cast(ReleaseGateDecisionValue, DENY_POLICY_VIOLATION_DECISION)
+    return cast(ReleaseGateDecisionValue, ALLOW_AUTONOMOUS_MERGE_DECISION)
+
+
+def _reason(decision: ReleaseGateDecisionValue) -> str:
+    """Return a compact reason for a release-gate decision."""
+
+    if decision == ALLOW_AUTONOMOUS_MERGE_DECISION:
+        return "Dry-run release gate would allow autonomous merge; no merge or GitHub write was performed."
+    if decision == DENY_STALE_BRANCH_DECISION:
+        return "Release gate denied because the PR branch is stale."
+    if decision == DENY_UNTRUSTED_CONTEXT_DECISION:
+        return "Release gate denied because the PR context is untrusted."
+    if decision == DENY_MISSING_EVIDENCE_DECISION:
+        return "Release gate denied because required evidence is missing or incomplete."
+    if decision == ERROR_FAIL_CLOSED_DECISION:
+        return "Release gate failed closed because the input payload was malformed."
+    return "Release gate denied because the PR violates autonomous release policy."
+
+
+def _check_run(decision: ReleaseGateDecisionValue, findings: list[str]) -> AoReleaseGateCheckRun:
+    """Build the future GitHub check-run output shape."""
+
+    allow = decision == ALLOW_AUTONOMOUS_MERGE_DECISION
+    summary = _reason(decision)
+    text = "Findings: " + ", ".join(findings) if findings else "All release-gate checks passed."
+    return {
+        "name": RELEASE_GATE_CHECK_NAME,
+        "status": "completed",
+        "conclusion": "success" if allow else "failure",
+        "title": f"{RELEASE_GATE_CHECK_NAME}: {decision}",
+        "summary": summary,
+        "text": text,
+    }
+
+
+def build_ao_release_gate_decision(
+    payload: object,
+    gpp_status: object,
+    *,
+    generated_at: str | None = None,
+) -> AoReleaseGateDecision:
+    """Build a fail-closed dry-run release-gate decision."""
+
+    context = extract_ao_release_gate_context(payload, gpp_status)
+    checks = [
+        _check(
+            "payload_shape",
+            isinstance(payload, dict),
+            finding_code="ao_release_gate_payload_not_object",
+            pass_detail="Release-gate payload is a JSON object.",
+            blocked_detail="Release-gate payload is not a JSON object.",
+        ),
+        _check(
+            "repository",
+            context["repository"] == EXPECTED_REPOSITORY,
+            finding_code="ao_release_gate_wrong_repository",
+            pass_detail=f"Repository is {EXPECTED_REPOSITORY}.",
+            blocked_detail="Repository is missing or is not the approved repository.",
+        ),
+        _check(
+            "pull_request",
+            context["pull_request_number"] is not None and context["head_sha"] is not None,
+            finding_code="ao_release_gate_missing_pull_request",
+            pass_detail="Pull request number and head SHA are present.",
+            blocked_detail="Pull request number or head SHA is missing.",
+        ),
+        _check(
+            "issue_link",
+            context["issue_url"] is not None,
+            finding_code="ao_release_gate_missing_issue",
+            pass_detail="Work-package issue URL is present.",
+            blocked_detail="Work-package issue URL is missing.",
+        ),
+        _check(
+            "base_ref",
+            context["base_ref"] == EXPECTED_BASE_REF,
+            finding_code="ao_release_gate_wrong_base_ref",
+            pass_detail=f"Base ref is {EXPECTED_BASE_REF}.",
+            blocked_detail="Base ref is missing or is not main.",
+        ),
+        _check(
+            "branch_freshness",
+            context["branch_up_to_date"] is True,
+            finding_code=(
+                "ao_release_gate_branch_freshness_unknown"
+                if context["branch_up_to_date"] is None
+                else "ao_release_gate_branch_not_up_to_date"
+            ),
+            pass_detail="PR branch is declared up to date with the protected base.",
+            blocked_detail="PR branch freshness is missing or stale.",
+        ),
+        _check(
+            "fork_boundary",
+            context["from_fork"] is False,
+            finding_code="ao_release_gate_untrusted_fork",
+            pass_detail="PR head is not a fork context.",
+            blocked_detail="PR head is missing or comes from a fork context.",
+        ),
+        _check(
+            "event_boundary",
+            context["event_name"] != "pull_request_target",
+            finding_code="ao_release_gate_pull_request_target_context",
+            pass_detail="Payload is not from pull_request_target.",
+            blocked_detail="pull_request_target context is not allowed for autonomous release gating.",
+        ),
+        _check(
+            "required_checks",
+            _required_checks_are_green(context["required_checks"]),
+            finding_code=(
+                "ao_release_gate_required_checks_missing"
+                if not context["required_checks"]
+                else "ao_release_gate_required_checks_not_green"
+            ),
+            pass_detail="All supplied required checks are completed successfully.",
+            blocked_detail="Required checks are missing, pending, failing, or not successful.",
+        ),
+        _check(
+            "gpp_status",
+            context["gpp_current_wp_id"] is not None and context["gpp_current_wp_status"] is not None,
+            finding_code="ao_release_gate_gpp_status_missing",
+            pass_detail="GPP current work-package status is present.",
+            blocked_detail="GPP current work-package status is missing.",
+        ),
+        _check(
+            "gpp_issue_consistency",
+            context["issue_url"] is not None and context["issue_url"] == context["gpp_current_wp_issue"],
+            finding_code="ao_release_gate_gpp_issue_mismatch",
+            pass_detail="Payload issue URL matches the current GPP work-package issue.",
+            blocked_detail="Payload issue URL does not match the current GPP work-package issue.",
+        ),
+        _check(
+            "gpp_closed_boundaries",
+            context["gpp_support_widening_allowed"] is False
+            and context["gpp_production_platform_claim_allowed"] is False
+            and context["gpp_live_adapter_execution_allowed"] is False,
+            finding_code="ao_release_gate_gpp_boundary_open",
+            pass_detail="GPP support, production claim, and live adapter execution flags are closed.",
+            blocked_detail="GPP support, production claim, or live adapter execution flag is open or missing.",
+        ),
+        _check(
+            "diff_scope",
+            bool(context["changed_paths"])
+            and bool(context["allowed_path_prefixes"])
+            and all(_path_allowed(path, context["allowed_path_prefixes"]) for path in context["changed_paths"]),
+            finding_code=(
+                "ao_release_gate_diff_scope_missing"
+                if not context["changed_paths"] or not context["allowed_path_prefixes"]
+                else "ao_release_gate_diff_out_of_scope"
+            ),
+            pass_detail="Changed paths are inside the explicit work-package allowlist.",
+            blocked_detail="Changed paths or allowlist are missing, or a changed path is out of scope.",
+        ),
+        _check(
+            "secret_boundary",
+            context["forbidden_secret_context_detected"] is False,
+            finding_code="ao_release_gate_forbidden_secret_context",
+            pass_detail="No forbidden secret context was detected.",
+            blocked_detail="Forbidden secret context was detected or not explicitly ruled out.",
+        ),
+        _check(
+            "admin_bypass_boundary",
+            context["admin_bypass_requested"] is False,
+            finding_code="ao_release_gate_admin_bypass_requested",
+            pass_detail="Admin bypass is not requested.",
+            blocked_detail="Admin bypass is requested or not explicitly ruled out.",
+        ),
+        _check(
+            "bot_boundary",
+            context["pat_backed_bot_actor"] is False,
+            finding_code="ao_release_gate_pat_backed_bot_actor",
+            pass_detail="PAT-backed bot actor is not used.",
+            blocked_detail="PAT-backed bot actor is used or not explicitly ruled out.",
+        ),
+        _check(
+            "agent_authority_boundary",
+            context["codex_or_claude_release_authority"] is False,
+            finding_code="ao_release_gate_agent_release_authority",
+            pass_detail="Codex/Claude output is not release authority.",
+            blocked_detail="Codex/Claude release authority is requested or not explicitly ruled out.",
+        ),
+        _check(
+            "live_adapter_boundary",
+            context["live_adapter_execution_requested"] is False,
+            finding_code="ao_release_gate_live_adapter_execution_requested",
+            pass_detail="Live adapter execution is not requested.",
+            blocked_detail="Live adapter execution is requested or not explicitly ruled out.",
+        ),
+    ]
+    findings = [check["finding_code"] for check in checks if check["finding_code"] is not None]
+    decision = _decision_from_findings(findings)
+    allow = decision == ALLOW_AUTONOMOUS_MERGE_DECISION
+    return {
+        "schema_version": RELEASE_GATE_SCHEMA_VERSION,
+        "artifact_kind": RELEASE_GATE_ARTIFACT_KIND,
+        "program_id": RELEASE_GATE_PROGRAM_ID,
+        "generated_at": generated_at or utc_timestamp(),
+        "app_slug": RELEASE_GATE_CHECK_NAME,
+        "dry_run": True,
+        "merge_authority_enabled": False,
+        "decision": decision,
+        "allow": allow,
+        "finding_code": None if allow else decision,
+        "reason": _reason(decision),
+        "context": context,
+        "checks": checks,
+        "findings": findings,
+        "github_check_run": _check_run(decision, findings),
+    }
+
+
+def render_ao_release_gate_decision_text(decision: AoReleaseGateDecision) -> str:
+    """Render a compact human-readable dry-run release-gate decision."""
+
+    context = decision["context"]
+    lines = [
+        f"decision: {decision['decision']}",
+        f"allow: {str(decision['allow']).lower()}",
+        f"dry_run: {str(decision['dry_run']).lower()}",
+        f"merge_authority_enabled: {str(decision['merge_authority_enabled']).lower()}",
+        f"github_check_run: {decision['github_check_run']['name']} {decision['github_check_run']['conclusion']}",
+        f"repository: {context['repository'] or '<missing>'}",
+        f"pull_request_number: {context['pull_request_number'] or '<missing>'}",
+        f"base_ref: {context['base_ref'] or '<missing>'}",
+        f"head_sha: {context['head_sha'] or '<missing>'}",
+        f"issue_url: {context['issue_url'] or '<missing>'}",
+        "checks:",
+    ]
+    for check in decision["checks"]:
+        finding = f" ({check['finding_code']})" if check["finding_code"] else ""
+        lines.append(f"- {check['name']}: {check['status']}{finding}")
+    if decision["findings"]:
+        lines.append("findings:")
+        lines.extend(f"- {finding}" for finding in decision["findings"])
+    return "\n".join(lines)
+
+
+def write_ao_release_gate_decision(path: Path, decision: AoReleaseGateDecision) -> None:
+    """Write a release-gate decision artifact as canonical pretty JSON."""
+
+    path.write_text(json.dumps(decision, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/ao_kernel/ao_release_gate_runtime.py
+++ b/ao_kernel/ao_release_gate_runtime.py
@@ -1,0 +1,608 @@
+"""Deployable runtime wrapper for the ao-release-gate check-run service."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Protocol, TypedDict, cast
+
+from ao_kernel.ao_release_gate_service import (
+    AoReleaseGateCheckRunRequest,
+    AoReleaseGateServiceResult,
+    build_ao_release_gate_service_result,
+)
+
+RELEASE_GATE_RUNTIME_PROGRAM_ID = "GPP-2w"
+DEFAULT_WEBHOOK_PATH = "/github/ao-release-gate"
+DEFAULT_HEALTH_PATH = "/healthz"
+DEFAULT_GITHUB_API_URL = "https://api.github.com"
+DEFAULT_MAX_BODY_BYTES = 1024 * 1024
+DEFAULT_HTTP_TIMEOUT_SECONDS = 10.0
+DEFAULT_GITHUB_APP_JWT_TTL_SECONDS = 540
+DEFAULT_GPP_STATUS_PATH = ".claude/plans/gpp_status.v1.json"
+
+WEBHOOK_SECRET_ENV = "AO_RELEASE_GATE_WEBHOOK_SECRET"
+GITHUB_APP_ID_ENV = "AO_GITHUB_APP_ID"
+GITHUB_APP_PRIVATE_KEY_ENV = "AO_GITHUB_APP_PRIVATE_KEY_PEM"
+GITHUB_APP_PRIVATE_KEY_PATH_ENV = "AO_GITHUB_APP_PRIVATE_KEY_PATH"
+GITHUB_API_URL_ENV = "AO_GITHUB_API_URL"
+GPP_STATUS_PATH_ENV = "AO_RELEASE_GATE_GPP_STATUS_PATH"
+MAX_BODY_BYTES_ENV = "AO_RELEASE_GATE_MAX_BODY_BYTES"
+
+
+class ReleaseGateRuntimeError(RuntimeError):
+    """Base runtime error with a stable finding code."""
+
+    def __init__(self, finding_code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.finding_code = finding_code
+        self.detail = detail
+
+
+class ReleaseGateRuntimeConfigError(ReleaseGateRuntimeError):
+    """Runtime configuration is incomplete or invalid."""
+
+
+class ReleaseGateRuntimePostError(ReleaseGateRuntimeError):
+    """GitHub check-run POST failed."""
+
+    def __init__(self, finding_code: str, detail: str, *, status_code: int | None = None) -> None:
+        super().__init__(finding_code, detail)
+        self.status_code = status_code
+
+
+class CheckRunPostResult(TypedDict):
+    """Sanitized check-run POST outcome."""
+
+    status: str
+    status_code: int | None
+    finding_code: str | None
+    detail: str
+
+
+class ReleaseGateRuntimeResult(TypedDict):
+    """Combined webhook service and check-run POST result."""
+
+    schema_version: str
+    program_id: str
+    status: str
+    finding_code: str | None
+    reason: str
+    service_result: AoReleaseGateServiceResult
+    check_run_post: CheckRunPostResult | None
+
+
+HttpTransport = Callable[[str, str, Mapping[str, str], bytes | None, float], tuple[int, bytes]]
+
+
+class GithubCheckRunClient(Protocol):
+    """Minimal client interface used by the release-gate runtime."""
+
+    def post_check_run(
+        self,
+        *,
+        installation_id: int,
+        check_run_request: AoReleaseGateCheckRunRequest,
+    ) -> CheckRunPostResult:
+        """Post an ao-release-gate check-run to GitHub."""
+
+
+@dataclass(frozen=True)
+class GithubAppConfig:
+    """GitHub App authentication config loaded from runtime-only secrets."""
+
+    app_id: str
+    private_key_pem: str
+    api_url: str = DEFAULT_GITHUB_API_URL
+
+
+@dataclass(frozen=True)
+class GithubAppCheckRunClient:
+    """GitHub App client for posting ao-release-gate check-runs."""
+
+    config: GithubAppConfig
+    transport: HttpTransport | None = None
+    timeout_seconds: float = DEFAULT_HTTP_TIMEOUT_SECONDS
+    now_seconds: Callable[[], int] = lambda: int(time.time())
+
+    def _transport(self) -> HttpTransport:
+        return self.transport or urllib_http_transport
+
+    def _installation_token(self, installation_id: int) -> str:
+        app_jwt = build_github_app_jwt(
+            app_id=self.config.app_id,
+            private_key_pem=self.config.private_key_pem,
+            now_seconds=self.now_seconds(),
+        )
+        url = f"{self.config.api_url.rstrip('/')}/app/installations/{installation_id}/access_tokens"
+        status_code, body = self._transport()(
+            "POST",
+            url,
+            {
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {app_jwt}",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            b"{}",
+            self.timeout_seconds,
+        )
+        if status_code < 200 or status_code >= 300:
+            raise ReleaseGateRuntimePostError(
+                "ao_release_gate_runtime_installation_token_failed",
+                f"GitHub installation token request failed with HTTP {status_code}.",
+                status_code=status_code,
+            )
+        payload = _decode_json_object(body)
+        token = payload.get("token")
+        if not isinstance(token, str) or not token:
+            raise ReleaseGateRuntimePostError(
+                "ao_release_gate_runtime_installation_token_missing",
+                "GitHub installation token response did not contain a token.",
+                status_code=status_code,
+            )
+        return token
+
+    def post_check_run(
+        self,
+        *,
+        installation_id: int,
+        check_run_request: AoReleaseGateCheckRunRequest,
+    ) -> CheckRunPostResult:
+        """POST the check-run request with a GitHub App installation token."""
+
+        check_run_url = check_run_request["url"]
+        check_run_json = check_run_request["json"]
+        if check_run_url is None or check_run_json is None:
+            raise ReleaseGateRuntimePostError(
+                "ao_release_gate_runtime_check_run_request_missing",
+                "Release-gate service did not produce a check-run URL and JSON body.",
+            )
+        installation_token = self._installation_token(installation_id)
+        request_body = json.dumps(check_run_json, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        headers = {
+            **check_run_request["headers"],
+            "Authorization": f"Bearer {installation_token}",
+            "Content-Type": "application/json",
+        }
+        status_code, _body = self._transport()("POST", check_run_url, headers, request_body, self.timeout_seconds)
+        if status_code < 200 or status_code >= 300:
+            raise ReleaseGateRuntimePostError(
+                "ao_release_gate_runtime_check_run_post_failed",
+                f"GitHub ao-release-gate check-run POST failed with HTTP {status_code}.",
+                status_code=status_code,
+            )
+        return {
+            "status": "posted",
+            "status_code": status_code,
+            "finding_code": None,
+            "detail": "GitHub ao-release-gate check-run was posted.",
+        }
+
+
+def urllib_http_transport(
+    method: str,
+    url: str,
+    headers: Mapping[str, str],
+    body: bytes | None,
+    timeout_seconds: float,
+) -> tuple[int, bytes]:
+    """Perform one HTTP request with stdlib urllib."""
+
+    request = urllib.request.Request(url=url, data=body, headers=dict(headers), method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            return int(response.status), response.read()
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), exc.read()
+
+
+def build_github_app_jwt(
+    *,
+    app_id: str,
+    private_key_pem: str,
+    now_seconds: int | None = None,
+    ttl_seconds: int = DEFAULT_GITHUB_APP_JWT_TTL_SECONDS,
+) -> str:
+    """Build a GitHub App JWT using a runtime-provided private key."""
+
+    try:
+        jwt_module = cast(Any, __import__("jwt"))
+    except ImportError as exc:
+        raise ReleaseGateRuntimeConfigError(
+            "ao_release_gate_runtime_pyjwt_missing",
+            "Install the policy-service extra so the hosted service can sign GitHub App JWTs.",
+        ) from exc
+
+    issued_at = int(time.time()) if now_seconds is None else now_seconds
+    payload = {
+        "iat": issued_at - 60,
+        "exp": issued_at + ttl_seconds,
+        "iss": app_id,
+    }
+    token = jwt_module.encode(payload, private_key_pem, algorithm="RS256")
+    return cast(str, token)
+
+
+def load_github_app_config(env: Mapping[str, str] | None = None) -> GithubAppConfig:
+    """Load GitHub App auth config from runtime environment variables."""
+
+    source = os.environ if env is None else env
+    app_id = _required_env(source, GITHUB_APP_ID_ENV)
+    private_key_pem = source.get(GITHUB_APP_PRIVATE_KEY_ENV)
+    private_key_path = source.get(GITHUB_APP_PRIVATE_KEY_PATH_ENV)
+    if private_key_pem is None and private_key_path:
+        try:
+            private_key_pem = Path(private_key_path).read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ReleaseGateRuntimeConfigError(
+                "ao_release_gate_runtime_private_key_read_failed",
+                f"Could not read GitHub App private key from {GITHUB_APP_PRIVATE_KEY_PATH_ENV}.",
+            ) from exc
+    if not private_key_pem:
+        raise ReleaseGateRuntimeConfigError(
+            "ao_release_gate_runtime_private_key_missing",
+            f"Set {GITHUB_APP_PRIVATE_KEY_ENV} or {GITHUB_APP_PRIVATE_KEY_PATH_ENV} in the hosted service.",
+        )
+    return GithubAppConfig(
+        app_id=app_id,
+        private_key_pem=private_key_pem,
+        api_url=source.get(GITHUB_API_URL_ENV, DEFAULT_GITHUB_API_URL),
+    )
+
+
+def load_gpp_status(env: Mapping[str, str] | None = None) -> object:
+    """Load the runtime GPP status file without reading secret material."""
+
+    source = os.environ if env is None else env
+    path = Path(source.get(GPP_STATUS_PATH_ENV, DEFAULT_GPP_STATUS_PATH))
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReleaseGateRuntimeConfigError(
+            "ao_release_gate_runtime_gpp_status_unavailable",
+            f"Could not load GPP status from {path}.",
+        ) from exc
+
+
+def handle_ao_release_gate_webhook(
+    body: bytes,
+    headers: Mapping[str, str],
+    *,
+    webhook_secret: str,
+    github_client: GithubCheckRunClient,
+    gpp_status: object,
+    generated_at: str | None = None,
+) -> ReleaseGateRuntimeResult:
+    """Evaluate one GitHub webhook delivery and post the dry-run check-run."""
+
+    service_result = build_ao_release_gate_service_result(
+        body,
+        headers,
+        gpp_status=gpp_status,
+        webhook_secret=webhook_secret,
+        require_signature=True,
+        generated_at=generated_at,
+    )
+    if not service_result["should_post_check_run"]:
+        finding_code = service_result["finding_code"] or "ao_release_gate_runtime_service_blocked"
+        return _runtime_result(
+            status="blocked",
+            finding_code=finding_code,
+            reason="Release-gate service did not produce a check-run request.",
+            service_result=service_result,
+            check_run_post=None,
+        )
+
+    payload = _decode_json_object(body)
+    installation_id = extract_installation_id(payload)
+    if installation_id is None:
+        check_run_post: CheckRunPostResult = {
+            "status": "blocked",
+            "status_code": None,
+            "finding_code": "ao_release_gate_runtime_installation_id_missing",
+            "detail": "Webhook payload did not include a GitHub App installation id.",
+        }
+        return _runtime_result(
+            status="blocked",
+            finding_code=check_run_post["finding_code"],
+            reason="Release-gate service could not authenticate a check-run POST without an installation id.",
+            service_result=service_result,
+            check_run_post=check_run_post,
+        )
+
+    try:
+        check_run_post = github_client.post_check_run(
+            installation_id=installation_id,
+            check_run_request=service_result["check_run_request"],
+        )
+    except ReleaseGateRuntimePostError as exc:
+        check_run_post = {
+            "status": "blocked",
+            "status_code": exc.status_code,
+            "finding_code": exc.finding_code,
+            "detail": exc.detail,
+        }
+        return _runtime_result(
+            status="blocked",
+            finding_code=exc.finding_code,
+            reason="Release-gate service could not post the GitHub check-run.",
+            service_result=service_result,
+            check_run_post=check_run_post,
+        )
+
+    return _runtime_result(
+        status="check_run_posted",
+        finding_code=None,
+        reason="Release-gate service evaluated the webhook and posted a dry-run GitHub check-run.",
+        service_result=service_result,
+        check_run_post=check_run_post,
+    )
+
+
+def extract_installation_id(payload: Mapping[str, Any]) -> int | None:
+    """Extract the GitHub App installation id from a webhook payload."""
+
+    installation = payload.get("installation")
+    candidate: object
+    if isinstance(installation, Mapping):
+        candidate = installation.get("id")
+    else:
+        candidate = None
+    if candidate is None:
+        candidate = payload.get("installation_id")
+    if isinstance(candidate, bool):
+        return None
+    if isinstance(candidate, int) and candidate > 0:
+        return candidate
+    if isinstance(candidate, str) and candidate.isdigit():
+        parsed = int(candidate)
+        return parsed if parsed > 0 else None
+    return None
+
+
+def release_gate_runtime_wsgi_app(
+    environ: Mapping[str, Any],
+    start_response: Callable[[str, list[tuple[str, str]]], None],
+) -> Iterable[bytes]:
+    """WSGI entrypoint for hosted ao-release-gate webhook services."""
+
+    method = str(environ.get("REQUEST_METHOD", "GET")).upper()
+    path = str(environ.get("PATH_INFO", "/"))
+    if method == "GET" and path == DEFAULT_HEALTH_PATH:
+        return _wsgi_json(start_response, 200, {"status": "ok", "program_id": RELEASE_GATE_RUNTIME_PROGRAM_ID})
+    if method != "POST" or path != DEFAULT_WEBHOOK_PATH:
+        return _wsgi_json(start_response, 404, {"status": "not_found", "program_id": RELEASE_GATE_RUNTIME_PROGRAM_ID})
+
+    try:
+        body = _read_wsgi_body(environ)
+        webhook_secret = _required_env(os.environ, WEBHOOK_SECRET_ENV)
+        config = load_github_app_config(os.environ)
+        gpp_status = load_gpp_status(os.environ)
+        result = handle_ao_release_gate_webhook(
+            body,
+            _wsgi_headers(environ),
+            webhook_secret=webhook_secret,
+            github_client=GithubAppCheckRunClient(config),
+            gpp_status=gpp_status,
+        )
+        return _wsgi_json(start_response, _status_code_for_runtime_result(result), _redacted_runtime_payload(result))
+    except ReleaseGateRuntimeConfigError as exc:
+        return _wsgi_json(
+            start_response,
+            503,
+            {
+                "status": "blocked",
+                "program_id": RELEASE_GATE_RUNTIME_PROGRAM_ID,
+                "finding_code": exc.finding_code,
+                "reason": exc.detail,
+            },
+        )
+    except ReleaseGateRuntimeError as exc:
+        status_code = 413 if exc.finding_code == "ao_release_gate_runtime_body_too_large" else 500
+        return _wsgi_json(
+            start_response,
+            status_code,
+            {
+                "status": "blocked",
+                "program_id": RELEASE_GATE_RUNTIME_PROGRAM_ID,
+                "finding_code": exc.finding_code,
+                "reason": exc.detail,
+            },
+        )
+
+
+application = release_gate_runtime_wsgi_app
+
+
+def _decode_json_object(body: bytes) -> dict[str, Any]:
+    payload = json.loads(body.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ReleaseGateRuntimePostError(
+            "ao_release_gate_runtime_invalid_json",
+            "JSON body was not an object.",
+        )
+    return cast(dict[str, Any], payload)
+
+
+def _required_env(env: Mapping[str, str], name: str) -> str:
+    value = env.get(name)
+    if value:
+        return value
+    raise ReleaseGateRuntimeConfigError(
+        "ao_release_gate_runtime_env_missing",
+        f"Set {name} in the hosted service runtime.",
+    )
+
+
+def _runtime_result(
+    *,
+    status: str,
+    finding_code: str | None,
+    reason: str,
+    service_result: AoReleaseGateServiceResult,
+    check_run_post: CheckRunPostResult | None,
+) -> ReleaseGateRuntimeResult:
+    return {
+        "schema_version": "1",
+        "program_id": RELEASE_GATE_RUNTIME_PROGRAM_ID,
+        "status": status,
+        "finding_code": finding_code,
+        "reason": reason,
+        "service_result": service_result,
+        "check_run_post": check_run_post,
+    }
+
+
+def _status_code_for_runtime_result(result: ReleaseGateRuntimeResult) -> int:
+    finding_code = result["finding_code"]
+    service_findings = set(result["service_result"]["findings"])
+    if result["status"] == "check_run_posted":
+        return 202
+    if finding_code in {
+        "ao_release_gate_service_signature_invalid",
+        "ao_release_gate_service_signature_secret_missing",
+    } or service_findings.intersection(
+        {
+            "ao_release_gate_service_signature_invalid",
+            "ao_release_gate_service_signature_secret_missing",
+        }
+    ):
+        return 401
+    if finding_code in {
+        "ao_release_gate_service_wrong_event",
+        "ao_release_gate_service_invalid_json",
+        "ao_release_gate_runtime_installation_id_missing",
+    } or service_findings.intersection(
+        {
+            "ao_release_gate_service_wrong_event",
+            "ao_release_gate_service_invalid_json",
+        }
+    ):
+        return 400
+    return 502
+
+
+def _redacted_runtime_payload(result: ReleaseGateRuntimeResult) -> dict[str, object]:
+    service_result = result["service_result"]
+    decision = service_result["decision"]
+    return {
+        "schema_version": result["schema_version"],
+        "program_id": result["program_id"],
+        "status": result["status"],
+        "finding_code": result["finding_code"],
+        "reason": result["reason"],
+        "event_name": service_result["event_name"],
+        "delivery_id": service_result["delivery_id"],
+        "signature_verified": service_result["signature_verified"],
+        "should_post_check_run": service_result["should_post_check_run"],
+        "release_gate_decision": decision["decision"] if decision is not None else None,
+        "dry_run": decision["dry_run"] if decision is not None else None,
+        "merge_authority_enabled": decision["merge_authority_enabled"] if decision is not None else None,
+        "check_run_conclusion": (
+            decision["github_check_run"]["conclusion"] if decision is not None else None
+        ),
+        "check_run_post": result["check_run_post"],
+        "findings": service_result["findings"],
+    }
+
+
+def _wsgi_headers(environ: Mapping[str, Any]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for key, value in environ.items():
+        if not key.startswith("HTTP_") or not isinstance(value, str):
+            continue
+        header_name = key.removeprefix("HTTP_").replace("_", "-")
+        headers[header_name] = value
+    if isinstance(environ.get("CONTENT_TYPE"), str):
+        headers["Content-Type"] = cast(str, environ["CONTENT_TYPE"])
+    return headers
+
+
+def _read_wsgi_body(environ: Mapping[str, Any]) -> bytes:
+    max_body_bytes = _positive_int_env(os.environ, MAX_BODY_BYTES_ENV, DEFAULT_MAX_BODY_BYTES)
+    content_length = _content_length(environ)
+    if content_length > max_body_bytes:
+        raise ReleaseGateRuntimeError(
+            "ao_release_gate_runtime_body_too_large",
+            f"Webhook body exceeds configured limit of {max_body_bytes} bytes.",
+        )
+    body_stream = environ.get("wsgi.input")
+    read = getattr(body_stream, "read", None)
+    if not callable(read):
+        raise ReleaseGateRuntimeError(
+            "ao_release_gate_runtime_body_stream_missing",
+            "WSGI input stream is missing.",
+        )
+    reader = cast(Callable[[int], bytes], read)
+    return reader(content_length)
+
+
+def _content_length(environ: Mapping[str, Any]) -> int:
+    value = environ.get("CONTENT_LENGTH")
+    if not isinstance(value, str) or not value:
+        return 0
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise ReleaseGateRuntimeError(
+            "ao_release_gate_runtime_invalid_content_length",
+            "CONTENT_LENGTH is not an integer.",
+        ) from exc
+    if parsed < 0:
+        raise ReleaseGateRuntimeError(
+            "ao_release_gate_runtime_invalid_content_length",
+            "CONTENT_LENGTH cannot be negative.",
+        )
+    return parsed
+
+
+def _positive_int_env(env: Mapping[str, str], name: str, default: int) -> int:
+    value = env.get(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise ReleaseGateRuntimeConfigError(
+            "ao_release_gate_runtime_invalid_integer_env",
+            f"{name} must be an integer.",
+        ) from exc
+    if parsed <= 0:
+        raise ReleaseGateRuntimeConfigError(
+            "ao_release_gate_runtime_invalid_integer_env",
+            f"{name} must be positive.",
+        )
+    return parsed
+
+
+def _wsgi_json(
+    start_response: Callable[[str, list[tuple[str, str]]], None],
+    status_code: int,
+    payload: Mapping[str, object],
+) -> Iterable[bytes]:
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    reason = {
+        200: "OK",
+        202: "Accepted",
+        400: "Bad Request",
+        401: "Unauthorized",
+        404: "Not Found",
+        413: "Payload Too Large",
+        500: "Internal Server Error",
+        502: "Bad Gateway",
+        503: "Service Unavailable",
+    }.get(status_code, "Status")
+    start_response(
+        f"{status_code} {reason}",
+        [
+            ("Content-Type", "application/json"),
+            ("Content-Length", str(len(body))),
+        ],
+    )
+    return [body]

--- a/ao_kernel/ao_release_gate_service.py
+++ b/ao_kernel/ao_release_gate_service.py
@@ -1,0 +1,349 @@
+"""Webhook service boundary for the ao-release-gate dry-run check."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal, Mapping, TypedDict, cast
+
+from ao_kernel.ao_release_gate import (
+    RELEASE_GATE_CHECK_NAME,
+    AoReleaseGateDecision,
+    build_ao_release_gate_decision,
+    render_ao_release_gate_decision_text,
+)
+from ao_kernel.live_adapter_gate import utc_timestamp
+from ao_kernel.live_adapter_gate_policy_service import (
+    GITHUB_DELIVERY_HEADER,
+    GITHUB_EVENT_HEADER,
+    GITHUB_SIGNATURE_HEADER,
+    verify_github_webhook_signature,
+)
+
+RELEASE_GATE_SERVICE_SCHEMA_VERSION = "1"
+RELEASE_GATE_SERVICE_PROGRAM_ID = "GPP-2w"
+RELEASE_GATE_SERVICE_ARTIFACT_KIND = "ao_release_gate_service_check_run_request"
+RELEASE_GATE_SERVICE_ARTIFACT = "ao-release-gate-service-check-run-request.v1.json"
+DEFAULT_GITHUB_API_URL = "https://api.github.com"
+SUPPORTED_RELEASE_GATE_EVENTS = frozenset({"pull_request", "check_suite", "check_run", "workflow_run"})
+
+ReleaseGateServiceStatus = Literal["check_run_ready", "blocked"]
+ReleaseGateServiceCheckStatus = Literal["pass", "blocked", "skipped"]
+
+
+class AoReleaseGateServiceCheck(TypedDict):
+    """Single service-boundary check."""
+
+    name: str
+    status: ReleaseGateServiceCheckStatus
+    finding_code: str | None
+    detail: str
+
+
+class AoReleaseGateCheckRunOutput(TypedDict):
+    """GitHub check-run output block."""
+
+    title: str
+    summary: str
+    text: str
+
+
+class AoReleaseGateCheckRunPayload(TypedDict):
+    """GitHub check-run request body."""
+
+    name: str
+    head_sha: str
+    status: str
+    conclusion: str
+    output: AoReleaseGateCheckRunOutput
+
+
+class AoReleaseGateCheckRunRequest(TypedDict):
+    """Network request shape for the GitHub check-run POST."""
+
+    method: str
+    url: str | None
+    headers: dict[str, str]
+    json: AoReleaseGateCheckRunPayload | None
+    authorization_required: bool
+
+
+class AoReleaseGateServiceResult(TypedDict):
+    """Machine-readable release-gate service artifact."""
+
+    schema_version: str
+    artifact_kind: str
+    program_id: str
+    generated_at: str
+    status: ReleaseGateServiceStatus
+    finding_code: str | None
+    reason: str
+    event_name: str | None
+    delivery_id: str | None
+    signature_verified: bool | None
+    should_post_check_run: bool
+    decision: AoReleaseGateDecision | None
+    check_run_request: AoReleaseGateCheckRunRequest
+    checks: list[AoReleaseGateServiceCheck]
+    findings: list[str]
+
+
+def _header(headers: Mapping[str, str], name: str) -> str | None:
+    """Return a case-insensitive header value."""
+
+    target = name.lower()
+    for key, value in headers.items():
+        if key.lower() == target and value.strip():
+            return value.strip()
+    return None
+
+
+def _pass(name: str, *, detail: str) -> AoReleaseGateServiceCheck:
+    """Build a passing service check."""
+
+    return {"name": name, "status": "pass", "finding_code": None, "detail": detail}
+
+
+def _blocked(name: str, *, finding_code: str, detail: str) -> AoReleaseGateServiceCheck:
+    """Build a blocked service check."""
+
+    return {"name": name, "status": "blocked", "finding_code": finding_code, "detail": detail}
+
+
+def _skipped(name: str, *, finding_code: str | None, detail: str) -> AoReleaseGateServiceCheck:
+    """Build a skipped service check."""
+
+    return {"name": name, "status": "skipped", "finding_code": finding_code, "detail": detail}
+
+
+def _decode_json_body(body: bytes) -> tuple[dict[str, Any] | None, str | None]:
+    """Decode a JSON object body."""
+
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return None, str(exc)
+    if not isinstance(payload, dict):
+        return None, "webhook JSON body must be an object"
+    return cast(dict[str, Any], payload), None
+
+
+def _empty_check_run_request() -> AoReleaseGateCheckRunRequest:
+    """Return an empty check-run request for blocked pre-policy states."""
+
+    return {
+        "method": "POST",
+        "url": None,
+        "headers": {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        "json": None,
+        "authorization_required": True,
+    }
+
+
+def build_ao_release_gate_check_run_request(
+    decision: AoReleaseGateDecision,
+    *,
+    github_api_url: str = DEFAULT_GITHUB_API_URL,
+) -> AoReleaseGateCheckRunRequest:
+    """Build the GitHub check-run POST request shape without executing it."""
+
+    repository = decision["context"]["repository"]
+    head_sha = decision["context"]["head_sha"]
+    if repository is None or head_sha is None:
+        return _empty_check_run_request()
+    check_run = decision["github_check_run"]
+    return {
+        "method": "POST",
+        "url": f"{github_api_url.rstrip('/')}/repos/{repository}/check-runs",
+        "headers": {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        "json": {
+            "name": RELEASE_GATE_CHECK_NAME,
+            "head_sha": head_sha,
+            "status": "completed",
+            "conclusion": check_run["conclusion"],
+            "output": {
+                "title": check_run["title"],
+                "summary": check_run["summary"],
+                "text": check_run["text"],
+            },
+        },
+        "authorization_required": True,
+    }
+
+
+def build_ao_release_gate_service_result(
+    body: bytes,
+    headers: Mapping[str, str],
+    *,
+    gpp_status: object,
+    webhook_secret: str | None = None,
+    require_signature: bool = True,
+    generated_at: str | None = None,
+    github_api_url: str = DEFAULT_GITHUB_API_URL,
+) -> AoReleaseGateServiceResult:
+    """Evaluate a release-gate webhook delivery and build a check-run request.
+
+    The function never posts to GitHub. Runtime deployment must attach a GitHub
+    App installation token outside this repository and execute the returned
+    request shape.
+    """
+
+    checks: list[AoReleaseGateServiceCheck] = []
+    event_name = _header(headers, GITHUB_EVENT_HEADER)
+    delivery_id = _header(headers, GITHUB_DELIVERY_HEADER)
+    signature_header = _header(headers, GITHUB_SIGNATURE_HEADER)
+
+    if require_signature:
+        if webhook_secret is None:
+            signature_verified: bool | None = False
+            checks.append(
+                _blocked(
+                    "webhook_signature",
+                    finding_code="ao_release_gate_service_signature_secret_missing",
+                    detail="Webhook signature verification is required, but no webhook secret was provided.",
+                )
+            )
+        elif verify_github_webhook_signature(body, webhook_secret, signature_header):
+            signature_verified = True
+            checks.append(_pass("webhook_signature", detail="GitHub webhook signature verified."))
+        else:
+            signature_verified = False
+            checks.append(
+                _blocked(
+                    "webhook_signature",
+                    finding_code="ao_release_gate_service_signature_invalid",
+                    detail="GitHub webhook signature is missing or does not match the body.",
+                )
+            )
+    else:
+        signature_verified = None
+        checks.append(
+            _skipped(
+                "webhook_signature",
+                finding_code="ao_release_gate_service_signature_not_required",
+                detail="Signature verification skipped for local fixture evaluation only.",
+            )
+        )
+
+    if event_name in SUPPORTED_RELEASE_GATE_EVENTS:
+        checks.append(_pass("webhook_event", detail=f"Webhook event is {event_name}."))
+    else:
+        checks.append(
+            _blocked(
+                "webhook_event",
+                finding_code="ao_release_gate_service_wrong_event",
+                detail="Webhook event is missing or is not supported for ao-release-gate.",
+            )
+        )
+
+    payload, json_error = _decode_json_body(body)
+    if payload is None:
+        checks.append(
+            _blocked(
+                "webhook_json",
+                finding_code="ao_release_gate_service_invalid_json",
+                detail=f"Webhook body is not a JSON object: {json_error}",
+            )
+        )
+    else:
+        checks.append(_pass("webhook_json", detail="Webhook body decoded as a JSON object."))
+
+    pre_policy_blockers = [
+        check["finding_code"]
+        for check in checks
+        if check["status"] == "blocked" and check["finding_code"] is not None
+    ]
+    if payload is None or pre_policy_blockers:
+        return {
+            "schema_version": RELEASE_GATE_SERVICE_SCHEMA_VERSION,
+            "artifact_kind": RELEASE_GATE_SERVICE_ARTIFACT_KIND,
+            "program_id": RELEASE_GATE_SERVICE_PROGRAM_ID,
+            "generated_at": generated_at or utc_timestamp(),
+            "status": "blocked",
+            "finding_code": "ao_release_gate_service_blocked",
+            "reason": "Release-gate webhook service rejected the delivery before policy evaluation.",
+            "event_name": event_name,
+            "delivery_id": delivery_id,
+            "signature_verified": signature_verified,
+            "should_post_check_run": False,
+            "decision": None,
+            "check_run_request": _empty_check_run_request(),
+            "checks": checks,
+            "findings": pre_policy_blockers,
+        }
+
+    decision = build_ao_release_gate_decision(payload, gpp_status, generated_at=generated_at)
+    check_run_request = build_ao_release_gate_check_run_request(decision, github_api_url=github_api_url)
+    check_run_ready = check_run_request["url"] is not None and check_run_request["json"] is not None
+    if check_run_ready:
+        checks.append(_pass("check_run_request", detail="GitHub ao-release-gate check-run request is ready."))
+    else:
+        checks.append(
+            _blocked(
+                "check_run_request",
+                finding_code="ao_release_gate_service_check_run_target_missing",
+                detail="Release-gate decision did not include repository and head SHA for check-run posting.",
+            )
+        )
+
+    findings = [
+        check["finding_code"]
+        for check in checks
+        if check["status"] == "blocked" and check["finding_code"] is not None
+    ]
+    return {
+        "schema_version": RELEASE_GATE_SERVICE_SCHEMA_VERSION,
+        "artifact_kind": RELEASE_GATE_SERVICE_ARTIFACT_KIND,
+        "program_id": RELEASE_GATE_SERVICE_PROGRAM_ID,
+        "generated_at": generated_at or utc_timestamp(),
+        "status": "check_run_ready" if check_run_ready else "blocked",
+        "finding_code": None if check_run_ready else "ao_release_gate_service_blocked",
+        "reason": (
+            "ao-release-gate check-run request is ready; caller must attach GitHub App auth and POST it."
+            if check_run_ready
+            else "ao-release-gate check-run request is not ready."
+        ),
+        "event_name": event_name,
+        "delivery_id": delivery_id,
+        "signature_verified": signature_verified,
+        "should_post_check_run": check_run_ready,
+        "decision": decision,
+        "check_run_request": check_run_request,
+        "checks": checks,
+        "findings": findings,
+    }
+
+
+def render_ao_release_gate_service_text(result: AoReleaseGateServiceResult) -> str:
+    """Render a compact human-readable release-gate service result."""
+
+    lines = [
+        f"status: {result['status']}",
+        f"event_name: {result['event_name'] or '<missing>'}",
+        f"delivery_id: {result['delivery_id'] or '<missing>'}",
+        f"signature_verified: {result['signature_verified']}",
+        f"should_post_check_run: {str(result['should_post_check_run']).lower()}",
+        f"check_run_url: {result['check_run_request']['url'] or '<missing>'}",
+    ]
+    if result["decision"] is not None:
+        lines.append(render_ao_release_gate_decision_text(result["decision"]))
+    lines.append("service_checks:")
+    for check in result["checks"]:
+        finding = f" ({check['finding_code']})" if check["finding_code"] else ""
+        lines.append(f"- {check['name']}: {check['status']}{finding}")
+    if result["findings"]:
+        lines.append("service_findings:")
+        lines.extend(f"- {finding}" for finding in result["findings"])
+    return "\n".join(lines)
+
+
+def write_ao_release_gate_service_result(path: Path, result: AoReleaseGateServiceResult) -> None:
+    """Write a release-gate service artifact as canonical pretty JSON."""
+
+    path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/deploy/ao-release-gate-service/Dockerfile
+++ b/deploy/ao-release-gate-service/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8000 \
+    WEB_CONCURRENCY=1 \
+    WEB_THREADS=4 \
+    WEB_TIMEOUT=30
+
+WORKDIR /app
+
+COPY README.md pyproject.toml ./
+COPY ao_kernel ./ao_kernel
+
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && python -m pip install --no-cache-dir ".[release-gate-service]" \
+    && useradd --create-home --uid 10001 --shell /usr/sbin/nologin ao-kernel
+
+USER 10001
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import os, urllib.request; urllib.request.urlopen('http://127.0.0.1:%s/healthz' % os.environ.get('PORT', '8000'), timeout=3).read()"
+
+CMD ["sh", "-c", "exec gunicorn --bind 0.0.0.0:${PORT:-8000} --workers ${WEB_CONCURRENCY:-1} --threads ${WEB_THREADS:-4} --timeout ${WEB_TIMEOUT:-30} ao_kernel.ao_release_gate_runtime:application"]

--- a/deploy/ao-release-gate-service/README.md
+++ b/deploy/ao-release-gate-service/README.md
@@ -1,0 +1,138 @@
+# AO Release Gate Service Container
+
+This container packages the GPP-2w WSGI runtime for the `ao-release-gate`
+GitHub App check-run service.
+
+It is not a merge runner and it is not a live-adapter runner. It only hosts:
+
+```text
+ao_kernel.ao_release_gate_runtime:application
+```
+
+## Build
+
+```bash
+docker build \
+  -f deploy/ao-release-gate-service/Dockerfile \
+  -t ao-kernel-ao-release-gate-service:local \
+  .
+```
+
+## Published Image
+
+The repository publication workflow builds this same Dockerfile, runs the
+no-secret `/healthz` smoke, and publishes trusted non-PR builds to GHCR:
+
+```text
+ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>
+ghcr.io/halildeu/ao-kernel-ao-release-gate-service:main
+```
+
+Use the immutable `sha-<commit>` tag for hosted deployments whenever possible.
+If the hosting provider cannot pull the package anonymously, configure a GHCR
+read token through that provider's secret manager. Do not bake registry tokens
+or runtime secrets into the image.
+
+## Runtime
+
+Required hosting secrets:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+or:
+
+```text
+AO_GITHUB_APP_PRIVATE_KEY_PATH
+```
+
+Optional runtime settings:
+
+```text
+PORT
+WEB_CONCURRENCY
+WEB_THREADS
+WEB_TIMEOUT
+AO_GITHUB_API_URL
+AO_RELEASE_GATE_GPP_STATUS_PATH
+AO_RELEASE_GATE_MAX_BODY_BYTES
+```
+
+The public GitHub App webhook URL must route to:
+
+```text
+POST /github/ao-release-gate
+```
+
+The container health endpoint is:
+
+```text
+GET /healthz
+```
+
+Do not pass `AO_CLAUDE_CODE_CLI_AUTH` to this service. The release gate posts
+dry-run check-runs only after it is explicitly hosted and configured with
+GitHub App runtime secrets; this container package alone is not release
+authority and does not change branch protection.
+
+## Autonomous Cloud Run Deployment
+
+The repository deploy workflow can mirror the immutable GHCR image into Google
+Artifact Registry, deploy it to Cloud Run, health-check `/healthz`, and upload
+deploy evidence:
+
+```text
+.github/workflows/ao-release-gate-deploy-cloud-run.yml
+```
+
+Required repository variables:
+
+```text
+GCP_PROJECT_ID
+GCP_WORKLOAD_IDENTITY_PROVIDER
+GCP_SERVICE_ACCOUNT
+GCP_CLOUD_RUN_REGION
+GCP_ARTIFACT_REGISTRY_LOCATION
+GCP_ARTIFACT_REGISTRY_REPOSITORY
+RELEASE_GATE_SERVICE_NAME
+AO_RELEASE_GATE_GITHUB_APP_ID
+AO_RELEASE_GATE_WEBHOOK_SECRET_NAME
+AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME
+```
+
+Optional repository variables:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET_VERSION
+AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION
+```
+
+`AO_RELEASE_GATE_WEBHOOK_SECRET_NAME` and
+`AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME` are Secret Manager object
+names, not secret values. The workflow must not read those values back. Cloud
+Run resolves them at runtime into:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+The deploy workflow proves only that the service revision is hosted and
+`GET /healthz` responds. It does not prove that the GitHub App webhook URL is
+configured, does not post a check-run, does not collect real PR evidence, does
+not change branch protection, and does not enable merge authority.
+
+## Local No-Secret Smoke
+
+The local container smoke only builds the image and checks `/healthz`. It does
+not configure GitHub App secrets, receive GitHub webhooks, post check-runs,
+merge pull requests, change branch protection, or execute a live adapter.
+
+```bash
+python3 scripts/ao_release_gate_container_smoke.py \
+  --image ao-kernel-ao-release-gate-service:smoke \
+  --build-timeout-seconds 600
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ policy-service = [
     "gunicorn>=22.0.0",
     "PyJWT[crypto]>=2.8.0",
 ]
+release-gate-service = [
+    "gunicorn>=22.0.0",
+    "PyJWT[crypto]>=2.8.0",
+]
 # Meta-extras (PR-A6, widened in PR-B5 for metrics)
 coding = [
     "ao-kernel[llm]",

--- a/scripts/ao_release_gate_container_smoke.py
+++ b/scripts/ao_release_gate_container_smoke.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Build and health-check the ao-release-gate check-run service container."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+DEFAULT_DOCKERFILE = Path("deploy/ao-release-gate-service/Dockerfile")
+DEFAULT_IMAGE = "ao-kernel-ao-release-gate-service:smoke"
+DEFAULT_TIMEOUT_SECONDS = 60.0
+DEFAULT_BUILD_TIMEOUT_SECONDS = 300.0
+DEFAULT_RUN_TIMEOUT_SECONDS = 30.0
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _run(
+    command: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    timeout_seconds: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+    )
+
+
+def _health_url(port: int) -> str:
+    return f"http://127.0.0.1:{port}/healthz"
+
+
+def _wait_for_health(url: str, *, timeout_seconds: float) -> dict[str, object]:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+                if isinstance(payload, dict):
+                    return payload
+        except Exception as exc:  # noqa: BLE001 - report final health failure compactly
+            last_error = exc
+        time.sleep(1)
+    detail = f": {last_error}" if last_error else ""
+    raise RuntimeError(f"container health endpoint did not become ready{detail}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", default=DEFAULT_IMAGE, help="Container image tag to build.")
+    parser.add_argument(
+        "--dockerfile",
+        type=Path,
+        default=DEFAULT_DOCKERFILE,
+        help="Path to the ao-release-gate service Dockerfile.",
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS, help="Health wait timeout.")
+    parser.add_argument(
+        "--build-timeout-seconds",
+        type=float,
+        default=DEFAULT_BUILD_TIMEOUT_SECONDS,
+        help="Docker build timeout.",
+    )
+    parser.add_argument(
+        "--run-timeout-seconds",
+        type=float,
+        default=DEFAULT_RUN_TIMEOUT_SECONDS,
+        help="Docker run command timeout.",
+    )
+    parser.add_argument("--skip-build", action="store_true", help="Run an already-built image.")
+    return parser
+
+
+def _print_process_output(stdout: str | bytes | None, stderr: str | bytes | None) -> None:
+    for output in (stdout, stderr):
+        if not output:
+            continue
+        if isinstance(output, bytes):
+            output = output.decode("utf-8", errors="replace")
+        print(output, file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = _repo_root()
+    port = _free_port()
+    container_id: str | None = None
+    try:
+        if not args.skip_build:
+            _run(
+                [
+                    "docker",
+                    "build",
+                    "-f",
+                    str(args.dockerfile),
+                    "-t",
+                    args.image,
+                    ".",
+                ],
+                cwd=repo_root,
+                timeout_seconds=args.build_timeout_seconds,
+            )
+        run = _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--detach",
+                "--publish",
+                f"127.0.0.1:{port}:8000",
+                args.image,
+            ],
+            cwd=repo_root,
+            timeout_seconds=args.run_timeout_seconds,
+        )
+        container_id = run.stdout.strip()
+        payload = _wait_for_health(_health_url(port), timeout_seconds=args.timeout_seconds)
+        print(
+            json.dumps(
+                {
+                    "status": "pass",
+                    "image": args.image,
+                    "health_url": _health_url(port),
+                    "health_payload": payload,
+                    "secret_value_readback": False,
+                    "live_adapter_execution": False,
+                    "github_check_run_post": False,
+                    "merge_authority_enabled": False,
+                    "branch_protection_cutover": False,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (OSError, RuntimeError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        print(f"release_gate_container_smoke: {exc}", file=sys.stderr)
+        if isinstance(exc, subprocess.CalledProcessError):
+            _print_process_output(exc.stdout, exc.stderr)
+        if isinstance(exc, subprocess.TimeoutExpired):
+            _print_process_output(exc.stdout, exc.stderr)
+        return 2
+    finally:
+        if container_id:
+            try:
+                subprocess.run(
+                    ["docker", "rm", "-f", container_id],
+                    cwd=repo_root,
+                    check=False,
+                    capture_output=True,
+                    timeout=15,
+                )
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ao_release_gate_decision.py
+++ b/scripts/ao_release_gate_decision.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Evaluate an ao-release-gate dry-run payload."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel.ao_release_gate import (  # noqa: E402
+    RELEASE_GATE_ARTIFACT,
+    build_ao_release_gate_decision,
+    render_ao_release_gate_decision_text,
+    write_ao_release_gate_decision,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--payload",
+        type=Path,
+        required=True,
+        help="Path to a PR-shaped release-gate payload JSON.",
+    )
+    parser.add_argument(
+        "--gpp-status",
+        type=Path,
+        default=Path(".claude/plans/gpp_status.v1.json"),
+        help="Path to the machine-readable GPP status JSON.",
+    )
+    parser.add_argument(
+        "--decision-path",
+        type=Path,
+        default=Path(RELEASE_GATE_ARTIFACT),
+        help="Path for the dry-run release-gate decision artifact.",
+    )
+    parser.add_argument("--output", choices=("json", "text"), default="json", help="Stdout render mode.")
+    parser.add_argument(
+        "--fail-on-deny",
+        action="store_true",
+        help="Return exit code 1 when the release-gate decision is not allow_autonomous_merge.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    payload: object = json.loads(args.payload.read_text(encoding="utf-8"))
+    gpp_status: object = json.loads(args.gpp_status.read_text(encoding="utf-8"))
+    decision = build_ao_release_gate_decision(payload, gpp_status)
+    write_ao_release_gate_decision(args.decision_path, decision)
+
+    if args.output == "json":
+        print(json.dumps(decision, indent=2, sort_keys=True))
+    else:
+        print(render_ao_release_gate_decision_text(decision))
+
+    if args.fail_on_deny and not decision["allow"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ao_release_gate.py
+++ b/tests/test_ao_release_gate.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from ao_kernel.ao_release_gate import (
+    ALLOW_AUTONOMOUS_MERGE_DECISION,
+    DENY_MISSING_EVIDENCE_DECISION,
+    DENY_POLICY_VIOLATION_DECISION,
+    DENY_STALE_BRANCH_DECISION,
+    DENY_UNTRUSTED_CONTEXT_DECISION,
+    RELEASE_GATE_CHECK_NAME,
+    build_ao_release_gate_decision,
+    render_ao_release_gate_decision_text,
+    write_ao_release_gate_decision,
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _gpp_status(*, issue: str = "https://github.com/Halildeu/ao-kernel/issues/539") -> dict[str, object]:
+    return {
+        "current_wp": {
+            "id": "GPP-2",
+            "status": "blocked",
+            "issue": issue,
+        },
+        "support_widening_allowed": False,
+        "production_platform_claim_allowed": False,
+        "live_adapter_execution_allowed": False,
+    }
+
+
+def _allow_payload() -> dict[str, object]:
+    return {
+        "repository": {"full_name": "Halildeu/ao-kernel"},
+        "pull_request": {
+            "number": 539,
+            "base": {"ref": "main"},
+            "head": {"ref": "codex/gpp-2v-release-gate-dry-run", "sha": "abc123", "repo": {"fork": False}},
+        },
+        "issue_url": "https://github.com/Halildeu/ao-kernel/issues/539",
+        "branch_up_to_date": True,
+        "event_name": "pull_request",
+        "changed_paths": [
+            "ao_kernel/ao_release_gate.py",
+            "scripts/ao_release_gate_decision.py",
+            "tests/test_ao_release_gate.py",
+            ".claude/plans/GPP-2v-AO-RELEASE-GATE-DRY-RUN-SCAFFOLD.md",
+        ],
+        "allowed_path_prefixes": [
+            "ao_kernel/",
+            "scripts/",
+            "tests/",
+            ".claude/plans/",
+        ],
+        "required_checks": [
+            {"name": "lint", "status": "completed", "conclusion": "success"},
+            {"name": "test (3.13)", "status": "completed", "conclusion": "success"},
+            {"name": RELEASE_GATE_CHECK_NAME, "status": "completed", "conclusion": "success"},
+        ],
+        "forbidden_secret_context_detected": False,
+        "admin_bypass_requested": False,
+        "pat_backed_bot_actor": False,
+        "codex_or_claude_release_authority": False,
+        "live_adapter_execution_requested": False,
+    }
+
+
+def _find_check(decision: dict[str, object], name: str) -> dict[str, object]:
+    checks = decision["checks"]
+    assert isinstance(checks, list)
+    for check in checks:
+        assert isinstance(check, dict)
+        if check["name"] == name:
+            return check
+    raise AssertionError(f"missing check: {name}")
+
+
+def test_release_gate_allows_closed_dry_run_context_without_merge_authority() -> None:
+    decision = build_ao_release_gate_decision(
+        _allow_payload(),
+        _gpp_status(),
+        generated_at="2026-04-28T00:00:00Z",
+    )
+
+    assert decision["schema_version"] == "1"
+    assert decision["program_id"] == "GPP-2v"
+    assert decision["app_slug"] == RELEASE_GATE_CHECK_NAME
+    assert decision["decision"] == ALLOW_AUTONOMOUS_MERGE_DECISION
+    assert decision["allow"] is True
+    assert decision["dry_run"] is True
+    assert decision["merge_authority_enabled"] is False
+    assert decision["finding_code"] is None
+    assert decision["findings"] == []
+    assert decision["github_check_run"]["name"] == RELEASE_GATE_CHECK_NAME
+    assert decision["github_check_run"]["conclusion"] == "success"
+    assert all(check["status"] == "pass" for check in decision["checks"])
+
+
+def test_release_gate_denies_stale_branch() -> None:
+    payload = _allow_payload()
+    payload["branch_up_to_date"] = False
+
+    decision = build_ao_release_gate_decision(payload, _gpp_status())
+
+    assert decision["decision"] == DENY_STALE_BRANCH_DECISION
+    assert decision["allow"] is False
+    assert decision["github_check_run"]["conclusion"] == "failure"
+    assert _find_check(decision, "branch_freshness")["finding_code"] == "ao_release_gate_branch_not_up_to_date"
+
+
+def test_release_gate_denies_untrusted_fork_context() -> None:
+    payload = _allow_payload()
+    pull_request = payload["pull_request"]
+    assert isinstance(pull_request, dict)
+    head = pull_request["head"]
+    assert isinstance(head, dict)
+    repo = head["repo"]
+    assert isinstance(repo, dict)
+    repo["fork"] = True
+
+    decision = build_ao_release_gate_decision(payload, _gpp_status())
+
+    assert decision["decision"] == DENY_UNTRUSTED_CONTEXT_DECISION
+    assert "ao_release_gate_untrusted_fork" in decision["findings"]
+
+
+def test_release_gate_denies_missing_ci_evidence() -> None:
+    payload = _allow_payload()
+    payload["required_checks"] = []
+
+    decision = build_ao_release_gate_decision(payload, _gpp_status())
+
+    assert decision["decision"] == DENY_MISSING_EVIDENCE_DECISION
+    assert _find_check(decision, "required_checks")["finding_code"] == "ao_release_gate_required_checks_missing"
+
+
+def test_release_gate_denies_policy_violations() -> None:
+    payload = _allow_payload()
+    payload["admin_bypass_requested"] = True
+
+    decision = build_ao_release_gate_decision(payload, _gpp_status())
+
+    assert decision["decision"] == DENY_POLICY_VIOLATION_DECISION
+    assert "ao_release_gate_admin_bypass_requested" in decision["findings"]
+
+
+def test_release_gate_denies_gpp_issue_mismatch_as_missing_evidence() -> None:
+    decision = build_ao_release_gate_decision(
+        _allow_payload(),
+        _gpp_status(issue="https://github.com/Halildeu/ao-kernel/issues/537"),
+    )
+
+    assert decision["decision"] == DENY_MISSING_EVIDENCE_DECISION
+    assert _find_check(decision, "gpp_issue_consistency")["finding_code"] == "ao_release_gate_gpp_issue_mismatch"
+
+
+def test_release_gate_render_and_write(tmp_path: Path) -> None:
+    decision = build_ao_release_gate_decision(
+        _allow_payload(),
+        _gpp_status(),
+        generated_at="2026-04-28T00:00:00Z",
+    )
+    path = tmp_path / "decision.json"
+
+    write_ao_release_gate_decision(path, decision)
+
+    assert json.loads(path.read_text(encoding="utf-8")) == decision
+    assert path.read_text(encoding="utf-8").endswith("\n")
+    rendered = render_ao_release_gate_decision_text(decision)
+    assert "decision: allow_autonomous_merge" in rendered
+    assert "merge_authority_enabled: false" in rendered
+    assert f"github_check_run: {RELEASE_GATE_CHECK_NAME} success" in rendered
+
+
+def test_release_gate_cli_writes_dry_run_artifact(tmp_path: Path) -> None:
+    payload_path = tmp_path / "payload.json"
+    status_path = tmp_path / "gpp_status.json"
+    decision_path = tmp_path / "decision.json"
+    payload_path.write_text(json.dumps(_allow_payload(), sort_keys=True), encoding="utf-8")
+    status_path.write_text(json.dumps(_gpp_status(), sort_keys=True), encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/ao_release_gate_decision.py",
+            "--payload",
+            str(payload_path),
+            "--gpp-status",
+            str(status_path),
+            "--decision-path",
+            str(decision_path),
+            "--output",
+            "text",
+            "--fail-on-deny",
+        ],
+        cwd=_repo_root(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    artifact = json.loads(decision_path.read_text(encoding="utf-8"))
+    assert "decision: allow_autonomous_merge" in completed.stdout
+    assert artifact["decision"] == ALLOW_AUTONOMOUS_MERGE_DECISION
+    assert artifact["dry_run"] is True
+    assert artifact["merge_authority_enabled"] is False

--- a/tests/test_ao_release_gate_container.py
+++ b/tests/test_ao_release_gate_container.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _container_smoke_module() -> Any:
+    module_path = _repo_root() / "scripts" / "ao_release_gate_container_smoke.py"
+    spec = importlib.util.spec_from_file_location("ao_release_gate_container_smoke", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ao_release_gate_dockerfile_hosts_wsgi_runtime_without_live_secret() -> None:
+    dockerfile = _repo_root() / "deploy" / "ao-release-gate-service" / "Dockerfile"
+    text = dockerfile.read_text(encoding="utf-8")
+
+    assert "python:3.13-slim" in text
+    assert ".[release-gate-service]" in text
+    assert "gunicorn" in text
+    assert "ao_kernel.ao_release_gate_runtime:application" in text
+    assert "/healthz" in text
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in text
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET" not in text
+    assert "AO_GITHUB_APP_PRIVATE_KEY" not in text
+
+
+def test_release_gate_container_smoke_defaults_to_no_secret_health_check_only() -> None:
+    module = _container_smoke_module()
+    parser = module.build_parser()
+    args = parser.parse_args([])
+
+    assert args.image == "ao-kernel-ao-release-gate-service:smoke"
+    assert args.dockerfile == Path("deploy/ao-release-gate-service/Dockerfile")
+    assert args.build_timeout_seconds == 300.0
+    assert args.run_timeout_seconds == 30.0
+    assert module._health_url(18080) == "http://127.0.0.1:18080/healthz"
+    smoke_source = Path(module.__file__).read_text(encoding="utf-8")
+    assert "timeout_seconds=args.build_timeout_seconds" in smoke_source
+    assert '"secret_value_readback": False' in smoke_source
+    assert '"live_adapter_execution": False' in smoke_source
+    assert '"github_check_run_post": False' in smoke_source
+    assert '"merge_authority_enabled": False' in smoke_source
+    assert '"branch_protection_cutover": False' in smoke_source
+
+
+def test_test_workflow_runs_release_gate_container_smoke_without_secret_context() -> None:
+    workflow = (_repo_root() / ".github" / "workflows" / "test.yml").read_text(encoding="utf-8")
+
+    assert "release-gate-container-smoke:" in workflow
+    assert "scripts/ao_release_gate_container_smoke.py" in workflow
+    assert "ao-kernel-ao-release-gate-service:ci" in workflow
+    release_gate_job = workflow.split("release-gate-container-smoke:", 1)[1].split("\n  typecheck:", 1)[0]
+    assert "secrets." not in release_gate_job
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in release_gate_job
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET" not in release_gate_job

--- a/tests/test_ao_release_gate_container_publish_workflow.py
+++ b/tests/test_ao_release_gate_container_publish_workflow.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _workflow_text() -> str:
+    workflow = _repo_root() / ".github" / "workflows" / "ao-release-gate-container-publish.yml"
+    return workflow.read_text(encoding="utf-8")
+
+
+def test_release_gate_container_publish_workflow_builds_smokes_and_publishes_ghcr() -> None:
+    text = _workflow_text()
+
+    assert "ghcr.io/halildeu/ao-kernel-ao-release-gate-service" in text
+    assert "deploy/ao-release-gate-service/Dockerfile" in text
+    assert "docker build -f \"$DOCKERFILE\"" in text
+    assert "scripts/ao_release_gate_container_smoke.py" in text
+    assert "--skip-build" in text
+    assert "docker push \"$image_sha\"" in text
+    assert "docker push \"$image_main\"" in text
+    assert "sha-${GITHUB_SHA}" in text
+
+
+def test_release_gate_container_publish_workflow_keeps_prs_and_live_credentials_closed() -> None:
+    text = _workflow_text()
+
+    assert "contents: read" in text
+    assert "packages: write" in text
+    assert "github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'" in text
+    assert "GHCR_TOKEN: ${{ github.token }}" in text
+    assert "pull_request" in text
+    assert "codex/**" in text
+    assert "secrets." not in text
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in text
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET" not in text
+    assert "AO_GITHUB_APP_PRIVATE_KEY" not in text
+    assert "/github/ao-release-gate" not in text
+    assert "branch_protection" not in text
+
+
+def test_release_gate_container_readme_records_publish_boundary() -> None:
+    readme = (_repo_root() / "deploy" / "ao-release-gate-service" / "README.md").read_text(encoding="utf-8")
+
+    assert "ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>" in readme
+    assert "ghcr.io/halildeu/ao-kernel-ao-release-gate-service:main" in readme
+    assert "POST /github/ao-release-gate" in readme
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET" in readme
+    assert "AO_CLAUDE_CODE_CLI_AUTH" in readme
+    assert "does not change branch protection" in readme

--- a/tests/test_ao_release_gate_deploy_workflow.py
+++ b/tests/test_ao_release_gate_deploy_workflow.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _workflow_text() -> str:
+    workflow = _repo_root() / ".github" / "workflows" / "ao-release-gate-deploy-cloud-run.yml"
+    return workflow.read_text(encoding="utf-8")
+
+
+def test_release_gate_deploy_workflow_is_trusted_oidc_cloud_run_path() -> None:
+    text = _workflow_text()
+
+    assert "name: Deploy AO Release Gate to Cloud Run" in text
+    assert "workflow_run:" in text
+    assert 'workflows: ["Publish AO Release Gate Container"]' in text
+    assert "workflow_dispatch:" in text
+    assert "id-token: write" in text
+    assert "packages: read" in text
+    assert "google-github-actions/auth@v2" in text
+    assert "workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}" in text
+    assert "google-github-actions/deploy-cloudrun@v2" in text
+    assert "--allow-unauthenticated --ingress=all --port=8000" in text
+
+
+def test_release_gate_deploy_workflow_uses_published_image_and_health_evidence() -> None:
+    text = _workflow_text()
+
+    assert "ghcr.io/halildeu/ao-kernel-ao-release-gate-service" in text
+    assert "sha-${source_sha}" in text
+    assert "docker pull \"${{ steps.images.outputs.ghcr_image }}\"" in text
+    assert "docker push \"${{ steps.images.outputs.gar_image }}\"" in text
+    assert "$service_url/healthz" in text
+    assert "ao-release-gate-deploy-evidence/healthz.json" in text
+    assert "ao-release-gate-deploy-evidence/ao-release-gate-deploy.v1.json" in text
+    assert "ao_release_gate_deployed_health_checked" in text
+    assert "$SERVICE_URL/github/ao-release-gate" in text
+    assert "secret_value_readback: false" in text
+    assert "check_run_post: false" in text
+    assert "real_pr_evidence: false" in text
+    assert "branch_protection_cutover: false" in text
+    assert "merge_authority_enabled: false" in text
+    assert "live_adapter_execution: false" in text
+
+
+def test_release_gate_deploy_workflow_keeps_prs_and_live_credentials_closed() -> None:
+    text = _workflow_text()
+
+    assert "github.event.workflow_run.head_branch == 'main'" in text
+    assert "github.event.workflow_run.event != 'pull_request'" in text
+    assert "pull_request:" not in text
+    assert "pull_request_target" not in text
+    assert "secrets." not in text
+    assert "GHCR_TOKEN: ${{ github.token }}" in text
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in text
+    assert "gh pr merge" not in text
+    assert "gh api repos/Halildeu/ao-kernel/branches/main/protection" not in text
+    assert "gcloud secrets versions access" not in text
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET=${{ env.AO_RELEASE_GATE_WEBHOOK_SECRET_NAME }}" in text
+    assert (
+        "AO_GITHUB_APP_PRIVATE_KEY_PEM=${{ env.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME }}"
+        in text
+    )

--- a/tests/test_ao_release_gate_runtime.py
+++ b/tests/test_ao_release_gate_runtime.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import builtins
+import json
+import sys
+import types
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
+
+from ao_kernel.ao_release_gate import ALLOW_AUTONOMOUS_MERGE_DECISION, DENY_POLICY_VIOLATION_DECISION
+from ao_kernel.ao_release_gate_runtime import (
+    DEFAULT_HEALTH_PATH,
+    DEFAULT_WEBHOOK_PATH,
+    GITHUB_APP_ID_ENV,
+    GITHUB_APP_PRIVATE_KEY_ENV,
+    GPP_STATUS_PATH_ENV,
+    WEBHOOK_SECRET_ENV,
+    CheckRunPostResult,
+    GithubAppCheckRunClient,
+    GithubAppConfig,
+    ReleaseGateRuntimeConfigError,
+    build_github_app_jwt,
+    handle_ao_release_gate_webhook,
+    release_gate_runtime_wsgi_app,
+)
+from ao_kernel.ao_release_gate_service import AoReleaseGateCheckRunRequest
+from ao_kernel.live_adapter_gate_policy_service import github_webhook_signature
+
+
+def _gpp_status(*, issue: str = "https://github.com/Halildeu/ao-kernel/issues/541") -> dict[str, object]:
+    return {
+        "current_wp": {
+            "id": "GPP-2",
+            "status": "blocked",
+            "issue": issue,
+        },
+        "support_widening_allowed": False,
+        "production_platform_claim_allowed": False,
+        "live_adapter_execution_allowed": False,
+    }
+
+
+def _allow_payload() -> dict[str, object]:
+    return {
+        "repository": {"full_name": "Halildeu/ao-kernel"},
+        "installation": {"id": 12345},
+        "pull_request": {
+            "number": 541,
+            "base": {"ref": "main"},
+            "head": {
+                "ref": "codex/gpp-2w-release-gate-service",
+                "sha": "abc123",
+                "repo": {"fork": False},
+            },
+        },
+        "issue_url": "https://github.com/Halildeu/ao-kernel/issues/541",
+        "branch_up_to_date": True,
+        "event_name": "pull_request",
+        "changed_paths": [
+            "ao_kernel/ao_release_gate_service.py",
+            "ao_kernel/ao_release_gate_runtime.py",
+            "tests/test_ao_release_gate_service.py",
+            "tests/test_ao_release_gate_runtime.py",
+            ".claude/plans/GPP-2w-AO-RELEASE-GATE-CHECK-RUN-SERVICE.md",
+        ],
+        "allowed_path_prefixes": [
+            "ao_kernel/",
+            "tests/",
+            ".claude/plans/",
+        ],
+        "required_checks": [
+            {"name": "lint", "status": "completed", "conclusion": "success"},
+            {"name": "test (3.13)", "status": "completed", "conclusion": "success"},
+        ],
+        "forbidden_secret_context_detected": False,
+        "admin_bypass_requested": False,
+        "pat_backed_bot_actor": False,
+        "codex_or_claude_release_authority": False,
+        "live_adapter_execution_requested": False,
+    }
+
+
+def _body(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(payload, sort_keys=True).encode("utf-8")
+
+
+def _headers(body: bytes, *, secret: str = "secret") -> dict[str, str]:
+    return {
+        "X-GitHub-Event": "pull_request",
+        "X-GitHub-Delivery": "delivery-1",
+        "X-Hub-Signature-256": github_webhook_signature(secret, body),
+    }
+
+
+class FakeGithubClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, AoReleaseGateCheckRunRequest]] = []
+
+    def post_check_run(
+        self,
+        *,
+        installation_id: int,
+        check_run_request: AoReleaseGateCheckRunRequest,
+    ) -> CheckRunPostResult:
+        self.calls.append((installation_id, check_run_request))
+        return {
+            "status": "posted",
+            "status_code": 201,
+            "finding_code": None,
+            "detail": "posted in test",
+        }
+
+
+def test_runtime_posts_success_check_run_for_allowed_context() -> None:
+    payload = _allow_payload()
+    body = _body(payload)
+    github_client = FakeGithubClient()
+
+    result = handle_ao_release_gate_webhook(
+        body,
+        _headers(body),
+        webhook_secret="secret",
+        github_client=github_client,
+        gpp_status=_gpp_status(),
+        generated_at="2026-04-28T00:00:00Z",
+    )
+
+    assert result["status"] == "check_run_posted"
+    assert result["finding_code"] is None
+    assert result["service_result"]["decision"] is not None
+    assert result["service_result"]["decision"]["decision"] == ALLOW_AUTONOMOUS_MERGE_DECISION
+    assert result["service_result"]["decision"]["dry_run"] is True
+    assert result["service_result"]["decision"]["merge_authority_enabled"] is False
+    assert github_client.calls == [(12345, result["service_result"]["check_run_request"])]
+    check_run_json = result["service_result"]["check_run_request"]["json"]
+    assert check_run_json is not None
+    assert check_run_json["conclusion"] == "success"
+
+
+def test_runtime_posts_failure_check_run_for_denied_policy() -> None:
+    payload = _allow_payload()
+    payload["admin_bypass_requested"] = True
+    body = _body(payload)
+    github_client = FakeGithubClient()
+
+    result = handle_ao_release_gate_webhook(
+        body,
+        _headers(body),
+        webhook_secret="secret",
+        github_client=github_client,
+        gpp_status=_gpp_status(),
+    )
+
+    assert result["status"] == "check_run_posted"
+    assert result["service_result"]["decision"] is not None
+    assert result["service_result"]["decision"]["decision"] == DENY_POLICY_VIOLATION_DECISION
+    assert github_client.calls[0][0] == 12345
+    check_run_json = github_client.calls[0][1]["json"]
+    assert check_run_json is not None
+    assert check_run_json["conclusion"] == "failure"
+
+
+def test_runtime_blocks_when_installation_id_is_missing() -> None:
+    payload = _allow_payload()
+    payload.pop("installation")
+    body = _body(payload)
+    github_client = FakeGithubClient()
+
+    result = handle_ao_release_gate_webhook(
+        body,
+        _headers(body),
+        webhook_secret="secret",
+        github_client=github_client,
+        gpp_status=_gpp_status(),
+    )
+
+    assert result["status"] == "blocked"
+    assert result["finding_code"] == "ao_release_gate_runtime_installation_id_missing"
+    assert result["check_run_post"] is not None
+    assert result["check_run_post"]["status"] == "blocked"
+    assert github_client.calls == []
+
+
+def test_github_app_client_posts_check_run_without_returning_secret_material(monkeypatch: pytest.MonkeyPatch) -> None:
+    jwt_module = types.ModuleType("jwt")
+    jwt_payloads: list[dict[str, object]] = []
+
+    def encode(payload: dict[str, object], private_key: str, *, algorithm: str) -> str:
+        jwt_payloads.append(payload)
+        assert private_key == "private-key"
+        assert algorithm == "RS256"
+        return "app-jwt"
+
+    jwt_module.encode = encode  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "jwt", jwt_module)
+    calls: list[tuple[str, str, dict[str, str], bytes | None, float]] = []
+
+    def transport(
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        body: bytes | None,
+        timeout_seconds: float,
+    ) -> tuple[int, bytes]:
+        calls.append((method, url, dict(headers), body, timeout_seconds))
+        if url.endswith("/access_tokens"):
+            return 201, b'{"token":"installation-token"}'
+        return 201, b"{}"
+
+    client = GithubAppCheckRunClient(
+        GithubAppConfig(app_id="3522435", private_key_pem="private-key"),
+        transport=transport,
+        now_seconds=lambda: 1000,
+    )
+    check_run_request: AoReleaseGateCheckRunRequest = {
+        "method": "POST",
+        "url": "https://api.github.com/repos/Halildeu/ao-kernel/check-runs",
+        "headers": {"Accept": "application/vnd.github+json"},
+        "json": {
+            "name": "ao-release-gate",
+            "head_sha": "abc123",
+            "status": "completed",
+            "conclusion": "success",
+            "output": {
+                "title": "ao-release-gate: allow_autonomous_merge",
+                "summary": "allowed",
+                "text": "All release-gate checks passed.",
+            },
+        },
+        "authorization_required": True,
+    }
+
+    result = client.post_check_run(installation_id=12345, check_run_request=check_run_request)
+
+    assert jwt_payloads == [{"iat": 940, "exp": 1540, "iss": "3522435"}]
+    assert calls[0][0] == "POST"
+    assert calls[0][2]["Authorization"] == "Bearer app-jwt"
+    assert calls[1][0] == "POST"
+    assert calls[1][1] == check_run_request["url"]
+    assert calls[1][2]["Authorization"] == "Bearer installation-token"
+    assert result == {
+        "status": "posted",
+        "status_code": 201,
+        "finding_code": None,
+        "detail": "GitHub ao-release-gate check-run was posted.",
+    }
+    assert "installation-token" not in json.dumps(result)
+    assert "private-key" not in json.dumps(result)
+
+
+def test_build_github_app_jwt_reports_missing_optional_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(sys.modules, "jwt", raising=False)
+    original_import = builtins.__import__
+
+    def missing_jwt_import(name: str, *args: Any, **kwargs: Any) -> object:
+        if name == "jwt":
+            raise ImportError("missing jwt")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", missing_jwt_import)
+
+    with pytest.raises(ReleaseGateRuntimeConfigError) as exc_info:
+        build_github_app_jwt(app_id="1", private_key_pem="private-key", now_seconds=1000)
+
+    assert "policy-service extra" in str(exc_info.value)
+
+
+def test_wsgi_health_endpoint() -> None:
+    status, payload = _call_wsgi("GET", DEFAULT_HEALTH_PATH, b"", {})
+
+    assert status == "200 OK"
+    assert payload == {"program_id": "GPP-2w", "status": "ok"}
+
+
+def test_wsgi_rejects_bad_signature_without_secret_echo(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    status_path = tmp_path / "gpp_status.json"
+    status_path.write_text(json.dumps(_gpp_status(), sort_keys=True), encoding="utf-8")
+    monkeypatch.setenv(WEBHOOK_SECRET_ENV, "secret")
+    monkeypatch.setenv(GITHUB_APP_ID_ENV, "3522435")
+    monkeypatch.setenv(GITHUB_APP_PRIVATE_KEY_ENV, "private-key")
+    monkeypatch.setenv(GPP_STATUS_PATH_ENV, str(status_path))
+    body = _body(_allow_payload())
+    headers = _headers(body)
+    headers["X-Hub-Signature-256"] = "sha256=bad"
+
+    status, payload = _call_wsgi("POST", DEFAULT_WEBHOOK_PATH, body, headers)
+
+    assert status == "401 Unauthorized"
+    assert payload["status"] == "blocked"
+    assert payload["signature_verified"] is False
+    assert "secret" not in json.dumps(payload)
+    assert "private-key" not in json.dumps(payload)
+
+
+def _call_wsgi(
+    method: str,
+    path: str,
+    body: bytes,
+    headers: Mapping[str, str],
+) -> tuple[str, dict[str, object]]:
+    environ: dict[str, object] = {
+        "REQUEST_METHOD": method,
+        "PATH_INFO": path,
+        "wsgi.input": BytesIO(body),
+        "CONTENT_LENGTH": str(len(body)),
+    }
+    for key, value in headers.items():
+        environ[f"HTTP_{key.upper().replace('-', '_')}"] = value
+    captured: dict[str, object] = {}
+
+    def start_response(status: str, response_headers: list[tuple[str, str]]) -> None:
+        captured["status"] = status
+        captured["headers"] = response_headers
+
+    chunks = list(release_gate_runtime_wsgi_app(environ, start_response))
+    response_body = b"".join(chunks)
+    return str(captured["status"]), json.loads(response_body.decode("utf-8"))

--- a/tests/test_ao_release_gate_service.py
+++ b/tests/test_ao_release_gate_service.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Mapping
+
+from ao_kernel.ao_release_gate import (
+    ALLOW_AUTONOMOUS_MERGE_DECISION,
+    DENY_POLICY_VIOLATION_DECISION,
+    RELEASE_GATE_CHECK_NAME,
+)
+from ao_kernel.ao_release_gate_service import (
+    build_ao_release_gate_service_result,
+    render_ao_release_gate_service_text,
+    write_ao_release_gate_service_result,
+)
+from ao_kernel.live_adapter_gate_policy_service import github_webhook_signature
+
+
+def _gpp_status(*, issue: str = "https://github.com/Halildeu/ao-kernel/issues/541") -> dict[str, object]:
+    return {
+        "current_wp": {
+            "id": "GPP-2",
+            "status": "blocked",
+            "issue": issue,
+        },
+        "support_widening_allowed": False,
+        "production_platform_claim_allowed": False,
+        "live_adapter_execution_allowed": False,
+    }
+
+
+def _allow_payload() -> dict[str, object]:
+    return {
+        "repository": {"full_name": "Halildeu/ao-kernel"},
+        "pull_request": {
+            "number": 541,
+            "base": {"ref": "main"},
+            "head": {
+                "ref": "codex/gpp-2w-release-gate-service",
+                "sha": "abc123",
+                "repo": {"fork": False},
+            },
+        },
+        "issue_url": "https://github.com/Halildeu/ao-kernel/issues/541",
+        "branch_up_to_date": True,
+        "event_name": "pull_request",
+        "changed_paths": [
+            "ao_kernel/ao_release_gate_service.py",
+            "ao_kernel/ao_release_gate_runtime.py",
+            "tests/test_ao_release_gate_service.py",
+            "tests/test_ao_release_gate_runtime.py",
+            ".claude/plans/GPP-2w-AO-RELEASE-GATE-CHECK-RUN-SERVICE.md",
+        ],
+        "allowed_path_prefixes": [
+            "ao_kernel/",
+            "tests/",
+            ".claude/plans/",
+        ],
+        "required_checks": [
+            {"name": "lint", "status": "completed", "conclusion": "success"},
+            {"name": "test (3.13)", "status": "completed", "conclusion": "success"},
+        ],
+        "forbidden_secret_context_detected": False,
+        "admin_bypass_requested": False,
+        "pat_backed_bot_actor": False,
+        "codex_or_claude_release_authority": False,
+        "live_adapter_execution_requested": False,
+    }
+
+
+def _body(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(payload, sort_keys=True).encode("utf-8")
+
+
+def _headers(body: bytes, *, secret: str = "secret", event: str = "pull_request") -> dict[str, str]:
+    return {
+        "X-GitHub-Event": event,
+        "X-GitHub-Delivery": "delivery-1",
+        "X-Hub-Signature-256": github_webhook_signature(secret, body),
+    }
+
+
+def test_service_blocks_missing_required_signature() -> None:
+    body = _body(_allow_payload())
+
+    result = build_ao_release_gate_service_result(
+        body,
+        {"X-GitHub-Event": "pull_request"},
+        gpp_status=_gpp_status(),
+        webhook_secret="secret",
+    )
+
+    assert result["status"] == "blocked"
+    assert result["should_post_check_run"] is False
+    assert result["decision"] is None
+    assert "ao_release_gate_service_signature_invalid" in result["findings"]
+
+
+def test_service_blocks_wrong_event_before_policy_evaluation() -> None:
+    body = _body(_allow_payload())
+
+    result = build_ao_release_gate_service_result(
+        body,
+        _headers(body, event="push"),
+        gpp_status=_gpp_status(),
+        webhook_secret="secret",
+    )
+
+    assert result["status"] == "blocked"
+    assert result["should_post_check_run"] is False
+    assert result["decision"] is None
+    assert "ao_release_gate_service_wrong_event" in result["findings"]
+
+
+def test_service_blocks_malformed_json_before_policy_evaluation() -> None:
+    body = b"{not-json"
+
+    result = build_ao_release_gate_service_result(
+        body,
+        _headers(body),
+        gpp_status=_gpp_status(),
+        webhook_secret="secret",
+    )
+
+    assert result["status"] == "blocked"
+    assert result["should_post_check_run"] is False
+    assert result["decision"] is None
+    assert "ao_release_gate_service_invalid_json" in result["findings"]
+
+
+def test_service_builds_success_check_run_for_allowed_dry_run() -> None:
+    payload = _allow_payload()
+    body = _body(payload)
+
+    result = build_ao_release_gate_service_result(
+        body,
+        _headers(body),
+        gpp_status=_gpp_status(),
+        webhook_secret="secret",
+        generated_at="2026-04-28T00:00:00Z",
+    )
+
+    assert result["status"] == "check_run_ready"
+    assert result["should_post_check_run"] is True
+    assert result["signature_verified"] is True
+    assert result["decision"] is not None
+    assert result["decision"]["decision"] == ALLOW_AUTONOMOUS_MERGE_DECISION
+    assert result["decision"]["dry_run"] is True
+    assert result["decision"]["merge_authority_enabled"] is False
+    assert result["check_run_request"]["method"] == "POST"
+    assert result["check_run_request"]["url"] == "https://api.github.com/repos/Halildeu/ao-kernel/check-runs"
+    assert result["check_run_request"]["authorization_required"] is True
+    assert result["check_run_request"]["json"] == {
+        "name": RELEASE_GATE_CHECK_NAME,
+        "head_sha": "abc123",
+        "status": "completed",
+        "conclusion": "success",
+        "output": {
+            "title": f"{RELEASE_GATE_CHECK_NAME}: allow_autonomous_merge",
+            "summary": "Dry-run release gate would allow autonomous merge; no merge or GitHub write was performed.",
+            "text": "All release-gate checks passed.",
+        },
+    }
+
+
+def test_service_builds_failure_check_run_for_denied_policy() -> None:
+    payload = _allow_payload()
+    payload["admin_bypass_requested"] = True
+    body = _body(payload)
+
+    result = build_ao_release_gate_service_result(
+        body,
+        _headers(body),
+        gpp_status=_gpp_status(),
+        webhook_secret="secret",
+    )
+
+    assert result["status"] == "check_run_ready"
+    assert result["should_post_check_run"] is True
+    assert result["decision"] is not None
+    assert result["decision"]["decision"] == DENY_POLICY_VIOLATION_DECISION
+    assert "ao_release_gate_admin_bypass_requested" in result["decision"]["findings"]
+    assert result["check_run_request"]["json"] is not None
+    assert result["check_run_request"]["json"]["conclusion"] == "failure"
+
+
+def test_service_render_and_write(tmp_path: Path) -> None:
+    body = _body(_allow_payload())
+    result = build_ao_release_gate_service_result(
+        body,
+        _headers(body),
+        gpp_status=_gpp_status(),
+        webhook_secret="secret",
+        generated_at="2026-04-28T00:00:00Z",
+    )
+    path = tmp_path / "service.json"
+
+    write_ao_release_gate_service_result(path, result)
+
+    assert json.loads(path.read_text(encoding="utf-8")) == result
+    assert path.read_text(encoding="utf-8").endswith("\n")
+    rendered = render_ao_release_gate_service_text(result)
+    assert "status: check_run_ready" in rendered
+    assert "should_post_check_run: true" in rendered
+    assert "check_run_url: https://api.github.com/repos/Halildeu/ao-kernel/check-runs" in rendered
+    assert "merge_authority_enabled: false" in rendered

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,10 +30,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/539"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/547"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "ao_release_gate_dry_run_scaffold_ready_policy_service_still_not_hosted"
+        == "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped"
     )
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
@@ -158,12 +158,41 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2w"
+        and item["decision"] == "ao_release_gate_check_run_service_ready_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/541"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
+    assert any(
+        item["id"] == "GPP-2x"
+        and item["decision"] == "ao_release_gate_container_ready_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/543"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
+    assert any(
+        item["id"] == "GPP-2y"
+        and item["decision"] == "ao_release_gate_publish_path_ready_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/545"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
+    assert any(
+        item["id"] == "GPP-2aa"
+        and item["decision"] == "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/547"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
-        "install and wire the ao-release-gate GitHub App or equivalent GitHub App required-check authority to call ao_kernel.ao_release_gate without PAT-backed bot users, admin bypass, or Codex/Claude release authority",
-        "collect dry-run ao-release-gate evidence on real PRs before granting merge authority or changing branch protection",
+        "bootstrap the ao-release-gate Cloud Run deploy trust path and run the trusted deploy workflow from main without treating health evidence as check-run evidence",
+        "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with runtime webhook secret and GitHub App authentication outside the repo",
+        "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
         "validate whether GitHub App pull request approvals count for the current branch protection; if not, cut over to a required ao-release-gate status check",
         "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
         "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
@@ -172,16 +201,23 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         {
             "id": "GPP-2",
             "reason": (
-                "repo-owned policy webhook container image publish path and ao-release-gate dry-run decision "
-                "scaffold are ready, but the deployment-protection service is not yet publicly hosted/configured "
-                "and ao-release-gate is not yet installed/wired to post a required GitHub App check-run"
+                "repo-owned policy webhook container image publish path, ao-release-gate dry-run decision "
+                "scaffold, check-run service surface, release-gate container package, release-gate "
+                "image publish path, and release-gate autonomous deploy path are ready, but neither the "
+                "release-gate service nor the deployment-protection service is publicly hosted/configured "
+                "with webhook evidence or cut over with protected evidence"
             ),
         }
     ]
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
     assert any(
         action
-        == "wire the ao-release-gate dry-run evaluator into a GitHub App webhook/check-run posting path without merge authority"
+        == "bootstrap and run the ao-release-gate Cloud Run deploy workflow from main before collecting real PR evidence"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "deploy or host the ao-release-gate check-run service in dry-run mode and collect real PR evidence before any branch protection cutover"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -232,7 +268,22 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(
         action
+        == "use scripts/ao_release_gate_container_smoke.py only for no-secret local container health validation, not check-run posting"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
         == "publish or pull ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service only as a deploy artifact, not hosted service evidence"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "publish or pull ghcr.io/halildeu/ao-kernel-ao-release-gate-service only as a deploy artifact, not hosted service evidence"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "configure ao_kernel.ao_release_gate_runtime:application only with runtime secret manager values, never committed or echoed secret material"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -358,8 +409,82 @@ def test_gpp2v_adds_dry_run_release_gate_scaffold_without_merge_authority() -> N
     assert "No admin bypass." in decision
     assert "No PAT-backed bot." in decision
     assert "No Claude/Codex release authority." in decision
+
+
+def test_gpp2w_wires_check_run_service_without_merge_authority() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2w-AO-RELEASE-GATE-CHECK-RUN-SERVICE.md"
+    ).read_text(encoding="utf-8")
+
+    assert "**Decision:** `ao_release_gate_check_run_service_ready_no_support_widening`" in decision
+    assert "`ao-release-gate`" in decision
+    assert "`ao_kernel/ao_release_gate_service.py`" in decision
+    assert "`ao_kernel/ao_release_gate_runtime.py`" in decision
+    assert "check-run" in decision
+    assert "`dry_run=true`" in decision
+    assert "`merge_authority_enabled=false`" in decision
+    assert "No branch protection/ruleset change." in decision
+    assert "No admin bypass." in decision
+    assert "No PAT-backed bot user." in decision
+    assert "No Claude/Codex release authority." in decision
+    assert "The `ao-release-gate` service is not yet publicly hosted." in decision
     assert "does not unblock GPP-2" in decision
     assert "authorize human-free merges yet" in decision
+
+
+def test_gpp2x_packages_release_gate_container_without_hosting_or_merge_authority() -> None:
+    decision = (_repo_root() / ".claude/plans/GPP-2x-AO-RELEASE-GATE-CONTAINER.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "**Decision:** `ao_release_gate_container_ready_no_support_widening`" in decision
+    assert "`ao-release-gate`" in decision
+    assert "`deploy/ao-release-gate-service/Dockerfile`" in decision
+    assert "`scripts/ao_release_gate_container_smoke.py`" in decision
+    assert "no-secret health smoke" in decision
+    assert "does not publish the image" in decision
+    assert "post a check-run to GitHub" in decision
+    assert "change branch protection" in decision
+    assert "does not unblock GPP-2" in decision
+    assert "does not authorize human-free merges" in decision
+    assert "AO_CLAUDE_CODE_CLI_AUTH" in decision
+
+
+def test_gpp2y_adds_release_gate_publish_path_without_hosting_or_merge_authority() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2y-AO-RELEASE-GATE-CONTAINER-PUBLISH.md"
+    ).read_text(encoding="utf-8")
+
+    assert "**Decision:** `ao_release_gate_publish_path_ready_no_support_widening`" in decision
+    assert "`ao-release-gate`" in decision
+    assert "`.github/workflows/ao-release-gate-container-publish.yml`" in decision
+    assert "`ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>`" in decision
+    assert "no-secret `/healthz` smoke" in decision
+    assert "does not host the service" in decision
+    assert "post check-runs" in decision
+    assert "change branch protection" in decision
+    assert "does not unblock GPP-2" in decision
+    assert "does not authorize human-free merges" in decision
+    assert "AO_CLAUDE_CODE_CLI_AUTH" in decision
+
+
+def test_gpp2aa_adds_release_gate_deploy_path_without_cutover_or_merge_authority() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md"
+    ).read_text(encoding="utf-8")
+
+    assert "**Decision:** `ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped`" in decision
+    assert "`ao-release-gate`" in decision
+    assert "`.github/workflows/ao-release-gate-deploy-cloud-run.yml`" in decision
+    assert "`ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>`" in decision
+    assert "GitHub OIDC" in decision
+    assert "Secret Manager" in decision
+    assert "check_run_post=false" in decision
+    assert "branch_protection_cutover=false" in decision
+    assert "merge_authority_enabled=false" in decision
+    assert "post check-runs" in decision
+    assert "change branch" in decision
+    assert "AO_CLAUDE_CODE_CLI_AUTH" in decision
 
 
 def test_gpp_next_load_status_validates_required_guards() -> None:
@@ -369,11 +494,11 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/539"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/547"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "ao_release_gate_dry_run_scaffold_ready_policy_service_still_not_hosted"
+        == "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped"
     )
     assert payload["support_widening_allowed"] is False
 

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,10 +30,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/537"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/539"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "autonomous_release_gate_selected_policy_service_still_not_hosted"
+        == "ao_release_gate_dry_run_scaffold_ready_policy_service_still_not_hosted"
     )
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
@@ -151,11 +151,19 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2v"
+        and item["decision"] == "ao_release_gate_dry_run_scaffold_ready_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/539"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
-        "implement and install the ao-release-gate GitHub App or equivalent GitHub App required-check authority without PAT-backed bot users, admin bypass, or Codex/Claude release authority",
+        "install and wire the ao-release-gate GitHub App or equivalent GitHub App required-check authority to call ao_kernel.ao_release_gate without PAT-backed bot users, admin bypass, or Codex/Claude release authority",
+        "collect dry-run ao-release-gate evidence on real PRs before granting merge authority or changing branch protection",
         "validate whether GitHub App pull request approvals count for the current branch protection; if not, cut over to a required ao-release-gate status check",
         "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
         "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
@@ -164,17 +172,21 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         {
             "id": "GPP-2",
             "reason": (
-                "repo-owned policy webhook container image publish path is ready and the autonomous GitHub App "
-                "release-gate model is selected, but the deployment-protection service is not yet publicly "
-                "hosted/configured and the ao-release-gate required status-check authority is not yet "
-                "implemented/cut over"
+                "repo-owned policy webhook container image publish path and ao-release-gate dry-run decision "
+                "scaffold are ready, but the deployment-protection service is not yet publicly hosted/configured "
+                "and ao-release-gate is not yet installed/wired to post a required GitHub App check-run"
             ),
         }
     ]
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
     assert any(
         action
-        == "implement a dry-run ao-release-gate GitHub App required status check before any human-free merge automation"
+        == "wire the ao-release-gate dry-run evaluator into a GitHub App webhook/check-run posting path without merge authority"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "collect ao-release-gate dry-run check-run evidence on real PRs before any branch protection cutover"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -331,6 +343,25 @@ def test_gpp2u_selects_autonomous_github_app_release_gate_not_admin_bypass() -> 
     assert "does not widen support" in decision
 
 
+def test_gpp2v_adds_dry_run_release_gate_scaffold_without_merge_authority() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2v-AO-RELEASE-GATE-DRY-RUN-SCAFFOLD.md"
+    ).read_text(encoding="utf-8")
+
+    assert "**Decision:** `ao_release_gate_dry_run_scaffold_ready_no_support_widening`" in decision
+    assert "`ao-release-gate`" in decision
+    assert "`ao_kernel/ao_release_gate.py`" in decision
+    assert "`scripts/ao_release_gate_decision.py`" in decision
+    assert "`merge_authority_enabled=false`" in decision
+    assert "No check-run POST to GitHub." in decision
+    assert "No branch protection/ruleset change." in decision
+    assert "No admin bypass." in decision
+    assert "No PAT-backed bot." in decision
+    assert "No Claude/Codex release authority." in decision
+    assert "does not unblock GPP-2" in decision
+    assert "authorize human-free merges yet" in decision
+
+
 def test_gpp_next_load_status_validates_required_guards() -> None:
     mod = _module()
 
@@ -338,11 +369,11 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/537"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/539"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "autonomous_release_gate_selected_policy_service_still_not_hosted"
+        == "ao_release_gate_dry_run_scaffold_ready_policy_service_still_not_hosted"
     )
     assert payload["support_widening_allowed"] is False
 
@@ -373,7 +404,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "Blocked work packages:\n- GPP-2: repo-owned policy webhook container image publish path is ready" in rendered
+    assert "Blocked work packages:\n- GPP-2: repo-owned policy webhook container image publish path" in rendered
     assert "divergence: 0\t0" in rendered
 
 


### PR DESCRIPTION
## Summary
- adds side-effect-free `ao_kernel.ao_release_gate` dry-run evaluator for the future `ao-release-gate` GitHub App check-run
- adds `scripts/ao_release_gate_decision.py` CLI for deterministic decision artifacts
- updates GPP status/roadmap to keep GPP-2 blocked until GitHub App wiring, dry-run evidence, branch-protection cutover, and deployment-protection service hosting exist

## Guardrails
- no GitHub App registration or private key handling
- no check-run POST to GitHub
- no branch protection/ruleset change
- no merge authority; decision artifacts keep `dry_run=true` and `merge_authority_enabled=false`
- no admin bypass, PAT-backed bot, or Codex/Claude release authority
- no support widening, production platform claim, or live adapter execution

## Validation
- `python3 -m ruff check ao_kernel/ao_release_gate.py scripts/ao_release_gate_decision.py tests/test_ao_release_gate.py tests/test_gpp_next.py`
- `pytest -q tests/test_ao_release_gate.py tests/test_gpp_next.py`
- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `python3 scripts/gpp_next.py`
- `git diff --check`

Depends on #538. Refs #539.