### PR TITLE
GPP-2x: package ao-release-gate container

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 `ao-release-gate` check-run service surface ready; hosted deployment/config, dry-run evidence, and cutover still blocked
+**Status:** GPP-2 `ao-release-gate` container package ready; hosted deployment/config, dry-run evidence, and cutover still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#541](https://github.com/Halildeu/ao-kernel/issues/541)
-for `ao-release-gate` check-run service wiring
-**Current slice record:** `.claude/plans/GPP-2w-AO-RELEASE-GATE-CHECK-RUN-SERVICE.md`
+**Current slice issue:** [#543](https://github.com/Halildeu/ao-kernel/issues/543)
+for `ao-release-gate` container package
+**Current slice record:** `.claude/plans/GPP-2x-AO-RELEASE-GATE-CONTAINER.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -187,6 +187,14 @@ Last live verification on current `origin/main` showed:
     GPP-2 remains blocked until the service is publicly hosted/configured, real
     PR dry-run check-run evidence is collected, branch protection is cut over,
     and the deployment-protection policy service is hosted.
+39. GPP-2x packages the `ao-release-gate` check-run service as a repo-owned
+    container with a no-secret `/healthz` smoke path. The Dockerfile runs
+    `ao_kernel.ao_release_gate_runtime:application`, the smoke script verifies
+    health without webhook secrets or GitHub writes, and CI builds the
+    container. GPP-2 remains blocked until the container is published or
+    deployed, the hosted service is configured, real PR dry-run check-run
+    evidence is collected, branch protection is cut over, and the
+    deployment-protection policy service is hosted.
 
 ## 3. Current Verdict
 
@@ -248,7 +256,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2u` | Completed / no support widening | Autonomous GitHub App release-gate decision | `ao-release-gate` required status-check model selected; app implementation/cutover still required |
 | `GPP-2v` | Completed / no support widening | `ao-release-gate` dry-run scaffold | side-effect-free decision core and CLI ready; GitHub App wiring/cutover still required |
 | `GPP-2w` | Completed / no support widening | `ao-release-gate` check-run service wiring | webhook/check-run request service and WSGI GitHub App POST runtime ready; hosting, real PR evidence, and branch-protection cutover still required |
-| `GPP-2` | Blocked / hosted services and release-gate cutover missing | Protected live-adapter gate runtime binding | deployment protection app/policy service image/container must be hosted/configured, and `ao-release-gate` must be hosted/evidenced/cut over before human-free program merges |
+| `GPP-2x` | Completed / no support widening | `ao-release-gate` container package | container build target, no-secret health smoke, and CI job ready; publish/hosting, real PR evidence, and branch-protection cutover still required |
+| `GPP-2` | Blocked / hosted services and release-gate cutover missing | Protected live-adapter gate runtime binding | deployment protection app/policy service image/container must be hosted/configured, and `ao-release-gate` must be published/hosted/evidenced/cut over before human-free program merges |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -377,12 +386,13 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2w; policy decision core, webhook scaffold,
+**Status:** blocked after GPP-2x; policy decision core, webhook scaffold,
 deployable WSGI runtime, container package, and GHCR image publication path
 exist. The autonomous GitHub App release-gate model, dry-run decision
-scaffold, and check-run service/runtime surface now exist. Hosted service
-deployment/configuration, real PR dry-run evidence, branch-protection cutover,
-and deployment-protection callback evidence are still missing.
+scaffold, check-run service/runtime surface, and release-gate container package
+now exist. Hosted service deployment/configuration, real PR dry-run evidence,
+branch-protection cutover, and deployment-protection callback evidence are
+still missing.
 
 **Entry criteria:**
 
@@ -420,6 +430,9 @@ GPP-2w adds the webhook service boundary and WSGI runtime that can post the
 dry-run `ao-release-gate` check-run with GitHub App installation auth when
 hosted. It still does not merge PRs, grant merge authority, change branch
 protection, or prove real PR check-run evidence.
+GPP-2x adds the container build target and no-secret health smoke for that WSGI
+runtime. It still does not publish the image, host the service, post check-runs
+to GitHub, grant merge authority, or change branch protection.
 
 **Acceptance criteria:**
 
@@ -693,7 +706,10 @@ check-run output. GPP-2w adds `ao_kernel/ao_release_gate_service.py` and
 webhooks, evaluate the dry-run release-gate decision, and post the check-run
 with installation auth. The service is still not publicly hosted/configured,
 real PR dry-run check-run evidence is not collected, and branch protection does
-not yet require it.
+not yet require it. GPP-2x adds `deploy/ao-release-gate-service/Dockerfile`
+and `scripts/ao_release_gate_container_smoke.py` so the same runtime has a
+repo-owned no-secret container health smoke path. The container image is still
+not published or hosted, and no GitHub delivery evidence exists.
 GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
@@ -715,6 +731,9 @@ operator provisioning runbook, and GPP-2u selects a separate GitHub App release
 gate for PR merge automation. GPP-2v provides the dry-run evaluator for that
 release gate while keeping `merge_authority_enabled=false`. GPP-2w provides the
 check-run service/runtime surface while still keeping merge authority disabled.
+GPP-2x provides the container package while still avoiding secret value
+readback, GitHub check-run POSTs, branch-protection cutover, and live adapter
+execution.
 Existing PRs
 [#536](https://github.com/Halildeu/ao-kernel/pull/536) and
 [#538](https://github.com/Halildeu/ao-kernel/pull/538) can stay blocked by
@@ -722,15 +741,16 @@ review-required branch protection until independent approval or the future
 `ao-release-gate` required-check cutover exists; admin bypass remains
 forbidden.
 
-The next GPP-2 action is to host/configure the dry-run `ao-release-gate`
-check-run service, collect real PR check-run evidence, and only then cut branch
-protection/rulesets over to require `ao-release-gate`. In parallel, deploy or
-configure the `ao-kernel-live-adapter-gate` deployment protection app/policy
-service using the GPP-2s GHCR image, the GPP-2r container package, the GPP-2q
-WSGI runtime, or an equivalent fail-closed implementation so it receives
-protected deployment callbacks, enriches them with trusted context, evaluates
-the repo-owned policy modules, attaches GitHub App auth outside the repo, and
-posts an explicit GitHub deployment review callback. Do not repeatedly dispatch
+The next GPP-2 action is to publish or deploy the dry-run `ao-release-gate`
+container package, host/configure that check-run service, collect real PR
+check-run evidence, and only then cut branch protection/rulesets over to
+require `ao-release-gate`. In parallel, deploy or configure the
+`ao-kernel-live-adapter-gate` deployment protection app/policy service using
+the GPP-2s GHCR image, the GPP-2r container package, the GPP-2q WSGI runtime,
+or an equivalent fail-closed implementation so it receives protected deployment
+callbacks, enriches them with trusted context, evaluates the repo-owned policy
+modules, attaches GitHub App auth outside the repo, and posts an explicit
+GitHub deployment review callback. Do not repeatedly dispatch
 `.github/workflows/live-adapter-gate.yml` until that service is expected to
 respond. Any follow-up must keep fork and pull-request contexts away from
 protected credentials, must not use `AO_CLAUDE_CODE_CLI_AUTH` through a
@@ -760,6 +780,7 @@ keep `live_execution_allowed=false`, `support_widening=false`, and
 | Human review requirement blocks autonomous program PRs | Green CI still cannot merge without manual approval | Implement `ao-release-gate` as a GitHub App required status check; reject admin bypass, PAT-backed bots, and Claude/Codex release authority |
 | Dry-run release gate mistaken for merge authority | A scaffold could be overclaimed as production release control | GPP-2v sets `dry_run=true` and `merge_authority_enabled=false`; require GitHub App wiring and real PR evidence before branch-protection cutover |
 | Check-run service mistaken for cutover evidence | A hosted-capable runtime could be overclaimed as active enforcement | GPP-2w still requires public hosting, real PR dry-run check-run evidence, and explicit branch-protection cutover before release authority is active |
+| Release-gate container mistaken for hosted evidence | A local/CI image health pass could be overclaimed as active GitHub enforcement | GPP-2x treats the container as deploy artifact readiness only; require public hosting, webhook configuration, real PR dry-run evidence, and branch-protection cutover |
 
 ## 19. Tracking Log
 
@@ -815,3 +836,5 @@ keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-28 | GPP-2v dry-run scaffold added | `ao_kernel/ao_release_gate.py` and `scripts/ao_release_gate_decision.py` produce side-effect-free future check-run decisions; GitHub App wiring, dry-run evidence, and branch-protection cutover remain required. |
 | 2026-04-28 | GPP-2w issue opened | Issue [#541](https://github.com/Halildeu/ao-kernel/issues/541) tracks the `ao-release-gate` webhook/check-run service wiring. |
 | 2026-04-28 | GPP-2w check-run service added | `ao_kernel/ao_release_gate_service.py` and `ao_kernel/ao_release_gate_runtime.py` verify webhook input, evaluate the dry-run release gate, and can post the GitHub App check-run when hosted; public hosting, real PR dry-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |
+| 2026-04-28 | GPP-2x issue opened | Issue [#543](https://github.com/Halildeu/ao-kernel/issues/543) tracks the `ao-release-gate` container package and no-secret health smoke path. |
+| 2026-04-28 | GPP-2x container package added | `deploy/ao-release-gate-service/Dockerfile`, `scripts/ao_release_gate_container_smoke.py`, and the `release-gate-container-smoke` CI job package the WSGI runtime as a no-secret health-checkable container; publish/hosting, real PR dry-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |

--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 `ao-release-gate` container package ready; hosted deployment/config, dry-run evidence, and cutover still blocked
+**Status:** GPP-2 `ao-release-gate` autonomous deploy path ready; hosting bootstrap/config, dry-run evidence, and cutover still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#543](https://github.com/Halildeu/ao-kernel/issues/543)
-for `ao-release-gate` container package
-**Current slice record:** `.claude/plans/GPP-2x-AO-RELEASE-GATE-CONTAINER.md`
+**Current slice issue:** [#547](https://github.com/Halildeu/ao-kernel/issues/547)
+for `ao-release-gate` autonomous Cloud Run deploy path
+**Current slice record:** `.claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -195,6 +195,23 @@ Last live verification on current `origin/main` showed:
     deployed, the hosted service is configured, real PR dry-run check-run
     evidence is collected, branch protection is cut over, and the
     deployment-protection policy service is hosted.
+40. GPP-2y adds a GHCR publication path for the `ao-release-gate` container.
+    PRs and codex branches build and no-secret smoke the image without pushing;
+    trusted `main` or manual dispatch can publish
+    `ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>` and the
+    moving `:main` tag. GPP-2 remains blocked until the image is actually
+    deployed to a public host, the GitHub App webhook/runtime secrets are
+    configured, real PR dry-run check-run evidence is collected, branch
+    protection is cut over, and the deployment-protection policy service is
+    hosted.
+41. GPP-2aa adds an autonomous Cloud Run deploy path for the `ao-release-gate`
+    image. Trusted `main` publication or explicit manual dispatch can mirror
+    the immutable GHCR image to Artifact Registry, deploy Cloud Run with
+    Secret Manager references, health-check `/healthz`, and upload deploy
+    evidence. GPP-2 remains blocked until the deploy trust bootstrap exists,
+    the GitHub App webhook URL is configured, real PR dry-run check-run
+    evidence is collected, branch protection is cut over, and the
+    deployment-protection policy service is hosted.
 
 ## 3. Current Verdict
 
@@ -257,7 +274,9 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2v` | Completed / no support widening | `ao-release-gate` dry-run scaffold | side-effect-free decision core and CLI ready; GitHub App wiring/cutover still required |
 | `GPP-2w` | Completed / no support widening | `ao-release-gate` check-run service wiring | webhook/check-run request service and WSGI GitHub App POST runtime ready; hosting, real PR evidence, and branch-protection cutover still required |
 | `GPP-2x` | Completed / no support widening | `ao-release-gate` container package | container build target, no-secret health smoke, and CI job ready; publish/hosting, real PR evidence, and branch-protection cutover still required |
-| `GPP-2` | Blocked / hosted services and release-gate cutover missing | Protected live-adapter gate runtime binding | deployment protection app/policy service image/container must be hosted/configured, and `ao-release-gate` must be published/hosted/evidenced/cut over before human-free program merges |
+| `GPP-2y` | Completed / no support widening | `ao-release-gate` container image publication | GHCR publish workflow ready; public hosting, real PR evidence, and branch-protection cutover still required |
+| `GPP-2aa` | Completed / no support widening | `ao-release-gate` autonomous deploy path | Cloud Run deploy workflow ready; cloud bootstrap, webhook config, real PR evidence, and branch-protection cutover still required |
+| `GPP-2` | Blocked / hosted services and release-gate cutover missing | Protected live-adapter gate runtime binding | deployment protection app/policy service image/container must be hosted/configured, and `ao-release-gate` must be deployed/hosted/evidenced/cut over before human-free program merges |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -386,11 +405,12 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2x; policy decision core, webhook scaffold,
+**Status:** blocked after GPP-2aa; policy decision core, webhook scaffold,
 deployable WSGI runtime, container package, and GHCR image publication path
 exist. The autonomous GitHub App release-gate model, dry-run decision
 scaffold, check-run service/runtime surface, and release-gate container package
-now exist. Hosted service deployment/configuration, real PR dry-run evidence,
+image publication path, and autonomous Cloud Run deploy workflow now exist.
+Hosted service bootstrap/configuration, real PR dry-run evidence,
 branch-protection cutover, and deployment-protection callback evidence are
 still missing.
 
@@ -433,6 +453,13 @@ protection, or prove real PR check-run evidence.
 GPP-2x adds the container build target and no-secret health smoke for that WSGI
 runtime. It still does not publish the image, host the service, post check-runs
 to GitHub, grant merge authority, or change branch protection.
+GPP-2y adds the GHCR image publication path for that release-gate container.
+It still does not host the service, configure a webhook URL, post check-runs to
+GitHub, grant merge authority, or change branch protection.
+GPP-2aa adds the autonomous Cloud Run deploy workflow for that release-gate
+image. It still does not prove cloud bootstrap, configure the GitHub App webhook
+URL, post check-runs, collect real PR evidence, grant merge authority, or change
+branch protection.
 
 **Acceptance criteria:**
 
@@ -708,8 +735,17 @@ with installation auth. The service is still not publicly hosted/configured,
 real PR dry-run check-run evidence is not collected, and branch protection does
 not yet require it. GPP-2x adds `deploy/ao-release-gate-service/Dockerfile`
 and `scripts/ao_release_gate_container_smoke.py` so the same runtime has a
-repo-owned no-secret container health smoke path. The container image is still
-not published or hosted, and no GitHub delivery evidence exists.
+repo-owned no-secret container health smoke path. GPP-2y adds
+`.github/workflows/ao-release-gate-container-publish.yml`, which builds and
+smokes the image on PR/codex branch changes and publishes only on trusted
+`main` or manual dispatch events. The image may now be published as a deploy
+artifact, but it is still not hosted and no GitHub delivery evidence exists.
+GPP-2aa adds `.github/workflows/ao-release-gate-deploy-cloud-run.yml`, which can
+mirror the immutable release-gate image to Artifact Registry, deploy Cloud Run
+with Secret Manager references, health-check `/healthz`, and upload deploy
+evidence after trusted `main` publication or manual dispatch. The deploy path
+is not itself GitHub App webhook configuration, check-run evidence, branch
+protection cutover, or merge authority.
 GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
@@ -733,7 +769,12 @@ release gate while keeping `merge_authority_enabled=false`. GPP-2w provides the
 check-run service/runtime surface while still keeping merge authority disabled.
 GPP-2x provides the container package while still avoiding secret value
 readback, GitHub check-run POSTs, branch-protection cutover, and live adapter
-execution.
+execution. GPP-2y provides the release-gate container publish path while still
+avoiding public hosting, webhook configuration, GitHub check-run POSTs,
+branch-protection cutover, and live adapter execution. GPP-2aa provides the
+release-gate Cloud Run deploy workflow while still avoiding secret value
+readback, GitHub check-run POST evidence, branch-protection cutover, merge
+authority, and live adapter execution.
 Existing PRs
 [#536](https://github.com/Halildeu/ao-kernel/pull/536) and
 [#538](https://github.com/Halildeu/ao-kernel/pull/538) can stay blocked by
@@ -741,10 +782,11 @@ review-required branch protection until independent approval or the future
 `ao-release-gate` required-check cutover exists; admin bypass remains
 forbidden.
 
-The next GPP-2 action is to publish or deploy the dry-run `ao-release-gate`
-container package, host/configure that check-run service, collect real PR
-check-run evidence, and only then cut branch protection/rulesets over to
-require `ao-release-gate`. In parallel, deploy or configure the
+The next GPP-2 action is to bootstrap/run the trusted dry-run `ao-release-gate`
+deploy path from `main`, configure that check-run service's GitHub App webhook
+URL, collect real PR check-run evidence, and only then cut branch
+protection/rulesets over to require `ao-release-gate`. In parallel, deploy or
+configure the
 `ao-kernel-live-adapter-gate` deployment protection app/policy service using
 the GPP-2s GHCR image, the GPP-2r container package, the GPP-2q WSGI runtime,
 or an equivalent fail-closed implementation so it receives protected deployment
@@ -781,6 +823,8 @@ keep `live_execution_allowed=false`, `support_widening=false`, and
 | Dry-run release gate mistaken for merge authority | A scaffold could be overclaimed as production release control | GPP-2v sets `dry_run=true` and `merge_authority_enabled=false`; require GitHub App wiring and real PR evidence before branch-protection cutover |
 | Check-run service mistaken for cutover evidence | A hosted-capable runtime could be overclaimed as active enforcement | GPP-2w still requires public hosting, real PR dry-run check-run evidence, and explicit branch-protection cutover before release authority is active |
 | Release-gate container mistaken for hosted evidence | A local/CI image health pass could be overclaimed as active GitHub enforcement | GPP-2x treats the container as deploy artifact readiness only; require public hosting, webhook configuration, real PR dry-run evidence, and branch-protection cutover |
+| Release-gate image publish mistaken for hosted evidence | A GHCR image tag could be overclaimed as an active GitHub App | GPP-2y treats GHCR publication as deploy artifact readiness only; require public hosting, webhook configuration, real PR dry-run evidence, and branch-protection cutover |
+| Release-gate deploy health mistaken for release authority | A hosted `/healthz` response could be overclaimed as required-check enforcement | GPP-2aa records `check_run_post=false`, `real_pr_evidence=false`, `branch_protection_cutover=false`, and `merge_authority_enabled=false`; require real PR evidence and explicit cutover |
 
 ## 19. Tracking Log
 
@@ -838,3 +882,7 @@ keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-28 | GPP-2w check-run service added | `ao_kernel/ao_release_gate_service.py` and `ao_kernel/ao_release_gate_runtime.py` verify webhook input, evaluate the dry-run release gate, and can post the GitHub App check-run when hosted; public hosting, real PR dry-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |
 | 2026-04-28 | GPP-2x issue opened | Issue [#543](https://github.com/Halildeu/ao-kernel/issues/543) tracks the `ao-release-gate` container package and no-secret health smoke path. |
 | 2026-04-28 | GPP-2x container package added | `deploy/ao-release-gate-service/Dockerfile`, `scripts/ao_release_gate_container_smoke.py`, and the `release-gate-container-smoke` CI job package the WSGI runtime as a no-secret health-checkable container; publish/hosting, real PR dry-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |
+| 2026-04-28 | GPP-2y issue opened | Issue [#545](https://github.com/Halildeu/ao-kernel/issues/545) tracks the `ao-release-gate` container image publication path. |
+| 2026-04-28 | GPP-2y publish path added | `.github/workflows/ao-release-gate-container-publish.yml` builds, no-secret smokes, and publishes trusted `main` or manual images to `ghcr.io/halildeu/ao-kernel-ao-release-gate-service`; public hosting, real PR dry-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |
+| 2026-04-28 | GPP-2aa issue opened | Issue [#547](https://github.com/Halildeu/ao-kernel/issues/547) tracks the `ao-release-gate` autonomous Cloud Run deploy path. |
+| 2026-04-28 | GPP-2aa deploy path added | `.github/workflows/ao-release-gate-deploy-cloud-run.yml` can mirror the trusted immutable release-gate image to Artifact Registry, deploy Cloud Run with Secret Manager references, health-check `/healthz`, and upload deploy evidence; webhook configuration, real PR check-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |

--- a/.claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md
+++ b/.claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md
@@ -1,0 +1,170 @@
+# GPP-2aa - AO Release Gate Autonomous Deploy Path
+
+**Issue:** [#547](https://github.com/Halildeu/ao-kernel/issues/547)
+**Decision:** `ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped`
+**Date:** 2026-04-28
+**Support widening:** false
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## Decision
+
+GPP-2aa adds a repo-owned autonomous Cloud Run deploy path for the
+`ao-release-gate` check-run service image. The workflow can deploy a trusted
+immutable image tag after the `Publish AO Release Gate Container` workflow
+succeeds on `main`, or by explicit trusted `workflow_dispatch`.
+
+This is a deploy automation path only. It does not prove that Google Cloud OIDC
+bootstrap exists, it does not configure the GitHub App webhook URL, it does not
+post check-runs, it does not collect real PR evidence, it does not change branch
+protection, it does not merge pull requests, it does not run a live adapter, it
+does not widen support, and it does not claim production readiness.
+
+## Added Surface
+
+1. `.github/workflows/ao-release-gate-deploy-cloud-run.yml`
+   - runs only after trusted `main` publication or explicit
+     `workflow_dispatch`;
+   - uses GitHub OIDC (`id-token: write`) for Google Cloud auth;
+   - reads cloud resource names and secret object names from repository
+     variables;
+   - pulls the immutable GHCR image tag
+     `ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>`;
+   - mirrors that immutable image to Google Artifact Registry;
+   - deploys Cloud Run with public ingress for GitHub webhook delivery;
+   - binds runtime secrets by Secret Manager name/version, not by secret value;
+   - health-checks `GET /healthz`;
+   - uploads `ao-release-gate-deploy.v1.json` and `healthz.json` evidence.
+
+2. `tests/test_ao_release_gate_deploy_workflow.py`
+   - pins trusted trigger scope, OIDC auth, immutable image flow, health
+     evidence, and security guardrails.
+
+3. `deploy/ao-release-gate-service/README.md`
+   - records the Cloud Run variable and Secret Manager contract.
+
+## Trust Boundary
+
+The workflow intentionally does not use:
+
+```text
+secrets.*
+AO_CLAUDE_CODE_CLI_AUTH
+gcloud secrets versions access
+pull_request
+pull_request_target
+gh pr merge
+branch protection update APIs
+```
+
+The hosted service receives only runtime GitHub App materials that Cloud Run
+resolves from Secret Manager:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+Repository variables such as `AO_RELEASE_GATE_WEBHOOK_SECRET_NAME` and
+`AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME` are secret object names,
+not secret values.
+
+## Bootstrap Contract
+
+The deploy workflow is autonomous only after this external machine-trust
+bootstrap exists:
+
+1. Google Cloud Workload Identity Provider trusts this repository's GitHub OIDC
+   identity for the deploy workflow.
+2. The configured Google service account can push to the selected Artifact
+   Registry repository and deploy the selected Cloud Run service.
+3. Google Secret Manager contains the release-gate webhook secret and GitHub
+   App private key under the configured secret object names.
+4. The Cloud Run service can access those secrets at runtime.
+5. The `ao-release-gate` GitHub App webhook URL points at:
+
+```text
+https://<cloud-run-service-url>/github/ao-release-gate
+```
+
+Secret values must not be pasted into issues, PRs, logs, chat, MCP prompts, or
+repository files.
+
+## Evidence Contract
+
+A successful deploy workflow uploads:
+
+```text
+ao-release-gate-deploy.v1.json
+healthz.json
+```
+
+The deployment evidence records:
+
+```text
+status=ao_release_gate_deployed_health_checked
+secret_value_readback=false
+check_run_post=false
+real_pr_evidence=false
+branch_protection_cutover=false
+merge_authority_enabled=false
+live_adapter_execution=false
+support_widening=false
+production_platform_claim=false
+```
+
+This evidence proves a hosted health endpoint for the `ao-release-gate`
+revision. It is not enough to grant release authority. GPP-2 remains blocked
+until the GitHub App webhook is configured to this URL, real PR dry-run
+check-run evidence is collected, branch protection or rulesets require
+`ao-release-gate`, and the deployment-protection policy service is also
+hosted/configured with protected callback evidence.
+
+## Current Decision
+
+Resolved by this slice:
+
+1. repo-owned autonomous deploy workflow exists for `ao-release-gate`;
+2. deploy authentication is OIDC-based, not a committed cloud key;
+3. PR/fork contexts cannot run the deploy job;
+4. immutable GHCR image tags remain the source of deployed revisions;
+5. runtime secrets are passed by Secret Manager reference only;
+6. deploy evidence records no secret readback, no check-run POST, no branch
+   protection cutover, no merge authority, and no live adapter execution.
+
+Still blocked:
+
+1. cloud OIDC/service-account/Secret Manager bootstrap is not attested by this
+   PR;
+2. no Cloud Run deployment run has completed from `main` in this slice;
+3. the `ao-release-gate` GitHub App webhook URL is not proven configured to the
+   Cloud Run endpoint;
+4. no real PR dry-run check-run has been posted by the hosted service;
+5. branch protection/rulesets do not yet require `ao-release-gate`;
+6. the deployment-protection policy service still needs hosted callback
+   evidence before live-adapter runtime work can continue.
+
+Still closed:
+
+1. `merge_authority_enabled=false`;
+2. `live_execution_allowed=false`;
+3. `support_widening=false`;
+4. `production_platform_claim=false`.
+
+## Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_ao_release_gate_deploy_workflow.py tests/test_ao_release_gate_container_publish_workflow.py tests/test_gpp_next.py
+python3 -m ruff check tests/test_ao_release_gate_deploy_workflow.py tests/test_ao_release_gate_container_publish_workflow.py tests/test_gpp_next.py
+actionlint .github/workflows/ao-release-gate-deploy-cloud-run.yml .github/workflows/ao-release-gate-container-publish.yml
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Recorded closeout decision:
+
+```text
+ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped
+```

--- a/.claude/plans/GPP-2x-AO-RELEASE-GATE-CONTAINER.md
+++ b/.claude/plans/GPP-2x-AO-RELEASE-GATE-CONTAINER.md
@@ -1,0 +1,118 @@
+# GPP-2x - AO Release Gate Container Package
+
+**Issue:** [#543](https://github.com/Halildeu/ao-kernel/issues/543)
+**Decision:** `ao_release_gate_container_ready_no_support_widening`
+**Date:** 2026-04-28
+**Support widening:** false
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## Decision
+
+GPP-2x packages the `ao-release-gate` check-run service runtime as a
+repo-owned container image build target with a bounded no-secret health smoke.
+This makes the GPP-2w WSGI runtime deployable by a hosting platform without
+inventing packaging steps outside the repo.
+
+This slice does not publish the image, host the service, configure the GitHub
+App webhook URL, post a check-run to GitHub, change branch protection, merge
+PRs, run a live adapter, widen support, or claim production readiness.
+It does not unblock GPP-2 and does not authorize human-free merges.
+
+## Added Surface
+
+1. `deploy/ao-release-gate-service/Dockerfile`
+   - builds from `python:3.13-slim`;
+   - installs `ao-kernel[release-gate-service]`;
+   - runs `gunicorn` against `ao_kernel.ao_release_gate_runtime:application`;
+   - exposes port `8000`;
+   - adds a container health check for `/healthz`;
+   - runs as a non-root user.
+
+2. `scripts/ao_release_gate_container_smoke.py`
+   - builds the container image;
+   - runs it on a loopback-only random host port;
+   - checks `GET /healthz`;
+   - bounds Docker build/run waits with explicit timeouts;
+   - reports no secret readback, no GitHub check-run POST, no merge authority,
+     no branch-protection cutover, and no live adapter execution.
+
+3. `.github/workflows/test.yml`
+   - adds `release-gate-container-smoke` to build and health-check the
+     container in CI without secret context.
+
+4. `pyproject.toml`
+   - adds a `release-gate-service` optional extra for hosted service runtime
+     dependencies.
+
+5. `tests/test_ao_release_gate_container.py`
+   - pins the Dockerfile runtime entrypoint and no-secret boundary;
+   - pins smoke-script defaults;
+   - pins CI wiring without secret context.
+
+## Container Contract
+
+Build:
+
+```bash
+docker build \
+  -f deploy/ao-release-gate-service/Dockerfile \
+  -t ao-kernel-ao-release-gate-service:local \
+  .
+```
+
+No-secret local health smoke:
+
+```bash
+python3 scripts/ao_release_gate_container_smoke.py \
+  --image ao-kernel-ao-release-gate-service:smoke \
+  --build-timeout-seconds 600
+```
+
+Hosted service configuration still must provide runtime-only values outside
+the repo:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+or:
+
+```text
+AO_GITHUB_APP_PRIVATE_KEY_PATH
+```
+
+The public GitHub App webhook URL must route to:
+
+```text
+POST /github/ao-release-gate
+```
+
+Do not pass `AO_CLAUDE_CODE_CLI_AUTH` to this container. The release-gate
+service posts dry-run check-runs only after it is explicitly hosted and
+configured with GitHub App runtime secrets.
+
+## Remaining Blockers
+
+GPP-2 remains blocked after this work because:
+
+1. The `ao-release-gate` container image is not yet published to GHCR or
+   deployed to a public host.
+2. The `ao-release-gate` GitHub App webhook URL/runtime secret configuration is
+   not yet proven on a real delivery.
+3. No real PR dry-run check-run evidence has been collected.
+4. Branch protection/rulesets do not yet require `ao-release-gate`.
+5. The deployment-protection policy service for
+   `ao-kernel-live-adapter-gate` is still not publicly hosted/configured and
+   still has no protected workflow callback evidence.
+
+## Next Allowed Action
+
+Publish or otherwise deploy the `ao-release-gate` container as a deploy
+artifact, configure the hosted dry-run service with runtime secret-manager
+values, collect real PR check-run evidence, and only then consider a branch
+protection/ruleset cutover. The deployment-protection policy service must also
+still be hosted/configured before protected live-adapter workflow evidence is
+rerun.

--- a/.claude/plans/GPP-2y-AO-RELEASE-GATE-CONTAINER-PUBLISH.md
+++ b/.claude/plans/GPP-2y-AO-RELEASE-GATE-CONTAINER-PUBLISH.md
@@ -1,0 +1,101 @@
+# GPP-2y - AO Release Gate Container Publish Path
+
+**Issue:** [#545](https://github.com/Halildeu/ao-kernel/issues/545)
+**Decision:** `ao_release_gate_publish_path_ready_no_support_widening`
+**Date:** 2026-04-28
+**Support widening:** false
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## Decision
+
+GPP-2y adds a repo-owned GHCR publication path for the `ao-release-gate`
+check-run service container. Pull requests and codex branches build and run the
+no-secret `/healthz` smoke without pushing. Trusted `main` or manual
+`workflow_dispatch` runs can publish immutable `sha-<commit>` tags and the
+moving `main` tag for hosted deployments.
+
+This is a deploy artifact path only. It does not host the service, configure
+the GitHub App webhook URL, post check-runs, change branch protection, merge
+PRs, run a live adapter, widen support, or claim production readiness.
+It does not unblock GPP-2 and does not authorize human-free merges.
+
+## Added Surface
+
+1. `.github/workflows/ao-release-gate-container-publish.yml`
+   - builds `deploy/ao-release-gate-service/Dockerfile`;
+   - tags the image as
+     `ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>`;
+   - runs `scripts/ao_release_gate_container_smoke.py --skip-build` before
+     any image push;
+   - builds and smokes PR/codex branch changes without pushing;
+   - pushes only for `refs/heads/main` or explicit `workflow_dispatch`;
+   - adds the moving `:main` tag only for `refs/heads/main`;
+   - uses `github.token` with `packages: write`, not `secrets.*`;
+   - does not reference `AO_CLAUDE_CODE_CLI_AUTH`, webhook secrets, GitHub App
+     private keys, or live adapter credentials.
+
+2. `deploy/ao-release-gate-service/README.md`
+   - records GHCR image tags;
+   - records runtime-only GitHub App secret names;
+   - records `POST /github/ao-release-gate`;
+   - states that the package does not change branch protection or grant
+     release authority.
+
+3. `tests/test_ao_release_gate_container_publish_workflow.py`
+   - pins GHCR image naming, no-secret smoke execution, trusted-event publish
+     gating, and live credential exclusions.
+
+## Image Contract
+
+Trusted `main` or manual publication can produce:
+
+```text
+ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>
+ghcr.io/halildeu/ao-kernel-ao-release-gate-service:main
+```
+
+Hosted deployments should prefer immutable `sha-<commit>` tags. If the hosting
+platform cannot pull the package anonymously, the host must receive a GHCR read
+token through its secret manager. Registry credentials must not be committed or
+baked into the image.
+
+The image still requires runtime host configuration for:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+or:
+
+```text
+AO_GITHUB_APP_PRIVATE_KEY_PATH
+```
+
+Do not pass `AO_CLAUDE_CODE_CLI_AUTH` to this container. The release-gate
+service is not a live-adapter runner and is not merge authority until a later
+explicit branch-protection/ruleset cutover is approved after real PR evidence.
+
+## Remaining Blockers
+
+GPP-2 remains blocked after this work because:
+
+1. The `ao-release-gate` image publication path exists, but no public hosted
+   endpoint is deployed.
+2. The `ao-release-gate` GitHub App webhook URL/runtime secret configuration is
+   not yet proven on a real delivery.
+3. No real PR dry-run check-run evidence has been collected.
+4. Branch protection/rulesets do not yet require `ao-release-gate`.
+5. The deployment-protection policy service for
+   `ao-kernel-live-adapter-gate` is still not publicly hosted/configured and
+   still has no protected workflow callback evidence.
+
+## Next Allowed Action
+
+Deploy the published `ao-release-gate` image or equivalent container package to
+a public hosting platform, configure runtime secret-manager values, collect real
+PR dry-run check-run evidence, and only then consider a branch-protection or
+ruleset cutover. The deployment-protection policy service must also still be
+hosted/configured before protected live-adapter workflow evidence is rerun.

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,9 +9,9 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/543",
-    "exit_decision": "ao_release_gate_container_ready_services_still_not_hosted",
-    "ready_after": "ao-release-gate container is published or deployed, hosted GitHub App check-run service is configured with runtime secrets, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, callback reviews are posted, and protected workflow evidence is produced with live_execution_allowed=false",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/547",
+    "exit_decision": "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped",
+    "ready_after": "ao-release-gate deploy workflow has completed from main, hosted GitHub App check-run service is configured with runtime secrets and webhook URL, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, callback reviews are posted, and protected workflow evidence is produced with live_execution_allowed=false",
     "allowed_scope": [
       "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
       "repeat protected workflow evidence collection from main after the policy service responds",
@@ -164,17 +164,29 @@
       "decision": "ao_release_gate_container_ready_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/543",
       "record": ".claude/plans/GPP-2x-AO-RELEASE-GATE-CONTAINER.md"
+    },
+    {
+      "id": "GPP-2y",
+      "decision": "ao_release_gate_publish_path_ready_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/545",
+      "record": ".claude/plans/GPP-2y-AO-RELEASE-GATE-CONTAINER-PUBLISH.md"
+    },
+    {
+      "id": "GPP-2aa",
+      "decision": "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/547",
+      "record": ".claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned policy webhook container image publish path, ao-release-gate dry-run decision scaffold, check-run service surface, and release-gate container package are ready, but neither the release-gate service nor the deployment-protection service is publicly hosted/configured or cut over with protected evidence"
+      "reason": "repo-owned policy webhook container image publish path, ao-release-gate dry-run decision scaffold, check-run service surface, release-gate container package, release-gate image publish path, and release-gate autonomous deploy path are ready, but neither the release-gate service nor the deployment-protection service is publicly hosted/configured with webhook evidence or cut over with protected evidence"
     }
   ],
   "pending_external_actions": [
-    "publish or deploy the ao-release-gate container package as a dry-run service deploy artifact without treating it as hosted evidence",
-    "host and configure the ao-release-gate GitHub App check-run service with runtime webhook secret and GitHub App authentication outside the repo",
+    "bootstrap the ao-release-gate Cloud Run deploy trust path and run the trusted deploy workflow from main without treating health evidence as check-run evidence",
+    "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with runtime webhook secret and GitHub App authentication outside the repo",
     "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
     "validate whether GitHub App pull request approvals count for the current branch protection; if not, cut over to a required ao-release-gate status check",
     "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
@@ -234,7 +246,7 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "publish or deploy the ao-release-gate container package as a dry-run service deploy artifact before collecting real PR evidence",
+    "bootstrap and run the ao-release-gate Cloud Run deploy workflow from main before collecting real PR evidence",
     "deploy or host the ao-release-gate check-run service in dry-run mode and collect real PR evidence before any branch protection cutover",
     "collect ao-release-gate dry-run check-run evidence on real PRs before any branch protection cutover",
     "validate GitHub App review-counting only as a spike; use required status check as the durable enforcement path unless proven otherwise",
@@ -246,7 +258,9 @@
     "use scripts/live_adapter_gate_policy_decision.py only for policy callback decision evaluation, not live adapter execution",
     "use scripts/live_adapter_gate_policy_container_smoke.py only for no-secret local container health validation, not live callback posting",
     "use scripts/ao_release_gate_container_smoke.py only for no-secret local container health validation, not check-run posting",
+    "publish or pull ghcr.io/halildeu/ao-kernel-ao-release-gate-service only as a deploy artifact, not hosted service evidence",
     "publish or pull ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service only as a deploy artifact, not hosted service evidence",
+    "configure ao_kernel.ao_release_gate_runtime:application only with runtime secret manager values, never committed or echoed secret material",
     "configure ao_kernel.live_adapter_gate_policy_runtime:application only with runtime secret manager values, never committed or echoed secret material",
     "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it",
     "keep fork and pull_request contexts away from protected credentials",

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,9 +9,9 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/541",
-    "exit_decision": "ao_release_gate_check_run_service_ready_policy_service_still_not_hosted",
-    "ready_after": "ao-release-gate GitHub App check-run service is hosted/configured, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, callback reviews are posted, and protected workflow evidence is produced with live_execution_allowed=false",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/543",
+    "exit_decision": "ao_release_gate_container_ready_services_still_not_hosted",
+    "ready_after": "ao-release-gate container is published or deployed, hosted GitHub App check-run service is configured with runtime secrets, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, callback reviews are posted, and protected workflow evidence is produced with live_execution_allowed=false",
     "allowed_scope": [
       "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
       "repeat protected workflow evidence collection from main after the policy service responds",
@@ -158,15 +158,22 @@
       "decision": "ao_release_gate_check_run_service_ready_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/541",
       "record": ".claude/plans/GPP-2w-AO-RELEASE-GATE-CHECK-RUN-SERVICE.md"
+    },
+    {
+      "id": "GPP-2x",
+      "decision": "ao_release_gate_container_ready_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/543",
+      "record": ".claude/plans/GPP-2x-AO-RELEASE-GATE-CONTAINER.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned policy webhook container image publish path, ao-release-gate dry-run decision scaffold, and ao-release-gate check-run service surface are ready, but neither the release-gate service nor the deployment-protection service is publicly hosted/configured or cut over with protected evidence"
+      "reason": "repo-owned policy webhook container image publish path, ao-release-gate dry-run decision scaffold, check-run service surface, and release-gate container package are ready, but neither the release-gate service nor the deployment-protection service is publicly hosted/configured or cut over with protected evidence"
     }
   ],
   "pending_external_actions": [
+    "publish or deploy the ao-release-gate container package as a dry-run service deploy artifact without treating it as hosted evidence",
     "host and configure the ao-release-gate GitHub App check-run service with runtime webhook secret and GitHub App authentication outside the repo",
     "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
     "validate whether GitHub App pull request approvals count for the current branch protection; if not, cut over to a required ao-release-gate status check",
@@ -227,6 +234,7 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
+    "publish or deploy the ao-release-gate container package as a dry-run service deploy artifact before collecting real PR evidence",
     "deploy or host the ao-release-gate check-run service in dry-run mode and collect real PR evidence before any branch protection cutover",
     "collect ao-release-gate dry-run check-run evidence on real PRs before any branch protection cutover",
     "validate GitHub App review-counting only as a spike; use required status check as the durable enforcement path unless proven otherwise",
@@ -237,6 +245,7 @@
     "use scripts/live_adapter_gate_policy_service_smoke.py only for local webhook/callback artifact validation, not live callback posting",
     "use scripts/live_adapter_gate_policy_decision.py only for policy callback decision evaluation, not live adapter execution",
     "use scripts/live_adapter_gate_policy_container_smoke.py only for no-secret local container health validation, not live callback posting",
+    "use scripts/ao_release_gate_container_smoke.py only for no-secret local container health validation, not check-run posting",
     "publish or pull ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service only as a deploy artifact, not hosted service evidence",
     "configure ao_kernel.live_adapter_gate_policy_runtime:application only with runtime secret manager values, never committed or echoed secret material",
     "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it",

--- a/.github/workflows/ao-release-gate-container-publish.yml
+++ b/.github/workflows/ao-release-gate-container-publish.yml
@@ -1,0 +1,91 @@
+name: Publish AO Release Gate Container
+
+on:
+  push:
+    branches:
+      - main
+      - "codex/**"
+    paths:
+      - "ao_kernel/**"
+      - "deploy/ao-release-gate-service/**"
+      - "scripts/ao_release_gate_container_smoke.py"
+      - "pyproject.toml"
+      - ".github/workflows/ao-release-gate-container-publish.yml"
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - edited
+    paths:
+      - "ao_kernel/**"
+      - "deploy/ao-release-gate-service/**"
+      - "scripts/ao_release_gate_container_smoke.py"
+      - "pyproject.toml"
+      - ".github/workflows/ao-release-gate-container-publish.yml"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Manual ao-release-gate container publication reason"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  DOCKERFILE: deploy/ao-release-gate-service/Dockerfile
+  IMAGE_NAME: ghcr.io/halildeu/ao-kernel-ao-release-gate-service
+
+jobs:
+  publish-ao-release-gate-container:
+    name: publish-ao-release-gate-container
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Build ao-release-gate service image
+        id: build
+        run: |
+          image_sha="${IMAGE_NAME}:sha-${GITHUB_SHA}"
+          docker build -f "$DOCKERFILE" -t "$image_sha" .
+          echo "image_sha=$image_sha" >> "$GITHUB_OUTPUT"
+
+      - name: No-secret container health smoke
+        run: |
+          python scripts/ao_release_gate_container_smoke.py \
+            --skip-build \
+            --image "${{ steps.build.outputs.image_sha }}" \
+            --timeout-seconds 90
+
+      - name: Log in to GHCR
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      - name: Publish ao-release-gate service image
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+        run: |
+          image_sha="${{ steps.build.outputs.image_sha }}"
+          docker push "$image_sha"
+
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            image_main="${IMAGE_NAME}:main"
+            docker tag "$image_sha" "$image_main"
+            docker push "$image_main"
+            {
+              echo "Published ao-release-gate service image:"
+              echo "- \`$image_sha\`"
+              echo "- \`$image_main\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Published ao-release-gate service image: \`$image_sha\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/ao-release-gate-deploy-cloud-run.yml
+++ b/.github/workflows/ao-release-gate-deploy-cloud-run.yml
@@ -1,0 +1,224 @@
+name: Deploy AO Release Gate to Cloud Run
+
+on:
+  workflow_run:
+    workflows: ["Publish AO Release Gate Container"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Trusted ao-release-gate deployment reason"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+  id-token: write
+
+env:
+  GHCR_IMAGE_NAME: ghcr.io/halildeu/ao-kernel-ao-release-gate-service
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+  GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+  GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+  GCP_CLOUD_RUN_REGION: ${{ vars.GCP_CLOUD_RUN_REGION }}
+  GCP_ARTIFACT_REGISTRY_LOCATION: ${{ vars.GCP_ARTIFACT_REGISTRY_LOCATION }}
+  GCP_ARTIFACT_REGISTRY_REPOSITORY: ${{ vars.GCP_ARTIFACT_REGISTRY_REPOSITORY }}
+  RELEASE_GATE_SERVICE_NAME: ${{ vars.RELEASE_GATE_SERVICE_NAME }}
+  AO_RELEASE_GATE_GITHUB_APP_ID: ${{ vars.AO_RELEASE_GATE_GITHUB_APP_ID }}
+  AO_RELEASE_GATE_WEBHOOK_SECRET_NAME: ${{ vars.AO_RELEASE_GATE_WEBHOOK_SECRET_NAME }}
+  AO_RELEASE_GATE_WEBHOOK_SECRET_VERSION: ${{ vars.AO_RELEASE_GATE_WEBHOOK_SECRET_VERSION || 'latest' }}
+  AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME: ${{ vars.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME }}
+  AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION: ${{ vars.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION || 'latest' }}
+
+jobs:
+  deploy-ao-release-gate:
+    name: deploy-ao-release-gate
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.event != 'pull_request'
+      )
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate trusted deploy configuration
+        env:
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+        run: |
+          set -euo pipefail
+
+          required_vars=(
+            GCP_PROJECT_ID
+            GCP_WORKLOAD_IDENTITY_PROVIDER
+            GCP_SERVICE_ACCOUNT
+            GCP_CLOUD_RUN_REGION
+            GCP_ARTIFACT_REGISTRY_LOCATION
+            GCP_ARTIFACT_REGISTRY_REPOSITORY
+            RELEASE_GATE_SERVICE_NAME
+            AO_RELEASE_GATE_GITHUB_APP_ID
+            AO_RELEASE_GATE_WEBHOOK_SECRET_NAME
+            AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME
+          )
+
+          missing=0
+          for name in "${required_vars[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Required repository variable $name is not configured."
+              missing=1
+            fi
+          done
+
+          source_sha="${WORKFLOW_RUN_HEAD_SHA:-$GITHUB_SHA}"
+          if [ -z "$source_sha" ]; then
+            echo "::error::Could not determine source SHA for ao-release-gate deployment."
+            missing=1
+          fi
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - id: images
+        name: Resolve immutable source and deployment images
+        env:
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+        run: |
+          set -euo pipefail
+
+          source_sha="${WORKFLOW_RUN_HEAD_SHA:-$GITHUB_SHA}"
+          ghcr_image="${GHCR_IMAGE_NAME}:sha-${source_sha}"
+          gar_host="${GCP_ARTIFACT_REGISTRY_LOCATION}-docker.pkg.dev"
+          gar_image="${gar_host}/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REGISTRY_REPOSITORY}/${RELEASE_GATE_SERVICE_NAME}:sha-${source_sha}"
+
+          {
+            echo "source_sha=$source_sha"
+            echo "ghcr_image=$ghcr_image"
+            echo "gar_host=$gar_host"
+            echo "gar_image=$gar_image"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud with OIDC
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Log in to GHCR for source image pull
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      - name: Configure Artifact Registry Docker auth
+        run: gcloud auth configure-docker "${{ steps.images.outputs.gar_host }}" --quiet
+
+      - name: Mirror immutable GHCR image to Artifact Registry
+        run: |
+          set -euo pipefail
+
+          docker pull "${{ steps.images.outputs.ghcr_image }}"
+          docker tag "${{ steps.images.outputs.ghcr_image }}" "${{ steps.images.outputs.gar_image }}"
+          docker push "${{ steps.images.outputs.gar_image }}"
+
+      - id: deploy
+        name: Deploy ao-release-gate revision
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.RELEASE_GATE_SERVICE_NAME }}
+          region: ${{ env.GCP_CLOUD_RUN_REGION }}
+          image: ${{ steps.images.outputs.gar_image }}
+          flags: "--allow-unauthenticated --ingress=all --port=8000"
+          env_vars: |
+            AO_GITHUB_APP_ID=${{ env.AO_RELEASE_GATE_GITHUB_APP_ID }}
+            PORT=8000
+          secrets: |
+            AO_RELEASE_GATE_WEBHOOK_SECRET=${{ env.AO_RELEASE_GATE_WEBHOOK_SECRET_NAME }}:${{ env.AO_RELEASE_GATE_WEBHOOK_SECRET_VERSION }}
+            AO_GITHUB_APP_PRIVATE_KEY_PEM=${{ env.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME }}:${{ env.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION }}
+
+      - name: Health-check deployed ao-release-gate
+        run: |
+          set -euo pipefail
+
+          mkdir -p ao-release-gate-deploy-evidence
+          service_url="${{ steps.deploy.outputs.url }}"
+          curl -fsS --retry 5 --retry-delay 5 --retry-connrefused \
+            "$service_url/healthz" \
+            > ao-release-gate-deploy-evidence/healthz.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("ao-release-gate-deploy-evidence/healthz.json").read_text(encoding="utf-8"))
+          if payload.get("status") != "ok":
+              raise SystemExit(f"unexpected ao-release-gate health status: {payload!r}")
+          PY
+
+      - name: Write deployment evidence
+        env:
+          SERVICE_URL: ${{ steps.deploy.outputs.url }}
+          SOURCE_SHA: ${{ steps.images.outputs.source_sha }}
+          GHCR_IMAGE: ${{ steps.images.outputs.ghcr_image }}
+          GAR_IMAGE: ${{ steps.images.outputs.gar_image }}
+        run: |
+          set -euo pipefail
+
+          jq -n \
+            --arg schema_version "1" \
+            --arg program_id "GPP-2aa" \
+            --arg service_name "$RELEASE_GATE_SERVICE_NAME" \
+            --arg cloud_run_region "$GCP_CLOUD_RUN_REGION" \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg source_image "$GHCR_IMAGE" \
+            --arg deployed_image "$GAR_IMAGE" \
+            --arg service_url "$SERVICE_URL" \
+            --arg webhook_url "$SERVICE_URL/github/ao-release-gate" \
+            --arg health_url "$SERVICE_URL/healthz" \
+            '{
+              schema_version: $schema_version,
+              program_id: $program_id,
+              status: "ao_release_gate_deployed_health_checked",
+              service_name: $service_name,
+              cloud_run_region: $cloud_run_region,
+              source_sha: $source_sha,
+              source_image: $source_image,
+              deployed_image: $deployed_image,
+              service_url: $service_url,
+              webhook_url: $webhook_url,
+              health_url: $health_url,
+              health_checked: true,
+              secret_value_readback: false,
+              check_run_post: false,
+              real_pr_evidence: false,
+              branch_protection_cutover: false,
+              merge_authority_enabled: false,
+              live_adapter_execution: false,
+              production_platform_claim: false,
+              support_widening: false
+            }' > ao-release-gate-deploy-evidence/ao-release-gate-deploy.v1.json
+
+          {
+            echo "AO release gate deployment evidence"
+            echo
+            echo "- Source image: \`$GHCR_IMAGE\`"
+            echo "- Deployed image: \`$GAR_IMAGE\`"
+            echo "- Health URL: \`$SERVICE_URL/healthz\`"
+            echo "- GitHub App webhook URL: \`$SERVICE_URL/github/ao-release-gate\`"
+            echo "- Secret value readback: \`false\`"
+            echo "- Check-run POST evidence: \`false\`"
+            echo "- Branch-protection cutover: \`false\`"
+            echo "- Merge authority enabled: \`false\`"
+            echo "- Live adapter execution: \`false\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload deployment evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: ao-release-gate-deploy-${{ steps.images.outputs.source_sha }}
+          path: ao-release-gate-deploy-evidence/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,6 +164,23 @@ jobs:
             --build-timeout-seconds 600 \
             --timeout-seconds 90
 
+  release-gate-container-smoke:
+    name: release-gate-container-smoke
+    runs-on: ubuntu-latest
+    needs: [event-gate]
+    if: needs.event-gate.outputs.should_run == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Build and health-check ao-release-gate service container
+        run: |
+          python scripts/ao_release_gate_container_smoke.py \
+            --image ao-kernel-ao-release-gate-service:ci \
+            --build-timeout-seconds 600 \
+            --timeout-seconds 90
+
   typecheck:
     name: typecheck
     runs-on: ubuntu-latest

--- a/deploy/ao-release-gate-service/Dockerfile
+++ b/deploy/ao-release-gate-service/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8000 \
+    WEB_CONCURRENCY=1 \
+    WEB_THREADS=4 \
+    WEB_TIMEOUT=30
+
+WORKDIR /app
+
+COPY README.md pyproject.toml ./
+COPY ao_kernel ./ao_kernel
+
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && python -m pip install --no-cache-dir ".[release-gate-service]" \
+    && useradd --create-home --uid 10001 --shell /usr/sbin/nologin ao-kernel
+
+USER 10001
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import os, urllib.request; urllib.request.urlopen('http://127.0.0.1:%s/healthz' % os.environ.get('PORT', '8000'), timeout=3).read()"
+
+CMD ["sh", "-c", "exec gunicorn --bind 0.0.0.0:${PORT:-8000} --workers ${WEB_CONCURRENCY:-1} --threads ${WEB_THREADS:-4} --timeout ${WEB_TIMEOUT:-30} ao_kernel.ao_release_gate_runtime:application"]

--- a/deploy/ao-release-gate-service/README.md
+++ b/deploy/ao-release-gate-service/README.md
@@ -1,0 +1,138 @@
+# AO Release Gate Service Container
+
+This container packages the GPP-2w WSGI runtime for the `ao-release-gate`
+GitHub App check-run service.
+
+It is not a merge runner and it is not a live-adapter runner. It only hosts:
+
+```text
+ao_kernel.ao_release_gate_runtime:application
+```
+
+## Build
+
+```bash
+docker build \
+  -f deploy/ao-release-gate-service/Dockerfile \
+  -t ao-kernel-ao-release-gate-service:local \
+  .
+```
+
+## Published Image
+
+The repository publication workflow builds this same Dockerfile, runs the
+no-secret `/healthz` smoke, and publishes trusted non-PR builds to GHCR:
+
+```text
+ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>
+ghcr.io/halildeu/ao-kernel-ao-release-gate-service:main
+```
+
+Use the immutable `sha-<commit>` tag for hosted deployments whenever possible.
+If the hosting provider cannot pull the package anonymously, configure a GHCR
+read token through that provider's secret manager. Do not bake registry tokens
+or runtime secrets into the image.
+
+## Runtime
+
+Required hosting secrets:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+or:
+
+```text
+AO_GITHUB_APP_PRIVATE_KEY_PATH
+```
+
+Optional runtime settings:
+
+```text
+PORT
+WEB_CONCURRENCY
+WEB_THREADS
+WEB_TIMEOUT
+AO_GITHUB_API_URL
+AO_RELEASE_GATE_GPP_STATUS_PATH
+AO_RELEASE_GATE_MAX_BODY_BYTES
+```
+
+The public GitHub App webhook URL must route to:
+
+```text
+POST /github/ao-release-gate
+```
+
+The container health endpoint is:
+
+```text
+GET /healthz
+```
+
+Do not pass `AO_CLAUDE_CODE_CLI_AUTH` to this service. The release gate posts
+dry-run check-runs only after it is explicitly hosted and configured with
+GitHub App runtime secrets; this container package alone is not release
+authority and does not change branch protection.
+
+## Autonomous Cloud Run Deployment
+
+The repository deploy workflow can mirror the immutable GHCR image into Google
+Artifact Registry, deploy it to Cloud Run, health-check `/healthz`, and upload
+deploy evidence:
+
+```text
+.github/workflows/ao-release-gate-deploy-cloud-run.yml
+```
+
+Required repository variables:
+
+```text
+GCP_PROJECT_ID
+GCP_WORKLOAD_IDENTITY_PROVIDER
+GCP_SERVICE_ACCOUNT
+GCP_CLOUD_RUN_REGION
+GCP_ARTIFACT_REGISTRY_LOCATION
+GCP_ARTIFACT_REGISTRY_REPOSITORY
+RELEASE_GATE_SERVICE_NAME
+AO_RELEASE_GATE_GITHUB_APP_ID
+AO_RELEASE_GATE_WEBHOOK_SECRET_NAME
+AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME
+```
+
+Optional repository variables:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET_VERSION
+AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION
+```
+
+`AO_RELEASE_GATE_WEBHOOK_SECRET_NAME` and
+`AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME` are Secret Manager object
+names, not secret values. The workflow must not read those values back. Cloud
+Run resolves them at runtime into:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+The deploy workflow proves only that the service revision is hosted and
+`GET /healthz` responds. It does not prove that the GitHub App webhook URL is
+configured, does not post a check-run, does not collect real PR evidence, does
+not change branch protection, and does not enable merge authority.
+
+## Local No-Secret Smoke
+
+The local container smoke only builds the image and checks `/healthz`. It does
+not configure GitHub App secrets, receive GitHub webhooks, post check-runs,
+merge pull requests, change branch protection, or execute a live adapter.
+
+```bash
+python3 scripts/ao_release_gate_container_smoke.py \
+  --image ao-kernel-ao-release-gate-service:smoke \
+  --build-timeout-seconds 600
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ policy-service = [
     "gunicorn>=22.0.0",
     "PyJWT[crypto]>=2.8.0",
 ]
+release-gate-service = [
+    "gunicorn>=22.0.0",
+    "PyJWT[crypto]>=2.8.0",
+]
 # Meta-extras (PR-A6, widened in PR-B5 for metrics)
 coding = [
     "ao-kernel[llm]",

--- a/scripts/ao_release_gate_container_smoke.py
+++ b/scripts/ao_release_gate_container_smoke.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Build and health-check the ao-release-gate check-run service container."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+DEFAULT_DOCKERFILE = Path("deploy/ao-release-gate-service/Dockerfile")
+DEFAULT_IMAGE = "ao-kernel-ao-release-gate-service:smoke"
+DEFAULT_TIMEOUT_SECONDS = 60.0
+DEFAULT_BUILD_TIMEOUT_SECONDS = 300.0
+DEFAULT_RUN_TIMEOUT_SECONDS = 30.0
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _run(
+    command: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    timeout_seconds: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+    )
+
+
+def _health_url(port: int) -> str:
+    return f"http://127.0.0.1:{port}/healthz"
+
+
+def _wait_for_health(url: str, *, timeout_seconds: float) -> dict[str, object]:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+                if isinstance(payload, dict):
+                    return payload
+        except Exception as exc:  # noqa: BLE001 - report final health failure compactly
+            last_error = exc
+        time.sleep(1)
+    detail = f": {last_error}" if last_error else ""
+    raise RuntimeError(f"container health endpoint did not become ready{detail}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", default=DEFAULT_IMAGE, help="Container image tag to build.")
+    parser.add_argument(
+        "--dockerfile",
+        type=Path,
+        default=DEFAULT_DOCKERFILE,
+        help="Path to the ao-release-gate service Dockerfile.",
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS, help="Health wait timeout.")
+    parser.add_argument(
+        "--build-timeout-seconds",
+        type=float,
+        default=DEFAULT_BUILD_TIMEOUT_SECONDS,
+        help="Docker build timeout.",
+    )
+    parser.add_argument(
+        "--run-timeout-seconds",
+        type=float,
+        default=DEFAULT_RUN_TIMEOUT_SECONDS,
+        help="Docker run command timeout.",
+    )
+    parser.add_argument("--skip-build", action="store_true", help="Run an already-built image.")
+    return parser
+
+
+def _print_process_output(stdout: str | bytes | None, stderr: str | bytes | None) -> None:
+    for output in (stdout, stderr):
+        if not output:
+            continue
+        if isinstance(output, bytes):
+            output = output.decode("utf-8", errors="replace")
+        print(output, file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = _repo_root()
+    port = _free_port()
+    container_id: str | None = None
+    try:
+        if not args.skip_build:
+            _run(
+                [
+                    "docker",
+                    "build",
+                    "-f",
+                    str(args.dockerfile),
+                    "-t",
+                    args.image,
+                    ".",
+                ],
+                cwd=repo_root,
+                timeout_seconds=args.build_timeout_seconds,
+            )
+        run = _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--detach",
+                "--publish",
+                f"127.0.0.1:{port}:8000",
+                args.image,
+            ],
+            cwd=repo_root,
+            timeout_seconds=args.run_timeout_seconds,
+        )
+        container_id = run.stdout.strip()
+        payload = _wait_for_health(_health_url(port), timeout_seconds=args.timeout_seconds)
+        print(
+            json.dumps(
+                {
+                    "status": "pass",
+                    "image": args.image,
+                    "health_url": _health_url(port),
+                    "health_payload": payload,
+                    "secret_value_readback": False,
+                    "live_adapter_execution": False,
+                    "github_check_run_post": False,
+                    "merge_authority_enabled": False,
+                    "branch_protection_cutover": False,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (OSError, RuntimeError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        print(f"release_gate_container_smoke: {exc}", file=sys.stderr)
+        if isinstance(exc, subprocess.CalledProcessError):
+            _print_process_output(exc.stdout, exc.stderr)
+        if isinstance(exc, subprocess.TimeoutExpired):
+            _print_process_output(exc.stdout, exc.stderr)
+        return 2
+    finally:
+        if container_id:
+            try:
+                subprocess.run(
+                    ["docker", "rm", "-f", container_id],
+                    cwd=repo_root,
+                    check=False,
+                    capture_output=True,
+                    timeout=15,
+                )
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ao_release_gate_container.py
+++ b/tests/test_ao_release_gate_container.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _container_smoke_module() -> Any:
+    module_path = _repo_root() / "scripts" / "ao_release_gate_container_smoke.py"
+    spec = importlib.util.spec_from_file_location("ao_release_gate_container_smoke", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ao_release_gate_dockerfile_hosts_wsgi_runtime_without_live_secret() -> None:
+    dockerfile = _repo_root() / "deploy" / "ao-release-gate-service" / "Dockerfile"
+    text = dockerfile.read_text(encoding="utf-8")
+
+    assert "python:3.13-slim" in text
+    assert ".[release-gate-service]" in text
+    assert "gunicorn" in text
+    assert "ao_kernel.ao_release_gate_runtime:application" in text
+    assert "/healthz" in text
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in text
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET" not in text
+    assert "AO_GITHUB_APP_PRIVATE_KEY" not in text
+
+
+def test_release_gate_container_smoke_defaults_to_no_secret_health_check_only() -> None:
+    module = _container_smoke_module()
+    parser = module.build_parser()
+    args = parser.parse_args([])
+
+    assert args.image == "ao-kernel-ao-release-gate-service:smoke"
+    assert args.dockerfile == Path("deploy/ao-release-gate-service/Dockerfile")
+    assert args.build_timeout_seconds == 300.0
+    assert args.run_timeout_seconds == 30.0
+    assert module._health_url(18080) == "http://127.0.0.1:18080/healthz"
+    smoke_source = Path(module.__file__).read_text(encoding="utf-8")
+    assert "timeout_seconds=args.build_timeout_seconds" in smoke_source
+    assert '"secret_value_readback": False' in smoke_source
+    assert '"live_adapter_execution": False' in smoke_source
+    assert '"github_check_run_post": False' in smoke_source
+    assert '"merge_authority_enabled": False' in smoke_source
+    assert '"branch_protection_cutover": False' in smoke_source
+
+
+def test_test_workflow_runs_release_gate_container_smoke_without_secret_context() -> None:
+    workflow = (_repo_root() / ".github" / "workflows" / "test.yml").read_text(encoding="utf-8")
+
+    assert "release-gate-container-smoke:" in workflow
+    assert "scripts/ao_release_gate_container_smoke.py" in workflow
+    assert "ao-kernel-ao-release-gate-service:ci" in workflow
+    release_gate_job = workflow.split("release-gate-container-smoke:", 1)[1].split("\n  typecheck:", 1)[0]
+    assert "secrets." not in release_gate_job
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in release_gate_job
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET" not in release_gate_job

--- a/tests/test_ao_release_gate_container_publish_workflow.py
+++ b/tests/test_ao_release_gate_container_publish_workflow.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _workflow_text() -> str:
+    workflow = _repo_root() / ".github" / "workflows" / "ao-release-gate-container-publish.yml"
+    return workflow.read_text(encoding="utf-8")
+
+
+def test_release_gate_container_publish_workflow_builds_smokes_and_publishes_ghcr() -> None:
+    text = _workflow_text()
+
+    assert "ghcr.io/halildeu/ao-kernel-ao-release-gate-service" in text
+    assert "deploy/ao-release-gate-service/Dockerfile" in text
+    assert "docker build -f \"$DOCKERFILE\"" in text
+    assert "scripts/ao_release_gate_container_smoke.py" in text
+    assert "--skip-build" in text
+    assert "docker push \"$image_sha\"" in text
+    assert "docker push \"$image_main\"" in text
+    assert "sha-${GITHUB_SHA}" in text
+
+
+def test_release_gate_container_publish_workflow_keeps_prs_and_live_credentials_closed() -> None:
+    text = _workflow_text()
+
+    assert "contents: read" in text
+    assert "packages: write" in text
+    assert "github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'" in text
+    assert "GHCR_TOKEN: ${{ github.token }}" in text
+    assert "pull_request" in text
+    assert "codex/**" in text
+    assert "secrets." not in text
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in text
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET" not in text
+    assert "AO_GITHUB_APP_PRIVATE_KEY" not in text
+    assert "/github/ao-release-gate" not in text
+    assert "branch_protection" not in text
+
+
+def test_release_gate_container_readme_records_publish_boundary() -> None:
+    readme = (_repo_root() / "deploy" / "ao-release-gate-service" / "README.md").read_text(encoding="utf-8")
+
+    assert "ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>" in readme
+    assert "ghcr.io/halildeu/ao-kernel-ao-release-gate-service:main" in readme
+    assert "POST /github/ao-release-gate" in readme
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET" in readme
+    assert "AO_CLAUDE_CODE_CLI_AUTH" in readme
+    assert "does not change branch protection" in readme

--- a/tests/test_ao_release_gate_deploy_workflow.py
+++ b/tests/test_ao_release_gate_deploy_workflow.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _workflow_text() -> str:
+    workflow = _repo_root() / ".github" / "workflows" / "ao-release-gate-deploy-cloud-run.yml"
+    return workflow.read_text(encoding="utf-8")
+
+
+def test_release_gate_deploy_workflow_is_trusted_oidc_cloud_run_path() -> None:
+    text = _workflow_text()
+
+    assert "name: Deploy AO Release Gate to Cloud Run" in text
+    assert "workflow_run:" in text
+    assert 'workflows: ["Publish AO Release Gate Container"]' in text
+    assert "workflow_dispatch:" in text
+    assert "id-token: write" in text
+    assert "packages: read" in text
+    assert "google-github-actions/auth@v2" in text
+    assert "workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}" in text
+    assert "google-github-actions/deploy-cloudrun@v2" in text
+    assert "--allow-unauthenticated --ingress=all --port=8000" in text
+
+
+def test_release_gate_deploy_workflow_uses_published_image_and_health_evidence() -> None:
+    text = _workflow_text()
+
+    assert "ghcr.io/halildeu/ao-kernel-ao-release-gate-service" in text
+    assert "sha-${source_sha}" in text
+    assert "docker pull \"${{ steps.images.outputs.ghcr_image }}\"" in text
+    assert "docker push \"${{ steps.images.outputs.gar_image }}\"" in text
+    assert "$service_url/healthz" in text
+    assert "ao-release-gate-deploy-evidence/healthz.json" in text
+    assert "ao-release-gate-deploy-evidence/ao-release-gate-deploy.v1.json" in text
+    assert "ao_release_gate_deployed_health_checked" in text
+    assert "$SERVICE_URL/github/ao-release-gate" in text
+    assert "secret_value_readback: false" in text
+    assert "check_run_post: false" in text
+    assert "real_pr_evidence: false" in text
+    assert "branch_protection_cutover: false" in text
+    assert "merge_authority_enabled: false" in text
+    assert "live_adapter_execution: false" in text
+
+
+def test_release_gate_deploy_workflow_keeps_prs_and_live_credentials_closed() -> None:
+    text = _workflow_text()
+
+    assert "github.event.workflow_run.head_branch == 'main'" in text
+    assert "github.event.workflow_run.event != 'pull_request'" in text
+    assert "pull_request:" not in text
+    assert "pull_request_target" not in text
+    assert "secrets." not in text
+    assert "GHCR_TOKEN: ${{ github.token }}" in text
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in text
+    assert "gh pr merge" not in text
+    assert "gh api repos/Halildeu/ao-kernel/branches/main/protection" not in text
+    assert "gcloud secrets versions access" not in text
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET=${{ env.AO_RELEASE_GATE_WEBHOOK_SECRET_NAME }}" in text
+    assert (
+        "AO_GITHUB_APP_PRIVATE_KEY_PEM=${{ env.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME }}"
+        in text
+    )

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,10 +30,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/541"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/543"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "ao_release_gate_check_run_service_ready_policy_service_still_not_hosted"
+        == "ao_release_gate_container_ready_services_still_not_hosted"
     )
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
@@ -165,10 +165,18 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2x"
+        and item["decision"] == "ao_release_gate_container_ready_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/543"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
+        "publish or deploy the ao-release-gate container package as a dry-run service deploy artifact without treating it as hosted evidence",
         "host and configure the ao-release-gate GitHub App check-run service with runtime webhook secret and GitHub App authentication outside the repo",
         "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
         "validate whether GitHub App pull request approvals count for the current branch protection; if not, cut over to a required ao-release-gate status check",
@@ -180,13 +188,18 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
             "id": "GPP-2",
             "reason": (
                 "repo-owned policy webhook container image publish path, ao-release-gate dry-run decision "
-                "scaffold, and ao-release-gate check-run service surface are ready, but neither the "
+                "scaffold, check-run service surface, and release-gate container package are ready, but neither the "
                 "release-gate service nor the deployment-protection service is publicly hosted/configured "
                 "or cut over with protected evidence"
             ),
         }
     ]
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
+    assert any(
+        action
+        == "publish or deploy the ao-release-gate container package as a dry-run service deploy artifact before collecting real PR evidence"
+        for action in payload["next_allowed_actions"]
+    )
     assert any(
         action
         == "deploy or host the ao-release-gate check-run service in dry-run mode and collect real PR evidence before any branch protection cutover"
@@ -236,6 +249,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(
         action
         == "use scripts/live_adapter_gate_policy_container_smoke.py only for no-secret local container health validation, not live callback posting"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "use scripts/ao_release_gate_container_smoke.py only for no-secret local container health validation, not check-run posting"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -389,6 +407,24 @@ def test_gpp2w_wires_check_run_service_without_merge_authority() -> None:
     assert "authorize human-free merges yet" in decision
 
 
+def test_gpp2x_packages_release_gate_container_without_hosting_or_merge_authority() -> None:
+    decision = (_repo_root() / ".claude/plans/GPP-2x-AO-RELEASE-GATE-CONTAINER.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "**Decision:** `ao_release_gate_container_ready_no_support_widening`" in decision
+    assert "`ao-release-gate`" in decision
+    assert "`deploy/ao-release-gate-service/Dockerfile`" in decision
+    assert "`scripts/ao_release_gate_container_smoke.py`" in decision
+    assert "no-secret health smoke" in decision
+    assert "does not publish the image" in decision
+    assert "post a check-run to GitHub" in decision
+    assert "change branch protection" in decision
+    assert "does not unblock GPP-2" in decision
+    assert "does not authorize human-free merges" in decision
+    assert "AO_CLAUDE_CODE_CLI_AUTH" in decision
+
+
 def test_gpp_next_load_status_validates_required_guards() -> None:
     mod = _module()
 
@@ -396,11 +432,11 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/541"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/543"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "ao_release_gate_check_run_service_ready_policy_service_still_not_hosted"
+        == "ao_release_gate_container_ready_services_still_not_hosted"
     )
     assert payload["support_widening_allowed"] is False
 

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,10 +30,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/543"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/547"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "ao_release_gate_container_ready_services_still_not_hosted"
+        == "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped"
     )
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
@@ -172,12 +172,26 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2y"
+        and item["decision"] == "ao_release_gate_publish_path_ready_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/545"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
+    assert any(
+        item["id"] == "GPP-2aa"
+        and item["decision"] == "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/547"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
-        "publish or deploy the ao-release-gate container package as a dry-run service deploy artifact without treating it as hosted evidence",
-        "host and configure the ao-release-gate GitHub App check-run service with runtime webhook secret and GitHub App authentication outside the repo",
+        "bootstrap the ao-release-gate Cloud Run deploy trust path and run the trusted deploy workflow from main without treating health evidence as check-run evidence",
+        "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with runtime webhook secret and GitHub App authentication outside the repo",
         "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
         "validate whether GitHub App pull request approvals count for the current branch protection; if not, cut over to a required ao-release-gate status check",
         "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
@@ -188,16 +202,17 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
             "id": "GPP-2",
             "reason": (
                 "repo-owned policy webhook container image publish path, ao-release-gate dry-run decision "
-                "scaffold, check-run service surface, and release-gate container package are ready, but neither the "
+                "scaffold, check-run service surface, release-gate container package, release-gate "
+                "image publish path, and release-gate autonomous deploy path are ready, but neither the "
                 "release-gate service nor the deployment-protection service is publicly hosted/configured "
-                "or cut over with protected evidence"
+                "with webhook evidence or cut over with protected evidence"
             ),
         }
     ]
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
     assert any(
         action
-        == "publish or deploy the ao-release-gate container package as a dry-run service deploy artifact before collecting real PR evidence"
+        == "bootstrap and run the ao-release-gate Cloud Run deploy workflow from main before collecting real PR evidence"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -259,6 +274,16 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(
         action
         == "publish or pull ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service only as a deploy artifact, not hosted service evidence"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "publish or pull ghcr.io/halildeu/ao-kernel-ao-release-gate-service only as a deploy artifact, not hosted service evidence"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "configure ao_kernel.ao_release_gate_runtime:application only with runtime secret manager values, never committed or echoed secret material"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -425,6 +450,43 @@ def test_gpp2x_packages_release_gate_container_without_hosting_or_merge_authorit
     assert "AO_CLAUDE_CODE_CLI_AUTH" in decision
 
 
+def test_gpp2y_adds_release_gate_publish_path_without_hosting_or_merge_authority() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2y-AO-RELEASE-GATE-CONTAINER-PUBLISH.md"
+    ).read_text(encoding="utf-8")
+
+    assert "**Decision:** `ao_release_gate_publish_path_ready_no_support_widening`" in decision
+    assert "`ao-release-gate`" in decision
+    assert "`.github/workflows/ao-release-gate-container-publish.yml`" in decision
+    assert "`ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>`" in decision
+    assert "no-secret `/healthz` smoke" in decision
+    assert "does not host the service" in decision
+    assert "post check-runs" in decision
+    assert "change branch protection" in decision
+    assert "does not unblock GPP-2" in decision
+    assert "does not authorize human-free merges" in decision
+    assert "AO_CLAUDE_CODE_CLI_AUTH" in decision
+
+
+def test_gpp2aa_adds_release_gate_deploy_path_without_cutover_or_merge_authority() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md"
+    ).read_text(encoding="utf-8")
+
+    assert "**Decision:** `ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped`" in decision
+    assert "`ao-release-gate`" in decision
+    assert "`.github/workflows/ao-release-gate-deploy-cloud-run.yml`" in decision
+    assert "`ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>`" in decision
+    assert "GitHub OIDC" in decision
+    assert "Secret Manager" in decision
+    assert "check_run_post=false" in decision
+    assert "branch_protection_cutover=false" in decision
+    assert "merge_authority_enabled=false" in decision
+    assert "post check-runs" in decision
+    assert "change branch" in decision
+    assert "AO_CLAUDE_CODE_CLI_AUTH" in decision
+
+
 def test_gpp_next_load_status_validates_required_guards() -> None:
     mod = _module()
 
@@ -432,11 +494,11 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/543"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/547"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "ao_release_gate_container_ready_services_still_not_hosted"
+        == "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped"
     )
     assert payload["support_widening_allowed"] is False
 


### PR DESCRIPTION
Refs #543
Depends on #542.

Summary:
- Add deploy/ao-release-gate-service/Dockerfile for the ao-release-gate WSGI runtime.
- Add scripts/ao_release_gate_container_smoke.py for bounded no-secret /healthz container smoke.
- Add release-gate-container-smoke CI job and a release-gate-service runtime extra.
- Update GPP status/decision record/tests to mark the container package ready while keeping GPP-2 blocked.

Guardrails:
- No image publish, public hosting, webhook configuration, real GitHub delivery, check-run POST, merge, branch-protection cutover, admin bypass, PAT-backed bot, or Claude/Codex release authority.
- No live adapter execution, support widening, production platform claim, or AO_CLAUDE_CODE_CLI_AUTH usage.

Validation:
- python3 -m json.tool .claude/plans/gpp_status.v1.json
- python3 -m ruff check ao_kernel/ tests/ scripts/ao_release_gate_container_smoke.py
- python3 -m mypy ao_kernel/ scripts/ao_release_gate_container_smoke.py
- pytest -q tests/test_ao_release_gate_container.py tests/test_gpp_next.py
- python3 scripts/ao_release_gate_container_smoke.py --image ao-kernel-ao-release-gate-service:local-smoke --build-timeout-seconds 600 --timeout-seconds 90
- python3 scripts/gpp_next.py
- git diff --check
- pytest -q
