### PR TITLE
GPP-2aa: add ao-release-gate Cloud Run deploy path

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 `ao-release-gate` image publish path ready; hosted deployment/config, dry-run evidence, and cutover still blocked
+**Status:** GPP-2 `ao-release-gate` autonomous deploy path ready; hosting bootstrap/config, dry-run evidence, and cutover still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#545](https://github.com/Halildeu/ao-kernel/issues/545)
-for `ao-release-gate` container publish path
-**Current slice record:** `.claude/plans/GPP-2y-AO-RELEASE-GATE-CONTAINER-PUBLISH.md`
+**Current slice issue:** [#547](https://github.com/Halildeu/ao-kernel/issues/547)
+for `ao-release-gate` autonomous Cloud Run deploy path
+**Current slice record:** `.claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -204,6 +204,14 @@ Last live verification on current `origin/main` showed:
     configured, real PR dry-run check-run evidence is collected, branch
     protection is cut over, and the deployment-protection policy service is
     hosted.
+41. GPP-2aa adds an autonomous Cloud Run deploy path for the `ao-release-gate`
+    image. Trusted `main` publication or explicit manual dispatch can mirror
+    the immutable GHCR image to Artifact Registry, deploy Cloud Run with
+    Secret Manager references, health-check `/healthz`, and upload deploy
+    evidence. GPP-2 remains blocked until the deploy trust bootstrap exists,
+    the GitHub App webhook URL is configured, real PR dry-run check-run
+    evidence is collected, branch protection is cut over, and the
+    deployment-protection policy service is hosted.
 
 ## 3. Current Verdict
 
@@ -267,7 +275,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2w` | Completed / no support widening | `ao-release-gate` check-run service wiring | webhook/check-run request service and WSGI GitHub App POST runtime ready; hosting, real PR evidence, and branch-protection cutover still required |
 | `GPP-2x` | Completed / no support widening | `ao-release-gate` container package | container build target, no-secret health smoke, and CI job ready; publish/hosting, real PR evidence, and branch-protection cutover still required |
 | `GPP-2y` | Completed / no support widening | `ao-release-gate` container image publication | GHCR publish workflow ready; public hosting, real PR evidence, and branch-protection cutover still required |
-| `GPP-2` | Blocked / hosted services and release-gate cutover missing | Protected live-adapter gate runtime binding | deployment protection app/policy service image/container must be hosted/configured, and `ao-release-gate` must be published/hosted/evidenced/cut over before human-free program merges |
+| `GPP-2aa` | Completed / no support widening | `ao-release-gate` autonomous deploy path | Cloud Run deploy workflow ready; cloud bootstrap, webhook config, real PR evidence, and branch-protection cutover still required |
+| `GPP-2` | Blocked / hosted services and release-gate cutover missing | Protected live-adapter gate runtime binding | deployment protection app/policy service image/container must be hosted/configured, and `ao-release-gate` must be deployed/hosted/evidenced/cut over before human-free program merges |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
@@ -396,13 +405,14 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2y; policy decision core, webhook scaffold,
+**Status:** blocked after GPP-2aa; policy decision core, webhook scaffold,
 deployable WSGI runtime, container package, and GHCR image publication path
 exist. The autonomous GitHub App release-gate model, dry-run decision
 scaffold, check-run service/runtime surface, and release-gate container package
-and image publication path now exist. Hosted service deployment/configuration,
-real PR dry-run evidence, branch-protection cutover, and deployment-protection
-callback evidence are still missing.
+image publication path, and autonomous Cloud Run deploy workflow now exist.
+Hosted service bootstrap/configuration, real PR dry-run evidence,
+branch-protection cutover, and deployment-protection callback evidence are
+still missing.
 
 **Entry criteria:**
 
@@ -446,6 +456,10 @@ to GitHub, grant merge authority, or change branch protection.
 GPP-2y adds the GHCR image publication path for that release-gate container.
 It still does not host the service, configure a webhook URL, post check-runs to
 GitHub, grant merge authority, or change branch protection.
+GPP-2aa adds the autonomous Cloud Run deploy workflow for that release-gate
+image. It still does not prove cloud bootstrap, configure the GitHub App webhook
+URL, post check-runs, collect real PR evidence, grant merge authority, or change
+branch protection.
 
 **Acceptance criteria:**
 
@@ -726,6 +740,12 @@ repo-owned no-secret container health smoke path. GPP-2y adds
 smokes the image on PR/codex branch changes and publishes only on trusted
 `main` or manual dispatch events. The image may now be published as a deploy
 artifact, but it is still not hosted and no GitHub delivery evidence exists.
+GPP-2aa adds `.github/workflows/ao-release-gate-deploy-cloud-run.yml`, which can
+mirror the immutable release-gate image to Artifact Registry, deploy Cloud Run
+with Secret Manager references, health-check `/healthz`, and upload deploy
+evidence after trusted `main` publication or manual dispatch. The deploy path
+is not itself GitHub App webhook configuration, check-run evidence, branch
+protection cutover, or merge authority.
 GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
@@ -751,7 +771,10 @@ GPP-2x provides the container package while still avoiding secret value
 readback, GitHub check-run POSTs, branch-protection cutover, and live adapter
 execution. GPP-2y provides the release-gate container publish path while still
 avoiding public hosting, webhook configuration, GitHub check-run POSTs,
-branch-protection cutover, and live adapter execution.
+branch-protection cutover, and live adapter execution. GPP-2aa provides the
+release-gate Cloud Run deploy workflow while still avoiding secret value
+readback, GitHub check-run POST evidence, branch-protection cutover, merge
+authority, and live adapter execution.
 Existing PRs
 [#536](https://github.com/Halildeu/ao-kernel/pull/536) and
 [#538](https://github.com/Halildeu/ao-kernel/pull/538) can stay blocked by
@@ -759,10 +782,11 @@ review-required branch protection until independent approval or the future
 `ao-release-gate` required-check cutover exists; admin bypass remains
 forbidden.
 
-The next GPP-2 action is to deploy or host the published dry-run
-`ao-release-gate` image/container package, configure that check-run service,
-collect real PR check-run evidence, and only then cut branch protection/rulesets
-over to require `ao-release-gate`. In parallel, deploy or configure the
+The next GPP-2 action is to bootstrap/run the trusted dry-run `ao-release-gate`
+deploy path from `main`, configure that check-run service's GitHub App webhook
+URL, collect real PR check-run evidence, and only then cut branch
+protection/rulesets over to require `ao-release-gate`. In parallel, deploy or
+configure the
 `ao-kernel-live-adapter-gate` deployment protection app/policy service using
 the GPP-2s GHCR image, the GPP-2r container package, the GPP-2q WSGI runtime,
 or an equivalent fail-closed implementation so it receives protected deployment
@@ -800,6 +824,7 @@ keep `live_execution_allowed=false`, `support_widening=false`, and
 | Check-run service mistaken for cutover evidence | A hosted-capable runtime could be overclaimed as active enforcement | GPP-2w still requires public hosting, real PR dry-run check-run evidence, and explicit branch-protection cutover before release authority is active |
 | Release-gate container mistaken for hosted evidence | A local/CI image health pass could be overclaimed as active GitHub enforcement | GPP-2x treats the container as deploy artifact readiness only; require public hosting, webhook configuration, real PR dry-run evidence, and branch-protection cutover |
 | Release-gate image publish mistaken for hosted evidence | A GHCR image tag could be overclaimed as an active GitHub App | GPP-2y treats GHCR publication as deploy artifact readiness only; require public hosting, webhook configuration, real PR dry-run evidence, and branch-protection cutover |
+| Release-gate deploy health mistaken for release authority | A hosted `/healthz` response could be overclaimed as required-check enforcement | GPP-2aa records `check_run_post=false`, `real_pr_evidence=false`, `branch_protection_cutover=false`, and `merge_authority_enabled=false`; require real PR evidence and explicit cutover |
 
 ## 19. Tracking Log
 
@@ -859,3 +884,5 @@ keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-28 | GPP-2x container package added | `deploy/ao-release-gate-service/Dockerfile`, `scripts/ao_release_gate_container_smoke.py`, and the `release-gate-container-smoke` CI job package the WSGI runtime as a no-secret health-checkable container; publish/hosting, real PR dry-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |
 | 2026-04-28 | GPP-2y issue opened | Issue [#545](https://github.com/Halildeu/ao-kernel/issues/545) tracks the `ao-release-gate` container image publication path. |
 | 2026-04-28 | GPP-2y publish path added | `.github/workflows/ao-release-gate-container-publish.yml` builds, no-secret smokes, and publishes trusted `main` or manual images to `ghcr.io/halildeu/ao-kernel-ao-release-gate-service`; public hosting, real PR dry-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |
+| 2026-04-28 | GPP-2aa issue opened | Issue [#547](https://github.com/Halildeu/ao-kernel/issues/547) tracks the `ao-release-gate` autonomous Cloud Run deploy path. |
+| 2026-04-28 | GPP-2aa deploy path added | `.github/workflows/ao-release-gate-deploy-cloud-run.yml` can mirror the trusted immutable release-gate image to Artifact Registry, deploy Cloud Run with Secret Manager references, health-check `/healthz`, and upload deploy evidence; webhook configuration, real PR check-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |

--- a/.claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md
+++ b/.claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md
@@ -1,0 +1,170 @@
+# GPP-2aa - AO Release Gate Autonomous Deploy Path
+
+**Issue:** [#547](https://github.com/Halildeu/ao-kernel/issues/547)
+**Decision:** `ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped`
+**Date:** 2026-04-28
+**Support widening:** false
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## Decision
+
+GPP-2aa adds a repo-owned autonomous Cloud Run deploy path for the
+`ao-release-gate` check-run service image. The workflow can deploy a trusted
+immutable image tag after the `Publish AO Release Gate Container` workflow
+succeeds on `main`, or by explicit trusted `workflow_dispatch`.
+
+This is a deploy automation path only. It does not prove that Google Cloud OIDC
+bootstrap exists, it does not configure the GitHub App webhook URL, it does not
+post check-runs, it does not collect real PR evidence, it does not change branch
+protection, it does not merge pull requests, it does not run a live adapter, it
+does not widen support, and it does not claim production readiness.
+
+## Added Surface
+
+1. `.github/workflows/ao-release-gate-deploy-cloud-run.yml`
+   - runs only after trusted `main` publication or explicit
+     `workflow_dispatch`;
+   - uses GitHub OIDC (`id-token: write`) for Google Cloud auth;
+   - reads cloud resource names and secret object names from repository
+     variables;
+   - pulls the immutable GHCR image tag
+     `ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>`;
+   - mirrors that immutable image to Google Artifact Registry;
+   - deploys Cloud Run with public ingress for GitHub webhook delivery;
+   - binds runtime secrets by Secret Manager name/version, not by secret value;
+   - health-checks `GET /healthz`;
+   - uploads `ao-release-gate-deploy.v1.json` and `healthz.json` evidence.
+
+2. `tests/test_ao_release_gate_deploy_workflow.py`
+   - pins trusted trigger scope, OIDC auth, immutable image flow, health
+     evidence, and security guardrails.
+
+3. `deploy/ao-release-gate-service/README.md`
+   - records the Cloud Run variable and Secret Manager contract.
+
+## Trust Boundary
+
+The workflow intentionally does not use:
+
+```text
+secrets.*
+AO_CLAUDE_CODE_CLI_AUTH
+gcloud secrets versions access
+pull_request
+pull_request_target
+gh pr merge
+branch protection update APIs
+```
+
+The hosted service receives only runtime GitHub App materials that Cloud Run
+resolves from Secret Manager:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+Repository variables such as `AO_RELEASE_GATE_WEBHOOK_SECRET_NAME` and
+`AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME` are secret object names,
+not secret values.
+
+## Bootstrap Contract
+
+The deploy workflow is autonomous only after this external machine-trust
+bootstrap exists:
+
+1. Google Cloud Workload Identity Provider trusts this repository's GitHub OIDC
+   identity for the deploy workflow.
+2. The configured Google service account can push to the selected Artifact
+   Registry repository and deploy the selected Cloud Run service.
+3. Google Secret Manager contains the release-gate webhook secret and GitHub
+   App private key under the configured secret object names.
+4. The Cloud Run service can access those secrets at runtime.
+5. The `ao-release-gate` GitHub App webhook URL points at:
+
+```text
+https://<cloud-run-service-url>/github/ao-release-gate
+```
+
+Secret values must not be pasted into issues, PRs, logs, chat, MCP prompts, or
+repository files.
+
+## Evidence Contract
+
+A successful deploy workflow uploads:
+
+```text
+ao-release-gate-deploy.v1.json
+healthz.json
+```
+
+The deployment evidence records:
+
+```text
+status=ao_release_gate_deployed_health_checked
+secret_value_readback=false
+check_run_post=false
+real_pr_evidence=false
+branch_protection_cutover=false
+merge_authority_enabled=false
+live_adapter_execution=false
+support_widening=false
+production_platform_claim=false
+```
+
+This evidence proves a hosted health endpoint for the `ao-release-gate`
+revision. It is not enough to grant release authority. GPP-2 remains blocked
+until the GitHub App webhook is configured to this URL, real PR dry-run
+check-run evidence is collected, branch protection or rulesets require
+`ao-release-gate`, and the deployment-protection policy service is also
+hosted/configured with protected callback evidence.
+
+## Current Decision
+
+Resolved by this slice:
+
+1. repo-owned autonomous deploy workflow exists for `ao-release-gate`;
+2. deploy authentication is OIDC-based, not a committed cloud key;
+3. PR/fork contexts cannot run the deploy job;
+4. immutable GHCR image tags remain the source of deployed revisions;
+5. runtime secrets are passed by Secret Manager reference only;
+6. deploy evidence records no secret readback, no check-run POST, no branch
+   protection cutover, no merge authority, and no live adapter execution.
+
+Still blocked:
+
+1. cloud OIDC/service-account/Secret Manager bootstrap is not attested by this
+   PR;
+2. no Cloud Run deployment run has completed from `main` in this slice;
+3. the `ao-release-gate` GitHub App webhook URL is not proven configured to the
+   Cloud Run endpoint;
+4. no real PR dry-run check-run has been posted by the hosted service;
+5. branch protection/rulesets do not yet require `ao-release-gate`;
+6. the deployment-protection policy service still needs hosted callback
+   evidence before live-adapter runtime work can continue.
+
+Still closed:
+
+1. `merge_authority_enabled=false`;
+2. `live_execution_allowed=false`;
+3. `support_widening=false`;
+4. `production_platform_claim=false`.
+
+## Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_ao_release_gate_deploy_workflow.py tests/test_ao_release_gate_container_publish_workflow.py tests/test_gpp_next.py
+python3 -m ruff check tests/test_ao_release_gate_deploy_workflow.py tests/test_ao_release_gate_container_publish_workflow.py tests/test_gpp_next.py
+actionlint .github/workflows/ao-release-gate-deploy-cloud-run.yml .github/workflows/ao-release-gate-container-publish.yml
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Recorded closeout decision:
+
+```text
+ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,9 +9,9 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/545",
-    "exit_decision": "ao_release_gate_publish_path_ready_services_still_not_hosted",
-    "ready_after": "ao-release-gate image is published or deployed to a public host, hosted GitHub App check-run service is configured with runtime secrets, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, callback reviews are posted, and protected workflow evidence is produced with live_execution_allowed=false",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/547",
+    "exit_decision": "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped",
+    "ready_after": "ao-release-gate deploy workflow has completed from main, hosted GitHub App check-run service is configured with runtime secrets and webhook URL, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, callback reviews are posted, and protected workflow evidence is produced with live_execution_allowed=false",
     "allowed_scope": [
       "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
       "repeat protected workflow evidence collection from main after the policy service responds",
@@ -170,17 +170,23 @@
       "decision": "ao_release_gate_publish_path_ready_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/545",
       "record": ".claude/plans/GPP-2y-AO-RELEASE-GATE-CONTAINER-PUBLISH.md"
+    },
+    {
+      "id": "GPP-2aa",
+      "decision": "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/547",
+      "record": ".claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned policy webhook container image publish path, ao-release-gate dry-run decision scaffold, check-run service surface, release-gate container package, and release-gate image publish path are ready, but neither the release-gate service nor the deployment-protection service is publicly hosted/configured or cut over with protected evidence"
+      "reason": "repo-owned policy webhook container image publish path, ao-release-gate dry-run decision scaffold, check-run service surface, release-gate container package, release-gate image publish path, and release-gate autonomous deploy path are ready, but neither the release-gate service nor the deployment-protection service is publicly hosted/configured with webhook evidence or cut over with protected evidence"
     }
   ],
   "pending_external_actions": [
-    "publish or deploy the ao-release-gate image or container package as a dry-run service deploy artifact without treating it as hosted evidence",
-    "host and configure the ao-release-gate GitHub App check-run service with runtime webhook secret and GitHub App authentication outside the repo",
+    "bootstrap the ao-release-gate Cloud Run deploy trust path and run the trusted deploy workflow from main without treating health evidence as check-run evidence",
+    "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with runtime webhook secret and GitHub App authentication outside the repo",
     "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
     "validate whether GitHub App pull request approvals count for the current branch protection; if not, cut over to a required ao-release-gate status check",
     "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
@@ -240,7 +246,7 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "publish or deploy the ao-release-gate image or container package as a dry-run service deploy artifact before collecting real PR evidence",
+    "bootstrap and run the ao-release-gate Cloud Run deploy workflow from main before collecting real PR evidence",
     "deploy or host the ao-release-gate check-run service in dry-run mode and collect real PR evidence before any branch protection cutover",
     "collect ao-release-gate dry-run check-run evidence on real PRs before any branch protection cutover",
     "validate GitHub App review-counting only as a spike; use required status check as the durable enforcement path unless proven otherwise",
@@ -254,6 +260,7 @@
     "use scripts/ao_release_gate_container_smoke.py only for no-secret local container health validation, not check-run posting",
     "publish or pull ghcr.io/halildeu/ao-kernel-ao-release-gate-service only as a deploy artifact, not hosted service evidence",
     "publish or pull ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service only as a deploy artifact, not hosted service evidence",
+    "configure ao_kernel.ao_release_gate_runtime:application only with runtime secret manager values, never committed or echoed secret material",
     "configure ao_kernel.live_adapter_gate_policy_runtime:application only with runtime secret manager values, never committed or echoed secret material",
     "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it",
     "keep fork and pull_request contexts away from protected credentials",

--- a/.github/workflows/ao-release-gate-deploy-cloud-run.yml
+++ b/.github/workflows/ao-release-gate-deploy-cloud-run.yml
@@ -1,0 +1,224 @@
+name: Deploy AO Release Gate to Cloud Run
+
+on:
+  workflow_run:
+    workflows: ["Publish AO Release Gate Container"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Trusted ao-release-gate deployment reason"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+  id-token: write
+
+env:
+  GHCR_IMAGE_NAME: ghcr.io/halildeu/ao-kernel-ao-release-gate-service
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+  GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+  GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+  GCP_CLOUD_RUN_REGION: ${{ vars.GCP_CLOUD_RUN_REGION }}
+  GCP_ARTIFACT_REGISTRY_LOCATION: ${{ vars.GCP_ARTIFACT_REGISTRY_LOCATION }}
+  GCP_ARTIFACT_REGISTRY_REPOSITORY: ${{ vars.GCP_ARTIFACT_REGISTRY_REPOSITORY }}
+  RELEASE_GATE_SERVICE_NAME: ${{ vars.RELEASE_GATE_SERVICE_NAME }}
+  AO_RELEASE_GATE_GITHUB_APP_ID: ${{ vars.AO_RELEASE_GATE_GITHUB_APP_ID }}
+  AO_RELEASE_GATE_WEBHOOK_SECRET_NAME: ${{ vars.AO_RELEASE_GATE_WEBHOOK_SECRET_NAME }}
+  AO_RELEASE_GATE_WEBHOOK_SECRET_VERSION: ${{ vars.AO_RELEASE_GATE_WEBHOOK_SECRET_VERSION || 'latest' }}
+  AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME: ${{ vars.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME }}
+  AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION: ${{ vars.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION || 'latest' }}
+
+jobs:
+  deploy-ao-release-gate:
+    name: deploy-ao-release-gate
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.event != 'pull_request'
+      )
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate trusted deploy configuration
+        env:
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+        run: |
+          set -euo pipefail
+
+          required_vars=(
+            GCP_PROJECT_ID
+            GCP_WORKLOAD_IDENTITY_PROVIDER
+            GCP_SERVICE_ACCOUNT
+            GCP_CLOUD_RUN_REGION
+            GCP_ARTIFACT_REGISTRY_LOCATION
+            GCP_ARTIFACT_REGISTRY_REPOSITORY
+            RELEASE_GATE_SERVICE_NAME
+            AO_RELEASE_GATE_GITHUB_APP_ID
+            AO_RELEASE_GATE_WEBHOOK_SECRET_NAME
+            AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME
+          )
+
+          missing=0
+          for name in "${required_vars[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Required repository variable $name is not configured."
+              missing=1
+            fi
+          done
+
+          source_sha="${WORKFLOW_RUN_HEAD_SHA:-$GITHUB_SHA}"
+          if [ -z "$source_sha" ]; then
+            echo "::error::Could not determine source SHA for ao-release-gate deployment."
+            missing=1
+          fi
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - id: images
+        name: Resolve immutable source and deployment images
+        env:
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+        run: |
+          set -euo pipefail
+
+          source_sha="${WORKFLOW_RUN_HEAD_SHA:-$GITHUB_SHA}"
+          ghcr_image="${GHCR_IMAGE_NAME}:sha-${source_sha}"
+          gar_host="${GCP_ARTIFACT_REGISTRY_LOCATION}-docker.pkg.dev"
+          gar_image="${gar_host}/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REGISTRY_REPOSITORY}/${RELEASE_GATE_SERVICE_NAME}:sha-${source_sha}"
+
+          {
+            echo "source_sha=$source_sha"
+            echo "ghcr_image=$ghcr_image"
+            echo "gar_host=$gar_host"
+            echo "gar_image=$gar_image"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud with OIDC
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Log in to GHCR for source image pull
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      - name: Configure Artifact Registry Docker auth
+        run: gcloud auth configure-docker "${{ steps.images.outputs.gar_host }}" --quiet
+
+      - name: Mirror immutable GHCR image to Artifact Registry
+        run: |
+          set -euo pipefail
+
+          docker pull "${{ steps.images.outputs.ghcr_image }}"
+          docker tag "${{ steps.images.outputs.ghcr_image }}" "${{ steps.images.outputs.gar_image }}"
+          docker push "${{ steps.images.outputs.gar_image }}"
+
+      - id: deploy
+        name: Deploy ao-release-gate revision
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.RELEASE_GATE_SERVICE_NAME }}
+          region: ${{ env.GCP_CLOUD_RUN_REGION }}
+          image: ${{ steps.images.outputs.gar_image }}
+          flags: "--allow-unauthenticated --ingress=all --port=8000"
+          env_vars: |
+            AO_GITHUB_APP_ID=${{ env.AO_RELEASE_GATE_GITHUB_APP_ID }}
+            PORT=8000
+          secrets: |
+            AO_RELEASE_GATE_WEBHOOK_SECRET=${{ env.AO_RELEASE_GATE_WEBHOOK_SECRET_NAME }}:${{ env.AO_RELEASE_GATE_WEBHOOK_SECRET_VERSION }}
+            AO_GITHUB_APP_PRIVATE_KEY_PEM=${{ env.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME }}:${{ env.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION }}
+
+      - name: Health-check deployed ao-release-gate
+        run: |
+          set -euo pipefail
+
+          mkdir -p ao-release-gate-deploy-evidence
+          service_url="${{ steps.deploy.outputs.url }}"
+          curl -fsS --retry 5 --retry-delay 5 --retry-connrefused \
+            "$service_url/healthz" \
+            > ao-release-gate-deploy-evidence/healthz.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("ao-release-gate-deploy-evidence/healthz.json").read_text(encoding="utf-8"))
+          if payload.get("status") != "ok":
+              raise SystemExit(f"unexpected ao-release-gate health status: {payload!r}")
+          PY
+
+      - name: Write deployment evidence
+        env:
+          SERVICE_URL: ${{ steps.deploy.outputs.url }}
+          SOURCE_SHA: ${{ steps.images.outputs.source_sha }}
+          GHCR_IMAGE: ${{ steps.images.outputs.ghcr_image }}
+          GAR_IMAGE: ${{ steps.images.outputs.gar_image }}
+        run: |
+          set -euo pipefail
+
+          jq -n \
+            --arg schema_version "1" \
+            --arg program_id "GPP-2aa" \
+            --arg service_name "$RELEASE_GATE_SERVICE_NAME" \
+            --arg cloud_run_region "$GCP_CLOUD_RUN_REGION" \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg source_image "$GHCR_IMAGE" \
+            --arg deployed_image "$GAR_IMAGE" \
+            --arg service_url "$SERVICE_URL" \
+            --arg webhook_url "$SERVICE_URL/github/ao-release-gate" \
+            --arg health_url "$SERVICE_URL/healthz" \
+            '{
+              schema_version: $schema_version,
+              program_id: $program_id,
+              status: "ao_release_gate_deployed_health_checked",
+              service_name: $service_name,
+              cloud_run_region: $cloud_run_region,
+              source_sha: $source_sha,
+              source_image: $source_image,
+              deployed_image: $deployed_image,
+              service_url: $service_url,
+              webhook_url: $webhook_url,
+              health_url: $health_url,
+              health_checked: true,
+              secret_value_readback: false,
+              check_run_post: false,
+              real_pr_evidence: false,
+              branch_protection_cutover: false,
+              merge_authority_enabled: false,
+              live_adapter_execution: false,
+              production_platform_claim: false,
+              support_widening: false
+            }' > ao-release-gate-deploy-evidence/ao-release-gate-deploy.v1.json
+
+          {
+            echo "AO release gate deployment evidence"
+            echo
+            echo "- Source image: \`$GHCR_IMAGE\`"
+            echo "- Deployed image: \`$GAR_IMAGE\`"
+            echo "- Health URL: \`$SERVICE_URL/healthz\`"
+            echo "- GitHub App webhook URL: \`$SERVICE_URL/github/ao-release-gate\`"
+            echo "- Secret value readback: \`false\`"
+            echo "- Check-run POST evidence: \`false\`"
+            echo "- Branch-protection cutover: \`false\`"
+            echo "- Merge authority enabled: \`false\`"
+            echo "- Live adapter execution: \`false\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload deployment evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: ao-release-gate-deploy-${{ steps.images.outputs.source_sha }}
+          path: ao-release-gate-deploy-evidence/

--- a/deploy/ao-release-gate-service/README.md
+++ b/deploy/ao-release-gate-service/README.md
@@ -78,6 +78,53 @@ dry-run check-runs only after it is explicitly hosted and configured with
 GitHub App runtime secrets; this container package alone is not release
 authority and does not change branch protection.
 
+## Autonomous Cloud Run Deployment
+
+The repository deploy workflow can mirror the immutable GHCR image into Google
+Artifact Registry, deploy it to Cloud Run, health-check `/healthz`, and upload
+deploy evidence:
+
+```text
+.github/workflows/ao-release-gate-deploy-cloud-run.yml
+```
+
+Required repository variables:
+
+```text
+GCP_PROJECT_ID
+GCP_WORKLOAD_IDENTITY_PROVIDER
+GCP_SERVICE_ACCOUNT
+GCP_CLOUD_RUN_REGION
+GCP_ARTIFACT_REGISTRY_LOCATION
+GCP_ARTIFACT_REGISTRY_REPOSITORY
+RELEASE_GATE_SERVICE_NAME
+AO_RELEASE_GATE_GITHUB_APP_ID
+AO_RELEASE_GATE_WEBHOOK_SECRET_NAME
+AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME
+```
+
+Optional repository variables:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET_VERSION
+AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION
+```
+
+`AO_RELEASE_GATE_WEBHOOK_SECRET_NAME` and
+`AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME` are Secret Manager object
+names, not secret values. The workflow must not read those values back. Cloud
+Run resolves them at runtime into:
+
+```text
+AO_RELEASE_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+```
+
+The deploy workflow proves only that the service revision is hosted and
+`GET /healthz` responds. It does not prove that the GitHub App webhook URL is
+configured, does not post a check-run, does not collect real PR evidence, does
+not change branch protection, and does not enable merge authority.
+
 ## Local No-Secret Smoke
 
 The local container smoke only builds the image and checks `/healthz`. It does

--- a/tests/test_ao_release_gate_deploy_workflow.py
+++ b/tests/test_ao_release_gate_deploy_workflow.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _workflow_text() -> str:
+    workflow = _repo_root() / ".github" / "workflows" / "ao-release-gate-deploy-cloud-run.yml"
+    return workflow.read_text(encoding="utf-8")
+
+
+def test_release_gate_deploy_workflow_is_trusted_oidc_cloud_run_path() -> None:
+    text = _workflow_text()
+
+    assert "name: Deploy AO Release Gate to Cloud Run" in text
+    assert "workflow_run:" in text
+    assert 'workflows: ["Publish AO Release Gate Container"]' in text
+    assert "workflow_dispatch:" in text
+    assert "id-token: write" in text
+    assert "packages: read" in text
+    assert "google-github-actions/auth@v2" in text
+    assert "workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}" in text
+    assert "google-github-actions/deploy-cloudrun@v2" in text
+    assert "--allow-unauthenticated --ingress=all --port=8000" in text
+
+
+def test_release_gate_deploy_workflow_uses_published_image_and_health_evidence() -> None:
+    text = _workflow_text()
+
+    assert "ghcr.io/halildeu/ao-kernel-ao-release-gate-service" in text
+    assert "sha-${source_sha}" in text
+    assert "docker pull \"${{ steps.images.outputs.ghcr_image }}\"" in text
+    assert "docker push \"${{ steps.images.outputs.gar_image }}\"" in text
+    assert "$service_url/healthz" in text
+    assert "ao-release-gate-deploy-evidence/healthz.json" in text
+    assert "ao-release-gate-deploy-evidence/ao-release-gate-deploy.v1.json" in text
+    assert "ao_release_gate_deployed_health_checked" in text
+    assert "$SERVICE_URL/github/ao-release-gate" in text
+    assert "secret_value_readback: false" in text
+    assert "check_run_post: false" in text
+    assert "real_pr_evidence: false" in text
+    assert "branch_protection_cutover: false" in text
+    assert "merge_authority_enabled: false" in text
+    assert "live_adapter_execution: false" in text
+
+
+def test_release_gate_deploy_workflow_keeps_prs_and_live_credentials_closed() -> None:
+    text = _workflow_text()
+
+    assert "github.event.workflow_run.head_branch == 'main'" in text
+    assert "github.event.workflow_run.event != 'pull_request'" in text
+    assert "pull_request:" not in text
+    assert "pull_request_target" not in text
+    assert "secrets." not in text
+    assert "GHCR_TOKEN: ${{ github.token }}" in text
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in text
+    assert "gh pr merge" not in text
+    assert "gh api repos/Halildeu/ao-kernel/branches/main/protection" not in text
+    assert "gcloud secrets versions access" not in text
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET=${{ env.AO_RELEASE_GATE_WEBHOOK_SECRET_NAME }}" in text
+    assert (
+        "AO_GITHUB_APP_PRIVATE_KEY_PEM=${{ env.AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_SECRET_NAME }}"
+        in text
+    )

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,10 +30,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/545"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/547"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "ao_release_gate_publish_path_ready_services_still_not_hosted"
+        == "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped"
     )
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
@@ -179,12 +179,19 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2aa"
+        and item["decision"] == "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/547"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
-        "publish or deploy the ao-release-gate image or container package as a dry-run service deploy artifact without treating it as hosted evidence",
-        "host and configure the ao-release-gate GitHub App check-run service with runtime webhook secret and GitHub App authentication outside the repo",
+        "bootstrap the ao-release-gate Cloud Run deploy trust path and run the trusted deploy workflow from main without treating health evidence as check-run evidence",
+        "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with runtime webhook secret and GitHub App authentication outside the repo",
         "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
         "validate whether GitHub App pull request approvals count for the current branch protection; if not, cut over to a required ao-release-gate status check",
         "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
@@ -195,17 +202,17 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
             "id": "GPP-2",
             "reason": (
                 "repo-owned policy webhook container image publish path, ao-release-gate dry-run decision "
-                "scaffold, check-run service surface, release-gate container package, and release-gate "
-                "image publish path are ready, but neither the "
+                "scaffold, check-run service surface, release-gate container package, release-gate "
+                "image publish path, and release-gate autonomous deploy path are ready, but neither the "
                 "release-gate service nor the deployment-protection service is publicly hosted/configured "
-                "or cut over with protected evidence"
+                "with webhook evidence or cut over with protected evidence"
             ),
         }
     ]
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
     assert any(
         action
-        == "publish or deploy the ao-release-gate image or container package as a dry-run service deploy artifact before collecting real PR evidence"
+        == "bootstrap and run the ao-release-gate Cloud Run deploy workflow from main before collecting real PR evidence"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -272,6 +279,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(
         action
         == "publish or pull ghcr.io/halildeu/ao-kernel-ao-release-gate-service only as a deploy artifact, not hosted service evidence"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "configure ao_kernel.ao_release_gate_runtime:application only with runtime secret manager values, never committed or echoed secret material"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -456,6 +468,25 @@ def test_gpp2y_adds_release_gate_publish_path_without_hosting_or_merge_authority
     assert "AO_CLAUDE_CODE_CLI_AUTH" in decision
 
 
+def test_gpp2aa_adds_release_gate_deploy_path_without_cutover_or_merge_authority() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md"
+    ).read_text(encoding="utf-8")
+
+    assert "**Decision:** `ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped`" in decision
+    assert "`ao-release-gate`" in decision
+    assert "`.github/workflows/ao-release-gate-deploy-cloud-run.yml`" in decision
+    assert "`ghcr.io/halildeu/ao-kernel-ao-release-gate-service:sha-<commit>`" in decision
+    assert "GitHub OIDC" in decision
+    assert "Secret Manager" in decision
+    assert "check_run_post=false" in decision
+    assert "branch_protection_cutover=false" in decision
+    assert "merge_authority_enabled=false" in decision
+    assert "post check-runs" in decision
+    assert "change branch" in decision
+    assert "AO_CLAUDE_CODE_CLI_AUTH" in decision
+
+
 def test_gpp_next_load_status_validates_required_guards() -> None:
     mod = _module()
 
@@ -463,11 +494,11 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/545"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/547"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "ao_release_gate_publish_path_ready_services_still_not_hosted"
+        == "ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped"
     )
     assert payload["support_widening_allowed"] is False
 


### PR DESCRIPTION
Refs #547
Depends on #546

## Summary
- Add a trusted Cloud Run deploy workflow for the `ao-release-gate` service image.
- Trigger deployment only after successful `Publish AO Release Gate Container` runs on `main`, or explicit trusted `workflow_dispatch`.
- Use GitHub OIDC for Google Cloud auth, mirror immutable GHCR `sha-<commit>` images to Artifact Registry, deploy Cloud Run, health-check `/healthz`, and upload deploy evidence.
- Document the required repository variables and Secret Manager object-name contract, and update GPP status/decision records.

## Guardrails
- No PR/fork deploy path is added.
- No `secrets.*`, `AO_CLAUDE_CODE_CLI_AUTH`, secret value readback, check-run evidence, branch-protection/ruleset update, merge authority, admin bypass, live adapter execution, support widening, or production platform claim is added.
- Deploy evidence explicitly records `check_run_post=false`, `real_pr_evidence=false`, `branch_protection_cutover=false`, and `merge_authority_enabled=false`.
- GPP-2 remains blocked until cloud bootstrap exists, the GitHub App webhook URL is configured, real PR dry-run check-run evidence is collected, branch protection/rulesets are cut over, and the deployment-protection policy service is hosted/configured.

## Validation
- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `pytest -q tests/test_ao_release_gate_deploy_workflow.py tests/test_ao_release_gate_container_publish_workflow.py tests/test_gpp_next.py`
- `python3 -m ruff check tests/test_ao_release_gate_deploy_workflow.py tests/test_ao_release_gate_container_publish_workflow.py tests/test_gpp_next.py`
- `actionlint .github/workflows/ao-release-gate-deploy-cloud-run.yml .github/workflows/ao-release-gate-container-publish.yml`
- `python3 scripts/gpp_next.py`
- `git diff --check`
- `pytest -q`