### PR TITLE
GPP-2ab: add policy Cloud Run bootstrap attestation

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,13 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 autonomous policy service deploy path ready; cloud/bootstrap and callback evidence still blocked
+**Status:** GPP-2 Cloud Run bootstrap attestation tool ready; repository variables, GCP trust, hosting, and callback evidence still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#535](https://github.com/Halildeu/ao-kernel/issues/535)
-for autonomous deployment protection policy service deployment
-**Current slice record:** `.claude/plans/GPP-2t-AUTONOMOUS-POLICY-SERVICE-DEPLOYMENT.md`
+**Current slice issue:** [#549](https://github.com/Halildeu/ao-kernel/issues/549)
+for policy service Cloud Run bootstrap attestation
+**Current slice record:** `.claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -174,6 +174,14 @@ Last live verification on current `origin/main` showed:
     deployment produces evidence from `main`, the GitHub App webhook URL is
     configured to the deployed endpoint, and protected workflow evidence
     confirms an explicit callback response.
+37. GPP-2ab adds a metadata-only bootstrap attestation tool for the GitHub
+    repository variable handles required by the Cloud Run deployment workflow.
+    The current live metadata check reports all required handles missing.
+    `metadata_ready` would mean only that the variable handles are present by
+    name/timestamp. It would not prove Google Cloud OIDC trust,
+    service-account permissions, Secret Manager objects, Cloud Run hosting,
+    GitHub App webhook configuration, callback posting, live adapter execution,
+    support widening, or production-platform readiness.
 
 ## 3. Current Verdict
 
@@ -233,6 +241,7 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2r` | Completed / no support widening | Policy webhook container deploy package | repo-owned container image package and bounded no-secret health smoke/CI job ready; hosted service is not yet deployed/configured |
 | `GPP-2s` | Completed / no support widening | Policy container image publication | repo-owned GHCR image publish path ready; hosted service is not yet deployed/configured |
 | `GPP-2t` | Completed / no support widening | Autonomous policy service deployment path | repo-owned Cloud Run OIDC deploy path ready; cloud bootstrap, hosted health evidence, GitHub App webhook config, and callback evidence are not yet attested |
+| `GPP-2ab` | Completed / no support widening | Policy Cloud Run bootstrap attestation | metadata-only attestation tool ready; required repository variable handles are currently missing; GCP trust, Secret Manager objects, hosted service evidence, GitHub App webhook config, and callback evidence are not yet attested |
 | `GPP-2` | Blocked / hosted service bootstrap/config/evidence missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be hosted/configured with webhook URL, webhook secret, and GitHub App auth and must post callback evidence before further runtime work |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -362,9 +371,11 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2s; policy decision core, webhook scaffold,
-deployable WSGI runtime, container package, and GHCR image publication path
-exist, but hosted service deployment/configuration is still missing.
+**Status:** blocked after GPP-2ab; policy decision core, webhook scaffold,
+deployable WSGI runtime, container package, GHCR image publication path,
+Cloud Run deploy automation, and metadata-only bootstrap attestation tooling
+exist, but required repository variables, GCP trust, hosted service
+deployment/configuration, and callback evidence are still missing.
 
 **Entry criteria:**
 
@@ -388,7 +399,13 @@ tooling with CI validation, but no public hosted endpoint, webhook URL, runtime
 secret manager configuration, or live callback evidence has been recorded.
 GPP-2s adds a GHCR image publication path for trusted non-PR builds, but no
 public hosted endpoint, webhook URL, runtime secret manager configuration, or
-live callback evidence has been recorded.
+live callback evidence has been recorded. GPP-2t adds an autonomous Cloud Run
+deploy path, but no GCP trust bootstrap, hosted health evidence, webhook URL
+configuration, or callback evidence has been recorded. GPP-2ab adds a
+metadata-only repository variable bootstrap attestation tool for that deploy
+path, and the current live metadata check reports required handles missing.
+Even after a future `metadata_ready`, that status is not Google Cloud OIDC,
+Secret Manager, Cloud Run, webhook, or callback evidence.
 
 **Acceptance criteria:**
 
@@ -655,7 +672,12 @@ has not yet been deployed to a public host or configured in the GitHub App
 webhook settings. GPP-2t adds the autonomous Cloud Run deploy path for the
 policy service, but cloud OIDC/Secret Manager bootstrap, hosted health evidence
 from `main`, GitHub App webhook URL configuration, and live callback evidence
-are not yet attested.
+are not yet attested. GPP-2ab adds a metadata-only bootstrap attestation tool
+for the Cloud Run deploy workflow's required GitHub repository variable
+handles, and the current live metadata check reports required handles missing.
+A future `metadata_ready` must be treated only as repository-variable evidence,
+not GCP trust, hosted service, webhook configuration, callback, or live
+execution evidence.
 GPP-2b
 [#482](https://github.com/Halildeu/ao-kernel/issues/482) and GPP-2c
 [#485](https://github.com/Halildeu/ao-kernel/issues/485) are resolved at the
@@ -675,8 +697,10 @@ only. GPP-2h selects GitHub App deployment protection, GPP-2i adds attestation
 support for that model, GPP-2j refreshes blocked metadata, and GPP-2k adds the
 operator provisioning runbook.
 
-The next GPP-2 action is to bootstrap or run the autonomous policy service
-deployment path: GitHub OIDC trust, Google service-account permissions,
+The next GPP-2 action is to run
+`scripts/policy_service_cloud_run_bootstrap_attest.py`, provision any missing
+repository variable handles, then bootstrap or run the autonomous policy
+service deployment path: GitHub OIDC trust, Google service-account permissions,
 Artifact Registry, Cloud Run, and Secret Manager object handles must exist
 without secret value readback, then the deploy workflow must produce hosted
 `/healthz` evidence from a trusted `main` image. After that, configure or verify
@@ -711,6 +735,8 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | Container package exists but is not hosted | Local image health does not prove GitHub can call the app | Treat GPP-2r as packaging readiness only; deploy to a public host and configure GitHub App webhook before rerunning evidence |
 | Container image exists but service is not hosted | GHCR image publication does not prove GitHub can call the app | Treat GPP-2s as deploy artifact readiness only; deploy the image to a public host and configure GitHub App webhook before rerunning evidence |
 | Deploy workflow exists but cloud bootstrap is missing | Automation path cannot produce hosted evidence | Treat GPP-2t as deploy automation readiness only; bootstrap OIDC/Secret Manager/Cloud Run and verify hosted health before rerunning protected workflow evidence |
+| Missing repository variables bypassed | Deploy workflow could be dispatched before non-secret handles exist | Run GPP-2ab attestation with `--fail-on-blocked` and provision missing GitHub repository variables before deploy dispatch |
+| `metadata_ready` mistaken for cloud readiness | Deployment could be treated as unblocked without GCP trust or hosting proof | Treat GPP-2ab as repository-variable metadata only; separately prove OIDC, service account permissions, Secret Manager objects, Cloud Run health, webhook URL, and callback evidence |
 
 ## 19. Tracking Log
 
@@ -762,3 +788,5 @@ and must keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-28 | GPP-2s image publish path added | `.github/workflows/policy-container-publish.yml` builds, no-secret smokes, and publishes trusted non-PR images to `ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service`; public hosting and GitHub App webhook configuration remain required before rerunning protected workflow evidence. |
 | 2026-04-28 | GPP-2t issue opened | Issue [#535](https://github.com/Halildeu/ao-kernel/issues/535) tracks the autonomous policy service deployment path. |
 | 2026-04-28 | GPP-2t deploy path added | `.github/workflows/policy-service-deploy-cloud-run.yml` can mirror trusted GHCR images to Artifact Registry, deploy Cloud Run with OIDC and Secret Manager references, health-check `/healthz`, and upload no-secret deployment evidence; cloud bootstrap, GitHub App webhook URL configuration, and callback evidence remain required before rerunning protected workflow evidence. |
+| 2026-04-28 | GPP-2ab issue opened | Issue [#549](https://github.com/Halildeu/ao-kernel/issues/549) tracks metadata-only Cloud Run bootstrap attestation for the policy service deploy path. |
+| 2026-04-28 | GPP-2ab bootstrap attestation added | `scripts/policy_service_cloud_run_bootstrap_attest.py` checks required GitHub repository variable handles with `gh variable list --json name,updatedAt`, ignores values, and records that current live metadata is `overall_status=blocked` because all required handles are missing; GCP trust, Secret Manager objects, Cloud Run hosting, webhook URL configuration, callback posting, live execution, support widening, and production-platform claims remain unproven. |

--- a/.claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md
+++ b/.claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md
@@ -1,0 +1,161 @@
+# GPP-2ab - Policy Cloud Run Bootstrap Attestation
+
+**Status:** closeout candidate
+**Date:** 2026-04-28
+**Authority:** `origin/main` at `02a4b7e`
+**Issue:** [#549](https://github.com/Halildeu/ao-kernel/issues/549)
+**Branch:** `codex/gpp-2ab-policy-cloud-run-bootstrap-attest`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2ab-policy-cloud-run-bootstrap-attest`
+**Program head:** `GPP-2` blocked on hosted policy service bootstrap/configuration
+**Support impact:** none
+**Runtime impact:** no Cloud Run deployment, no GitHub callback post, no
+protected workflow dispatch, no live adapter call
+
+## 1. Purpose
+
+GPP-2t added the autonomous Cloud Run deployment path for the policy service,
+but the next repeatable question was whether the repository has the non-secret
+variable handles required before dispatching that workflow. This slice adds a
+metadata-only bootstrap attestation for those handles.
+
+Decision:
+
+```text
+policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing
+```
+
+This slice creates the bootstrap attestation tool. It does not prove Google
+Cloud Workload Identity, service-account permissions, Artifact Registry,
+Secret Manager objects, Cloud Run hosting, GitHub App webhook configuration, a
+deployment protection callback post, live adapter execution, support widening,
+or production-platform readiness.
+
+## 2. Implemented Surface
+
+Code and docs:
+
+1. `scripts/policy_service_cloud_run_bootstrap_attest.py`
+   - collects GitHub repository variable metadata with
+     `gh variable list --json name,updatedAt`;
+   - records only variable names, presence, and update timestamps;
+   - ignores any variable `value` fields present in fixtures;
+   - writes `policy-service-cloud-run-bootstrap-attestation.v1.json`;
+   - exits non-zero with `--fail-on-blocked` when required handles are missing.
+2. `tests/test_policy_service_cloud_run_bootstrap_attest.py`
+   - pins metadata-only behavior, missing-variable blocking, CLI rendering, and
+     no-secret/no-live-operation guardrails.
+3. `deploy/live-adapter-gate-policy-service/README.md`
+   - documents the bootstrap attestation before Cloud Run deployment.
+4. `docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md`
+   - records how to run and interpret the attestation.
+
+## 3. Metadata Contract
+
+Required repository variables:
+
+```text
+GCP_PROJECT_ID
+GCP_WORKLOAD_IDENTITY_PROVIDER
+GCP_SERVICE_ACCOUNT
+GCP_CLOUD_RUN_REGION
+GCP_ARTIFACT_REGISTRY_LOCATION
+GCP_ARTIFACT_REGISTRY_REPOSITORY
+POLICY_SERVICE_NAME
+AO_GITHUB_APP_ID
+AO_POLICY_SERVICE_WEBHOOK_SECRET_NAME
+AO_GITHUB_APP_PRIVATE_KEY_SECRET_NAME
+```
+
+Optional repository variables:
+
+```text
+AO_POLICY_SERVICE_WEBHOOK_SECRET_VERSION
+AO_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION
+```
+
+The two `*_SECRET_NAME` variables are Secret Manager object names, not secret
+values. A `metadata_ready` attestation means only that these repository
+variable handles are visible by metadata. It is not cloud trust evidence.
+
+Current live metadata observation on 2026-04-28:
+
+```text
+overall_status=blocked
+finding_code=policy_cloud_run_bootstrap_missing_repository_variables
+```
+
+The live repository metadata check reported all required handles missing. Do
+not dispatch the Cloud Run deploy workflow until those handles are provisioned
+and a new attestation reports `overall_status=metadata_ready`.
+
+## 4. Trust Boundary
+
+The attestation intentionally does not use:
+
+```text
+gcloud secrets versions access
+secrets.*
+AO_CLAUDE_CODE_CLI_AUTH
+```
+
+It also does not deploy, dispatch, or post:
+
+```text
+Cloud Run deployment
+GitHub deployment protection callback
+.github/workflows/live-adapter-gate.yml
+live adapter execution
+```
+
+## 5. Current Decision
+
+Resolved by this slice:
+
+1. a repo-owned metadata-only attestation exists for the Cloud Run deploy
+   workflow's required repository variable handles;
+2. missing required handles produce `overall_status=blocked`;
+3. present required handles produce `overall_status=metadata_ready`;
+4. fixture values are ignored and are not serialized into evidence;
+5. the artifact records no secret value readback, no Cloud Run deployment, no
+   GitHub callback post, no live adapter execution, no support widening, and
+   no production-platform claim.
+
+Still blocked:
+
+1. required GitHub repository variable handles are currently missing;
+2. Google Cloud OIDC trust is not proven;
+3. Google service-account permissions are not proven;
+4. Artifact Registry and Secret Manager objects are not proven;
+5. Cloud Run hosting evidence is not present;
+6. the GitHub App webhook URL is not proven configured to a hosted endpoint;
+7. no real GitHub deployment callback review has been posted by the hosted
+   service;
+8. no new protected workflow evidence artifacts exist after policy response.
+
+Still closed:
+
+1. `live_execution_allowed=false`;
+2. `support_widening=false`;
+3. `production_platform_claim=false`.
+
+## 6. Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+pytest -q tests/test_policy_service_cloud_run_bootstrap_attest.py tests/test_policy_service_deploy_workflow.py tests/test_gpp_next.py
+python3 -m ruff check scripts/policy_service_cloud_run_bootstrap_attest.py tests/test_policy_service_cloud_run_bootstrap_attest.py tests/test_policy_service_deploy_workflow.py tests/test_gpp_next.py
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Expected closeout decision:
+
+```text
+policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing
+```
+
+Recorded closeout decision:
+
+```text
+policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,9 +9,9 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/535",
-    "exit_decision": "policy_service_autonomous_deploy_path_ready_service_not_bootstrapped",
-    "ready_after": "deployment protection policy service is deployed/configured with webhook secret and GitHub App auth, posts callback reviews, and produces protected workflow evidence with live_execution_allowed=false",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/549",
+    "exit_decision": "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing",
+    "ready_after": "policy service deploy workflow has completed from trusted main, hosted endpoint is configured as the GitHub App webhook URL, callback review evidence exists, and protected workflow evidence confirms live_execution_allowed=false",
     "allowed_scope": [
       "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
       "repeat protected workflow evidence collection from main after the policy service responds",
@@ -146,15 +146,22 @@
       "decision": "policy_service_autonomous_deploy_path_ready_service_not_bootstrapped",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/535",
       "record": ".claude/plans/GPP-2t-AUTONOMOUS-POLICY-SERVICE-DEPLOYMENT.md"
+    },
+    {
+      "id": "GPP-2ab",
+      "decision": "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/549",
+      "record": ".claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned autonomous Cloud Run deployment path is ready, but cloud OIDC/secret-manager bootstrap, hosted service evidence, GitHub App webhook URL configuration, and live deployment callback review evidence are not yet attested"
+      "reason": "repo-owned autonomous Cloud Run deployment path is ready, and metadata-only bootstrap attestation tool is ready, but the required GitHub repository variable handles are currently missing; Google Cloud OIDC trust, Secret Manager objects, hosted service evidence, GitHub App webhook URL configuration, and live deployment callback review evidence are not yet attested"
     }
   ],
   "pending_external_actions": [
+    "run scripts/policy_service_cloud_run_bootstrap_attest.py and provision any missing GitHub repository variable handles before dispatching the Cloud Run deploy workflow, while treating metadata_ready as repository-variable evidence only",
     "bootstrap the policy service deploy trust path with GitHub OIDC, Google service-account permissions, Artifact Registry, Cloud Run, and Secret Manager object handles without secret value readback",
     "run or observe the autonomous Cloud Run deployment workflow from a trusted main image until it produces health evidence for the policy service endpoint",
     "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the deployed /github/deployment-protection endpoint and can post deployment callback reviews",
@@ -212,6 +219,7 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
+    "run scripts/policy_service_cloud_run_bootstrap_attest.py to verify required GitHub repository variable handles before dispatching the Cloud Run deploy workflow, and treat metadata_ready as repository-variable evidence only",
     "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work",
     "configure or verify the GitHub App webhook URL only after the deployed policy service endpoint is health-checked",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",

--- a/deploy/live-adapter-gate-policy-service/README.md
+++ b/deploy/live-adapter-gate-policy-service/README.md
@@ -83,6 +83,23 @@ The deploy workflow does not dispatch the protected live-adapter workflow, post
 GitHub deployment protection callbacks itself, or run a live adapter. It only
 deploys and health-checks the webhook service.
 
+Before dispatching or relying on this deploy path, run the metadata-only
+bootstrap attestation:
+
+```bash
+python3 scripts/policy_service_cloud_run_bootstrap_attest.py \
+  --artifact-path /tmp/policy-service-cloud-run-bootstrap-attestation.v1.json \
+  --output text \
+  --fail-on-blocked
+```
+
+That attestation checks only GitHub repository variable handles with
+`gh variable list --json name,updatedAt`. It does not read variable values,
+does not access Secret Manager, does not prove Google Cloud Workload Identity
+or Cloud Run permissions, does not deploy the service, and does not post a
+GitHub deployment protection callback. Missing repository variables mean the
+Cloud Run deployment must stay blocked.
+
 ## Runtime
 
 Required hosting secrets:

--- a/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
+++ b/docs/LIVE-ADAPTER-GATE-PROVISIONING-RUNBOOK.md
@@ -327,6 +327,29 @@ production_platform_claim=false
    in the GitHub App and the service is expected to answer real
    `deployment_protection_rule` deliveries.
 
+Bootstrap attestation after GPP-2ab:
+
+```bash
+python3 scripts/policy_service_cloud_run_bootstrap_attest.py \
+  --artifact-path /tmp/policy-service-cloud-run-bootstrap-attestation.v1.json \
+  --output text \
+  --fail-on-blocked
+```
+
+Interpretation:
+
+1. `overall_status=metadata_ready` means only that the required GitHub
+   repository variable handles are present by name/timestamp.
+2. Missing required variables block deployment workflow dispatch until the
+   handles are provisioned.
+3. The attestation does not read variable values, read Secret Manager values,
+   prove Workload Identity trust, prove Google service-account permissions,
+   prove Artifact Registry, deploy Cloud Run, configure the GitHub App webhook
+   URL, post a callback, dispatch the protected live-adapter workflow, or run a
+   live adapter.
+4. Treat the attestation artifact as bootstrap metadata only. Hosted health
+   evidence and protected callback evidence still require later steps.
+
 ### 3. Attach the Deployment Protection Rule
 
 Attach the GitHub App as a custom deployment protection rule on environment:

--- a/scripts/policy_service_cloud_run_bootstrap_attest.py
+++ b/scripts/policy_service_cloud_run_bootstrap_attest.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Emit metadata-only policy service Cloud Run deploy bootstrap attestation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Literal, TypedDict
+
+ARTIFACT_KIND = "policy_service_cloud_run_bootstrap_attestation"
+ARTIFACT_NAME = "policy-service-cloud-run-bootstrap-attestation.v1.json"
+PROGRAM_ID = "GPP-2ab"
+SERVICE_ID = "ao-kernel-live-adapter-gate-policy-service"
+
+REQUIRED_REPOSITORY_VARIABLES: tuple[str, ...] = (
+    "GCP_PROJECT_ID",
+    "GCP_WORKLOAD_IDENTITY_PROVIDER",
+    "GCP_SERVICE_ACCOUNT",
+    "GCP_CLOUD_RUN_REGION",
+    "GCP_ARTIFACT_REGISTRY_LOCATION",
+    "GCP_ARTIFACT_REGISTRY_REPOSITORY",
+    "POLICY_SERVICE_NAME",
+    "AO_GITHUB_APP_ID",
+    "AO_POLICY_SERVICE_WEBHOOK_SECRET_NAME",
+    "AO_GITHUB_APP_PRIVATE_KEY_SECRET_NAME",
+)
+
+OPTIONAL_REPOSITORY_VARIABLES: tuple[str, ...] = (
+    "AO_POLICY_SERVICE_WEBHOOK_SECRET_VERSION",
+    "AO_GITHUB_APP_PRIVATE_KEY_SECRET_VERSION",
+)
+
+
+class VariableStatus(TypedDict):
+    """Sanitized repository variable metadata."""
+
+    name: str
+    present: bool
+    updated_at: str | None
+
+
+class BootstrapCheck(TypedDict):
+    """One attestation check row."""
+
+    id: str
+    status: Literal["pass", "blocked"]
+    detail: str
+
+
+class BootstrapAttestation(TypedDict):
+    """Policy service Cloud Run bootstrap attestation artifact."""
+
+    schema_version: str
+    artifact_kind: str
+    program_id: str
+    service_id: str
+    overall_status: Literal["metadata_ready", "blocked"]
+    finding_code: str | None
+    reason: str
+    required_repository_variables: list[VariableStatus]
+    optional_repository_variables: list[VariableStatus]
+    missing_repository_variables: list[str]
+    checks: list[BootstrapCheck]
+    github_repository_variable_metadata_checked: bool
+    cloud_oidc_bootstrap_attested: bool
+    cloud_run_deploy_executed: bool
+    secret_value_readback: bool
+    github_callback_post: bool
+    live_adapter_execution: bool
+    support_widening: bool
+    production_platform_claim: bool
+
+
+def _variable_index(variable_payload: object) -> dict[str, str | None]:
+    """Return variable name -> updatedAt without preserving values."""
+
+    if not isinstance(variable_payload, list):
+        raise ValueError("repository variable payload must be a JSON list")
+    variables: dict[str, str | None] = {}
+    for item in variable_payload:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        updated_at = item.get("updatedAt")
+        variables[name] = updated_at if isinstance(updated_at, str) else None
+    return variables
+
+
+def _statuses(names: tuple[str, ...], variables: dict[str, str | None]) -> list[VariableStatus]:
+    return [{"name": name, "present": name in variables, "updated_at": variables.get(name)} for name in names]
+
+
+def _check(check_id: str, *, ok: bool, detail: str) -> BootstrapCheck:
+    return {"id": check_id, "status": "pass" if ok else "blocked", "detail": detail}
+
+
+def build_policy_service_cloud_run_bootstrap_attestation(variable_payload: object) -> BootstrapAttestation:
+    """Build a metadata-only deploy bootstrap attestation.
+
+    This intentionally validates repository variable handles only. It does not
+    prove Google Cloud Workload Identity, Artifact Registry, Secret Manager, or
+    Cloud Run are configured correctly.
+    """
+
+    variables = _variable_index(variable_payload)
+    missing = [name for name in REQUIRED_REPOSITORY_VARIABLES if name not in variables]
+    metadata_ready = not missing
+    checks = [
+        _check(
+            "required_repository_variables",
+            ok=metadata_ready,
+            detail=(
+                "All required repository variable handles are present."
+                if metadata_ready
+                else f"Missing required repository variable handles: {', '.join(missing)}."
+            ),
+        ),
+        _check(
+            "secret_value_readback",
+            ok=True,
+            detail="Only repository variable names and update timestamps were inspected.",
+        ),
+        _check(
+            "cloud_bootstrap_scope",
+            ok=True,
+            detail="Google Cloud OIDC, Artifact Registry, Secret Manager, and Cloud Run were not contacted.",
+        ),
+        _check(
+            "runtime_side_effects",
+            ok=True,
+            detail="No deploy, GitHub callback post, protected workflow dispatch, or live adapter execution was performed.",
+        ),
+    ]
+    return {
+        "schema_version": "1",
+        "artifact_kind": ARTIFACT_KIND,
+        "program_id": PROGRAM_ID,
+        "service_id": SERVICE_ID,
+        "overall_status": "metadata_ready" if metadata_ready else "blocked",
+        "finding_code": None if metadata_ready else "policy_cloud_run_bootstrap_missing_repository_variables",
+        "reason": (
+            "Required GitHub repository variable handles are present; Google Cloud bootstrap remains unproven."
+            if metadata_ready
+            else "Required GitHub repository variable handles are missing; do not dispatch deployment."
+        ),
+        "required_repository_variables": _statuses(REQUIRED_REPOSITORY_VARIABLES, variables),
+        "optional_repository_variables": _statuses(OPTIONAL_REPOSITORY_VARIABLES, variables),
+        "missing_repository_variables": missing,
+        "checks": checks,
+        "github_repository_variable_metadata_checked": True,
+        "cloud_oidc_bootstrap_attested": False,
+        "cloud_run_deploy_executed": False,
+        "secret_value_readback": False,
+        "github_callback_post": False,
+        "live_adapter_execution": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+    }
+
+
+def write_attestation(path: Path, attestation: BootstrapAttestation) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(attestation, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def render_attestation_text(attestation: BootstrapAttestation) -> str:
+    missing = attestation["missing_repository_variables"]
+    lines = [
+        "Policy Service Cloud Run Bootstrap Attestation",
+        f"overall_status: {attestation['overall_status']}",
+        f"finding_code: {attestation['finding_code'] or '<none>'}",
+        f"reason: {attestation['reason']}",
+        f"missing_repository_variables: {', '.join(missing) if missing else '<none>'}",
+        f"cloud_oidc_bootstrap_attested: {str(attestation['cloud_oidc_bootstrap_attested']).lower()}",
+        f"cloud_run_deploy_executed: {str(attestation['cloud_run_deploy_executed']).lower()}",
+        f"secret_value_readback: {str(attestation['secret_value_readback']).lower()}",
+        f"github_callback_post: {str(attestation['github_callback_post']).lower()}",
+        f"live_adapter_execution: {str(attestation['live_adapter_execution']).lower()}",
+        f"support_widening: {str(attestation['support_widening']).lower()}",
+        f"production_platform_claim: {str(attestation['production_platform_claim']).lower()}",
+        "",
+        "Required repository variables:",
+    ]
+    for item in attestation["required_repository_variables"]:
+        status = "present" if item["present"] else "missing"
+        lines.append(f"- {item['name']}: {status}")
+    lines.append("")
+    lines.append("Checks:")
+    for check in attestation["checks"]:
+        lines.append(f"- {check['id']}: {check['status']} - {check['detail']}")
+    return "\n".join(lines) + "\n"
+
+
+def _load_json(path: Path | None) -> object | None:
+    if path is None:
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _collect_repository_variables(repo: str) -> object:
+    completed = subprocess.run(
+        ["gh", "variable", "list", "--repo", repo, "--json", "name,updatedAt"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout or "[]")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="Halildeu/ao-kernel", help="GitHub repository owner/name.")
+    parser.add_argument("--variables-json", type=Path, default=None, help="Fixture JSON from gh variable list.")
+    parser.add_argument(
+        "--artifact-path",
+        type=Path,
+        default=Path(ARTIFACT_NAME),
+        help="Path for the metadata-only bootstrap attestation artifact.",
+    )
+    parser.add_argument("--output", choices=("json", "text"), default="json", help="Stdout render mode.")
+    parser.add_argument("--fail-on-blocked", action="store_true", help="Return exit code 1 when metadata is blocked.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    variable_payload = _load_json(args.variables_json)
+    if variable_payload is None:
+        variable_payload = _collect_repository_variables(args.repo)
+
+    attestation = build_policy_service_cloud_run_bootstrap_attestation(variable_payload)
+    write_attestation(args.artifact_path, attestation)
+
+    if args.output == "json":
+        print(json.dumps(attestation, indent=2, sort_keys=True))
+    else:
+        print(render_attestation_text(attestation), end="")
+
+    if args.fail_on_blocked and attestation["overall_status"] != "metadata_ready":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,8 +30,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/535"
-    assert payload["current_wp"]["exit_decision"] == "policy_service_autonomous_deploy_path_ready_service_not_bootstrapped"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/549"
+    assert (
+        payload["current_wp"]["exit_decision"]
+        == "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing"
+    )
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
         item["id"] == "GPP-2a" and item["decision"] == "still_blocked_protected_prerequisites_missing"
@@ -148,10 +151,22 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2ab"
+        and item["decision"] == "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/549"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
+        (
+            "run scripts/policy_service_cloud_run_bootstrap_attest.py and provision any missing GitHub repository "
+            "variable handles before dispatching the Cloud Run deploy workflow, while treating metadata_ready as "
+            "repository-variable evidence only"
+        ),
         "bootstrap the policy service deploy trust path with GitHub OIDC, Google service-account permissions, Artifact Registry, Cloud Run, and Secret Manager object handles without secret value readback",
         "run or observe the autonomous Cloud Run deployment workflow from a trusted main image until it produces health evidence for the policy service endpoint",
         "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the deployed /github/deployment-protection endpoint and can post deployment callback reviews",
@@ -161,9 +176,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         {
             "id": "GPP-2",
             "reason": (
-                "repo-owned autonomous Cloud Run deployment path is ready, but cloud OIDC/secret-manager "
-                "bootstrap, hosted service evidence, GitHub App webhook URL configuration, and live deployment "
-                "callback review evidence are not yet attested"
+                "repo-owned autonomous Cloud Run deployment path is ready, and metadata-only bootstrap attestation "
+                "tool is ready, but the required GitHub repository variable handles are currently missing; Google "
+                "Cloud OIDC trust, Secret Manager objects, hosted service evidence, GitHub App webhook URL "
+                "configuration, and live deployment callback review evidence are not yet attested"
             ),
         }
     ]
@@ -178,6 +194,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"])
     assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
+    assert any(
+        action
+        == "run scripts/policy_service_cloud_run_bootstrap_attest.py to verify required GitHub repository variable handles before dispatching the Cloud Run deploy workflow, and treat metadata_ready as repository-variable evidence only"
+        for action in payload["next_allowed_actions"]
+    )
     assert any(
         action
         == "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work"
@@ -302,6 +323,22 @@ def test_gpp2i_attestation_support_keeps_gate_blocked() -> None:
     assert "does not widen support" in decision
 
 
+def test_gpp2ab_policy_cloud_run_bootstrap_attestation_is_metadata_only() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md"
+    ).read_text(encoding="utf-8")
+
+    assert "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing" in decision
+    assert "gh variable list --json name,updatedAt" in decision
+    assert "A `metadata_ready` attestation means only" in decision
+    assert "Google Cloud OIDC trust is not proven" in decision
+    assert "Cloud Run deployment" in decision
+    assert "AO_CLAUDE_CODE_CLI_AUTH" in decision
+    assert "`live_execution_allowed=false`" in decision
+    assert "`support_widening=false`" in decision
+    assert "`production_platform_claim=false`" in decision
+
+
 def test_gpp_next_load_status_validates_required_guards() -> None:
     mod = _module()
 
@@ -309,9 +346,12 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/535"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/549"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
-    assert payload["current_wp"]["exit_decision"] == "policy_service_autonomous_deploy_path_ready_service_not_bootstrapped"
+    assert (
+        payload["current_wp"]["exit_decision"]
+        == "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing"
+    )
     assert payload["support_widening_allowed"] is False
 
 
@@ -341,7 +381,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "Blocked work packages:\n- GPP-2: repo-owned autonomous Cloud Run deployment path is ready" in rendered
+    assert "metadata-only bootstrap attestation tool is ready" in rendered
     assert "divergence: 0\t0" in rendered
 
 

--- a/tests/test_policy_service_cloud_run_bootstrap_attest.py
+++ b/tests/test_policy_service_cloud_run_bootstrap_attest.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _module() -> Any:
+    module_path = _repo_root() / "scripts" / "policy_service_cloud_run_bootstrap_attest.py"
+    spec = importlib.util.spec_from_file_location("policy_service_cloud_run_bootstrap_attest", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ready_variables() -> list[dict[str, str]]:
+    mod = _module()
+    return [
+        {"name": name, "updatedAt": "2026-04-28T00:00:00Z", "value": f"hidden-{name}"}
+        for name in mod.REQUIRED_REPOSITORY_VARIABLES
+    ]
+
+
+def test_policy_cloud_run_bootstrap_attestation_records_metadata_ready_without_values() -> None:
+    mod = _module()
+
+    attestation = mod.build_policy_service_cloud_run_bootstrap_attestation(_ready_variables())
+    serialized = json.dumps(attestation, sort_keys=True)
+
+    assert attestation["artifact_kind"] == "policy_service_cloud_run_bootstrap_attestation"
+    assert attestation["program_id"] == "GPP-2ab"
+    assert attestation["service_id"] == "ao-kernel-live-adapter-gate-policy-service"
+    assert attestation["overall_status"] == "metadata_ready"
+    assert attestation["missing_repository_variables"] == []
+    assert all(item["present"] for item in attestation["required_repository_variables"])
+    assert attestation["github_repository_variable_metadata_checked"] is True
+    assert attestation["cloud_oidc_bootstrap_attested"] is False
+    assert attestation["cloud_run_deploy_executed"] is False
+    assert attestation["secret_value_readback"] is False
+    assert attestation["github_callback_post"] is False
+    assert attestation["live_adapter_execution"] is False
+    assert attestation["support_widening"] is False
+    assert attestation["production_platform_claim"] is False
+    assert "hidden-" not in serialized
+
+
+def test_policy_cloud_run_bootstrap_attestation_blocks_missing_required_variables() -> None:
+    mod = _module()
+    payload = [item for item in _ready_variables() if item["name"] != "GCP_SERVICE_ACCOUNT"]
+
+    attestation = mod.build_policy_service_cloud_run_bootstrap_attestation(payload)
+
+    assert attestation["overall_status"] == "blocked"
+    assert attestation["finding_code"] == "policy_cloud_run_bootstrap_missing_repository_variables"
+    assert attestation["missing_repository_variables"] == ["GCP_SERVICE_ACCOUNT"]
+    account = next(item for item in attestation["required_repository_variables"] if item["name"] == "GCP_SERVICE_ACCOUNT")
+    assert account == {"name": "GCP_SERVICE_ACCOUNT", "present": False, "updated_at": None}
+
+
+def test_policy_cloud_run_bootstrap_attestation_cli_uses_fixture_without_secret_readback(
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    mod = _module()
+    fixture_path = tmp_path / "variables.json"
+    artifact_path = tmp_path / "attestation.json"
+    fixture_path.write_text(json.dumps(_ready_variables()), encoding="utf-8")
+
+    exit_code = mod.main(
+        [
+            "--variables-json",
+            str(fixture_path),
+            "--artifact-path",
+            str(artifact_path),
+            "--output",
+            "text",
+            "--fail-on-blocked",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert "overall_status: metadata_ready" in captured.out
+    assert "secret_value_readback: false" in captured.out
+    assert artifact["overall_status"] == "metadata_ready"
+    assert artifact["secret_value_readback"] is False
+    assert "hidden-" not in artifact_path.read_text(encoding="utf-8")
+
+
+def test_policy_cloud_run_bootstrap_attestation_cli_can_fail_on_blocked(tmp_path: Path) -> None:
+    mod = _module()
+    fixture_path = tmp_path / "variables.json"
+    artifact_path = tmp_path / "attestation.json"
+    fixture_path.write_text(json.dumps([]), encoding="utf-8")
+
+    exit_code = mod.main(
+        [
+            "--variables-json",
+            str(fixture_path),
+            "--artifact-path",
+            str(artifact_path),
+            "--fail-on-blocked",
+        ]
+    )
+
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert exit_code == 1
+    assert artifact["overall_status"] == "blocked"
+    assert artifact["secret_value_readback"] is False
+    assert len(artifact["missing_repository_variables"]) == len(mod.REQUIRED_REPOSITORY_VARIABLES)
+
+
+def test_policy_cloud_run_bootstrap_live_collection_does_not_request_values() -> None:
+    source = (_repo_root() / "scripts" / "policy_service_cloud_run_bootstrap_attest.py").read_text(encoding="utf-8")
+
+    assert "--json\", \"name,updatedAt\"" in source
+    assert "gcloud secrets versions access" not in source
+    assert "secrets." not in source
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in source


### PR DESCRIPTION
Refs #549
Depends on #536

## Summary
- Add a metadata-only Cloud Run bootstrap attestation CLI for required GitHub repository variable handles.
- Record that live repository metadata is currently blocked because the required handles are missing.
- Update GPP status, runbook, policy service README, and tests so metadata_ready is not treated as GCP trust, hosting, webhook, callback, or live execution evidence.

## Guardrails
- No repository variable values are serialized.
- No Secret Manager values are read back.
- No Cloud Run deploy, GitHub callback post, protected workflow dispatch, live adapter execution, support widening, or production-platform claim is introduced.
- AO_CLAUDE_CODE_CLI_AUTH remains out of this deploy/bootstrap path.

## Validation
- python3 -m json.tool .claude/plans/gpp_status.v1.json
- pytest -q tests/test_policy_service_cloud_run_bootstrap_attest.py tests/test_policy_service_deploy_workflow.py tests/test_gpp_next.py
- python3 -m ruff check scripts/policy_service_cloud_run_bootstrap_attest.py tests/test_policy_service_cloud_run_bootstrap_attest.py tests/test_policy_service_deploy_workflow.py tests/test_gpp_next.py
- python3 scripts/gpp_next.py
- git diff --check
- pytest -q
- python3 scripts/policy_service_cloud_run_bootstrap_attest.py --artifact-path /tmp/policy-service-cloud-run-bootstrap-attestation.v1.json --output text

Live metadata observation: overall_status=blocked because all required repository variable handles are currently missing.