### PR TITLE
GPP-2ac: record operator-owned gate boundary

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,13 +1,14 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 Cloud Run bootstrap attestation tool ready; repository variables, GCP trust, hosting, and callback evidence still blocked
+**Status:** GPP-2 end-user boundary recorded; operator-owned gate hosting,
+GCP trust, webhook configuration, and callback evidence still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#549](https://github.com/Halildeu/ao-kernel/issues/549)
-for policy service Cloud Run bootstrap attestation
-**Current slice record:** `.claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md`
+**Current slice issue:** [#551](https://github.com/Halildeu/ao-kernel/issues/551)
+for operator gate and end-user onboarding boundary
+**Current slice record:** `.claude/plans/GPP-2ac-OPERATOR-GATE-END-USER-BOUNDARY.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -176,12 +177,19 @@ Last live verification on current `origin/main` showed:
     confirms an explicit callback response.
 37. GPP-2ab adds a metadata-only bootstrap attestation tool for the GitHub
     repository variable handles required by the Cloud Run deployment workflow.
-    The current live metadata check reports all required handles missing.
+    The current live metadata check reports required handles missing.
     `metadata_ready` would mean only that the variable handles are present by
     name/timestamp. It would not prove Google Cloud OIDC trust,
     service-account permissions, Secret Manager objects, Cloud Run hosting,
     GitHub App webhook configuration, callback posting, live adapter execution,
     support widening, or production-platform readiness.
+38. GPP-2ac records the product boundary after the Cloud Run/vault/webhook
+    discussion. The deployment-protection policy service is operator-owned
+    platform infrastructure, not an end-user setup requirement. End users must
+    not be required to self-host Cloud Run, a vault, a webhook secret, or a
+    GitHub App private key. GPP-2 remains blocked on operator-owned hosted
+    callback evidence; repo-intelligence onboarding can be prioritized only as
+    explicit opt-in/read-only work with no support widening.
 
 ## 3. Current Verdict
 
@@ -242,6 +250,7 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2s` | Completed / no support widening | Policy container image publication | repo-owned GHCR image publish path ready; hosted service is not yet deployed/configured |
 | `GPP-2t` | Completed / no support widening | Autonomous policy service deployment path | repo-owned Cloud Run OIDC deploy path ready; cloud bootstrap, hosted health evidence, GitHub App webhook config, and callback evidence are not yet attested |
 | `GPP-2ab` | Completed / no support widening | Policy Cloud Run bootstrap attestation | metadata-only attestation tool ready; required repository variable handles are currently missing; GCP trust, Secret Manager objects, hosted service evidence, GitHub App webhook config, and callback evidence are not yet attested |
+| `GPP-2ac` | Completed / no support widening | Operator gate and end-user onboarding boundary | GPP-2 gate hosting is operator-owned platform infrastructure; end users must not self-host Cloud Run, vault, webhook, or GitHub App private-key setup |
 | `GPP-2` | Blocked / hosted service bootstrap/config/evidence missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be hosted/configured with webhook URL, webhook secret, and GitHub App auth and must post callback evidence before further runtime work |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -371,11 +380,12 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2ab; policy decision core, webhook scaffold,
+**Status:** blocked after GPP-2ac; policy decision core, webhook scaffold,
 deployable WSGI runtime, container package, GHCR image publication path,
-Cloud Run deploy automation, and metadata-only bootstrap attestation tooling
-exist, but required repository variables, GCP trust, hosted service
-deployment/configuration, and callback evidence are still missing.
+Cloud Run deploy automation, metadata-only bootstrap attestation tooling, and
+operator/end-user boundary decision exist, but operator-owned GCP trust,
+hosted service deployment/configuration, and callback evidence are still
+missing.
 
 **Entry criteria:**
 
@@ -406,6 +416,10 @@ metadata-only repository variable bootstrap attestation tool for that deploy
 path, and the current live metadata check reports required handles missing.
 Even after a future `metadata_ready`, that status is not Google Cloud OIDC,
 Secret Manager, Cloud Run, webhook, or callback evidence.
+GPP-2ac records that this hosting path is operator-owned platform
+infrastructure. It is not a setup requirement for product end users, and it
+does not block read-only repo-intelligence onboarding design work that avoids
+live execution and support widening.
 
 **Acceptance criteria:**
 

--- a/.claude/plans/GPP-2ac-OPERATOR-GATE-END-USER-BOUNDARY.md
+++ b/.claude/plans/GPP-2ac-OPERATOR-GATE-END-USER-BOUNDARY.md
@@ -1,0 +1,146 @@
+# GPP-2ac - Operator Gate and End-User Onboarding Boundary
+
+**Status:** closeout candidate
+**Date:** 2026-04-28
+**Authority:** `origin/main` at `14608b2`
+**Issue:** [#551](https://github.com/Halildeu/ao-kernel/issues/551)
+**Branch:** `codex/gpp-2ac-end-user-boundary`
+**Worktree:** `/Users/halilkocoglu/Documents/ao-kernel-gpp-2ac-end-user-boundary`
+**Program head:** `GPP-2` remains blocked on operator-owned hosted callback
+evidence
+**Support impact:** none
+**Runtime impact:** no Cloud Run deployment, no GitHub callback post, no
+protected workflow dispatch, no live adapter call
+
+## 1. Purpose
+
+GPP-2t and GPP-2ab made the deployment-protection policy service deployable,
+but they also exposed a product boundary problem: asking every product user to
+create Cloud Run, a vault, a webhook endpoint, a GitHub App private key, and a
+deployment protection service would make onboarding too complex.
+
+This slice records the boundary. The GPP-2 policy service is operator-owned
+platform infrastructure. End users must not self-host it to use the product.
+GPP-2 stays blocked until the operator-owned service has hosted callback
+evidence.
+
+Decision:
+
+```text
+operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening
+```
+
+## 2. Boundary
+
+Operator-owned platform infrastructure:
+
+1. `ao-kernel-live-adapter-gate` GitHub App deployment protection policy
+   service hosting.
+2. Webhook secret storage and GitHub App private-key storage.
+3. GitHub deployment protection callback authority.
+4. Hosted endpoint health evidence and callback review evidence.
+5. Any Cloud Run, Artifact Registry, Secret Manager, or equivalent hosting
+   bootstrap chosen by the operator.
+
+End-user onboarding:
+
+1. install the product's GitHub App or equivalent product connector;
+2. select repositories;
+3. optionally add explicit repo-local configuration such as `.ao/config.yml`;
+4. use repo-intelligence features through read-only, explicit, auditable
+   workflow surfaces.
+
+Not allowed:
+
+1. require a product end user to create a Cloud Run project;
+2. require a product end user to manage a vault or secret manager;
+3. require a product end user to paste or host a GitHub App private key;
+4. require a product end user to expose a deployment-protection webhook;
+5. treat a product end-user account as release authority.
+
+## 3. Current Evidence
+
+The current metadata-only bootstrap check remains blocked:
+
+```text
+overall_status: blocked
+missing_repository_variables: GCP_PROJECT_ID, GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT
+cloud_oidc_bootstrap_attested: false
+cloud_run_deploy_executed: false
+secret_value_readback: false
+github_callback_post: false
+live_adapter_execution: false
+support_widening: false
+production_platform_claim: false
+```
+
+That evidence is operator bootstrap evidence only. It does not become a user
+setup checklist, and it does not block read-only repo-intelligence onboarding
+design work that avoids live-adapter execution and support widening.
+
+## 4. Product Direction
+
+The next product-facing path is repo intelligence, not asking users to host the
+GPP-2 gate. GPP-5 can proceed only within these boundaries:
+
+1. explicit opt-in ingestion;
+2. read-only workflow context surfaces;
+3. no hidden root export, MCP feed, or context compiler auto-feed;
+4. no live adapter execution;
+5. no support widening or production-platform claim.
+
+This keeps GitHub in the loop: the user-facing product still uses GitHub App
+installation, repository selection, repository permissions, workflow evidence,
+and branch/protection signals. GitHub is not bypassed. The difference is that
+the deployment-protection service is platform infrastructure operated for the
+product, not infrastructure each customer must assemble.
+
+## 5. Current Decision
+
+Resolved by this slice:
+
+1. GPP-2 gate hosting is operator-owned platform infrastructure;
+2. end-user onboarding must not require Cloud Run, vault, webhook, or GitHub
+   App private-key setup;
+3. repo-intelligence product onboarding may be prioritized as read-only and
+   explicit opt-in work while GPP-2 remains blocked;
+4. GitHub remains the integration and governance surface for install, repo
+   selection, permissions, workflow evidence, and branch/protection state.
+
+Still blocked:
+
+1. Google Cloud OIDC trust is not proven;
+2. Secret Manager objects are not proven;
+3. hosted policy service evidence is not present;
+4. the GitHub App webhook URL is not proven configured to a hosted endpoint;
+5. no real GitHub deployment callback review has been posted by the hosted
+   service;
+6. no new protected workflow evidence artifacts exist after policy response.
+
+Still closed:
+
+1. `live_execution_allowed=false`;
+2. `support_widening=false`;
+3. `production_platform_claim=false`.
+
+## 6. Validation
+
+```bash
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+python3 -m pytest tests/test_gpp_next.py -q
+python3 -m ruff check tests/test_gpp_next.py
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Expected closeout decision:
+
+```text
+operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening
+```
+
+Recorded closeout decision:
+
+```text
+operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,11 +9,12 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/549",
-    "exit_decision": "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing",
-    "ready_after": "policy service deploy workflow has completed from trusted main, hosted endpoint is configured as the GitHub App webhook URL, callback review evidence exists, and protected workflow evidence confirms live_execution_allowed=false",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/551",
+    "exit_decision": "operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening",
+    "ready_after": "operator-owned policy service deploy workflow has completed from trusted main, hosted endpoint is configured as the GitHub App webhook URL, callback review evidence exists, and protected workflow evidence confirms live_execution_allowed=false",
     "allowed_scope": [
       "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
+      "document or build end-user onboarding paths that do not require users to self-host the GPP-2 policy service, vault, webhook secret, GitHub App private key, or Cloud Run project",
       "repeat protected workflow evidence collection from main after the policy service responds",
       "keep live execution disabled until protected workflow evidence explicitly permits a later live run"
     ]
@@ -152,20 +153,27 @@
       "decision": "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/549",
       "record": ".claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md"
+    },
+    {
+      "id": "GPP-2ac",
+      "decision": "operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/551",
+      "record": ".claude/plans/GPP-2ac-OPERATOR-GATE-END-USER-BOUNDARY.md"
     }
   ],
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned autonomous Cloud Run deployment path is ready, and metadata-only bootstrap attestation tool is ready, but the required GitHub repository variable handles are currently missing; Google Cloud OIDC trust, Secret Manager objects, hosted service evidence, GitHub App webhook URL configuration, and live deployment callback review evidence are not yet attested"
+      "reason": "repo-owned autonomous Cloud Run deployment path and metadata-only bootstrap attestation tooling are ready, and the policy service is now explicitly operator-owned platform infrastructure rather than an end-user setup requirement; GPP-2 remains blocked because Google Cloud OIDC trust, Secret Manager objects, hosted service evidence, GitHub App webhook URL configuration, and live deployment callback review evidence are not yet attested"
     }
   ],
   "pending_external_actions": [
-    "run scripts/policy_service_cloud_run_bootstrap_attest.py and provision any missing GitHub repository variable handles before dispatching the Cloud Run deploy workflow, while treating metadata_ready as repository-variable evidence only",
-    "bootstrap the policy service deploy trust path with GitHub OIDC, Google service-account permissions, Artifact Registry, Cloud Run, and Secret Manager object handles without secret value readback",
-    "run or observe the autonomous Cloud Run deployment workflow from a trusted main image until it produces health evidence for the policy service endpoint",
+    "if the operator chooses to unblock GPP-2 with Cloud Run, run scripts/policy_service_cloud_run_bootstrap_attest.py and provision any missing GitHub repository variable handles before dispatching the deploy workflow, while treating metadata_ready as repository-variable evidence only",
+    "bootstrap the operator-owned policy service deploy trust path with GitHub OIDC, Google service-account permissions, Artifact Registry, Cloud Run, and Secret Manager object handles without secret value readback",
+    "run or observe the autonomous Cloud Run deployment workflow from a trusted main image only after operator-owned billing/project/trust handles are intentionally available",
     "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the deployed /github/deployment-protection endpoint and can post deployment callback reviews",
-    "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly"
+    "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
+    "keep end-user repo-intelligence onboarding independent from GPP-2 gate hosting by requiring at most GitHub App installation, repository selection, and explicit opt-in configuration"
   ],
   "support_widening_allowed": false,
   "production_platform_claim_allowed": false,
@@ -211,6 +219,7 @@
     "run a live adapter before a later protected runtime evidence slice permits it",
     "use --equivalent-release-gate-approved while GPP-2e remains not_approved",
     "treat a product end-user account as release authority",
+    "require product end users to self-host the GPP-2 deployment-protection policy service, vault, webhook secret, GitHub App private key, or Cloud Run project",
     "treat a PAT-backed bot user as release authority",
     "treat Claude MCP consultation as release authority",
     "use ao_memory_write or ao_llm_call during Claude MCP consultation",
@@ -219,6 +228,9 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
+    "treat the GPP-2 deployment-protection policy service as operator-owned platform infrastructure, not an end-user setup requirement",
+    "prioritize repo-intelligence onboarding as a read-only product workflow that requires GitHub App installation and repository selection, not Cloud Run, vault, webhook, or private-key setup by each user",
+    "open GPP-5 repo-intelligence workflow integration only as explicit opt-in or read-only work while support_widening_allowed=false and production_platform_claim_allowed=false",
     "run scripts/policy_service_cloud_run_bootstrap_attest.py to verify required GitHub repository variable handles before dispatching the Cloud Run deploy workflow, and treat metadata_ready as repository-variable evidence only",
     "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work",
     "configure or verify the GitHub App webhook URL only after the deployed policy service endpoint is health-checked",

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,10 +30,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/549"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/551"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing"
+        == "operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening"
     )
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
@@ -158,28 +158,47 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-2ac"
+        and item["decision"] == "operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/551"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
         (
-            "run scripts/policy_service_cloud_run_bootstrap_attest.py and provision any missing GitHub repository "
-            "variable handles before dispatching the Cloud Run deploy workflow, while treating metadata_ready as "
+            "if the operator chooses to unblock GPP-2 with Cloud Run, run "
+            "scripts/policy_service_cloud_run_bootstrap_attest.py and provision any missing GitHub repository "
+            "variable handles before dispatching the deploy workflow, while treating metadata_ready as "
             "repository-variable evidence only"
         ),
-        "bootstrap the policy service deploy trust path with GitHub OIDC, Google service-account permissions, Artifact Registry, Cloud Run, and Secret Manager object handles without secret value readback",
-        "run or observe the autonomous Cloud Run deployment workflow from a trusted main image until it produces health evidence for the policy service endpoint",
+        (
+            "bootstrap the operator-owned policy service deploy trust path with GitHub OIDC, Google service-account "
+            "permissions, Artifact Registry, Cloud Run, and Secret Manager object handles without secret value readback"
+        ),
+        (
+            "run or observe the autonomous Cloud Run deployment workflow from a trusted main image only after "
+            "operator-owned billing/project/trust handles are intentionally available"
+        ),
         "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the deployed /github/deployment-protection endpoint and can post deployment callback reviews",
         "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
+        (
+            "keep end-user repo-intelligence onboarding independent from GPP-2 gate hosting by requiring at most "
+            "GitHub App installation, repository selection, and explicit opt-in configuration"
+        ),
     ]
     assert payload["blocked_wps"] == [
         {
             "id": "GPP-2",
             "reason": (
-                "repo-owned autonomous Cloud Run deployment path is ready, and metadata-only bootstrap attestation "
-                "tool is ready, but the required GitHub repository variable handles are currently missing; Google "
-                "Cloud OIDC trust, Secret Manager objects, hosted service evidence, GitHub App webhook URL "
-                "configuration, and live deployment callback review evidence are not yet attested"
+                "repo-owned autonomous Cloud Run deployment path and metadata-only bootstrap attestation tooling "
+                "are ready, and the policy service is now explicitly operator-owned platform infrastructure rather "
+                "than an end-user setup requirement; GPP-2 remains blocked because Google Cloud OIDC trust, Secret "
+                "Manager objects, hosted service evidence, GitHub App webhook URL configuration, and live "
+                "deployment callback review evidence are not yet attested"
             ),
         }
     ]
@@ -193,7 +212,27 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         for action in payload["forbidden_actions"]
     )
     assert any(action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"])
+    assert any(
+        action
+        == "require product end users to self-host the GPP-2 deployment-protection policy service, vault, webhook secret, GitHub App private key, or Cloud Run project"
+        for action in payload["forbidden_actions"]
+    )
     assert any(action == "treat a PAT-backed bot user as release authority" for action in payload["forbidden_actions"])
+    assert any(
+        action
+        == "treat the GPP-2 deployment-protection policy service as operator-owned platform infrastructure, not an end-user setup requirement"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "prioritize repo-intelligence onboarding as a read-only product workflow that requires GitHub App installation and repository selection, not Cloud Run, vault, webhook, or private-key setup by each user"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "open GPP-5 repo-intelligence workflow integration only as explicit opt-in or read-only work while support_widening_allowed=false and production_platform_claim_allowed=false"
+        for action in payload["next_allowed_actions"]
+    )
     assert any(
         action
         == "run scripts/policy_service_cloud_run_bootstrap_attest.py to verify required GitHub repository variable handles before dispatching the Cloud Run deploy workflow, and treat metadata_ready as repository-variable evidence only"
@@ -339,6 +378,24 @@ def test_gpp2ab_policy_cloud_run_bootstrap_attestation_is_metadata_only() -> Non
     assert "`production_platform_claim=false`" in decision
 
 
+def test_gpp2ac_keeps_gate_operator_owned_and_end_user_onboarding_simple() -> None:
+    decision = (
+        _repo_root() / ".claude/plans/GPP-2ac-OPERATOR-GATE-END-USER-BOUNDARY.md"
+    ).read_text(encoding="utf-8")
+
+    assert "operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening" in decision
+    assert "End users must not self-host it to use the product." in decision
+    assert "Operator-owned platform infrastructure" in decision
+    assert "GitHub App private-key storage" in decision
+    assert "install the product's GitHub App" in decision
+    assert "select repositories" in decision
+    assert "repo-intelligence" in decision
+    assert "GitHub is not bypassed" in decision
+    assert "`live_execution_allowed=false`" in decision
+    assert "`support_widening=false`" in decision
+    assert "`production_platform_claim=false`" in decision
+
+
 def test_gpp_next_load_status_validates_required_guards() -> None:
     mod = _module()
 
@@ -346,11 +403,11 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/549"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/551"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing"
+        == "operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening"
     )
     assert payload["support_widening_allowed"] is False
 
@@ -381,7 +438,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "metadata-only bootstrap attestation tool is ready" in rendered
+    assert "operator-owned platform infrastructure" in rendered
     assert "divergence: 0\t0" in rendered
 
 


### PR DESCRIPTION
## Summary

- record GPP-2ac as the operator-owned gate vs end-user onboarding boundary
- keep GPP-2 blocked until hosted policy-service callback evidence exists
- make repo-intelligence onboarding the next product-facing direction without requiring end users to self-host Cloud Run, vault, webhook, or GitHub App private-key setup
- pin the no-support-widening boundary in GPP status tests

## Validation

- python3 -m json.tool .claude/plans/gpp_status.v1.json
- python3 scripts/gpp_next.py
- python3 -m pytest tests/test_gpp_next.py -q
- python3 -m ruff check tests/test_gpp_next.py
- git diff --check

Closes #551