### PR TITLE
GPP-5a: define repo-intelligence product onboarding

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -309,7 +309,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2` | Blocked / hosted service bootstrap/config/evidence and release-gate cutover missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be hosted/configured and post callback evidence, and `ao-release-gate` must be deployed/hosted/evidenced/cut over before human-free program merges |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
-| `GPP-5` | Not started | Repo-intelligence explicit workflow integration | `workflow_context_ready` / `keep_beta_explicit_handoff` |
+| `GPP-5a` | Completed / no support widening | Repo-intelligence product onboarding contract | GitHub App install + selected repositories + optional `.ao/config.yml`; no end-user Cloud Run, vault, webhook, private key, or gate service hosting |
+| `GPP-5` | Started / no support widening | Repo-intelligence explicit workflow integration | onboarding contract ready; workflow context ingestion still must remain explicit opt-in/read-only |
 | `GPP-6` | Not started | Read-only production E2E over real adapter + repo intelligence | `read_only_e2e_ready` / `blocked_e2e` |
 | `GPP-7` | Not started | Controlled write-side production candidate | `write_candidate_ready` / `keep_rehearsal_only` |
 | `GPP-8` | Not started | Remote PR live-write promotion candidate | `remote_pr_candidate_ready` / `keep_sandbox_only` |
@@ -607,6 +608,19 @@ governed workflow integration without hidden prompt injection.
 3. missing metadata test
 4. disabled-config test
 5. negative grep for hidden MCP/root export/context compiler wiring
+
+**GPP-5a closeout:** PR for issue
+[#553](https://github.com/Halildeu/ao-kernel/issues/553) defines the
+product-facing onboarding contract before workflow ingestion is widened. The
+accepted user path is GitHub App installation, explicit repository selection,
+and optional repo-local `.ao/config.yml` style configuration. Product users are
+not required to host Cloud Run, vault/Secret Manager, webhook endpoints, GitHub
+App private keys, deployment-protection services, or `ao-release-gate`.
+
+GPP-5 remains open for explicit read-only workflow integration. GPP-2 remains
+blocked, and this slice does not authorize live-adapter execution, support
+widening, production platform claims, hidden prompt injection, MCP exposure,
+root export requirements, or context-compiler auto-feed.
 
 ## 13. GPP-6 - Read-Only Production E2E
 

--- a/.claude/plans/GPP-5a-REPO-INTELLIGENCE-PRODUCT-ONBOARDING.md
+++ b/.claude/plans/GPP-5a-REPO-INTELLIGENCE-PRODUCT-ONBOARDING.md
@@ -1,0 +1,71 @@
+# GPP-5a - Repo-Intelligence Product Onboarding Contract
+
+**Issue:** [#553](https://github.com/Halildeu/ao-kernel/issues/553)
+
+**Decision:** `repo_intelligence_product_onboarding_contract_ready_no_support_widening`
+
+**Status:** completed / no support widening
+
+**Date:** 2026-04-28
+
+## Scope
+
+Define the product-facing repo-intelligence onboarding contract while GPP-2
+remains blocked. This slice does not start live-adapter runtime binding, host
+gate services, configure branch protection, or widen support.
+
+## Decision
+
+Repo-intelligence onboarding for product users is limited to:
+
+1. Install the GitHub App.
+2. Select the repositories the app may inspect.
+3. Optionally add repo-local configuration at an approved `.ao/*` path.
+
+The following remain operator-owned platform infrastructure and must not be
+required from product users:
+
+1. Cloud Run project or service hosting.
+2. Vault, Secret Manager, or secret broker setup.
+3. Webhook endpoint hosting.
+4. GitHub App private-key handling.
+5. `ao-release-gate` check-run service hosting.
+6. Deployment-protection policy service hosting.
+7. Branch-protection cutover.
+
+## Evidence
+
+This work package adds:
+
+1. Runtime validator:
+   `ao_kernel/_internal/repo_intelligence/product_onboarding.py`
+2. Public facade:
+   `ao_kernel.repo_intelligence.validate_repo_intelligence_product_onboarding`
+3. Contract schema:
+   `ao_kernel/defaults/schemas/repo-intelligence-product-onboarding.schema.v1.json`
+4. Behavior tests:
+   `tests/test_repo_intelligence_product_onboarding.py`
+
+The validator accepts only a read-only, explicit opt-in onboarding shape. It
+blocks end-user Cloud Run, vault, webhook, private-key, deployment-protection
+service, and release-gate service requirements. It also blocks hidden prompt
+injection, MCP exposure, root export requirements, context-compiler auto-feed,
+implicit vector/artifact writes, live-adapter execution, support widening, and
+production platform claims.
+
+## Non-Goals
+
+1. No GitHub App installation automation is added in this slice.
+2. No GitHub API calls are made by the validator.
+3. No repository artifacts are written by the validator.
+4. No workflow runtime ingestion or context compiler wiring is enabled.
+5. No GPP-2 deployment-protection or release-gate hosting evidence is claimed.
+
+## Exit Decision
+
+`repo_intelligence_product_onboarding_contract_ready_no_support_widening`
+
+GPP-5 can continue from this contract into explicit read-only workflow
+integration, but GPP-2 remains blocked and the program still forbids support
+widening or production platform claims until a later explicit promotion
+decision.

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -195,6 +195,12 @@
       "decision": "operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/551",
       "record": ".claude/plans/GPP-2ac-OPERATOR-GATE-END-USER-BOUNDARY.md"
+    },
+    {
+      "id": "GPP-5a",
+      "decision": "repo_intelligence_product_onboarding_contract_ready_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/553",
+      "record": ".claude/plans/GPP-5a-REPO-INTELLIGENCE-PRODUCT-ONBOARDING.md"
     }
   ],
   "blocked_wps": [
@@ -274,7 +280,7 @@
   "next_allowed_actions": [
     "treat the GPP-2 deployment-protection policy service as operator-owned platform infrastructure, not an end-user setup requirement",
     "prioritize repo-intelligence onboarding as a read-only product workflow that requires GitHub App installation and repository selection, not Cloud Run, vault, webhook, or private-key setup by each user",
-    "open GPP-5 repo-intelligence workflow integration only as explicit opt-in or read-only work while support_widening_allowed=false and production_platform_claim_allowed=false",
+    "continue GPP-5 repo-intelligence workflow integration only behind explicit opt-in or read-only onboarding while support_widening_allowed=false and production_platform_claim_allowed=false",
     "run scripts/policy_service_cloud_run_bootstrap_attest.py to verify required GitHub repository variable handles before dispatching the Cloud Run deploy workflow, and treat metadata_ready as repository-variable evidence only",
     "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work",
     "configure or verify the GitHub App webhook URL only after the deployed policy service endpoint is health-checked",

--- a/ao_kernel/_internal/repo_intelligence/product_onboarding.py
+++ b/ao_kernel/_internal/repo_intelligence/product_onboarding.py
@@ -1,0 +1,181 @@
+"""Product onboarding guardrails for repo-intelligence workflows.
+
+This module validates the product-facing repo-intelligence onboarding shape.
+It does not install GitHub Apps, call GitHub, write repo artifacts, inject
+context, expose MCP tools, or bind the live adapter.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+SCHEMA_VERSION = "1"
+ARTIFACT_KIND = "repo_intelligence_product_onboarding"
+SUPPORT_TIER = "beta_read_only_product_onboarding"
+INSTALLATION = "required"
+REPOSITORY_SELECTION = "selected_repositories"
+PERMISSION_BOUNDARY = "read_only_repo_intelligence"
+WORKFLOW_MODE = "read_only"
+WORKFLOW_ACTIVATION = "explicit_opt_in"
+
+APPROVED_REPO_CONFIG_PATHS = frozenset(
+    {
+        ".ao/config.yml",
+        ".ao/config.yaml",
+        ".ao/repo-intelligence.yml",
+        ".ao/repo-intelligence.yaml",
+        ".ao/repo-intelligence.json",
+    }
+)
+
+_END_USER_INFRA_FALSE_FIELDS = {
+    "cloud_run_required": "end_user_cloud_run_required_not_false",
+    "vault_required": "end_user_vault_required_not_false",
+    "webhook_required": "end_user_webhook_required_not_false",
+    "github_app_private_key_required": "end_user_github_app_private_key_required_not_false",
+    "release_gate_service_required": "end_user_release_gate_service_required_not_false",
+    "deployment_protection_service_required": "end_user_deployment_protection_service_required_not_false",
+}
+
+_SAFETY_FALSE_FIELDS = {
+    "hidden_prompt_injection": "safety_hidden_prompt_injection_not_false",
+    "mcp_tool_exposure": "safety_mcp_tool_exposure_not_false",
+    "root_export_required": "safety_root_export_required_not_false",
+    "context_compiler_auto_feed": "safety_context_compiler_auto_feed_not_false",
+    "implicit_vector_writes": "safety_implicit_vector_writes_not_false",
+    "implicit_artifact_writes": "safety_implicit_artifact_writes_not_false",
+    "live_adapter_execution": "safety_live_adapter_execution_not_false",
+    "support_widening": "safety_support_widening_not_false",
+    "production_platform_claim": "safety_production_platform_claim_not_false",
+}
+
+
+def validate_repo_intelligence_product_onboarding(config: Mapping[str, Any] | None) -> JsonDict:
+    """Validate the repo-intelligence product onboarding contract.
+
+    Disabled or absent config is a no-op. Enabled config is accepted only when
+    the product user path is limited to GitHub App installation, explicit
+    repository selection, and optional repo-local configuration.
+    """
+    if not config or config.get("enabled") is not True:
+        return {
+            "status": "disabled",
+            "enabled": False,
+            "decision": "repo_intelligence_product_onboarding_not_enabled",
+        }
+
+    findings: list[str] = []
+    if _string(config.get("schema_version")) != SCHEMA_VERSION:
+        findings.append("schema_version_invalid")
+    if _string(config.get("artifact_kind")) != ARTIFACT_KIND:
+        findings.append("artifact_kind_invalid")
+    if _string(config.get("support_tier")) != SUPPORT_TIER:
+        findings.append("support_tier_not_beta_read_only_product_onboarding")
+
+    setup = _mapping(config.get("setup"))
+    if not setup:
+        findings.append("setup_missing")
+    github_app = _mapping(setup.get("github_app"))
+    repo_local_config = _mapping(setup.get("repo_local_config"))
+    end_user_infra = _mapping(setup.get("end_user_infrastructure"))
+    workflow = _mapping(config.get("workflow"))
+    safety = _mapping(config.get("safety"))
+
+    if not github_app:
+        findings.append("github_app_missing")
+    if _string(github_app.get("installation")) != INSTALLATION:
+        findings.append("github_app_installation_not_required")
+    if _string(github_app.get("repository_selection")) != REPOSITORY_SELECTION:
+        findings.append("github_app_repository_selection_not_selected_repositories")
+    if _string(github_app.get("permission_boundary")) != PERMISSION_BOUNDARY:
+        findings.append("github_app_permission_boundary_not_read_only_repo_intelligence")
+
+    if not repo_local_config:
+        findings.append("repo_local_config_missing")
+    repo_config_path = _string(repo_local_config.get("path"))
+    if repo_config_path not in APPROVED_REPO_CONFIG_PATHS:
+        findings.append("repo_local_config_path_not_approved")
+    if repo_local_config.get("required") is not False:
+        findings.append("repo_local_config_required_not_false")
+
+    if not end_user_infra:
+        findings.append("end_user_infrastructure_missing")
+    _require_false_fields(end_user_infra, _END_USER_INFRA_FALSE_FIELDS, findings)
+
+    if not workflow:
+        findings.append("workflow_missing")
+    if _string(workflow.get("mode")) != WORKFLOW_MODE:
+        findings.append("workflow_mode_not_read_only")
+    if _string(workflow.get("activation")) != WORKFLOW_ACTIVATION:
+        findings.append("workflow_activation_not_explicit_opt_in")
+    if workflow.get("default_enabled") is not False:
+        findings.append("workflow_default_enabled_not_false")
+    if workflow.get("default_auto_feed") is not False:
+        findings.append("workflow_default_auto_feed_not_false")
+
+    if not safety:
+        findings.append("safety_missing")
+    _require_false_fields(safety, _SAFETY_FALSE_FIELDS, findings)
+
+    if findings:
+        return {
+            "status": "blocked",
+            "enabled": True,
+            "decision": "blocked_repo_intelligence_product_onboarding",
+            "findings": sorted(set(findings)),
+            "support_widening": False,
+            "production_platform_claim": False,
+            "live_adapter_execution_allowed": False,
+        }
+
+    return {
+        "status": "accepted",
+        "enabled": True,
+        "decision": "accepted_repo_intelligence_product_onboarding",
+        "support_tier": SUPPORT_TIER,
+        "required_end_user_steps": [
+            "install_github_app",
+            "select_repositories",
+        ],
+        "optional_repo_config_path": repo_config_path,
+        "operator_owned_infrastructure": [
+            "deployment_protection_policy_service",
+            "ao_release_gate_service",
+        ],
+        "end_user_infrastructure_required": {field: False for field in _END_USER_INFRA_FALSE_FIELDS},
+        "workflow": {
+            "mode": WORKFLOW_MODE,
+            "activation": WORKFLOW_ACTIVATION,
+            "default_enabled": False,
+            "default_auto_feed": False,
+        },
+        "safety": {field: False for field in _SAFETY_FALSE_FIELDS},
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution_allowed": False,
+    }
+
+
+def _require_false_fields(
+    payload: Mapping[str, Any],
+    required_false_fields: Mapping[str, str],
+    findings: list[str],
+) -> None:
+    for field, finding in required_false_fields.items():
+        if payload.get(field) is not False:
+            findings.append(finding)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _string(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return ""

--- a/ao_kernel/defaults/schemas/repo-intelligence-product-onboarding.schema.v1.json
+++ b/ao_kernel/defaults/schemas/repo-intelligence-product-onboarding.schema.v1.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:repo-intelligence-product-onboarding:v1",
+  "title": "Repo Intelligence Product Onboarding Contract",
+  "description": "Product-facing repo-intelligence onboarding contract. It requires only GitHub App installation, explicit repository selection, and optional repo-local configuration from product users; it does not authorize hosted gate setup, live adapter execution, hidden prompt injection, or support widening.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "enabled",
+    "support_tier",
+    "setup",
+    "workflow",
+    "safety"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1"
+    },
+    "artifact_kind": {
+      "type": "string",
+      "const": "repo_intelligence_product_onboarding"
+    },
+    "enabled": {
+      "type": "boolean",
+      "const": true
+    },
+    "support_tier": {
+      "type": "string",
+      "const": "beta_read_only_product_onboarding"
+    },
+    "setup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["github_app", "repo_local_config", "end_user_infrastructure"],
+      "properties": {
+        "github_app": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["installation", "repository_selection", "permission_boundary"],
+          "properties": {
+            "installation": {
+              "type": "string",
+              "const": "required"
+            },
+            "repository_selection": {
+              "type": "string",
+              "const": "selected_repositories"
+            },
+            "permission_boundary": {
+              "type": "string",
+              "const": "read_only_repo_intelligence"
+            }
+          }
+        },
+        "repo_local_config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["path", "required"],
+          "properties": {
+            "path": {
+              "type": "string",
+              "enum": [
+                ".ao/config.yml",
+                ".ao/config.yaml",
+                ".ao/repo-intelligence.yml",
+                ".ao/repo-intelligence.yaml",
+                ".ao/repo-intelligence.json"
+              ]
+            },
+            "required": {
+              "type": "boolean",
+              "const": false
+            }
+          }
+        },
+        "end_user_infrastructure": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "cloud_run_required",
+            "vault_required",
+            "webhook_required",
+            "github_app_private_key_required",
+            "release_gate_service_required",
+            "deployment_protection_service_required"
+          ],
+          "properties": {
+            "cloud_run_required": {
+              "type": "boolean",
+              "const": false
+            },
+            "vault_required": {
+              "type": "boolean",
+              "const": false
+            },
+            "webhook_required": {
+              "type": "boolean",
+              "const": false
+            },
+            "github_app_private_key_required": {
+              "type": "boolean",
+              "const": false
+            },
+            "release_gate_service_required": {
+              "type": "boolean",
+              "const": false
+            },
+            "deployment_protection_service_required": {
+              "type": "boolean",
+              "const": false
+            }
+          }
+        }
+      }
+    },
+    "workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "activation", "default_enabled", "default_auto_feed"],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "const": "read_only"
+        },
+        "activation": {
+          "type": "string",
+          "const": "explicit_opt_in"
+        },
+        "default_enabled": {
+          "type": "boolean",
+          "const": false
+        },
+        "default_auto_feed": {
+          "type": "boolean",
+          "const": false
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hidden_prompt_injection",
+        "mcp_tool_exposure",
+        "root_export_required",
+        "context_compiler_auto_feed",
+        "implicit_vector_writes",
+        "implicit_artifact_writes",
+        "live_adapter_execution",
+        "support_widening",
+        "production_platform_claim"
+      ],
+      "properties": {
+        "hidden_prompt_injection": {
+          "type": "boolean",
+          "const": false
+        },
+        "mcp_tool_exposure": {
+          "type": "boolean",
+          "const": false
+        },
+        "root_export_required": {
+          "type": "boolean",
+          "const": false
+        },
+        "context_compiler_auto_feed": {
+          "type": "boolean",
+          "const": false
+        },
+        "implicit_vector_writes": {
+          "type": "boolean",
+          "const": false
+        },
+        "implicit_artifact_writes": {
+          "type": "boolean",
+          "const": false
+        },
+        "live_adapter_execution": {
+          "type": "boolean",
+          "const": false
+        },
+        "support_widening": {
+          "type": "boolean",
+          "const": false
+        },
+        "production_platform_claim": {
+          "type": "boolean",
+          "const": false
+        }
+      }
+    }
+  }
+}

--- a/ao_kernel/repo_intelligence/__init__.py
+++ b/ao_kernel/repo_intelligence/__init__.py
@@ -32,6 +32,7 @@ from ao_kernel._internal.repo_intelligence.root_exporter import (
     export_repo_roots,
 )
 from ao_kernel._internal.repo_intelligence.workflow_opt_in import validate_repo_intelligence_workflow_opt_in
+from ao_kernel._internal.repo_intelligence.product_onboarding import validate_repo_intelligence_product_onboarding
 
 __all__ = [
     "build_agent_context_pack",
@@ -54,4 +55,5 @@ __all__ = [
     "write_repo_vectors",
     "write_repo_vector_write_plan_artifact",
     "validate_repo_intelligence_workflow_opt_in",
+    "validate_repo_intelligence_product_onboarding",
 ]

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -207,6 +207,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-5a"
+        and item["decision"] == "repo_intelligence_product_onboarding_contract_ready_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/553"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -306,7 +313,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(
         action
-        == "open GPP-5 repo-intelligence workflow integration only as explicit opt-in or read-only work while support_widening_allowed=false and production_platform_claim_allowed=false"
+        == "continue GPP-5 repo-intelligence workflow integration only behind explicit opt-in or read-only onboarding while support_widening_allowed=false and production_platform_claim_allowed=false"
         for action in payload["next_allowed_actions"]
     )
     assert any(

--- a/tests/test_repo_intelligence_product_onboarding.py
+++ b/tests/test_repo_intelligence_product_onboarding.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from ao_kernel.repo_intelligence import validate_repo_intelligence_product_onboarding
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = (
+    ROOT / "ao_kernel" / "defaults" / "schemas" / "repo-intelligence-product-onboarding.schema.v1.json"
+)
+
+
+def _schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _valid_contract() -> dict:
+    return {
+        "schema_version": "1",
+        "artifact_kind": "repo_intelligence_product_onboarding",
+        "enabled": True,
+        "support_tier": "beta_read_only_product_onboarding",
+        "setup": {
+            "github_app": {
+                "installation": "required",
+                "repository_selection": "selected_repositories",
+                "permission_boundary": "read_only_repo_intelligence",
+            },
+            "repo_local_config": {
+                "path": ".ao/config.yml",
+                "required": False,
+            },
+            "end_user_infrastructure": {
+                "cloud_run_required": False,
+                "vault_required": False,
+                "webhook_required": False,
+                "github_app_private_key_required": False,
+                "release_gate_service_required": False,
+                "deployment_protection_service_required": False,
+            },
+        },
+        "workflow": {
+            "mode": "read_only",
+            "activation": "explicit_opt_in",
+            "default_enabled": False,
+            "default_auto_feed": False,
+        },
+        "safety": {
+            "hidden_prompt_injection": False,
+            "mcp_tool_exposure": False,
+            "root_export_required": False,
+            "context_compiler_auto_feed": False,
+            "implicit_vector_writes": False,
+            "implicit_artifact_writes": False,
+            "live_adapter_execution": False,
+            "support_widening": False,
+            "production_platform_claim": False,
+        },
+    }
+
+
+def test_repo_intelligence_product_onboarding_schema_accepts_minimal_product_contract() -> None:
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    errors = list(Draft202012Validator(schema).iter_errors(_valid_contract()))
+    assert errors == []
+
+
+def test_repo_intelligence_product_onboarding_schema_rejects_end_user_infra_or_auto_feed() -> None:
+    validator = Draft202012Validator(_schema())
+
+    cloud_run = _valid_contract()
+    cloud_run["setup"]["end_user_infrastructure"]["cloud_run_required"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(cloud_run)
+
+    auto_feed = _valid_contract()
+    auto_feed["workflow"]["default_auto_feed"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(auto_feed)
+
+    support_widening = _valid_contract()
+    support_widening["safety"]["support_widening"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(support_widening)
+
+
+def test_product_onboarding_accepts_github_app_selected_repo_only() -> None:
+    result = validate_repo_intelligence_product_onboarding(_valid_contract())
+
+    assert result["status"] == "accepted"
+    assert result["decision"] == "accepted_repo_intelligence_product_onboarding"
+    assert result["required_end_user_steps"] == ["install_github_app", "select_repositories"]
+    assert result["optional_repo_config_path"] == ".ao/config.yml"
+    assert result["operator_owned_infrastructure"] == [
+        "deployment_protection_policy_service",
+        "ao_release_gate_service",
+    ]
+    assert result["end_user_infrastructure_required"] == {
+        "cloud_run_required": False,
+        "vault_required": False,
+        "webhook_required": False,
+        "github_app_private_key_required": False,
+        "release_gate_service_required": False,
+        "deployment_protection_service_required": False,
+    }
+    assert result["workflow"] == {
+        "mode": "read_only",
+        "activation": "explicit_opt_in",
+        "default_enabled": False,
+        "default_auto_feed": False,
+    }
+    assert result["safety"]["context_compiler_auto_feed"] is False
+    assert result["safety"]["live_adapter_execution"] is False
+    assert result["support_widening"] is False
+    assert result["production_platform_claim"] is False
+    assert result["live_adapter_execution_allowed"] is False
+
+
+def test_product_onboarding_disabled_is_noop() -> None:
+    assert validate_repo_intelligence_product_onboarding(None) == {
+        "status": "disabled",
+        "enabled": False,
+        "decision": "repo_intelligence_product_onboarding_not_enabled",
+    }
+    assert validate_repo_intelligence_product_onboarding({"enabled": False}) == {
+        "status": "disabled",
+        "enabled": False,
+        "decision": "repo_intelligence_product_onboarding_not_enabled",
+    }
+
+
+def test_product_onboarding_blocks_end_user_hosting_and_private_key_requirements() -> None:
+    contract = _valid_contract()
+    contract["setup"]["end_user_infrastructure"]["webhook_required"] = True
+    contract["setup"]["end_user_infrastructure"]["github_app_private_key_required"] = True
+    contract["setup"]["end_user_infrastructure"]["release_gate_service_required"] = True
+
+    result = validate_repo_intelligence_product_onboarding(contract)
+
+    assert result["status"] == "blocked"
+    assert result["decision"] == "blocked_repo_intelligence_product_onboarding"
+    assert "end_user_webhook_required_not_false" in result["findings"]
+    assert "end_user_github_app_private_key_required_not_false" in result["findings"]
+    assert "end_user_release_gate_service_required_not_false" in result["findings"]
+    assert result["support_widening"] is False
+    assert result["production_platform_claim"] is False
+    assert result["live_adapter_execution_allowed"] is False
+
+
+def test_product_onboarding_blocks_implicit_context_feed_or_live_adapter_execution() -> None:
+    contract = _valid_contract()
+    contract["workflow"]["default_enabled"] = True
+    contract["workflow"]["default_auto_feed"] = True
+    contract["safety"]["context_compiler_auto_feed"] = True
+    contract["safety"]["live_adapter_execution"] = True
+
+    result = validate_repo_intelligence_product_onboarding(contract)
+
+    assert result["status"] == "blocked"
+    assert "workflow_default_enabled_not_false" in result["findings"]
+    assert "workflow_default_auto_feed_not_false" in result["findings"]
+    assert "safety_context_compiler_auto_feed_not_false" in result["findings"]
+    assert "safety_live_adapter_execution_not_false" in result["findings"]
+
+
+def test_product_onboarding_blocks_unapproved_repo_config_path_or_support_claim() -> None:
+    contract = _valid_contract()
+    contract["support_tier"] = "production"
+    contract["setup"]["repo_local_config"]["path"] = "../.ao/config.yml"
+    contract["setup"]["repo_local_config"]["required"] = True
+    contract["safety"]["production_platform_claim"] = True
+
+    result = validate_repo_intelligence_product_onboarding(contract)
+
+    assert result["status"] == "blocked"
+    assert "support_tier_not_beta_read_only_product_onboarding" in result["findings"]
+    assert "repo_local_config_path_not_approved" in result["findings"]
+    assert "repo_local_config_required_not_false" in result["findings"]
+    assert "safety_production_platform_claim_not_false" in result["findings"]
+    assert result["support_widening"] is False
+    assert result["production_platform_claim"] is False


### PR DESCRIPTION
## Summary

- Adds a product-facing repo-intelligence onboarding validator and public facade.
- Adds a JSON Schema contract for GitHub App installation + selected repositories + optional repo-local config, while blocking end-user Cloud Run/vault/webhook/private-key/gate-service setup.
- Records GPP-5a in the GPP status docs without unblocking GPP-2 or widening support.

## Validation

- python3 -m pytest tests/test_repo_intelligence_product_onboarding.py tests/test_repo_intelligence_workflow_opt_in_contract.py tests/test_gpp_next.py -q
- python3 -m ruff check ao_kernel/_internal/repo_intelligence/product_onboarding.py ao_kernel/repo_intelligence/__init__.py tests/test_repo_intelligence_product_onboarding.py tests/test_gpp_next.py
- python3 -m json.tool .claude/plans/gpp_status.v1.json
- python3 -m json.tool ao_kernel/defaults/schemas/repo-intelligence-product-onboarding.schema.v1.json
- python3 scripts/gpp_next.py
- git diff --check

Closes #553