### PR TITLE
GPP-5b: add explicit repo-intelligence workflow context

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -310,7 +310,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5a` | Completed / no support widening | Repo-intelligence product onboarding contract | GitHub App install + selected repositories + optional `.ao/config.yml`; no end-user Cloud Run, vault, webhook, private key, or gate service hosting |
-| `GPP-5` | Started / no support widening | Repo-intelligence explicit workflow integration | onboarding contract ready; workflow context ingestion still must remain explicit opt-in/read-only |
+| `GPP-5b` | Completed / no support widening | Repo-intelligence explicit workflow context resolver | product onboarding + explicit handoff validation compose into visible read-only handoff pointer; no auto-feed or runtime execution |
+| `GPP-5` | Started / no support widening | Repo-intelligence explicit workflow integration | onboarding and workflow-context resolver ready; output contract and read-only workflow surface remain |
 | `GPP-6` | Not started | Read-only production E2E over real adapter + repo intelligence | `read_only_e2e_ready` / `blocked_e2e` |
 | `GPP-7` | Not started | Controlled write-side production candidate | `write_candidate_ready` / `keep_rehearsal_only` |
 | `GPP-8` | Not started | Remote PR live-write promotion candidate | `remote_pr_candidate_ready` / `keep_sandbox_only` |
@@ -621,6 +622,18 @@ GPP-5 remains open for explicit read-only workflow integration. GPP-2 remains
 blocked, and this slice does not authorize live-adapter execution, support
 widening, production platform claims, hidden prompt injection, MCP exposure,
 root export requirements, or context-compiler auto-feed.
+
+**GPP-5b closeout:** PR for issue
+[#555](https://github.com/Halildeu/ao-kernel/issues/555) adds a workflow-level
+resolver that composes the product onboarding contract with the existing
+explicit repo-query handoff validator. The accepted result is a visible handoff
+pointer and source metadata only. It does not return hidden prompt content,
+write context artifacts, expose MCP tools, enable root export, auto-feed the
+context compiler, call adapters, or run live-adapter code.
+
+GPP-5 remains open for output contract and read-only workflow surface work.
+GPP-2 remains blocked, and support widening / production platform claims remain
+closed.
 
 ## 13. GPP-6 - Read-Only Production E2E
 

--- a/.claude/plans/GPP-5b-REPO-INTELLIGENCE-WORKFLOW-CONTEXT.md
+++ b/.claude/plans/GPP-5b-REPO-INTELLIGENCE-WORKFLOW-CONTEXT.md
@@ -1,0 +1,69 @@
+# GPP-5b - Repo-Intelligence Explicit Workflow Context
+
+**Issue:** [#555](https://github.com/Halildeu/ao-kernel/issues/555)
+
+**Decision:** `repo_intelligence_explicit_workflow_context_ready_no_support_widening`
+
+**Status:** completed / no support widening
+
+**Date:** 2026-04-28
+
+## Scope
+
+Compose the GPP-5a product onboarding contract with the existing explicit
+repo-query handoff validator so a workflow can resolve repo-intelligence
+context only through an explicit, read-only, operator-visible handoff.
+
+## Decision
+
+The workflow-level repo-intelligence context surface is accepted only when:
+
+1. product onboarding accepts the end-user path as GitHub App installation,
+   selected repositories, and optional repo-local `.ao/*` configuration;
+2. workflow opt-in accepts a current `repo query --output markdown` handoff;
+3. the handoff is operator-visible and not automatically injected into prompts;
+4. context compiler auto-feed remains disabled;
+5. MCP exposure, root export, vector writes, artifact writes, live-adapter
+   execution, support widening, and production platform claims all remain
+   disabled.
+
+The resolver returns handoff metadata and a visible handoff pointer. It does
+not return hidden prompt content, write files, expose MCP tools, call adapters,
+or change workflow runtime defaults.
+
+## Evidence
+
+This work package adds:
+
+1. Runtime resolver:
+   `ao_kernel/_internal/repo_intelligence/workflow_context.py`
+2. Public facade:
+   `ao_kernel.repo_intelligence.resolve_repo_intelligence_workflow_context`
+3. Contract schema:
+   `ao_kernel/defaults/schemas/repo-intelligence-explicit-workflow-context.schema.v1.json`
+4. Behavior tests:
+   `tests/test_repo_intelligence_workflow_context.py`
+
+The behavior tests cover disabled/no-op config, valid visible handoff pointer
+resolution, stale handoff fail-closed behavior, unsafe onboarding fail-closed
+behavior, auto-feed rejection, and the negative guarantee that
+`compile_context()` does not automatically ingest resolved repo-intelligence
+workflow context.
+
+## Non-Goals
+
+1. No GitHub App runtime or webhook hosting is added in this slice.
+2. No context compiler ingestion path is enabled by default.
+3. No MCP repo-intelligence exposure is added.
+4. No root export, vector write, or artifact write is introduced.
+5. No live adapter execution is enabled.
+6. No support tier is widened.
+7. No production platform claim is made.
+
+## Exit Decision
+
+`repo_intelligence_explicit_workflow_context_ready_no_support_widening`
+
+GPP-5 can continue into output contract and read-only workflow surface work.
+GPP-2 remains blocked, and this slice does not authorize live-adapter
+execution or any support/production promotion.

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -201,6 +201,12 @@
       "decision": "repo_intelligence_product_onboarding_contract_ready_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/553",
       "record": ".claude/plans/GPP-5a-REPO-INTELLIGENCE-PRODUCT-ONBOARDING.md"
+    },
+    {
+      "id": "GPP-5b",
+      "decision": "repo_intelligence_explicit_workflow_context_ready_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/555",
+      "record": ".claude/plans/GPP-5b-REPO-INTELLIGENCE-WORKFLOW-CONTEXT.md"
     }
   ],
   "blocked_wps": [
@@ -280,7 +286,7 @@
   "next_allowed_actions": [
     "treat the GPP-2 deployment-protection policy service as operator-owned platform infrastructure, not an end-user setup requirement",
     "prioritize repo-intelligence onboarding as a read-only product workflow that requires GitHub App installation and repository selection, not Cloud Run, vault, webhook, or private-key setup by each user",
-    "continue GPP-5 repo-intelligence workflow integration only behind explicit opt-in or read-only onboarding while support_widening_allowed=false and production_platform_claim_allowed=false",
+    "continue GPP-5 repo-intelligence output contract and read-only workflow surface work behind explicit opt-in while support_widening_allowed=false and production_platform_claim_allowed=false",
     "run scripts/policy_service_cloud_run_bootstrap_attest.py to verify required GitHub repository variable handles before dispatching the Cloud Run deploy workflow, and treat metadata_ready as repository-variable evidence only",
     "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work",
     "configure or verify the GitHub App webhook URL only after the deployed policy service endpoint is health-checked",

--- a/ao_kernel/_internal/repo_intelligence/workflow_context.py
+++ b/ao_kernel/_internal/repo_intelligence/workflow_context.py
@@ -1,0 +1,194 @@
+"""Explicit repo-intelligence workflow context resolver.
+
+This module composes product onboarding and explicit handoff validation into a
+single read-only workflow context contract. It returns metadata and a visible
+handoff pointer; it does not inject prompt context, write artifacts, expose MCP
+tools, or call adapters.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ao_kernel._internal.repo_intelligence.product_onboarding import (
+    validate_repo_intelligence_product_onboarding,
+)
+from ao_kernel._internal.repo_intelligence.workflow_opt_in import validate_repo_intelligence_workflow_opt_in
+
+JsonDict = dict[str, Any]
+
+SCHEMA_VERSION = "1"
+ARTIFACT_KIND = "repo_intelligence_explicit_workflow_context"
+SUPPORT_TIER = "beta_explicit_read_only_workflow_context"
+MODE = "visible_operator_handoff"
+CONSUMER = "workflow_runtime"
+
+_WORKFLOW_CONTEXT_FALSE_FIELDS = {
+    "default_enabled": "workflow_context_default_enabled_not_false",
+    "automatic_prompt_injection": "workflow_context_automatic_prompt_injection_not_false",
+    "context_compiler_auto_feed": "workflow_context_context_compiler_auto_feed_not_false",
+    "write_context_artifacts": "workflow_context_write_context_artifacts_not_false",
+}
+
+_SAFETY_FALSE_FIELDS = {
+    "hidden_prompt_injection": "safety_hidden_prompt_injection_not_false",
+    "mcp_tool_exposure": "safety_mcp_tool_exposure_not_false",
+    "root_export": "safety_root_export_not_false",
+    "context_compiler_auto_feed": "safety_context_compiler_auto_feed_not_false",
+    "vector_writes": "safety_vector_writes_not_false",
+    "artifact_writes": "safety_artifact_writes_not_false",
+    "live_adapter_execution": "safety_live_adapter_execution_not_false",
+    "support_widening": "safety_support_widening_not_false",
+    "production_platform_claim": "safety_production_platform_claim_not_false",
+}
+
+
+def resolve_repo_intelligence_workflow_context(
+    config: Mapping[str, Any] | None,
+    *,
+    project_root: Path,
+) -> JsonDict:
+    """Resolve explicit repo-intelligence context for a workflow.
+
+    Disabled or absent config is a no-op. Enabled config must compose an
+    accepted product onboarding contract with an accepted explicit handoff. The
+    returned context is a pointer and metadata bundle only; callers must provide
+    the Markdown as visible input and must not auto-feed it into prompts.
+    """
+    if not config or config.get("enabled") is not True:
+        return {
+            "status": "disabled",
+            "enabled": False,
+            "decision": "repo_intelligence_workflow_context_not_enabled",
+        }
+
+    findings: list[str] = []
+    if _string(config.get("schema_version")) != SCHEMA_VERSION:
+        findings.append("schema_version_invalid")
+    if _string(config.get("artifact_kind")) != ARTIFACT_KIND:
+        findings.append("artifact_kind_invalid")
+    if _string(config.get("support_tier")) != SUPPORT_TIER:
+        findings.append("support_tier_not_beta_explicit_read_only_workflow_context")
+
+    product_onboarding_config = _mapping(config.get("product_onboarding"))
+    workflow_opt_in_config = _mapping(config.get("workflow_opt_in"))
+    workflow_context = _mapping(config.get("workflow_context"))
+    safety = _mapping(config.get("safety"))
+
+    if not product_onboarding_config:
+        findings.append("product_onboarding_missing")
+    if not workflow_opt_in_config:
+        findings.append("workflow_opt_in_missing")
+    if not workflow_context:
+        findings.append("workflow_context_missing")
+    if not safety:
+        findings.append("safety_missing")
+
+    if _string(workflow_context.get("mode")) != MODE:
+        findings.append("workflow_context_mode_not_visible_operator_handoff")
+    if _string(workflow_context.get("consumer")) != CONSUMER:
+        findings.append("workflow_context_consumer_not_workflow_runtime")
+    if workflow_context.get("operator_visible") is not True:
+        findings.append("workflow_context_operator_visible_not_true")
+    if workflow_context.get("requires_behavior_tests") is not True:
+        findings.append("workflow_context_requires_behavior_tests_not_true")
+    _require_false_fields(workflow_context, _WORKFLOW_CONTEXT_FALSE_FIELDS, findings)
+    _require_false_fields(safety, _SAFETY_FALSE_FIELDS, findings)
+
+    product_result = validate_repo_intelligence_product_onboarding(product_onboarding_config)
+    opt_in_result = validate_repo_intelligence_workflow_opt_in(workflow_opt_in_config, project_root=project_root)
+
+    if product_result.get("status") != "accepted":
+        findings.extend(_nested_findings("product_onboarding", product_result))
+    if opt_in_result.get("status") != "accepted":
+        findings.extend(_nested_findings("workflow_opt_in", opt_in_result))
+
+    if findings:
+        return {
+            "status": "blocked",
+            "enabled": True,
+            "decision": "blocked_repo_intelligence_workflow_context",
+            "findings": sorted(set(findings)),
+            "product_onboarding": _summary(product_result),
+            "workflow_opt_in": _summary(opt_in_result),
+            "support_widening": False,
+            "production_platform_claim": False,
+            "live_adapter_execution_allowed": False,
+        }
+
+    handoff = _mapping(opt_in_result.get("handoff"))
+    return {
+        "status": "accepted",
+        "enabled": True,
+        "decision": "accepted_repo_intelligence_workflow_context",
+        "support_tier": SUPPORT_TIER,
+        "context": {
+            "mode": MODE,
+            "consumer": CONSUMER,
+            "handoff_path": handoff.get("path", ""),
+            "markdown_sha256": handoff.get("markdown_sha256", ""),
+            "handoff_support_tier": handoff.get("support_tier", ""),
+            "operator_visible": True,
+            "automatic_prompt_injection": False,
+            "context_compiler_auto_feed": False,
+            "write_context_artifacts": False,
+        },
+        "source_metadata": opt_in_result.get("source_metadata", {}),
+        "product_onboarding": {
+            "decision": product_result["decision"],
+            "required_end_user_steps": product_result["required_end_user_steps"],
+            "optional_repo_config_path": product_result["optional_repo_config_path"],
+            "operator_owned_infrastructure": product_result["operator_owned_infrastructure"],
+        },
+        "workflow_opt_in": {
+            "decision": opt_in_result["decision"],
+            "handoff": opt_in_result["handoff"],
+        },
+        "safety": {field: False for field in _SAFETY_FALSE_FIELDS},
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution_allowed": False,
+    }
+
+
+def _require_false_fields(
+    payload: Mapping[str, Any],
+    required_false_fields: Mapping[str, str],
+    findings: list[str],
+) -> None:
+    for field, finding in required_false_fields.items():
+        if payload.get(field) is not False:
+            findings.append(finding)
+
+
+def _nested_findings(prefix: str, result: Mapping[str, Any]) -> list[str]:
+    findings = result.get("findings")
+    if isinstance(findings, list) and findings:
+        return [f"{prefix}_{_string(item)}" for item in findings]
+    decision = _string(result.get("decision")) or "not_accepted"
+    return [f"{prefix}_{decision}"]
+
+
+def _summary(result: Mapping[str, Any]) -> JsonDict:
+    summary: JsonDict = {
+        "status": result.get("status", "unknown"),
+        "decision": result.get("decision", "unknown"),
+    }
+    findings = result.get("findings")
+    if isinstance(findings, list):
+        summary["findings"] = findings
+    return summary
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _string(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return ""

--- a/ao_kernel/defaults/schemas/repo-intelligence-explicit-workflow-context.schema.v1.json
+++ b/ao_kernel/defaults/schemas/repo-intelligence-explicit-workflow-context.schema.v1.json
@@ -1,0 +1,371 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:repo-intelligence-explicit-workflow-context:v1",
+  "title": "Repo Intelligence Explicit Workflow Context Contract",
+  "description": "Workflow-level contract that composes product onboarding and explicit repo-query handoff validation. It returns visible handoff metadata only and does not authorize hidden prompt injection, MCP exposure, root export, context-compiler auto-feed, live adapter execution, support widening, or production platform claims.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "enabled",
+    "support_tier",
+    "product_onboarding",
+    "workflow_opt_in",
+    "workflow_context",
+    "safety"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1"
+    },
+    "artifact_kind": {
+      "type": "string",
+      "const": "repo_intelligence_explicit_workflow_context"
+    },
+    "enabled": {
+      "type": "boolean",
+      "const": true
+    },
+    "support_tier": {
+      "type": "string",
+      "const": "beta_explicit_read_only_workflow_context"
+    },
+    "product_onboarding": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "schema_version",
+        "artifact_kind",
+        "enabled",
+        "support_tier",
+        "setup",
+        "workflow",
+        "safety"
+      ],
+      "properties": {
+        "schema_version": {
+          "type": "string",
+          "const": "1"
+        },
+        "artifact_kind": {
+          "type": "string",
+          "const": "repo_intelligence_product_onboarding"
+        },
+        "enabled": {
+          "type": "boolean",
+          "const": true
+        },
+        "support_tier": {
+          "type": "string",
+          "const": "beta_read_only_product_onboarding"
+        },
+        "setup": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["github_app", "repo_local_config", "end_user_infrastructure"],
+          "properties": {
+            "github_app": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": ["installation", "repository_selection", "permission_boundary"],
+              "properties": {
+                "installation": {
+                  "type": "string",
+                  "const": "required"
+                },
+                "repository_selection": {
+                  "type": "string",
+                  "const": "selected_repositories"
+                },
+                "permission_boundary": {
+                  "type": "string",
+                  "const": "read_only_repo_intelligence"
+                }
+              }
+            },
+            "repo_local_config": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": ["path", "required"],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "enum": [
+                    ".ao/config.yml",
+                    ".ao/config.yaml",
+                    ".ao/repo-intelligence.yml",
+                    ".ao/repo-intelligence.yaml",
+                    ".ao/repo-intelligence.json"
+                  ]
+                },
+                "required": {
+                  "type": "boolean",
+                  "const": false
+                }
+              }
+            },
+            "end_user_infrastructure": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": [
+                "cloud_run_required",
+                "vault_required",
+                "webhook_required",
+                "github_app_private_key_required",
+                "release_gate_service_required",
+                "deployment_protection_service_required"
+              ],
+              "properties": {
+                "cloud_run_required": {
+                  "type": "boolean",
+                  "const": false
+                },
+                "vault_required": {
+                  "type": "boolean",
+                  "const": false
+                },
+                "webhook_required": {
+                  "type": "boolean",
+                  "const": false
+                },
+                "github_app_private_key_required": {
+                  "type": "boolean",
+                  "const": false
+                },
+                "release_gate_service_required": {
+                  "type": "boolean",
+                  "const": false
+                },
+                "deployment_protection_service_required": {
+                  "type": "boolean",
+                  "const": false
+                }
+              }
+            }
+          }
+        },
+        "workflow": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["mode", "activation", "default_enabled", "default_auto_feed"],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "const": "read_only"
+            },
+            "activation": {
+              "type": "string",
+              "const": "explicit_opt_in"
+            },
+            "default_enabled": {
+              "type": "boolean",
+              "const": false
+            },
+            "default_auto_feed": {
+              "type": "boolean",
+              "const": false
+            }
+          }
+        },
+        "safety": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "hidden_prompt_injection",
+            "mcp_tool_exposure",
+            "root_export_required",
+            "context_compiler_auto_feed",
+            "implicit_vector_writes",
+            "implicit_artifact_writes",
+            "live_adapter_execution",
+            "support_widening",
+            "production_platform_claim"
+          ],
+          "properties": {
+            "hidden_prompt_injection": {
+              "type": "boolean",
+              "const": false
+            },
+            "mcp_tool_exposure": {
+              "type": "boolean",
+              "const": false
+            },
+            "root_export_required": {
+              "type": "boolean",
+              "const": false
+            },
+            "context_compiler_auto_feed": {
+              "type": "boolean",
+              "const": false
+            },
+            "implicit_vector_writes": {
+              "type": "boolean",
+              "const": false
+            },
+            "implicit_artifact_writes": {
+              "type": "boolean",
+              "const": false
+            },
+            "live_adapter_execution": {
+              "type": "boolean",
+              "const": false
+            },
+            "support_widening": {
+              "type": "boolean",
+              "const": false
+            },
+            "production_platform_claim": {
+              "type": "boolean",
+              "const": false
+            }
+          }
+        }
+      }
+    },
+    "workflow_opt_in": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "source",
+        "handoff_path",
+        "require_fresh",
+        "expected_namespace",
+        "support_tier"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "const": true
+        },
+        "source": {
+          "type": "string",
+          "const": "explicit_handoff_file"
+        },
+        "handoff_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "require_fresh": {
+          "type": "boolean",
+          "const": true
+        },
+        "expected_namespace": {
+          "type": "string",
+          "pattern": "^repo_chunk::[^:]+::[^:]+::$"
+        },
+        "support_tier": {
+          "type": "string",
+          "const": "beta_explicit_handoff"
+        },
+        "expected_markdown_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "workflow_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "consumer",
+        "operator_visible",
+        "default_enabled",
+        "automatic_prompt_injection",
+        "context_compiler_auto_feed",
+        "write_context_artifacts",
+        "requires_behavior_tests"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "const": "visible_operator_handoff"
+        },
+        "consumer": {
+          "type": "string",
+          "const": "workflow_runtime"
+        },
+        "operator_visible": {
+          "type": "boolean",
+          "const": true
+        },
+        "default_enabled": {
+          "type": "boolean",
+          "const": false
+        },
+        "automatic_prompt_injection": {
+          "type": "boolean",
+          "const": false
+        },
+        "context_compiler_auto_feed": {
+          "type": "boolean",
+          "const": false
+        },
+        "write_context_artifacts": {
+          "type": "boolean",
+          "const": false
+        },
+        "requires_behavior_tests": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hidden_prompt_injection",
+        "mcp_tool_exposure",
+        "root_export",
+        "context_compiler_auto_feed",
+        "vector_writes",
+        "artifact_writes",
+        "live_adapter_execution",
+        "support_widening",
+        "production_platform_claim"
+      ],
+      "properties": {
+        "hidden_prompt_injection": {
+          "type": "boolean",
+          "const": false
+        },
+        "mcp_tool_exposure": {
+          "type": "boolean",
+          "const": false
+        },
+        "root_export": {
+          "type": "boolean",
+          "const": false
+        },
+        "context_compiler_auto_feed": {
+          "type": "boolean",
+          "const": false
+        },
+        "vector_writes": {
+          "type": "boolean",
+          "const": false
+        },
+        "artifact_writes": {
+          "type": "boolean",
+          "const": false
+        },
+        "live_adapter_execution": {
+          "type": "boolean",
+          "const": false
+        },
+        "support_widening": {
+          "type": "boolean",
+          "const": false
+        },
+        "production_platform_claim": {
+          "type": "boolean",
+          "const": false
+        }
+      }
+    }
+  }
+}

--- a/ao_kernel/repo_intelligence/__init__.py
+++ b/ao_kernel/repo_intelligence/__init__.py
@@ -33,6 +33,7 @@ from ao_kernel._internal.repo_intelligence.root_exporter import (
 )
 from ao_kernel._internal.repo_intelligence.workflow_opt_in import validate_repo_intelligence_workflow_opt_in
 from ao_kernel._internal.repo_intelligence.product_onboarding import validate_repo_intelligence_product_onboarding
+from ao_kernel._internal.repo_intelligence.workflow_context import resolve_repo_intelligence_workflow_context
 
 __all__ = [
     "build_agent_context_pack",
@@ -56,4 +57,5 @@ __all__ = [
     "write_repo_vector_write_plan_artifact",
     "validate_repo_intelligence_workflow_opt_in",
     "validate_repo_intelligence_product_onboarding",
+    "resolve_repo_intelligence_workflow_context",
 ]

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -214,6 +214,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-5b"
+        and item["decision"] == "repo_intelligence_explicit_workflow_context_ready_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/555"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -313,7 +320,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(
         action
-        == "continue GPP-5 repo-intelligence workflow integration only behind explicit opt-in or read-only onboarding while support_widening_allowed=false and production_platform_claim_allowed=false"
+        == "continue GPP-5 repo-intelligence output contract and read-only workflow surface work behind explicit opt-in while support_widening_allowed=false and production_platform_claim_allowed=false"
         for action in payload["next_allowed_actions"]
     )
     assert any(

--- a/tests/test_repo_intelligence_workflow_context.py
+++ b/tests/test_repo_intelligence_workflow_context.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from ao_kernel.context.context_compiler import compile_context
+from ao_kernel.repo_intelligence import (
+    build_repo_query_context_pack,
+    resolve_repo_intelligence_workflow_context,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = (
+    ROOT / "ao_kernel" / "defaults" / "schemas" / "repo-intelligence-explicit-workflow-context.schema.v1.json"
+)
+
+
+def _schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _product_onboarding() -> dict:
+    return {
+        "schema_version": "1",
+        "artifact_kind": "repo_intelligence_product_onboarding",
+        "enabled": True,
+        "support_tier": "beta_read_only_product_onboarding",
+        "setup": {
+            "github_app": {
+                "installation": "required",
+                "repository_selection": "selected_repositories",
+                "permission_boundary": "read_only_repo_intelligence",
+            },
+            "repo_local_config": {
+                "path": ".ao/config.yml",
+                "required": False,
+            },
+            "end_user_infrastructure": {
+                "cloud_run_required": False,
+                "vault_required": False,
+                "webhook_required": False,
+                "github_app_private_key_required": False,
+                "release_gate_service_required": False,
+                "deployment_protection_service_required": False,
+            },
+        },
+        "workflow": {
+            "mode": "read_only",
+            "activation": "explicit_opt_in",
+            "default_enabled": False,
+            "default_auto_feed": False,
+        },
+        "safety": {
+            "hidden_prompt_injection": False,
+            "mcp_tool_exposure": False,
+            "root_export_required": False,
+            "context_compiler_auto_feed": False,
+            "implicit_vector_writes": False,
+            "implicit_artifact_writes": False,
+            "live_adapter_execution": False,
+            "support_widening": False,
+            "production_platform_claim": False,
+        },
+    }
+
+
+def _workflow_context_config(handoff_path: str = "repo-query-handoff.md") -> dict:
+    return {
+        "schema_version": "1",
+        "artifact_kind": "repo_intelligence_explicit_workflow_context",
+        "enabled": True,
+        "support_tier": "beta_explicit_read_only_workflow_context",
+        "product_onboarding": _product_onboarding(),
+        "workflow_opt_in": {
+            "enabled": True,
+            "source": "explicit_handoff_file",
+            "handoff_path": handoff_path,
+            "require_fresh": True,
+            "expected_namespace": "repo_chunk::demo::space::",
+            "support_tier": "beta_explicit_handoff",
+        },
+        "workflow_context": {
+            "mode": "visible_operator_handoff",
+            "consumer": "workflow_runtime",
+            "operator_visible": True,
+            "default_enabled": False,
+            "automatic_prompt_injection": False,
+            "context_compiler_auto_feed": False,
+            "write_context_artifacts": False,
+            "requires_behavior_tests": True,
+        },
+        "safety": {
+            "hidden_prompt_injection": False,
+            "mcp_tool_exposure": False,
+            "root_export": False,
+            "context_compiler_auto_feed": False,
+            "vector_writes": False,
+            "artifact_writes": False,
+            "live_adapter_execution": False,
+            "support_widening": False,
+            "production_platform_claim": False,
+        },
+    }
+
+
+def test_explicit_workflow_context_schema_accepts_visible_read_only_contract() -> None:
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    errors = list(Draft202012Validator(schema).iter_errors(_workflow_context_config()))
+    assert errors == []
+
+
+def test_explicit_workflow_context_schema_rejects_auto_feed_or_end_user_hosting() -> None:
+    validator = Draft202012Validator(_schema())
+
+    auto_feed = _workflow_context_config()
+    auto_feed["workflow_context"]["context_compiler_auto_feed"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(auto_feed)
+
+    end_user_cloud_run = _workflow_context_config()
+    end_user_cloud_run["product_onboarding"]["setup"]["end_user_infrastructure"]["cloud_run_required"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(end_user_cloud_run)
+
+    production_claim = _workflow_context_config()
+    production_claim["safety"]["production_platform_claim"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(production_claim)
+
+
+def test_explicit_workflow_context_disabled_is_noop(tmp_path: Path) -> None:
+    assert resolve_repo_intelligence_workflow_context(None, project_root=tmp_path) == {
+        "status": "disabled",
+        "enabled": False,
+        "decision": "repo_intelligence_workflow_context_not_enabled",
+    }
+    assert resolve_repo_intelligence_workflow_context({"enabled": False}, project_root=tmp_path) == {
+        "status": "disabled",
+        "enabled": False,
+        "decision": "repo_intelligence_workflow_context_not_enabled",
+    }
+
+
+def test_explicit_workflow_context_accepts_visible_handoff_pointer(tmp_path: Path) -> None:
+    handoff_path = tmp_path / "repo-query-handoff.md"
+    handoff_path.write_text(build_repo_query_context_pack(query_result=_query_result()), encoding="utf-8")
+
+    result = resolve_repo_intelligence_workflow_context(
+        _workflow_context_config(),
+        project_root=tmp_path,
+    )
+
+    assert result["status"] == "accepted"
+    assert result["decision"] == "accepted_repo_intelligence_workflow_context"
+    assert result["context"]["mode"] == "visible_operator_handoff"
+    assert result["context"]["consumer"] == "workflow_runtime"
+    assert result["context"]["handoff_path"] == str(handoff_path)
+    assert len(result["context"]["markdown_sha256"]) == 64
+    assert result["context"]["operator_visible"] is True
+    assert result["context"]["automatic_prompt_injection"] is False
+    assert result["context"]["context_compiler_auto_feed"] is False
+    assert result["context"]["write_context_artifacts"] is False
+    assert result["source_metadata"]["vector_namespace_key_prefix"] == "repo_chunk::demo::space::"
+    assert result["source_metadata"]["source_paths"] == ["pkg/main.py"]
+    assert result["product_onboarding"]["required_end_user_steps"] == ["install_github_app", "select_repositories"]
+    assert result["workflow_opt_in"]["decision"] == "accepted_repo_intelligence_workflow_opt_in"
+    assert result["safety"] == {
+        "hidden_prompt_injection": False,
+        "mcp_tool_exposure": False,
+        "root_export": False,
+        "context_compiler_auto_feed": False,
+        "vector_writes": False,
+        "artifact_writes": False,
+        "live_adapter_execution": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+    }
+    assert result["support_widening"] is False
+    assert result["production_platform_claim"] is False
+    assert result["live_adapter_execution_allowed"] is False
+
+
+def test_explicit_workflow_context_blocks_stale_or_unsafe_handoff(tmp_path: Path) -> None:
+    query_result = _query_result()
+    query_result["summary"]["stale_candidates"] = 1
+    handoff_path = tmp_path / "stale.md"
+    handoff_path.write_text(build_repo_query_context_pack(query_result=query_result), encoding="utf-8")
+
+    result = resolve_repo_intelligence_workflow_context(
+        _workflow_context_config("stale.md"),
+        project_root=tmp_path,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["decision"] == "blocked_repo_intelligence_workflow_context"
+    assert "workflow_opt_in_freshness_not_current_only" in result["findings"]
+    assert "workflow_opt_in_stale_candidates_not_zero" in result["findings"]
+    assert result["workflow_opt_in"]["decision"] == "blocked_repo_intelligence_workflow_opt_in"
+    assert result["support_widening"] is False
+    assert result["production_platform_claim"] is False
+    assert result["live_adapter_execution_allowed"] is False
+
+
+def test_explicit_workflow_context_blocks_unsafe_onboarding_or_auto_feed(tmp_path: Path) -> None:
+    handoff_path = tmp_path / "repo-query-handoff.md"
+    handoff_path.write_text(build_repo_query_context_pack(query_result=_query_result()), encoding="utf-8")
+    config = _workflow_context_config()
+    config["product_onboarding"]["setup"]["end_user_infrastructure"]["webhook_required"] = True
+    config["workflow_context"]["default_enabled"] = True
+    config["workflow_context"]["automatic_prompt_injection"] = True
+    config["safety"]["mcp_tool_exposure"] = True
+
+    result = resolve_repo_intelligence_workflow_context(config, project_root=tmp_path)
+
+    assert result["status"] == "blocked"
+    assert "product_onboarding_end_user_webhook_required_not_false" in result["findings"]
+    assert "workflow_context_default_enabled_not_false" in result["findings"]
+    assert "workflow_context_automatic_prompt_injection_not_false" in result["findings"]
+    assert "safety_mcp_tool_exposure_not_false" in result["findings"]
+
+
+def test_explicit_workflow_context_does_not_auto_ingest_into_context_compiler(tmp_path: Path) -> None:
+    handoff_path = tmp_path / "repo-query-handoff.md"
+    handoff = build_repo_query_context_pack(query_result=_query_result())
+    handoff_path.write_text(handoff, encoding="utf-8")
+    resolved = resolve_repo_intelligence_workflow_context(_workflow_context_config(), project_root=tmp_path)
+
+    result = compile_context(
+        {
+            "session_id": "test",
+            "ephemeral_decisions": [],
+            "repo_intelligence_workflow_context": resolved,
+            "repo_query_context": handoff,
+        },
+        profile="TASK_EXECUTION",
+    )
+
+    assert result.preamble == ""
+    assert "Repo Query Context Pack" not in result.preamble
+    assert result.items_included == 0
+
+
+def _query_result() -> dict:
+    return {
+        "schema_version": "1",
+        "artifact_kind": "repo_vector_query_result",
+        "generator": {
+            "name": "ao-kernel",
+            "version": "4.0.0",
+            "generated_at": "2026-04-27T00:00:00Z",
+        },
+        "project": {
+            "root": ".",
+            "root_name": "demo",
+            "name": "demo",
+            "root_identity_sha256": "a" * 64,
+        },
+        "retriever": {
+            "name": "ao-kernel-repo-vector-retriever",
+            "version": "repo-vector-retriever.v1",
+            "mode": "query_vectors",
+        },
+        "query": {
+            "text": "where is run defined",
+            "top_k": 5,
+            "candidate_limit": 50,
+            "min_similarity": 0.3,
+            "max_tokens": 2000,
+            "max_snippet_chars": 1200,
+            "filters": {
+                "source_path_prefix": "pkg/",
+                "language": "python",
+                "symbol": "run",
+            },
+        },
+        "embedding_space": {
+            "provider": "openai",
+            "model": "text-embedding-3-small",
+            "dimension": 1536,
+            "embedding_space_id": "b" * 64,
+        },
+        "vector_namespace": {
+            "key_prefix": "repo_chunk::demo::space::",
+            "project_root_identity_sha256": "a" * 64,
+        },
+        "source_artifacts": {
+            "repo_chunks_sha256": "c" * 64,
+            "repo_vector_index_manifest_sha256": "d" * 64,
+        },
+        "summary": {
+            "matches": 1,
+            "candidate_matches": 1,
+            "filtered_candidates": 1,
+            "stale_candidates": 0,
+            "embedding_calls": 1,
+            "estimated_tokens": 12,
+            "truncated_results": 0,
+        },
+        "results": [
+            {
+                "key": "repo_chunk::demo::space::repo-chunk-v1:1",
+                "similarity": 0.9876,
+                "source_path": "pkg/main.py",
+                "start_line": 3,
+                "end_line": 4,
+                "language": "python",
+                "kind": "symbol",
+                "module": "pkg.main",
+                "symbol": "run",
+                "chunk_id": "repo-chunk-v1:1",
+                "content_sha256": "e" * 64,
+                "token_estimate": 12,
+                "snippet": "def run():\n    return VALUE\n",
+                "snippet_truncated": False,
+                "content_status": "current",
+            }
+        ],
+        "diagnostics": [],
+    }


### PR DESCRIPTION
## Summary
- add an explicit repo-intelligence workflow context resolver that composes product onboarding and explicit workflow opt-in validation
- add the `repo_intelligence_explicit_workflow_context` schema and public facade export
- record the GPP-5b decision and update program status/next-action tests

## Safety boundary
- GPP-2 remains blocked
- no support widening
- no production platform claim
- no live adapter execution
- no hidden prompt injection, MCP exposure, root export, vector writes, or context compiler auto-feed

## Validation
- `python3 -m pytest tests/test_repo_intelligence_workflow_context.py tests/test_repo_intelligence_product_onboarding.py tests/test_repo_intelligence_workflow_opt_in_contract.py tests/test_gpp_next.py -q`
- `python3 -m ruff check ao_kernel/_internal/repo_intelligence/workflow_context.py ao_kernel/repo_intelligence/__init__.py tests/test_repo_intelligence_workflow_context.py tests/test_gpp_next.py`
- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `python3 -m json.tool ao_kernel/defaults/schemas/repo-intelligence-explicit-workflow-context.schema.v1.json`
- `git diff --check`
- `python3 scripts/gpp_next.py`

Closes #555
