### PR TITLE
GPP-5c: add repo-intelligence read-only workflow surface

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -311,7 +311,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5a` | Completed / no support widening | Repo-intelligence product onboarding contract | GitHub App install + selected repositories + optional `.ao/config.yml`; no end-user Cloud Run, vault, webhook, private key, or gate service hosting |
 | `GPP-5b` | Completed / no support widening | Repo-intelligence explicit workflow context resolver | product onboarding + explicit handoff validation compose into visible read-only handoff pointer; no auto-feed or runtime execution |
-| `GPP-5` | Started / no support widening | Repo-intelligence explicit workflow integration | onboarding and workflow-context resolver ready; output contract and read-only workflow surface remain |
+| `GPP-5c` | Completed / no support widening | Repo-intelligence read-only workflow surface output contract | accepted workflow context converts to a visible pointer + source metadata payload; no Markdown body, auto-feed, MCP, root export, or runtime execution |
+| `GPP-5` | Started / no support widening | Repo-intelligence explicit workflow integration | onboarding, workflow-context resolver, and output contract ready; runtime ingestion remains disabled and read-only surface closeout remains |
 | `GPP-6` | Not started | Read-only production E2E over real adapter + repo intelligence | `read_only_e2e_ready` / `blocked_e2e` |
 | `GPP-7` | Not started | Controlled write-side production candidate | `write_candidate_ready` / `keep_rehearsal_only` |
 | `GPP-8` | Not started | Remote PR live-write promotion candidate | `remote_pr_candidate_ready` / `keep_sandbox_only` |
@@ -634,6 +635,20 @@ context compiler, call adapters, or run live-adapter code.
 GPP-5 remains open for output contract and read-only workflow surface work.
 GPP-2 remains blocked, and support widening / production platform claims remain
 closed.
+
+**GPP-5c closeout:** PR for issue
+[#557](https://github.com/Halildeu/ao-kernel/issues/557) adds a read-only
+workflow surface output contract on top of the accepted explicit workflow
+context. The accepted output carries handoff path, Markdown SHA-256, namespace,
+source artifact hashes, freshness state, stale candidate count, source paths,
+line ranges, and source content hashes. It explicitly excludes Markdown body
+text and keeps hidden prompt injection, context compiler auto-feed, MCP
+exposure, root export, artifact/vector writes, live adapter execution, support
+widening, and production platform claims disabled.
+
+GPP-5 remains open for read-only workflow surface closeout and GPP-6
+preparation. GPP-2 remains blocked, and this slice does not authorize runtime
+adapter execution or support/production promotion.
 
 ## 13. GPP-6 - Read-Only Production E2E
 

--- a/.claude/plans/GPP-5c-REPO-INTELLIGENCE-WORKFLOW-SURFACE.md
+++ b/.claude/plans/GPP-5c-REPO-INTELLIGENCE-WORKFLOW-SURFACE.md
@@ -1,0 +1,69 @@
+# GPP-5c - Repo-Intelligence Read-Only Workflow Surface
+
+**Issue:** [#557](https://github.com/Halildeu/ao-kernel/issues/557)
+
+**Decision:** `repo_intelligence_read_only_workflow_surface_ready_no_support_widening`
+
+**Status:** completed / no support widening
+
+**Date:** 2026-04-28
+
+## Scope
+
+Add the output contract layer after GPP-5b. This slice turns an accepted
+explicit repo-intelligence workflow context into a read-only workflow surface
+payload that can be inspected by workflow runtime code without hidden prompt
+injection or automatic context ingestion.
+
+## Decision
+
+The read-only workflow surface is accepted only when:
+
+1. the upstream workflow context is already accepted;
+2. the visible handoff file remains under the project root;
+3. the current handoff file digest matches the accepted context digest;
+4. namespace, source artifact hashes, freshness state, stale candidate count,
+   source paths, line ranges, and source content hashes are present and valid;
+5. the output contract carries no Markdown body or snippet text;
+6. automatic prompt injection, context compiler auto-feed, MCP exposure, root
+   export, vector writes, artifact writes, live adapter execution, support
+   widening, and production platform claims remain disabled.
+
+The surface is a pointer and metadata contract. Operators still have to provide
+the Markdown handoff as visible agent input.
+
+## Evidence
+
+This work package adds:
+
+1. Runtime builder:
+   `ao_kernel/_internal/repo_intelligence/workflow_surface.py`
+2. Public facade:
+   `ao_kernel.repo_intelligence.build_repo_intelligence_read_only_workflow_surface`
+3. Contract schema:
+   `ao_kernel/defaults/schemas/repo-intelligence-read-only-workflow-surface.schema.v1.json`
+4. Behavior tests:
+   `tests/test_repo_intelligence_workflow_surface.py`
+
+The behavior tests cover accepted schema-valid output, disabled/no-op config,
+hash mismatch fail-closed behavior, missing metadata/unknown namespace
+fail-closed behavior, and the negative guarantee that `compile_context()` does
+not automatically ingest the read-only workflow surface or repo-query context.
+
+## Non-Goals
+
+1. No workflow runtime ingestion is enabled by default.
+2. No Markdown body is embedded into the output payload.
+3. No MCP repo-intelligence surface is added.
+4. No root export, vector write, or artifact write is introduced.
+5. No live adapter execution is enabled.
+6. No support tier is widened.
+7. No production platform claim is made.
+
+## Exit Decision
+
+`repo_intelligence_read_only_workflow_surface_ready_no_support_widening`
+
+GPP-5 can continue into read-only workflow surface closeout and later GPP-6
+preparation, but GPP-2 remains blocked and this slice does not authorize
+live-adapter execution or any support/production promotion.

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -207,6 +207,12 @@
       "decision": "repo_intelligence_explicit_workflow_context_ready_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/555",
       "record": ".claude/plans/GPP-5b-REPO-INTELLIGENCE-WORKFLOW-CONTEXT.md"
+    },
+    {
+      "id": "GPP-5c",
+      "decision": "repo_intelligence_read_only_workflow_surface_ready_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/557",
+      "record": ".claude/plans/GPP-5c-REPO-INTELLIGENCE-WORKFLOW-SURFACE.md"
     }
   ],
   "blocked_wps": [
@@ -286,7 +292,7 @@
   "next_allowed_actions": [
     "treat the GPP-2 deployment-protection policy service as operator-owned platform infrastructure, not an end-user setup requirement",
     "prioritize repo-intelligence onboarding as a read-only product workflow that requires GitHub App installation and repository selection, not Cloud Run, vault, webhook, or private-key setup by each user",
-    "continue GPP-5 repo-intelligence output contract and read-only workflow surface work behind explicit opt-in while support_widening_allowed=false and production_platform_claim_allowed=false",
+    "continue GPP-5 repo-intelligence read-only workflow surface closeout and GPP-6 preparation behind explicit opt-in while support_widening_allowed=false and production_platform_claim_allowed=false",
     "run scripts/policy_service_cloud_run_bootstrap_attest.py to verify required GitHub repository variable handles before dispatching the Cloud Run deploy workflow, and treat metadata_ready as repository-variable evidence only",
     "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work",
     "configure or verify the GitHub App webhook URL only after the deployed policy service endpoint is health-checked",

--- a/ao_kernel/_internal/repo_intelligence/workflow_surface.py
+++ b/ao_kernel/_internal/repo_intelligence/workflow_surface.py
@@ -1,0 +1,296 @@
+"""Read-only repo-intelligence workflow surface output contract.
+
+This module converts an accepted explicit workflow context into a small,
+operator-visible output contract. It carries handoff/source metadata only; it
+does not embed Markdown body text, inject prompts, write artifacts, expose MCP
+tools, or call adapters.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+SCHEMA_VERSION = "1"
+ARTIFACT_KIND = "repo_intelligence_read_only_workflow_surface"
+SUPPORT_TIER = "beta_read_only_workflow_surface"
+MODE = "operator_visible_read_only_context_pointer"
+CONSUMER = "workflow_runtime"
+
+_HEX64_RE = re.compile(r"^[a-f0-9]{64}$")
+_NAMESPACE_RE = re.compile(r"^repo_chunk::[^:]+::[^:]+::$")
+_CHUNK_HEADING_RE = re.compile(r"^### \d+\. `(?P<path>.+):(?P<start>\d+)-(?P<end>\d+)`$")
+
+_SAFETY_FALSE_FIELDS = {
+    "hidden_prompt_injection": "safety_hidden_prompt_injection_not_false",
+    "mcp_tool_exposure": "safety_mcp_tool_exposure_not_false",
+    "root_export": "safety_root_export_not_false",
+    "context_compiler_auto_feed": "safety_context_compiler_auto_feed_not_false",
+    "vector_writes": "safety_vector_writes_not_false",
+    "artifact_writes": "safety_artifact_writes_not_false",
+    "live_adapter_execution": "safety_live_adapter_execution_not_false",
+    "support_widening": "safety_support_widening_not_false",
+    "production_platform_claim": "safety_production_platform_claim_not_false",
+}
+
+
+def build_repo_intelligence_read_only_workflow_surface(
+    resolved_context: Mapping[str, Any] | None,
+    *,
+    project_root: Path,
+) -> JsonDict:
+    """Build a read-only workflow surface contract from accepted context.
+
+    Disabled context is a no-op. Enabled-but-unaccepted context fails closed.
+    Accepted context must still prove a current handoff file, matching digest,
+    valid namespace, source artifact hashes, and current source chunks. The
+    returned payload intentionally excludes Markdown content; callers may only
+    pass the handoff Markdown as visible operator input.
+    """
+    if not resolved_context or resolved_context.get("enabled") is not True:
+        return {
+            "status": "disabled",
+            "enabled": False,
+            "decision": "repo_intelligence_read_only_workflow_surface_not_enabled",
+        }
+
+    findings: list[str] = []
+    if _string(resolved_context.get("status")) != "accepted":
+        findings.append("workflow_context_not_accepted")
+    if _string(resolved_context.get("decision")) != "accepted_repo_intelligence_workflow_context":
+        findings.append("workflow_context_decision_not_accepted")
+    if _string(resolved_context.get("support_tier")) != "beta_explicit_read_only_workflow_context":
+        findings.append("workflow_context_support_tier_invalid")
+    if resolved_context.get("support_widening") is not False:
+        findings.append("workflow_context_support_widening_not_false")
+    if resolved_context.get("production_platform_claim") is not False:
+        findings.append("workflow_context_production_platform_claim_not_false")
+    if resolved_context.get("live_adapter_execution_allowed") is not False:
+        findings.append("workflow_context_live_adapter_execution_allowed_not_false")
+
+    context = _mapping(resolved_context.get("context"))
+    source_metadata = _mapping(resolved_context.get("source_metadata"))
+    safety = _mapping(resolved_context.get("safety"))
+    _require_false_fields(safety, _SAFETY_FALSE_FIELDS, findings)
+
+    if _string(context.get("mode")) != "visible_operator_handoff":
+        findings.append("context_mode_not_visible_operator_handoff")
+    if _string(context.get("consumer")) != CONSUMER:
+        findings.append("context_consumer_not_workflow_runtime")
+    if context.get("operator_visible") is not True:
+        findings.append("context_operator_visible_not_true")
+    if context.get("automatic_prompt_injection") is not False:
+        findings.append("context_automatic_prompt_injection_not_false")
+    if context.get("context_compiler_auto_feed") is not False:
+        findings.append("context_context_compiler_auto_feed_not_false")
+    if context.get("write_context_artifacts") is not False:
+        findings.append("context_write_context_artifacts_not_false")
+    if _string(context.get("handoff_support_tier")) != "beta_explicit_handoff":
+        findings.append("context_handoff_support_tier_invalid")
+
+    namespace = _string(source_metadata.get("vector_namespace_key_prefix"))
+    repo_chunks_sha256 = _string(source_metadata.get("repo_chunks_sha256"))
+    vector_index_sha256 = _string(source_metadata.get("repo_vector_index_manifest_sha256"))
+    freshness_state = _string(source_metadata.get("freshness_state"))
+    stale_candidates = source_metadata.get("stale_candidates")
+    if not _NAMESPACE_RE.fullmatch(namespace):
+        findings.append("namespace_invalid")
+    if not _HEX64_RE.fullmatch(repo_chunks_sha256):
+        findings.append("repo_chunks_sha256_invalid")
+    if not _HEX64_RE.fullmatch(vector_index_sha256):
+        findings.append("repo_vector_index_manifest_sha256_invalid")
+    if freshness_state != "current_only":
+        findings.append("freshness_state_not_current_only")
+    if stale_candidates != 0:
+        findings.append("stale_candidates_not_zero")
+
+    handoff_path = _resolve_handoff_path(_string(context.get("handoff_path")), project_root.resolve())
+    if handoff_path is None:
+        findings.append("handoff_path_escape")
+    elif not handoff_path.is_file():
+        findings.append("handoff_file_missing")
+
+    markdown = ""
+    actual_sha256 = ""
+    if handoff_path is not None and handoff_path.is_file():
+        markdown = handoff_path.read_text(encoding="utf-8")
+        actual_sha256 = hashlib.sha256(markdown.encode("utf-8")).hexdigest()
+    expected_sha256 = _string(context.get("markdown_sha256"))
+    if not _HEX64_RE.fullmatch(expected_sha256):
+        findings.append("handoff_sha256_invalid")
+    elif actual_sha256 and actual_sha256 != expected_sha256:
+        findings.append("handoff_sha256_mismatch")
+
+    retrieved_sources = _chunk_sources(markdown) if markdown else []
+    if not retrieved_sources:
+        findings.append("retrieved_sources_missing")
+    _validate_retrieved_sources(retrieved_sources, source_metadata=source_metadata, findings=findings)
+
+    if findings:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "artifact_kind": ARTIFACT_KIND,
+            "status": "blocked",
+            "enabled": True,
+            "decision": "blocked_repo_intelligence_read_only_workflow_surface",
+            "findings": sorted(set(findings)),
+            "source": {
+                "workflow_context_status": resolved_context.get("status", "unknown"),
+                "workflow_context_decision": resolved_context.get("decision", "unknown"),
+                "handoff_path": str(handoff_path) if handoff_path is not None else _string(context.get("handoff_path")),
+                "markdown_sha256": actual_sha256 or expected_sha256,
+                "vector_namespace_key_prefix": namespace,
+                "freshness_state": freshness_state,
+                "stale_candidates": stale_candidates,
+            },
+            "surface": _surface_contract(),
+            "safety": {field: False for field in _SAFETY_FALSE_FIELDS},
+            "support_widening": False,
+            "production_platform_claim": False,
+            "live_adapter_execution_allowed": False,
+        }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_kind": ARTIFACT_KIND,
+        "status": "accepted",
+        "enabled": True,
+        "decision": "accepted_repo_intelligence_read_only_workflow_surface",
+        "support_tier": SUPPORT_TIER,
+        "source": {
+            "workflow_context_decision": resolved_context["decision"],
+            "workflow_context_support_tier": resolved_context["support_tier"],
+            "handoff_support_tier": context["handoff_support_tier"],
+            "handoff_path": str(handoff_path),
+            "markdown_sha256": actual_sha256,
+            "vector_namespace_key_prefix": namespace,
+            "repo_chunks_sha256": repo_chunks_sha256,
+            "repo_vector_index_manifest_sha256": vector_index_sha256,
+            "freshness_state": freshness_state,
+            "stale_candidates": 0,
+            "retrieved_chunks": len(retrieved_sources),
+        },
+        "retrieved_sources": retrieved_sources,
+        "surface": _surface_contract(),
+        "safety": {field: False for field in _SAFETY_FALSE_FIELDS},
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution_allowed": False,
+    }
+
+
+def _surface_contract() -> JsonDict:
+    return {
+        "mode": MODE,
+        "consumer": CONSUMER,
+        "operator_visible": True,
+        "requires_visible_agent_input": True,
+        "includes_markdown_body": False,
+        "automatic_prompt_injection": False,
+        "context_compiler_auto_feed": False,
+        "write_context_artifacts": False,
+    }
+
+
+def _validate_retrieved_sources(
+    retrieved_sources: list[JsonDict],
+    *,
+    source_metadata: Mapping[str, Any],
+    findings: list[str],
+) -> None:
+    metadata_paths = [_string(item) for item in _list(source_metadata.get("source_paths"))]
+    metadata_hashes = [_string(item) for item in _list(source_metadata.get("content_sha256"))]
+    if [source["source_path"] for source in retrieved_sources] != metadata_paths:
+        findings.append("source_metadata_source_paths_mismatch")
+    if [source["content_sha256"] for source in retrieved_sources] != metadata_hashes:
+        findings.append("source_metadata_content_sha256_mismatch")
+    for source in retrieved_sources:
+        source_path = Path(source["source_path"])
+        if source_path.is_absolute() or ".." in source_path.parts:
+            findings.append("source_path_escape")
+        if source["start_line"] > source["end_line"]:
+            findings.append("invalid_line_range")
+        if not _HEX64_RE.fullmatch(source["content_sha256"]):
+            findings.append("content_sha256_invalid")
+
+
+def _chunk_sources(markdown: str) -> list[JsonDict]:
+    lines = markdown.splitlines()
+    sources: list[JsonDict] = []
+    for index, line in enumerate(lines):
+        match = _CHUNK_HEADING_RE.match(line)
+        if match is None:
+            continue
+        metadata: dict[str, str] = {}
+        for table_line in lines[index + 1 :]:
+            if table_line.startswith("### ") or table_line.startswith("## "):
+                break
+            if not table_line.startswith("|"):
+                continue
+            cells = [cell.strip().replace("\\|", "|") for cell in table_line.strip().strip("|").split("|")]
+            if len(cells) < 2 or cells[0] in {"---", "Field"}:
+                continue
+            if set(cells[0]) == {"-"}:
+                continue
+            metadata[cells[0]] = cells[1]
+        sources.append(
+            {
+                "source_path": match.group("path"),
+                "start_line": int(match.group("start")),
+                "end_line": int(match.group("end")),
+                "content_sha256": metadata.get("Content SHA256", ""),
+            }
+        )
+    return sources
+
+
+def _require_false_fields(
+    payload: Mapping[str, Any],
+    required_false_fields: Mapping[str, str],
+    findings: list[str],
+) -> None:
+    for field, finding in required_false_fields.items():
+        if payload.get(field) is not False:
+            findings.append(finding)
+
+
+def _resolve_handoff_path(value: str, root: Path) -> Path | None:
+    if not value:
+        return None
+    raw = Path(value)
+    candidate = raw if raw.is_absolute() else root / raw
+    resolved = candidate.resolve()
+    if not _is_relative_to(resolved, root):
+        return None
+    return resolved
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    return []
+
+
+def _string(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return ""
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True

--- a/ao_kernel/defaults/schemas/repo-intelligence-read-only-workflow-surface.schema.v1.json
+++ b/ao_kernel/defaults/schemas/repo-intelligence-read-only-workflow-surface.schema.v1.json
@@ -1,0 +1,260 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:repo-intelligence-read-only-workflow-surface:v1",
+  "title": "Repo Intelligence Read-Only Workflow Surface Output Contract",
+  "description": "Accepted output contract for an explicit repo-intelligence workflow surface. It carries visible handoff and source metadata only and does not authorize hidden prompt injection, context-compiler auto-feed, MCP exposure, root export, artifact/vector writes, live adapter execution, support widening, or production platform claims.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "status",
+    "enabled",
+    "decision",
+    "support_tier",
+    "source",
+    "retrieved_sources",
+    "surface",
+    "safety",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution_allowed"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1"
+    },
+    "artifact_kind": {
+      "type": "string",
+      "const": "repo_intelligence_read_only_workflow_surface"
+    },
+    "status": {
+      "type": "string",
+      "const": "accepted"
+    },
+    "enabled": {
+      "type": "boolean",
+      "const": true
+    },
+    "decision": {
+      "type": "string",
+      "const": "accepted_repo_intelligence_read_only_workflow_surface"
+    },
+    "support_tier": {
+      "type": "string",
+      "const": "beta_read_only_workflow_surface"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "workflow_context_decision",
+        "workflow_context_support_tier",
+        "handoff_support_tier",
+        "handoff_path",
+        "markdown_sha256",
+        "vector_namespace_key_prefix",
+        "repo_chunks_sha256",
+        "repo_vector_index_manifest_sha256",
+        "freshness_state",
+        "stale_candidates",
+        "retrieved_chunks"
+      ],
+      "properties": {
+        "workflow_context_decision": {
+          "type": "string",
+          "const": "accepted_repo_intelligence_workflow_context"
+        },
+        "workflow_context_support_tier": {
+          "type": "string",
+          "const": "beta_explicit_read_only_workflow_context"
+        },
+        "handoff_support_tier": {
+          "type": "string",
+          "const": "beta_explicit_handoff"
+        },
+        "handoff_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "markdown_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "vector_namespace_key_prefix": {
+          "type": "string",
+          "pattern": "^repo_chunk::[^:]+::[^:]+::$"
+        },
+        "repo_chunks_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "repo_vector_index_manifest_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "freshness_state": {
+          "type": "string",
+          "const": "current_only"
+        },
+        "stale_candidates": {
+          "type": "integer",
+          "const": 0
+        },
+        "retrieved_chunks": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "retrieved_sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "source_path",
+          "start_line",
+          "end_line",
+          "content_sha256"
+        ],
+        "properties": {
+          "source_path": {
+            "type": "string",
+            "minLength": 1,
+            "not": {
+              "pattern": "^(?:/|.*(?:^|/)\\.\\.(?:/|$))"
+            }
+          },
+          "start_line": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "end_line": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "content_sha256": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          }
+        }
+      }
+    },
+    "surface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "consumer",
+        "operator_visible",
+        "requires_visible_agent_input",
+        "includes_markdown_body",
+        "automatic_prompt_injection",
+        "context_compiler_auto_feed",
+        "write_context_artifacts"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "const": "operator_visible_read_only_context_pointer"
+        },
+        "consumer": {
+          "type": "string",
+          "const": "workflow_runtime"
+        },
+        "operator_visible": {
+          "type": "boolean",
+          "const": true
+        },
+        "requires_visible_agent_input": {
+          "type": "boolean",
+          "const": true
+        },
+        "includes_markdown_body": {
+          "type": "boolean",
+          "const": false
+        },
+        "automatic_prompt_injection": {
+          "type": "boolean",
+          "const": false
+        },
+        "context_compiler_auto_feed": {
+          "type": "boolean",
+          "const": false
+        },
+        "write_context_artifacts": {
+          "type": "boolean",
+          "const": false
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hidden_prompt_injection",
+        "mcp_tool_exposure",
+        "root_export",
+        "context_compiler_auto_feed",
+        "vector_writes",
+        "artifact_writes",
+        "live_adapter_execution",
+        "support_widening",
+        "production_platform_claim"
+      ],
+      "properties": {
+        "hidden_prompt_injection": {
+          "type": "boolean",
+          "const": false
+        },
+        "mcp_tool_exposure": {
+          "type": "boolean",
+          "const": false
+        },
+        "root_export": {
+          "type": "boolean",
+          "const": false
+        },
+        "context_compiler_auto_feed": {
+          "type": "boolean",
+          "const": false
+        },
+        "vector_writes": {
+          "type": "boolean",
+          "const": false
+        },
+        "artifact_writes": {
+          "type": "boolean",
+          "const": false
+        },
+        "live_adapter_execution": {
+          "type": "boolean",
+          "const": false
+        },
+        "support_widening": {
+          "type": "boolean",
+          "const": false
+        },
+        "production_platform_claim": {
+          "type": "boolean",
+          "const": false
+        }
+      }
+    },
+    "support_widening": {
+      "type": "boolean",
+      "const": false
+    },
+    "production_platform_claim": {
+      "type": "boolean",
+      "const": false
+    },
+    "live_adapter_execution_allowed": {
+      "type": "boolean",
+      "const": false
+    }
+  }
+}

--- a/ao_kernel/repo_intelligence/__init__.py
+++ b/ao_kernel/repo_intelligence/__init__.py
@@ -34,6 +34,9 @@ from ao_kernel._internal.repo_intelligence.root_exporter import (
 from ao_kernel._internal.repo_intelligence.workflow_opt_in import validate_repo_intelligence_workflow_opt_in
 from ao_kernel._internal.repo_intelligence.product_onboarding import validate_repo_intelligence_product_onboarding
 from ao_kernel._internal.repo_intelligence.workflow_context import resolve_repo_intelligence_workflow_context
+from ao_kernel._internal.repo_intelligence.workflow_surface import (
+    build_repo_intelligence_read_only_workflow_surface,
+)
 
 __all__ = [
     "build_agent_context_pack",
@@ -58,4 +61,5 @@ __all__ = [
     "validate_repo_intelligence_workflow_opt_in",
     "validate_repo_intelligence_product_onboarding",
     "resolve_repo_intelligence_workflow_context",
+    "build_repo_intelligence_read_only_workflow_surface",
 ]

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -221,6 +221,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-5c"
+        and item["decision"] == "repo_intelligence_read_only_workflow_surface_ready_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/557"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -320,7 +327,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(
         action
-        == "continue GPP-5 repo-intelligence output contract and read-only workflow surface work behind explicit opt-in while support_widening_allowed=false and production_platform_claim_allowed=false"
+        == "continue GPP-5 repo-intelligence read-only workflow surface closeout and GPP-6 preparation behind explicit opt-in while support_widening_allowed=false and production_platform_claim_allowed=false"
         for action in payload["next_allowed_actions"]
     )
     assert any(

--- a/tests/test_repo_intelligence_workflow_surface.py
+++ b/tests/test_repo_intelligence_workflow_surface.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from ao_kernel.context.context_compiler import compile_context
+from ao_kernel.repo_intelligence import (
+    build_repo_intelligence_read_only_workflow_surface,
+    build_repo_query_context_pack,
+    resolve_repo_intelligence_workflow_context,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = (
+    ROOT
+    / "ao_kernel"
+    / "defaults"
+    / "schemas"
+    / "repo-intelligence-read-only-workflow-surface.schema.v1.json"
+)
+
+
+def _schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _product_onboarding() -> dict:
+    return {
+        "schema_version": "1",
+        "artifact_kind": "repo_intelligence_product_onboarding",
+        "enabled": True,
+        "support_tier": "beta_read_only_product_onboarding",
+        "setup": {
+            "github_app": {
+                "installation": "required",
+                "repository_selection": "selected_repositories",
+                "permission_boundary": "read_only_repo_intelligence",
+            },
+            "repo_local_config": {
+                "path": ".ao/config.yml",
+                "required": False,
+            },
+            "end_user_infrastructure": {
+                "cloud_run_required": False,
+                "vault_required": False,
+                "webhook_required": False,
+                "github_app_private_key_required": False,
+                "release_gate_service_required": False,
+                "deployment_protection_service_required": False,
+            },
+        },
+        "workflow": {
+            "mode": "read_only",
+            "activation": "explicit_opt_in",
+            "default_enabled": False,
+            "default_auto_feed": False,
+        },
+        "safety": {
+            "hidden_prompt_injection": False,
+            "mcp_tool_exposure": False,
+            "root_export_required": False,
+            "context_compiler_auto_feed": False,
+            "implicit_vector_writes": False,
+            "implicit_artifact_writes": False,
+            "live_adapter_execution": False,
+            "support_widening": False,
+            "production_platform_claim": False,
+        },
+    }
+
+
+def _workflow_context_config(handoff_path: str = "repo-query-handoff.md") -> dict:
+    return {
+        "schema_version": "1",
+        "artifact_kind": "repo_intelligence_explicit_workflow_context",
+        "enabled": True,
+        "support_tier": "beta_explicit_read_only_workflow_context",
+        "product_onboarding": _product_onboarding(),
+        "workflow_opt_in": {
+            "enabled": True,
+            "source": "explicit_handoff_file",
+            "handoff_path": handoff_path,
+            "require_fresh": True,
+            "expected_namespace": "repo_chunk::demo::space::",
+            "support_tier": "beta_explicit_handoff",
+        },
+        "workflow_context": {
+            "mode": "visible_operator_handoff",
+            "consumer": "workflow_runtime",
+            "operator_visible": True,
+            "default_enabled": False,
+            "automatic_prompt_injection": False,
+            "context_compiler_auto_feed": False,
+            "write_context_artifacts": False,
+            "requires_behavior_tests": True,
+        },
+        "safety": {
+            "hidden_prompt_injection": False,
+            "mcp_tool_exposure": False,
+            "root_export": False,
+            "context_compiler_auto_feed": False,
+            "vector_writes": False,
+            "artifact_writes": False,
+            "live_adapter_execution": False,
+            "support_widening": False,
+            "production_platform_claim": False,
+        },
+    }
+
+
+def test_read_only_workflow_surface_schema_accepts_output_contract(tmp_path: Path) -> None:
+    surface = _accepted_surface(tmp_path)
+
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    errors = list(Draft202012Validator(schema).iter_errors(surface))
+
+    assert errors == []
+
+
+def test_read_only_workflow_surface_schema_rejects_hidden_body_or_support_claim(tmp_path: Path) -> None:
+    validator = Draft202012Validator(_schema())
+    surface = _accepted_surface(tmp_path)
+
+    hidden_body = dict(surface)
+    hidden_body["surface"] = dict(surface["surface"])
+    hidden_body["surface"]["includes_markdown_body"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(hidden_body)
+
+    production_claim = dict(surface)
+    production_claim["safety"] = dict(surface["safety"])
+    production_claim["safety"]["production_platform_claim"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(production_claim)
+
+
+def test_read_only_workflow_surface_disabled_is_noop(tmp_path: Path) -> None:
+    assert build_repo_intelligence_read_only_workflow_surface(None, project_root=tmp_path) == {
+        "status": "disabled",
+        "enabled": False,
+        "decision": "repo_intelligence_read_only_workflow_surface_not_enabled",
+    }
+    assert build_repo_intelligence_read_only_workflow_surface({"enabled": False}, project_root=tmp_path) == {
+        "status": "disabled",
+        "enabled": False,
+        "decision": "repo_intelligence_read_only_workflow_surface_not_enabled",
+    }
+
+
+def test_read_only_workflow_surface_carries_metadata_without_markdown_body(tmp_path: Path) -> None:
+    surface = _accepted_surface(tmp_path)
+
+    assert surface["status"] == "accepted"
+    assert surface["decision"] == "accepted_repo_intelligence_read_only_workflow_surface"
+    assert surface["support_tier"] == "beta_read_only_workflow_surface"
+    assert surface["source"]["workflow_context_decision"] == "accepted_repo_intelligence_workflow_context"
+    assert surface["source"]["handoff_support_tier"] == "beta_explicit_handoff"
+    assert surface["source"]["vector_namespace_key_prefix"] == "repo_chunk::demo::space::"
+    assert surface["source"]["repo_chunks_sha256"] == "c" * 64
+    assert surface["source"]["repo_vector_index_manifest_sha256"] == "d" * 64
+    assert surface["source"]["freshness_state"] == "current_only"
+    assert surface["source"]["stale_candidates"] == 0
+    assert surface["source"]["retrieved_chunks"] == 1
+    assert surface["retrieved_sources"] == [
+        {
+            "source_path": "pkg/main.py",
+            "start_line": 3,
+            "end_line": 4,
+            "content_sha256": "e" * 64,
+        }
+    ]
+    assert surface["surface"] == {
+        "mode": "operator_visible_read_only_context_pointer",
+        "consumer": "workflow_runtime",
+        "operator_visible": True,
+        "requires_visible_agent_input": True,
+        "includes_markdown_body": False,
+        "automatic_prompt_injection": False,
+        "context_compiler_auto_feed": False,
+        "write_context_artifacts": False,
+    }
+    rendered = json.dumps(surface, sort_keys=True)
+    assert "def run():" not in rendered
+    assert "Repo Query Context Pack" not in rendered
+    assert surface["support_widening"] is False
+    assert surface["production_platform_claim"] is False
+    assert surface["live_adapter_execution_allowed"] is False
+
+
+def test_read_only_workflow_surface_blocks_unaccepted_context(tmp_path: Path) -> None:
+    result = build_repo_intelligence_read_only_workflow_surface(
+        {
+            "status": "blocked",
+            "enabled": True,
+            "decision": "blocked_repo_intelligence_workflow_context",
+            "findings": ["freshness_not_current_only"],
+        },
+        project_root=tmp_path,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["decision"] == "blocked_repo_intelligence_read_only_workflow_surface"
+    assert "workflow_context_not_accepted" in result["findings"]
+    assert result["support_widening"] is False
+    assert result["production_platform_claim"] is False
+    assert result["live_adapter_execution_allowed"] is False
+
+
+def test_read_only_workflow_surface_blocks_handoff_hash_mismatch(tmp_path: Path) -> None:
+    resolved = _accepted_context(tmp_path)
+    handoff_path = Path(resolved["context"]["handoff_path"])
+    handoff_path.write_text("# modified\n", encoding="utf-8")
+
+    result = build_repo_intelligence_read_only_workflow_surface(resolved, project_root=tmp_path)
+
+    assert result["status"] == "blocked"
+    assert "handoff_sha256_mismatch" in result["findings"]
+    assert "retrieved_sources_missing" in result["findings"]
+
+
+def test_read_only_workflow_surface_blocks_missing_metadata_or_unknown_namespace(tmp_path: Path) -> None:
+    resolved = _accepted_context(tmp_path)
+    resolved["source_metadata"]["vector_namespace_key_prefix"] = "repo_chunks"
+    resolved["source_metadata"].pop("repo_chunks_sha256")
+    resolved["source_metadata"]["stale_candidates"] = 1
+
+    result = build_repo_intelligence_read_only_workflow_surface(resolved, project_root=tmp_path)
+
+    assert result["status"] == "blocked"
+    assert "namespace_invalid" in result["findings"]
+    assert "repo_chunks_sha256_invalid" in result["findings"]
+    assert "stale_candidates_not_zero" in result["findings"]
+
+
+def test_read_only_workflow_surface_does_not_auto_ingest_into_context_compiler(tmp_path: Path) -> None:
+    handoff = build_repo_query_context_pack(query_result=_query_result())
+    surface = _accepted_surface(tmp_path)
+
+    result = compile_context(
+        {
+            "session_id": "test",
+            "ephemeral_decisions": [],
+            "repo_intelligence_workflow_surface": surface,
+            "repo_query_context": handoff,
+        },
+        profile="TASK_EXECUTION",
+    )
+
+    assert result.preamble == ""
+    assert "Repo Query Context Pack" not in result.preamble
+    assert result.items_included == 0
+
+
+def _accepted_surface(tmp_path: Path) -> dict:
+    return build_repo_intelligence_read_only_workflow_surface(_accepted_context(tmp_path), project_root=tmp_path)
+
+
+def _accepted_context(tmp_path: Path) -> dict:
+    handoff_path = tmp_path / "repo-query-handoff.md"
+    handoff_path.write_text(build_repo_query_context_pack(query_result=_query_result()), encoding="utf-8")
+    result = resolve_repo_intelligence_workflow_context(_workflow_context_config(), project_root=tmp_path)
+    assert result["status"] == "accepted"
+    return result
+
+
+def _query_result() -> dict:
+    return {
+        "schema_version": "1",
+        "artifact_kind": "repo_vector_query_result",
+        "generator": {
+            "name": "ao-kernel",
+            "version": "4.0.0",
+            "generated_at": "2026-04-27T00:00:00Z",
+        },
+        "project": {
+            "root": ".",
+            "root_name": "demo",
+            "name": "demo",
+            "root_identity_sha256": "a" * 64,
+        },
+        "retriever": {
+            "name": "ao-kernel-repo-vector-retriever",
+            "version": "repo-vector-retriever.v1",
+            "mode": "query_vectors",
+        },
+        "query": {
+            "text": "where is run defined",
+            "top_k": 5,
+            "candidate_limit": 50,
+            "min_similarity": 0.3,
+            "max_tokens": 2000,
+            "max_snippet_chars": 1200,
+            "filters": {
+                "source_path_prefix": "pkg/",
+                "language": "python",
+                "symbol": "run",
+            },
+        },
+        "embedding_space": {
+            "provider": "openai",
+            "model": "text-embedding-3-small",
+            "dimension": 1536,
+            "embedding_space_id": "b" * 64,
+        },
+        "vector_namespace": {
+            "key_prefix": "repo_chunk::demo::space::",
+            "project_root_identity_sha256": "a" * 64,
+        },
+        "source_artifacts": {
+            "repo_chunks_sha256": "c" * 64,
+            "repo_vector_index_manifest_sha256": "d" * 64,
+        },
+        "summary": {
+            "matches": 1,
+            "candidate_matches": 1,
+            "filtered_candidates": 1,
+            "stale_candidates": 0,
+            "embedding_calls": 1,
+            "estimated_tokens": 12,
+            "truncated_results": 0,
+        },
+        "results": [
+            {
+                "key": "repo_chunk::demo::space::repo-chunk-v1:1",
+                "similarity": 0.9876,
+                "source_path": "pkg/main.py",
+                "start_line": 3,
+                "end_line": 4,
+                "language": "python",
+                "kind": "symbol",
+                "module": "pkg.main",
+                "symbol": "run",
+                "chunk_id": "repo-chunk-v1:1",
+                "content_sha256": "e" * 64,
+                "token_estimate": 12,
+                "snippet": "def run():\n    return VALUE\n",
+                "snippet_truncated": False,
+                "content_status": "current",
+            }
+        ],
+        "diagnostics": [],
+    }


### PR DESCRIPTION
## Summary
- add a read-only repo-intelligence workflow surface builder that consumes only an accepted explicit workflow context
- add the `repo_intelligence_read_only_workflow_surface` output schema and public facade export
- record the GPP-5c decision and update GPP status/next-action tests

## Safety boundary
- GPP-2 remains blocked
- no support widening
- no production platform claim
- no live adapter execution
- no Markdown body in the output payload
- no hidden prompt injection, context compiler auto-feed, MCP exposure, root export, vector writes, or artifact writes

## Validation
- `python3 -m pytest tests/test_repo_intelligence_workflow_surface.py tests/test_repo_intelligence_workflow_context.py tests/test_repo_intelligence_product_onboarding.py tests/test_repo_intelligence_workflow_opt_in_contract.py tests/test_gpp_next.py -q`
- `python3 -m ruff check ao_kernel/_internal/repo_intelligence/workflow_surface.py ao_kernel/repo_intelligence/__init__.py tests/test_repo_intelligence_workflow_surface.py tests/test_gpp_next.py`
- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `python3 -m json.tool ao_kernel/defaults/schemas/repo-intelligence-read-only-workflow-surface.schema.v1.json`
- `git diff --check`
- `python3 scripts/gpp_next.py`

Closes #557
