### PR TITLE
GPP-5d: add repo-intelligence closeout preflight

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -239,6 +239,11 @@ Last live verification on current `origin/main` showed:
     GitHub App private key. GPP-2 remains blocked on operator-owned hosted
     callback evidence; repo-intelligence onboarding can be prioritized only as
     explicit opt-in/read-only work with no support widening.
+45. GPP-5d closes the repo-intelligence read-only workflow surface with a
+    schema-backed preflight over GPP-5a/GPP-5b/GPP-5c records, public APIs,
+    schemas, and negative runtime guards. GPP-6 preparation may use this
+    closeout as repo-intelligence evidence, but GPP-6 execution remains
+    blocked by GPP-2 and GPP-4.
 
 ## 3. Current Verdict
 
@@ -312,7 +317,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-5a` | Completed / no support widening | Repo-intelligence product onboarding contract | GitHub App install + selected repositories + optional `.ao/config.yml`; no end-user Cloud Run, vault, webhook, private key, or gate service hosting |
 | `GPP-5b` | Completed / no support widening | Repo-intelligence explicit workflow context resolver | product onboarding + explicit handoff validation compose into visible read-only handoff pointer; no auto-feed or runtime execution |
 | `GPP-5c` | Completed / no support widening | Repo-intelligence read-only workflow surface output contract | accepted workflow context converts to a visible pointer + source metadata payload; no Markdown body, auto-feed, MCP, root export, or runtime execution |
-| `GPP-5` | Started / no support widening | Repo-intelligence explicit workflow integration | onboarding, workflow-context resolver, and output contract ready; runtime ingestion remains disabled and read-only surface closeout remains |
+| `GPP-5d` | Completed / no support widening | Repo-intelligence read-only workflow surface closeout preflight | schema-backed closeout verifies GPP-5a/GPP-5b/GPP-5c, public APIs, schemas, and negative runtime guards; GPP-6 execution remains blocked by GPP-2/GPP-4 |
+| `GPP-5` | Completed as read-only building block / no support widening | Repo-intelligence explicit workflow integration | onboarding, workflow-context resolver, output contract, and closeout preflight ready; runtime ingestion remains disabled |
 | `GPP-6` | Not started | Read-only production E2E over real adapter + repo intelligence | `read_only_e2e_ready` / `blocked_e2e` |
 | `GPP-7` | Not started | Controlled write-side production candidate | `write_candidate_ready` / `keep_rehearsal_only` |
 | `GPP-8` | Not started | Remote PR live-write promotion candidate | `remote_pr_candidate_ready` / `keep_sandbox_only` |
@@ -646,9 +652,23 @@ text and keeps hidden prompt injection, context compiler auto-feed, MCP
 exposure, root export, artifact/vector writes, live adapter execution, support
 widening, and production platform claims disabled.
 
-GPP-5 remains open for read-only workflow surface closeout and GPP-6
-preparation. GPP-2 remains blocked, and this slice does not authorize runtime
-adapter execution or support/production promotion.
+After GPP-5c, GPP-5 remained open for read-only workflow surface closeout and
+GPP-6 preparation. GPP-2 remained blocked, and that slice did not authorize
+runtime adapter execution or support/production promotion.
+
+**GPP-5d closeout:** PR for issue
+[#559](https://github.com/Halildeu/ao-kernel/issues/559) adds the
+schema-backed closeout preflight for GPP-5. The preflight verifies the
+GPP-5a/GPP-5b/GPP-5c records, public repo-intelligence APIs, JSON schemas,
+context compiler negative guard, workflow-definition negative guard, MCP
+negative guard, and program flags. GPP-5 is now closed as a read-only building
+block only.
+
+GPP-6 preparation may use this closeout as repo-intelligence evidence, but
+GPP-6 execution remains blocked until GPP-2 protected gate evidence and the
+GPP-4 read-only adapter decision are ready. This closeout does not authorize
+runtime ingestion, live-adapter execution, support widening, or production
+platform claims.
 
 ## 13. GPP-6 - Read-Only Production E2E
 
@@ -670,7 +690,7 @@ repo scan/index/query
 
 1. `GPP-4` has a production-certified read-only adapter decision or explicit
    protected beta permission for this rehearsal.
-2. `GPP-5` workflow context ingestion is ready.
+2. `GPP-5d` repo-intelligence closeout is ready.
 
 **Acceptance criteria:**
 
@@ -889,13 +909,16 @@ policy modules, attach GitHub App auth at runtime, and post an explicit GitHub
 deployment review callback. In parallel, bootstrap/run the trusted dry-run
 `ao-release-gate` deploy path from `main`, configure that check-run service's
 GitHub App webhook URL, collect real PR check-run evidence, and only then cut
-branch protection/rulesets over to require `ao-release-gate`. Do not repeatedly dispatch
-`.github/workflows/live-adapter-gate.yml` until that service is expected to
-respond. Any follow-up must keep fork and pull-request contexts away from
-protected credentials, must not use `AO_CLAUDE_CODE_CLI_AUTH` through a
-`secrets.` expression until a later live-execution slice explicitly permits it,
-must reject PAT-backed bots and admin bypass for PR merge automation, and must
-keep `live_execution_allowed=false`, `support_widening=false`, and
+branch protection/rulesets over to require `ao-release-gate`. Do not
+repeatedly dispatch `.github/workflows/live-adapter-gate.yml` until that
+service is expected to respond. GPP-5d closes repo-intelligence as a read-only
+building block for future GPP-6 preparation, but GPP-6 execution remains
+blocked by GPP-2 and GPP-4. Any follow-up must keep fork and pull-request
+contexts away from protected credentials, must not use
+`AO_CLAUDE_CODE_CLI_AUTH` through a `secrets.` expression until a later
+live-execution slice explicitly permits it, must reject PAT-backed bots and
+admin bypass for PR merge automation, and must keep
+`live_execution_allowed=false`, `support_widening=false`, and
 `production_platform_claim=false`.
 
 ## 18. Risk Register
@@ -925,6 +948,7 @@ keep `live_execution_allowed=false`, `support_widening=false`, and
 | Release-gate deploy health mistaken for release authority | A hosted `/healthz` response could be overclaimed as required-check enforcement | GPP-2aa records `check_run_post=false`, `real_pr_evidence=false`, `branch_protection_cutover=false`, and `merge_authority_enabled=false`; require real PR evidence and explicit cutover |
 | Missing repository variables bypassed | Deploy workflow could be dispatched before non-secret handles exist | Run GPP-2ab attestation with `--fail-on-blocked` and provision missing GitHub repository variables before deploy dispatch |
 | `metadata_ready` mistaken for cloud readiness | Deployment could be treated as unblocked without GCP trust or hosting proof | Treat GPP-2ab as repository-variable metadata only; separately prove OIDC, service account permissions, Secret Manager objects, Cloud Run health, webhook URL, and callback evidence |
+| GPP-5 closeout mistaken for GPP-6 approval | Read-only repo-intelligence evidence could be overclaimed as protected E2E readiness | GPP-5d records `gpp6_readiness=blocked_by_upstream_gates`; require GPP-2 protected gate evidence and GPP-4 adapter decision before GPP-6 execution |
 
 ## 19. Tracking Log
 
@@ -990,3 +1014,5 @@ keep `live_execution_allowed=false`, `support_widening=false`, and
 | 2026-04-28 | GPP-2aa deploy path added | `.github/workflows/ao-release-gate-deploy-cloud-run.yml` can mirror the trusted immutable release-gate image to Artifact Registry, deploy Cloud Run with Secret Manager references, health-check `/healthz`, and upload deploy evidence; webhook configuration, real PR check-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |
 | 2026-04-28 | GPP-2ab issue opened | Issue [#549](https://github.com/Halildeu/ao-kernel/issues/549) tracks metadata-only Cloud Run bootstrap attestation for the policy service deploy path. |
 | 2026-04-28 | GPP-2ab bootstrap attestation added | `scripts/policy_service_cloud_run_bootstrap_attest.py` checks required GitHub repository variable handles with `gh variable list --json name,updatedAt`, ignores values, and records that current live metadata is `overall_status=blocked` because all required handles are missing; GCP trust, Secret Manager objects, Cloud Run hosting, webhook URL configuration, callback posting, live execution, support widening, and production-platform claims remain unproven. |
+| 2026-04-28 | GPP-5d issue opened | Issue [#559](https://github.com/Halildeu/ao-kernel/issues/559) tracks repo-intelligence read-only workflow closeout before GPP-6 preparation. |
+| 2026-04-28 | GPP-5d closeout preflight added | `scripts/gpp5_repo_intelligence_closeout.py` records GPP-5 as closed for read-only workflow-surface purposes while keeping GPP-6 execution blocked by GPP-2 and GPP-4. |

--- a/.claude/plans/GPP-5d-REPO-INTELLIGENCE-CLOSEOUT.md
+++ b/.claude/plans/GPP-5d-REPO-INTELLIGENCE-CLOSEOUT.md
@@ -1,0 +1,87 @@
+# GPP-5d - Repo-Intelligence Closeout Preflight
+
+**Issue:** [#559](https://github.com/Halildeu/ao-kernel/issues/559)
+
+**Decision:** `repo_intelligence_read_only_workflow_surface_closed_no_support_widening`
+
+**Status:** completed / no support widening
+
+**Date:** 2026-04-28
+
+## Scope
+
+Close the GPP-5 repo-intelligence read-only workflow surface as a bounded
+building block and prepare GPP-6 entry evidence without enabling GPP-6
+execution.
+
+This slice adds a schema-backed closeout preflight that checks:
+
+1. GPP-5a product onboarding, GPP-5b explicit workflow context, and GPP-5c
+   read-only workflow surface decisions are present in program status.
+2. The public repo-intelligence contract surfaces and their JSON schemas are
+   present.
+3. The context compiler and SDK do not accept hidden repo-intelligence
+   auto-feed parameters.
+4. Default workflow definitions do not carry hidden repo-intelligence context
+   feed tokens.
+5. The MCP tool surface still exposes no repo-intelligence or repo query tool.
+6. Support widening, production platform claim, and live adapter execution
+   remain closed.
+
+## Decision
+
+GPP-5 is closed as a read-only product-workflow building block. The accepted
+path is still explicit: GitHub App installation, selected repositories,
+optional repo-local configuration, explicit operator-visible handoff, and a
+metadata-only workflow surface pointer.
+
+This closeout does not make repo intelligence a hidden prompt feed and does
+not authorize runtime ingestion, MCP exposure, root export, artifact/vector
+writes, live adapter execution, support widening, or production platform
+claims.
+
+## Evidence
+
+This work package adds:
+
+1. Closeout preflight script:
+   `scripts/gpp5_repo_intelligence_closeout.py`
+2. Contract schema:
+   `ao_kernel/defaults/schemas/gpp5-repo-intelligence-closeout.schema.v1.json`
+3. Behavior tests:
+   `tests/test_gpp5_repo_intelligence_closeout.py`
+
+The report exits `closed` only when all GPP-5a/GPP-5b/GPP-5c records, schemas,
+public APIs, negative runtime guards, and program flags pass. It also records
+GPP-6 readiness separately.
+
+## GPP-6 Readiness
+
+GPP-6 preparation may use the GPP-5d closeout report as repo-intelligence
+evidence, but GPP-6 execution remains blocked by upstream gates:
+
+1. `GPP-2` protected live-adapter gate is still blocked.
+2. `GPP-4` production-certified read-only adapter decision is still missing.
+
+The closeout report therefore records `gpp6_readiness.status` as
+`blocked_by_upstream_gates` even when GPP-5 itself is closed.
+
+## Non-Goals
+
+1. No GPP-6 protected E2E run is started.
+2. No live adapter is invoked.
+3. No context compiler auto-feed is introduced.
+4. No MCP repo-intelligence tool is exposed.
+5. No root export or write-side artifact/vector write is introduced.
+6. No end-user Cloud Run, vault, webhook, GitHub App private key, deployment
+   protection service, or `ao-release-gate` hosting requirement is added.
+7. No support tier is widened.
+8. No production platform claim is made.
+
+## Exit Decision
+
+`repo_intelligence_read_only_workflow_surface_closed_no_support_widening`
+
+GPP-5 is closed for read-only workflow-surface purposes. The next allowed
+program work is GPP-6 preparation only; GPP-6 execution remains blocked until
+GPP-2 protected gate evidence and GPP-4 read-only adapter decision are ready.

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -213,6 +213,12 @@
       "decision": "repo_intelligence_read_only_workflow_surface_ready_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/557",
       "record": ".claude/plans/GPP-5c-REPO-INTELLIGENCE-WORKFLOW-SURFACE.md"
+    },
+    {
+      "id": "GPP-5d",
+      "decision": "repo_intelligence_read_only_workflow_surface_closed_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/559",
+      "record": ".claude/plans/GPP-5d-REPO-INTELLIGENCE-CLOSEOUT.md"
     }
   ],
   "blocked_wps": [
@@ -292,7 +298,7 @@
   "next_allowed_actions": [
     "treat the GPP-2 deployment-protection policy service as operator-owned platform infrastructure, not an end-user setup requirement",
     "prioritize repo-intelligence onboarding as a read-only product workflow that requires GitHub App installation and repository selection, not Cloud Run, vault, webhook, or private-key setup by each user",
-    "continue GPP-5 repo-intelligence read-only workflow surface closeout and GPP-6 preparation behind explicit opt-in while support_widening_allowed=false and production_platform_claim_allowed=false",
+    "use GPP-5d repo-intelligence closeout evidence for GPP-6 preparation only, while GPP-6 execution remains blocked until GPP-2 protected gate and GPP-4 read-only adapter decision are ready and support_widening_allowed=false and production_platform_claim_allowed=false",
     "run scripts/policy_service_cloud_run_bootstrap_attest.py to verify required GitHub repository variable handles before dispatching the Cloud Run deploy workflow, and treat metadata_ready as repository-variable evidence only",
     "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work",
     "configure or verify the GitHub App webhook URL only after the deployed policy service endpoint is health-checked",

--- a/ao_kernel/defaults/schemas/gpp5-repo-intelligence-closeout.schema.v1.json
+++ b/ao_kernel/defaults/schemas/gpp5-repo-intelligence-closeout.schema.v1.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ao-kernel.local/schemas/gpp5-repo-intelligence-closeout.schema.v1.json",
+  "title": "GPP-5d repo-intelligence closeout preflight",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "program_id",
+    "issue",
+    "overall_status",
+    "decision",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution_allowed",
+    "work_packages",
+    "contract_surfaces",
+    "negative_runtime_guards",
+    "program_flags",
+    "gpp6_readiness",
+    "next_actions"
+  ],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "artifact_kind": { "const": "gpp5_repo_intelligence_closeout_preflight" },
+    "program_id": { "const": "GPP-5d" },
+    "issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["number", "url"],
+      "properties": {
+        "number": { "const": 559 },
+        "url": { "const": "https://github.com/Halildeu/ao-kernel/issues/559" }
+      }
+    },
+    "overall_status": { "enum": ["closed", "blocked"] },
+    "decision": {
+      "enum": [
+        "repo_intelligence_read_only_workflow_surface_closed_no_support_widening",
+        "blocked_repo_intelligence_closeout_no_support_widening"
+      ]
+    },
+    "support_widening": { "const": false },
+    "production_platform_claim": { "const": false },
+    "live_adapter_execution_allowed": { "const": false },
+    "blocked_reason": { "type": "string", "minLength": 1 },
+    "work_packages": {
+      "type": "array",
+      "minItems": 3,
+      "items": { "$ref": "#/$defs/work_package_summary" }
+    },
+    "contract_surfaces": {
+      "type": "array",
+      "minItems": 3,
+      "items": { "$ref": "#/$defs/contract_surface_summary" }
+    },
+    "negative_runtime_guards": {
+      "type": "array",
+      "minItems": 3,
+      "items": { "$ref": "#/$defs/negative_runtime_guard" }
+    },
+    "program_flags": { "$ref": "#/$defs/program_flags" },
+    "gpp6_readiness": { "$ref": "#/$defs/gpp6_readiness" },
+    "next_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "overall_status": { "const": "blocked" } } },
+      "then": { "required": ["blocked_reason"] }
+    },
+    {
+      "if": { "properties": { "overall_status": { "const": "closed" } } },
+      "then": {
+        "properties": {
+          "decision": {
+            "const": "repo_intelligence_read_only_workflow_surface_closed_no_support_widening"
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "finding_list": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "work_package_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status", "decision", "issue", "record", "findings"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "status": { "enum": ["ready", "blocked"] },
+        "decision": { "type": "string", "minLength": 1 },
+        "issue": { "type": "string", "minLength": 1 },
+        "record": { "type": "string", "minLength": 1 },
+        "findings": { "$ref": "#/$defs/finding_list" }
+      }
+    },
+    "contract_surface_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["surface", "status", "schema_ref", "public_api", "findings"],
+      "properties": {
+        "surface": { "type": "string", "minLength": 1 },
+        "status": { "enum": ["ready", "blocked"] },
+        "schema_ref": { "type": "string", "minLength": 1 },
+        "public_api": { "type": "string", "minLength": 1 },
+        "findings": { "$ref": "#/$defs/finding_list" }
+      }
+    },
+    "negative_runtime_guard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["guard", "status", "findings"],
+      "properties": {
+        "guard": { "type": "string", "minLength": 1 },
+        "status": { "enum": ["pass", "fail"] },
+        "scanned_files": { "type": "integer", "minimum": 0 },
+        "findings": { "$ref": "#/$defs/finding_list" }
+      }
+    },
+    "program_flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "support_widening_allowed",
+        "production_platform_claim_allowed",
+        "live_adapter_execution_allowed",
+        "findings"
+      ],
+      "properties": {
+        "status": { "enum": ["pass", "fail"] },
+        "support_widening_allowed": { "type": ["boolean", "null"] },
+        "production_platform_claim_allowed": { "type": ["boolean", "null"] },
+        "live_adapter_execution_allowed": { "type": ["boolean", "null"] },
+        "findings": { "$ref": "#/$defs/finding_list" }
+      }
+    },
+    "gpp6_readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "entry_criteria",
+        "blockers",
+        "support_widening_allowed",
+        "production_platform_claim_allowed",
+        "live_adapter_execution_allowed"
+      ],
+      "properties": {
+        "status": { "enum": ["ready", "blocked_by_upstream_gates"] },
+        "entry_criteria": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "blockers": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "support_widening_allowed": { "const": false },
+        "production_platform_claim_allowed": { "const": false },
+        "live_adapter_execution_allowed": { "const": false }
+      }
+    }
+  }
+}

--- a/scripts/gpp5_repo_intelligence_closeout.py
+++ b/scripts/gpp5_repo_intelligence_closeout.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Generate the GPP-5 repo-intelligence closeout preflight report.
+
+This closeout is deliberately read-only. It verifies that the GPP-5
+repo-intelligence building blocks are present and that the runtime still has no
+hidden prompt injection, context-compiler auto-feed, MCP exposure, root export,
+artifact/vector writes, live adapter execution, support widening, or production
+platform claim. It does not run GPP-6.
+"""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel.config import load_default  # noqa: E402
+from ao_kernel.context.agent_coordination import compile_context_sdk  # noqa: E402
+from ao_kernel.context.context_compiler import compile_context  # noqa: E402
+from ao_kernel.mcp_server import TOOL_DEFINITIONS, TOOL_DISPATCH, create_tool_gateway  # noqa: E402
+from ao_kernel import repo_intelligence  # noqa: E402
+
+JsonDict = dict[str, Any]
+
+_SCHEMA = "gpp5-repo-intelligence-closeout.schema.v1.json"
+_PASS_DECISION = "repo_intelligence_read_only_workflow_surface_closed_no_support_widening"
+_BLOCKED_DECISION = "blocked_repo_intelligence_closeout_no_support_widening"
+
+_REQUIRED_WPS = (
+    (
+        "GPP-5a",
+        "repo_intelligence_product_onboarding_contract_ready_no_support_widening",
+        "https://github.com/Halildeu/ao-kernel/issues/553",
+        ".claude/plans/GPP-5a-REPO-INTELLIGENCE-PRODUCT-ONBOARDING.md",
+    ),
+    (
+        "GPP-5b",
+        "repo_intelligence_explicit_workflow_context_ready_no_support_widening",
+        "https://github.com/Halildeu/ao-kernel/issues/555",
+        ".claude/plans/GPP-5b-REPO-INTELLIGENCE-WORKFLOW-CONTEXT.md",
+    ),
+    (
+        "GPP-5c",
+        "repo_intelligence_read_only_workflow_surface_ready_no_support_widening",
+        "https://github.com/Halildeu/ao-kernel/issues/557",
+        ".claude/plans/GPP-5c-REPO-INTELLIGENCE-WORKFLOW-SURFACE.md",
+    ),
+)
+
+_CONTRACT_SURFACES = (
+    (
+        "product_onboarding",
+        "repo-intelligence-product-onboarding.schema.v1.json",
+        "validate_repo_intelligence_product_onboarding",
+    ),
+    (
+        "explicit_workflow_context",
+        "repo-intelligence-explicit-workflow-context.schema.v1.json",
+        "resolve_repo_intelligence_workflow_context",
+    ),
+    (
+        "read_only_workflow_surface",
+        "repo-intelligence-read-only-workflow-surface.schema.v1.json",
+        "build_repo_intelligence_read_only_workflow_surface",
+    ),
+)
+
+_FORBIDDEN_CONTEXT_PARAMETERS = {
+    "repo_intelligence_context",
+    "repo_intelligence_workflow_context",
+    "repo_intelligence_workflow_surface",
+    "repo_query_context",
+    "context_compiler_feed",
+}
+_FORBIDDEN_WORKFLOW_TOKENS = {
+    "repo_intelligence_context",
+    "repo_intelligence_workflow_context",
+    "repo_intelligence_workflow_surface",
+    "repo_query_context",
+    "context_compiler_feed",
+}
+_DISALLOWED_REPO_MCP_TOOL_NAMES = {
+    "ao_repo_scan",
+    "ao_repo_index",
+    "ao_repo_query",
+    "ao_repo_export",
+    "ao_repo_export_plan",
+    "ao_repo_intelligence",
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate the GPP-5 repo-intelligence closeout preflight report"
+    )
+    parser.add_argument(
+        "--output",
+        choices=("json", "text"),
+        default="text",
+        help="Output format",
+    )
+    parser.add_argument(
+        "--report-path",
+        type=Path,
+        help="Optional path to persist the JSON report",
+    )
+    args = parser.parse_args(argv)
+
+    report = build_gpp5_repo_intelligence_closeout(repo_root=_REPO_ROOT)
+    validate_report(report)
+
+    if args.report_path is not None:
+        args.report_path.parent.mkdir(parents=True, exist_ok=True)
+        args.report_path.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    if args.output == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"overall_status: {report['overall_status']}")
+        print(f"decision: {report['decision']}")
+        print(f"gpp6_readiness: {report['gpp6_readiness']['status']}")
+        if report["overall_status"] == "blocked":
+            print(f"blocked_reason: {report['blocked_reason']}")
+    return 0 if report["overall_status"] == "closed" else 1
+
+
+def build_gpp5_repo_intelligence_closeout(*, repo_root: Path) -> JsonDict:
+    status_payload = _load_json(repo_root / ".claude" / "plans" / "gpp_status.v1.json")
+    work_packages = [
+        _completed_wp_summary(
+            status_payload=status_payload,
+            repo_root=repo_root,
+            wp_id=wp_id,
+            expected_decision=decision,
+            expected_issue=issue,
+            record_path=record,
+        )
+        for wp_id, decision, issue, record in _REQUIRED_WPS
+    ]
+    contract_surfaces = [
+        _contract_surface_summary(surface_id=surface_id, schema_name=schema_name, api_name=api_name)
+        for surface_id, schema_name, api_name in _CONTRACT_SURFACES
+    ]
+    negative_guards = [
+        _context_compiler_guard(),
+        _workflow_definition_guard(repo_root),
+        _mcp_surface_guard(),
+    ]
+    program_flags = _program_flag_summary(status_payload)
+    findings = _collect_findings(
+        work_packages=work_packages,
+        contract_surfaces=contract_surfaces,
+        negative_guards=negative_guards,
+        program_flags=program_flags,
+    )
+    closed = not findings
+
+    report: JsonDict = {
+        "schema_version": "1",
+        "artifact_kind": "gpp5_repo_intelligence_closeout_preflight",
+        "program_id": "GPP-5d",
+        "issue": {
+            "number": 559,
+            "url": "https://github.com/Halildeu/ao-kernel/issues/559",
+        },
+        "overall_status": "closed" if closed else "blocked",
+        "decision": _PASS_DECISION if closed else _BLOCKED_DECISION,
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution_allowed": False,
+        "work_packages": work_packages,
+        "contract_surfaces": contract_surfaces,
+        "negative_runtime_guards": negative_guards,
+        "program_flags": program_flags,
+        "gpp6_readiness": _gpp6_readiness(status_payload),
+        "next_actions": [
+            "Use this closeout as repo-intelligence evidence for GPP-6 preparation only.",
+            "Keep GPP-6 execution blocked until GPP-2 protected gate and GPP-4 real-adapter read-only decision are explicitly ready.",
+            "Do not wire context compiler auto-feed, MCP exposure, root export, or live adapter execution without a later design gate.",
+        ],
+    }
+    if findings:
+        report["blocked_reason"] = "; ".join(findings)
+    return report
+
+
+def validate_report(report: JsonDict) -> None:
+    schema = load_default("schemas", _SCHEMA)
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(report),
+        key=lambda error: (list(error.path), error.message),
+    )
+    if errors:
+        messages = "; ".join(error.message for error in errors)
+        raise ValueError(f"invalid GPP-5 repo-intelligence closeout report: {messages}")
+
+
+def _completed_wp_summary(
+    *,
+    status_payload: JsonDict,
+    repo_root: Path,
+    wp_id: str,
+    expected_decision: str,
+    expected_issue: str,
+    record_path: str,
+) -> JsonDict:
+    completed = {
+        _string(item.get("id")): item
+        for item in _list(status_payload.get("completed_wps"))
+        if isinstance(item, dict)
+    }
+    item = completed.get(wp_id, {})
+    findings: list[str] = []
+    if not item:
+        findings.append("completed_wp_missing")
+    if _string(item.get("decision")) != expected_decision:
+        findings.append("decision_mismatch")
+    if _string(item.get("issue")) != expected_issue:
+        findings.append("issue_mismatch")
+    if _string(item.get("record")) != record_path:
+        findings.append("record_path_mismatch")
+    if not (repo_root / record_path).is_file():
+        findings.append("record_file_missing")
+    return {
+        "id": wp_id,
+        "status": "ready" if not findings else "blocked",
+        "decision": _string(item.get("decision")) or expected_decision,
+        "issue": _string(item.get("issue")) or expected_issue,
+        "record": _string(item.get("record")) or record_path,
+        "findings": findings,
+    }
+
+
+def _contract_surface_summary(*, surface_id: str, schema_name: str, api_name: str) -> JsonDict:
+    findings: list[str] = []
+    try:
+        schema = load_default("schemas", schema_name)
+        Draft202012Validator.check_schema(schema)
+    except Exception as exc:  # pragma: no cover - defensive report detail
+        findings.append(f"schema_invalid:{type(exc).__name__}")
+    if not hasattr(repo_intelligence, api_name):
+        findings.append("public_api_missing")
+    return {
+        "surface": surface_id,
+        "status": "ready" if not findings else "blocked",
+        "schema_ref": schema_name,
+        "public_api": f"ao_kernel.repo_intelligence.{api_name}",
+        "findings": findings,
+    }
+
+
+def _context_compiler_guard() -> JsonDict:
+    findings: list[str] = []
+    compile_parameters = set(inspect.signature(compile_context).parameters)
+    sdk_parameters = set(inspect.signature(compile_context_sdk).parameters)
+    forbidden_compile = sorted(compile_parameters & _FORBIDDEN_CONTEXT_PARAMETERS)
+    forbidden_sdk = sorted(sdk_parameters & _FORBIDDEN_CONTEXT_PARAMETERS)
+    if forbidden_compile:
+        findings.append("compile_context_forbidden_parameters:" + ",".join(forbidden_compile))
+    if forbidden_sdk:
+        findings.append("compile_context_sdk_forbidden_parameters:" + ",".join(forbidden_sdk))
+
+    compiled = compile_context(
+        {
+            "session_id": "gpp5-closeout",
+            "repo_intelligence_workflow_surface": {
+                "content": "hidden repo-intelligence payload must not render"
+            },
+            "repo_query_context": "# Repo Query Context Pack\n\nhidden payload\n",
+            "context_compiler_feed": {
+                "enabled": True,
+            },
+            "ephemeral_decisions": [],
+        },
+        profile="TASK_EXECUTION",
+    )
+    if compiled.preamble != "" or compiled.items_included != 0:
+        findings.append("repo_intelligence_hidden_payload_rendered")
+    return {
+        "guard": "context_compiler_auto_feed_disabled",
+        "status": "pass" if not findings else "fail",
+        "findings": findings,
+    }
+
+
+def _workflow_definition_guard(repo_root: Path) -> JsonDict:
+    workflow_dir = repo_root / "ao_kernel" / "defaults" / "workflows"
+    findings: list[str] = []
+    scanned_files = 0
+    for path in sorted(workflow_dir.glob("*.json")):
+        scanned_files += 1
+        payload = _load_json(path)
+        tokens = _payload_tokens(payload)
+        matches = sorted(tokens & _FORBIDDEN_WORKFLOW_TOKENS)
+        if matches:
+            findings.append(f"{path.name}:{','.join(matches)}")
+    return {
+        "guard": "workflow_definitions_no_repo_intelligence_auto_feed",
+        "status": "pass" if not findings else "fail",
+        "scanned_files": scanned_files,
+        "findings": findings,
+    }
+
+
+def _mcp_surface_guard() -> JsonDict:
+    findings: list[str] = []
+    tool_names = {str(tool["name"]) for tool in TOOL_DEFINITIONS}
+    gateway_tool_names = {str(tool["name"]) for tool in create_tool_gateway().list_tools()}
+    if tool_names != set(TOOL_DISPATCH):
+        findings.append("tool_definitions_dispatch_mismatch")
+    if gateway_tool_names != set(TOOL_DISPATCH):
+        findings.append("tool_gateway_dispatch_mismatch")
+    disallowed = sorted(tool_names & _DISALLOWED_REPO_MCP_TOOL_NAMES)
+    gateway_disallowed = sorted(gateway_tool_names & _DISALLOWED_REPO_MCP_TOOL_NAMES)
+    if disallowed:
+        findings.append("mcp_disallowed_repo_tools:" + ",".join(disallowed))
+    if gateway_disallowed:
+        findings.append("gateway_disallowed_repo_tools:" + ",".join(gateway_disallowed))
+    if any(name.startswith("ao_repo_") or "repo_intelligence" in name for name in tool_names):
+        findings.append("mcp_repo_intelligence_tool_present")
+    return {
+        "guard": "mcp_repo_intelligence_surface_absent",
+        "status": "pass" if not findings else "fail",
+        "findings": findings,
+    }
+
+
+def _program_flag_summary(status_payload: JsonDict) -> JsonDict:
+    findings: list[str] = []
+    if status_payload.get("support_widening_allowed") is not False:
+        findings.append("support_widening_allowed_not_false")
+    if status_payload.get("production_platform_claim_allowed") is not False:
+        findings.append("production_platform_claim_allowed_not_false")
+    if status_payload.get("live_adapter_execution_allowed") is not False:
+        findings.append("live_adapter_execution_allowed_not_false")
+    return {
+        "status": "pass" if not findings else "fail",
+        "support_widening_allowed": status_payload.get("support_widening_allowed"),
+        "production_platform_claim_allowed": status_payload.get("production_platform_claim_allowed"),
+        "live_adapter_execution_allowed": status_payload.get("live_adapter_execution_allowed"),
+        "findings": findings,
+    }
+
+
+def _gpp6_readiness(status_payload: JsonDict) -> JsonDict:
+    completed_ids = {
+        _string(item.get("id"))
+        for item in _list(status_payload.get("completed_wps"))
+        if isinstance(item, dict)
+    }
+    current_wp = status_payload.get("current_wp", {})
+    blockers: list[str] = []
+    if not (isinstance(current_wp, dict) and current_wp.get("id") == "GPP-2" and current_wp.get("status") != "blocked"):
+        blockers.append("gpp2_protected_gate_blocked")
+    if "GPP-4" not in completed_ids:
+        blockers.append("gpp4_real_adapter_read_only_decision_missing")
+    return {
+        "status": "ready" if not blockers else "blocked_by_upstream_gates",
+        "entry_criteria": [
+            "GPP-4 production-certified read-only adapter decision or explicit protected beta permission",
+            "GPP-5 repo-intelligence workflow context ingestion closeout",
+        ],
+        "blockers": blockers,
+        "support_widening_allowed": False,
+        "production_platform_claim_allowed": False,
+        "live_adapter_execution_allowed": False,
+    }
+
+
+def _collect_findings(
+    *,
+    work_packages: list[JsonDict],
+    contract_surfaces: list[JsonDict],
+    negative_guards: list[JsonDict],
+    program_flags: JsonDict,
+) -> list[str]:
+    findings: list[str] = []
+    for item in work_packages:
+        if item["status"] != "ready":
+            findings.append(f"{item['id']}:{','.join(item['findings'])}")
+    for item in contract_surfaces:
+        if item["status"] != "ready":
+            findings.append(f"{item['surface']}:{','.join(item['findings'])}")
+    for item in negative_guards:
+        if item["status"] != "pass":
+            findings.append(f"{item['guard']}:{','.join(item['findings'])}")
+    if program_flags["status"] != "pass":
+        findings.append("program_flags:" + ",".join(program_flags["findings"]))
+    return findings
+
+
+def _payload_tokens(payload: Any) -> set[str]:
+    tokens: set[str] = set()
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            tokens.add(str(key))
+            tokens.update(_payload_tokens(value))
+    elif isinstance(payload, list):
+        for value in payload:
+            tokens.update(_payload_tokens(value))
+    elif isinstance(payload, str):
+        tokens.add(payload)
+    return tokens
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gpp5_repo_intelligence_closeout.py
+++ b/tests/test_gpp5_repo_intelligence_closeout.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from ao_kernel.config import load_default
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _module() -> Any:
+    module_path = _repo_root() / "scripts" / "gpp5_repo_intelligence_closeout.py"
+    spec = importlib.util.spec_from_file_location("gpp5_repo_intelligence_closeout", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", "gpp5-repo-intelligence-closeout.schema.v1.json")
+
+
+def _schema_errors(payload: dict[str, Any]) -> list[str]:
+    errors = Draft202012Validator(_schema()).iter_errors(payload)
+    return sorted(error.message for error in errors)
+
+
+def _status_payload() -> dict[str, Any]:
+    return json.loads((_repo_root() / ".claude" / "plans" / "gpp_status.v1.json").read_text(encoding="utf-8"))
+
+
+def _write_minimal_closeout_repo(tmp_path: Path, status_payload: dict[str, Any]) -> Path:
+    plans = tmp_path / ".claude" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "gpp_status.v1.json").write_text(
+        json.dumps(status_payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    for item in status_payload.get("completed_wps", []):
+        record = item.get("record")
+        if isinstance(record, str):
+            record_path = tmp_path / record
+            record_path.parent.mkdir(parents=True, exist_ok=True)
+            record_path.write_text(f"# {item['id']}\n", encoding="utf-8")
+    workflows = tmp_path / "ao_kernel" / "defaults" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "minimal.v1.json").write_text('{"workflow_id":"minimal"}\n', encoding="utf-8")
+    return tmp_path
+
+
+def test_closeout_report_is_schema_valid_and_keeps_gpp6_blocked() -> None:
+    module = _module()
+
+    report = module.build_gpp5_repo_intelligence_closeout(repo_root=_repo_root())
+
+    assert _schema_errors(report) == []
+    module.validate_report(report)
+    assert report["overall_status"] == "closed"
+    assert report["decision"] == "repo_intelligence_read_only_workflow_surface_closed_no_support_widening"
+    assert report["support_widening"] is False
+    assert report["production_platform_claim"] is False
+    assert report["live_adapter_execution_allowed"] is False
+    assert {item["id"] for item in report["work_packages"]} == {"GPP-5a", "GPP-5b", "GPP-5c"}
+    assert all(item["status"] == "ready" and item["findings"] == [] for item in report["work_packages"])
+    assert {item["surface"] for item in report["contract_surfaces"]} == {
+        "product_onboarding",
+        "explicit_workflow_context",
+        "read_only_workflow_surface",
+    }
+    assert all(item["status"] == "ready" and item["findings"] == [] for item in report["contract_surfaces"])
+    assert all(item["status"] == "pass" and item["findings"] == [] for item in report["negative_runtime_guards"])
+    assert report["program_flags"] == {
+        "status": "pass",
+        "support_widening_allowed": False,
+        "production_platform_claim_allowed": False,
+        "live_adapter_execution_allowed": False,
+        "findings": [],
+    }
+    assert report["gpp6_readiness"]["status"] == "blocked_by_upstream_gates"
+    assert report["gpp6_readiness"]["blockers"] == [
+        "gpp2_protected_gate_blocked",
+        "gpp4_real_adapter_read_only_decision_missing",
+    ]
+
+
+def test_closeout_schema_rejects_support_or_runtime_widening() -> None:
+    module = _module()
+    validator = Draft202012Validator(_schema())
+    report = module.build_gpp5_repo_intelligence_closeout(repo_root=_repo_root())
+
+    support_claim = copy.deepcopy(report)
+    support_claim["support_widening"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(support_claim)
+
+    runtime_claim = copy.deepcopy(report)
+    runtime_claim["live_adapter_execution_allowed"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(runtime_claim)
+
+
+def test_closeout_blocks_missing_required_work_package(tmp_path: Path) -> None:
+    module = _module()
+    status_payload = _status_payload()
+    status_payload["completed_wps"] = [
+        item for item in status_payload["completed_wps"] if item.get("id") != "GPP-5c"
+    ]
+    repo_root = _write_minimal_closeout_repo(tmp_path, status_payload)
+
+    report = module.build_gpp5_repo_intelligence_closeout(repo_root=repo_root)
+
+    assert _schema_errors(report) == []
+    assert report["overall_status"] == "blocked"
+    assert report["decision"] == "blocked_repo_intelligence_closeout_no_support_widening"
+    gpp5c = next(item for item in report["work_packages"] if item["id"] == "GPP-5c")
+    assert gpp5c["status"] == "blocked"
+    assert "completed_wp_missing" in gpp5c["findings"]
+    assert "record_file_missing" in gpp5c["findings"]
+    assert "GPP-5c" in report["blocked_reason"]
+
+
+def test_closeout_blocks_hidden_workflow_auto_feed_token(tmp_path: Path) -> None:
+    module = _module()
+    repo_root = _write_minimal_closeout_repo(tmp_path, _status_payload())
+    workflow_path = repo_root / "ao_kernel" / "defaults" / "workflows" / "hidden-feed.v1.json"
+    workflow_path.write_text(
+        json.dumps({"workflow_id": "hidden", "repo_intelligence_context": {"enabled": True}}),
+        encoding="utf-8",
+    )
+
+    report = module.build_gpp5_repo_intelligence_closeout(repo_root=repo_root)
+
+    assert _schema_errors(report) == []
+    assert report["overall_status"] == "blocked"
+    workflow_guard = next(
+        item
+        for item in report["negative_runtime_guards"]
+        if item["guard"] == "workflow_definitions_no_repo_intelligence_auto_feed"
+    )
+    assert workflow_guard["status"] == "fail"
+    assert "hidden-feed.v1.json:repo_intelligence_context" in workflow_guard["findings"]

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -228,6 +228,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-5d"
+        and item["decision"] == "repo_intelligence_read_only_workflow_surface_closed_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/559"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -327,7 +334,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(
         action
-        == "continue GPP-5 repo-intelligence read-only workflow surface closeout and GPP-6 preparation behind explicit opt-in while support_widening_allowed=false and production_platform_claim_allowed=false"
+        == "use GPP-5d repo-intelligence closeout evidence for GPP-6 preparation only, while GPP-6 execution remains blocked until GPP-2 protected gate and GPP-4 read-only adapter decision are ready and support_widening_allowed=false and production_platform_claim_allowed=false"
         for action in payload["next_allowed_actions"]
     )
     assert any(


### PR DESCRIPTION
## Summary
- add a schema-backed GPP-5d repo-intelligence closeout preflight script
- validate GPP-5a/GPP-5b/GPP-5c records, public APIs, schemas, MCP/context/workflow negative guards, and closed program flags
- update GPP status/docs so GPP-5 is closed as a read-only building block while GPP-6 remains blocked by GPP-2/GPP-4

## Validation
- python3 -m pytest tests/test_gpp5_repo_intelligence_closeout.py tests/test_repo_intelligence_workflow_surface.py tests/test_gpp_next.py -q
- python3 -m ruff check scripts/gpp5_repo_intelligence_closeout.py tests/test_gpp5_repo_intelligence_closeout.py tests/test_gpp_next.py
- python3 -m json.tool ao_kernel/defaults/schemas/gpp5-repo-intelligence-closeout.schema.v1.json
- python3 -m json.tool .claude/plans/gpp_status.v1.json
- python3 scripts/gpp5_repo_intelligence_closeout.py --output text
- python3 scripts/gpp_next.py
- git diff --check

Closes #559