### PR TITLE
GPP-6a: add read-only E2E preflight

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -244,6 +244,12 @@ Last live verification on current `origin/main` showed:
     schemas, and negative runtime guards. GPP-6 preparation may use this
     closeout as repo-intelligence evidence, but GPP-6 execution remains
     blocked by GPP-2 and GPP-4.
+46. GPP-6a adds a preparation-only read-only E2E preflight. The preflight
+    report is ready and records `execution_status=blocked_by_upstream_gates`
+    because GPP-2 protected gate evidence and the GPP-4 read-only adapter
+    decision are still missing. It does not dispatch protected workflows, call
+    live adapters, write artifacts/vectors, perform remote writes, widen
+    support, or claim production-platform readiness.
 
 ## 3. Current Verdict
 
@@ -319,7 +325,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-5c` | Completed / no support widening | Repo-intelligence read-only workflow surface output contract | accepted workflow context converts to a visible pointer + source metadata payload; no Markdown body, auto-feed, MCP, root export, or runtime execution |
 | `GPP-5d` | Completed / no support widening | Repo-intelligence read-only workflow surface closeout preflight | schema-backed closeout verifies GPP-5a/GPP-5b/GPP-5c, public APIs, schemas, and negative runtime guards; GPP-6 execution remains blocked by GPP-2/GPP-4 |
 | `GPP-5` | Completed as read-only building block / no support widening | Repo-intelligence explicit workflow integration | onboarding, workflow-context resolver, output contract, and closeout preflight ready; runtime ingestion remains disabled |
-| `GPP-6` | Not started | Read-only production E2E over real adapter + repo intelligence | `read_only_e2e_ready` / `blocked_e2e` |
+| `GPP-6a` | Completed / preparation only / no support widening | Read-only E2E preflight contract | preflight ready; execution blocked by GPP-2 protected gate and GPP-4 adapter decision |
+| `GPP-6` | Preparation only / execution blocked | Read-only production E2E over real adapter + repo intelligence | `read_only_e2e_ready` / `blocked_e2e` |
 | `GPP-7` | Not started | Controlled write-side production candidate | `write_candidate_ready` / `keep_rehearsal_only` |
 | `GPP-8` | Not started | Remote PR live-write promotion candidate | `remote_pr_candidate_ready` / `keep_sandbox_only` |
 | `GPP-9` | Not started | Full production matrix + claim decision | `promote_general_purpose_production` / `promote_general_purpose_beta` / `keep_narrow_stable_runtime` |
@@ -708,6 +715,17 @@ repo scan/index/query
 3. event-order assertions
 4. runbook reproduction check
 
+**GPP-6a preflight:** PR for issue
+[#561](https://github.com/Halildeu/ao-kernel/issues/561) adds a
+preparation-only GPP-6 preflight. The report records the target chain and entry
+criteria, verifies GPP-5d closeout evidence, and pins
+`execution_status=blocked_by_upstream_gates` because `GPP-2` remains blocked
+and `GPP-4` is missing.
+
+This slice does not dispatch protected workflows, invoke live adapters, write
+repo-intelligence artifacts or vectors, perform remote writes, widen support,
+or claim production-platform readiness. GPP-6 execution remains blocked.
+
 ## 14. GPP-7 - Controlled Write-Side Production Candidate
 
 **Goal:** Promote local patch/test from rehearsal-only toward a production
@@ -911,10 +929,10 @@ deployment review callback. In parallel, bootstrap/run the trusted dry-run
 GitHub App webhook URL, collect real PR check-run evidence, and only then cut
 branch protection/rulesets over to require `ao-release-gate`. Do not
 repeatedly dispatch `.github/workflows/live-adapter-gate.yml` until that
-service is expected to respond. GPP-5d closes repo-intelligence as a read-only
-building block for future GPP-6 preparation, but GPP-6 execution remains
-blocked by GPP-2 and GPP-4. Any follow-up must keep fork and pull-request
-contexts away from protected credentials, must not use
+service is expected to respond. GPP-6a records read-only E2E preflight
+preparation, but GPP-6 execution remains blocked by GPP-2 and GPP-4. Any
+follow-up must keep fork and pull-request contexts away from protected
+credentials, must not use
 `AO_CLAUDE_CODE_CLI_AUTH` through a `secrets.` expression until a later
 live-execution slice explicitly permits it, must reject PAT-backed bots and
 admin bypass for PR merge automation, and must keep
@@ -949,6 +967,7 @@ admin bypass for PR merge automation, and must keep
 | Missing repository variables bypassed | Deploy workflow could be dispatched before non-secret handles exist | Run GPP-2ab attestation with `--fail-on-blocked` and provision missing GitHub repository variables before deploy dispatch |
 | `metadata_ready` mistaken for cloud readiness | Deployment could be treated as unblocked without GCP trust or hosting proof | Treat GPP-2ab as repository-variable metadata only; separately prove OIDC, service account permissions, Secret Manager objects, Cloud Run health, webhook URL, and callback evidence |
 | GPP-5 closeout mistaken for GPP-6 approval | Read-only repo-intelligence evidence could be overclaimed as protected E2E readiness | GPP-5d records `gpp6_readiness=blocked_by_upstream_gates`; require GPP-2 protected gate evidence and GPP-4 adapter decision before GPP-6 execution |
+| GPP-6 preflight mistaken for E2E execution approval | A preparation report could be overclaimed as a protected adapter run | GPP-6a records `execution_status=blocked_by_upstream_gates`, `protected_workflow_dispatch_allowed=false`, and `live_adapter_execution_allowed=false`; require GPP-2/GPP-4 before any execution |
 
 ## 19. Tracking Log
 
@@ -1016,3 +1035,5 @@ admin bypass for PR merge automation, and must keep
 | 2026-04-28 | GPP-2ab bootstrap attestation added | `scripts/policy_service_cloud_run_bootstrap_attest.py` checks required GitHub repository variable handles with `gh variable list --json name,updatedAt`, ignores values, and records that current live metadata is `overall_status=blocked` because all required handles are missing; GCP trust, Secret Manager objects, Cloud Run hosting, webhook URL configuration, callback posting, live execution, support widening, and production-platform claims remain unproven. |
 | 2026-04-28 | GPP-5d issue opened | Issue [#559](https://github.com/Halildeu/ao-kernel/issues/559) tracks repo-intelligence read-only workflow closeout before GPP-6 preparation. |
 | 2026-04-28 | GPP-5d closeout preflight added | `scripts/gpp5_repo_intelligence_closeout.py` records GPP-5 as closed for read-only workflow-surface purposes while keeping GPP-6 execution blocked by GPP-2 and GPP-4. |
+| 2026-04-28 | GPP-6a issue opened | Issue [#561](https://github.com/Halildeu/ao-kernel/issues/561) tracks the read-only E2E preflight contract for GPP-6 preparation. |
+| 2026-04-28 | GPP-6a preflight added | `scripts/gpp6_read_only_e2e_preflight.py` records GPP-6 preparation as ready while keeping execution blocked by GPP-2 and GPP-4 with no live adapter, protected workflow dispatch, remote write, support widening, or production claim. |

--- a/.claude/plans/GPP-6a-READ-ONLY-E2E-PREFLIGHT.md
+++ b/.claude/plans/GPP-6a-READ-ONLY-E2E-PREFLIGHT.md
@@ -1,0 +1,66 @@
+# GPP-6a - Read-Only E2E Preflight
+
+**Issue:** [#561](https://github.com/Halildeu/ao-kernel/issues/561)
+
+**Decision:** `read_only_e2e_preflight_ready_execution_blocked_no_support_widening`
+
+**Status:** completed / preparation only / no support widening
+
+**Date:** 2026-04-28
+
+## Scope
+
+Add a preparation-only preflight for the GPP-6 read-only production E2E path.
+This slice records the target chain and entry criteria without dispatching a
+protected workflow, invoking a live adapter, writing repo-intelligence
+artifacts, writing vectors, or performing any remote write.
+
+## Decision
+
+The GPP-6 preflight report is ready, but GPP-6 execution remains blocked by
+upstream gates:
+
+1. `GPP-2` protected live-adapter gate remains blocked.
+2. `GPP-4` production-certified read-only adapter decision is missing.
+
+The report therefore records:
+
+```text
+overall_status=ready
+execution_status=blocked_by_upstream_gates
+```
+
+This means the preflight itself is usable as preparation evidence, not that
+GPP-6 protected E2E execution is authorized.
+
+## Evidence
+
+This work package adds:
+
+1. Preflight script:
+   `scripts/gpp6_read_only_e2e_preflight.py`
+2. Contract schema:
+   `ao_kernel/defaults/schemas/gpp6-read-only-e2e-preflight.schema.v1.json`
+3. Behavior tests:
+   `tests/test_gpp6_read_only_e2e_preflight.py`
+
+The report checks that GPP-5d closeout evidence is present, records GPP-2 and
+GPP-4 as upstream blockers, and pins all side-effect flags closed.
+
+## Non-Goals
+
+1. No protected workflow is dispatched.
+2. No live adapter is invoked.
+3. No GPP-6 read-only E2E run is executed.
+4. No repo-intelligence root export, artifact write, or vector write is
+   introduced.
+5. No remote write is performed.
+6. No support tier is widened.
+7. No production platform claim is made.
+
+## Exit Decision
+
+`read_only_e2e_preflight_ready_execution_blocked_no_support_widening`
+
+GPP-6 can continue only as preparation work until GPP-2 protected gate
+evidence and GPP-4 read-only adapter decision are ready.

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -219,6 +219,12 @@
       "decision": "repo_intelligence_read_only_workflow_surface_closed_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/559",
       "record": ".claude/plans/GPP-5d-REPO-INTELLIGENCE-CLOSEOUT.md"
+    },
+    {
+      "id": "GPP-6a",
+      "decision": "read_only_e2e_preflight_ready_execution_blocked_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/561",
+      "record": ".claude/plans/GPP-6a-READ-ONLY-E2E-PREFLIGHT.md"
     }
   ],
   "blocked_wps": [
@@ -298,7 +304,7 @@
   "next_allowed_actions": [
     "treat the GPP-2 deployment-protection policy service as operator-owned platform infrastructure, not an end-user setup requirement",
     "prioritize repo-intelligence onboarding as a read-only product workflow that requires GitHub App installation and repository selection, not Cloud Run, vault, webhook, or private-key setup by each user",
-    "use GPP-5d repo-intelligence closeout evidence for GPP-6 preparation only, while GPP-6 execution remains blocked until GPP-2 protected gate and GPP-4 read-only adapter decision are ready and support_widening_allowed=false and production_platform_claim_allowed=false",
+    "use GPP-6a read-only E2E preflight evidence for preparation only, while GPP-6 execution remains blocked until GPP-2 protected gate and GPP-4 read-only adapter decision are ready and support_widening_allowed=false and production_platform_claim_allowed=false",
     "run scripts/policy_service_cloud_run_bootstrap_attest.py to verify required GitHub repository variable handles before dispatching the Cloud Run deploy workflow, and treat metadata_ready as repository-variable evidence only",
     "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work",
     "configure or verify the GitHub App webhook URL only after the deployed policy service endpoint is health-checked",

--- a/ao_kernel/defaults/schemas/gpp6-read-only-e2e-preflight.schema.v1.json
+++ b/ao_kernel/defaults/schemas/gpp6-read-only-e2e-preflight.schema.v1.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ao-kernel.local/schemas/gpp6-read-only-e2e-preflight.schema.v1.json",
+  "title": "GPP-6a read-only E2E preflight",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "program_id",
+    "issue",
+    "overall_status",
+    "decision",
+    "execution_status",
+    "upstream_blockers",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution_allowed",
+    "protected_workflow_dispatch_allowed",
+    "remote_write_allowed",
+    "gpp5d_closeout",
+    "entry_criteria",
+    "execution_plan",
+    "program_flags",
+    "safety",
+    "next_actions"
+  ],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "artifact_kind": { "const": "gpp6_read_only_e2e_preflight" },
+    "program_id": { "const": "GPP-6a" },
+    "issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["number", "url"],
+      "properties": {
+        "number": { "const": 561 },
+        "url": { "const": "https://github.com/Halildeu/ao-kernel/issues/561" }
+      }
+    },
+    "overall_status": { "enum": ["ready", "blocked"] },
+    "decision": {
+      "enum": [
+        "read_only_e2e_preflight_ready_execution_blocked_no_support_widening",
+        "read_only_e2e_preflight_ready_no_support_widening",
+        "blocked_read_only_e2e_preflight_no_support_widening"
+      ]
+    },
+    "execution_status": {
+      "enum": ["blocked_by_upstream_gates", "ready_for_protected_rehearsal"]
+    },
+    "upstream_blockers": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "support_widening": { "const": false },
+    "production_platform_claim": { "const": false },
+    "live_adapter_execution_allowed": { "const": false },
+    "protected_workflow_dispatch_allowed": { "const": false },
+    "remote_write_allowed": { "const": false },
+    "blocked_reason": { "type": "string", "minLength": 1 },
+    "gpp5d_closeout": { "$ref": "#/$defs/completed_wp_summary" },
+    "entry_criteria": {
+      "type": "array",
+      "minItems": 3,
+      "items": { "$ref": "#/$defs/entry_criterion" }
+    },
+    "execution_plan": {
+      "type": "array",
+      "minItems": 6,
+      "items": { "$ref": "#/$defs/execution_step" }
+    },
+    "program_flags": { "$ref": "#/$defs/program_flags" },
+    "safety": { "$ref": "#/$defs/safety" },
+    "next_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "overall_status": { "const": "blocked" } } },
+      "then": { "required": ["blocked_reason"] }
+    },
+    {
+      "if": { "properties": { "overall_status": { "const": "ready" } } },
+      "then": {
+        "properties": {
+          "decision": {
+            "enum": [
+              "read_only_e2e_preflight_ready_execution_blocked_no_support_widening",
+              "read_only_e2e_preflight_ready_no_support_widening"
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "finding_list": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "completed_wp_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status", "decision", "issue", "record", "findings"],
+      "properties": {
+        "id": { "const": "GPP-5d" },
+        "status": { "enum": ["ready", "blocked"] },
+        "decision": { "type": "string", "minLength": 1 },
+        "issue": { "type": "string", "minLength": 1 },
+        "record": { "type": "string", "minLength": 1 },
+        "findings": { "$ref": "#/$defs/finding_list" }
+      }
+    },
+    "entry_criterion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status", "required_for_execution", "evidence", "findings"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "status": { "enum": ["ready", "blocked", "missing"] },
+        "required_for_execution": { "const": true },
+        "evidence": { "type": "string" },
+        "findings": { "$ref": "#/$defs/finding_list" }
+      }
+    },
+    "execution_step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "step",
+        "status",
+        "protected_workflow_dispatch",
+        "live_adapter_execution",
+        "remote_side_effects"
+      ],
+      "properties": {
+        "step": { "type": "string", "minLength": 1 },
+        "status": { "const": "not_executed" },
+        "protected_workflow_dispatch": { "const": false },
+        "live_adapter_execution": { "const": false },
+        "remote_side_effects": { "const": false }
+      }
+    },
+    "program_flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "support_widening_allowed",
+        "production_platform_claim_allowed",
+        "live_adapter_execution_allowed",
+        "findings"
+      ],
+      "properties": {
+        "status": { "enum": ["pass", "fail"] },
+        "support_widening_allowed": { "type": ["boolean", "null"] },
+        "production_platform_claim_allowed": { "type": ["boolean", "null"] },
+        "live_adapter_execution_allowed": { "type": ["boolean", "null"] },
+        "findings": { "$ref": "#/$defs/finding_list" }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "protected_workflow_dispatch",
+        "live_adapter_execution",
+        "remote_write",
+        "context_compiler_auto_feed",
+        "mcp_repo_intelligence",
+        "root_export",
+        "artifact_writes",
+        "vector_writes",
+        "secret_value_readback",
+        "support_widening",
+        "production_platform_claim",
+        "findings"
+      ],
+      "properties": {
+        "status": { "enum": ["pass", "fail"] },
+        "protected_workflow_dispatch": { "const": false },
+        "live_adapter_execution": { "const": false },
+        "remote_write": { "const": false },
+        "context_compiler_auto_feed": { "const": false },
+        "mcp_repo_intelligence": { "const": false },
+        "root_export": { "const": false },
+        "artifact_writes": { "const": false },
+        "vector_writes": { "const": false },
+        "secret_value_readback": { "const": false },
+        "support_widening": { "const": false },
+        "production_platform_claim": { "const": false },
+        "findings": { "$ref": "#/$defs/finding_list" }
+      }
+    }
+  }
+}

--- a/scripts/gpp6_read_only_e2e_preflight.py
+++ b/scripts/gpp6_read_only_e2e_preflight.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Generate the GPP-6 read-only E2E preparation preflight report.
+
+This script does not run GPP-6. It verifies that the repo-intelligence
+closeout evidence is present, records that upstream protected-runtime gates are
+still blocking execution, and keeps all runtime side effects disabled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel.config import load_default  # noqa: E402
+
+JsonDict = dict[str, Any]
+
+_SCHEMA = "gpp6-read-only-e2e-preflight.schema.v1.json"
+_PASS_BLOCKED_DECISION = "read_only_e2e_preflight_ready_execution_blocked_no_support_widening"
+_PASS_READY_DECISION = "read_only_e2e_preflight_ready_no_support_widening"
+_BLOCKED_DECISION = "blocked_read_only_e2e_preflight_no_support_widening"
+
+_GPP5D = {
+    "id": "GPP-5d",
+    "decision": "repo_intelligence_read_only_workflow_surface_closed_no_support_widening",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/559",
+    "record": ".claude/plans/GPP-5d-REPO-INTELLIGENCE-CLOSEOUT.md",
+}
+
+_CHAIN_STEPS = (
+    "repo_scan_index_query",
+    "explicit_context_handoff",
+    "protected_real_adapter",
+    "governed_workflow",
+    "review_findings_or_patch_plan_artifact",
+    "evidence_timeline",
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate the GPP-6 read-only E2E preflight report")
+    parser.add_argument("--output", choices=("json", "text"), default="text", help="Output format")
+    parser.add_argument("--report-path", type=Path, help="Optional path to persist the JSON report")
+    parser.add_argument(
+        "--fail-on-execution-blocked",
+        action="store_true",
+        help="Return exit code 1 when upstream gates still block GPP-6 execution.",
+    )
+    args = parser.parse_args(argv)
+
+    report = build_gpp6_read_only_e2e_preflight(repo_root=_REPO_ROOT)
+    validate_report(report)
+
+    if args.report_path is not None:
+        args.report_path.parent.mkdir(parents=True, exist_ok=True)
+        args.report_path.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    if args.output == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"overall_status: {report['overall_status']}")
+        print(f"decision: {report['decision']}")
+        print(f"execution_status: {report['execution_status']}")
+        if report["upstream_blockers"]:
+            print(f"upstream_blockers: {', '.join(report['upstream_blockers'])}")
+        if report["overall_status"] == "blocked":
+            print(f"blocked_reason: {report['blocked_reason']}")
+
+    if args.fail_on_execution_blocked and report["execution_status"] != "ready_for_protected_rehearsal":
+        return 1
+    return 0 if report["overall_status"] == "ready" else 1
+
+
+def build_gpp6_read_only_e2e_preflight(*, repo_root: Path) -> JsonDict:
+    status_payload = _load_json(repo_root / ".claude" / "plans" / "gpp_status.v1.json")
+    gpp5d = _completed_wp_summary(status_payload=status_payload, repo_root=repo_root, expected=_GPP5D)
+    entry_criteria = [
+        _gpp5d_entry(gpp5d),
+        _gpp2_entry(status_payload),
+        _gpp4_entry(status_payload),
+    ]
+    upstream_blockers = _upstream_blockers(entry_criteria)
+    program_flags = _program_flag_summary(status_payload)
+    safety = _safety_summary()
+    findings = _collect_findings(gpp5d=gpp5d, program_flags=program_flags, safety=safety)
+    ready = not findings
+    execution_status = "ready_for_protected_rehearsal" if ready and not upstream_blockers else "blocked_by_upstream_gates"
+
+    if not ready:
+        decision = _BLOCKED_DECISION
+    elif execution_status == "ready_for_protected_rehearsal":
+        decision = _PASS_READY_DECISION
+    else:
+        decision = _PASS_BLOCKED_DECISION
+
+    report: JsonDict = {
+        "schema_version": "1",
+        "artifact_kind": "gpp6_read_only_e2e_preflight",
+        "program_id": "GPP-6a",
+        "issue": {
+            "number": 561,
+            "url": "https://github.com/Halildeu/ao-kernel/issues/561",
+        },
+        "overall_status": "ready" if ready else "blocked",
+        "decision": decision,
+        "execution_status": execution_status,
+        "upstream_blockers": upstream_blockers,
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution_allowed": False,
+        "protected_workflow_dispatch_allowed": False,
+        "remote_write_allowed": False,
+        "gpp5d_closeout": gpp5d,
+        "entry_criteria": entry_criteria,
+        "execution_plan": _execution_plan(),
+        "program_flags": program_flags,
+        "safety": safety,
+        "next_actions": [
+            "Use this preflight as GPP-6 preparation evidence only.",
+            "Keep GPP-6 execution blocked until GPP-2 protected gate evidence and GPP-4 read-only adapter decision are ready.",
+            "Do not dispatch protected workflows, invoke live adapters, write artifacts, write vectors, or perform remote writes from this slice.",
+        ],
+    }
+    if findings:
+        report["blocked_reason"] = "; ".join(findings)
+    return report
+
+
+def validate_report(report: JsonDict) -> None:
+    schema = load_default("schemas", _SCHEMA)
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(report),
+        key=lambda error: (list(error.path), error.message),
+    )
+    if errors:
+        messages = "; ".join(error.message for error in errors)
+        raise ValueError(f"invalid GPP-6 read-only E2E preflight report: {messages}")
+
+
+def _completed_wp_summary(*, status_payload: JsonDict, repo_root: Path, expected: JsonDict) -> JsonDict:
+    completed = {
+        _string(item.get("id")): item
+        for item in _list(status_payload.get("completed_wps"))
+        if isinstance(item, dict)
+    }
+    item = completed.get(expected["id"], {})
+    findings: list[str] = []
+    if not item:
+        findings.append("completed_wp_missing")
+    if _string(item.get("decision")) != expected["decision"]:
+        findings.append("decision_mismatch")
+    if _string(item.get("issue")) != expected["issue"]:
+        findings.append("issue_mismatch")
+    if _string(item.get("record")) != expected["record"]:
+        findings.append("record_path_mismatch")
+    if not (repo_root / expected["record"]).is_file():
+        findings.append("record_file_missing")
+    return {
+        "id": expected["id"],
+        "status": "ready" if not findings else "blocked",
+        "decision": _string(item.get("decision")) or expected["decision"],
+        "issue": _string(item.get("issue")) or expected["issue"],
+        "record": _string(item.get("record")) or expected["record"],
+        "findings": findings,
+    }
+
+
+def _gpp5d_entry(gpp5d: JsonDict) -> JsonDict:
+    return {
+        "id": "gpp5d_repo_intelligence_closeout",
+        "status": "ready" if gpp5d["status"] == "ready" else "blocked",
+        "required_for_execution": True,
+        "evidence": gpp5d["record"],
+        "findings": list(gpp5d["findings"]),
+    }
+
+
+def _gpp2_entry(status_payload: JsonDict) -> JsonDict:
+    current_wp = status_payload.get("current_wp", {})
+    ready = isinstance(current_wp, dict) and current_wp.get("id") == "GPP-2" and current_wp.get("status") != "blocked"
+    return {
+        "id": "gpp2_protected_gate",
+        "status": "ready" if ready else "blocked",
+        "required_for_execution": True,
+        "evidence": _string(current_wp.get("issue")) if isinstance(current_wp, dict) else "",
+        "findings": [] if ready else ["gpp2_protected_gate_blocked"],
+    }
+
+
+def _gpp4_entry(status_payload: JsonDict) -> JsonDict:
+    completed_ids = {
+        _string(item.get("id"))
+        for item in _list(status_payload.get("completed_wps"))
+        if isinstance(item, dict)
+    }
+    ready = "GPP-4" in completed_ids
+    return {
+        "id": "gpp4_read_only_adapter_decision",
+        "status": "ready" if ready else "missing",
+        "required_for_execution": True,
+        "evidence": "completed_wps:GPP-4" if ready else "",
+        "findings": [] if ready else ["gpp4_real_adapter_read_only_decision_missing"],
+    }
+
+
+def _upstream_blockers(entry_criteria: list[JsonDict]) -> list[str]:
+    blockers: list[str] = []
+    for item in entry_criteria:
+        if item["id"] == "gpp5d_repo_intelligence_closeout":
+            continue
+        blockers.extend(_string(finding) for finding in item["findings"])
+    return [blocker for blocker in blockers if blocker]
+
+
+def _execution_plan() -> list[JsonDict]:
+    return [
+        {
+            "step": step,
+            "status": "not_executed",
+            "protected_workflow_dispatch": False,
+            "live_adapter_execution": False,
+            "remote_side_effects": False,
+        }
+        for step in _CHAIN_STEPS
+    ]
+
+
+def _program_flag_summary(status_payload: JsonDict) -> JsonDict:
+    findings: list[str] = []
+    if status_payload.get("support_widening_allowed") is not False:
+        findings.append("support_widening_allowed_not_false")
+    if status_payload.get("production_platform_claim_allowed") is not False:
+        findings.append("production_platform_claim_allowed_not_false")
+    if status_payload.get("live_adapter_execution_allowed") is not False:
+        findings.append("live_adapter_execution_allowed_not_false")
+    return {
+        "status": "pass" if not findings else "fail",
+        "support_widening_allowed": status_payload.get("support_widening_allowed"),
+        "production_platform_claim_allowed": status_payload.get("production_platform_claim_allowed"),
+        "live_adapter_execution_allowed": status_payload.get("live_adapter_execution_allowed"),
+        "findings": findings,
+    }
+
+
+def _safety_summary() -> JsonDict:
+    return {
+        "status": "pass",
+        "protected_workflow_dispatch": False,
+        "live_adapter_execution": False,
+        "remote_write": False,
+        "context_compiler_auto_feed": False,
+        "mcp_repo_intelligence": False,
+        "root_export": False,
+        "artifact_writes": False,
+        "vector_writes": False,
+        "secret_value_readback": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+        "findings": [],
+    }
+
+
+def _collect_findings(*, gpp5d: JsonDict, program_flags: JsonDict, safety: JsonDict) -> list[str]:
+    findings: list[str] = []
+    if gpp5d["status"] != "ready":
+        findings.append("gpp5d_closeout:" + ",".join(gpp5d["findings"]))
+    if program_flags["status"] != "pass":
+        findings.append("program_flags:" + ",".join(program_flags["findings"]))
+    if safety["status"] != "pass":
+        findings.append("safety:" + ",".join(safety["findings"]))
+    return findings
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gpp6_read_only_e2e_preflight.py
+++ b/tests/test_gpp6_read_only_e2e_preflight.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from ao_kernel.config import load_default
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _module() -> Any:
+    module_path = _repo_root() / "scripts" / "gpp6_read_only_e2e_preflight.py"
+    spec = importlib.util.spec_from_file_location("gpp6_read_only_e2e_preflight", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", "gpp6-read-only-e2e-preflight.schema.v1.json")
+
+
+def _schema_errors(payload: dict[str, Any]) -> list[str]:
+    errors = Draft202012Validator(_schema()).iter_errors(payload)
+    return sorted(error.message for error in errors)
+
+
+def _status_payload() -> dict[str, Any]:
+    return json.loads((_repo_root() / ".claude" / "plans" / "gpp_status.v1.json").read_text(encoding="utf-8"))
+
+
+def _write_minimal_preflight_repo(tmp_path: Path, status_payload: dict[str, Any]) -> Path:
+    plans = tmp_path / ".claude" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "gpp_status.v1.json").write_text(
+        json.dumps(status_payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    for item in status_payload.get("completed_wps", []):
+        record = item.get("record")
+        if isinstance(record, str):
+            record_path = tmp_path / record
+            record_path.parent.mkdir(parents=True, exist_ok=True)
+            record_path.write_text(f"# {item['id']}\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_gpp6_preflight_is_schema_valid_and_execution_blocked() -> None:
+    module = _module()
+
+    report = module.build_gpp6_read_only_e2e_preflight(repo_root=_repo_root())
+
+    assert _schema_errors(report) == []
+    module.validate_report(report)
+    assert report["overall_status"] == "ready"
+    assert report["decision"] == "read_only_e2e_preflight_ready_execution_blocked_no_support_widening"
+    assert report["execution_status"] == "blocked_by_upstream_gates"
+    assert report["upstream_blockers"] == [
+        "gpp2_protected_gate_blocked",
+        "gpp4_real_adapter_read_only_decision_missing",
+    ]
+    assert report["support_widening"] is False
+    assert report["production_platform_claim"] is False
+    assert report["live_adapter_execution_allowed"] is False
+    assert report["protected_workflow_dispatch_allowed"] is False
+    assert report["remote_write_allowed"] is False
+    assert report["gpp5d_closeout"]["status"] == "ready"
+    assert all(step["status"] == "not_executed" for step in report["execution_plan"])
+    assert all(step["protected_workflow_dispatch"] is False for step in report["execution_plan"])
+    assert all(step["live_adapter_execution"] is False for step in report["execution_plan"])
+    assert all(step["remote_side_effects"] is False for step in report["execution_plan"])
+    assert report["program_flags"]["status"] == "pass"
+    assert report["safety"]["status"] == "pass"
+
+
+def test_gpp6_preflight_schema_rejects_support_or_runtime_claims() -> None:
+    module = _module()
+    validator = Draft202012Validator(_schema())
+    report = module.build_gpp6_read_only_e2e_preflight(repo_root=_repo_root())
+
+    support_claim = copy.deepcopy(report)
+    support_claim["support_widening"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(support_claim)
+
+    dispatch_claim = copy.deepcopy(report)
+    dispatch_claim["protected_workflow_dispatch_allowed"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(dispatch_claim)
+
+    live_claim = copy.deepcopy(report)
+    live_claim["safety"] = dict(live_claim["safety"])
+    live_claim["safety"]["live_adapter_execution"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(live_claim)
+
+
+def test_gpp6_preflight_blocks_missing_gpp5d_closeout(tmp_path: Path) -> None:
+    module = _module()
+    status_payload = _status_payload()
+    status_payload["completed_wps"] = [
+        item for item in status_payload["completed_wps"] if item.get("id") != "GPP-5d"
+    ]
+    repo_root = _write_minimal_preflight_repo(tmp_path, status_payload)
+
+    report = module.build_gpp6_read_only_e2e_preflight(repo_root=repo_root)
+
+    assert _schema_errors(report) == []
+    assert report["overall_status"] == "blocked"
+    assert report["decision"] == "blocked_read_only_e2e_preflight_no_support_widening"
+    assert report["gpp5d_closeout"]["status"] == "blocked"
+    assert "completed_wp_missing" in report["gpp5d_closeout"]["findings"]
+    assert "record_file_missing" in report["gpp5d_closeout"]["findings"]
+    assert "gpp5d_closeout" in report["blocked_reason"]
+
+
+def test_gpp6_preflight_blocks_program_flag_widening(tmp_path: Path) -> None:
+    module = _module()
+    status_payload = _status_payload()
+    status_payload["support_widening_allowed"] = True
+    repo_root = _write_minimal_preflight_repo(tmp_path, status_payload)
+
+    report = module.build_gpp6_read_only_e2e_preflight(repo_root=repo_root)
+
+    assert _schema_errors(report) == []
+    assert report["overall_status"] == "blocked"
+    assert report["program_flags"]["status"] == "fail"
+    assert "support_widening_allowed_not_false" in report["program_flags"]["findings"]

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -235,6 +235,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         and (_repo_root() / item["record"]).exists()
         for item in payload["completed_wps"]
     )
+    assert any(
+        item["id"] == "GPP-6a"
+        and item["decision"] == "read_only_e2e_preflight_ready_execution_blocked_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/561"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
@@ -334,7 +341,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(
         action
-        == "use GPP-5d repo-intelligence closeout evidence for GPP-6 preparation only, while GPP-6 execution remains blocked until GPP-2 protected gate and GPP-4 read-only adapter decision are ready and support_widening_allowed=false and production_platform_claim_allowed=false"
+        == "use GPP-6a read-only E2E preflight evidence for preparation only, while GPP-6 execution remains blocked until GPP-2 protected gate and GPP-4 read-only adapter decision are ready and support_widening_allowed=false and production_platform_claim_allowed=false"
         for action in payload["next_allowed_actions"]
     )
     assert any(


### PR DESCRIPTION
## Summary
- add a schema-backed GPP-6a read-only E2E preflight report
- verify GPP-5d closeout evidence while recording GPP-2 and GPP-4 as upstream execution blockers
- update GPP status/docs so GPP-6 is preparation-only and execution remains blocked with no live adapter, protected workflow dispatch, remote write, support widening, or production claim

## Validation
- python3 -m pytest tests/test_gpp6_read_only_e2e_preflight.py tests/test_gpp5_repo_intelligence_closeout.py tests/test_repo_intelligence_workflow_surface.py tests/test_gpp_next.py -q
- python3 -m pytest tests/test_gpp6_read_only_e2e_preflight.py tests/test_gpp_next.py -q
- python3 -m ruff check scripts/gpp6_read_only_e2e_preflight.py tests/test_gpp6_read_only_e2e_preflight.py tests/test_gpp_next.py
- python3 -m json.tool ao_kernel/defaults/schemas/gpp6-read-only-e2e-preflight.schema.v1.json
- python3 -m json.tool .claude/plans/gpp_status.v1.json
- python3 scripts/gpp6_read_only_e2e_preflight.py --output text
- python3 scripts/gpp6_read_only_e2e_preflight.py --output json
- python3 scripts/gpp_next.py
- git diff --check

Closes #561