### PR TITLE
GPP-2ad: add internal vault gate secret contract

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,16 +1,16 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 end-user boundary recorded after policy Cloud Run bootstrap
-attestation and `ao-release-gate` autonomous deploy paths; operator-owned
-repository variables, GCP trust, hosting, callback/check-run evidence, and
-cutover still blocked
+**Status:** GPP-2 internal vault gate secret contract recorded after Cloud Run
+bootstrap and `ao-release-gate` autonomous deploy paths; operator-owned
+internal hosting, vault-backed runtime configuration, callback/check-run
+evidence, and cutover still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#551](https://github.com/Halildeu/ao-kernel/issues/551)
-for operator gate and end-user onboarding boundary
-**Current slice record:** `.claude/plans/GPP-2ac-OPERATOR-GATE-END-USER-BOUNDARY.md`
+**Current slice issue:** [#563](https://github.com/Halildeu/ao-kernel/issues/563)
+for internal vault gate secret contract
+**Current slice record:** `.claude/plans/GPP-2ad-INTERNAL-VAULT-GATE-SECRET-CONTRACT.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -239,12 +239,21 @@ Last live verification on current `origin/main` showed:
     GitHub App private key. GPP-2 remains blocked on operator-owned hosted
     callback evidence; repo-intelligence onboarding can be prioritized only as
     explicit opt-in/read-only work with no support widening.
-45. GPP-5d closes the repo-intelligence read-only workflow surface with a
+45. GPP-2ad records the internal vault path. The policy service and
+    `ao-release-gate` runtimes now accept vault-backed secret ids for webhook
+    secrets and the GitHub App private key while preserving direct env/path
+    compatibility. This makes the preferred GPP-2 unblock route
+    operator-owned internal hosting plus vault-backed runtime configuration,
+    not a Cloud Run-only path and not an end-user setup requirement. GPP-2
+    remains blocked until public HTTPS health, GitHub App webhook, callback
+    review, real PR dry-run check-run, branch-protection cutover, and protected
+    workflow evidence exist.
+46. GPP-5d closes the repo-intelligence read-only workflow surface with a
     schema-backed preflight over GPP-5a/GPP-5b/GPP-5c records, public APIs,
     schemas, and negative runtime guards. GPP-6 preparation may use this
     closeout as repo-intelligence evidence, but GPP-6 execution remains
     blocked by GPP-2 and GPP-4.
-46. GPP-6a adds a preparation-only read-only E2E preflight. The preflight
+47. GPP-6a adds a preparation-only read-only E2E preflight. The preflight
     report is ready and records `execution_status=blocked_by_upstream_gates`
     because GPP-2 protected gate evidence and the GPP-4 read-only adapter
     decision are still missing. It does not dispatch protected workflows, call
@@ -317,7 +326,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2aa` | Completed / no support widening | `ao-release-gate` autonomous deploy path | Cloud Run deploy workflow ready; cloud bootstrap, webhook config, real PR evidence, and branch-protection cutover still required |
 | `GPP-2ab` | Completed / no support widening | Policy Cloud Run bootstrap attestation | metadata-only attestation tool ready; required repository variable handles are currently missing; GCP trust, Secret Manager objects, hosted service evidence, GitHub App webhook config, and callback evidence are not yet attested |
 | `GPP-2ac` | Completed / no support widening | Operator gate and end-user onboarding boundary | GPP-2 gate hosting is operator-owned platform infrastructure; end users must not self-host Cloud Run, vault, webhook, or GitHub App private-key setup |
-| `GPP-2` | Blocked / hosted service bootstrap/config/evidence and release-gate cutover missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be hosted/configured and post callback evidence, and `ao-release-gate` must be deployed/hosted/evidenced/cut over before human-free program merges |
+| `GPP-2ad` | Completed / no support widening | Internal vault gate secret contract | policy and release-gate runtimes accept vault-backed secret ids; services are still not hosted/evidenced |
+| `GPP-2` | Blocked / internal hosting/config/evidence and release-gate cutover missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be hosted/configured with vault-backed runtime secrets and post callback evidence, and `ao-release-gate` must be deployed/hosted/evidenced/cut over before human-free program merges |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5a` | Completed / no support widening | Repo-intelligence product onboarding contract | GitHub App install + selected repositories + optional `.ao/config.yml`; no end-user Cloud Run, vault, webhook, private key, or gate service hosting |
@@ -451,13 +461,13 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2ac; policy decision core, webhook scaffold,
+**Status:** blocked after GPP-2ad; policy decision core, webhook scaffold,
 deployable WSGI runtime, container package, GHCR image publication path,
 Cloud Run deploy automation, metadata-only bootstrap attestation tooling,
-`ao-release-gate` dry-run/check-run/container/publish/deploy automation, and
-release-gate fail-closed policy records and operator/end-user boundary
-decision exist, but required operator-owned repository variables, GCP trust,
-hosted service deployment/configuration, real PR check-run evidence,
+internal vault-backed secret-id runtime support, `ao-release-gate`
+dry-run/check-run/container/publish/deploy automation, and release-gate
+fail-closed policy records and operator/end-user boundary decision exist, but
+operator-owned hosted service deployment/configuration, real PR check-run evidence,
 branch-protection cutover, and callback evidence are still
 missing.
 
@@ -518,6 +528,14 @@ release-gate hosting path are operator-owned platform infrastructure. They are
 not setup requirements for product end users, and they do not block read-only
 repo-intelligence onboarding design work that avoids live execution and support
 widening.
+GPP-2ad adds internal vault-backed secret-id resolution to both hosted gate
+runtimes. This lets the operator run the repo-owned containers on internal
+platform infrastructure with secret ids such as
+`AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID`,
+`AO_RELEASE_GATE_WEBHOOK_SECRET_ID`, and
+`AO_GITHUB_APP_PRIVATE_KEY_PEM_ID`. It does not host either service, configure
+GitHub webhooks, post callbacks/check-runs, grant merge authority, or unblock
+live adapter execution.
 
 **Acceptance criteria:**
 

--- a/.claude/plans/GPP-2ad-INTERNAL-VAULT-GATE-SECRET-CONTRACT.md
+++ b/.claude/plans/GPP-2ad-INTERNAL-VAULT-GATE-SECRET-CONTRACT.md
@@ -1,0 +1,138 @@
+# GPP-2ad - Internal Vault Gate Secret Contract
+
+**Issue:** [#563](https://github.com/Halildeu/ao-kernel/issues/563)
+**Decision:** `internal_vault_gate_secret_contract_ready_service_not_hosted_no_support_widening`
+**Date:** 2026-04-28
+**Program head:** `GPP-2` remains blocked on hosted callback/check-run evidence
+**Support widening:** false
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## Decision
+
+GPP-2ad switches the preferred unblock direction from a Cloud Run-only
+bootstrap path to an operator-owned internal host plus vault-backed runtime
+secret contract.
+
+The policy service and `ao-release-gate` can now resolve GitHub App runtime
+secrets through the existing ao-kernel secrets provider interface. Hosted
+operators may pass secret ids instead of secret values:
+
+```text
+AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID
+AO_RELEASE_GATE_WEBHOOK_SECRET_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM_ID
+```
+
+The existing direct environment and private-key path inputs remain supported
+for compatibility:
+
+```text
+AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET
+AO_RELEASE_GATE_WEBHOOK_SECRET
+AO_GITHUB_APP_PRIVATE_KEY_PEM
+AO_GITHUB_APP_PRIVATE_KEY_PATH
+```
+
+## Internal Vault Model
+
+The operator-owned internal path is:
+
+1. run the repo-owned policy service container on an operator host;
+2. run the repo-owned `ao-release-gate` container on an operator host;
+3. expose both services through public HTTPS routes reachable by GitHub;
+4. configure the host with a secrets provider such as `hashicorp_vault` or
+   `vault_stub`;
+5. pass secret ids into the runtime, not secret values;
+6. keep vault credentials as operator host material outside repository files,
+   GitHub variables, PRs, issues, logs, and chat.
+
+Required policy service runtime handles:
+
+```text
+SECRETS_PROVIDER
+AO_GITHUB_APP_ID
+AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM_ID
+```
+
+Required `ao-release-gate` runtime handles:
+
+```text
+SECRETS_PROVIDER
+AO_GITHUB_APP_ID
+AO_RELEASE_GATE_WEBHOOK_SECRET_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM_ID
+AO_RELEASE_GATE_GPP_STATUS_PATH
+```
+
+For `hashicorp_vault`, the host also supplies provider-local configuration:
+
+```text
+VAULT_ADDR
+VAULT_TOKEN
+VAULT_SECRET_MOUNT
+```
+
+Those provider credentials are not product user configuration and are not
+repository configuration.
+
+## Trust Boundary
+
+This path is operator-owned platform infrastructure. End users must not be
+asked to self-host the policy service, `ao-release-gate`, a vault, webhook
+secrets, GitHub App private keys, Cloud Run, or equivalent hosting. End-user
+repo-intelligence onboarding remains GitHub App installation, repository
+selection, and explicit read-only opt-in.
+
+This slice does not:
+
+1. read or echo secret values;
+2. configure a public host;
+3. configure GitHub App webhook URLs;
+4. post deployment protection callback reviews;
+5. post `ao-release-gate` check-runs;
+6. change branch protection or rulesets;
+7. dispatch the protected live-adapter workflow;
+8. run a live adapter;
+9. widen support;
+10. claim production platform readiness.
+
+## Still Blocked
+
+GPP-2 remains blocked until all of the following evidence exists:
+
+1. policy service public `/healthz` evidence;
+2. policy service public `/github/deployment-protection` GitHub App webhook
+   configuration evidence;
+3. policy service deployment protection callback review evidence;
+4. `ao-release-gate` public `/healthz` evidence;
+5. `ao-release-gate` public `/github/ao-release-gate` webhook configuration
+   evidence;
+6. real PR dry-run `ao-release-gate` check-run evidence;
+7. branch protection or ruleset cutover requiring the durable
+   `ao-release-gate` status check after dry-run evidence;
+8. protected workflow evidence from `main` proving the policy service responds
+   fail-closed or approve-contract-gate while `live_execution_allowed=false`.
+
+Still closed:
+
+1. `live_execution_allowed=false`;
+2. `support_widening=false`;
+3. `production_platform_claim=false`.
+
+## Validation
+
+```bash
+python3 -m pytest tests/test_live_adapter_gate_policy_runtime.py tests/test_ao_release_gate_runtime.py tests/test_gpp_next.py -q
+python3 -m ruff check ao_kernel/live_adapter_gate_policy_runtime.py ao_kernel/ao_release_gate_runtime.py tests/test_live_adapter_gate_policy_runtime.py tests/test_ao_release_gate_runtime.py tests/test_gpp_next.py
+python3 -m json.tool .claude/plans/gpp_status.v1.json
+python3 scripts/gpp_next.py
+git diff --check
+```
+
+Recorded closeout decision:
+
+```text
+internal_vault_gate_secret_contract_ready_service_not_hosted_no_support_widening
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,11 +9,13 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/551",
-    "exit_decision": "operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening",
-    "ready_after": "operator-owned policy service deploy workflow has completed from trusted main, the ao-release-gate deploy workflow has completed from main, hosted endpoints are configured with runtime secrets and webhook URLs, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, callback review evidence exists, and protected workflow evidence confirms live_execution_allowed=false",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/563",
+    "exit_decision": "internal_vault_gate_secret_contract_ready_service_not_hosted_no_support_widening",
+    "ready_after": "operator-owned policy service and ao-release-gate are hosted on public HTTPS endpoints with internal vault-backed runtime secret ids, GitHub App webhook URLs are configured, policy callback review evidence exists, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, and protected workflow evidence confirms live_execution_allowed=false",
     "allowed_scope": [
-      "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service without secret value exposure",
+      "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service on operator-owned internal infrastructure without secret value exposure",
+      "use the repo-owned ao-release-gate GHCR image or container package to deploy or configure the ao-release-gate GitHub App check-run service on operator-owned internal infrastructure without secret value exposure",
+      "configure hosted gate runtimes with internal vault secret ids rather than committed, echoed, or repository-stored secret values",
       "document or build end-user onboarding paths that do not require users to self-host the GPP-2 policy service, vault, webhook secret, GitHub App private key, or Cloud Run project",
       "repeat protected workflow evidence collection from main after the policy service responds",
       "keep live execution disabled until protected workflow evidence explicitly permits a later live run"
@@ -197,6 +199,12 @@
       "record": ".claude/plans/GPP-2ac-OPERATOR-GATE-END-USER-BOUNDARY.md"
     },
     {
+      "id": "GPP-2ad",
+      "decision": "internal_vault_gate_secret_contract_ready_service_not_hosted_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/563",
+      "record": ".claude/plans/GPP-2ad-INTERNAL-VAULT-GATE-SECRET-CONTRACT.md"
+    },
+    {
       "id": "GPP-5a",
       "decision": "repo_intelligence_product_onboarding_contract_ready_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/553",
@@ -230,19 +238,16 @@
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned autonomous policy service deploy path, metadata-only policy bootstrap attestation tool, ao-release-gate dry-run decision scaffold, check-run service surface, release-gate container package, release-gate image publish path, release-gate autonomous deploy path, and operator-owned end-user onboarding boundary are ready, but required policy GitHub repository variable handles are currently missing and neither the release-gate service nor the deployment-protection service is publicly hosted/configured with webhook evidence, dry-run check-run evidence, callback review evidence, or protected workflow cutover evidence"
+      "reason": "repo-owned policy and ao-release-gate decision cores, webhook runtimes, container packages, GHCR publish paths, Cloud Run deploy paths, and internal vault-backed secret-id runtime contract are ready, but neither service is publicly hosted/configured with vault-backed runtime secrets, webhook evidence, dry-run check-run evidence, callback review evidence, or protected workflow cutover evidence"
     }
   ],
   "pending_external_actions": [
-    "if the operator chooses to unblock GPP-2 with Cloud Run, run scripts/policy_service_cloud_run_bootstrap_attest.py and provision any missing GitHub repository variable handles before dispatching the deploy workflow, while treating metadata_ready as repository-variable evidence only",
-    "bootstrap the operator-owned policy service deploy trust path with GitHub OIDC, Google service-account permissions, Artifact Registry, Cloud Run, and Secret Manager object handles without secret value readback",
-    "run or observe the autonomous Cloud Run deployment workflow from a trusted main image only after operator-owned billing/project/trust handles are intentionally available",
-    "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the deployed /github/deployment-protection endpoint and can post deployment callback reviews",
-    "bootstrap the ao-release-gate Cloud Run deploy trust path and run the trusted deploy workflow from main without treating health evidence as check-run evidence",
-    "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with runtime webhook secret and GitHub App authentication outside the repo",
+    "host the operator-owned policy service on public HTTPS using the repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
+    "host the operator-owned ao-release-gate service on public HTTPS using the repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
+    "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the hosted /github/deployment-protection endpoint and can post deployment callback reviews",
+    "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with vault-backed runtime webhook secret and GitHub App authentication outside the repo",
     "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
     "validate whether GitHub App review-counting works for the current branch protection; if not, cut over to a required ao-release-gate status check",
-    "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
     "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
     "keep end-user repo-intelligence onboarding independent from GPP-2 gate hosting by requiring at most GitHub App installation, repository selection, and explicit opt-in configuration"
   ],
@@ -305,14 +310,15 @@
     "treat the GPP-2 deployment-protection policy service as operator-owned platform infrastructure, not an end-user setup requirement",
     "prioritize repo-intelligence onboarding as a read-only product workflow that requires GitHub App installation and repository selection, not Cloud Run, vault, webhook, or private-key setup by each user",
     "use GPP-6a read-only E2E preflight evidence for preparation only, while GPP-6 execution remains blocked until GPP-2 protected gate and GPP-4 read-only adapter decision are ready and support_widening_allowed=false and production_platform_claim_allowed=false",
-    "run scripts/policy_service_cloud_run_bootstrap_attest.py to verify required GitHub repository variable handles before dispatching the Cloud Run deploy workflow, and treat metadata_ready as repository-variable evidence only",
-    "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work",
-    "configure or verify the GitHub App webhook URL only after the deployed policy service endpoint is health-checked",
-    "bootstrap and run the ao-release-gate Cloud Run deploy workflow from main before collecting real PR evidence",
+    "prefer the internal operator host plus vault-backed secret-id path for GPP-2 service hosting unless a later decision reselects Cloud Run",
+    "configure ao_kernel.live_adapter_gate_policy_runtime:application with internal vault secret ids or direct runtime secret manager values, never committed or echoed secret material",
+    "configure ao_kernel.ao_release_gate_runtime:application with internal vault secret ids or direct runtime secret manager values, never committed or echoed secret material",
+    "configure or verify the GitHub App webhook URL only after the hosted policy service endpoint is health-checked",
+    "host the ao-release-gate service in dry-run mode before collecting real PR evidence",
     "deploy or host the ao-release-gate check-run service in dry-run mode and collect real PR evidence before any branch protection cutover",
     "collect ao-release-gate dry-run check-run evidence on real PRs before any branch protection cutover",
     "validate GitHub App review-counting only as a spike; use required status check as the durable enforcement path unless proven otherwise",
-    "deploy or configure the deployment-protection policy service using the repo-owned GHCR image or container package before any further live-adapter runtime work",
+    "deploy or configure the deployment-protection policy service using the repo-owned GHCR image or container package and internal vault-backed runtime secret ids before any further live-adapter runtime work",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
     "use Claude MCP consultation only as advisory review, not release authority",
     "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active",
@@ -322,8 +328,6 @@
     "use scripts/ao_release_gate_container_smoke.py only for no-secret local container health validation, not check-run posting",
     "publish or pull ghcr.io/halildeu/ao-kernel-ao-release-gate-service only as a deploy artifact, not hosted service evidence",
     "publish or pull ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service only as a deploy artifact, not hosted service evidence",
-    "configure ao_kernel.ao_release_gate_runtime:application only with runtime secret manager values, never committed or echoed secret material",
-    "configure ao_kernel.live_adapter_gate_policy_runtime:application only with runtime secret manager values, never committed or echoed secret material",
     "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it",
     "keep fork and pull_request contexts away from protected credentials",
     "preserve live_execution_allowed=false until protected runtime evidence permits a later live run",

--- a/ao_kernel/ao_release_gate_runtime.py
+++ b/ao_kernel/ao_release_gate_runtime.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Protocol, TypedDict, cast
 
+from ao_kernel._internal.secrets.factory import create_provider_from_env
 from ao_kernel.ao_release_gate_service import (
     AoReleaseGateCheckRunRequest,
     AoReleaseGateServiceResult,
@@ -27,8 +28,10 @@ DEFAULT_GITHUB_APP_JWT_TTL_SECONDS = 540
 DEFAULT_GPP_STATUS_PATH = ".claude/plans/gpp_status.v1.json"
 
 WEBHOOK_SECRET_ENV = "AO_RELEASE_GATE_WEBHOOK_SECRET"
+WEBHOOK_SECRET_ID_ENV = "AO_RELEASE_GATE_WEBHOOK_SECRET_ID"
 GITHUB_APP_ID_ENV = "AO_GITHUB_APP_ID"
 GITHUB_APP_PRIVATE_KEY_ENV = "AO_GITHUB_APP_PRIVATE_KEY_PEM"
+GITHUB_APP_PRIVATE_KEY_SECRET_ID_ENV = "AO_GITHUB_APP_PRIVATE_KEY_PEM_ID"
 GITHUB_APP_PRIVATE_KEY_PATH_ENV = "AO_GITHUB_APP_PRIVATE_KEY_PATH"
 GITHUB_API_URL_ENV = "AO_GITHUB_API_URL"
 GPP_STATUS_PATH_ENV = "AO_RELEASE_GATE_GPP_STATUS_PATH"
@@ -236,6 +239,7 @@ def load_github_app_config(env: Mapping[str, str] | None = None) -> GithubAppCon
     app_id = _required_env(source, GITHUB_APP_ID_ENV)
     private_key_pem = source.get(GITHUB_APP_PRIVATE_KEY_ENV)
     private_key_path = source.get(GITHUB_APP_PRIVATE_KEY_PATH_ENV)
+    private_key_secret_id = source.get(GITHUB_APP_PRIVATE_KEY_SECRET_ID_ENV)
     if private_key_pem is None and private_key_path:
         try:
             private_key_pem = Path(private_key_path).read_text(encoding="utf-8")
@@ -244,15 +248,43 @@ def load_github_app_config(env: Mapping[str, str] | None = None) -> GithubAppCon
                 "ao_release_gate_runtime_private_key_read_failed",
                 f"Could not read GitHub App private key from {GITHUB_APP_PRIVATE_KEY_PATH_ENV}.",
             ) from exc
+    if not private_key_pem and private_key_secret_id:
+        private_key_pem = _resolve_runtime_secret(
+            source,
+            GITHUB_APP_PRIVATE_KEY_SECRET_ID_ENV,
+            missing_code="ao_release_gate_runtime_private_key_secret_missing",
+            provider_code="ao_release_gate_runtime_secret_provider_failed",
+        )
     if not private_key_pem:
         raise ReleaseGateRuntimeConfigError(
             "ao_release_gate_runtime_private_key_missing",
-            f"Set {GITHUB_APP_PRIVATE_KEY_ENV} or {GITHUB_APP_PRIVATE_KEY_PATH_ENV} in the hosted service.",
+            f"Set {GITHUB_APP_PRIVATE_KEY_ENV}, {GITHUB_APP_PRIVATE_KEY_PATH_ENV}, "
+            f"or {GITHUB_APP_PRIVATE_KEY_SECRET_ID_ENV} in the hosted service.",
         )
     return GithubAppConfig(
         app_id=app_id,
         private_key_pem=private_key_pem,
         api_url=source.get(GITHUB_API_URL_ENV, DEFAULT_GITHUB_API_URL),
+    )
+
+
+def load_webhook_secret(env: Mapping[str, str] | None = None) -> str:
+    """Load the GitHub webhook secret from direct env or a vault secret id."""
+
+    source = os.environ if env is None else env
+    direct_secret = source.get(WEBHOOK_SECRET_ENV)
+    if direct_secret:
+        return direct_secret
+    if source.get(WEBHOOK_SECRET_ID_ENV):
+        return _resolve_runtime_secret(
+            source,
+            WEBHOOK_SECRET_ID_ENV,
+            missing_code="ao_release_gate_runtime_webhook_secret_missing",
+            provider_code="ao_release_gate_runtime_secret_provider_failed",
+        )
+    raise ReleaseGateRuntimeConfigError(
+        "ao_release_gate_runtime_env_missing",
+        f"Set {WEBHOOK_SECRET_ENV} or {WEBHOOK_SECRET_ID_ENV} in the hosted service runtime.",
     )
 
 
@@ -381,7 +413,7 @@ def release_gate_runtime_wsgi_app(
 
     try:
         body = _read_wsgi_body(environ)
-        webhook_secret = _required_env(os.environ, WEBHOOK_SECRET_ENV)
+        webhook_secret = load_webhook_secret(os.environ)
         config = load_github_app_config(os.environ)
         gpp_status = load_gpp_status(os.environ)
         result = handle_ao_release_gate_webhook(
@@ -438,6 +470,31 @@ def _required_env(env: Mapping[str, str], name: str) -> str:
         "ao_release_gate_runtime_env_missing",
         f"Set {name} in the hosted service runtime.",
     )
+
+
+def _resolve_runtime_secret(
+    env: Mapping[str, str],
+    secret_id_env: str,
+    *,
+    missing_code: str,
+    provider_code: str,
+) -> str:
+    secret_id = env.get(secret_id_env, "").strip()
+    if not secret_id:
+        raise ReleaseGateRuntimeConfigError(missing_code, f"Set {secret_id_env} in the hosted service runtime.")
+    try:
+        secret_value = create_provider_from_env().get(secret_id)
+    except Exception as exc:
+        raise ReleaseGateRuntimeConfigError(
+            provider_code,
+            f"Configured secrets provider could not resolve {secret_id_env}.",
+        ) from exc
+    if not secret_value:
+        raise ReleaseGateRuntimeConfigError(
+            missing_code,
+            f"Configured {secret_id_env} did not resolve to a runtime secret.",
+        )
+    return secret_value
 
 
 def _runtime_result(
@@ -504,9 +561,7 @@ def _redacted_runtime_payload(result: ReleaseGateRuntimeResult) -> dict[str, obj
         "release_gate_decision": decision["decision"] if decision is not None else None,
         "dry_run": decision["dry_run"] if decision is not None else None,
         "merge_authority_enabled": decision["merge_authority_enabled"] if decision is not None else None,
-        "check_run_conclusion": (
-            decision["github_check_run"]["conclusion"] if decision is not None else None
-        ),
+        "check_run_conclusion": (decision["github_check_run"]["conclusion"] if decision is not None else None),
         "check_run_post": result["check_run_post"],
         "findings": service_result["findings"],
     }

--- a/ao_kernel/live_adapter_gate_policy_runtime.py
+++ b/ao_kernel/live_adapter_gate_policy_runtime.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Protocol, TypedDict, cast
 
+from ao_kernel._internal.secrets.factory import create_provider_from_env
 from ao_kernel.live_adapter_gate_policy_service import (
     LiveAdapterGateDeploymentReviewRequest,
     LiveAdapterGatePolicyServiceResult,
@@ -26,8 +27,10 @@ DEFAULT_HTTP_TIMEOUT_SECONDS = 10.0
 DEFAULT_GITHUB_APP_JWT_TTL_SECONDS = 540
 
 WEBHOOK_SECRET_ENV = "AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET"
+WEBHOOK_SECRET_ID_ENV = "AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID"
 GITHUB_APP_ID_ENV = "AO_GITHUB_APP_ID"
 GITHUB_APP_PRIVATE_KEY_ENV = "AO_GITHUB_APP_PRIVATE_KEY_PEM"
+GITHUB_APP_PRIVATE_KEY_SECRET_ID_ENV = "AO_GITHUB_APP_PRIVATE_KEY_PEM_ID"
 GITHUB_APP_PRIVATE_KEY_PATH_ENV = "AO_GITHUB_APP_PRIVATE_KEY_PATH"
 GITHUB_API_URL_ENV = "AO_GITHUB_API_URL"
 MAX_BODY_BYTES_ENV = "AO_POLICY_SERVICE_MAX_BODY_BYTES"
@@ -234,6 +237,7 @@ def load_github_app_config(env: Mapping[str, str] | None = None) -> GithubAppCon
     app_id = _required_env(source, GITHUB_APP_ID_ENV)
     private_key_pem = source.get(GITHUB_APP_PRIVATE_KEY_ENV)
     private_key_path = source.get(GITHUB_APP_PRIVATE_KEY_PATH_ENV)
+    private_key_secret_id = source.get(GITHUB_APP_PRIVATE_KEY_SECRET_ID_ENV)
     if private_key_pem is None and private_key_path:
         try:
             private_key_pem = Path(private_key_path).read_text(encoding="utf-8")
@@ -242,15 +246,43 @@ def load_github_app_config(env: Mapping[str, str] | None = None) -> GithubAppCon
                 "live_gate_policy_runtime_private_key_read_failed",
                 f"Could not read GitHub App private key from {GITHUB_APP_PRIVATE_KEY_PATH_ENV}.",
             ) from exc
+    if not private_key_pem and private_key_secret_id:
+        private_key_pem = _resolve_runtime_secret(
+            source,
+            GITHUB_APP_PRIVATE_KEY_SECRET_ID_ENV,
+            missing_code="live_gate_policy_runtime_private_key_secret_missing",
+            provider_code="live_gate_policy_runtime_secret_provider_failed",
+        )
     if not private_key_pem:
         raise PolicyRuntimeConfigError(
             "live_gate_policy_runtime_private_key_missing",
-            f"Set {GITHUB_APP_PRIVATE_KEY_ENV} or {GITHUB_APP_PRIVATE_KEY_PATH_ENV} in the hosted service.",
+            f"Set {GITHUB_APP_PRIVATE_KEY_ENV}, {GITHUB_APP_PRIVATE_KEY_PATH_ENV}, "
+            f"or {GITHUB_APP_PRIVATE_KEY_SECRET_ID_ENV} in the hosted service.",
         )
     return GithubAppConfig(
         app_id=app_id,
         private_key_pem=private_key_pem,
         api_url=source.get(GITHUB_API_URL_ENV, DEFAULT_GITHUB_API_URL),
+    )
+
+
+def load_webhook_secret(env: Mapping[str, str] | None = None) -> str:
+    """Load the GitHub webhook secret from direct env or a vault secret id."""
+
+    source = os.environ if env is None else env
+    direct_secret = source.get(WEBHOOK_SECRET_ENV)
+    if direct_secret:
+        return direct_secret
+    if source.get(WEBHOOK_SECRET_ID_ENV):
+        return _resolve_runtime_secret(
+            source,
+            WEBHOOK_SECRET_ID_ENV,
+            missing_code="live_gate_policy_runtime_webhook_secret_missing",
+            provider_code="live_gate_policy_runtime_secret_provider_failed",
+        )
+    raise PolicyRuntimeConfigError(
+        "live_gate_policy_runtime_env_missing",
+        f"Set {WEBHOOK_SECRET_ENV} or {WEBHOOK_SECRET_ID_ENV} in the hosted service runtime.",
     )
 
 
@@ -348,7 +380,9 @@ def extract_installation_id(payload: Mapping[str, Any]) -> int | None:
     return None
 
 
-def policy_runtime_wsgi_app(environ: Mapping[str, Any], start_response: Callable[[str, list[tuple[str, str]]], None]) -> Iterable[bytes]:
+def policy_runtime_wsgi_app(
+    environ: Mapping[str, Any], start_response: Callable[[str, list[tuple[str, str]]], None]
+) -> Iterable[bytes]:
     """WSGI entrypoint for hosted deployment-protection webhook services."""
 
     method = str(environ.get("REQUEST_METHOD", "GET")).upper()
@@ -360,7 +394,7 @@ def policy_runtime_wsgi_app(environ: Mapping[str, Any], start_response: Callable
 
     try:
         body = _read_wsgi_body(environ)
-        webhook_secret = _required_env(os.environ, WEBHOOK_SECRET_ENV)
+        webhook_secret = load_webhook_secret(os.environ)
         config = load_github_app_config(os.environ)
         result = handle_live_adapter_gate_policy_webhook(
             body,
@@ -415,6 +449,31 @@ def _required_env(env: Mapping[str, str], name: str) -> str:
         "live_gate_policy_runtime_env_missing",
         f"Set {name} in the hosted service runtime.",
     )
+
+
+def _resolve_runtime_secret(
+    env: Mapping[str, str],
+    secret_id_env: str,
+    *,
+    missing_code: str,
+    provider_code: str,
+) -> str:
+    secret_id = env.get(secret_id_env, "").strip()
+    if not secret_id:
+        raise PolicyRuntimeConfigError(missing_code, f"Set {secret_id_env} in the hosted service runtime.")
+    try:
+        secret_value = create_provider_from_env().get(secret_id)
+    except Exception as exc:
+        raise PolicyRuntimeConfigError(
+            provider_code,
+            f"Configured secrets provider could not resolve {secret_id_env}.",
+        ) from exc
+    if not secret_value:
+        raise PolicyRuntimeConfigError(
+            missing_code,
+            f"Configured {secret_id_env} did not resolve to a runtime secret.",
+        )
+    return secret_value
 
 
 def _runtime_result(

--- a/deploy/ao-release-gate-service/README.md
+++ b/deploy/ao-release-gate-service/README.md
@@ -49,6 +49,25 @@ or:
 AO_GITHUB_APP_PRIVATE_KEY_PATH
 ```
 
+Operator-owned internal hosts may resolve the same runtime secrets from the
+ao-kernel secrets provider interface instead of injecting secret values
+directly. Configure a supported provider such as `vault_stub` or
+`hashicorp_vault` with provider-local credentials, then pass secret ids:
+
+```text
+SECRETS_PROVIDER=hashicorp_vault
+VAULT_ADDR=<operator vault URL>
+VAULT_TOKEN=<operator vault token>
+VAULT_SECRET_MOUNT=secret
+AO_RELEASE_GATE_WEBHOOK_SECRET_ID=gpp2/release-gate/webhook-secret
+AO_GITHUB_APP_PRIVATE_KEY_PEM_ID=gpp2/github/private-key-pem
+```
+
+For local operator rehearsals, `SECRETS_PROVIDER=vault_stub` reads
+`.secrets/vault.json` from the service working directory. That file is local
+operator material and must not be committed or copied into PRs, issues, logs,
+or chat.
+
 Optional runtime settings:
 
 ```text
@@ -77,6 +96,11 @@ Do not pass `AO_CLAUDE_CODE_CLI_AUTH` to this service. The release gate posts
 dry-run check-runs only after it is explicitly hosted and configured with
 GitHub App runtime secrets; this container package alone is not release
 authority and does not change branch protection.
+
+The internal vault path changes only how runtime secret values are resolved by
+the operator-owned hosted service. It does not remove the need for a public
+HTTPS route that GitHub can reach, a configured GitHub App webhook URL, real PR
+dry-run check-run evidence, and a later branch-protection/ruleset cutover.
 
 ## Autonomous Cloud Run Deployment
 

--- a/deploy/live-adapter-gate-policy-service/README.md
+++ b/deploy/live-adapter-gate-policy-service/README.md
@@ -143,6 +143,25 @@ or:
 AO_GITHUB_APP_PRIVATE_KEY_PATH
 ```
 
+Operator-owned internal hosts may resolve the same runtime secrets from the
+ao-kernel secrets provider interface instead of injecting secret values
+directly. Configure a supported provider such as `vault_stub` or
+`hashicorp_vault` with provider-local credentials, then pass secret ids:
+
+```text
+SECRETS_PROVIDER=hashicorp_vault
+VAULT_ADDR=<operator vault URL>
+VAULT_TOKEN=<operator vault token>
+VAULT_SECRET_MOUNT=secret
+AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID=gpp2/policy/webhook-secret
+AO_GITHUB_APP_PRIVATE_KEY_PEM_ID=gpp2/github/private-key-pem
+```
+
+For local operator rehearsals, `SECRETS_PROVIDER=vault_stub` reads
+`.secrets/vault.json` from the service working directory. That file is local
+operator material and must not be committed or copied into PRs, issues, logs,
+or chat.
+
 Optional runtime settings:
 
 ```text
@@ -169,6 +188,11 @@ GET /healthz
 Do not pass `AO_CLAUDE_CODE_CLI_AUTH` to this service. The protected live
 adapter credential remains unavailable to the policy service until a later GPP
 slice explicitly permits live execution.
+
+The internal vault path changes only how runtime secret values are resolved by
+the operator-owned hosted service. It does not remove the need for a public
+HTTPS route that GitHub can reach, a configured GitHub App webhook URL, a
+deployment-protection callback post, and protected workflow evidence.
 
 ## Local No-Secret Smoke
 

--- a/tests/test_ao_release_gate_runtime.py
+++ b/tests/test_ao_release_gate_runtime.py
@@ -16,14 +16,18 @@ from ao_kernel.ao_release_gate_runtime import (
     DEFAULT_WEBHOOK_PATH,
     GITHUB_APP_ID_ENV,
     GITHUB_APP_PRIVATE_KEY_ENV,
+    GITHUB_APP_PRIVATE_KEY_SECRET_ID_ENV,
     GPP_STATUS_PATH_ENV,
     WEBHOOK_SECRET_ENV,
+    WEBHOOK_SECRET_ID_ENV,
     CheckRunPostResult,
     GithubAppCheckRunClient,
     GithubAppConfig,
     ReleaseGateRuntimeConfigError,
     build_github_app_jwt,
     handle_ao_release_gate_webhook,
+    load_github_app_config,
+    load_webhook_secret,
     release_gate_runtime_wsgi_app,
 )
 from ao_kernel.ao_release_gate_service import AoReleaseGateCheckRunRequest
@@ -266,6 +270,52 @@ def test_build_github_app_jwt_reports_missing_optional_dependency(monkeypatch: p
         build_github_app_jwt(app_id="1", private_key_pem="private-key", now_seconds=1000)
 
     assert "policy-service extra" in str(exc_info.value)
+
+
+def test_runtime_loads_release_gate_secrets_from_internal_vault_stub(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault_path = tmp_path / ".secrets" / "vault.json"
+    vault_path.parent.mkdir()
+    vault_path.write_text(
+        json.dumps(
+            {
+                "gpp2/release-gate/webhook-secret": " release-secret-from-vault ",
+                "gpp2/github/private-key-pem": " private-key-from-vault ",
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SECRETS_PROVIDER", "vault_stub")
+    env = {
+        GITHUB_APP_ID_ENV: "3522435",
+        WEBHOOK_SECRET_ID_ENV: "gpp2/release-gate/webhook-secret",
+        GITHUB_APP_PRIVATE_KEY_SECRET_ID_ENV: "gpp2/github/private-key-pem",
+    }
+
+    assert load_webhook_secret(env) == "release-secret-from-vault"
+    config = load_github_app_config(env)
+    assert config.app_id == "3522435"
+    assert config.private_key_pem == "private-key-from-vault"
+
+
+def test_runtime_reports_missing_release_gate_vault_secret_without_echoing_secret_id(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".secrets").mkdir()
+    (tmp_path / ".secrets" / "vault.json").write_text("{}", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SECRETS_PROVIDER", "vault_stub")
+
+    with pytest.raises(ReleaseGateRuntimeConfigError) as exc_info:
+        load_webhook_secret({WEBHOOK_SECRET_ID_ENV: "gpp2/release/missing-secret"})
+
+    assert exc_info.value.finding_code == "ao_release_gate_runtime_webhook_secret_missing"
+    assert "gpp2/release/missing-secret" not in str(exc_info.value)
 
 
 def test_wsgi_health_endpoint() -> None:

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,10 +30,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/551"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/563"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening"
+        == "internal_vault_gate_secret_contract_ready_service_not_hosted_no_support_widening"
     )
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
@@ -208,6 +208,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         for item in payload["completed_wps"]
     )
     assert any(
+        item["id"] == "GPP-2ad"
+        and item["decision"] == "internal_vault_gate_secret_contract_ready_service_not_hosted_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/563"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
+    assert any(
         item["id"] == "GPP-5a"
         and item["decision"] == "repo_intelligence_product_onboarding_contract_ready_no_support_widening"
         and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/553"
@@ -246,26 +253,12 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
-        (
-            "if the operator chooses to unblock GPP-2 with Cloud Run, run "
-            "scripts/policy_service_cloud_run_bootstrap_attest.py and provision any missing GitHub repository "
-            "variable handles before dispatching the deploy workflow, while treating metadata_ready as "
-            "repository-variable evidence only"
-        ),
-        (
-            "bootstrap the operator-owned policy service deploy trust path with GitHub OIDC, Google service-account "
-            "permissions, Artifact Registry, Cloud Run, and Secret Manager object handles without secret value readback"
-        ),
-        (
-            "run or observe the autonomous Cloud Run deployment workflow from a trusted main image only after "
-            "operator-owned billing/project/trust handles are intentionally available"
-        ),
-        "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the deployed /github/deployment-protection endpoint and can post deployment callback reviews",
-        "bootstrap the ao-release-gate Cloud Run deploy trust path and run the trusted deploy workflow from main without treating health evidence as check-run evidence",
-        "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with runtime webhook secret and GitHub App authentication outside the repo",
+        "host the operator-owned policy service on public HTTPS using the repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
+        "host the operator-owned ao-release-gate service on public HTTPS using the repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
+        "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the hosted /github/deployment-protection endpoint and can post deployment callback reviews",
+        "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with vault-backed runtime webhook secret and GitHub App authentication outside the repo",
         "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
         "validate whether GitHub App review-counting works for the current branch protection; if not, cut over to a required ao-release-gate status check",
-        "deploy or configure the ao-kernel-live-adapter-gate GitHub App deployment-protection policy service/webhook using the repo-owned GHCR image or container package with webhook secret verification and GitHub App auth so it posts deployment callback reviews",
         "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
         (
             "keep end-user repo-intelligence onboarding independent from GPP-2 gate hosting by requiring at most "
@@ -276,20 +269,17 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         {
             "id": "GPP-2",
             "reason": (
-                "repo-owned autonomous policy service deploy path, metadata-only policy bootstrap attestation "
-                "tool, ao-release-gate dry-run decision scaffold, check-run service surface, release-gate "
-                "container package, release-gate image publish path, release-gate autonomous deploy path, and "
-                "operator-owned end-user onboarding boundary are ready, but required policy GitHub repository "
-                "variable handles are currently missing and neither the release-gate service nor the "
-                "deployment-protection service is publicly hosted/configured with webhook evidence, dry-run "
-                "check-run evidence, callback review evidence, or protected workflow cutover evidence"
+                "repo-owned policy and ao-release-gate decision cores, webhook runtimes, container packages, "
+                "GHCR publish paths, Cloud Run deploy paths, and internal vault-backed secret-id runtime "
+                "contract are ready, but neither service is publicly hosted/configured with vault-backed "
+                "runtime secrets, webhook evidence, dry-run check-run evidence, callback review evidence, or "
+                "protected workflow cutover evidence"
             ),
         }
     ]
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
     assert any(
-        action
-        == "bootstrap and run the ao-release-gate Cloud Run deploy workflow from main before collecting real PR evidence"
+        action == "host the ao-release-gate service in dry-run mode before collecting real PR evidence"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -298,8 +288,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         for action in payload["next_allowed_actions"]
     )
     assert any(
-        action
-        == "collect ao-release-gate dry-run check-run evidence on real PRs before any branch protection cutover"
+        action == "collect ao-release-gate dry-run check-run evidence on real PRs before any branch protection cutover"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -308,14 +297,17 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         for action in payload["next_allowed_actions"]
     )
     assert any(
-        action == "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded"
+        action
+        == "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded"
         for action in payload["next_allowed_actions"]
     )
     assert any(
         action == "use --equivalent-release-gate-approved while GPP-2e remains not_approved"
         for action in payload["forbidden_actions"]
     )
-    assert any(action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"])
+    assert any(
+        action == "treat a product end-user account as release authority" for action in payload["forbidden_actions"]
+    )
     assert any(
         action
         == "require product end users to self-host the GPP-2 deployment-protection policy service, vault, webhook secret, GitHub App private key, or Cloud Run project"
@@ -346,20 +338,27 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(
         action
-        == "run scripts/policy_service_cloud_run_bootstrap_attest.py to verify required GitHub repository variable handles before dispatching the Cloud Run deploy workflow, and treat metadata_ready as repository-variable evidence only"
+        == "prefer the internal operator host plus vault-backed secret-id path for GPP-2 service hosting unless a later decision reselects Cloud Run"
         for action in payload["next_allowed_actions"]
     )
     assert any(
         action
-        == "bootstrap or run the autonomous deployment-protection policy service deploy path using GitHub OIDC, Cloud Run, Artifact Registry, and Secret Manager handles before any further live-adapter runtime work"
+        == "configure ao_kernel.live_adapter_gate_policy_runtime:application with internal vault secret ids or direct runtime secret manager values, never committed or echoed secret material"
         for action in payload["next_allowed_actions"]
     )
     assert any(
-        action == "configure or verify the GitHub App webhook URL only after the deployed policy service endpoint is health-checked"
+        action
+        == "configure ao_kernel.ao_release_gate_runtime:application with internal vault secret ids or direct runtime secret manager values, never committed or echoed secret material"
         for action in payload["next_allowed_actions"]
     )
     assert any(
-        action == "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active"
+        action
+        == "configure or verify the GitHub App webhook URL only after the hosted policy service endpoint is health-checked"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -394,12 +393,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(
         action
-        == "configure ao_kernel.ao_release_gate_runtime:application only with runtime secret manager values, never committed or echoed secret material"
-        for action in payload["next_allowed_actions"]
-    )
-    assert any(
-        action
-        == "configure ao_kernel.live_adapter_gate_policy_runtime:application only with runtime secret manager values, never committed or echoed secret material"
+        == "deploy or configure the deployment-protection policy service using the repo-owned GHCR image or container package and internal vault-backed runtime secret ids before any further live-adapter runtime work"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -407,7 +401,9 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         == "do not reference AO_CLAUDE_CODE_CLI_AUTH through secrets context until a later live execution slice explicitly permits it"
         for action in payload["next_allowed_actions"]
     )
-    assert any(action == "treat Claude MCP consultation as release authority" for action in payload["forbidden_actions"])
+    assert any(
+        action == "treat Claude MCP consultation as release authority" for action in payload["forbidden_actions"]
+    )
     assert any(
         action == "use ao_memory_write or ao_llm_call during Claude MCP consultation"
         for action in payload["forbidden_actions"]
@@ -419,9 +415,9 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
 
 
 def test_gpp2e_equivalent_gate_decision_defaults_to_not_approved() -> None:
-    decision = (
-        _repo_root() / ".claude/plans/GPP-2e-SINGLE-ADMIN-EQUIVALENT-GATE-DECISION.md"
-    ).read_text(encoding="utf-8")
+    decision = (_repo_root() / ".claude/plans/GPP-2e-SINGLE-ADMIN-EQUIVALENT-GATE-DECISION.md").read_text(
+        encoding="utf-8"
+    )
 
     assert "**Decision:** `not_approved`" in decision
     assert "does not approve that equivalent gate" in decision
@@ -430,9 +426,9 @@ def test_gpp2e_equivalent_gate_decision_defaults_to_not_approved() -> None:
 
 
 def test_gpp2f_independent_release_gate_replaces_end_user_reviewer_model() -> None:
-    decision = (
-        _repo_root() / ".claude/plans/GPP-2f-INDEPENDENT-RELEASE-GATE-ARCHITECTURE.md"
-    ).read_text(encoding="utf-8")
+    decision = (_repo_root() / ".claude/plans/GPP-2f-INDEPENDENT-RELEASE-GATE-ARCHITECTURE.md").read_text(
+        encoding="utf-8"
+    )
 
     assert "**Decision:** `independent_release_gate_required`" in decision
     assert "not a product end-user account" in decision
@@ -460,9 +456,9 @@ def test_gpp2g_claude_mcp_consultation_is_advisory_only() -> None:
 
 
 def test_gpp2h_selects_deployment_protection_bot_not_bot_user() -> None:
-    decision = (
-        _repo_root() / ".claude/plans/GPP-2h-DEPLOYMENT-PROTECTION-BOT-GATE-DECISION.md"
-    ).read_text(encoding="utf-8")
+    decision = (_repo_root() / ".claude/plans/GPP-2h-DEPLOYMENT-PROTECTION-BOT-GATE-DECISION.md").read_text(
+        encoding="utf-8"
+    )
 
     assert "**Decision:** `github_app_deployment_protection_rule_selected`" in decision
     assert "supersedes the first provisioning path selected in `GPP-2g`" in decision
@@ -475,9 +471,9 @@ def test_gpp2h_selects_deployment_protection_bot_not_bot_user() -> None:
 
 
 def test_gpp2i_attestation_support_keeps_gate_blocked() -> None:
-    decision = (
-        _repo_root() / ".claude/plans/GPP-2i-DEPLOYMENT-PROTECTION-ATTESTATION-SUPPORT.md"
-    ).read_text(encoding="utf-8")
+    decision = (_repo_root() / ".claude/plans/GPP-2i-DEPLOYMENT-PROTECTION-ATTESTATION-SUPPORT.md").read_text(
+        encoding="utf-8"
+    )
 
     assert "**Decision:** `deployment_protection_attestation_supported_gate_still_blocked`" in decision
     assert "`release_gate_model = github_app_deployment_protection_rule`" in decision
@@ -489,9 +485,7 @@ def test_gpp2i_attestation_support_keeps_gate_blocked() -> None:
 
 
 def test_gpp2u_selects_autonomous_github_app_release_gate_not_admin_bypass() -> None:
-    decision = (
-        _repo_root() / ".claude/plans/GPP-2u-AUTONOMOUS-GITHUB-APP-RELEASE-GATE.md"
-    ).read_text(encoding="utf-8")
+    decision = (_repo_root() / ".claude/plans/GPP-2u-AUTONOMOUS-GITHUB-APP-RELEASE-GATE.md").read_text(encoding="utf-8")
 
     assert "**Decision:** `autonomous_github_app_release_gate_selected_no_support_widening`" in decision
     assert "GitHub App release gate" in decision
@@ -506,9 +500,7 @@ def test_gpp2u_selects_autonomous_github_app_release_gate_not_admin_bypass() -> 
 
 
 def test_gpp2v_adds_dry_run_release_gate_scaffold_without_merge_authority() -> None:
-    decision = (
-        _repo_root() / ".claude/plans/GPP-2v-AO-RELEASE-GATE-DRY-RUN-SCAFFOLD.md"
-    ).read_text(encoding="utf-8")
+    decision = (_repo_root() / ".claude/plans/GPP-2v-AO-RELEASE-GATE-DRY-RUN-SCAFFOLD.md").read_text(encoding="utf-8")
 
     assert "**Decision:** `ao_release_gate_dry_run_scaffold_ready_no_support_widening`" in decision
     assert "`ao-release-gate`" in decision
@@ -523,9 +515,7 @@ def test_gpp2v_adds_dry_run_release_gate_scaffold_without_merge_authority() -> N
 
 
 def test_gpp2w_wires_check_run_service_without_merge_authority() -> None:
-    decision = (
-        _repo_root() / ".claude/plans/GPP-2w-AO-RELEASE-GATE-CHECK-RUN-SERVICE.md"
-    ).read_text(encoding="utf-8")
+    decision = (_repo_root() / ".claude/plans/GPP-2w-AO-RELEASE-GATE-CHECK-RUN-SERVICE.md").read_text(encoding="utf-8")
 
     assert "**Decision:** `ao_release_gate_check_run_service_ready_no_support_widening`" in decision
     assert "`ao-release-gate`" in decision
@@ -544,9 +534,7 @@ def test_gpp2w_wires_check_run_service_without_merge_authority() -> None:
 
 
 def test_gpp2x_packages_release_gate_container_without_hosting_or_merge_authority() -> None:
-    decision = (_repo_root() / ".claude/plans/GPP-2x-AO-RELEASE-GATE-CONTAINER.md").read_text(
-        encoding="utf-8"
-    )
+    decision = (_repo_root() / ".claude/plans/GPP-2x-AO-RELEASE-GATE-CONTAINER.md").read_text(encoding="utf-8")
 
     assert "**Decision:** `ao_release_gate_container_ready_no_support_widening`" in decision
     assert "`ao-release-gate`" in decision
@@ -562,9 +550,7 @@ def test_gpp2x_packages_release_gate_container_without_hosting_or_merge_authorit
 
 
 def test_gpp2y_adds_release_gate_publish_path_without_hosting_or_merge_authority() -> None:
-    decision = (
-        _repo_root() / ".claude/plans/GPP-2y-AO-RELEASE-GATE-CONTAINER-PUBLISH.md"
-    ).read_text(encoding="utf-8")
+    decision = (_repo_root() / ".claude/plans/GPP-2y-AO-RELEASE-GATE-CONTAINER-PUBLISH.md").read_text(encoding="utf-8")
 
     assert "**Decision:** `ao_release_gate_publish_path_ready_no_support_widening`" in decision
     assert "`ao-release-gate`" in decision
@@ -580,9 +566,7 @@ def test_gpp2y_adds_release_gate_publish_path_without_hosting_or_merge_authority
 
 
 def test_gpp2aa_adds_release_gate_deploy_path_without_cutover_or_merge_authority() -> None:
-    decision = (
-        _repo_root() / ".claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md"
-    ).read_text(encoding="utf-8")
+    decision = (_repo_root() / ".claude/plans/GPP-2aa-AO-RELEASE-GATE-AUTONOMOUS-DEPLOY.md").read_text(encoding="utf-8")
 
     assert "**Decision:** `ao_release_gate_autonomous_deploy_path_ready_service_not_bootstrapped`" in decision
     assert "`ao-release-gate`" in decision
@@ -599,9 +583,9 @@ def test_gpp2aa_adds_release_gate_deploy_path_without_cutover_or_merge_authority
 
 
 def test_gpp2ab_policy_cloud_run_bootstrap_attestation_is_metadata_only() -> None:
-    decision = (
-        _repo_root() / ".claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md"
-    ).read_text(encoding="utf-8")
+    decision = (_repo_root() / ".claude/plans/GPP-2ab-POLICY-CLOUD-RUN-BOOTSTRAP-ATTESTATION.md").read_text(
+        encoding="utf-8"
+    )
 
     assert "policy_cloud_run_bootstrap_attestation_tool_ready_variables_missing" in decision
     assert "gh variable list --json name,updatedAt" in decision
@@ -615,9 +599,7 @@ def test_gpp2ab_policy_cloud_run_bootstrap_attestation_is_metadata_only() -> Non
 
 
 def test_gpp2ac_keeps_gate_operator_owned_and_end_user_onboarding_simple() -> None:
-    decision = (
-        _repo_root() / ".claude/plans/GPP-2ac-OPERATOR-GATE-END-USER-BOUNDARY.md"
-    ).read_text(encoding="utf-8")
+    decision = (_repo_root() / ".claude/plans/GPP-2ac-OPERATOR-GATE-END-USER-BOUNDARY.md").read_text(encoding="utf-8")
 
     assert "operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening" in decision
     assert "self-host them to use the product" in decision
@@ -634,6 +616,26 @@ def test_gpp2ac_keeps_gate_operator_owned_and_end_user_onboarding_simple() -> No
     assert "`production_platform_claim=false`" in decision
 
 
+def test_gpp2ad_records_internal_vault_gate_secret_contract() -> None:
+    decision = (_repo_root() / ".claude/plans/GPP-2ad-INTERNAL-VAULT-GATE-SECRET-CONTRACT.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "internal_vault_gate_secret_contract_ready_service_not_hosted_no_support_widening" in decision
+    assert "internal host plus vault-backed runtime" in decision
+    assert "secret contract" in decision
+    assert "AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID" in decision
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET_ID" in decision
+    assert "AO_GITHUB_APP_PRIVATE_KEY_PEM_ID" in decision
+    assert "End users must not be" in decision
+    assert "asked to" in decision
+    assert "self-host the policy service" in decision
+    assert "public `/healthz` evidence" in decision
+    assert "`live_execution_allowed=false`" in decision
+    assert "`support_widening=false`" in decision
+    assert "`production_platform_claim=false`" in decision
+
+
 def test_gpp_next_load_status_validates_required_guards() -> None:
     mod = _module()
 
@@ -641,11 +643,11 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/551"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/563"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "operator_owned_gate_end_user_onboarding_boundary_recorded_no_support_widening"
+        == "internal_vault_gate_secret_contract_ready_service_not_hosted_no_support_widening"
     )
     assert payload["support_widening_allowed"] is False
 
@@ -676,9 +678,9 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "metadata-only policy bootstrap attestation tool" in rendered
-    assert "ao-release-gate dry-run decision scaffold" in rendered
-    assert "operator-owned end-user onboarding boundary" in rendered
+    assert "internal vault-backed secret-id runtime contract" in rendered
+    assert "webhook runtimes, container packages" in rendered
+    assert "publicly hosted/configured with vault-backed runtime secrets" in rendered
     assert "divergence: 0\t0" in rendered
 
 

--- a/tests/test_live_adapter_gate_policy_runtime.py
+++ b/tests/test_live_adapter_gate_policy_runtime.py
@@ -5,6 +5,7 @@ import json
 import sys
 import types
 from io import BytesIO
+from pathlib import Path
 from typing import Any, Mapping
 
 import pytest
@@ -15,13 +16,17 @@ from ao_kernel.live_adapter_gate_policy_runtime import (
     DEFAULT_WEBHOOK_PATH,
     GITHUB_APP_ID_ENV,
     GITHUB_APP_PRIVATE_KEY_ENV,
+    GITHUB_APP_PRIVATE_KEY_SECRET_ID_ENV,
     WEBHOOK_SECRET_ENV,
+    WEBHOOK_SECRET_ID_ENV,
     CallbackPostResult,
     GithubAppConfig,
     GithubAppDeploymentReviewClient,
     PolicyRuntimeConfigError,
     build_github_app_jwt,
     handle_live_adapter_gate_policy_webhook,
+    load_github_app_config,
+    load_webhook_secret,
     policy_runtime_wsgi_app,
 )
 from ao_kernel.live_adapter_gate_policy_service import (
@@ -38,8 +43,7 @@ def _approved_payload() -> dict[str, object]:
         "sha": "abc123",
         "ref": "refs/heads/main",
         "deployment_callback_url": (
-            "https://api.github.com/repos/Halildeu/ao-kernel/actions/runs/25020015357/"
-            "deployment_protection_rule"
+            "https://api.github.com/repos/Halildeu/ao-kernel/actions/runs/25020015357/deployment_protection_rule"
         ),
         "repository": {"full_name": "Halildeu/ao-kernel"},
         "installation": {"id": 12345},
@@ -230,6 +234,52 @@ def test_build_github_app_jwt_reports_missing_optional_dependency(monkeypatch: p
         build_github_app_jwt(app_id="1", private_key_pem="private-key", now_seconds=1000)
 
     assert "policy-service extra" in str(exc_info.value)
+
+
+def test_runtime_loads_policy_secrets_from_internal_vault_stub(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault_path = tmp_path / ".secrets" / "vault.json"
+    vault_path.parent.mkdir()
+    vault_path.write_text(
+        json.dumps(
+            {
+                "gpp2/policy/webhook-secret": " secret-from-vault ",
+                "gpp2/github/private-key-pem": " private-key-from-vault ",
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SECRETS_PROVIDER", "vault_stub")
+    env = {
+        GITHUB_APP_ID_ENV: "3522435",
+        WEBHOOK_SECRET_ID_ENV: "gpp2/policy/webhook-secret",
+        GITHUB_APP_PRIVATE_KEY_SECRET_ID_ENV: "gpp2/github/private-key-pem",
+    }
+
+    assert load_webhook_secret(env) == "secret-from-vault"
+    config = load_github_app_config(env)
+    assert config.app_id == "3522435"
+    assert config.private_key_pem == "private-key-from-vault"
+
+
+def test_runtime_reports_missing_vault_secret_without_echoing_secret_id(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".secrets").mkdir()
+    (tmp_path / ".secrets" / "vault.json").write_text("{}", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SECRETS_PROVIDER", "vault_stub")
+
+    with pytest.raises(PolicyRuntimeConfigError) as exc_info:
+        load_webhook_secret({WEBHOOK_SECRET_ID_ENV: "gpp2/policy/missing-secret"})
+
+    assert exc_info.value.finding_code == "live_gate_policy_runtime_webhook_secret_missing"
+    assert "gpp2/policy/missing-secret" not in str(exc_info.value)
 
 
 def test_wsgi_health_endpoint() -> None:


### PR DESCRIPTION
## Summary

- Add runtime secret-id resolution for the live-adapter policy gate and ao-release-gate services through the configured secrets provider.
- Document the operator-owned internal host plus vault-backed secret contract for GPP-2 instead of requiring Cloud Run or end-user self-hosting.
- Update the GPP machine-readable and human-readable status to keep GPP-2 blocked until public HTTPS hosting, webhook configuration, check-run evidence, callback evidence, and protected workflow evidence exist.

## Safety boundaries

- No secret values are committed, echoed, or required through repository storage.
- No webhook URL is configured by this PR.
- No callback/check-run is posted by this PR.
- No branch protection/ruleset change is made by this PR.
- No protected workflow dispatch, live adapter execution, support widening, or production platform claim is enabled.

## Validation

- `python3 -m pytest tests/test_secrets_factory.py tests/test_api_key_resolver.py tests/test_live_adapter_gate_policy_runtime.py tests/test_ao_release_gate_runtime.py tests/test_gpp_next.py tests/test_live_adapter_gate_policy_service.py tests/test_ao_release_gate_service.py tests/test_live_adapter_gate_policy.py tests/test_ao_release_gate.py -q` (`96 passed`)
- `python3 -m ruff check ao_kernel/live_adapter_gate_policy_runtime.py ao_kernel/ao_release_gate_runtime.py tests/test_live_adapter_gate_policy_runtime.py tests/test_ao_release_gate_runtime.py tests/test_gpp_next.py`
- `python3 -m ruff format --check ao_kernel/live_adapter_gate_policy_runtime.py ao_kernel/ao_release_gate_runtime.py tests/test_live_adapter_gate_policy_runtime.py tests/test_ao_release_gate_runtime.py tests/test_gpp_next.py`
- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `git diff --check`

Closes #563