### PR TITLE
GPP-2ae: add internal operator host bundle

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,16 +1,16 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 internal vault gate secret contract recorded after Cloud Run
-bootstrap and `ao-release-gate` autonomous deploy paths; operator-owned
-internal hosting, vault-backed runtime configuration, callback/check-run
-evidence, and cutover still blocked
+**Status:** GPP-2 internal operator host bundle recorded after Cloud Run
+bootstrap, `ao-release-gate` autonomous deploy paths, and internal vault
+secret-id contract; operator-owned public hosting, webhook configuration,
+callback/check-run evidence, and cutover still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#563](https://github.com/Halildeu/ao-kernel/issues/563)
-for internal vault gate secret contract
-**Current slice record:** `.claude/plans/GPP-2ad-INTERNAL-VAULT-GATE-SECRET-CONTRACT.md`
+**Current slice issue:** [#565](https://github.com/Halildeu/ao-kernel/issues/565)
+for internal operator host bundle
+**Current slice record:** `.claude/plans/GPP-2ae-INTERNAL-OPERATOR-HOST-BUNDLE.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -248,12 +248,19 @@ Last live verification on current `origin/main` showed:
     remains blocked until public HTTPS health, GitHub App webhook, callback
     review, real PR dry-run check-run, branch-protection cutover, and protected
     workflow evidence exist.
-46. GPP-5d closes the repo-intelligence read-only workflow surface with a
+46. GPP-2ae adds the internal operator host bundle. `deploy/internal-gate-host`
+    composes Caddy, the policy service container, and the `ao-release-gate`
+    container with vault-backed secret ids and a metadata-only no-secret
+    attestation. This gives the no-paid-cloud operator path a repeatable repo
+    surface, but it still does not prove public DNS/HTTPS, GitHub webhook
+    configuration, callback/check-run posting, branch-protection cutover, or
+    protected workflow pass behavior.
+47. GPP-5d closes the repo-intelligence read-only workflow surface with a
     schema-backed preflight over GPP-5a/GPP-5b/GPP-5c records, public APIs,
     schemas, and negative runtime guards. GPP-6 preparation may use this
     closeout as repo-intelligence evidence, but GPP-6 execution remains
     blocked by GPP-2 and GPP-4.
-47. GPP-6a adds a preparation-only read-only E2E preflight. The preflight
+48. GPP-6a adds a preparation-only read-only E2E preflight. The preflight
     report is ready and records `execution_status=blocked_by_upstream_gates`
     because GPP-2 protected gate evidence and the GPP-4 read-only adapter
     decision are still missing. It does not dispatch protected workflows, call
@@ -327,6 +334,7 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2ab` | Completed / no support widening | Policy Cloud Run bootstrap attestation | metadata-only attestation tool ready; required repository variable handles are currently missing; GCP trust, Secret Manager objects, hosted service evidence, GitHub App webhook config, and callback evidence are not yet attested |
 | `GPP-2ac` | Completed / no support widening | Operator gate and end-user onboarding boundary | GPP-2 gate hosting is operator-owned platform infrastructure; end users must not self-host Cloud Run, vault, webhook, or GitHub App private-key setup |
 | `GPP-2ad` | Completed / no support widening | Internal vault gate secret contract | policy and release-gate runtimes accept vault-backed secret ids; services are still not hosted/evidenced |
+| `GPP-2ae` | Completed / no support widening | Internal operator host bundle | Caddy + policy service + `ao-release-gate` compose bundle and no-secret metadata attestation ready; services are still not publicly hosted/evidenced |
 | `GPP-2` | Blocked / internal hosting/config/evidence and release-gate cutover missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be hosted/configured with vault-backed runtime secrets and post callback evidence, and `ao-release-gate` must be deployed/hosted/evidenced/cut over before human-free program merges |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
@@ -536,6 +544,15 @@ platform infrastructure with secret ids such as
 `AO_GITHUB_APP_PRIVATE_KEY_PEM_ID`. It does not host either service, configure
 GitHub webhooks, post callbacks/check-runs, grant merge authority, or unblock
 live adapter execution.
+GPP-2ae adds `deploy/internal-gate-host` as the no-paid-cloud operator host
+bundle. It composes Caddy with the two repo-owned gate service containers,
+routes `/github/deployment-protection` and `/github/ao-release-gate`, mounts
+the GPP status file for `ao-release-gate`, and keeps secret material behind
+vault-backed secret ids. Its metadata-only attestation proves only that the
+checked-in host bundle is coherent and no direct secret markers are present. It
+does not run Docker, contact a vault, configure webhooks, post callbacks or
+check-runs, change branch protection, dispatch protected workflows, or execute
+a live adapter.
 
 **Acceptance criteria:**
 
@@ -1051,6 +1068,8 @@ admin bypass for PR merge automation, and must keep
 | 2026-04-28 | GPP-2aa deploy path added | `.github/workflows/ao-release-gate-deploy-cloud-run.yml` can mirror the trusted immutable release-gate image to Artifact Registry, deploy Cloud Run with Secret Manager references, health-check `/healthz`, and upload deploy evidence; webhook configuration, real PR check-run evidence, branch-protection cutover, and deployment-protection hosting remain required. |
 | 2026-04-28 | GPP-2ab issue opened | Issue [#549](https://github.com/Halildeu/ao-kernel/issues/549) tracks metadata-only Cloud Run bootstrap attestation for the policy service deploy path. |
 | 2026-04-28 | GPP-2ab bootstrap attestation added | `scripts/policy_service_cloud_run_bootstrap_attest.py` checks required GitHub repository variable handles with `gh variable list --json name,updatedAt`, ignores values, and records that current live metadata is `overall_status=blocked` because all required handles are missing; GCP trust, Secret Manager objects, Cloud Run hosting, webhook URL configuration, callback posting, live execution, support widening, and production-platform claims remain unproven. |
+| 2026-04-28 | GPP-2ae issue opened | Issue [#565](https://github.com/Halildeu/ao-kernel/issues/565) tracks the internal operator host bundle for the vault-backed no-paid-cloud GPP-2 path. |
+| 2026-04-28 | GPP-2ae host bundle added | `deploy/internal-gate-host` composes Caddy, the policy service container, and `ao-release-gate` with vault-backed secret ids; `scripts/internal_gate_host_bootstrap_attest.py` records metadata readiness only, with no Docker run, vault access, webhook configuration, callback/check-run posting, live adapter execution, support widening, or production claim. |
 | 2026-04-28 | GPP-5d issue opened | Issue [#559](https://github.com/Halildeu/ao-kernel/issues/559) tracks repo-intelligence read-only workflow closeout before GPP-6 preparation. |
 | 2026-04-28 | GPP-5d closeout preflight added | `scripts/gpp5_repo_intelligence_closeout.py` records GPP-5 as closed for read-only workflow-surface purposes while keeping GPP-6 execution blocked by GPP-2 and GPP-4. |
 | 2026-04-28 | GPP-6a issue opened | Issue [#561](https://github.com/Halildeu/ao-kernel/issues/561) tracks the read-only E2E preflight contract for GPP-6 preparation. |

--- a/.claude/plans/GPP-2ae-INTERNAL-OPERATOR-HOST-BUNDLE.md
+++ b/.claude/plans/GPP-2ae-INTERNAL-OPERATOR-HOST-BUNDLE.md
@@ -1,0 +1,133 @@
+# GPP-2ae - Internal Operator Host Bundle
+
+**Issue:** [#565](https://github.com/Halildeu/ao-kernel/issues/565)
+**Program head:** `GPP-2` remains blocked
+**Decision:** `internal_operator_host_bundle_ready_service_not_hosted_no_support_widening`
+**Support impact:** none
+**Production platform claim:** no
+**Live adapter execution:** no
+
+## Decision
+
+GPP-2ae adds a repo-owned internal operator host bundle for the two GPP-2 gate
+services. This makes the no-paid-cloud path repeatable without requiring each
+product end user to self-host Cloud Run, a vault, webhook secrets, or a GitHub
+App private key.
+
+The bundle lives at:
+
+```text
+deploy/internal-gate-host/
+```
+
+It includes:
+
+```text
+deploy/internal-gate-host/compose.yaml
+deploy/internal-gate-host/Caddyfile.example
+deploy/internal-gate-host/.env.example
+deploy/internal-gate-host/README.md
+```
+
+The bundle composes the existing repo-owned container packages:
+
+```text
+ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service
+ghcr.io/halildeu/ao-kernel-ao-release-gate-service
+```
+
+The preferred runtime secret path remains vault-backed secret ids:
+
+```text
+AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID
+AO_RELEASE_GATE_WEBHOOK_SECRET_ID
+AO_GITHUB_APP_PRIVATE_KEY_PEM_ID
+```
+
+The bundle does not commit, render, or require secret values in repo state.
+
+## Operator-Owned Boundary
+
+This is platform infrastructure owned by the operator of the ao-kernel service.
+It is not a product end-user setup requirement.
+
+End users must not be asked to:
+
+1. host the deployment-protection policy service;
+2. host `ao-release-gate`;
+3. run a vault;
+4. manage webhook secret values;
+5. manage a GitHub App private key;
+6. create a Cloud Run or equivalent hosting project.
+
+End-user repo-intelligence onboarding remains limited to GitHub App
+installation, selected repositories, and explicit opt-in configuration.
+
+## Attestation
+
+GPP-2ae adds a metadata-only attestation:
+
+```bash
+python3 scripts/internal_gate_host_bootstrap_attest.py \
+  --output text \
+  --fail-on-blocked
+```
+
+The attestation verifies only checked-in deployment metadata:
+
+1. the internal host bundle files exist;
+2. the compose bundle references both repo-owned GHCR container packages;
+3. the Caddy route file exposes the two GitHub webhook paths;
+4. the runtime configuration uses vault-backed secret ids;
+5. forbidden direct secret markers are absent.
+
+The attestation does not:
+
+1. run Docker or Docker Compose;
+2. contact HashiCorp Vault or `vault_stub`;
+3. read secret values;
+4. configure GitHub App webhook URLs;
+5. receive GitHub webhook deliveries;
+6. post deployment-protection callback reviews;
+7. post `ao-release-gate` check-runs;
+8. change branch protection or rulesets;
+9. dispatch the protected live-adapter workflow;
+10. execute a live adapter.
+
+## Remaining GPP-2 Blockers
+
+GPP-2 remains blocked until the following evidence exists from trusted
+operator infrastructure:
+
+1. public HTTPS health evidence for the hosted policy service;
+2. public HTTPS health evidence for the hosted `ao-release-gate` service;
+3. GitHub App webhook URL configuration for `/github/deployment-protection`;
+4. GitHub App webhook URL configuration for `/github/ao-release-gate`;
+5. policy callback review evidence;
+6. real PR dry-run check-run evidence from `ao-release-gate`;
+7. branch-protection or ruleset cutover to require `ao-release-gate`;
+8. protected workflow evidence showing fail-closed/pass behavior through the
+   hosted deployment-protection gate.
+
+Until those are recorded:
+
+```text
+live_execution_allowed=false
+support_widening=false
+production_platform_claim=false
+```
+
+The machine-readable flags remain `live_execution_allowed=false`,
+`support_widening=false`, and `production_platform_claim=false`.
+
+## Validation
+
+```bash
+python3 scripts/internal_gate_host_bootstrap_attest.py \
+  --output text \
+  --fail-on-blocked
+```
+
+```bash
+python3 -m pytest tests/test_internal_gate_host_bootstrap_attest.py -q
+```

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,12 +9,13 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/563",
-    "exit_decision": "internal_vault_gate_secret_contract_ready_service_not_hosted_no_support_widening",
-    "ready_after": "operator-owned policy service and ao-release-gate are hosted on public HTTPS endpoints with internal vault-backed runtime secret ids, GitHub App webhook URLs are configured, policy callback review evidence exists, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, and protected workflow evidence confirms live_execution_allowed=false",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/565",
+    "exit_decision": "internal_operator_host_bundle_ready_service_not_hosted_no_support_widening",
+    "ready_after": "operator-owned policy service and ao-release-gate are hosted on public HTTPS endpoints from the internal operator host bundle or equivalent infrastructure with internal vault-backed runtime secret ids, GitHub App webhook URLs are configured, policy callback review evidence exists, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, and protected workflow evidence confirms live_execution_allowed=false",
     "allowed_scope": [
       "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service on operator-owned internal infrastructure without secret value exposure",
       "use the repo-owned ao-release-gate GHCR image or container package to deploy or configure the ao-release-gate GitHub App check-run service on operator-owned internal infrastructure without secret value exposure",
+      "use deploy/internal-gate-host or equivalent operator-owned infrastructure as the no-paid-cloud default host bundle for both GPP-2 gate services",
       "configure hosted gate runtimes with internal vault secret ids rather than committed, echoed, or repository-stored secret values",
       "document or build end-user onboarding paths that do not require users to self-host the GPP-2 policy service, vault, webhook secret, GitHub App private key, or Cloud Run project",
       "repeat protected workflow evidence collection from main after the policy service responds",
@@ -205,6 +206,12 @@
       "record": ".claude/plans/GPP-2ad-INTERNAL-VAULT-GATE-SECRET-CONTRACT.md"
     },
     {
+      "id": "GPP-2ae",
+      "decision": "internal_operator_host_bundle_ready_service_not_hosted_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/565",
+      "record": ".claude/plans/GPP-2ae-INTERNAL-OPERATOR-HOST-BUNDLE.md"
+    },
+    {
       "id": "GPP-5a",
       "decision": "repo_intelligence_product_onboarding_contract_ready_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/553",
@@ -238,12 +245,12 @@
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned policy and ao-release-gate decision cores, webhook runtimes, container packages, GHCR publish paths, Cloud Run deploy paths, and internal vault-backed secret-id runtime contract are ready, but neither service is publicly hosted/configured with vault-backed runtime secrets, webhook evidence, dry-run check-run evidence, callback review evidence, or protected workflow cutover evidence"
+      "reason": "repo-owned policy and ao-release-gate decision cores, webhook runtimes, container packages, GHCR publish paths, Cloud Run deploy paths, internal vault-backed secret-id runtime contract, and internal operator host bundle are ready, but neither service is publicly hosted/configured with vault-backed runtime secrets, webhook evidence, dry-run check-run evidence, callback review evidence, or protected workflow cutover evidence"
     }
   ],
   "pending_external_actions": [
-    "host the operator-owned policy service on public HTTPS using the repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
-    "host the operator-owned ao-release-gate service on public HTTPS using the repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
+    "host the operator-owned policy service on public HTTPS using deploy/internal-gate-host or equivalent repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
+    "host the operator-owned ao-release-gate service on public HTTPS using deploy/internal-gate-host or equivalent repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
     "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the hosted /github/deployment-protection endpoint and can post deployment callback reviews",
     "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with vault-backed runtime webhook secret and GitHub App authentication outside the repo",
     "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
@@ -311,6 +318,7 @@
     "prioritize repo-intelligence onboarding as a read-only product workflow that requires GitHub App installation and repository selection, not Cloud Run, vault, webhook, or private-key setup by each user",
     "use GPP-6a read-only E2E preflight evidence for preparation only, while GPP-6 execution remains blocked until GPP-2 protected gate and GPP-4 read-only adapter decision are ready and support_widening_allowed=false and production_platform_claim_allowed=false",
     "prefer the internal operator host plus vault-backed secret-id path for GPP-2 service hosting unless a later decision reselects Cloud Run",
+    "use deploy/internal-gate-host as the default no-paid-cloud operator host bundle and validate it with scripts/internal_gate_host_bootstrap_attest.py before collecting hosted evidence",
     "configure ao_kernel.live_adapter_gate_policy_runtime:application with internal vault secret ids or direct runtime secret manager values, never committed or echoed secret material",
     "configure ao_kernel.ao_release_gate_runtime:application with internal vault secret ids or direct runtime secret manager values, never committed or echoed secret material",
     "configure or verify the GitHub App webhook URL only after the hosted policy service endpoint is health-checked",

--- a/deploy/internal-gate-host/.env.example
+++ b/deploy/internal-gate-host/.env.example
@@ -1,0 +1,29 @@
+# Operator-owned public HTTPS host for the GPP-2 gate services.
+AO_GATE_HOSTNAME=gate.operator.example
+AO_GATE_HTTP_BIND=80
+AO_GATE_HTTPS_BIND=443
+AO_GATE_CADDYFILE=./Caddyfile.example
+
+# Prefer immutable sha-* tags after the publish workflows run on main.
+AO_POLICY_SERVICE_IMAGE=ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service:main
+AO_RELEASE_GATE_SERVICE_IMAGE=ghcr.io/halildeu/ao-kernel-ao-release-gate-service:main
+
+# Shared GitHub App identity. Secret material stays in the operator vault.
+AO_GITHUB_API_URL=https://api.github.com
+AO_GITHUB_APP_ID=<github-app-id>
+AO_GITHUB_APP_PRIVATE_KEY_PEM_ID=gpp2/github/private-key-pem
+
+# Vault-backed runtime secret ids.
+SECRETS_PROVIDER=hashicorp_vault
+VAULT_ADDR=https://vault.operator.example
+VAULT_TOKEN=<operator-runtime-vault-token>
+VAULT_SECRET_MOUNT=secret
+AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID=gpp2/policy/webhook-secret
+AO_RELEASE_GATE_WEBHOOK_SECRET_ID=gpp2/release-gate/webhook-secret
+
+# Runtime sizing and request limits.
+WEB_CONCURRENCY=1
+WEB_THREADS=4
+WEB_TIMEOUT=30
+AO_POLICY_SERVICE_MAX_BODY_BYTES=1048576
+AO_RELEASE_GATE_MAX_BODY_BYTES=1048576

--- a/deploy/internal-gate-host/Caddyfile.example
+++ b/deploy/internal-gate-host/Caddyfile.example
@@ -1,0 +1,23 @@
+{$AO_GATE_HOSTNAME} {
+	encode zstd gzip
+
+	@policyWebhook path /github/deployment-protection
+	reverse_proxy @policyWebhook live-adapter-gate-policy:8000
+
+	@releaseGateWebhook path /github/ao-release-gate
+	reverse_proxy @releaseGateWebhook ao-release-gate:8000
+
+	@policyHealth path /policy/healthz
+	handle @policyHealth {
+		rewrite * /healthz
+		reverse_proxy live-adapter-gate-policy:8000
+	}
+
+	@releaseGateHealth path /release-gate/healthz
+	handle @releaseGateHealth {
+		rewrite * /healthz
+		reverse_proxy ao-release-gate:8000
+	}
+
+	respond /healthz 200
+}

--- a/deploy/internal-gate-host/README.md
+++ b/deploy/internal-gate-host/README.md
@@ -1,0 +1,96 @@
+# Internal Gate Host Bundle
+
+This bundle is the operator-owned, no-paid-cloud default for hosting the GPP-2
+gate services after the internal vault secret-id contract. It composes the
+existing repo-owned containers:
+
+```text
+ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service
+ghcr.io/halildeu/ao-kernel-ao-release-gate-service
+```
+
+It is not an end-user setup requirement. Product users should only install the
+GitHub App, select repositories, and opt in to read-only repo-intelligence
+configuration. They must not be asked to host this bundle, run a vault, manage
+webhook secrets, or handle GitHub App private keys.
+
+## Files
+
+```text
+deploy/internal-gate-host/compose.yaml
+deploy/internal-gate-host/Caddyfile.example
+deploy/internal-gate-host/.env.example
+```
+
+`compose.yaml` runs three containers:
+
+1. `caddy`, the public HTTPS reverse proxy.
+2. `live-adapter-gate-policy`, the GitHub deployment-protection callback
+   policy service.
+3. `ao-release-gate`, the dry-run check-run service.
+
+The public GitHub App webhook URLs are:
+
+```text
+https://<AO_GATE_HOSTNAME>/github/deployment-protection
+https://<AO_GATE_HOSTNAME>/github/ao-release-gate
+```
+
+The no-secret health URLs are:
+
+```text
+https://<AO_GATE_HOSTNAME>/policy/healthz
+https://<AO_GATE_HOSTNAME>/release-gate/healthz
+```
+
+## Runtime Secret Contract
+
+The services read secret values only at runtime. The checked-in bundle uses
+vault secret ids and provider-local configuration:
+
+```text
+SECRETS_PROVIDER=hashicorp_vault
+VAULT_ADDR=<operator vault URL>
+VAULT_TOKEN=<operator vault token>
+VAULT_SECRET_MOUNT=secret
+AO_GITHUB_APP_PRIVATE_KEY_PEM_ID=gpp2/github/private-key-pem
+AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID=gpp2/policy/webhook-secret
+AO_RELEASE_GATE_WEBHOOK_SECRET_ID=gpp2/release-gate/webhook-secret
+```
+
+`VAULT_TOKEN`, webhook secret values, and the GitHub App private key are
+operator runtime material. They must not be committed, pasted into issues,
+printed in logs, or sent through chat.
+
+For local operator rehearsal, `SECRETS_PROVIDER=vault_stub` can be used with a
+local `.secrets/vault.json` file in the service working directory. That file is
+still secret material and must stay outside git.
+
+## GPP Boundary
+
+This bundle only makes the internal host path repeatable. It does not prove:
+
+- public DNS and HTTPS are configured;
+- the GitHub App webhook URLs are set;
+- a deployment-protection callback review was posted;
+- an `ao-release-gate` check-run was posted on a real PR;
+- branch protection requires `ao-release-gate`;
+- the protected live-adapter workflow can pass the gate;
+- live adapter execution is allowed;
+- support widening or a production platform claim is allowed.
+
+Until those evidence items exist, GPP-2 remains blocked and fail-closed.
+
+## Metadata-Only Attestation
+
+The repository provides a no-secret static attestation for this bundle:
+
+```bash
+python3 scripts/internal_gate_host_bootstrap_attest.py \
+  --output text \
+  --fail-on-blocked
+```
+
+The attestation reads only checked-in deployment metadata. It does not run
+Docker, contact a vault, call GitHub, configure webhooks, post callbacks,
+post check-runs, dispatch protected workflows, or execute a live adapter.

--- a/deploy/internal-gate-host/compose.yaml
+++ b/deploy/internal-gate-host/compose.yaml
@@ -1,0 +1,63 @@
+name: ao-kernel-gpp2-gates
+
+services:
+  caddy:
+    image: caddy:2.8-alpine
+    restart: unless-stopped
+    depends_on:
+      live-adapter-gate-policy:
+        condition: service_healthy
+      ao-release-gate:
+        condition: service_healthy
+    environment:
+      AO_GATE_HOSTNAME: ${AO_GATE_HOSTNAME:?set AO_GATE_HOSTNAME to the public HTTPS host}
+    ports:
+      - "${AO_GATE_HTTP_BIND:-80}:80"
+      - "${AO_GATE_HTTPS_BIND:-443}:443"
+    volumes:
+      - ${AO_GATE_CADDYFILE:-./Caddyfile.example}:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+
+  live-adapter-gate-policy:
+    image: ${AO_POLICY_SERVICE_IMAGE:-ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service:main}
+    restart: unless-stopped
+    environment:
+      PORT: "8000"
+      WEB_CONCURRENCY: ${WEB_CONCURRENCY:-1}
+      WEB_THREADS: ${WEB_THREADS:-4}
+      WEB_TIMEOUT: ${WEB_TIMEOUT:-30}
+      SECRETS_PROVIDER: ${SECRETS_PROVIDER:-hashicorp_vault}
+      VAULT_ADDR: ${VAULT_ADDR:?set VAULT_ADDR on the operator host}
+      VAULT_TOKEN: ${VAULT_TOKEN:?set VAULT_TOKEN on the operator host}
+      VAULT_SECRET_MOUNT: ${VAULT_SECRET_MOUNT:-secret}
+      AO_GITHUB_API_URL: ${AO_GITHUB_API_URL:-https://api.github.com}
+      AO_GITHUB_APP_ID: ${AO_GITHUB_APP_ID:?set AO_GITHUB_APP_ID on the operator host}
+      AO_GITHUB_APP_PRIVATE_KEY_PEM_ID: ${AO_GITHUB_APP_PRIVATE_KEY_PEM_ID:?set vault secret id}
+      AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID: ${AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID:?set vault secret id}
+      AO_POLICY_SERVICE_MAX_BODY_BYTES: ${AO_POLICY_SERVICE_MAX_BODY_BYTES:-1048576}
+
+  ao-release-gate:
+    image: ${AO_RELEASE_GATE_SERVICE_IMAGE:-ghcr.io/halildeu/ao-kernel-ao-release-gate-service:main}
+    restart: unless-stopped
+    environment:
+      PORT: "8000"
+      WEB_CONCURRENCY: ${WEB_CONCURRENCY:-1}
+      WEB_THREADS: ${WEB_THREADS:-4}
+      WEB_TIMEOUT: ${WEB_TIMEOUT:-30}
+      SECRETS_PROVIDER: ${SECRETS_PROVIDER:-hashicorp_vault}
+      VAULT_ADDR: ${VAULT_ADDR:?set VAULT_ADDR on the operator host}
+      VAULT_TOKEN: ${VAULT_TOKEN:?set VAULT_TOKEN on the operator host}
+      VAULT_SECRET_MOUNT: ${VAULT_SECRET_MOUNT:-secret}
+      AO_GITHUB_API_URL: ${AO_GITHUB_API_URL:-https://api.github.com}
+      AO_GITHUB_APP_ID: ${AO_GITHUB_APP_ID:?set AO_GITHUB_APP_ID on the operator host}
+      AO_GITHUB_APP_PRIVATE_KEY_PEM_ID: ${AO_GITHUB_APP_PRIVATE_KEY_PEM_ID:?set vault secret id}
+      AO_RELEASE_GATE_WEBHOOK_SECRET_ID: ${AO_RELEASE_GATE_WEBHOOK_SECRET_ID:?set vault secret id}
+      AO_RELEASE_GATE_GPP_STATUS_PATH: /app/gpp_status.v1.json
+      AO_RELEASE_GATE_MAX_BODY_BYTES: ${AO_RELEASE_GATE_MAX_BODY_BYTES:-1048576}
+    volumes:
+      - ../../.claude/plans/gpp_status.v1.json:/app/gpp_status.v1.json:ro
+
+volumes:
+  caddy-data:
+  caddy-config:

--- a/scripts/internal_gate_host_bootstrap_attest.py
+++ b/scripts/internal_gate_host_bootstrap_attest.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Emit metadata-only attestation for the internal GPP-2 gate host bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_BUNDLE_DIR = Path("deploy/internal-gate-host")
+REQUIRED_FILES = ("compose.yaml", ".env.example", "Caddyfile.example", "README.md")
+
+COMPOSE_MARKERS = (
+    "live-adapter-gate-policy:",
+    "ao-release-gate:",
+    "caddy:",
+    "ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service",
+    "ghcr.io/halildeu/ao-kernel-ao-release-gate-service",
+    "AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID",
+    "AO_RELEASE_GATE_WEBHOOK_SECRET_ID",
+    "AO_GITHUB_APP_PRIVATE_KEY_PEM_ID",
+    "SECRETS_PROVIDER",
+    "VAULT_ADDR",
+    "VAULT_TOKEN",
+    "AO_RELEASE_GATE_GPP_STATUS_PATH",
+)
+
+CADDY_MARKERS = (
+    "/github/deployment-protection",
+    "/github/ao-release-gate",
+    "live-adapter-gate-policy:8000",
+    "ao-release-gate:8000",
+)
+
+ENV_MARKERS = (
+    "SECRETS_PROVIDER=hashicorp_vault",
+    "AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID=",
+    "AO_RELEASE_GATE_WEBHOOK_SECRET_ID=",
+    "AO_GITHUB_APP_PRIVATE_KEY_PEM_ID=",
+)
+
+FORBIDDEN_MARKERS = (
+    "AO_CLAUDE_CODE_CLI_AUTH",
+    "AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET:",
+    "AO_RELEASE_GATE_WEBHOOK_SECRET:",
+    "AO_GITHUB_APP_PRIVATE_KEY_PEM:",
+    "BEGIN PRIVATE KEY",
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _missing_markers(text: str, markers: Iterable[str]) -> list[str]:
+    return [marker for marker in markers if marker not in text]
+
+
+def build_attestation(bundle_dir: Path) -> dict[str, object]:
+    """Build static, no-secret attestation for the internal host bundle."""
+
+    bundle_dir = bundle_dir.resolve()
+    findings: list[dict[str, str]] = []
+    file_text: dict[str, str] = {}
+
+    for filename in REQUIRED_FILES:
+        path = bundle_dir / filename
+        if not path.exists():
+            findings.append(
+                {
+                    "code": "internal_gate_host_required_file_missing",
+                    "detail": f"Missing {filename}.",
+                }
+            )
+            continue
+        file_text[filename] = _read(path)
+
+    if "compose.yaml" in file_text:
+        for marker in _missing_markers(file_text["compose.yaml"], COMPOSE_MARKERS):
+            findings.append(
+                {
+                    "code": "internal_gate_host_compose_marker_missing",
+                    "detail": f"compose.yaml does not include {marker}.",
+                }
+            )
+
+    if "Caddyfile.example" in file_text:
+        for marker in _missing_markers(file_text["Caddyfile.example"], CADDY_MARKERS):
+            findings.append(
+                {
+                    "code": "internal_gate_host_caddy_marker_missing",
+                    "detail": f"Caddyfile.example does not include {marker}.",
+                }
+            )
+
+    if ".env.example" in file_text:
+        for marker in _missing_markers(file_text[".env.example"], ENV_MARKERS):
+            findings.append(
+                {
+                    "code": "internal_gate_host_env_marker_missing",
+                    "detail": f".env.example does not include {marker}.",
+                }
+            )
+
+    checked_text = "\n".join(file_text.values())
+    for marker in FORBIDDEN_MARKERS:
+        if marker in checked_text:
+            findings.append(
+                {
+                    "code": "internal_gate_host_forbidden_secret_marker",
+                    "detail": f"Checked-in bundle includes forbidden marker {marker}.",
+                }
+            )
+
+    status = "metadata_ready" if not findings else "blocked"
+    return {
+        "schema_version": "1",
+        "program_id": "GPP-2ae",
+        "status": status,
+        "bundle_dir": str(bundle_dir),
+        "required_files": list(REQUIRED_FILES),
+        "services": [
+            "caddy",
+            "live-adapter-gate-policy",
+            "ao-release-gate",
+        ],
+        "operator_owned_platform_infrastructure": True,
+        "end_user_self_host_required": False,
+        "uses_repo_owned_container_packages": True,
+        "uses_internal_vault_secret_ids": True,
+        "secret_value_readback": False,
+        "public_https_hosting_evidence": False,
+        "github_webhook_configured": False,
+        "github_callback_post": False,
+        "github_check_run_post": False,
+        "branch_protection_cutover": False,
+        "protected_workflow_dispatch": False,
+        "live_adapter_execution": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+        "findings": findings,
+    }
+
+
+def _render_text(payload: dict[str, object]) -> str:
+    lines = [
+        "Internal Gate Host Bootstrap Attestation",
+        f"status: {payload['status']}",
+        f"bundle_dir: {payload['bundle_dir']}",
+        f"operator_owned_platform_infrastructure: {str(payload['operator_owned_platform_infrastructure']).lower()}",
+        f"end_user_self_host_required: {str(payload['end_user_self_host_required']).lower()}",
+        f"secret_value_readback: {str(payload['secret_value_readback']).lower()}",
+        f"github_callback_post: {str(payload['github_callback_post']).lower()}",
+        f"github_check_run_post: {str(payload['github_check_run_post']).lower()}",
+        f"live_adapter_execution: {str(payload['live_adapter_execution']).lower()}",
+        f"support_widening: {str(payload['support_widening']).lower()}",
+        f"production_platform_claim: {str(payload['production_platform_claim']).lower()}",
+    ]
+    findings = payload.get("findings", [])
+    if findings:
+        lines.append("findings:")
+        for finding in findings:
+            if isinstance(finding, dict):
+                lines.append(f"- {finding.get('code')}: {finding.get('detail')}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-dir", type=Path, default=DEFAULT_BUNDLE_DIR)
+    parser.add_argument("--artifact-path", type=Path, default=None)
+    parser.add_argument("--output", choices=("json", "text"), default="json")
+    parser.add_argument("--fail-on-blocked", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    bundle_dir = args.bundle_dir
+    if not bundle_dir.is_absolute():
+        bundle_dir = _repo_root() / bundle_dir
+    payload = build_attestation(bundle_dir)
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    if args.artifact_path is not None:
+        args.artifact_path.write_text(rendered + "\n", encoding="utf-8")
+    if args.output == "text":
+        print(_render_text(payload))
+    else:
+        print(rendered)
+    if args.fail_on_blocked and payload["status"] != "metadata_ready":
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,10 +30,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/563"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/565"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "internal_vault_gate_secret_contract_ready_service_not_hosted_no_support_widening"
+        == "internal_operator_host_bundle_ready_service_not_hosted_no_support_widening"
     )
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
@@ -215,6 +215,13 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         for item in payload["completed_wps"]
     )
     assert any(
+        item["id"] == "GPP-2ae"
+        and item["decision"] == "internal_operator_host_bundle_ready_service_not_hosted_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/565"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
+    assert any(
         item["id"] == "GPP-5a"
         and item["decision"] == "repo_intelligence_product_onboarding_contract_ready_no_support_widening"
         and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/553"
@@ -253,8 +260,8 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
-        "host the operator-owned policy service on public HTTPS using the repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
-        "host the operator-owned ao-release-gate service on public HTTPS using the repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
+        "host the operator-owned policy service on public HTTPS using deploy/internal-gate-host or equivalent repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
+        "host the operator-owned ao-release-gate service on public HTTPS using deploy/internal-gate-host or equivalent repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
         "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the hosted /github/deployment-protection endpoint and can post deployment callback reviews",
         "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with vault-backed runtime webhook secret and GitHub App authentication outside the repo",
         "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
@@ -270,10 +277,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
             "id": "GPP-2",
             "reason": (
                 "repo-owned policy and ao-release-gate decision cores, webhook runtimes, container packages, "
-                "GHCR publish paths, Cloud Run deploy paths, and internal vault-backed secret-id runtime "
-                "contract are ready, but neither service is publicly hosted/configured with vault-backed "
-                "runtime secrets, webhook evidence, dry-run check-run evidence, callback review evidence, or "
-                "protected workflow cutover evidence"
+                "GHCR publish paths, Cloud Run deploy paths, internal vault-backed secret-id runtime "
+                "contract, and internal operator host bundle are ready, but neither service is publicly "
+                "hosted/configured with vault-backed runtime secrets, webhook evidence, dry-run check-run "
+                "evidence, callback review evidence, or protected workflow cutover evidence"
             ),
         }
     ]
@@ -339,6 +346,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(
         action
         == "prefer the internal operator host plus vault-backed secret-id path for GPP-2 service hosting unless a later decision reselects Cloud Run"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "use deploy/internal-gate-host as the default no-paid-cloud operator host bundle and validate it with scripts/internal_gate_host_bootstrap_attest.py before collecting hosted evidence"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -636,6 +648,24 @@ def test_gpp2ad_records_internal_vault_gate_secret_contract() -> None:
     assert "`production_platform_claim=false`" in decision
 
 
+def test_gpp2ae_records_internal_operator_host_bundle() -> None:
+    decision = (_repo_root() / ".claude/plans/GPP-2ae-INTERNAL-OPERATOR-HOST-BUNDLE.md").read_text(encoding="utf-8")
+
+    assert "internal_operator_host_bundle_ready_service_not_hosted_no_support_widening" in decision
+    assert "deploy/internal-gate-host/" in decision
+    assert "ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service" in decision
+    assert "ghcr.io/halildeu/ao-kernel-ao-release-gate-service" in decision
+    assert "AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID" in decision
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET_ID" in decision
+    assert "AO_GITHUB_APP_PRIVATE_KEY_PEM_ID" in decision
+    assert "End users must not be asked" in decision
+    assert "python3 scripts/internal_gate_host_bootstrap_attest.py" in decision
+    assert "does not" in decision
+    assert "`live_execution_allowed=false`" in decision
+    assert "`support_widening=false`" in decision
+    assert "`production_platform_claim=false`" in decision
+
+
 def test_gpp_next_load_status_validates_required_guards() -> None:
     mod = _module()
 
@@ -643,11 +673,11 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/563"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/565"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "internal_vault_gate_secret_contract_ready_service_not_hosted_no_support_widening"
+        == "internal_operator_host_bundle_ready_service_not_hosted_no_support_widening"
     )
     assert payload["support_widening_allowed"] is False
 
@@ -679,6 +709,7 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
     assert "internal vault-backed secret-id runtime contract" in rendered
+    assert "internal operator host bundle" in rendered
     assert "webhook runtimes, container packages" in rendered
     assert "publicly hosted/configured with vault-backed runtime secrets" in rendered
     assert "divergence: 0\t0" in rendered

--- a/tests/test_internal_gate_host_bootstrap_attest.py
+++ b/tests/test_internal_gate_host_bootstrap_attest.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _module() -> Any:
+    module_path = _repo_root() / "scripts" / "internal_gate_host_bootstrap_attest.py"
+    spec = importlib.util.spec_from_file_location("internal_gate_host_bootstrap_attest", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _bundle_dir() -> Path:
+    return _repo_root() / "deploy" / "internal-gate-host"
+
+
+def test_internal_gate_host_bundle_attests_metadata_ready_without_side_effects() -> None:
+    mod = _module()
+
+    payload = mod.build_attestation(_bundle_dir())
+
+    assert payload["status"] == "metadata_ready"
+    assert payload["operator_owned_platform_infrastructure"] is True
+    assert payload["end_user_self_host_required"] is False
+    assert payload["uses_repo_owned_container_packages"] is True
+    assert payload["uses_internal_vault_secret_ids"] is True
+    assert payload["secret_value_readback"] is False
+    assert payload["github_callback_post"] is False
+    assert payload["github_check_run_post"] is False
+    assert payload["protected_workflow_dispatch"] is False
+    assert payload["live_adapter_execution"] is False
+    assert payload["support_widening"] is False
+    assert payload["production_platform_claim"] is False
+    assert payload["findings"] == []
+
+
+def test_internal_gate_host_bundle_uses_secret_ids_without_direct_secret_envs() -> None:
+    compose = (_bundle_dir() / "compose.yaml").read_text(encoding="utf-8")
+    env_example = (_bundle_dir() / ".env.example").read_text(encoding="utf-8")
+    caddyfile = (_bundle_dir() / "Caddyfile.example").read_text(encoding="utf-8")
+
+    assert "ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service" in compose
+    assert "ghcr.io/halildeu/ao-kernel-ao-release-gate-service" in compose
+    assert "AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID" in compose
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET_ID" in compose
+    assert "AO_GITHUB_APP_PRIVATE_KEY_PEM_ID" in compose
+    assert "AO_RELEASE_GATE_GPP_STATUS_PATH" in compose
+    assert "AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET:" not in compose
+    assert "AO_RELEASE_GATE_WEBHOOK_SECRET:" not in compose
+    assert "AO_GITHUB_APP_PRIVATE_KEY_PEM:" not in compose
+    assert "AO_CLAUDE_CODE_CLI_AUTH" not in compose
+    assert "BEGIN PRIVATE KEY" not in env_example
+    assert "/github/deployment-protection" in caddyfile
+    assert "/github/ao-release-gate" in caddyfile
+
+
+def test_internal_gate_host_attestation_blocks_missing_bundle_file(tmp_path: Path) -> None:
+    mod = _module()
+    copied = tmp_path / "internal-gate-host"
+    shutil.copytree(_bundle_dir(), copied)
+    (copied / "compose.yaml").unlink()
+
+    payload = mod.build_attestation(copied)
+
+    assert payload["status"] == "blocked"
+    assert any(
+        finding["code"] == "internal_gate_host_required_file_missing" and finding["detail"] == "Missing compose.yaml."
+        for finding in payload["findings"]
+    )
+
+
+def test_internal_gate_host_attestation_blocks_direct_secret_markers(tmp_path: Path) -> None:
+    mod = _module()
+    copied = tmp_path / "internal-gate-host"
+    shutil.copytree(_bundle_dir(), copied)
+    compose = copied / "compose.yaml"
+    compose.write_text(
+        compose.read_text(encoding="utf-8") + "\n      AO_RELEASE_GATE_WEBHOOK_SECRET: ${BAD}\n",
+        encoding="utf-8",
+    )
+
+    payload = mod.build_attestation(copied)
+
+    assert payload["status"] == "blocked"
+    assert any(
+        finding["code"] == "internal_gate_host_forbidden_secret_marker"
+        and "AO_RELEASE_GATE_WEBHOOK_SECRET:" in finding["detail"]
+        for finding in payload["findings"]
+    )
+
+
+def test_internal_gate_host_attestation_cli_writes_json_artifact(tmp_path: Path, capsys: Any) -> None:
+    mod = _module()
+    artifact = tmp_path / "attestation.json"
+
+    result = mod.main(["--artifact-path", str(artifact), "--output", "text", "--fail-on-blocked"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert result == 0
+    assert payload["status"] == "metadata_ready"
+    assert "status: metadata_ready" in captured.out


### PR DESCRIPTION
## Summary

- Add `deploy/internal-gate-host` as the no-paid-cloud operator host bundle for the GPP-2 deployment-protection policy service and `ao-release-gate` service.
- Compose Caddy with the two repo-owned GHCR service containers and vault-backed secret-id runtime configuration.
- Add `scripts/internal_gate_host_bootstrap_attest.py`, a metadata-only no-secret attestation for the bundle.
- Update GPP status and tests so GPP-2 remains blocked until real public HTTPS hosting, webhook configuration, callback/check-run evidence, branch-protection cutover, and protected workflow evidence exist.

## Safety boundaries

- No secret values are committed, echoed, read, or required in repo state.
- No Docker/Compose run is treated as production evidence in this PR.
- No vault, GitHub API, webhook URL configuration, callback post, check-run post, branch protection change, protected workflow dispatch, live adapter execution, support widening, or production platform claim is performed.
- End users are still not required to self-host Cloud Run, vault, webhooks, private keys, or these gate services.

## Validation

- `python3 scripts/internal_gate_host_bootstrap_attest.py --output text --fail-on-blocked`
- `python3 scripts/internal_gate_host_bootstrap_attest.py --artifact-path /tmp/internal-gate-host-bootstrap-attestation.v1.json --output json --fail-on-blocked`
- `python3 -m pytest tests/test_internal_gate_host_bootstrap_attest.py tests/test_gpp_next.py tests/test_live_adapter_gate_policy_container.py tests/test_ao_release_gate_container.py tests/test_live_adapter_gate_policy_runtime.py tests/test_ao_release_gate_runtime.py -q` (`48 passed`)
- `python3 -m ruff check scripts/internal_gate_host_bootstrap_attest.py tests/test_internal_gate_host_bootstrap_attest.py tests/test_gpp_next.py`
- `python3 -m ruff format --check scripts/internal_gate_host_bootstrap_attest.py tests/test_internal_gate_host_bootstrap_attest.py tests/test_gpp_next.py`
- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `python3 scripts/gpp_next.py`
- `git diff --check`

Closes #565