### PR TITLE
GPP-2af: add internal gate host health probe

### DIFF
--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,16 +1,17 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 internal operator host bundle recorded after Cloud Run
-bootstrap, `ao-release-gate` autonomous deploy paths, and internal vault
-secret-id contract; operator-owned public hosting, webhook configuration,
-callback/check-run evidence, and cutover still blocked
+**Status:** GPP-2 internal gate host health probe recorded after internal
+operator host bundle, Cloud Run bootstrap paths, `ao-release-gate` autonomous
+deploy paths, and internal vault secret-id contract; operator-owned public
+hosting evidence, webhook configuration, callback/check-run evidence, and
+cutover still blocked
 **Date:** 2026-04-28
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
-**Current slice issue:** [#565](https://github.com/Halildeu/ao-kernel/issues/565)
-for internal operator host bundle
-**Current slice record:** `.claude/plans/GPP-2ae-INTERNAL-OPERATOR-HOST-BUNDLE.md`
+**Current slice issue:** [#567](https://github.com/Halildeu/ao-kernel/issues/567)
+for internal gate host health probe
+**Current slice record:** `.claude/plans/GPP-2af-INTERNAL-GATE-HOST-HEALTH-PROBE.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -255,12 +256,19 @@ Last live verification on current `origin/main` showed:
     surface, but it still does not prove public DNS/HTTPS, GitHub webhook
     configuration, callback/check-run posting, branch-protection cutover, or
     protected workflow pass behavior.
-47. GPP-5d closes the repo-intelligence read-only workflow surface with a
+47. GPP-2af adds a no-secret hosted health probe for the internal gate host.
+    `scripts/internal_gate_host_health_probe.py` checks the public HTTPS
+    `/policy/healthz` and `/release-gate/healthz` endpoints and emits a JSON
+    evidence artifact with callback, check-run, branch-protection, protected
+    workflow, live-adapter, support-widening, and production-claim side effects
+    pinned false. It does not configure webhooks or collect real callback/
+    check-run evidence.
+48. GPP-5d closes the repo-intelligence read-only workflow surface with a
     schema-backed preflight over GPP-5a/GPP-5b/GPP-5c records, public APIs,
     schemas, and negative runtime guards. GPP-6 preparation may use this
     closeout as repo-intelligence evidence, but GPP-6 execution remains
     blocked by GPP-2 and GPP-4.
-48. GPP-6a adds a preparation-only read-only E2E preflight. The preflight
+49. GPP-6a adds a preparation-only read-only E2E preflight. The preflight
     report is ready and records `execution_status=blocked_by_upstream_gates`
     because GPP-2 protected gate evidence and the GPP-4 read-only adapter
     decision are still missing. It does not dispatch protected workflows, call
@@ -335,7 +343,8 @@ The final production claim stays closed until `GPP-9` passes.
 | `GPP-2ac` | Completed / no support widening | Operator gate and end-user onboarding boundary | GPP-2 gate hosting is operator-owned platform infrastructure; end users must not self-host Cloud Run, vault, webhook, or GitHub App private-key setup |
 | `GPP-2ad` | Completed / no support widening | Internal vault gate secret contract | policy and release-gate runtimes accept vault-backed secret ids; services are still not hosted/evidenced |
 | `GPP-2ae` | Completed / no support widening | Internal operator host bundle | Caddy + policy service + `ao-release-gate` compose bundle and no-secret metadata attestation ready; services are still not publicly hosted/evidenced |
-| `GPP-2` | Blocked / internal hosting/config/evidence and release-gate cutover missing | Protected live-adapter gate runtime binding | deployment protection app/policy service must be hosted/configured with vault-backed runtime secrets and post callback evidence, and `ao-release-gate` must be deployed/hosted/evidenced/cut over before human-free program merges |
+| `GPP-2af` | Completed / no support widening | Internal gate host health probe | no-secret public HTTPS health probe ready; actual hosted health evidence, webhooks, callback/check-run evidence, and cutover are still missing |
+| `GPP-2` | Blocked / internal hosting/config/evidence and release-gate cutover missing | Protected live-adapter gate runtime binding | deployment protection app/policy service and `ao-release-gate` must be hosted with public HTTPS health evidence, configured with vault-backed runtime secrets and webhooks, and evidenced/cut over before human-free program merges |
 | `GPP-3` | Not started | Real-adapter usage/cost evidence closure | `cost_evidence_ready` / `defer_cost_policy` |
 | `GPP-4` | Not started | `claude-code-cli` production-certified read-only decision | `promote_read_only` / `keep_operator_beta` / `defer` |
 | `GPP-5a` | Completed / no support widening | Repo-intelligence product onboarding contract | GitHub App install + selected repositories + optional `.ao/config.yml`; no end-user Cloud Run, vault, webhook, private key, or gate service hosting |
@@ -469,15 +478,15 @@ before choosing or implementing the next work package.
 protected manual gate that can actually run a real adapter under project-owned
 evidence.
 
-**Status:** blocked after GPP-2ad; policy decision core, webhook scaffold,
+**Status:** blocked after GPP-2af; policy decision core, webhook scaffold,
 deployable WSGI runtime, container package, GHCR image publication path,
 Cloud Run deploy automation, metadata-only bootstrap attestation tooling,
-internal vault-backed secret-id runtime support, `ao-release-gate`
-dry-run/check-run/container/publish/deploy automation, and release-gate
-fail-closed policy records and operator/end-user boundary decision exist, but
-operator-owned hosted service deployment/configuration, real PR check-run evidence,
-branch-protection cutover, and callback evidence are still
-missing.
+internal vault-backed secret-id runtime support, internal operator host bundle,
+hosted health probe, `ao-release-gate` dry-run/check-run/container/publish/
+deploy automation, and release-gate fail-closed policy records and
+operator/end-user boundary decision exist, but operator-owned hosted service
+deployment/configuration, real PR check-run evidence, branch-protection
+cutover, and callback evidence are still missing.
 
 **Entry criteria:**
 
@@ -553,6 +562,14 @@ checked-in host bundle is coherent and no direct secret markers are present. It
 does not run Docker, contact a vault, configure webhooks, post callbacks or
 check-runs, change branch protection, dispatch protected workflows, or execute
 a live adapter.
+GPP-2af adds `scripts/internal_gate_host_health_probe.py` so the operator can
+collect no-secret health evidence after that host is deployed. The probe
+requires HTTPS for public evidence, validates the expected `GPP-2q` and
+`GPP-2w` health payloads, and emits an artifact with secret readback, webhook
+configuration, callback posts, check-run posts, branch-protection cutover,
+protected workflow dispatch, live adapter execution, support widening, and
+production-platform claims all false. It does not by itself host services or
+unblock GPP-2.
 
 **Acceptance criteria:**
 
@@ -999,6 +1016,7 @@ admin bypass for PR merge automation, and must keep
 | Release-gate container mistaken for hosted evidence | A local/CI image health pass could be overclaimed as active GitHub enforcement | GPP-2x treats the container as deploy artifact readiness only; require public hosting, webhook configuration, real PR dry-run evidence, and branch-protection cutover |
 | Release-gate image publish mistaken for hosted evidence | A GHCR image tag could be overclaimed as an active GitHub App | GPP-2y treats GHCR publication as deploy artifact readiness only; require public hosting, webhook configuration, real PR dry-run evidence, and branch-protection cutover |
 | Release-gate deploy health mistaken for release authority | A hosted `/healthz` response could be overclaimed as required-check enforcement | GPP-2aa records `check_run_post=false`, `real_pr_evidence=false`, `branch_protection_cutover=false`, and `merge_authority_enabled=false`; require real PR evidence and explicit cutover |
+| Internal gate host health mistaken for webhook evidence | Public HTTPS health could be overclaimed as callback/check-run readiness | GPP-2af records `github_webhook_configured=false`, `github_callback_post=false`, `github_check_run_post=false`, and `branch_protection_cutover=false`; require webhook, real PR, and cutover evidence separately |
 | Missing repository variables bypassed | Deploy workflow could be dispatched before non-secret handles exist | Run GPP-2ab attestation with `--fail-on-blocked` and provision missing GitHub repository variables before deploy dispatch |
 | `metadata_ready` mistaken for cloud readiness | Deployment could be treated as unblocked without GCP trust or hosting proof | Treat GPP-2ab as repository-variable metadata only; separately prove OIDC, service account permissions, Secret Manager objects, Cloud Run health, webhook URL, and callback evidence |
 | GPP-5 closeout mistaken for GPP-6 approval | Read-only repo-intelligence evidence could be overclaimed as protected E2E readiness | GPP-5d records `gpp6_readiness=blocked_by_upstream_gates`; require GPP-2 protected gate evidence and GPP-4 adapter decision before GPP-6 execution |
@@ -1070,6 +1088,8 @@ admin bypass for PR merge automation, and must keep
 | 2026-04-28 | GPP-2ab bootstrap attestation added | `scripts/policy_service_cloud_run_bootstrap_attest.py` checks required GitHub repository variable handles with `gh variable list --json name,updatedAt`, ignores values, and records that current live metadata is `overall_status=blocked` because all required handles are missing; GCP trust, Secret Manager objects, Cloud Run hosting, webhook URL configuration, callback posting, live execution, support widening, and production-platform claims remain unproven. |
 | 2026-04-28 | GPP-2ae issue opened | Issue [#565](https://github.com/Halildeu/ao-kernel/issues/565) tracks the internal operator host bundle for the vault-backed no-paid-cloud GPP-2 path. |
 | 2026-04-28 | GPP-2ae host bundle added | `deploy/internal-gate-host` composes Caddy, the policy service container, and `ao-release-gate` with vault-backed secret ids; `scripts/internal_gate_host_bootstrap_attest.py` records metadata readiness only, with no Docker run, vault access, webhook configuration, callback/check-run posting, live adapter execution, support widening, or production claim. |
+| 2026-04-28 | GPP-2af issue opened | Issue [#567](https://github.com/Halildeu/ao-kernel/issues/567) tracks the no-secret hosted health probe for the internal gate host path. |
+| 2026-04-28 | GPP-2af health probe added | `scripts/internal_gate_host_health_probe.py` can collect public HTTPS health evidence for `/policy/healthz` and `/release-gate/healthz`; it does not configure webhooks, post callbacks/check-runs, change branch protection, dispatch protected workflows, execute live adapters, widen support, or claim production readiness. |
 | 2026-04-28 | GPP-5d issue opened | Issue [#559](https://github.com/Halildeu/ao-kernel/issues/559) tracks repo-intelligence read-only workflow closeout before GPP-6 preparation. |
 | 2026-04-28 | GPP-5d closeout preflight added | `scripts/gpp5_repo_intelligence_closeout.py` records GPP-5 as closed for read-only workflow-surface purposes while keeping GPP-6 execution blocked by GPP-2 and GPP-4. |
 | 2026-04-28 | GPP-6a issue opened | Issue [#561](https://github.com/Halildeu/ao-kernel/issues/561) tracks the read-only E2E preflight contract for GPP-6 preparation. |

--- a/.claude/plans/GPP-2af-INTERNAL-GATE-HOST-HEALTH-PROBE.md
+++ b/.claude/plans/GPP-2af-INTERNAL-GATE-HOST-HEALTH-PROBE.md
@@ -1,0 +1,108 @@
+# GPP-2af - Internal Gate Host Health Probe
+
+**Issue:** [#567](https://github.com/Halildeu/ao-kernel/issues/567)
+**Program head:** `GPP-2` remains blocked
+**Decision:** `internal_gate_host_health_probe_ready_hosting_evidence_not_collected_no_support_widening`
+**Support impact:** none
+**Production platform claim:** no
+**Live adapter execution:** no
+
+## Decision
+
+GPP-2af adds a repo-owned, no-secret health evidence probe for the internal
+operator host path introduced by GPP-2ae.
+
+The probe lives at:
+
+```text
+scripts/internal_gate_host_health_probe.py
+```
+
+It checks the public health endpoints exposed by `deploy/internal-gate-host`:
+
+```text
+https://<AO_GATE_HOSTNAME>/policy/healthz
+https://<AO_GATE_HOSTNAME>/release-gate/healthz
+```
+
+The probe expects:
+
+1. the policy service to return HTTP 200 with `status=ok` and
+   `program_id=GPP-2q`;
+2. `ao-release-gate` to return HTTP 200 with `status=ok` and
+   `program_id=GPP-2w`;
+3. both URLs to use HTTPS before `public_https_hosting_evidence=true` can be
+   recorded.
+
+Local `http://127.0.0.1` rehearsal can be allowed explicitly with
+`--allow-http-localhost`, but that produces `local_health_ready`, not public
+hosted evidence.
+
+## Boundary
+
+This is an evidence collection tool for operator-owned platform
+infrastructure. It is not a product end-user setup requirement.
+
+The probe does not:
+
+1. read webhook secrets or GitHub App private keys;
+2. configure GitHub App webhook URLs;
+3. receive GitHub webhook deliveries;
+4. post deployment-protection callback reviews;
+5. post `ao-release-gate` check-runs;
+6. change branch protection or rulesets;
+7. dispatch protected workflows;
+8. execute a live adapter;
+9. widen support or claim production-platform readiness.
+
+The emitted evidence keeps these flags closed:
+
+```text
+secret_value_readback=false
+github_webhook_configured=false
+github_callback_post=false
+github_check_run_post=false
+branch_protection_cutover=false
+protected_workflow_dispatch=false
+live_adapter_execution=false
+support_widening=false
+production_platform_claim=false
+```
+
+## Remaining GPP-2 Blockers
+
+GPP-2 remains blocked until trusted operator infrastructure records the full
+sequence:
+
+1. public HTTPS health evidence for the hosted policy service;
+2. public HTTPS health evidence for the hosted `ao-release-gate` service;
+3. GitHub App webhook URL configuration for `/github/deployment-protection`;
+4. GitHub App webhook URL configuration for `/github/ao-release-gate`;
+5. policy callback review evidence;
+6. real PR dry-run check-run evidence from `ao-release-gate`;
+7. branch-protection or ruleset cutover to require `ao-release-gate`;
+8. protected workflow evidence through the hosted deployment-protection gate.
+
+Until those are recorded:
+
+```text
+live_execution_allowed=false
+support_widening=false
+production_platform_claim=false
+```
+
+## Validation
+
+```bash
+python3 -m pytest tests/test_internal_gate_host_health_probe.py -q
+```
+
+```bash
+python3 scripts/internal_gate_host_health_probe.py \
+  --host gate.example.test \
+  --output text \
+  --fail-on-blocked
+```
+
+The second command is expected to block unless `gate.example.test` is replaced
+with the real operator-owned public HTTPS host.

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -9,13 +9,14 @@
     "id": "GPP-2",
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
-    "issue": "https://github.com/Halildeu/ao-kernel/issues/565",
-    "exit_decision": "internal_operator_host_bundle_ready_service_not_hosted_no_support_widening",
-    "ready_after": "operator-owned policy service and ao-release-gate are hosted on public HTTPS endpoints from the internal operator host bundle or equivalent infrastructure with internal vault-backed runtime secret ids, GitHub App webhook URLs are configured, policy callback review evidence exists, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, and protected workflow evidence confirms live_execution_allowed=false",
+    "issue": "https://github.com/Halildeu/ao-kernel/issues/567",
+    "exit_decision": "internal_gate_host_health_probe_ready_hosting_evidence_not_collected_no_support_widening",
+    "ready_after": "operator-owned policy service and ao-release-gate are hosted on public HTTPS endpoints from the internal operator host bundle or equivalent infrastructure with internal vault-backed runtime secret ids, public HTTPS health evidence is collected, GitHub App webhook URLs are configured, policy callback review evidence exists, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, and protected workflow evidence confirms live_execution_allowed=false",
     "allowed_scope": [
       "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service on operator-owned internal infrastructure without secret value exposure",
       "use the repo-owned ao-release-gate GHCR image or container package to deploy or configure the ao-release-gate GitHub App check-run service on operator-owned internal infrastructure without secret value exposure",
       "use deploy/internal-gate-host or equivalent operator-owned infrastructure as the no-paid-cloud default host bundle for both GPP-2 gate services",
+      "collect no-secret public HTTPS health evidence with scripts/internal_gate_host_health_probe.py after the internal gate host is deployed",
       "configure hosted gate runtimes with internal vault secret ids rather than committed, echoed, or repository-stored secret values",
       "document or build end-user onboarding paths that do not require users to self-host the GPP-2 policy service, vault, webhook secret, GitHub App private key, or Cloud Run project",
       "repeat protected workflow evidence collection from main after the policy service responds",
@@ -212,6 +213,12 @@
       "record": ".claude/plans/GPP-2ae-INTERNAL-OPERATOR-HOST-BUNDLE.md"
     },
     {
+      "id": "GPP-2af",
+      "decision": "internal_gate_host_health_probe_ready_hosting_evidence_not_collected_no_support_widening",
+      "issue": "https://github.com/Halildeu/ao-kernel/issues/567",
+      "record": ".claude/plans/GPP-2af-INTERNAL-GATE-HOST-HEALTH-PROBE.md"
+    },
+    {
       "id": "GPP-5a",
       "decision": "repo_intelligence_product_onboarding_contract_ready_no_support_widening",
       "issue": "https://github.com/Halildeu/ao-kernel/issues/553",
@@ -245,12 +252,12 @@
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned policy and ao-release-gate decision cores, webhook runtimes, container packages, GHCR publish paths, Cloud Run deploy paths, internal vault-backed secret-id runtime contract, and internal operator host bundle are ready, but neither service is publicly hosted/configured with vault-backed runtime secrets, webhook evidence, dry-run check-run evidence, callback review evidence, or protected workflow cutover evidence"
+      "reason": "repo-owned policy and ao-release-gate decision cores, webhook runtimes, container packages, GHCR publish paths, Cloud Run deploy paths, internal vault-backed secret-id runtime contract, internal operator host bundle, and no-secret hosted health probe are ready, but neither service has collected public HTTPS health evidence or been configured with GitHub webhook evidence, dry-run check-run evidence, callback review evidence, or protected workflow cutover evidence"
     }
   ],
   "pending_external_actions": [
-    "host the operator-owned policy service on public HTTPS using deploy/internal-gate-host or equivalent repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
-    "host the operator-owned ao-release-gate service on public HTTPS using deploy/internal-gate-host or equivalent repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
+    "host the operator-owned policy service on public HTTPS using deploy/internal-gate-host or equivalent repo-owned container package and internal vault-backed runtime secret ids, then collect no-secret public HTTPS health evidence with scripts/internal_gate_host_health_probe.py",
+    "host the operator-owned ao-release-gate service on public HTTPS using deploy/internal-gate-host or equivalent repo-owned container package and internal vault-backed runtime secret ids, then collect no-secret public HTTPS health evidence with scripts/internal_gate_host_health_probe.py",
     "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the hosted /github/deployment-protection endpoint and can post deployment callback reviews",
     "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with vault-backed runtime webhook secret and GitHub App authentication outside the repo",
     "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
@@ -319,6 +326,7 @@
     "use GPP-6a read-only E2E preflight evidence for preparation only, while GPP-6 execution remains blocked until GPP-2 protected gate and GPP-4 read-only adapter decision are ready and support_widening_allowed=false and production_platform_claim_allowed=false",
     "prefer the internal operator host plus vault-backed secret-id path for GPP-2 service hosting unless a later decision reselects Cloud Run",
     "use deploy/internal-gate-host as the default no-paid-cloud operator host bundle and validate it with scripts/internal_gate_host_bootstrap_attest.py before collecting hosted evidence",
+    "use scripts/internal_gate_host_health_probe.py to collect no-secret public HTTPS health evidence after the internal gate host is deployed and before configuring GitHub App webhooks",
     "configure ao_kernel.live_adapter_gate_policy_runtime:application with internal vault secret ids or direct runtime secret manager values, never committed or echoed secret material",
     "configure ao_kernel.ao_release_gate_runtime:application with internal vault secret ids or direct runtime secret manager values, never committed or echoed secret material",
     "configure or verify the GitHub App webhook URL only after the hosted policy service endpoint is health-checked",

--- a/deploy/internal-gate-host/README.md
+++ b/deploy/internal-gate-host/README.md
@@ -43,6 +43,33 @@ https://<AO_GATE_HOSTNAME>/policy/healthz
 https://<AO_GATE_HOSTNAME>/release-gate/healthz
 ```
 
+## Hosted Health Evidence Probe
+
+After the operator host is deployed and DNS/HTTPS are live, collect the
+no-secret hosted health evidence with:
+
+```bash
+python3 scripts/internal_gate_host_health_probe.py \
+  --host <AO_GATE_HOSTNAME> \
+  --artifact-path internal-gate-host-health-evidence.json \
+  --output text \
+  --fail-on-blocked
+```
+
+The probe performs only `GET` requests against the two public health endpoints.
+It expects the policy service health payload to report `program_id=GPP-2q` and
+the `ao-release-gate` health payload to report `program_id=GPP-2w`.
+
+The resulting artifact can record `public_https_hosting_evidence=true` only
+when both services respond over HTTPS. Local `http://127.0.0.1` rehearsal is
+available with `--allow-http-localhost`, but that produces only
+`local_health_ready` and must not be treated as public hosted evidence.
+
+The probe does not configure GitHub webhooks, read secret values, post
+deployment-protection callback reviews, post `ao-release-gate` check-runs,
+change branch protection, dispatch protected workflows, or execute a live
+adapter.
+
 ## Runtime Secret Contract
 
 The services read secret values only at runtime. The checked-in bundle uses

--- a/scripts/internal_gate_host_health_probe.py
+++ b/scripts/internal_gate_host_health_probe.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Probe hosted no-secret health endpoints for the internal GPP-2 gate host."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+DEFAULT_TIMEOUT_SECONDS = 10.0
+DEFAULT_POLICY_HEALTH_PATH = "/policy/healthz"
+DEFAULT_RELEASE_GATE_HEALTH_PATH = "/release-gate/healthz"
+EXPECTED_POLICY_PROGRAM_ID = "GPP-2q"
+EXPECTED_RELEASE_GATE_PROGRAM_ID = "GPP-2w"
+MAX_HEALTH_BODY_BYTES = 64 * 1024
+
+LOCAL_HTTP_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+HealthTransport = Callable[[str, float], tuple[int, bytes]]
+
+
+def _safe_text(value: object) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _base_url_from_host(host: str) -> str:
+    value = host.strip()
+    if not value:
+        raise ValueError("host must not be empty")
+    if "://" not in value:
+        value = f"https://{value}"
+    return value.rstrip("/")
+
+
+def _join_url(base_url: str, path: str) -> str:
+    parsed = urllib.parse.urlparse(base_url)
+    normalized_path = "/" + path.lstrip("/")
+    return urllib.parse.urlunparse((parsed.scheme, parsed.netloc, normalized_path, "", "", ""))
+
+
+def build_health_urls(host: str) -> tuple[str, str]:
+    """Build the two public health URLs from an operator host name."""
+
+    base_url = _base_url_from_host(host)
+    return (
+        _join_url(base_url, DEFAULT_POLICY_HEALTH_PATH),
+        _join_url(base_url, DEFAULT_RELEASE_GATE_HEALTH_PATH),
+    )
+
+
+def _is_local_http_url(parsed: urllib.parse.ParseResult) -> bool:
+    return parsed.scheme == "http" and parsed.hostname in LOCAL_HTTP_HOSTS
+
+
+def _url_findings(url: str, *, allow_http_localhost: bool) -> list[dict[str, str]]:
+    parsed = urllib.parse.urlparse(url)
+    findings: list[dict[str, str]] = []
+
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return [
+            {
+                "code": "internal_gate_host_health_url_invalid",
+                "detail": "Health URL must be absolute HTTP(S).",
+            }
+        ]
+
+    if parsed.username or parsed.password:
+        findings.append(
+            {
+                "code": "internal_gate_host_health_url_credentials_forbidden",
+                "detail": "Health URL must not include userinfo or credentials.",
+            }
+        )
+
+    if parsed.query or parsed.fragment:
+        findings.append(
+            {
+                "code": "internal_gate_host_health_url_not_canonical",
+                "detail": "Health URL must not include query strings or fragments.",
+            }
+        )
+
+    if parsed.scheme != "https":
+        if not (allow_http_localhost and _is_local_http_url(parsed)):
+            findings.append(
+                {
+                    "code": "internal_gate_host_health_url_not_https",
+                    "detail": "Hosted GPP-2 health evidence must use HTTPS.",
+                }
+            )
+
+    return findings
+
+
+def _is_public_https_url(url: str) -> bool:
+    parsed = urllib.parse.urlparse(url)
+    return parsed.scheme == "https" and parsed.hostname not in LOCAL_HTTP_HOSTS
+
+
+def urllib_health_get(url: str, timeout_seconds: float) -> tuple[int, bytes]:
+    """Perform one no-secret health GET request."""
+
+    request = urllib.request.Request(url=url, headers={"Accept": "application/json"}, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            return int(response.status), response.read(MAX_HEALTH_BODY_BYTES)
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), exc.read(MAX_HEALTH_BODY_BYTES)
+
+
+def _decode_json_object(body: bytes) -> tuple[dict[str, Any] | None, dict[str, str] | None]:
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return None, {
+            "code": "internal_gate_host_health_payload_invalid_json",
+            "detail": f"Health response body was not JSON: {type(exc).__name__}.",
+        }
+    if not isinstance(payload, dict):
+        return None, {
+            "code": "internal_gate_host_health_payload_not_object",
+            "detail": "Health response body was not a JSON object.",
+        }
+    return payload, None
+
+
+def _probe_service(
+    *,
+    service: str,
+    url: str,
+    expected_program_id: str,
+    timeout_seconds: float,
+    allow_http_localhost: bool,
+    transport: HealthTransport,
+) -> dict[str, object]:
+    findings = _url_findings(url, allow_http_localhost=allow_http_localhost)
+    if findings:
+        return {
+            "service": service,
+            "url": url,
+            "status": "blocked",
+            "http_status": None,
+            "health_status": None,
+            "program_id": None,
+            "is_public_https": _is_public_https_url(url),
+            "findings": findings,
+        }
+
+    try:
+        status_code, body = transport(url, timeout_seconds)
+    except (OSError, TimeoutError, urllib.error.URLError) as exc:
+        return {
+            "service": service,
+            "url": url,
+            "status": "blocked",
+            "http_status": None,
+            "health_status": None,
+            "program_id": None,
+            "is_public_https": _is_public_https_url(url),
+            "findings": [
+                {
+                    "code": "internal_gate_host_health_request_failed",
+                    "detail": f"Health request failed: {type(exc).__name__}.",
+                }
+            ],
+        }
+
+    payload, decode_finding = _decode_json_object(body)
+    if decode_finding is not None:
+        findings.append(decode_finding)
+
+    health_status = _safe_text(payload.get("status")) if payload is not None else None
+    program_id = _safe_text(payload.get("program_id")) if payload is not None else None
+
+    if status_code != 200:
+        findings.append(
+            {
+                "code": "internal_gate_host_health_http_status_not_ok",
+                "detail": f"Health endpoint returned HTTP {status_code}.",
+            }
+        )
+    if health_status != "ok":
+        findings.append(
+            {
+                "code": "internal_gate_host_health_status_not_ok",
+                "detail": "Health payload did not report status=ok.",
+            }
+        )
+    if program_id != expected_program_id:
+        findings.append(
+            {
+                "code": "internal_gate_host_health_program_id_mismatch",
+                "detail": f"Health payload did not report program_id={expected_program_id}.",
+            }
+        )
+
+    return {
+        "service": service,
+        "url": url,
+        "status": "pass" if not findings else "blocked",
+        "http_status": status_code,
+        "health_status": health_status,
+        "program_id": program_id,
+        "is_public_https": _is_public_https_url(url),
+        "findings": findings,
+    }
+
+
+def build_evidence(
+    *,
+    policy_url: str,
+    release_gate_url: str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    allow_http_localhost: bool = False,
+    transport: HealthTransport | None = None,
+) -> dict[str, object]:
+    """Build no-secret hosted health evidence for both internal gate services."""
+
+    probe_transport = transport or urllib_health_get
+    policy = _probe_service(
+        service="live-adapter-gate-policy",
+        url=policy_url,
+        expected_program_id=EXPECTED_POLICY_PROGRAM_ID,
+        timeout_seconds=timeout_seconds,
+        allow_http_localhost=allow_http_localhost,
+        transport=probe_transport,
+    )
+    release_gate = _probe_service(
+        service="ao-release-gate",
+        url=release_gate_url,
+        expected_program_id=EXPECTED_RELEASE_GATE_PROGRAM_ID,
+        timeout_seconds=timeout_seconds,
+        allow_http_localhost=allow_http_localhost,
+        transport=probe_transport,
+    )
+
+    policy_health_evidence = policy["status"] == "pass"
+    release_gate_health_evidence = release_gate["status"] == "pass"
+    public_https_hosting_evidence = (
+        policy_health_evidence
+        and release_gate_health_evidence
+        and bool(policy["is_public_https"])
+        and bool(release_gate["is_public_https"])
+    )
+    if public_https_hosting_evidence:
+        status = "hosted_health_ready"
+    elif policy_health_evidence and release_gate_health_evidence:
+        status = "local_health_ready"
+    else:
+        status = "blocked"
+
+    findings: list[dict[str, str]] = []
+    for result in (policy, release_gate):
+        for finding in result["findings"]:
+            if isinstance(finding, dict):
+                findings.append(
+                    {
+                        "service": str(result["service"]),
+                        "code": str(finding.get("code")),
+                        "detail": str(finding.get("detail")),
+                    }
+                )
+
+    return {
+        "schema_version": "1",
+        "program_id": "GPP-2af",
+        "status": status,
+        "operator_owned_platform_infrastructure": True,
+        "end_user_self_host_required": False,
+        "policy_url": policy_url,
+        "release_gate_url": release_gate_url,
+        "policy_health_evidence": policy_health_evidence,
+        "release_gate_health_evidence": release_gate_health_evidence,
+        "public_https_hosting_evidence": public_https_hosting_evidence,
+        "allow_http_localhost": allow_http_localhost,
+        "secret_value_readback": False,
+        "github_webhook_configured": False,
+        "github_callback_post": False,
+        "github_check_run_post": False,
+        "branch_protection_cutover": False,
+        "protected_workflow_dispatch": False,
+        "live_adapter_execution": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+        "service_results": {
+            "policy": policy,
+            "release_gate": release_gate,
+        },
+        "findings": findings,
+    }
+
+
+def _render_text(payload: Mapping[str, object]) -> str:
+    lines = [
+        "Internal Gate Host Health Probe",
+        f"status: {payload['status']}",
+        f"policy_url: {payload['policy_url']}",
+        f"release_gate_url: {payload['release_gate_url']}",
+        f"policy_health_evidence: {str(payload['policy_health_evidence']).lower()}",
+        f"release_gate_health_evidence: {str(payload['release_gate_health_evidence']).lower()}",
+        f"public_https_hosting_evidence: {str(payload['public_https_hosting_evidence']).lower()}",
+        f"secret_value_readback: {str(payload['secret_value_readback']).lower()}",
+        f"github_webhook_configured: {str(payload['github_webhook_configured']).lower()}",
+        f"github_callback_post: {str(payload['github_callback_post']).lower()}",
+        f"github_check_run_post: {str(payload['github_check_run_post']).lower()}",
+        f"branch_protection_cutover: {str(payload['branch_protection_cutover']).lower()}",
+        f"protected_workflow_dispatch: {str(payload['protected_workflow_dispatch']).lower()}",
+        f"live_adapter_execution: {str(payload['live_adapter_execution']).lower()}",
+        f"support_widening: {str(payload['support_widening']).lower()}",
+        f"production_platform_claim: {str(payload['production_platform_claim']).lower()}",
+    ]
+    findings = payload.get("findings", [])
+    if findings:
+        lines.append("findings:")
+        for finding in findings:
+            if isinstance(finding, dict):
+                lines.append(f"- {finding.get('service')}: {finding.get('code')}: {finding.get('detail')}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--host", help="Operator gate host name or base URL.")
+    source.add_argument("--policy-url", help="Hosted policy service health URL.")
+    parser.add_argument("--release-gate-url", help="Hosted ao-release-gate health URL.")
+    parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--artifact-path", type=Path, default=None)
+    parser.add_argument("--output", choices=("json", "text"), default="json")
+    parser.add_argument(
+        "--allow-http-localhost",
+        action="store_true",
+        help="Allow http://localhost or 127.0.0.1 only for local rehearsal evidence.",
+    )
+    parser.add_argument("--fail-on-blocked", action="store_true")
+    return parser
+
+
+def _resolve_urls(args: argparse.Namespace) -> tuple[str, str]:
+    if args.host:
+        return build_health_urls(args.host)
+    if not args.release_gate_url:
+        raise ValueError("--release-gate-url is required when --policy-url is used")
+    return str(args.policy_url), str(args.release_gate_url)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        policy_url, release_gate_url = _resolve_urls(args)
+    except ValueError as exc:
+        print(f"internal_gate_host_health_probe: {exc}", file=sys.stderr)
+        return 2
+
+    payload = build_evidence(
+        policy_url=policy_url,
+        release_gate_url=release_gate_url,
+        timeout_seconds=args.timeout_seconds,
+        allow_http_localhost=args.allow_http_localhost,
+    )
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    if args.artifact_path is not None:
+        args.artifact_path.write_text(rendered + "\n", encoding="utf-8")
+    if args.output == "text":
+        print(_render_text(payload))
+    else:
+        print(rendered)
+    if args.fail_on_blocked and payload["status"] != "hosted_health_ready":
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -30,10 +30,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["program_id"] == "general-purpose-production-promotion"
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/565"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/567"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "internal_operator_host_bundle_ready_service_not_hosted_no_support_widening"
+        == "internal_gate_host_health_probe_ready_hosting_evidence_not_collected_no_support_widening"
     )
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
@@ -222,6 +222,14 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         for item in payload["completed_wps"]
     )
     assert any(
+        item["id"] == "GPP-2af"
+        and item["decision"]
+        == "internal_gate_host_health_probe_ready_hosting_evidence_not_collected_no_support_widening"
+        and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/567"
+        and (_repo_root() / item["record"]).exists()
+        for item in payload["completed_wps"]
+    )
+    assert any(
         item["id"] == "GPP-5a"
         and item["decision"] == "repo_intelligence_product_onboarding_contract_ready_no_support_widening"
         and item["issue"] == "https://github.com/Halildeu/ao-kernel/issues/553"
@@ -260,8 +268,16 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
     assert payload["pending_external_actions"] == [
-        "host the operator-owned policy service on public HTTPS using deploy/internal-gate-host or equivalent repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
-        "host the operator-owned ao-release-gate service on public HTTPS using deploy/internal-gate-host or equivalent repo-owned container package and internal vault-backed runtime secret ids without secret value readback",
+        (
+            "host the operator-owned policy service on public HTTPS using deploy/internal-gate-host or equivalent "
+            "repo-owned container package and internal vault-backed runtime secret ids, then collect no-secret "
+            "public HTTPS health evidence with scripts/internal_gate_host_health_probe.py"
+        ),
+        (
+            "host the operator-owned ao-release-gate service on public HTTPS using deploy/internal-gate-host or "
+            "equivalent repo-owned container package and internal vault-backed runtime secret ids, then collect "
+            "no-secret public HTTPS health evidence with scripts/internal_gate_host_health_probe.py"
+        ),
         "configure or verify the ao-kernel-live-adapter-gate GitHub App webhook URL points to the hosted /github/deployment-protection endpoint and can post deployment callback reviews",
         "configure the ao-release-gate GitHub App webhook URL to the hosted /github/ao-release-gate endpoint with vault-backed runtime webhook secret and GitHub App authentication outside the repo",
         "collect dry-run ao-release-gate check-run evidence on real PRs before granting merge authority or changing branch protection",
@@ -278,9 +294,10 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
             "reason": (
                 "repo-owned policy and ao-release-gate decision cores, webhook runtimes, container packages, "
                 "GHCR publish paths, Cloud Run deploy paths, internal vault-backed secret-id runtime "
-                "contract, and internal operator host bundle are ready, but neither service is publicly "
-                "hosted/configured with vault-backed runtime secrets, webhook evidence, dry-run check-run "
-                "evidence, callback review evidence, or protected workflow cutover evidence"
+                "contract, internal operator host bundle, and no-secret hosted health probe are ready, but "
+                "neither service has collected public HTTPS health evidence or been configured with GitHub "
+                "webhook evidence, dry-run check-run evidence, callback review evidence, or protected workflow "
+                "cutover evidence"
             ),
         }
     ]
@@ -351,6 +368,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(
         action
         == "use deploy/internal-gate-host as the default no-paid-cloud operator host bundle and validate it with scripts/internal_gate_host_bootstrap_attest.py before collecting hosted evidence"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "use scripts/internal_gate_host_health_probe.py to collect no-secret public HTTPS health evidence after the internal gate host is deployed and before configuring GitHub App webhooks"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -666,6 +688,27 @@ def test_gpp2ae_records_internal_operator_host_bundle() -> None:
     assert "`production_platform_claim=false`" in decision
 
 
+def test_gpp2af_records_internal_gate_host_health_probe() -> None:
+    decision = (_repo_root() / ".claude/plans/GPP-2af-INTERNAL-GATE-HOST-HEALTH-PROBE.md").read_text(encoding="utf-8")
+
+    assert "internal_gate_host_health_probe_ready_hosting_evidence_not_collected_no_support_widening" in decision
+    assert "scripts/internal_gate_host_health_probe.py" in decision
+    assert "https://<AO_GATE_HOSTNAME>/policy/healthz" in decision
+    assert "https://<AO_GATE_HOSTNAME>/release-gate/healthz" in decision
+    assert "program_id=GPP-2q" in decision
+    assert "program_id=GPP-2w" in decision
+    assert "local_health_ready" in decision
+    assert "secret_value_readback=false" in decision
+    assert "github_webhook_configured=false" in decision
+    assert "github_callback_post=false" in decision
+    assert "github_check_run_post=false" in decision
+    assert "branch_protection_cutover=false" in decision
+    assert "protected_workflow_dispatch=false" in decision
+    assert "live_adapter_execution=false" in decision
+    assert "support_widening=false" in decision
+    assert "production_platform_claim=false" in decision
+
+
 def test_gpp_next_load_status_validates_required_guards() -> None:
     mod = _module()
 
@@ -673,11 +716,11 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
 
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
-    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/565"
+    assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/567"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "internal_operator_host_bundle_ready_service_not_hosted_no_support_widening"
+        == "internal_gate_host_health_probe_ready_hosting_evidence_not_collected_no_support_widening"
     )
     assert payload["support_widening_allowed"] is False
 
@@ -710,8 +753,9 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Live adapter execution allowed: false" in rendered
     assert "internal vault-backed secret-id runtime contract" in rendered
     assert "internal operator host bundle" in rendered
+    assert "no-secret hosted health probe" in rendered
     assert "webhook runtimes, container packages" in rendered
-    assert "publicly hosted/configured with vault-backed runtime secrets" in rendered
+    assert "public HTTPS health evidence" in rendered
     assert "divergence: 0\t0" in rendered
 
 

--- a/tests/test_internal_gate_host_health_probe.py
+++ b/tests/test_internal_gate_host_health_probe.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _module() -> Any:
+    module_path = _repo_root() / "scripts" / "internal_gate_host_health_probe.py"
+    spec = importlib.util.spec_from_file_location("internal_gate_host_health_probe", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _json_response(program_id: str) -> bytes:
+    return json.dumps({"status": "ok", "program_id": program_id}).encode("utf-8")
+
+
+def test_build_health_urls_uses_internal_gate_public_paths() -> None:
+    mod = _module()
+
+    policy_url, release_gate_url = mod.build_health_urls("gate.example.test")
+
+    assert policy_url == "https://gate.example.test/policy/healthz"
+    assert release_gate_url == "https://gate.example.test/release-gate/healthz"
+
+
+def test_health_probe_accepts_public_https_evidence_without_side_effects() -> None:
+    mod = _module()
+
+    def transport(url: str, _timeout_seconds: float) -> tuple[int, bytes]:
+        if url.endswith("/policy/healthz"):
+            return 200, _json_response("GPP-2q")
+        if url.endswith("/release-gate/healthz"):
+            return 200, _json_response("GPP-2w")
+        raise AssertionError(f"unexpected URL {url}")
+
+    payload = mod.build_evidence(
+        policy_url="https://gate.example.test/policy/healthz",
+        release_gate_url="https://gate.example.test/release-gate/healthz",
+        transport=transport,
+    )
+
+    assert payload["status"] == "hosted_health_ready"
+    assert payload["policy_health_evidence"] is True
+    assert payload["release_gate_health_evidence"] is True
+    assert payload["public_https_hosting_evidence"] is True
+    assert payload["secret_value_readback"] is False
+    assert payload["github_webhook_configured"] is False
+    assert payload["github_callback_post"] is False
+    assert payload["github_check_run_post"] is False
+    assert payload["branch_protection_cutover"] is False
+    assert payload["protected_workflow_dispatch"] is False
+    assert payload["live_adapter_execution"] is False
+    assert payload["support_widening"] is False
+    assert payload["production_platform_claim"] is False
+    assert payload["findings"] == []
+
+
+def test_health_probe_blocks_public_http_without_requesting_endpoint() -> None:
+    mod = _module()
+
+    def transport(_url: str, _timeout_seconds: float) -> tuple[int, bytes]:
+        raise AssertionError("invalid public HTTP URL should not be requested")
+
+    payload = mod.build_evidence(
+        policy_url="http://gate.example.test/policy/healthz",
+        release_gate_url="http://gate.example.test/release-gate/healthz",
+        transport=transport,
+    )
+
+    assert payload["status"] == "blocked"
+    assert payload["policy_health_evidence"] is False
+    assert payload["public_https_hosting_evidence"] is False
+    assert any(
+        finding["service"] == "live-adapter-gate-policy"
+        and finding["code"] == "internal_gate_host_health_url_not_https"
+        for finding in payload["findings"]
+    )
+
+
+def test_health_probe_allows_local_http_without_public_https_claim() -> None:
+    mod = _module()
+
+    def transport(url: str, _timeout_seconds: float) -> tuple[int, bytes]:
+        if url.endswith("/policy/healthz"):
+            return 200, _json_response("GPP-2q")
+        if url.endswith("/release-gate/healthz"):
+            return 200, _json_response("GPP-2w")
+        raise AssertionError(f"unexpected URL {url}")
+
+    payload = mod.build_evidence(
+        policy_url="http://127.0.0.1:8000/policy/healthz",
+        release_gate_url="http://127.0.0.1:8000/release-gate/healthz",
+        allow_http_localhost=True,
+        transport=transport,
+    )
+
+    assert payload["status"] == "local_health_ready"
+    assert payload["policy_health_evidence"] is True
+    assert payload["release_gate_health_evidence"] is True
+    assert payload["public_https_hosting_evidence"] is False
+    assert payload["github_webhook_configured"] is False
+    assert payload["github_callback_post"] is False
+    assert payload["github_check_run_post"] is False
+
+
+def test_health_probe_does_not_treat_loopback_https_as_public_evidence() -> None:
+    mod = _module()
+
+    def transport(url: str, _timeout_seconds: float) -> tuple[int, bytes]:
+        if url.endswith("/policy/healthz"):
+            return 200, _json_response("GPP-2q")
+        if url.endswith("/release-gate/healthz"):
+            return 200, _json_response("GPP-2w")
+        raise AssertionError(f"unexpected URL {url}")
+
+    payload = mod.build_evidence(
+        policy_url="https://localhost/policy/healthz",
+        release_gate_url="https://localhost/release-gate/healthz",
+        transport=transport,
+    )
+
+    assert payload["status"] == "local_health_ready"
+    assert payload["policy_health_evidence"] is True
+    assert payload["release_gate_health_evidence"] is True
+    assert payload["public_https_hosting_evidence"] is False
+
+
+def test_health_probe_blocks_wrong_program_id() -> None:
+    mod = _module()
+
+    def transport(url: str, _timeout_seconds: float) -> tuple[int, bytes]:
+        if url.endswith("/policy/healthz"):
+            return 200, _json_response("wrong-program")
+        if url.endswith("/release-gate/healthz"):
+            return 200, _json_response("GPP-2w")
+        raise AssertionError(f"unexpected URL {url}")
+
+    payload = mod.build_evidence(
+        policy_url="https://gate.example.test/policy/healthz",
+        release_gate_url="https://gate.example.test/release-gate/healthz",
+        transport=transport,
+    )
+
+    assert payload["status"] == "blocked"
+    assert payload["policy_health_evidence"] is False
+    assert payload["release_gate_health_evidence"] is True
+    assert payload["public_https_hosting_evidence"] is False
+    assert any(
+        finding["service"] == "live-adapter-gate-policy"
+        and finding["code"] == "internal_gate_host_health_program_id_mismatch"
+        for finding in payload["findings"]
+    )
+
+
+def test_health_probe_cli_writes_json_artifact(tmp_path: Path, capsys: Any, monkeypatch: Any) -> None:
+    mod = _module()
+    artifact = tmp_path / "health-evidence.json"
+
+    def transport(url: str, _timeout_seconds: float) -> tuple[int, bytes]:
+        if url.endswith("/policy/healthz"):
+            return 200, _json_response("GPP-2q")
+        if url.endswith("/release-gate/healthz"):
+            return 200, _json_response("GPP-2w")
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr(mod, "urllib_health_get", transport)
+
+    result = mod.main(
+        [
+            "--host",
+            "gate.example.test",
+            "--artifact-path",
+            str(artifact),
+            "--output",
+            "text",
+            "--fail-on-blocked",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert result == 0
+    assert payload["status"] == "hosted_health_ready"
+    assert payload["public_https_hosting_evidence"] is True
+    assert "public_https_hosting_evidence: true" in captured.out


### PR DESCRIPTION
## Summary
- Add `scripts/internal_gate_host_health_probe.py` to collect no-secret health evidence from the internal gate host policy and release-gate endpoints.
- Document the hosted health evidence flow in `deploy/internal-gate-host/README.md`.
- Record GPP-2af in the machine-readable and human-readable GPP status files while keeping GPP-2 blocked and fail-closed.

## Guardrails
- No secret value readback.
- No GitHub webhook configuration.
- No callback POST or check-run POST.
- No branch-protection/ruleset cutover.
- No protected workflow dispatch.
- No live adapter execution.
- No support widening or production platform claim.

## Validation
- `python3 -m pytest tests/test_internal_gate_host_bootstrap_attest.py tests/test_internal_gate_host_health_probe.py tests/test_gpp_next.py -q`
- `python3 -m ruff check scripts/internal_gate_host_health_probe.py tests/test_internal_gate_host_health_probe.py tests/test_gpp_next.py`
- `python3 -m ruff format --check scripts/internal_gate_host_health_probe.py tests/test_internal_gate_host_health_probe.py tests/test_gpp_next.py`
- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `python3 scripts/internal_gate_host_bootstrap_attest.py --output text --fail-on-blocked`
- `python3 scripts/gpp_next.py`
- `git diff --check`

Closes #567.