### PR TITLE
GPP-2a: per-service GitHub App config contract (Codex 019e4a10 Decision 2 AGREE_A)

### DIFF
--- a/deploy/internal-gate-host/.env.example
+++ b/deploy/internal-gate-host/.env.example
@@ -8,10 +8,24 @@ AO_GATE_CADDYFILE=./Caddyfile.example
 AO_POLICY_SERVICE_IMAGE=ghcr.io/halildeu/ao-kernel-live-adapter-gate-policy-service:main
 AO_RELEASE_GATE_SERVICE_IMAGE=ghcr.io/halildeu/ao-kernel-ao-release-gate-service:main
 
-# Shared GitHub App identity. Secret material stays in the operator vault.
+# GitHub App identity. Two GitHub Apps is the chosen routing model
+# (Codex `019e4a10` Decision 2 PARTIAL → AGREE_A): one App per service,
+# one webhook URL per App, one private-key secret-id per App. The
+# operator vault holds the actual private-key PEM material under each
+# secret id; nothing in this file is a secret value.
+#
+# Required for new operators (per-service, recommended):
+AO_POLICY_GITHUB_APP_ID=<policy-github-app-id>
+AO_POLICY_GITHUB_APP_PRIVATE_KEY_PEM_ID=gpp2/github/policy-private-key-pem
+AO_RELEASE_GATE_GITHUB_APP_ID=<release-gate-github-app-id>
+AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_PEM_ID=gpp2/github/release-gate-private-key-pem
+
 AO_GITHUB_API_URL=https://api.github.com
-AO_GITHUB_APP_ID=<github-app-id>
-AO_GITHUB_APP_PRIVATE_KEY_PEM_ID=gpp2/github/private-key-pem
+# Legacy single-App fallback (compose.yaml accepts this when the
+# per-service env above is unset — backward compatibility for
+# operators who deployed against a single App before the split):
+# AO_GITHUB_APP_ID=<github-app-id>
+# AO_GITHUB_APP_PRIVATE_KEY_PEM_ID=gpp2/github/private-key-pem
 
 # Vault-backed runtime secret ids.
 SECRETS_PROVIDER=hashicorp_vault

--- a/deploy/internal-gate-host/README.md
+++ b/deploy/internal-gate-host/README.md
@@ -80,9 +80,23 @@ SECRETS_PROVIDER=hashicorp_vault
 VAULT_ADDR=<operator vault URL>
 VAULT_TOKEN=<operator vault token>
 VAULT_SECRET_MOUNT=secret
-AO_GITHUB_APP_PRIVATE_KEY_PEM_ID=gpp2/github/private-key-pem
+
+# Per-service GitHub App identity (Codex 019e4a10 Decision 2 AGREE_A:
+# two Apps, one App per service):
+AO_POLICY_GITHUB_APP_ID=<policy-github-app-id>
+AO_POLICY_GITHUB_APP_PRIVATE_KEY_PEM_ID=gpp2/github/policy-private-key-pem
+AO_RELEASE_GATE_GITHUB_APP_ID=<release-gate-github-app-id>
+AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_PEM_ID=gpp2/github/release-gate-private-key-pem
+
+# Webhook secret ids stay per-service (each App gets its own
+# webhook secret in vault):
 AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID=gpp2/policy/webhook-secret
 AO_RELEASE_GATE_WEBHOOK_SECRET_ID=gpp2/release-gate/webhook-secret
+
+# Legacy single-App fallback (compose.yaml accepts this when the
+# per-service env above is unset; kept for backward compatibility):
+# AO_GITHUB_APP_ID=<github-app-id>
+# AO_GITHUB_APP_PRIVATE_KEY_PEM_ID=gpp2/github/private-key-pem
 ```
 
 `VAULT_TOKEN`, webhook secret values, and the GitHub App private key are

--- a/deploy/internal-gate-host/compose.yaml
+++ b/deploy/internal-gate-host/compose.yaml
@@ -32,8 +32,16 @@ services:
       VAULT_TOKEN: ${VAULT_TOKEN:?set VAULT_TOKEN on the operator host}
       VAULT_SECRET_MOUNT: ${VAULT_SECRET_MOUNT:-secret}
       AO_GITHUB_API_URL: ${AO_GITHUB_API_URL:-https://api.github.com}
-      AO_GITHUB_APP_ID: ${AO_GITHUB_APP_ID:?set AO_GITHUB_APP_ID on the operator host}
-      AO_GITHUB_APP_PRIVATE_KEY_PEM_ID: ${AO_GITHUB_APP_PRIVATE_KEY_PEM_ID:?set vault secret id}
+      # Per-service GitHub App identity (Codex `019e4a10` Decision 2
+      # PARTIAL → AGREE_A absorb). Two GitHub Apps is the chosen
+      # routing model: one App per service, one webhook URL per App,
+      # one private-key secret-id per App. Fallback to the legacy
+      # shared `AO_GITHUB_APP_ID` / `AO_GITHUB_APP_PRIVATE_KEY_PEM_ID`
+      # preserves backward compatibility for operators who deployed
+      # against a single App before this split landed; new operators
+      # supply only the per-service env.
+      AO_GITHUB_APP_ID: ${AO_POLICY_GITHUB_APP_ID:-${AO_GITHUB_APP_ID:?set AO_POLICY_GITHUB_APP_ID (preferred) or AO_GITHUB_APP_ID (legacy) on the operator host}}
+      AO_GITHUB_APP_PRIVATE_KEY_PEM_ID: ${AO_POLICY_GITHUB_APP_PRIVATE_KEY_PEM_ID:-${AO_GITHUB_APP_PRIVATE_KEY_PEM_ID:?set AO_POLICY_GITHUB_APP_PRIVATE_KEY_PEM_ID (preferred) or AO_GITHUB_APP_PRIVATE_KEY_PEM_ID (legacy) — vault secret id}}
       AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID: ${AO_LIVE_ADAPTER_GATE_WEBHOOK_SECRET_ID:?set vault secret id}
       AO_POLICY_SERVICE_MAX_BODY_BYTES: ${AO_POLICY_SERVICE_MAX_BODY_BYTES:-1048576}
 
@@ -50,8 +58,11 @@ services:
       VAULT_TOKEN: ${VAULT_TOKEN:?set VAULT_TOKEN on the operator host}
       VAULT_SECRET_MOUNT: ${VAULT_SECRET_MOUNT:-secret}
       AO_GITHUB_API_URL: ${AO_GITHUB_API_URL:-https://api.github.com}
-      AO_GITHUB_APP_ID: ${AO_GITHUB_APP_ID:?set AO_GITHUB_APP_ID on the operator host}
-      AO_GITHUB_APP_PRIVATE_KEY_PEM_ID: ${AO_GITHUB_APP_PRIVATE_KEY_PEM_ID:?set vault secret id}
+      # Per-service GitHub App identity (see policy-service block for
+      # the full rationale; same fallback pattern applies for the
+      # release-gate App).
+      AO_GITHUB_APP_ID: ${AO_RELEASE_GATE_GITHUB_APP_ID:-${AO_GITHUB_APP_ID:?set AO_RELEASE_GATE_GITHUB_APP_ID (preferred) or AO_GITHUB_APP_ID (legacy) on the operator host}}
+      AO_GITHUB_APP_PRIVATE_KEY_PEM_ID: ${AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_PEM_ID:-${AO_GITHUB_APP_PRIVATE_KEY_PEM_ID:?set AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_PEM_ID (preferred) or AO_GITHUB_APP_PRIVATE_KEY_PEM_ID (legacy) — vault secret id}}
       AO_RELEASE_GATE_WEBHOOK_SECRET_ID: ${AO_RELEASE_GATE_WEBHOOK_SECRET_ID:?set vault secret id}
       AO_RELEASE_GATE_GPP_STATUS_PATH: /app/gpp_status.v1.json
       AO_RELEASE_GATE_MAX_BODY_BYTES: ${AO_RELEASE_GATE_MAX_BODY_BYTES:-1048576}


### PR DESCRIPTION
## Summary
Codex thread \`019e4a10-0fd5-7ff3-9601-80f56a9c8e81\` Decision 2 verdict: **PARTIAL → AGREE_A** (two GitHub Apps, one App per service, one webhook URL per App, one private-key secret-id per App).

`compose.yaml` was mapping a single shared `AO_GITHUB_APP_ID` + `AO_GITHUB_APP_PRIVATE_KEY_PEM_ID` into both containers, which contradicts the two-Apps routing model the rest of the bundle assumes (Caddy already exposes two webhook endpoints; webhook-secret env-ids are already per-service).

This PR lands the config contract:
- per-service env (recommended): `AO_POLICY_GITHUB_APP_ID` + `AO_POLICY_GITHUB_APP_PRIVATE_KEY_PEM_ID` + `AO_RELEASE_GATE_GITHUB_APP_ID` + `AO_RELEASE_GATE_GITHUB_APP_PRIVATE_KEY_PEM_ID`
- backward-compat fallback: legacy `AO_GITHUB_APP_ID` / `AO_GITHUB_APP_PRIVATE_KEY_PEM_ID` still resolve when per-service env unset
- README + .env.example synchronized

## Why fallback (not hard cut)
Existing operator deploys (single App + shared env) continue to start unchanged. New deploys explicitly pick the per-service env. No operator migration required immediately.

## Out of scope
- GitHub App webhook URL configuration (separate PR; webhook config does NOT proceed until both this PR and the gitops paralel PR are merged)
- Webhook-secret env-id changes (already per-service; unchanged)
- Removing legacy fallback (kept for backward compat; future cleanup PR if needed)

## Cross-AI

Implementer AI: claude
Reviewer AI: codex
Codex thread: 019e4a10-0fd5-7ff3-9601-80f56a9c8e81
Verdict: AGREE_A
Absorb edilen düzeltmeler: Decision 2 PARTIAL absorb — webhook routing model A (two Apps) + per-service env split + backward-compat fallback chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)