### PR TITLE
feat(ao-release-gate): add shadow/enforce conclusion mode (Codex AGREE_B)

### DIFF
--- a/.claude/plans/GPP-2u-AUTONOMOUS-GITHUB-APP-RELEASE-GATE.md
+++ b/.claude/plans/GPP-2u-AUTONOMOUS-GITHUB-APP-RELEASE-GATE.md
@@ -47,8 +47,15 @@ protection app:
 
 ## Required Policy Checks
 
-The release gate must deny by default and set the required status check to
-failure unless every required condition passes.
+The release gate must deny by default. In `enforce` mode (the production
+configuration once AO-GATE-8 lands), the check-run conclusion is
+`failure` unless every required condition passes. In `shadow` mode (the
+default during the dry-run rollout), the same deny path posts a `neutral`
+conclusion so the advisory check does not surface as red CI before the
+branch-protection cutover. `allow_autonomous_merge` maps to `success`
+in either mode. Switching from `shadow` to `enforce` is the AO-GATE-8
+prerequisite; the check must not be marked required on `main` until the
+hosted runtime is running in `enforce` mode.
 
 Required conditions:
 

--- a/.claude/plans/GPP-2v-AO-RELEASE-GATE-DRY-RUN-SCAFFOLD.md
+++ b/.claude/plans/GPP-2v-AO-RELEASE-GATE-DRY-RUN-SCAFFOLD.md
@@ -62,8 +62,12 @@ Terminal decisions:
 5. `deny_untrusted_context`
 6. `error_fail_closed`
 
-The dry-run check-run conclusion is `success` only for
-`allow_autonomous_merge`; all deny/error decisions produce `failure`.
+The release-gate decision remains fail-closed. In shadow mode, GitHub
+check-run conclusion is `success` only for `allow_autonomous_merge` and
+`neutral` for deny/error decisions so advisory evidence does not create
+red CI. In enforce mode, `success` is still only `allow_autonomous_merge`
+and all deny/error decisions produce `failure`. AO-GATE-8 must switch to
+enforce mode before requiring the `ao-release-gate` check.
 
 ## Non-Goals
 

--- a/.claude/plans/GPP-2w-AO-RELEASE-GATE-CHECK-RUN-SERVICE.md
+++ b/.claude/plans/GPP-2w-AO-RELEASE-GATE-CHECK-RUN-SERVICE.md
@@ -44,7 +44,13 @@ It does not unblock GPP-2 and does not authorize human-free merges yet.
    - missing or invalid signatures blocking before policy evaluation;
    - unsupported events and malformed JSON blocking before policy evaluation;
    - successful dry-run check-run request generation;
-   - denied-policy check-run generation with `failure` conclusion;
+   - denied-policy check-run conclusion mapping in both `shadow` (default,
+     `neutral`) and `enforce` (`failure`) modes;
+   - `allow_autonomous_merge` mapping to `success` regardless of mode;
+   - `AO_RELEASE_GATE_CONCLUSION_MODE` env loader defaulting to `shadow`,
+     accepting `enforce`, and raising a stable config error on invalid
+     values;
+   - service result artifact recording the active `conclusion_mode`;
    - runtime check-run POST path using a fake GitHub client;
    - missing installation id blocking before POST;
    - GitHub App client token/check-run POST behavior without returning secret

--- a/ao_kernel/ao_release_gate.py
+++ b/ao_kernel/ao_release_gate.py
@@ -37,7 +37,9 @@ ReleaseGateDecisionValue = Literal[
     "error_fail_closed",
 ]
 ReleaseGateCheckStatus = Literal["pass", "blocked"]
-GithubCheckConclusion = Literal["success", "failure"]
+GithubCheckConclusion = Literal["success", "failure", "neutral"]
+ConclusionMode = Literal["shadow", "enforce"]
+DEFAULT_CONCLUSION_MODE: ConclusionMode = "shadow"
 
 
 class AoReleaseGateInputCheck(TypedDict):
@@ -106,6 +108,7 @@ class AoReleaseGateDecision(TypedDict):
     app_slug: str
     dry_run: bool
     merge_authority_enabled: bool
+    conclusion_mode: ConclusionMode
     decision: ReleaseGateDecisionValue
     allow: bool
     finding_code: str | None
@@ -402,16 +405,38 @@ def _reason(decision: ReleaseGateDecisionValue) -> str:
     return "Release gate denied because the PR violates autonomous release policy."
 
 
-def _check_run(decision: ReleaseGateDecisionValue, findings: list[str]) -> AoReleaseGateCheckRun:
-    """Build the future GitHub check-run output shape."""
+def _check_run(
+    decision: ReleaseGateDecisionValue,
+    findings: list[str],
+    *,
+    conclusion_mode: ConclusionMode = DEFAULT_CONCLUSION_MODE,
+) -> AoReleaseGateCheckRun:
+    """Build the future GitHub check-run output shape.
+
+    The check-run conclusion is mode-aware:
+
+    - ``allow_autonomous_merge`` always maps to ``success`` (both modes).
+    - In ``shadow`` mode (default), every deny/error decision maps to
+      ``neutral`` so advisory evidence does not surface as red CI before
+      the AO-GATE-8 enforcement cutover.
+    - In ``enforce`` mode, every deny/error decision maps to ``failure``
+      (the original fail-closed behavior required once the check is wired
+      as a required status check).
+    """
 
     allow = decision == ALLOW_AUTONOMOUS_MERGE_DECISION
     summary = _reason(decision)
     text = "Findings: " + ", ".join(findings) if findings else "All release-gate checks passed."
+    if allow:
+        conclusion: GithubCheckConclusion = "success"
+    elif conclusion_mode == "enforce":
+        conclusion = "failure"
+    else:
+        conclusion = "neutral"
     return {
         "name": RELEASE_GATE_CHECK_NAME,
         "status": "completed",
-        "conclusion": "success" if allow else "failure",
+        "conclusion": conclusion,
         "title": f"{RELEASE_GATE_CHECK_NAME}: {decision}",
         "summary": summary,
         "text": text,
@@ -423,8 +448,16 @@ def build_ao_release_gate_decision(
     gpp_status: object,
     *,
     generated_at: str | None = None,
+    conclusion_mode: ConclusionMode = DEFAULT_CONCLUSION_MODE,
 ) -> AoReleaseGateDecision:
-    """Build a fail-closed dry-run release-gate decision."""
+    """Build a fail-closed dry-run release-gate decision.
+
+    ``conclusion_mode`` controls how deny/error decisions surface on the
+    GitHub check-run: ``shadow`` (default) maps them to ``neutral`` so the
+    advisory check does not produce red CI before AO-GATE-8 enforcement,
+    while ``enforce`` maps them to ``failure`` (the historical behavior
+    needed once the check is required on branch protection).
+    """
 
     context = extract_ao_release_gate_context(payload, gpp_status)
     checks = [
@@ -582,6 +615,7 @@ def build_ao_release_gate_decision(
         "app_slug": RELEASE_GATE_CHECK_NAME,
         "dry_run": True,
         "merge_authority_enabled": False,
+        "conclusion_mode": conclusion_mode,
         "decision": decision,
         "allow": allow,
         "finding_code": None if allow else decision,
@@ -589,7 +623,7 @@ def build_ao_release_gate_decision(
         "context": context,
         "checks": checks,
         "findings": findings,
-        "github_check_run": _check_run(decision, findings),
+        "github_check_run": _check_run(decision, findings, conclusion_mode=conclusion_mode),
     }
 
 
@@ -602,6 +636,7 @@ def render_ao_release_gate_decision_text(decision: AoReleaseGateDecision) -> str
         f"allow: {str(decision['allow']).lower()}",
         f"dry_run: {str(decision['dry_run']).lower()}",
         f"merge_authority_enabled: {str(decision['merge_authority_enabled']).lower()}",
+        f"conclusion_mode: {decision['conclusion_mode']}",
         f"github_check_run: {decision['github_check_run']['name']} {decision['github_check_run']['conclusion']}",
         f"repository: {context['repository'] or '<missing>'}",
         f"pull_request_number: {context['pull_request_number'] or '<missing>'}",

--- a/ao_kernel/ao_release_gate_runtime.py
+++ b/ao_kernel/ao_release_gate_runtime.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Protocol, TypedDict, cast
 
 from ao_kernel._internal.secrets.factory import create_provider_from_env
+from ao_kernel.ao_release_gate import DEFAULT_CONCLUSION_MODE, ConclusionMode
 from ao_kernel.ao_release_gate_service import (
     AoReleaseGateCheckRunRequest,
     AoReleaseGateServiceResult,
@@ -36,6 +37,7 @@ GITHUB_APP_PRIVATE_KEY_PATH_ENV = "AO_GITHUB_APP_PRIVATE_KEY_PATH"
 GITHUB_API_URL_ENV = "AO_GITHUB_API_URL"
 GPP_STATUS_PATH_ENV = "AO_RELEASE_GATE_GPP_STATUS_PATH"
 MAX_BODY_BYTES_ENV = "AO_RELEASE_GATE_MAX_BODY_BYTES"
+CONCLUSION_MODE_ENV = "AO_RELEASE_GATE_CONCLUSION_MODE"
 
 
 class ReleaseGateRuntimeError(RuntimeError):
@@ -302,6 +304,33 @@ def load_gpp_status(env: Mapping[str, str] | None = None) -> object:
         ) from exc
 
 
+def load_conclusion_mode(env: Mapping[str, str] | None = None) -> ConclusionMode:
+    """Load the runtime conclusion mode from the environment.
+
+    Returns ``shadow`` (the default) when ``AO_RELEASE_GATE_CONCLUSION_MODE``
+    is missing or empty. Returns ``enforce`` only when the env var is set
+    exactly to ``enforce``. Any other non-empty value is treated as a
+    configuration error so a typo cannot silently flip the gate into the
+    unintended mode.
+    """
+
+    source = os.environ if env is None else env
+    raw_value = source.get(CONCLUSION_MODE_ENV)
+    if raw_value is None:
+        return DEFAULT_CONCLUSION_MODE
+    candidate = raw_value.strip()
+    if not candidate:
+        return DEFAULT_CONCLUSION_MODE
+    if candidate == "shadow":
+        return "shadow"
+    if candidate == "enforce":
+        return "enforce"
+    raise ReleaseGateRuntimeConfigError(
+        "ao_release_gate_runtime_invalid_conclusion_mode",
+        f"{CONCLUSION_MODE_ENV} must be 'shadow' or 'enforce'.",
+    )
+
+
 def handle_ao_release_gate_webhook(
     body: bytes,
     headers: Mapping[str, str],
@@ -310,8 +339,15 @@ def handle_ao_release_gate_webhook(
     github_client: GithubCheckRunClient,
     gpp_status: object,
     generated_at: str | None = None,
+    conclusion_mode: ConclusionMode = DEFAULT_CONCLUSION_MODE,
 ) -> ReleaseGateRuntimeResult:
-    """Evaluate one GitHub webhook delivery and post the dry-run check-run."""
+    """Evaluate one GitHub webhook delivery and post the dry-run check-run.
+
+    ``conclusion_mode`` is forwarded to the service boundary so the GitHub
+    check-run conclusion stays mode-aware. The default ``shadow`` mode keeps
+    advisory deliveries from producing red CI; ``enforce`` restores the
+    historical ``failure`` mapping required before the AO-GATE-8 cutover.
+    """
 
     service_result = build_ao_release_gate_service_result(
         body,
@@ -320,6 +356,7 @@ def handle_ao_release_gate_webhook(
         webhook_secret=webhook_secret,
         require_signature=True,
         generated_at=generated_at,
+        conclusion_mode=conclusion_mode,
     )
     if not service_result["should_post_check_run"]:
         finding_code = service_result["finding_code"] or "ao_release_gate_runtime_service_blocked"
@@ -416,12 +453,14 @@ def release_gate_runtime_wsgi_app(
         webhook_secret = load_webhook_secret(os.environ)
         config = load_github_app_config(os.environ)
         gpp_status = load_gpp_status(os.environ)
+        conclusion_mode = load_conclusion_mode(os.environ)
         result = handle_ao_release_gate_webhook(
             body,
             _wsgi_headers(environ),
             webhook_secret=webhook_secret,
             github_client=GithubAppCheckRunClient(config),
             gpp_status=gpp_status,
+            conclusion_mode=conclusion_mode,
         )
         return _wsgi_json(start_response, _status_code_for_runtime_result(result), _redacted_runtime_payload(result))
     except ReleaseGateRuntimeConfigError as exc:
@@ -558,6 +597,7 @@ def _redacted_runtime_payload(result: ReleaseGateRuntimeResult) -> dict[str, obj
         "delivery_id": service_result["delivery_id"],
         "signature_verified": service_result["signature_verified"],
         "should_post_check_run": service_result["should_post_check_run"],
+        "conclusion_mode": service_result["conclusion_mode"],
         "release_gate_decision": decision["decision"] if decision is not None else None,
         "dry_run": decision["dry_run"] if decision is not None else None,
         "merge_authority_enabled": decision["merge_authority_enabled"] if decision is not None else None,

--- a/ao_kernel/ao_release_gate_service.py
+++ b/ao_kernel/ao_release_gate_service.py
@@ -7,8 +7,10 @@ from pathlib import Path
 from typing import Any, Literal, Mapping, TypedDict, cast
 
 from ao_kernel.ao_release_gate import (
+    DEFAULT_CONCLUSION_MODE,
     RELEASE_GATE_CHECK_NAME,
     AoReleaseGateDecision,
+    ConclusionMode,
     build_ao_release_gate_decision,
     render_ao_release_gate_decision_text,
 )
@@ -82,6 +84,7 @@ class AoReleaseGateServiceResult(TypedDict):
     delivery_id: str | None
     signature_verified: bool | None
     should_post_check_run: bool
+    conclusion_mode: ConclusionMode
     decision: AoReleaseGateDecision | None
     check_run_request: AoReleaseGateCheckRunRequest
     checks: list[AoReleaseGateServiceCheck]
@@ -186,12 +189,17 @@ def build_ao_release_gate_service_result(
     require_signature: bool = True,
     generated_at: str | None = None,
     github_api_url: str = DEFAULT_GITHUB_API_URL,
+    conclusion_mode: ConclusionMode = DEFAULT_CONCLUSION_MODE,
 ) -> AoReleaseGateServiceResult:
     """Evaluate a release-gate webhook delivery and build a check-run request.
 
     The function never posts to GitHub. Runtime deployment must attach a GitHub
     App installation token outside this repository and execute the returned
     request shape.
+
+    ``conclusion_mode`` is forwarded to the core decision builder so the
+    GitHub check-run conclusion stays mode-aware (``shadow`` maps deny/error
+    to ``neutral``, ``enforce`` keeps the historical ``failure``).
     """
 
     checks: list[AoReleaseGateServiceCheck] = []
@@ -272,13 +280,19 @@ def build_ao_release_gate_service_result(
             "delivery_id": delivery_id,
             "signature_verified": signature_verified,
             "should_post_check_run": False,
+            "conclusion_mode": conclusion_mode,
             "decision": None,
             "check_run_request": _empty_check_run_request(),
             "checks": checks,
             "findings": pre_policy_blockers,
         }
 
-    decision = build_ao_release_gate_decision(payload, gpp_status, generated_at=generated_at)
+    decision = build_ao_release_gate_decision(
+        payload,
+        gpp_status,
+        generated_at=generated_at,
+        conclusion_mode=conclusion_mode,
+    )
     check_run_request = build_ao_release_gate_check_run_request(decision, github_api_url=github_api_url)
     check_run_ready = check_run_request["url"] is not None and check_run_request["json"] is not None
     if check_run_ready:
@@ -313,6 +327,7 @@ def build_ao_release_gate_service_result(
         "delivery_id": delivery_id,
         "signature_verified": signature_verified,
         "should_post_check_run": check_run_ready,
+        "conclusion_mode": conclusion_mode,
         "decision": decision,
         "check_run_request": check_run_request,
         "checks": checks,
@@ -329,6 +344,7 @@ def render_ao_release_gate_service_text(result: AoReleaseGateServiceResult) -> s
         f"delivery_id: {result['delivery_id'] or '<missing>'}",
         f"signature_verified: {result['signature_verified']}",
         f"should_post_check_run: {str(result['should_post_check_run']).lower()}",
+        f"conclusion_mode: {result['conclusion_mode']}",
         f"check_run_url: {result['check_run_request']['url'] or '<missing>'}",
     ]
     if result["decision"] is not None:

--- a/deploy/internal-gate-host/compose.yaml
+++ b/deploy/internal-gate-host/compose.yaml
@@ -66,6 +66,13 @@ services:
       AO_RELEASE_GATE_WEBHOOK_SECRET_ID: ${AO_RELEASE_GATE_WEBHOOK_SECRET_ID:?set vault secret id}
       AO_RELEASE_GATE_GPP_STATUS_PATH: /app/gpp_status.v1.json
       AO_RELEASE_GATE_MAX_BODY_BYTES: ${AO_RELEASE_GATE_MAX_BODY_BYTES:-1048576}
+      # GitHub check-run conclusion mode (Codex `019e4e6c` AGREE_B).
+      # `shadow` (default) maps deny/error decisions to `neutral` so the
+      # advisory check does not surface as red CI before the AO-GATE-8
+      # branch-protection cutover. `enforce` restores the historical
+      # `failure` mapping and must be set before `ao-release-gate` is
+      # required on `main`.
+      AO_RELEASE_GATE_CONCLUSION_MODE: ${AO_RELEASE_GATE_CONCLUSION_MODE:-shadow}
     volumes:
       - ../../.claude/plans/gpp_status.v1.json:/app/gpp_status.v1.json:ro
 

--- a/tests/test_ao_release_gate.py
+++ b/tests/test_ao_release_gate.py
@@ -110,7 +110,10 @@ def test_release_gate_denies_stale_branch() -> None:
 
     assert decision["decision"] == DENY_STALE_BRANCH_DECISION
     assert decision["allow"] is False
-    assert decision["github_check_run"]["conclusion"] == "failure"
+    # Shadow mode (the default) maps deny/error decisions to ``neutral`` so
+    # advisory deliveries do not surface as red CI before AO-GATE-8.
+    assert decision["conclusion_mode"] == "shadow"
+    assert decision["github_check_run"]["conclusion"] == "neutral"
     assert _find_check(decision, "branch_freshness")["finding_code"] == "ao_release_gate_branch_not_up_to_date"
 
 
@@ -176,6 +179,67 @@ def test_release_gate_render_and_write(tmp_path: Path) -> None:
     assert "decision: allow_autonomous_merge" in rendered
     assert "merge_authority_enabled: false" in rendered
     assert f"github_check_run: {RELEASE_GATE_CHECK_NAME} success" in rendered
+
+
+def test_check_run_conclusion_shadow_neutral_for_deny_missing_evidence() -> None:
+    payload = _allow_payload()
+    payload["required_checks"] = []
+
+    decision = build_ao_release_gate_decision(payload, _gpp_status())
+
+    assert decision["decision"] == DENY_MISSING_EVIDENCE_DECISION
+    assert decision["conclusion_mode"] == "shadow"
+    assert decision["github_check_run"]["conclusion"] == "neutral"
+
+
+def test_check_run_conclusion_enforce_failure_for_deny_missing_evidence() -> None:
+    payload = _allow_payload()
+    payload["required_checks"] = []
+
+    decision = build_ao_release_gate_decision(payload, _gpp_status(), conclusion_mode="enforce")
+
+    assert decision["decision"] == DENY_MISSING_EVIDENCE_DECISION
+    assert decision["conclusion_mode"] == "enforce"
+    assert decision["github_check_run"]["conclusion"] == "failure"
+
+
+def test_check_run_conclusion_shadow_neutral_for_deny_policy_violation() -> None:
+    payload = _allow_payload()
+    payload["admin_bypass_requested"] = True
+
+    decision = build_ao_release_gate_decision(payload, _gpp_status())
+
+    assert decision["decision"] == DENY_POLICY_VIOLATION_DECISION
+    assert decision["conclusion_mode"] == "shadow"
+    assert decision["github_check_run"]["conclusion"] == "neutral"
+
+
+def test_check_run_conclusion_enforce_failure_for_deny_policy_violation() -> None:
+    payload = _allow_payload()
+    payload["admin_bypass_requested"] = True
+
+    decision = build_ao_release_gate_decision(payload, _gpp_status(), conclusion_mode="enforce")
+
+    assert decision["decision"] == DENY_POLICY_VIOLATION_DECISION
+    assert decision["conclusion_mode"] == "enforce"
+    assert decision["github_check_run"]["conclusion"] == "failure"
+
+
+def test_check_run_conclusion_success_for_allow_in_both_modes() -> None:
+    payload = _allow_payload()
+
+    shadow_decision = build_ao_release_gate_decision(payload, _gpp_status())
+    enforce_decision = build_ao_release_gate_decision(payload, _gpp_status(), conclusion_mode="enforce")
+
+    assert shadow_decision["decision"] == ALLOW_AUTONOMOUS_MERGE_DECISION
+    assert enforce_decision["decision"] == ALLOW_AUTONOMOUS_MERGE_DECISION
+    # The allow path is ``success`` regardless of mode — only deny/error
+    # decisions diverge between ``shadow`` (``neutral``) and ``enforce``
+    # (``failure``).
+    assert shadow_decision["github_check_run"]["conclusion"] == "success"
+    assert enforce_decision["github_check_run"]["conclusion"] == "success"
+    assert shadow_decision["conclusion_mode"] == "shadow"
+    assert enforce_decision["conclusion_mode"] == "enforce"
 
 
 def test_release_gate_cli_writes_dry_run_artifact(tmp_path: Path) -> None:

--- a/tests/test_ao_release_gate_runtime.py
+++ b/tests/test_ao_release_gate_runtime.py
@@ -12,6 +12,7 @@ import pytest
 
 from ao_kernel.ao_release_gate import ALLOW_AUTONOMOUS_MERGE_DECISION, DENY_POLICY_VIOLATION_DECISION
 from ao_kernel.ao_release_gate_runtime import (
+    CONCLUSION_MODE_ENV,
     DEFAULT_HEALTH_PATH,
     DEFAULT_WEBHOOK_PATH,
     GITHUB_APP_ID_ENV,
@@ -26,6 +27,7 @@ from ao_kernel.ao_release_gate_runtime import (
     ReleaseGateRuntimeConfigError,
     build_github_app_jwt,
     handle_ao_release_gate_webhook,
+    load_conclusion_mode,
     load_github_app_config,
     load_webhook_secret,
     release_gate_runtime_wsgi_app,
@@ -144,7 +146,7 @@ def test_runtime_posts_success_check_run_for_allowed_context() -> None:
     assert check_run_json["conclusion"] == "success"
 
 
-def test_runtime_posts_failure_check_run_for_denied_policy() -> None:
+def test_runtime_posts_neutral_check_run_for_denied_policy_in_shadow_mode() -> None:
     payload = _allow_payload()
     payload["admin_bypass_requested"] = True
     body = _body(payload)
@@ -159,11 +161,41 @@ def test_runtime_posts_failure_check_run_for_denied_policy() -> None:
     )
 
     assert result["status"] == "check_run_posted"
+    assert result["service_result"]["conclusion_mode"] == "shadow"
     assert result["service_result"]["decision"] is not None
     assert result["service_result"]["decision"]["decision"] == DENY_POLICY_VIOLATION_DECISION
     assert github_client.calls[0][0] == 12345
     check_run_json = github_client.calls[0][1]["json"]
     assert check_run_json is not None
+    # Shadow mode (default) maps deny/error to ``neutral`` so the advisory
+    # check does not surface as red CI before AO-GATE-8.
+    assert check_run_json["conclusion"] == "neutral"
+
+
+def test_runtime_posts_failure_check_run_for_denied_policy_in_enforce_mode() -> None:
+    payload = _allow_payload()
+    payload["admin_bypass_requested"] = True
+    body = _body(payload)
+    github_client = FakeGithubClient()
+
+    result = handle_ao_release_gate_webhook(
+        body,
+        _headers(body),
+        webhook_secret="secret",
+        github_client=github_client,
+        gpp_status=_gpp_status(),
+        conclusion_mode="enforce",
+    )
+
+    assert result["status"] == "check_run_posted"
+    assert result["service_result"]["conclusion_mode"] == "enforce"
+    assert result["service_result"]["decision"] is not None
+    assert result["service_result"]["decision"]["decision"] == DENY_POLICY_VIOLATION_DECISION
+    assert github_client.calls[0][0] == 12345
+    check_run_json = github_client.calls[0][1]["json"]
+    assert check_run_json is not None
+    # Enforce mode restores the historical ``failure`` mapping required
+    # before AO-GATE-8 makes the check a required branch protection gate.
     assert check_run_json["conclusion"] == "failure"
 
 
@@ -316,6 +348,38 @@ def test_runtime_reports_missing_release_gate_vault_secret_without_echoing_secre
 
     assert exc_info.value.finding_code == "ao_release_gate_runtime_webhook_secret_missing"
     assert "gpp2/release/missing-secret" not in str(exc_info.value)
+
+
+def test_load_conclusion_mode_default_shadow() -> None:
+    # No env var set → shadow default keeps the historical hosted
+    # behavior unchanged for operators who have not opted into enforce.
+    assert load_conclusion_mode({}) == "shadow"
+
+
+def test_load_conclusion_mode_enforce() -> None:
+    assert load_conclusion_mode({CONCLUSION_MODE_ENV: "enforce"}) == "enforce"
+    # Whitespace is tolerated so operators who paste-with-padding still
+    # get the intended mode rather than a config error.
+    assert load_conclusion_mode({CONCLUSION_MODE_ENV: " enforce "}) == "enforce"
+
+
+def test_load_conclusion_mode_empty_falls_back_to_default() -> None:
+    # Empty / whitespace-only values fall back to shadow rather than
+    # erroring; this mirrors how the compose default expands when no
+    # operator override is provided.
+    assert load_conclusion_mode({CONCLUSION_MODE_ENV: ""}) == "shadow"
+    assert load_conclusion_mode({CONCLUSION_MODE_ENV: "   "}) == "shadow"
+
+
+def test_load_conclusion_mode_invalid_raises_config_error() -> None:
+    with pytest.raises(ReleaseGateRuntimeConfigError) as exc_info:
+        load_conclusion_mode({CONCLUSION_MODE_ENV: "wat"})
+
+    assert exc_info.value.finding_code == "ao_release_gate_runtime_invalid_conclusion_mode"
+    # The detail must mention the expected values so an operator typo is
+    # easy to fix without echoing secret material.
+    assert "shadow" in str(exc_info.value)
+    assert "enforce" in str(exc_info.value)
 
 
 def test_wsgi_health_endpoint() -> None:

--- a/tests/test_ao_release_gate_service.py
+++ b/tests/test_ao_release_gate_service.py
@@ -164,7 +164,7 @@ def test_service_builds_success_check_run_for_allowed_dry_run() -> None:
     }
 
 
-def test_service_builds_failure_check_run_for_denied_policy() -> None:
+def test_service_builds_neutral_check_run_for_denied_policy_in_shadow_mode() -> None:
     payload = _allow_payload()
     payload["admin_bypass_requested"] = True
     body = _body(payload)
@@ -178,11 +178,61 @@ def test_service_builds_failure_check_run_for_denied_policy() -> None:
 
     assert result["status"] == "check_run_ready"
     assert result["should_post_check_run"] is True
+    assert result["conclusion_mode"] == "shadow"
     assert result["decision"] is not None
     assert result["decision"]["decision"] == DENY_POLICY_VIOLATION_DECISION
     assert "ao_release_gate_admin_bypass_requested" in result["decision"]["findings"]
     assert result["check_run_request"]["json"] is not None
+    assert result["check_run_request"]["json"]["conclusion"] == "neutral"
+
+
+def test_service_builds_failure_check_run_for_denied_policy_in_enforce_mode() -> None:
+    payload = _allow_payload()
+    payload["admin_bypass_requested"] = True
+    body = _body(payload)
+
+    result = build_ao_release_gate_service_result(
+        body,
+        _headers(body),
+        gpp_status=_gpp_status(),
+        webhook_secret="secret",
+        conclusion_mode="enforce",
+    )
+
+    assert result["status"] == "check_run_ready"
+    assert result["should_post_check_run"] is True
+    assert result["conclusion_mode"] == "enforce"
+    assert result["decision"] is not None
+    assert result["decision"]["decision"] == DENY_POLICY_VIOLATION_DECISION
+    assert result["check_run_request"]["json"] is not None
     assert result["check_run_request"]["json"]["conclusion"] == "failure"
+
+
+def test_service_result_includes_conclusion_mode() -> None:
+    payload = _allow_payload()
+    body = _body(payload)
+
+    shadow_result = build_ao_release_gate_service_result(
+        body,
+        _headers(body),
+        gpp_status=_gpp_status(),
+        webhook_secret="secret",
+    )
+    enforce_result = build_ao_release_gate_service_result(
+        body,
+        _headers(body),
+        gpp_status=_gpp_status(),
+        webhook_secret="secret",
+        conclusion_mode="enforce",
+    )
+
+    assert shadow_result["conclusion_mode"] == "shadow"
+    assert enforce_result["conclusion_mode"] == "enforce"
+    # Allow path stays ``success`` in either mode.
+    assert shadow_result["check_run_request"]["json"] is not None
+    assert enforce_result["check_run_request"]["json"] is not None
+    assert shadow_result["check_run_request"]["json"]["conclusion"] == "success"
+    assert enforce_result["check_run_request"]["json"]["conclusion"] == "success"
 
 
 def test_service_render_and_write(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add `AO_RELEASE_GATE_CONCLUSION_MODE` env (shadow|enforce, default shadow)
- Mode-aware GitHub check-run conclusion mapping (decision values unchanged)
- AO-GATE-8 branch protection cutover must explicitly switch to enforce mode

## Mapping

| Decision | shadow conclusion | enforce conclusion |
|---|---|---|
| `allow_autonomous_merge` | `success` | `success` |
| `deny_policy_violation` | `neutral` | `failure` |
| `deny_missing_evidence` | `neutral` | `failure` |
| `deny_stale_branch` | `neutral` | `failure` |
| `deny_untrusted_context` | `neutral` | `failure` |
| `error_fail_closed` | `neutral` | `failure` |

Decision values themselves are unchanged. Only the GitHub check-run conclusion channel differentiates shadow observability from enforce gating. Output title/text still includes the decision name (e.g. `ao-release-gate: deny_missing_evidence`) so observability is preserved in shadow mode.

## Why

Without this, dry-run advisory check-runs produce red CI on PRs that legitimately have no production gate evidence (e.g. docs-only PRs like #572). HARD RULE "CI Kırmızıyken Merge YASAK" treats advisory failures as blocking. Shadow mode keeps observability without false-red enforcement; enforce mode is required for AO-GATE-8 cutover.

## Test evidence

- `pytest tests/test_ao_release_gate.py tests/test_ao_release_gate_service.py tests/test_ao_release_gate_runtime.py -v` → **35 passed in 2.03s**
- `pytest -k release_gate` → **62 passed** (full regression set; no regressions)
- `mypy ao_kernel/ao_release_gate{,_service,_runtime}.py` → **Success: no issues found in 3 source files**

## Files changed (10)

Code (3): ao_release_gate.py, ao_release_gate_service.py, ao_release_gate_runtime.py
Compose (1): deploy/internal-gate-host/compose.yaml
Tests (3, +10 new tests): test_ao_release_gate.py, test_ao_release_gate_service.py, test_ao_release_gate_runtime.py
Design docs (3, same PR per Codex): GPP-2u, GPP-2v, GPP-2w

## Cross-AI peer review

- Codex thread `019e4e6c-4680-79c1-9f0e-8a9c271eefa7`: plan-time **AGREE_B** verdict for shadow/enforce conclusion mode with 7-step concrete plan
- Implementer Claude (Anthropic) / Reviewer Codex (OpenAI) — provider-level per HARD RULE Cross-AI Peer Review

## Hard stops respected

- `live_adapter_execution_allowed=false` (unchanged)
- `support_widening_allowed=false` (unchanged)
- `production_platform_claim_allowed=false` (unchanged)
- No secret value in chat/log/repo/issue/PR
- AO-GATE-8 branch protection cutover NOT yet (shadow default keeps current advisory posture; enforce switch required before required-check cutover)

## Forward path

After this merges:
1. Image build/publish triggers on main → new `ao-kernel-ao-release-gate-service:main` digest
2. staging-sw container redeploy (`docker compose pull && up -d --force-recreate`); env `AO_RELEASE_GATE_CONCLUSION_MODE=shadow` (default; explicit set optional)
3. PR #572 new head (empty commit or main merge) triggers `pull_request synchronize` → release-gate posts `neutral / deny_missing_evidence` check-run instead of `failure`
4. PR #572 can then merge with all checks green or neutral

## Test plan

- [ ] CI green (all required checks)
- [ ] Codex post-impl review on this diff
- [ ] Merge → image build/publish
- [ ] staging-sw redeploy
- [ ] PR #572 new head → neutral conclusion verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)