### PR TITLE
docs(gpp2): record local AI review gate pivot

### DIFF
--- a/.claude/plans/AO-GATE-ROADMAP-TODO.md
+++ b/.claude/plans/AO-GATE-ROADMAP-TODO.md
@@ -1,10 +1,13 @@
 # AO Gate / Repo Intelligence Roadmap Todo
 
-**Status:** draft / editable tracking plan  
-**Date:** 2026-04-28  
-**Owner model:** operator-owned gate infrastructure, product-facing repo-intelligence onboarding  
-**Current program blocker:** `GPP-2 - Protected Live-Adapter Gate Runtime Binding` remains blocked / fail-closed  
-**Decision baseline:** `testai.acik.com/ao-gate` path-based hosting is the preferred internal operator-host path
+**Status:** active / editable tracking plan
+**Date:** 2026-05-22
+**Owner model:** operator-owned gate infrastructure, product-facing repo-intelligence onboarding
+**Current program blocker:** `GPP-2 - Protected Live-Adapter Gate Runtime Binding` remains blocked / fail-closed
+**Decision baseline:** `testai.acik.com/ao-gate` path-based hosting is the
+preferred internal operator-host path; local AI review gate evidence is now the
+preferred next simplification step before further deployment-protection
+callback work.
 
 ## How To Use This Todo
 
@@ -23,6 +26,9 @@
 - [ ] No secret value, private key, webhook secret, or Vault token is committed, echoed, pasted into chat, or stored in evidence.
 - [ ] Claude/Codex consultation remains advisory and is not release authority.
 - [ ] Admin bypass is not used for GPP program PRs.
+- [ ] Local AI review gate evidence is local operator evidence only; it does not
+  close GPP-2, widen support, claim production readiness, or replace later
+  protected-runtime evidence.
 
 ## Public URL Contract
 
@@ -71,15 +77,16 @@ location = /ao-gate/github/ao-release-gate {
 
 | ID | Work package | Repo / surface | Status | Blocking rule | Exit evidence |
 |---|---|---|---|---|---|
-| AO-GATE-1 | Path-based edge plan and runbook | `platform-k8s-gitops` | Not started | No live apply | PR with nginx route, host compose/env example, runbook, rollback |
-| AO-GATE-2 | Operator host service rehearsal | `staging-sw` | Not started | AO-GATE-1 merged | Localhost health JSON for both services |
-| AO-GATE-3 | Public `/ao-gate` nginx route apply | `staging-sw` | Not started | Localhost health passed | Public JSON health via `testai.acik.com/ao-gate/*` |
-| AO-GATE-4 | Public HTTPS health evidence | `ao-kernel` | Not started | Public route returns JSON | `public_https_hosting_evidence=true` artifact |
-| AO-GATE-5 | GitHub App webhook config evidence | GitHub App | Not started | AO-GATE-4 passed | Webhook URLs configured to `/ao-gate/github/*` |
-| AO-GATE-6 | `ao-release-gate` dry-run PR evidence | GitHub PR | Not started | Webhook evidence present | Real PR dry-run check-run evidence |
-| AO-GATE-7 | Deployment-protection callback evidence | GitHub deployment protection | Not started | Policy webhook configured | Callback review evidence or fail-closed evidence |
-| AO-GATE-8 | Branch protection/ruleset cutover | GitHub repo settings | Not started | Dry-run check-run evidence present | Required `ao-release-gate` check blocks merge without pass |
-| AO-GATE-9 | GPP-2 closeout update | `ao-kernel` | Not started | Evidence chain complete | GPP status updated without support widening |
+| AO-GATE-1 | Path-based edge plan and runbook | `platform-k8s-gitops` | DONE | No live apply | PR with nginx route, host compose/env example, runbook, rollback |
+| AO-GATE-2 | Operator host service rehearsal | `staging-sw` | DONE | AO-GATE-1 merged | Localhost health JSON for both services |
+| AO-GATE-3 | Public `/ao-gate` nginx route apply | `staging-sw` | DONE | Localhost health passed | Public JSON health via `testai.acik.com/ao-gate/*` |
+| AO-GATE-4 | Public HTTPS health evidence | `ao-kernel` | DONE | Public route returns JSON | `public_https_hosting_evidence=true` artifact |
+| AO-GATE-5 | GitHub App webhook config evidence | GitHub App | DONE | AO-GATE-4 passed | Webhook URLs configured to `/ao-gate/github/*` |
+| AO-GATE-6 | `ao-release-gate` dry-run PR evidence | GitHub PR | EVIDENCE CAPTURED | Webhook evidence present | Real PR dry-run check-run evidence |
+| LOCAL-GATE-1 | Local AI review evidence gate | `ao-kernel` | PLANNED | GPP-2 remains blocked; no production claim | Local no-secret evidence JSON + fail-closed tests |
+| AO-GATE-7 | Deployment-protection callback evidence | GitHub deployment protection | DEFERRED | Local gate pivot recorded first; policy callback still needs production topology | Callback review evidence or fail-closed evidence |
+| AO-GATE-8 | Branch protection/ruleset cutover | GitHub repo settings | DEFERRED | Enforce-mode success/failure evidence first | Required `ao-release-gate` check blocks merge without pass |
+| AO-GATE-9 | GPP-2 closeout update | `ao-kernel` | BLOCKED | Evidence chain complete | GPP status updated without support widening |
 | RI-NEXT | Repo Intelligence read-only E2E continuation | `ao-kernel` | Blocked | GPP-2 and GPP-4 blockers | GPP-6 execution path reopened |
 
 ## Evidence Artifact Paths
@@ -95,6 +102,7 @@ selects a more specific location.
 | AO-GATE-4 | `internal-gate-host-health-evidence.json` from `scripts/internal_gate_host_health_probe.py` |
 | AO-GATE-5 | `docs/evidence/ao-gate/github-app-webhook-config.v1.md`, with no secret material |
 | AO-GATE-6 | `docs/evidence/ao-gate/ao-release-gate-dry-run-pr.v1.md`, with PR number and commit SHA |
+| LOCAL-GATE-1 | `.ao/evidence/local-gate/<timestamp>-<work-package>.json`, with no secret material |
 | AO-GATE-7 | `docs/evidence/ao-gate/deployment-protection-callback.v1.md`, with no secret material |
 | AO-GATE-8 | `docs/evidence/ao-gate/ao-release-gate-required-check-cutover.v1.md` |
 | AO-GATE-9 | `.claude/plans/gpp_status.v1.json` and `GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md` update PR |
@@ -103,9 +111,9 @@ selects a more specific location.
 
 **Goal:** Prepare the durable, reviewable infrastructure plan without changing live runtime.
 
-**Branch:** `codex/ao-gate-path-edge-plan`  
-**Repo:** `platform-k8s-gitops`  
-**Live change:** no  
+**Branch:** `codex/ao-gate-path-edge-plan`
+**Repo:** `platform-k8s-gitops`
+**Live change:** no
 **Exit decision:** `ao_gate_path_edge_plan_ready_no_live_change`
 
 ### Todo
@@ -137,8 +145,8 @@ selects a more specific location.
 
 **Goal:** Run the two gate services on localhost high ports before public route exposure.
 
-**Repo / surface:** `staging-sw` operator host  
-**Live public change:** no  
+**Repo / surface:** `staging-sw` operator host
+**Live public change:** no
 **Exit decision:** `ao_gate_localhost_health_ready_no_public_route_claim`
 
 ### Todo
@@ -174,8 +182,8 @@ selects a more specific location.
 
 **Goal:** Expose only the planned `/ao-gate` paths through existing `platform-web-nginx`.
 
-**Repo / surface:** `staging-sw` operator host  
-**Live public change:** yes  
+**Repo / surface:** `staging-sw` operator host
+**Live public change:** yes
 **Exit decision:** `ao_gate_public_path_routes_ready_health_probe_pending`
 
 ### Pre-Apply Record
@@ -215,7 +223,7 @@ selects a more specific location.
 
 **Goal:** Produce no-secret hosted health evidence for GPP-2.
 
-**Repo:** `ao-kernel`  
+**Repo:** `ao-kernel`
 **Exit decision:** `internal_gate_host_public_https_health_evidence_collected_no_support_widening`
 
 ### Todo
@@ -250,7 +258,7 @@ selects a more specific location.
 
 **Goal:** Point GitHub App webhook delivery at the hosted gate endpoints after health evidence passes.
 
-**Surface:** GitHub App settings  
+**Surface:** GitHub App settings
 **Exit decision:** `github_app_webhook_configured_after_health_evidence_no_support_widening`
 
 ### Todo
@@ -275,7 +283,7 @@ selects a more specific location.
 
 **Goal:** Prove the check-run service can post a dry-run release gate result on a real PR.
 
-**Surface:** GitHub PR  
+**Surface:** GitHub PR
 **Exit decision:** `ao_release_gate_real_pr_dry_run_check_run_evidence_ready`
 
 ### Todo
@@ -288,11 +296,45 @@ selects a more specific location.
 - [ ] Record status, conclusion, URL, PR number, and commit SHA.
 - [ ] Keep branch protection/ruleset unchanged.
 
+## LOCAL-GATE-1: Local AI Review Evidence Gate
+
+**Goal:** Turn the operator's current local "implementer AI + reviewer AI"
+practice into a repeatable, no-secret, fail-closed local evidence gate before
+continuing heavier deployment-protection callback work.
+
+**Branch:** `codex/gpp2-local-ai-review-gate`
+**Repo:** `ao-kernel`
+**Live change:** no
+**Exit decision:** `local_ai_review_gate_planned_or_implemented_no_production_claim`
+
+### Todo
+
+- [ ] Add or implement `scripts/local_gpp_gate.py`.
+- [ ] Define reviewer evidence JSON with `AGREE`, `REVISE`, and `BLOCK`
+  verdict handling.
+- [ ] Fail closed when reviewer evidence is missing or non-`AGREE`.
+- [ ] Fail closed on forbidden actions, scope mismatch, secret risk, test
+  failure, `support_widening=true`, `production_platform_claim=true`, or
+  `live_adapter_execution=true`.
+- [ ] Emit `.ao/evidence/local-gate/<timestamp>-<work-package>.json` only when
+  explicitly requested.
+- [ ] Add tests for missing review, negative review, positive review, and
+  forbidden flag cases.
+- [ ] Keep this evidence local/operator-scoped; do not wire it to branch
+  protection in this slice.
+
+### Acceptance
+
+- [ ] `python3 scripts/gpp_next.py` still reports GPP-2 blocked.
+- [ ] Local gate tests pass.
+- [ ] Demo evidence artifact contains no secret material.
+- [ ] Docs state that local evidence does not claim production readiness.
+
 ## AO-GATE-7: Deployment-Protection Callback Evidence
 
 **Goal:** Prove the policy service handles deployment-protection callback review behavior.
 
-**Surface:** GitHub deployment protection  
+**Surface:** GitHub deployment protection
 **Exit decision:** `deployment_protection_callback_evidence_ready_fail_closed_preserved`
 
 ### Todo
@@ -309,7 +351,7 @@ selects a more specific location.
 
 **Goal:** Make `ao-release-gate` the durable autonomous merge/release enforcement path after dry-run evidence.
 
-**Surface:** GitHub repository rules  
+**Surface:** GitHub repository rules
 **Exit decision:** `ao_release_gate_required_status_check_cutover_ready_no_admin_bypass`
 
 ### Todo
@@ -326,7 +368,7 @@ selects a more specific location.
 
 **Goal:** Update program state only after the evidence chain exists.
 
-**Repo:** `ao-kernel`  
+**Repo:** `ao-kernel`
 **Exit decision:** `gpp2_protected_gate_runtime_binding_evidence_ready_no_support_widening`
 
 ### Required Evidence Checklist
@@ -362,7 +404,7 @@ selects a more specific location.
 
 **Goal:** Continue the general product path once upstream gates are ready.
 
-**Current status:** blocked by GPP-2 and GPP-4  
+**Current status:** blocked by GPP-2 and GPP-4
 **GPP-4 dependency:** production-certified read-only adapter decision for the real adapter path.
 
 ### Product User Surface
@@ -402,6 +444,7 @@ service, or branch-protection cutover.
 |---|---|---|
 | 2026-04-28 | Initial editable roadmap todo created from Codex + Claude advisory review | Codex |
 | 2026-05-21 | AO-GATE-1..4 + AO-GATE-9 completed; AO-GATE-5..8 remain operator-bound. Codex thread 019e4a10 plan+post-impl AGREE v2.1 + Decision 1 Alt-B + Decision 2 AGREE_A. | Claude |
+| 2026-05-22 | AO-GATE-5..6 evidence captured; AO-GATE-7..8 remain blocked. Local AI review gate pivot added as the next simplification step before more deployment-protection callback work. | Codex |
 
 ## Post-Merge Status (2026-05-21)
 
@@ -427,6 +470,7 @@ ao-kernel#570 (config contract per-service split) + platform-k8s-gitops#942 (git
 |---|---|---|
 | AO-GATE-5 | ✅ DONE (2026-05-22) | Two GitHub Apps created (`ao-kernel-live-adapter-gate-policy` id=3800120 + `ao-release-gate` id=3800233); Vault PEM + webhook-secret seeded (`/pem` and `/value` field-name suffix per ao-kernel `hashicorp_vault_provider.py` contract); `.env` updated per-service; containers Healthy + HMAC verification confirmed (origin returns sig-verified 4xx for ping = `wrong_event` not `signature_invalid`) |
 | AO-GATE-6 | ✅ Evidence captured (2026-05-22) | Webhook delivery chain GREEN via smee.io non-production dry-run proxy (TCP/443 outbound; office firewall blocks TCP+UDP/7844, cloudflared infeasible). PR #572 opened → release-gate App posted check-run `ao-release-gate` conclusion=`failure` output_title=`deny_missing_evidence` (correct fail-closed posture, advisory only — no branch protection cutover) |
+| LOCAL-GATE-1 | ⏳ Planned (2026-05-22) | Local operator trust model pivot: implementer AI + reviewer AI + local fail-closed evidence gate before continuing production callback topology. This does not close GPP-2 and does not replace AO-GATE-7/AO-GATE-8 protected-runtime evidence. |
 | AO-GATE-7 | ⏳ Blocked on App slug reconciliation + production topology | (a) Policy App slug drift: new App is `ao-kernel-live-adapter-gate-policy` but repo constant `REQUIRED_DEPLOYMENT_PROTECTION_APP_SLUG = "ao-kernel-live-adapter-gate"` and protected environment name expect old slug (`ao_kernel/live_adapter_gate.py:34,46`; `ao_kernel/defaults/schemas/live-adapter-gate-environment.schema.v1.json:107,119`); decision needed: rename new App OR update constant/schema/tests/attestation to new slug. (b) Production topology: smee.io is dry-run only; deployment-protection callback path needs publicly-reachable HTTPS endpoint with verified-context. (c) After (a)+(b): `workflow_dispatch` on `live-adapter-gate.yml` with `target_ref=main`, capture deployment_protection_rule webhook id + policy origin signature_verified + callback POST result + workflow run id |
 | AO-GATE-8 | ⏳ Blocked on AO-GATE-6 + AO-GATE-7 | Branch protection cutover: required ao-release-gate check; admin bypass YASAK. Additional gate: at least one **positive `success` conclusion path** demonstrated (not only fail-closed `failure / deny_missing_evidence`) OR explicit documented decision that required check stays advisory until enrichment model produces verified-context |
 

--- a/.claude/plans/AO-GATE-ROADMAP-TODO.md
+++ b/.claude/plans/AO-GATE-ROADMAP-TODO.md
@@ -312,14 +312,19 @@ continuing heavier deployment-protection callback work.
 - [ ] Add or implement `scripts/local_gpp_gate.py`.
 - [ ] Define reviewer evidence JSON with `AGREE`, `REVISE`, and `BLOCK`
   verdict handling.
+- [ ] Require implementer/reviewer provider separation when both identities are
+  declared; same-provider review fails closed.
 - [ ] Fail closed when reviewer evidence is missing or non-`AGREE`.
 - [ ] Fail closed on forbidden actions, scope mismatch, secret risk, test
   failure, `support_widening=true`, `production_platform_claim=true`, or
   `live_adapter_execution=true`.
 - [ ] Emit `.ao/evidence/local-gate/<timestamp>-<work-package>.json` only when
-  explicitly requested.
+  explicitly requested; keep generated evidence local by default because
+  `.ao/evidence/` is gitignored.
 - [ ] Add tests for missing review, negative review, positive review, and
   forbidden flag cases.
+- [ ] Add a no-secret reviewer-evidence template or helper so review evidence is
+  repeatable and not copied from free-form chat.
 - [ ] Keep this evidence local/operator-scoped; do not wire it to branch
   protection in this slice.
 

--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -1,17 +1,19 @@
 # General-Purpose Production Promotion Status
 
-**Status:** GPP-2 internal gate host health probe recorded after internal
-operator host bundle, Cloud Run bootstrap paths, `ao-release-gate` autonomous
-deploy paths, and internal vault secret-id contract; operator-owned public
-hosting evidence, webhook configuration, callback/check-run evidence, and
-cutover still blocked
-**Date:** 2026-04-28
+**Status:** GPP-2 public HTTPS health evidence, GitHub App webhook delivery
+chain evidence, and `ao-release-gate` shadow dry-run check-run evidence are
+recorded; deployment-protection callback evidence, production callback
+topology, enforce-mode success/failure evidence, and branch-protection cutover
+remain blocked. The next simplification step is a local AI review evidence
+gate that codifies the current operator workflow without claiming production
+readiness.
+**Date:** 2026-05-22
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
 **Tracker issue:** [#470](https://github.com/Halildeu/ao-kernel/issues/470)
 **Current slice issue:** [#567](https://github.com/Halildeu/ao-kernel/issues/567)
-for internal gate host health probe
-**Current slice record:** `.claude/plans/GPP-2af-INTERNAL-GATE-HOST-HEALTH-PROBE.md`
+for GPP-2 protected live-adapter gate runtime binding
+**Current slice record:** `.claude/plans/GPP-2ag-LOCAL-AI-REVIEW-GATE-PIVOT.md`
 **Machine-readable status:** `.claude/plans/gpp_status.v1.json`
 **Branch:** none active
 **Worktree:** none active
@@ -30,6 +32,30 @@ until the work packages below close with evidence. Completing a roadmap or
 decision record is not enough; production support requires runtime behavior,
 tests, smoke evidence, CI or protected-gate evidence, docs, runbooks, known-bug
 state, and support-boundary wording to agree.
+
+## 1a. 2026-05-22 Scope Correction
+
+The GPP-2 deployment-protection path has collected useful hosted health,
+webhook delivery, and shadow dry-run check-run evidence. It also introduced
+substantial operator infrastructure: GitHub Apps, Vault-backed private keys,
+webhook secrets, public callback routes, smee.io dry-run proxying, and
+production endpoint decisions.
+
+For the immediate operator-controlled workflow, the core trust requirement is
+smaller:
+
+```text
+implementer AI changes the repo
+reviewer AI reviews independently
+local gate validates rules, tests, scope, secrets, and reviewer verdict
+operator decides whether to merge
+```
+
+Therefore the next planning slice is `GPP-2ag`, a local AI review evidence gate.
+This local gate is preparatory/local evidence only. It does not close GPP-2,
+does not replace AO-GATE-7 deployment-protection callback evidence, does not
+change branch protection, does not execute live adapters, and does not widen
+support or claim production platform readiness.
 
 ## 2. Current Baseline
 
@@ -1090,6 +1116,9 @@ admin bypass for PR merge automation, and must keep
 | 2026-04-28 | GPP-2ae host bundle added | `deploy/internal-gate-host` composes Caddy, the policy service container, and `ao-release-gate` with vault-backed secret ids; `scripts/internal_gate_host_bootstrap_attest.py` records metadata readiness only, with no Docker run, vault access, webhook configuration, callback/check-run posting, live adapter execution, support widening, or production claim. |
 | 2026-04-28 | GPP-2af issue opened | Issue [#567](https://github.com/Halildeu/ao-kernel/issues/567) tracks the no-secret hosted health probe for the internal gate host path. |
 | 2026-04-28 | GPP-2af health probe added | `scripts/internal_gate_host_health_probe.py` can collect public HTTPS health evidence for `/policy/healthz` and `/release-gate/healthz`; it does not configure webhooks, post callbacks/check-runs, change branch protection, dispatch protected workflows, execute live adapters, widen support, or claim production readiness. |
+| 2026-05-21 | GPP-2 public HTTPS hosting evidence recorded | platform-k8s-gitops#938 and ao-kernel#569 recorded no-secret hosted health evidence for the policy service and `ao-release-gate`; GPP-2 remained blocked. |
+| 2026-05-22 | GPP-2 webhook and shadow check-run evidence recorded | ao-kernel#572/#574 recorded GitHub App webhook delivery chain evidence through smee.io non-production dry-run proxy and a real `ao-release-gate` shadow check-run; GPP-2 remained blocked pending callback, topology, enforce-mode, and cutover evidence. |
+| 2026-05-22 | GPP-2ag local AI review gate pivot planned | `.claude/plans/GPP-2ag-LOCAL-AI-REVIEW-GATE-PIVOT.md` records the scope correction: codify the current local implementer-AI + reviewer-AI trust model before continuing the heavier deployment-protection callback path. |
 | 2026-04-28 | GPP-5d issue opened | Issue [#559](https://github.com/Halildeu/ao-kernel/issues/559) tracks repo-intelligence read-only workflow closeout before GPP-6 preparation. |
 | 2026-04-28 | GPP-5d closeout preflight added | `scripts/gpp5_repo_intelligence_closeout.py` records GPP-5 as closed for read-only workflow-surface purposes while keeping GPP-6 execution blocked by GPP-2 and GPP-4. |
 | 2026-04-28 | GPP-6a issue opened | Issue [#561](https://github.com/Halildeu/ao-kernel/issues/561) tracks the read-only E2E preflight contract for GPP-6 preparation. |

--- a/.claude/plans/GPP-2ag-LOCAL-AI-REVIEW-GATE-PIVOT.md
+++ b/.claude/plans/GPP-2ag-LOCAL-AI-REVIEW-GATE-PIVOT.md
@@ -1,0 +1,188 @@
+# GPP-2ag - Local AI Review Gate Pivot
+
+**Status:** planned / local-only gate design
+**Date:** 2026-05-22
+**Parent:** `GPP-2 - Protected Live-Adapter Gate Runtime Binding`
+**Support impact:** none
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## 1. Purpose
+
+Record the scope correction for GPP-2 after PHASE 7-8 evidence collection.
+
+The existing local operator workflow already uses the core trust pattern:
+
+```text
+implementer AI changes the repo
+reviewer AI reviews independently
+operator decides whether to merge
+repo rules and evidence remain the authority
+```
+
+The next near-term goal is to make that local trust pattern explicit,
+repeatable, and evidence-backed before continuing the heavier
+deployment-protection callback path.
+
+This slice does not retire the GitHub App, webhook, or deployment-protection
+work. It splits the program into a smaller sequence:
+
+```text
+GPP-2A: local AI review gate evidence
+GPP-2B: GitHub required check / release-gate enforcement
+GPP-2C: deployment-protection callback / protected workflow gate
+```
+
+GPP-2 remains blocked until the existing protected runtime evidence chain is
+complete. Local evidence is useful operator evidence, not production readiness.
+
+## 2. Current State
+
+Collected evidence:
+
+1. Hosted public HTTPS health evidence exists for the policy service and
+   `ao-release-gate`.
+2. GitHub App webhook delivery chain evidence exists through a smee.io
+   non-production dry-run proxy.
+3. `ao-release-gate` posted a real PR check-run in shadow mode.
+4. Shadow/enforce conclusion mode support is implemented.
+
+Remaining protected-runtime blockers:
+
+1. policy App slug reconciliation;
+2. production-suitable deployment-protection callback topology;
+3. deployment-protection callback review evidence;
+4. enforce-mode positive and negative path evidence;
+5. branch protection / ruleset cutover;
+6. protected workflow evidence rerun.
+
+The heavy callback path is still valid, but it is not the shortest path to
+codifying the operator's current local AI-review trust model.
+
+## 3. Decision
+
+Before continuing AO-GATE-7 production callback topology work, define and
+implement a local AI review gate.
+
+The local gate must:
+
+1. read the repo operating contract and current GPP state;
+2. require an independent reviewer evidence file;
+3. validate that reviewer verdict is `AGREE` before allowing an
+   operator-merge recommendation;
+4. fail closed on missing review, `REVISE`, `BLOCK`, test failure, secret risk,
+   forbidden action, or scope mismatch;
+5. emit a durable no-secret JSON artifact under `.ao/evidence/local-gate/`;
+6. explicitly keep `support_widening=false`,
+   `production_platform_claim=false`, and `live_adapter_execution=false`.
+
+## 4. Non-Goals
+
+This local gate does not:
+
+1. configure GitHub Apps;
+2. change webhook URLs;
+3. use smee.io;
+4. alter branch protection;
+5. dispatch the protected live-adapter workflow;
+6. execute a live adapter;
+7. claim production readiness;
+8. widen support.
+
+## 5. Proposed Local Gate Contract
+
+### Inputs
+
+```text
+AGENTS.md
+.claude/plans/gpp_status.v1.json
+python3 scripts/gpp_next.py
+git status / git diff metadata
+test command result metadata
+secret scan result metadata
+reviewer evidence JSON
+```
+
+### Reviewer Evidence Shape
+
+```json
+{
+  "schema_version": "local-ai-review-evidence.v1",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "GPP-2ag",
+  "reviewer": {
+    "agent": "codex-or-claude",
+    "provider": "openai-or-anthropic",
+    "verdict": "AGREE"
+  },
+  "scope_reviewed": {
+    "base_ref": "origin/main",
+    "head_ref": "codex/example",
+    "changed_files": []
+  },
+  "checks_considered": [],
+  "findings": [],
+  "secrets_recorded": false,
+  "live_adapter_execution": false,
+  "support_widening": false,
+  "production_platform_claim": false
+}
+```
+
+### Gate Output Shape
+
+```json
+{
+  "schema_version": "local-gpp-gate-evidence.v1",
+  "decision": "operator_may_merge",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "GPP-2ag",
+  "checks": {
+    "startup_preflight_passed": true,
+    "gpp_status_checked": true,
+    "scope_allowed": true,
+    "tests_passed": true,
+    "secret_scan_passed": true,
+    "reviewer_agree": true,
+    "forbidden_actions_absent": true
+  },
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false
+}
+```
+
+## 6. Initial Implementation Plan
+
+1. Add `scripts/local_gpp_gate.py`.
+2. Add a JSON-schema-like validator in code for reviewer evidence.
+3. Add unit tests covering:
+   - missing reviewer evidence fails;
+   - reviewer `REVISE` fails;
+   - reviewer `BLOCK` fails;
+   - reviewer `AGREE` plus passing checks succeeds;
+   - forbidden-action flag fails;
+   - `support_widening=true`, `production_platform_claim=true`, or
+     `live_adapter_execution=true` fails.
+4. Add a sample no-secret fixture under `tests/fixtures/local_gpp_gate/`.
+5. Emit evidence only when requested with an explicit output path.
+6. Do not wire this to branch protection in this slice.
+
+## 7. Acceptance
+
+The slice is acceptable when:
+
+1. local gate tests pass;
+2. `python3 scripts/gpp_next.py` still reports GPP-2 blocked;
+3. a demo run can produce a no-secret local evidence artifact;
+4. missing/negative reviewer evidence fails closed;
+5. docs clearly state this is local operator evidence, not production readiness.
+
+## 8. Follow-Up Split
+
+After GPP-2A local evidence is stable:
+
+1. GPP-2B can map the same local evidence contract to `ao-release-gate`
+   required check behavior.
+2. GPP-2C can continue production deployment-protection callback evidence when
+   a stable endpoint and App slug decision are ready.

--- a/.claude/plans/GPP-2ag-LOCAL-AI-REVIEW-GATE-PIVOT.md
+++ b/.claude/plans/GPP-2ag-LOCAL-AI-REVIEW-GATE-PIVOT.md
@@ -70,10 +70,12 @@ The local gate must:
 2. require an independent reviewer evidence file;
 3. validate that reviewer verdict is `AGREE` before allowing an
    operator-merge recommendation;
-4. fail closed on missing review, `REVISE`, `BLOCK`, test failure, secret risk,
-   forbidden action, or scope mismatch;
-5. emit a durable no-secret JSON artifact under `.ao/evidence/local-gate/`;
-6. explicitly keep `support_widening=false`,
+4. verify implementer and reviewer provider separation when both identities are
+   declared;
+5. fail closed on missing review, `REVISE`, `BLOCK`, same-provider review,
+   test failure, secret risk, forbidden action, or scope mismatch;
+6. emit a durable no-secret JSON artifact under `.ao/evidence/local-gate/`;
+7. explicitly keep `support_widening=false`,
    `production_platform_claim=false`, and `live_adapter_execution=false`.
 
 ## 4. Non-Goals
@@ -110,6 +112,10 @@ reviewer evidence JSON
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
   "work_package": "GPP-2ag",
+  "implementer": {
+    "agent": "codex-or-claude",
+    "provider": "openai-or-anthropic"
+  },
   "reviewer": {
     "agent": "codex-or-claude",
     "provider": "openai-or-anthropic",
@@ -144,6 +150,7 @@ reviewer evidence JSON
     "tests_passed": true,
     "secret_scan_passed": true,
     "reviewer_agree": true,
+    "cross_provider_verified": true,
     "forbidden_actions_absent": true
   },
   "support_widening": false,
@@ -155,18 +162,32 @@ reviewer evidence JSON
 ## 6. Initial Implementation Plan
 
 1. Add `scripts/local_gpp_gate.py`.
-2. Add a JSON-schema-like validator in code for reviewer evidence.
+2. Add a real JSON Schema contract for reviewer evidence and validate it with
+   the existing JSON Schema toolchain rather than a free-form parser.
 3. Add unit tests covering:
    - missing reviewer evidence fails;
    - reviewer `REVISE` fails;
    - reviewer `BLOCK` fails;
+   - implementer and reviewer with the same provider fails;
    - reviewer `AGREE` plus passing checks succeeds;
    - forbidden-action flag fails;
    - `support_widening=true`, `production_platform_claim=true`, or
      `live_adapter_execution=true` fails.
 4. Add a sample no-secret fixture under `tests/fixtures/local_gpp_gate/`.
-5. Emit evidence only when requested with an explicit output path.
-6. Do not wire this to branch protection in this slice.
+5. Add a no-secret reviewer-evidence template or helper so the reviewer output
+   path is repeatable instead of ad hoc chat text.
+6. Emit evidence only when requested with an explicit output path, for example:
+
+   ```bash
+   python3 scripts/local_gpp_gate.py \
+     --review-evidence tests/fixtures/local_gpp_gate/reviewer_agree.v1.json \
+     --output .ao/evidence/local-gate/demo-gpp-2ag.json
+   ```
+
+7. Keep `.ao/evidence/local-gate/` local by default because `.ao/evidence/` is
+   gitignored. Commit only curated no-secret fixtures or deliberate evidence
+   summaries.
+8. Do not wire this to branch protection in this slice.
 
 ## 7. Acceptance
 

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -11,7 +11,7 @@
     "status": "blocked",
     "issue": "https://github.com/Halildeu/ao-kernel/issues/567",
     "exit_decision": "webhook_delivery_chain_and_shadow_dry_run_check_run_collected_policy_callback_and_cutover_blocked_no_support_widening",
-    "ready_after": "operator-owned policy service and ao-release-gate are hosted on public HTTPS endpoints from the internal operator host bundle or equivalent infrastructure with internal vault-backed runtime secret ids, GitHub App webhook URLs are configured, policy callback review evidence exists, real PR dry-run check-run evidence is collected, branch protection requires ao-release-gate after evidence, and protected workflow evidence confirms live_execution_allowed=false",
+    "ready_after": "operator-owned policy service and ao-release-gate are hosted on public HTTPS endpoints from the internal operator host bundle or equivalent infrastructure with internal vault-backed runtime secret ids, GitHub App webhook URLs are configured, policy callback review evidence exists, real PR dry-run check-run evidence is collected, local AI review gate evidence is available for operator-controlled merges, branch protection requires ao-release-gate after evidence, and protected workflow evidence confirms live_execution_allowed=false",
     "allowed_scope": [
       "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service on operator-owned internal infrastructure without secret value exposure",
       "use the repo-owned ao-release-gate GHCR image or container package to deploy or configure the ao-release-gate GitHub App check-run service on operator-owned internal infrastructure without secret value exposure",
@@ -19,6 +19,7 @@
       "collect no-secret public HTTPS health evidence with scripts/internal_gate_host_health_probe.py after the internal gate host is deployed",
       "configure hosted gate runtimes with internal vault secret ids rather than committed, echoed, or repository-stored secret values",
       "document or build end-user onboarding paths that do not require users to self-host the GPP-2 policy service, vault, webhook secret, GitHub App private key, or Cloud Run project",
+      "design or implement a local AI review evidence gate that validates implementer AI plus independent reviewer AI evidence for operator-controlled local merges without changing branch protection or claiming production readiness",
       "repeat protected workflow evidence collection from main after the policy service responds",
       "keep live execution disabled until protected workflow evidence explicitly permits a later live run"
     ],
@@ -376,6 +377,7 @@
     "cut branch protection/ruleset over to require ao-release-gate only after enforce-mode evidence is captured; admin bypass YASAK",
     "validate whether GitHub App review-counting works for the current branch protection; if not, cut over to a required ao-release-gate status check",
     "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
+    "define and implement the local AI review evidence gate as GPP-2A local/operator evidence before continuing heavier deployment-protection callback topology work",
     "keep end-user repo-intelligence onboarding independent from GPP-2 gate hosting by requiring at most GitHub App installation, repository selection, and explicit opt-in configuration"
   ],
   "support_widening_allowed": false,
@@ -435,6 +437,7 @@
   ],
   "next_allowed_actions": [
     "treat the GPP-2 deployment-protection policy service as operator-owned platform infrastructure, not an end-user setup requirement",
+    "use the local AI review evidence gate as a preparatory operator-controlled trust mechanism only; it does not close GPP-2, change branch protection, execute live adapters, widen support, or claim production readiness",
     "prioritize repo-intelligence onboarding as a read-only product workflow that requires GitHub App installation and repository selection, not Cloud Run, vault, webhook, or private-key setup by each user",
     "use GPP-6a read-only E2E preflight evidence for preparation only, while GPP-6 execution remains blocked until GPP-2 protected gate and GPP-4 read-only adapter decision are ready and support_widening_allowed=false and production_platform_claim_allowed=false",
     "prefer the internal operator host plus vault-backed secret-id path for GPP-2 service hosting unless a later decision reselects Cloud Run",
@@ -463,5 +466,5 @@
     "treat inactive, denied, timed out, cancelled, or failing deployment protection as fail-closed evidence, not approval",
     "do not widen support or claim production platform readiness"
   ],
-  "last_updated": "2026-05-22T07:58:24Z"
+  "last_updated": "2026-05-22T09:15:00Z"
 }

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -275,8 +275,9 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     # 'ao-kernel-live-adapter-gate-policy' vs repo constant), production-
     # suitable callback topology (smee.io is non-production dry-run),
     # callback review evidence, enforce-mode positive/negative paths,
-    # and branch-protection cutover (admin bypass YASAK). Audit trail
-    # of PHASE 7 + 8 lives in `current_wp.evidence_collected[]`.
+    # branch-protection cutover (admin bypass YASAK), and the local
+    # AI-review evidence gate pivot. Audit trail of PHASE 7 + 8 lives
+    # in `current_wp.evidence_collected[]`.
     assert payload["pending_external_actions"] == [
         "resolve policy App slug drift: either rename new GitHub App from 'ao-kernel-live-adapter-gate-policy' to canonical 'ao-kernel-live-adapter-gate' or migrate repo constants/schema/tests/attestation to new slug",
         "establish production-suitable deployment-protection callback topology; smee.io remains non-production dry-run only",
@@ -285,6 +286,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
         "cut branch protection/ruleset over to require ao-release-gate only after enforce-mode evidence is captured; admin bypass YASAK",
         "validate whether GitHub App review-counting works for the current branch protection; if not, cut over to a required ao-release-gate status check",
         "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
+        "define and implement the local AI review evidence gate as GPP-2A local/operator evidence before continuing heavier deployment-protection callback topology work",
         (
             "keep end-user repo-intelligence onboarding independent from GPP-2 gate hosting by requiring at most "
             "GitHub App installation, repository selection, and explicit opt-in configuration"
@@ -362,6 +364,11 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(
         action
         == "treat the GPP-2 deployment-protection policy service as operator-owned platform infrastructure, not an end-user setup requirement"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "use the local AI review evidence gate as a preparatory operator-controlled trust mechanism only; it does not close GPP-2, change branch protection, execute live adapters, widen support, or claim production readiness"
         for action in payload["next_allowed_actions"]
     )
     assert any(


### PR DESCRIPTION
## Summary

Records the GPP-2 scope correction we discussed: use a local AI-review evidence gate as the next simplification step before continuing heavier deployment-protection callback topology work.

This PR:
- adds `GPP-2ag-LOCAL-AI-REVIEW-GATE-PIVOT.md`
- updates the editable AO-GATE roadmap so AO-GATE-1..6 reflect current evidence and `LOCAL-GATE-1` is the next planned local step
- refreshes the human-readable GPP status header/timeline
- updates `gpp_status.v1.json` so `gpp_next.py` shows local AI review gate work as allowed preparatory/operator evidence
- keeps GPP-2 blocked; no support widening, production claim, live adapter execution, branch protection, webhook, or runtime change

## Validation

- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `python3 scripts/gpp_next.py`
- `python3 -m pytest -q tests/test_gpp_next.py tests/test_ao_release_gate.py tests/test_ao_release_gate_runtime.py tests/test_ao_release_gate_service.py`
- `python3 -m pytest -q tests/test_gpp_next.py`
- `git diff --check`

## Guardrails

- `support_widening_allowed=false` preserved
- `production_platform_claim_allowed=false` preserved
- `live_adapter_execution_allowed=false` preserved
- local gate evidence is explicitly local/operator-scoped and does not close GPP-2
