### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # Default owner
-* @Halildeu
+* @Halildeu @gladyatore-lab
 
 # Governance-sensitive surfaces
-/.github/ @Halildeu
-/.claude/ @Halildeu
-/CLAUDE.md @Halildeu
-/ao_kernel/defaults/policies/ @Halildeu
-/docs/ @Halildeu
+/.github/ @Halildeu @gladyatore-lab
+/.claude/ @Halildeu @gladyatore-lab
+/CLAUDE.md @Halildeu @gladyatore-lab
+/ao_kernel/defaults/policies/ @Halildeu @gladyatore-lab
+/docs/ @Halildeu @gladyatore-lab

--- a/.github/REPO-GOVERNANCE.md
+++ b/.github/REPO-GOVERNANCE.md
@@ -1,6 +1,6 @@
 # Repo Governance and Merge Gates
 
-**Durum tarihi:** 2026-04-22
+**Durum tarihi:** 2026-05-22
 **Program status SSOT:** [`.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md`](../.claude/plans/PRODUCTION-HARDENING-PROGRAM-STATUS.md)
 **Operasyon protokolü:** `CLAUDE.md` §19 ve §20
 
@@ -54,7 +54,8 @@ Kaynak: `gh api repos/Halildeu/ao-kernel/branches/main/protection`
 Şu an aktif branch protection unsurları:
 
 - required status checks
-- 1 approval
+- 1 approval (`required_approving_review_count = 1`)
+- code-owner review zorunlu (`require_code_owner_reviews = true`)
 - conversation resolution
 - force-push kapalı
 - branch deletion kapalı
@@ -81,24 +82,31 @@ WP-5 hedefi olarak `main` branch protection için beklenen minimum set:
 - `required_conversation_resolution = true`
 - `enforce_admins = true`
 
-### 3.3 Code-owner notu
+### 3.3 Code-owner notu (2026-05-22 güncellemesi)
 
-`CODEOWNERS` dosyası repo içinde şimdi mevcuttur, ancak `require_code_owner_reviews = true`
-ayarının platformda açılması operasyonel bir önkoşula bağlıdır:
+`require_code_owner_reviews = true` platformda **aktiftir** ve `.github/CODEOWNERS`
+artık iki code owner taşır: `@Halildeu` ve `@gladyatore-lab`.
 
-- Şu an canlı GitHub collaborator görünümünde yalnız `@Halildeu` yazma/admin
-  yetkisi ile görünmektedir.
-- Bu durumda code-owner review zorunluluğu tek maintainer döneminde normal
-  merge akışını kilitleyebilir.
+**Single-owner, dual-account, non-author approval lane:** `ao-kernel` tek
+operatör tarafından yönetilen bir repodur. `@gladyatore-lab`, operatörün ikinci
+GitHub hesabıdır — bağımsız bir ikinci insan reviewer DEĞİLDİR. Write
+collaborator + code owner olarak eklenmesinin tek amacı, GitHub'ın "author kendi
+PR'ını approve edemez" kısıtını **branch protection'ı gevşetmeden** aşmaktır:
 
-Bu yüzden code-owner enforcement kararı iki şekilde ele alınmalıdır:
+- Agent-üretimi PR'ların author'ı genelde `@Halildeu` olur; `@gladyatore-lab`
+  non-author code-owner approval'ı sağlar (tersi de geçerlidir).
+- Bu bir branch-protection bypass DEĞİLDİR: `--admin` kullanılmaz,
+  `required_approving_review_count` / `require_code_owner_reviews` kapatılmaz,
+  required status checks aynen korunur.
+- Esas bağımsız teknik review, cross-AI peer review'dur (farklı sağlayıcı —
+  Codex); `@gladyatore-lab` onayı bunun GitHub'daki mekanik kaydıdır.
+- Bu düzenleme support widening, production-platform claim veya live-adapter
+  execution **üretmez**; GPP-2 `blocked` kalır.
 
-1. en az bir ikinci write-access maintainer görünür hale geldiğinde platformda
-   `require_code_owner_reviews = true` açılır
-2. aksi durumda `CODEOWNERS` repo içi ownership ve review hedefi olarak kalır,
-   ama platform enforcement ayrı karar olarak tutulur
-
-Bu nüans `WP-5.3` sırasında açıkça yeniden değerlendirilmelidir.
+Bootstrap: ilk `CODEOWNERS` değişikliği (`@gladyatore-lab`'ın owner eklenmesi)
+`@gladyatore-lab` tarafından açılan PR ile yapıldı; böylece `@Halildeu` (code
+owner + non-author) onu approve edebildi — chicken-and-egg deadlock,
+branch-protection mutation olmadan kırıldı.
 
 ## 4. İşletim Kuralları
 


### PR DESCRIPTION
## Scope

- Issue: — CODEOWNERS bootstrap enabling the PR #578 merge path
- Work package: GPP-2 — single-owner dual-account non-author approval lane
- Why now: agent-authored PRs (author `Halildeu`) are blocked by branch protection's required code-owner review — `Halildeu` cannot self-approve and was the only code owner. This adds `@gladyatore-lab` (the operator's second account, a Write collaborator) as a co-code-owner so it can provide the non-author code-owner review, with no `--admin` and no branch-protection mutation.

## Validation

- [x] Relevant tests: n/a — `.github/CODEOWNERS` + `.github/REPO-GOVERNANCE.md` only; required CI checks run on the PR
- [x] Smoke or packaging proof (if required): n/a
- [x] Docs or status updated: `.github/REPO-GOVERNANCE.md` §2 + §3.3 updated to record the dual-account model
- [x] Deferred risks noted: none

## Governance checks

- [x] Branch is short-lived and based on fresh `main`
- [x] No unrelated dirty files were included
- [x] If stacked: n/a — not stacked
- [x] Required check impact reviewed (`lint`, `test (3.11)`, `test (3.12)`, `test (3.13)`, `coverage`, `typecheck`, `packaging-smoke`)
- [x] If governance changed: `.github/REPO-GOVERNANCE.md` updated

## Merge notes

- [x] Merge method chosen deliberately — squash (non-stacked PR)

## Cross-AI peer review

- Implementer: Claude (Anthropic) — CODEOWNERS + REPO-GOVERNANCE.md content
- Reviewer: Codex (OpenAI), thread `019e5067` — **AGREE**, no blocking finding (initial REVISE on the missing REPO-GOVERNANCE.md update was absorbed in commit `f27f1e7`)
- Provider-level cross-AI per HARD RULE

## Bootstrap note

Authored by `gladyatore-lab` so `@Halildeu` (code owner, non-author) can approve it — this breaks the chicken-and-egg deadlock without `--admin` or branch-protection mutation. Operator-controlled dual-account model; `gladyatore-lab` is the operator's second account, not an independent reviewer. No support widening, no production claim, no live adapter; GPP-2 stays blocked.