### PR TITLE
docs(gpp2b): resolve Category-C gap + ao-release-gate review-evidence input schema

### DIFF
--- a/.claude/plans/GPP-2B-AO-RELEASE-GATE-REQUIRED-CHECK-MAPPING.md
+++ b/.claude/plans/GPP-2B-AO-RELEASE-GATE-REQUIRED-CHECK-MAPPING.md
@@ -154,6 +154,63 @@ it keeps the required check from being weaker than the local gate without
 reintroducing raw-reviewer-text leakage. The final choice is deferred to the
 GPP-2B implementation slice (GPP-2B-3) plus a Codex consultation.
 
+### 5.1 Resolution (GPP-2B-3)
+
+Resolved via Codex consultation (thread `019e50c8`): **Option 1**.
+
+**Decision.** `ao-release-gate` will eventually require attested cross-AI
+review evidence. Option 2 would leave the required check deliberately weaker
+than the local gate on the Category-C dimension. GPP-2B-3 closes the gap's
+**design decision** only — the runtime enforcement gap closes later, when
+`ao-release-gate` actually consumes the artifact and enters the
+required-check / enforce chain. GPP-2 stays `blocked`.
+
+**Accepted artifact.** The existing no-secret `local-gpp-gate-evidence.v1`
+gate output, consumed as-is. No new evidence artifact is introduced, and no
+replacement for `local-gpp-gate-evidence.schema.v1.json` is introduced —
+`local-gpp-gate-evidence.v1` remains the evidence SSOT. It already encodes
+`reviewer_agree`, `cross_provider_verified`, and `operator_may_merge`, and is
+no-secret by schema construction. A second evidence artifact would duplicate it
+and risk drift. (The acceptance-profile schema added by this slice, described
+next, is a consumption contract — not an evidence schema.)
+
+**Acceptance-profile schema.** GPP-2B-3 adds one design-only schema,
+`ao_kernel/defaults/schemas/ao-release-gate-review-evidence-input.schema.v1.json`.
+It is an *acceptance profile*, not a standalone structural validator: it
+constrains only the acceptance-critical fields (`decision` =
+`operator_may_merge`; `checks.reviewer_agree` and `checks.cross_provider_verified`
+= `true`; the closed GPP guard flags) and permits the artifact's other fields.
+It deliberately omits a `$ref` / `allOf` to `local-gpp-gate-evidence.schema.v1.json`
+because the bundled-schema loader resolves single files only and builds no
+registry for an external `$ref`. The future check therefore validates in two
+steps: **first** the full `local-gpp-gate-evidence.schema.v1.json`, **then**
+this acceptance profile.
+
+**Future check (design only — not implemented in this slice).** A future
+`ao-release-gate` check named `cross_ai_review` would verify that the review
+evidence is present, structurally valid against
+`local-gpp-gate-evidence.schema.v1.json`, conformant to the acceptance profile,
+and context-consistent:
+
+- `repo` equals the normalized PR repository;
+- `work_package` equals the PR's explicitly declared reviewed slice — it is
+  **not** equated blindly to `gpp_status.current_wp.id`, since the current work
+  package may be the parent `GPP-2` while a valid artifact carries a slice id
+  such as `GPP-2B-3` — and implies no work outside the parent `GPP-2` scope;
+- `gpp_2_status` is `blocked`.
+
+Missing, schema-invalid, non-accepting, or context-mismatched evidence maps to
+`deny_missing_evidence`, with granular finding codes:
+`ao_release_gate_cross_ai_review_evidence_missing`,
+`ao_release_gate_cross_ai_review_evidence_schema_invalid`,
+`ao_release_gate_cross_ai_review_evidence_not_accepting`,
+`ao_release_gate_cross_ai_review_evidence_context_mismatch`.
+
+**Scope.** Design only: no `ao_release_gate.py` change, no service wiring, no
+payload-field handling, no webhook or GitHub App config, no enforce-mode
+switch, no branch-protection cutover, no `gpp_status.v1.json` change. GPP-2
+stays `blocked`; the guard flags stay `false`.
+
 ## 6. GPP-2B implementation plan (phased)
 
 All slices are docs/schema/test scope. No cutover, no enforce-mode switch, no
@@ -163,7 +220,7 @@ webhook/App configuration, no live adapter.
 |---|---|---|
 | **GPP-2B-1** | This mapping record (this PR). | docs only |
 | **GPP-2B-2** | A machine-checkable mapping test pinning the §3.1 table to both gates' live check sets: every local-gate check (8, from `local-gpp-gate-evidence.schema.v1.json`) and every `ao-release-gate` check (18, from `build_ao_release_gate_decision`) must appear in the table with a documented counterpart or an explicit `local-only` marker, so the mapping cannot silently drift on either side. Implemented as `tests/test_gpp2b_mapping_drift_guard.py`. | docs + test |
-| **GPP-2B-3** | Resolve the Category-C gap (§5) via Codex consultation; if Option 1 is selected, design the attested-review-evidence schema/contract (design only — no service wiring). | docs + schema |
+| **GPP-2B-3** | Resolve the Category-C gap (§5) via Codex consultation; if Option 1 is selected, design the attested-review-evidence schema/contract (design only — no service wiring). Resolved as Option 1 in §5.1; acceptance-profile schema `ao_kernel/defaults/schemas/ao-release-gate-review-evidence-input.schema.v1.json` + contract test `tests/test_gpp2b3_review_evidence_input_schema.py`. | docs + schema + test |
 | **GPP-2B-4** | Unit/schema-level conclusion-mapping test against the side-effect-free decision core: assert `build_ao_release_gate_decision(..., conclusion_mode=...)` maps decisions to GitHub conclusions correctly — `allow_autonomous_merge` → `success`; `deny_*` / `error_fail_closed` → `neutral` under `shadow` and `failure` under `enforce`. Pure in-process unit test; the hosted runtime mode is not changed, no check-run is posted to any PR, branch protection is untouched. | docs + test |
 
 Real enforce-mode evidence on live PRs — switching the hosted runtime to

--- a/ao_kernel/defaults/schemas/ao-release-gate-review-evidence-input.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-release-gate-review-evidence-input.schema.v1.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:ao-release-gate-review-evidence-input:v1",
+  "title": "ao-release-gate Attested Review Evidence Input",
+  "description": "GPP-2B-3 design-only acceptance profile for the attested cross-AI review evidence that a future ao-release-gate check would consume to close the Category-C gap (see .claude/plans/GPP-2B-AO-RELEASE-GATE-REQUIRED-CHECK-MAPPING.md section 5.1). The accepted artifact is the existing no-secret local-gpp-gate-evidence.v1 gate output, consumed as-is; no new evidence artifact is introduced. This is an acceptance profile, not a standalone structural validator: it constrains only the acceptance-critical fields and permits the artifact's other fields. A future ao-release-gate check MUST first validate the artifact against local-gpp-gate-evidence.schema.v1.json, then validate the same artifact against this acceptance profile. No service wiring exists: ao_release_gate.py does not read this contract, no check-run is posted, branch protection is unchanged, and GPP-2 stays blocked.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "decision",
+    "repo",
+    "work_package",
+    "checks",
+    "gpp_2_status",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "local-gpp-gate-evidence.v1",
+      "description": "The attested artifact must be a local-gpp-gate-evidence.v1 gate output."
+    },
+    "decision": {
+      "const": "operator_may_merge",
+      "description": "ao-release-gate accepts the attestation only when the local gate recorded operator_may_merge. A fail_closed artifact is not accepting evidence and maps to deny_missing_evidence."
+    },
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Repository the local gate evaluated. The future check compares this against the normalized PR repository."
+    },
+    "work_package": {
+      "type": "string",
+      "minLength": 1,
+      "description": "GPP work package or slice the local gate evaluated. The future check compares this against the PR's explicitly declared reviewed slice, not blindly against gpp_status.current_wp.id, because the current work package may be the parent GPP-2 while the artifact carries a slice id such as GPP-2B-3."
+    },
+    "checks": {
+      "type": "object",
+      "required": [
+        "reviewer_agree",
+        "cross_provider_verified"
+      ],
+      "properties": {
+        "reviewer_agree": {
+          "const": true,
+          "description": "The independent reviewer AI returned AGREE."
+        },
+        "cross_provider_verified": {
+          "const": true,
+          "description": "The implementer AI provider and the reviewer AI provider differ."
+        }
+      },
+      "description": "The acceptance profile constrains only the two Category-C checks. The full checks object (all eight local-gate checks) is validated separately against local-gpp-gate-evidence.schema.v1.json; additional check keys are permitted here by design."
+    },
+    "gpp_2_status": {
+      "const": "blocked",
+      "description": "The attested artifact must confirm GPP-2 is still blocked."
+    },
+    "support_widening": {
+      "const": false,
+      "description": "The attested artifact must confirm support widening stays closed."
+    },
+    "production_platform_claim": {
+      "const": false,
+      "description": "The attested artifact must confirm no production platform claim."
+    },
+    "live_adapter_execution": {
+      "const": false,
+      "description": "The attested artifact must confirm no live adapter execution."
+    }
+  }
+}

--- a/tests/test_gpp2b3_review_evidence_input_schema.py
+++ b/tests/test_gpp2b3_review_evidence_input_schema.py
@@ -1,0 +1,115 @@
+"""GPP-2B-3 contract test for the ao-release-gate attested review evidence input.
+
+The acceptance-profile schema
+``ao-release-gate-review-evidence-input.schema.v1.json`` constrains which
+``local-gpp-gate-evidence.v1`` artifacts a future ao-release-gate
+``cross_ai_review`` check would accept. These tests pin that contract: a valid
+``operator_may_merge`` artifact is accepted, and every acceptance-critical
+deviation is rejected.
+
+Design-only slice: no ``ao_release_gate.py`` wiring consumes this schema yet.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+_PROFILE = "ao-release-gate-review-evidence-input.schema.v1.json"
+_FULL = "local-gpp-gate-evidence.schema.v1.json"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _schema(name: str) -> dict:
+    path = _repo_root() / "ao_kernel" / "defaults" / "schemas" / name
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _accepting_artifact() -> dict:
+    """A real local-gpp-gate-evidence.v1 artifact recording operator_may_merge."""
+    return {
+        "schema_version": "local-gpp-gate-evidence.v1",
+        "decision": "operator_may_merge",
+        "repo": "Halildeu/ao-kernel",
+        "work_package": "GPP-2B-3",
+        "generated_at": "2026-05-22T00:00:00Z",
+        "checks": {
+            "startup_preflight_passed": True,
+            "gpp_status_checked": True,
+            "scope_allowed": True,
+            "tests_passed": True,
+            "secret_scan_passed": True,
+            "reviewer_agree": True,
+            "cross_provider_verified": True,
+            "forbidden_actions_absent": True,
+        },
+        "findings": [],
+        "reviewer_findings_count": 0,
+        "gpp_2_status": "blocked",
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+    }
+
+
+def test_acceptance_profile_is_valid_schema() -> None:
+    """The acceptance-profile schema is a valid Draft 2020-12 schema."""
+    profile = _schema(_PROFILE)
+    Draft202012Validator.check_schema(profile)
+    assert profile["$id"] == "urn:ao:ao-release-gate-review-evidence-input:v1"
+
+
+def test_accepting_artifact_passes_full_schema_then_profile() -> None:
+    """A real operator_may_merge artifact passes the full evidence schema and
+    then the acceptance profile — the documented two-step validation order.
+
+    The artifact deliberately carries the gate-output-only fields
+    (generated_at, findings, reviewer_findings_count); the profile accepting it
+    proves the acceptance profile keeps additionalProperties open by design.
+    """
+    artifact = _accepting_artifact()
+    assert {"generated_at", "findings", "reviewer_findings_count"} <= set(artifact)
+    full_errors = list(Draft202012Validator(_schema(_FULL)).iter_errors(artifact))
+    assert full_errors == [], f"artifact rejected by full evidence schema: {full_errors}"
+    profile_errors = list(Draft202012Validator(_schema(_PROFILE)).iter_errors(artifact))
+    assert profile_errors == [], f"artifact rejected by acceptance profile: {profile_errors}"
+
+
+def test_profile_rejects_fail_closed_decision() -> None:
+    """A fail_closed artifact is not accepting review evidence."""
+    artifact = _accepting_artifact()
+    artifact["decision"] = "fail_closed"
+    assert not Draft202012Validator(_schema(_PROFILE)).is_valid(artifact)
+
+
+def test_profile_rejects_reviewer_disagreement() -> None:
+    """reviewer_agree=false fails the acceptance profile."""
+    artifact = _accepting_artifact()
+    artifact["checks"]["reviewer_agree"] = False
+    assert not Draft202012Validator(_schema(_PROFILE)).is_valid(artifact)
+
+
+def test_profile_rejects_same_provider_review() -> None:
+    """cross_provider_verified=false fails the acceptance profile."""
+    artifact = _accepting_artifact()
+    artifact["checks"]["cross_provider_verified"] = False
+    assert not Draft202012Validator(_schema(_PROFILE)).is_valid(artifact)
+
+
+def test_profile_rejects_open_gpp_guards() -> None:
+    """A non-blocked GPP-2 status or any open GPP guard flag fails the profile."""
+    validator = Draft202012Validator(_schema(_PROFILE))
+    for field, bad_value in (
+        ("gpp_2_status", "active"),
+        ("support_widening", True),
+        ("production_platform_claim", True),
+        ("live_adapter_execution", True),
+    ):
+        artifact = _accepting_artifact()
+        artifact[field] = bad_value
+        assert not validator.is_valid(artifact), f"profile wrongly accepted open {field}"


### PR DESCRIPTION
## Summary

GPP-2B-3 slice — resolve the Category-C cross-AI-review gap and add the
attested-review-evidence input contract.

- **Resolution.** The mapping doc §5 left the Category-C gap (cross-AI review
  has no `ao-release-gate` counterpart) to a Codex consultation. Resolved as
  **Option 1**: `ao-release-gate` will eventually require attested cross-AI
  review evidence, consuming the existing no-secret `local-gpp-gate-evidence.v1`
  artifact as-is. No new evidence artifact, no replacement evidence schema —
  `local-gpp-gate-evidence.v1` stays the evidence SSOT. Recorded in mapping doc
  §5.1.
- **Schema.** Adds `ao_kernel/defaults/schemas/ao-release-gate-review-evidence-input.schema.v1.json`,
  a design-only *acceptance profile*: it constrains the acceptance-critical
  fields (`decision` = `operator_may_merge`; `checks.reviewer_agree` /
  `cross_provider_verified` = `true`; the closed GPP guards) and keeps
  `additionalProperties` open so the full gate output still validates. No
  `$ref` — the bundled-schema loader resolves single files only.
- **Test.** Adds `tests/test_gpp2b3_review_evidence_input_schema.py` (6 checks):
  schema validity, the two-step positive path, and four acceptance-critical
  rejections.

## Scope / non-goals

Design only. **No** `ao_release_gate.py` change, **no** service wiring, **no**
payload-field handling, **no** webhook / GitHub App config, **no** enforce-mode
switch, **no** branch-protection cutover. GPP-2 stays `blocked`;
`gpp_status.v1.json` guard flags stay `false`. GPP-2B-3 closes the gap's
*design decision* only — runtime enforcement closes later (GPP-2C / AO-GATE-8).

## Cross-AI peer review

- Implementer: Claude (Anthropic)
- Reviewer: Codex (OpenAI, thread `019e50c8`) — plan-time **AGREE** (4
  decisions resolved) and post-impl **AGREE** (after one REVISE round: doc
  wording contradiction + add the contract test — both absorbed).

## Test plan

- [x] `pytest tests/test_gpp2b3_review_evidence_input_schema.py` — 6/6 pass
- [x] `pytest tests/test_gpp2b_mapping_drift_guard.py` — 7/7 (GPP-2B-2 regression)
- [x] Schema validity + positive/negative artifact validation verified
- [x] `ruff check tests/` clean
- [ ] Required CI checks green
- [ ] Non-author code-owner approval (`gladyatore-lab`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)