### PR TITLE
docs(gpp-2): sync no-testai active blocker model

### DIFF
--- a/.claude/plans/AO-GATE-ROADMAP-TODO.md
+++ b/.claude/plans/AO-GATE-ROADMAP-TODO.md
@@ -4,10 +4,12 @@
 **Date:** 2026-05-22
 **Owner model:** operator-owned gate infrastructure, product-facing repo-intelligence onboarding
 **Current program blocker:** `GPP-2 - Protected Live-Adapter Gate Runtime Binding` remains blocked / fail-closed
-**Decision baseline:** `testai.acik.com/ao-gate` path-based hosting is the
-preferred internal operator-host path; local AI review gate evidence is now the
-preferred next simplification step before further deployment-protection
-callback work.
+**Decision baseline:** the active no-testai near-term path is local/operator
+release governance: cross-provider AI review, non-author GitHub approval,
+`local_gpp_gate` evidence, and `ao-release-gate` required-check mapping.
+`testai.acik.com/ao-gate`, smee.io delivery, deployment-protection callback
+evidence, and policy App slug reconciliation are deferred optional GPP-2C
+infrastructure, not active GPP-2B blockers.
 
 ## How To Use This Todo
 
@@ -19,9 +21,9 @@ callback work.
 
 ## Guardrails
 
-- [ ] GPP-2 remains fail-closed until public HTTPS health evidence, webhook evidence, dry-run check-run evidence, callback evidence, and branch protection/ruleset evidence exist.
-- [ ] No GitHub App webhook URL is configured before public HTTPS health evidence passes.
-- [ ] No branch protection/ruleset cutover happens before real PR `ao-release-gate` dry-run check-run evidence exists.
+- [ ] GPP-2 remains fail-closed until `ao-release-gate` enforce-mode success/failure evidence, required-check branch-protection cutover, and AO-GATE-9 closeout exist.
+- [ ] No GitHub App webhook URL is repointed to `testai.acik.com/ao-gate` in the no-testai GPP-2B path.
+- [ ] No branch protection/ruleset cutover happens before real PR `ao-release-gate` enforce-mode success and failure evidence exists.
 - [ ] No live adapter execution is started from this roadmap.
 - [ ] No secret value, private key, webhook secret, or Vault token is committed, echoed, pasted into chat, or stored in evidence.
 - [ ] Claude/Codex consultation remains advisory and is not release authority.
@@ -30,7 +32,12 @@ callback work.
   close GPP-2, widen support, claim production readiness, or replace later
   protected-runtime evidence.
 
-## Public URL Contract
+## Historical / Deferred Public URL Contract
+
+These URLs document the hosted health/callback work already completed or
+rehearsed. They are not part of the active no-testai GPP-2B blocker list.
+Do not repoint GitHub App webhooks to `testai.acik.com/ao-gate` in the
+near-term path.
 
 ```text
 Policy health:
@@ -84,9 +91,9 @@ location = /ao-gate/github/ao-release-gate {
 | AO-GATE-5 | GitHub App webhook config evidence | GitHub App | DONE | AO-GATE-4 passed | Webhook URLs configured to `/ao-gate/github/*` |
 | AO-GATE-6 | `ao-release-gate` dry-run PR evidence | GitHub PR | EVIDENCE CAPTURED | Webhook evidence present | Real PR dry-run check-run evidence |
 | LOCAL-GATE-1 | Local AI review evidence gate | `ao-kernel` | DONE | GPP-2 remains blocked; no production claim | PR #576 pivot plan + PR #577 implementation merged (`bd8eb35`); local no-secret evidence JSON + fail-closed tests |
-| AO-GATE-7 | Deployment-protection callback evidence | GitHub deployment protection | DEFERRED | Local gate pivot recorded first; policy callback still needs production topology | Callback review evidence or fail-closed evidence |
-| AO-GATE-8 | Branch protection/ruleset cutover | GitHub repo settings | DEFERRED | Enforce-mode success/failure evidence first | Required `ao-release-gate` check blocks merge without pass |
-| AO-GATE-9 | GPP-2 closeout update | `ao-kernel` | BLOCKED | Evidence chain complete | GPP status updated without support widening |
+| AO-GATE-7 | Deployment-protection callback evidence | GitHub deployment protection | DEFERRED / OPTIONAL | Deferred GPP-2C infrastructure; not an active GPP-2B blocker | Future callback review evidence or explicit superseding decision |
+| AO-GATE-8 | Branch protection/ruleset cutover | GitHub repo settings | BLOCKED | Enforce-mode success/failure evidence first | Required `ao-release-gate` check blocks merge without pass; admin bypass disabled |
+| AO-GATE-9 | GPP-2 closeout update | `ao-kernel` | BLOCKED | GPP-2B evidence chain complete | GPP status updated without support widening |
 | RI-NEXT | Repo Intelligence read-only E2E continuation | `ao-kernel` | Blocked | GPP-2 and GPP-4 blockers | GPP-6 execution path reopened |
 
 ## Evidence Artifact Paths
@@ -467,12 +474,16 @@ service, or branch-protection cutover.
 |---|---|---|
 | 2026-04-28 | Initial editable roadmap todo created from Codex + Claude advisory review | Codex |
 | 2026-05-21 | AO-GATE-1..4 + AO-GATE-9 completed; AO-GATE-5..8 remain operator-bound. Codex thread 019e4a10 plan+post-impl AGREE v2.1 + Decision 1 Alt-B + Decision 2 AGREE_A. | Claude |
-| 2026-05-22 | AO-GATE-5..6 evidence captured; AO-GATE-7..8 remain blocked. Local AI review gate pivot added as the next simplification step before more deployment-protection callback work. | Codex |
-| 2026-05-22 | LOCAL-GATE-1 (GPP-2A) implemented and merged — PR #576 pivot plan + PR #577 implementation. Local AI review evidence gate is operator-controlled local trust evidence only; GPP-2 remains blocked. AO-GATE-7..8 (GPP-2C) still blocked on policy App slug reconciliation, production callback topology, enforce-mode evidence, and branch-protection cutover. | Claude |
+| 2026-05-22 | AO-GATE-5..6 evidence captured; AO-GATE-7..8 were still treated as blocked at that point. Local AI review gate pivot added as the next simplification step before more deployment-protection callback work. Superseded by the no-testai active-path decision below. | Codex |
+| 2026-05-22 | LOCAL-GATE-1 (GPP-2A) implemented and merged — PR #576 pivot plan + PR #577 implementation. Local AI review evidence gate is operator-controlled local trust evidence only; GPP-2 remains blocked. Superseded blocker framing: AO-GATE-7..8 were still grouped under GPP-2C before the no-testai active-path decision below. | Claude |
+| 2026-05-22 | No-testai active path selected. `testai.acik.com/ao-gate`, smee.io delivery, deployment-protection callback evidence, and policy App slug reconciliation are deferred optional GPP-2C infrastructure, not active GPP-2B blockers. Active GPP-2 blockers are now `ao-release-gate` enforce-mode success/failure evidence, required-check branch-protection cutover with admin bypass disabled, and AO-GATE-9 closeout. | Codex |
 
 ## Post-Merge Status (2026-05-21)
 
-Public HTTPS health hosting evidence collected; GPP-2 SSOT updated. GPP-2 overall remains `blocked` until AO-GATE-5..8.
+Public HTTPS health hosting evidence collected; GPP-2 SSOT updated. After the
+2026-05-22 no-testai decision, GPP-2 remains `blocked` on the narrower active
+path: `ao-release-gate` enforce-mode success/failure evidence, required-check
+branch-protection cutover, and AO-GATE-9 closeout.
 
 ### Completed work packages
 
@@ -495,8 +506,8 @@ ao-kernel#570 (config contract per-service split) + platform-k8s-gitops#942 (git
 | AO-GATE-5 | ✅ DONE (2026-05-22) | Two GitHub Apps created (`ao-kernel-live-adapter-gate-policy` id=3800120 + `ao-release-gate` id=3800233); Vault PEM + webhook-secret seeded (`/pem` and `/value` field-name suffix per ao-kernel `hashicorp_vault_provider.py` contract); `.env` updated per-service; containers Healthy + HMAC verification confirmed (origin returns sig-verified 4xx for ping = `wrong_event` not `signature_invalid`) |
 | AO-GATE-6 | ✅ Evidence captured (2026-05-22) | Webhook delivery chain GREEN via smee.io non-production dry-run proxy (TCP/443 outbound; office firewall blocks TCP+UDP/7844, cloudflared infeasible). PR #572 opened → release-gate App posted check-run `ao-release-gate` conclusion=`failure` output_title=`deny_missing_evidence` (correct fail-closed posture, advisory only — no branch protection cutover) |
 | LOCAL-GATE-1 | ✅ DONE (2026-05-22) | Local operator trust model pivot implemented: implementer AI + reviewer AI + local fail-closed evidence gate. PR #576 pivot plan + PR #577 implementation merged (`bd8eb35`). Operator-controlled local trust evidence only — this does not close GPP-2 and does not replace AO-GATE-7/AO-GATE-8 protected-runtime evidence. |
-| AO-GATE-7 | ⏳ Blocked on App slug reconciliation + production topology | (a) Policy App slug drift: new App is `ao-kernel-live-adapter-gate-policy` but repo constant `REQUIRED_DEPLOYMENT_PROTECTION_APP_SLUG = "ao-kernel-live-adapter-gate"` and protected environment name expect old slug (`ao_kernel/live_adapter_gate.py:34,46`; `ao_kernel/defaults/schemas/live-adapter-gate-environment.schema.v1.json:107,119`); decision needed: rename new App OR update constant/schema/tests/attestation to new slug. (b) Production topology: smee.io is dry-run only; deployment-protection callback path needs publicly-reachable HTTPS endpoint with verified-context. (c) After (a)+(b): `workflow_dispatch` on `live-adapter-gate.yml` with `target_ref=main`, capture deployment_protection_rule webhook id + policy origin signature_verified + callback POST result + workflow run id |
-| AO-GATE-8 | ⏳ Blocked on AO-GATE-6 + AO-GATE-7 | Branch protection cutover: required ao-release-gate check; admin bypass YASAK. Additional gate: at least one **positive `success` conclusion path** demonstrated (not only fail-closed `failure / deny_missing_evidence`) OR explicit documented decision that required check stays advisory until enrichment model produces verified-context |
+| AO-GATE-7 | ⏸ Deferred optional GPP-2C infrastructure | Policy App slug reconciliation, production callback topology, and deployment-protection callback review evidence are no longer active GPP-2B blockers. If reopened later, choose `testai` or another owner-controlled endpoint in a separate GPP-2C infrastructure slice. |
+| AO-GATE-8 | ⏳ Active GPP-2B blocker: enforce evidence + cutover | Branch protection cutover: required `ao-release-gate` status check; admin bypass YASAK. Required before cutover: one positive `success` conclusion path and one negative `failure` path on real PRs in enforce mode. |
 
 ### Constraints carried (unchanged from initial draft)
 

--- a/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
+++ b/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md
@@ -2,12 +2,15 @@
 
 **Status:** GPP-2 public HTTPS health evidence, GitHub App webhook delivery
 chain evidence, and `ao-release-gate` shadow dry-run check-run evidence are
-recorded. The local AI review evidence gate (GPP-2A / LOCAL-GATE-1) is now
-implemented and merged (PR #576 pivot plan + PR #577 implementation); it is
-operator-controlled local trust evidence only. deployment-protection callback
-evidence, policy App slug reconciliation, production callback topology,
-enforce-mode success/failure evidence, and branch-protection cutover remain
-missing. GPP-2 stays blocked.
+recorded. The local AI review evidence gate (GPP-2A / LOCAL-GATE-1) is
+implemented and merged (PR #576 pivot plan + PR #577 implementation). The
+active no-testai near-term path is cross-provider AI review, non-author GitHub
+approval, `local_gpp_gate` evidence, and `ao-release-gate` required-check
+mapping. `testai.acik.com/ao-gate`, smee.io delivery, deployment-protection
+callback evidence, and policy App slug reconciliation are deferred optional
+GPP-2C infrastructure, not active GPP-2B blockers. GPP-2 still stays blocked
+until `ao-release-gate` enforce-mode success/failure evidence, branch-protection
+required-check cutover, and final AO-GATE-9/GPP closeout are complete.
 **Date:** 2026-05-22
 **Authority:** live `origin/main`; run `git rev-parse --short origin/main` for
 the current head
@@ -54,25 +57,27 @@ operator decides whether to merge
 
 `GPP-2ag` recorded that scope correction as a local AI review evidence gate.
 That gate is now implemented and merged as `LOCAL-GATE-1` (PR #576 pivot plan
-`7c32879` + PR #577 implementation `bd8eb35`). It is preparatory/local operator
-evidence only: it does not close GPP-2, does not replace AO-GATE-7
-deployment-protection callback evidence, does not change branch protection, does
-not execute live adapters, and does not widen support or claim production
-platform readiness.
+`7c32879` + PR #577 implementation `bd8eb35`). It is local operator evidence
+only: it does not close GPP-2, does not change branch protection, does not
+execute live adapters, and does not widen support or claim production platform
+readiness.
 
 GPP-2 is split into three slices:
 
 - **GPP-2A** — Local AI Review Gate (`LOCAL-GATE-1`): **DONE** (PR #576 + #577).
 - **GPP-2B** — `ao-release-gate` required check / enforcement mapping: **next**
-  (planning only; shadow mode continues; no branch-protection cutover, no
-  enforce mode, no cutover before positive/negative path evidence).
+  (near-term active path; no branch-protection cutover before positive/negative
+  enforce-mode path evidence).
 - **GPP-2C** — deployment-protection callback / production topology
-  (AO-GATE-7 + AO-GATE-8): **blocked / later**, pending policy App slug
-  reconciliation, production-suitable callback topology, enforce-mode
-  success/failure evidence, and branch-protection / ruleset cutover.
+  (AO-GATE-7 plus optional future callback topology): **deferred / later**.
+  `testai.acik.com/ao-gate`, smee.io delivery, callback review evidence, and
+  policy App slug reconciliation are not active GPP-2B blockers.
 
-GPP-2 remains `blocked` until the GPP-2C evidence chain is complete. Post-pivot
-handoff: `docs/session-handoff-2026-05-22-gpp2-local-gate-1.md`.
+GPP-2 remains `blocked`, but the active blocker list is now narrower: collect
+`ao-release-gate` enforce-mode success and failure evidence on real pull
+requests, cut branch protection/rulesets over to require that status check with
+admin bypass disallowed, then record the final AO-GATE-9/GPP closeout.
+Post-pivot handoff: `docs/session-handoff-2026-05-22-gpp2-local-gate-1.md`.
 
 ## 2. Current Baseline
 
@@ -1138,6 +1143,7 @@ admin bypass for PR merge automation, and must keep
 | 2026-05-22 | GPP-2 webhook and shadow check-run evidence recorded | ao-kernel#572/#574 recorded GitHub App webhook delivery chain evidence through smee.io non-production dry-run proxy and a real `ao-release-gate` shadow check-run; GPP-2 remained blocked pending callback, topology, enforce-mode, and cutover evidence. |
 | 2026-05-22 | GPP-2ag local AI review gate pivot planned | `.claude/plans/GPP-2ag-LOCAL-AI-REVIEW-GATE-PIVOT.md` records the scope correction: codify the current local implementer-AI + reviewer-AI trust model before continuing the heavier deployment-protection callback path. |
 | 2026-05-22 | LOCAL-GATE-1 (GPP-2A) implemented and merged | PR #576 pivot plan (`7c32879`) + PR #577 implementation (`bd8eb35`) shipped `scripts/local_gpp_gate.py`, the local AI review evidence JSON Schemas, no-secret fixtures, and fail-closed tests. The gate is operator-controlled local trust evidence only and does not close GPP-2. GPP-2 split recorded: GPP-2A (LOCAL-GATE-1) done, GPP-2B (`ao-release-gate` required-check mapping) next, GPP-2C (deployment-protection callback / production topology) blocked. Handoff: `docs/session-handoff-2026-05-22-gpp2-local-gate-1.md`. |
+| 2026-05-22 | GPP-2 no-testai active blocker sync | The no-testai near-term release-governance model is now the active GPP-2B path: cross-provider AI review, non-author GitHub approval, `local_gpp_gate` evidence, and `ao-release-gate` required-check mapping. `testai.acik.com/ao-gate`, smee.io delivery, deployment-protection callback evidence, and policy App slug reconciliation are deferred optional GPP-2C infrastructure, not active GPP-2B blockers. GPP-2 remains blocked pending `ao-release-gate` enforce-mode success/failure evidence, required-check branch-protection cutover, and final AO-GATE-9 closeout. |
 | 2026-04-28 | GPP-5d issue opened | Issue [#559](https://github.com/Halildeu/ao-kernel/issues/559) tracks repo-intelligence read-only workflow closeout before GPP-6 preparation. |
 | 2026-04-28 | GPP-5d closeout preflight added | `scripts/gpp5_repo_intelligence_closeout.py` records GPP-5 as closed for read-only workflow-surface purposes while keeping GPP-6 execution blocked by GPP-2 and GPP-4. |
 | 2026-04-28 | GPP-6a issue opened | Issue [#561](https://github.com/Halildeu/ao-kernel/issues/561) tracks the read-only E2E preflight contract for GPP-6 preparation. |

--- a/.claude/plans/GPP-2B-AO-RELEASE-GATE-REQUIRED-CHECK-MAPPING.md
+++ b/.claude/plans/GPP-2B-AO-RELEASE-GATE-REQUIRED-CHECK-MAPPING.md
@@ -15,7 +15,7 @@ The GPP-2ag pivot split `GPP-2` into three slices:
 ```text
 GPP-2A: local AI review gate evidence            — DONE (PR #576 + #577)
 GPP-2B: ao-release-gate required check / mapping  — this slice
-GPP-2C: deployment-protection callback / topology — blocked / later
+GPP-2C: deployment-protection callback / topology — deferred optional infra
 ```
 
 This record is the **GPP-2B planning slice**. It maps the two repo-owned merge
@@ -225,21 +225,24 @@ webhook/App configuration, no live adapter.
 
 Real enforce-mode evidence on live PRs — switching the hosted runtime to
 `conclusion_mode="enforce"` and observing a positive (`success`) and a negative
-(`failure`) path on actual pull requests — is **not** a GPP-2B slice. It
-belongs to GPP-2C / AO-GATE-8. The AO-GATE-8 branch-protection cutover (making
-`ao-release-gate` a required status check) stays in GPP-2C and is **out of
-scope for every GPP-2B slice**; it cannot proceed before that real enforce-mode
-evidence exists and the GPP-2C production callback topology is resolved.
+(`failure`) path on actual pull requests — is now the active no-testai GPP-2B
+follow-up after the mapping/test contract exists. The AO-GATE-8
+branch-protection cutover (making `ao-release-gate` a required status check)
+must still wait for that real enforce-mode evidence, but it no longer waits on
+deployment-protection callback topology, `testai.acik.com/ao-gate`, smee.io, or
+policy App slug reconciliation. Those are deferred optional GPP-2C
+infrastructure.
 
 ## 7. Hard stops / non-goals
 
-- No branch protection / ruleset mutation; no AO-GATE-8 cutover.
-- No `ao-release-gate` enforce-mode switch (`DEFAULT_CONCLUSION_MODE` stays
-  `shadow`).
+- No branch protection / ruleset mutation in this planning record.
+- No `ao-release-gate` enforce-mode switch in this planning record
+  (`DEFAULT_CONCLUSION_MODE` stays `shadow`).
 - No real PR check-run posting and no runtime `conclusion_mode` env flip; no
-  enforce-mode evidence collection on live PRs in any GPP-2B slice. A GPP-2B-4
-  unit test may pass `conclusion_mode="enforce"` to the in-process decision
-  function only — real enforce-mode evidence on live PRs is GPP-2C / AO-GATE-8.
+  enforce-mode evidence collection on live PRs in this planning record. A
+  GPP-2B-4 unit test may pass `conclusion_mode="enforce"` to the in-process
+  decision function only; a later evidence slice collects real enforce-mode PR
+  evidence before cutover.
 - No webhook URL or GitHub App configuration change.
 - No live adapter execution.
 - No `--admin` merge.
@@ -249,9 +252,10 @@ evidence exists and the GPP-2C production callback topology is resolved.
 
 ## 8. Follow-up
 
-GPP-2C continues the deployment-protection callback evidence and the
-production-suitable callback topology (AO-GATE-7) and the branch-protection /
-ruleset cutover (AO-GATE-8). Both remain blocked on a production-reachable
-HTTPS endpoint decision; `smee.io` is non-production dry-run only. GPP-2B
-slices do not depend on GPP-2C and may proceed in parallel as docs/schema/test
-work while GPP-2C topology is unresolved.
+The active no-testai path continues with `ao-release-gate` enforce-mode
+success/failure evidence on real PRs, then branch-protection / ruleset cutover
+to require that status check with admin bypass disabled, then AO-GATE-9 closeout.
+Deployment-protection callback evidence, production-suitable callback topology
+(including `testai.acik.com/ao-gate` or any replacement endpoint), smee.io
+delivery, and policy App slug reconciliation are deferred optional GPP-2C
+infrastructure and are not active GPP-2B blockers.

--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -10,8 +10,8 @@
     "title": "Protected Live-Adapter Gate Runtime Binding",
     "status": "blocked",
     "issue": "https://github.com/Halildeu/ao-kernel/issues/567",
-    "exit_decision": "webhook_delivery_chain_and_shadow_dry_run_check_run_collected_policy_callback_and_cutover_blocked_no_support_widening",
-    "ready_after": "operator-owned policy service and ao-release-gate are hosted on public HTTPS endpoints from the internal operator host bundle or equivalent infrastructure with internal vault-backed runtime secret ids, GitHub App webhook URLs are configured, policy callback review evidence exists, real PR dry-run check-run evidence is collected, local AI review gate evidence is available for operator-controlled merges, branch protection requires ao-release-gate after evidence, and protected workflow evidence confirms live_execution_allowed=false",
+    "exit_decision": "no_testai_near_term_release_governance_selected_enforce_mode_and_required_check_cutover_pending_callback_deferred_no_support_widening",
+    "ready_after": "the no-testai near-term release-governance model is selected and recorded, the ao-release-gate required-check path has enforce-mode success and failure evidence on real pull requests, branch protection requires the ao-release-gate status check with admin bypass disallowed, and the final AO-GATE-9 GPP status closeout is recorded; deployment-protection callback topology and callback review evidence are deferred optional future infrastructure",
     "allowed_scope": [
       "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service on operator-owned internal infrastructure without secret value exposure",
       "use the repo-owned ao-release-gate GHCR image or container package to deploy or configure the ao-release-gate GitHub App check-run service on operator-owned internal infrastructure without secret value exposure",
@@ -366,18 +366,16 @@
   "blocked_wps": [
     {
       "id": "GPP-2",
-      "reason": "repo-owned policy and ao-release-gate decision cores, webhook runtimes, container packages, GHCR publish paths, Cloud Run deploy paths, internal vault-backed secret-id runtime contract, internal operator host bundle, no-secret hosted health probe, public HTTPS health evidence, GitHub App webhook delivery chain evidence via smee.io non-production proxy, and ao-release-gate shadow dry-run check-run evidence are all collected, but deployment-protection callback review evidence, policy App slug reconciliation (new App slug 'ao-kernel-live-adapter-gate-policy' vs repo constant 'ao-kernel-live-adapter-gate'), production-suitable topology for the policy callback path (smee.io is dry-run only), protected workflow evidence, enforce-mode success/failure evidence, and branch-protection/ruleset cutover remain missing"
+      "reason": "the no-testai near-term release-governance model is selected and recorded: cross-provider AI review, non-author GitHub approval, local_gpp_gate operator evidence, and the ao-release-gate required-check mapping plus conclusion-mode matrix are the active GPP-2B path; repo-owned policy and ao-release-gate decision cores, container packages, GHCR publish paths, internal operator host bundle, hosted health evidence, webhook delivery chain evidence, and ao-release-gate shadow dry-run check-run evidence are collected; GPP-2 remains blocked pending ao-release-gate enforce-mode success and failure evidence on real pull requests, branch-protection/ruleset cutover that makes ao-release-gate a required status check with admin bypass disallowed, and the final AO-GATE-9/GPP status closeout; deployment-protection callback topology and callback review evidence, including any testai.acik.com/ao-gate or smee.io path, are deferred optional future infrastructure and are not active GPP-2B blockers"
     }
   ],
   "pending_external_actions": [
-    "resolve policy App slug drift: either rename new GitHub App from 'ao-kernel-live-adapter-gate-policy' to canonical 'ao-kernel-live-adapter-gate' or migrate repo constants/schema/tests/attestation to new slug",
-    "establish production-suitable deployment-protection callback topology; smee.io remains non-production dry-run only",
-    "collect deployment-protection callback review evidence from live-adapter-gate workflow_dispatch (no live adapter execution)",
-    "before AO-GATE-8 cutover, switch ao-release-gate to enforce mode and demonstrate one positive success path plus one negative failure path",
+    "defer production-suitable deployment-protection callback topology, including any testai.acik.com/ao-gate or smee.io path, to an optional future GPP-2C infrastructure initiative",
+    "defer deployment-protection callback review evidence and the protected-workflow callback rerun; no protected workflow dispatch or callback evidence is required for the no-testai GPP-2B near-term path",
+    "defer policy App slug reconciliation ('ao-kernel-live-adapter-gate-policy' vs 'ao-kernel-live-adapter-gate') with the deferred deployment-protection callback initiative; it is not a near-term GPP-2B blocker",
+    "before branch-protection cutover, switch ao-release-gate to enforce mode and demonstrate one positive success path plus one negative failure path on real pull requests",
     "cut branch protection/ruleset over to require ao-release-gate only after enforce-mode evidence is captured; admin bypass YASAK",
-    "validate whether GitHub App review-counting works for the current branch protection; if not, cut over to a required ao-release-gate status check",
-    "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
-    "define and implement the local AI review evidence gate as GPP-2A local/operator evidence before continuing heavier deployment-protection callback topology work",
+    "preserve local_gpp_gate as operator-controlled local/process evidence only; do not treat it as GPP-2 closure, support widening, live adapter execution approval, or production platform readiness",
     "keep end-user repo-intelligence onboarding independent from GPP-2 gate hosting by requiring at most GitHub App installation, repository selection, and explicit opt-in configuration"
   ],
   "support_widening_allowed": false,
@@ -436,26 +434,21 @@
     "set production_platform_claim=true without explicit GPP-9 promotion decision"
   ],
   "next_allowed_actions": [
-    "treat the GPP-2 deployment-protection policy service as operator-owned platform infrastructure, not an end-user setup requirement",
-    "use the local AI review evidence gate as a preparatory operator-controlled trust mechanism only; it does not close GPP-2, change branch protection, execute live adapters, widen support, or claim production readiness",
+    "use the no-testai local/operator release-governance model as the active GPP-2 path: cross-provider AI review, non-author GitHub approval, local_gpp_gate evidence, and ao-release-gate required-check mapping",
+    "treat testai.acik.com/ao-gate, smee.io delivery, deployment-protection callback evidence, and policy App slug reconciliation as deferred GPP-2C infrastructure, not active GPP-2B blockers",
+    "use the local AI review evidence gate as operator-controlled trust evidence only; it does not close GPP-2, change branch protection, execute live adapters, widen support, or claim production readiness",
     "prioritize repo-intelligence onboarding as a read-only product workflow that requires GitHub App installation and repository selection, not Cloud Run, vault, webhook, or private-key setup by each user",
     "use GPP-6a read-only E2E preflight evidence for preparation only, while GPP-6 execution remains blocked until GPP-2 protected gate and GPP-4 read-only adapter decision are ready and support_widening_allowed=false and production_platform_claim_allowed=false",
-    "prefer the internal operator host plus vault-backed secret-id path for GPP-2 service hosting unless a later decision reselects Cloud Run",
-    "use deploy/internal-gate-host as the default no-paid-cloud operator host bundle and validate it with scripts/internal_gate_host_bootstrap_attest.py before collecting hosted evidence",
-    "use scripts/internal_gate_host_health_probe.py to collect no-secret public HTTPS health evidence after the internal gate host is deployed and before configuring GitHub App webhooks",
     "configure ao_kernel.live_adapter_gate_policy_runtime:application with internal vault secret ids or direct runtime secret manager values, never committed or echoed secret material",
     "configure ao_kernel.ao_release_gate_runtime:application with internal vault secret ids or direct runtime secret manager values, never committed or echoed secret material",
-    "configure or verify the GitHub App webhook URL only after the hosted policy service endpoint is health-checked",
-    "host the ao-release-gate service in dry-run mode before collecting real PR evidence",
-    "deploy or host the ao-release-gate check-run service in dry-run mode and collect real PR evidence before any branch protection cutover",
-    "collect ao-release-gate dry-run check-run evidence on real PRs before any branch protection cutover",
-    "validate GitHub App review-counting only as a spike; use required status check as the durable enforcement path unless proven otherwise",
-    "deploy or configure the deployment-protection policy service using the repo-owned GHCR image or container package and internal vault-backed runtime secret ids before any further live-adapter runtime work",
+    "collect ao-release-gate enforce-mode success and failure evidence on real pull requests before any branch-protection cutover",
+    "cut branch protection/ruleset over to require the ao-release-gate status check only after enforce-mode evidence is captured; admin bypass remains disallowed",
+    "do not repoint GitHub App webhooks to testai.acik.com/ao-gate in the no-testai GPP-2B path",
     "keep the single-admin equivalent release gate not approved unless issue #489 is explicitly superseded",
     "use Claude MCP consultation only as advisory review, not release authority",
-    "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active",
+    "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml while deployment-protection callback topology is deferred",
     "use scripts/live_adapter_gate_policy_service_smoke.py only for local webhook/callback artifact validation, not live callback posting",
-    "use scripts/live_adapter_gate_policy_decision.py only for policy callback decision evaluation, not live adapter execution",
+    "use scripts/live_adapter_gate_policy_decision.py only for policy decision evaluation, not live callback posting or live adapter execution",
     "use scripts/live_adapter_gate_policy_container_smoke.py only for no-secret local container health validation, not live callback posting",
     "use scripts/ao_release_gate_container_smoke.py only for no-secret local container health validation, not check-run posting",
     "publish or pull ghcr.io/halildeu/ao-kernel-ao-release-gate-service only as a deploy artifact, not hosted service evidence",
@@ -466,5 +459,5 @@
     "treat inactive, denied, timed out, cancelled, or failing deployment protection as fail-closed evidence, not approval",
     "do not widen support or claim production platform readiness"
   ],
-  "last_updated": "2026-05-22T09:15:00Z"
+  "last_updated": "2026-05-22T20:30:00Z"
 }

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -33,7 +33,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["current_wp"]["issue"] == "https://github.com/Halildeu/ao-kernel/issues/567"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "webhook_delivery_chain_and_shadow_dry_run_check_run_collected_policy_callback_and_cutover_blocked_no_support_widening"
+        == "no_testai_near_term_release_governance_selected_enforce_mode_and_required_check_cutover_pending_callback_deferred_no_support_widening"
     )
     assert any(item["id"] == "GPP-1b" for item in payload["completed_wps"])
     assert any(
@@ -267,73 +267,57 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert payload["support_widening_allowed"] is False
     assert payload["production_platform_claim_allowed"] is False
     assert payload["live_adapter_execution_allowed"] is False
-    # PHASE 7 webhook delivery chain evidence + PHASE 8 shadow dry-run
-    # check-run evidence collected (source: Halildeu/ao-kernel#572 +
-    # Halildeu/ao-kernel#573). The two AO-GATE-6 webhook config items and
-    # the dry-run check-run collection item are no longer pending. New
-    # pending items capture: policy App slug drift (new App slug
-    # 'ao-kernel-live-adapter-gate-policy' vs repo constant), production-
-    # suitable callback topology (smee.io is non-production dry-run),
-    # callback review evidence, enforce-mode positive/negative paths,
-    # branch-protection cutover (admin bypass YASAK), and the local
-    # AI-review evidence gate pivot. Audit trail of PHASE 7 + 8 lives
-    # in `current_wp.evidence_collected[]`.
+    # The no-testai near-term decision (GPP-2C plan, PR #585) is synced
+    # into the machine-readable SSOT. Deployment-protection callback
+    # topology (testai.acik.com/ao-gate, smee.io), callback review
+    # evidence, and policy App slug reconciliation are reframed as a
+    # deferred optional GPP-2C initiative; the active near-term path is
+    # ao-release-gate enforce-mode evidence plus the required-check
+    # cutover. GPP-2 stays blocked.
     assert payload["pending_external_actions"] == [
-        "resolve policy App slug drift: either rename new GitHub App from 'ao-kernel-live-adapter-gate-policy' to canonical 'ao-kernel-live-adapter-gate' or migrate repo constants/schema/tests/attestation to new slug",
-        "establish production-suitable deployment-protection callback topology; smee.io remains non-production dry-run only",
-        "collect deployment-protection callback review evidence from live-adapter-gate workflow_dispatch (no live adapter execution)",
-        "before AO-GATE-8 cutover, switch ao-release-gate to enforce mode and demonstrate one positive success path plus one negative failure path",
+        "defer production-suitable deployment-protection callback topology, including any testai.acik.com/ao-gate or smee.io path, to an optional future GPP-2C infrastructure initiative",
+        "defer deployment-protection callback review evidence and the protected-workflow callback rerun; no protected workflow dispatch or callback evidence is required for the no-testai GPP-2B near-term path",
+        "defer policy App slug reconciliation ('ao-kernel-live-adapter-gate-policy' vs 'ao-kernel-live-adapter-gate') with the deferred deployment-protection callback initiative; it is not a near-term GPP-2B blocker",
+        "before branch-protection cutover, switch ao-release-gate to enforce mode and demonstrate one positive success path plus one negative failure path on real pull requests",
         "cut branch protection/ruleset over to require ao-release-gate only after enforce-mode evidence is captured; admin bypass YASAK",
-        "validate whether GitHub App review-counting works for the current branch protection; if not, cut over to a required ao-release-gate status check",
-        "rerun the protected workflow evidence slice from main after the policy service can approve_contract_gate, reject, or fail explicitly",
-        "define and implement the local AI review evidence gate as GPP-2A local/operator evidence before continuing heavier deployment-protection callback topology work",
-        (
-            "keep end-user repo-intelligence onboarding independent from GPP-2 gate hosting by requiring at most "
-            "GitHub App installation, repository selection, and explicit opt-in configuration"
-        ),
+        "preserve local_gpp_gate as operator-controlled local/process evidence only; do not treat it as GPP-2 closure, support widening, live adapter execution approval, or production platform readiness",
+        "keep end-user repo-intelligence onboarding independent from GPP-2 gate hosting by requiring at most GitHub App installation, repository selection, and explicit opt-in configuration",
     ]
-    # PHASE 7 + 8 evidence collected. Blocker narrative is updated to
-    # reflect the new state: webhook delivery chain via smee.io (non-
-    # production dry-run) + shadow dry-run check-run are now in the
-    # "collected" list; deployment-protection callback review evidence,
-    # policy App slug reconciliation, production-suitable callback
-    # topology, protected workflow evidence, enforce-mode success/failure
-    # evidence, and branch-protection cutover remain missing. Substantive
-    # blocker condition is unchanged — GPP-2 still blocked.
+    # GPP-2 stays blocked. The blocker narrative is synced to the
+    # no-testai near-term model (GPP-2C plan, PR #585): the
+    # deployment-protection callback path is deferred optional future
+    # infrastructure; GPP-2 remains blocked pending ao-release-gate
+    # enforce-mode evidence, the required-check cutover, and the
+    # AO-GATE-9 closeout. Guard flags stay false.
     assert payload["blocked_wps"] == [
         {
             "id": "GPP-2",
-            "reason": (
-                "repo-owned policy and ao-release-gate decision cores, webhook runtimes, container packages, "
-                "GHCR publish paths, Cloud Run deploy paths, internal vault-backed secret-id runtime "
-                "contract, internal operator host bundle, no-secret hosted health probe, public HTTPS "
-                "health evidence, GitHub App webhook delivery chain evidence via smee.io non-production "
-                "proxy, and ao-release-gate shadow dry-run check-run evidence are all collected, but "
-                "deployment-protection callback review evidence, policy App slug reconciliation (new App "
-                "slug 'ao-kernel-live-adapter-gate-policy' vs repo constant 'ao-kernel-live-adapter-gate'), "
-                "production-suitable topology for the policy callback path (smee.io is dry-run only), "
-                "protected workflow evidence, enforce-mode success/failure evidence, and branch-protection/"
-                "ruleset cutover remain missing"
-            ),
+            "reason": "the no-testai near-term release-governance model is selected and recorded: cross-provider AI review, non-author GitHub approval, local_gpp_gate operator evidence, and the ao-release-gate required-check mapping plus conclusion-mode matrix are the active GPP-2B path; repo-owned policy and ao-release-gate decision cores, container packages, GHCR publish paths, internal operator host bundle, hosted health evidence, webhook delivery chain evidence, and ao-release-gate shadow dry-run check-run evidence are collected; GPP-2 remains blocked pending ao-release-gate enforce-mode success and failure evidence on real pull requests, branch-protection/ruleset cutover that makes ao-release-gate a required status check with admin bypass disallowed, and the final AO-GATE-9/GPP status closeout; deployment-protection callback topology and callback review evidence, including any testai.acik.com/ao-gate or smee.io path, are deferred optional future infrastructure and are not active GPP-2B blockers",
         }
     ]
     assert any("python3 scripts/gpp_next.py" == item["command"] for item in payload["required_startup_checks"])
     assert any(
-        action == "host the ao-release-gate service in dry-run mode before collecting real PR evidence"
+        action
+        == "use the no-testai local/operator release-governance model as the active GPP-2 path: cross-provider AI review, non-author GitHub approval, local_gpp_gate evidence, and ao-release-gate required-check mapping"
         for action in payload["next_allowed_actions"]
     )
     assert any(
         action
-        == "deploy or host the ao-release-gate check-run service in dry-run mode and collect real PR evidence before any branch protection cutover"
-        for action in payload["next_allowed_actions"]
-    )
-    assert any(
-        action == "collect ao-release-gate dry-run check-run evidence on real PRs before any branch protection cutover"
+        == "treat testai.acik.com/ao-gate, smee.io delivery, deployment-protection callback evidence, and policy App slug reconciliation as deferred GPP-2C infrastructure, not active GPP-2B blockers"
         for action in payload["next_allowed_actions"]
     )
     assert any(
         action
-        == "validate GitHub App review-counting only as a spike; use required status check as the durable enforcement path unless proven otherwise"
+        == "collect ao-release-gate enforce-mode success and failure evidence on real pull requests before any branch-protection cutover"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action
+        == "cut branch protection/ruleset over to require the ao-release-gate status check only after enforce-mode evidence is captured; admin bypass remains disallowed"
+        for action in payload["next_allowed_actions"]
+    )
+    assert any(
+        action == "do not repoint GitHub App webhooks to testai.acik.com/ao-gate in the no-testai GPP-2B path"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -363,12 +347,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(action == "treat Codex or Claude output as release authority" for action in payload["forbidden_actions"])
     assert any(
         action
-        == "treat the GPP-2 deployment-protection policy service as operator-owned platform infrastructure, not an end-user setup requirement"
-        for action in payload["next_allowed_actions"]
-    )
-    assert any(
-        action
-        == "use the local AI review evidence gate as a preparatory operator-controlled trust mechanism only; it does not close GPP-2, change branch protection, execute live adapters, widen support, or claim production readiness"
+        == "use the local AI review evidence gate as operator-controlled trust evidence only; it does not close GPP-2, change branch protection, execute live adapters, widen support, or claim production readiness"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -383,21 +362,6 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(
         action
-        == "prefer the internal operator host plus vault-backed secret-id path for GPP-2 service hosting unless a later decision reselects Cloud Run"
-        for action in payload["next_allowed_actions"]
-    )
-    assert any(
-        action
-        == "use deploy/internal-gate-host as the default no-paid-cloud operator host bundle and validate it with scripts/internal_gate_host_bootstrap_attest.py before collecting hosted evidence"
-        for action in payload["next_allowed_actions"]
-    )
-    assert any(
-        action
-        == "use scripts/internal_gate_host_health_probe.py to collect no-secret public HTTPS health evidence after the internal gate host is deployed and before configuring GitHub App webhooks"
-        for action in payload["next_allowed_actions"]
-    )
-    assert any(
-        action
         == "configure ao_kernel.live_adapter_gate_policy_runtime:application with internal vault secret ids or direct runtime secret manager values, never committed or echoed secret material"
         for action in payload["next_allowed_actions"]
     )
@@ -408,12 +372,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(
         action
-        == "configure or verify the GitHub App webhook URL only after the hosted policy service endpoint is health-checked"
-        for action in payload["next_allowed_actions"]
-    )
-    assert any(
-        action
-        == "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml until the ao-kernel-live-adapter-gate policy service is active"
+        == "do not repeatedly dispatch .github/workflows/live-adapter-gate.yml while deployment-protection callback topology is deferred"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -423,7 +382,7 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     )
     assert any(
         action
-        == "use scripts/live_adapter_gate_policy_decision.py only for policy callback decision evaluation, not live adapter execution"
+        == "use scripts/live_adapter_gate_policy_decision.py only for policy decision evaluation, not live callback posting or live adapter execution"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -444,11 +403,6 @@ def test_gpp_status_contract_keeps_support_widening_closed() -> None:
     assert any(
         action
         == "publish or pull ghcr.io/halildeu/ao-kernel-ao-release-gate-service only as a deploy artifact, not hosted service evidence"
-        for action in payload["next_allowed_actions"]
-    )
-    assert any(
-        action
-        == "deploy or configure the deployment-protection policy service using the repo-owned GHCR image or container package and internal vault-backed runtime secret ids before any further live-adapter runtime work"
         for action in payload["next_allowed_actions"]
     )
     assert any(
@@ -741,7 +695,7 @@ def test_gpp_next_load_status_validates_required_guards() -> None:
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
     assert (
         payload["current_wp"]["exit_decision"]
-        == "webhook_delivery_chain_and_shadow_dry_run_check_run_collected_policy_callback_and_cutover_blocked_no_support_widening"
+        == "no_testai_near_term_release_governance_selected_enforce_mode_and_required_check_cutover_pending_callback_deferred_no_support_widening"
     )
     assert payload["support_widening_allowed"] is False
 
@@ -772,11 +726,11 @@ def test_gpp_next_text_output_names_current_and_blocked_work() -> None:
     assert "Support widening allowed: false" in rendered
     assert "Production platform claim allowed: false" in rendered
     assert "Live adapter execution allowed: false" in rendered
-    assert "internal vault-backed secret-id runtime contract" in rendered
+    assert "the no-testai near-term release-governance model is selected and recorded" in rendered
     assert "internal operator host bundle" in rendered
-    assert "no-secret hosted health probe" in rendered
-    assert "webhook runtimes, container packages" in rendered
-    assert "public HTTPS health evidence" in rendered
+    assert "GPP-2 remains blocked pending ao-release-gate enforce-mode" in rendered
+    assert "deferred optional future infrastructure" in rendered
+    assert "are not active GPP-2B blockers" in rendered
     assert "divergence: 0\t0" in rendered
 
 


### PR DESCRIPTION
## Summary
- sync `gpp_status.v1.json` with the no-testai near-term release-governance decision
- reframe `testai.acik.com/ao-gate`, smee.io delivery, deployment-protection callback evidence, and policy App slug reconciliation as deferred optional GPP-2C infrastructure, not active GPP-2B blockers
- keep GPP-2 blocked on `ao-release-gate` enforce-mode success/failure evidence, required-check branch-protection cutover, and AO-GATE-9 closeout
- update human-readable SSOT docs and `test_gpp_next.py` pins to match

## Guardrails
- no runtime code changes
- no GitHub App / webhook / branch-protection changes
- no live adapter execution
- support_widening_allowed remains false
- production_platform_claim_allowed remains false

## Validation
- `python3 -m json.tool .claude/plans/gpp_status.v1.json`
- `python3 scripts/gpp_next.py`
- `python3 -m pytest -q tests/test_gpp_next.py` (21 passed)
- `python3 -m pytest -q tests/test_local_gpp_gate.py` (34 passed)
- `python3 -m pytest -q tests/test_gpp2b_mapping_drift_guard.py tests/test_gpp2b3_review_evidence_input_schema.py tests/test_ao_release_gate.py` (27 passed)
- `git diff --check`
