### PR TITLE
docs(gpp-2): sync allowed_scope to the no-testai active model

### DIFF
--- a/.claude/plans/gpp_status.v1.json
+++ b/.claude/plans/gpp_status.v1.json
@@ -13,15 +13,16 @@
     "exit_decision": "no_testai_near_term_release_governance_selected_enforce_mode_and_required_check_cutover_pending_callback_deferred_no_support_widening",
     "ready_after": "the no-testai near-term release-governance model is selected and recorded, the ao-release-gate required-check path has enforce-mode success and failure evidence on real pull requests, branch protection requires the ao-release-gate status check with admin bypass disallowed, and the final AO-GATE-9 GPP status closeout is recorded; deployment-protection callback topology and callback review evidence are deferred optional future infrastructure",
     "allowed_scope": [
-      "use the repo-owned policy service GHCR image or container package to deploy or configure the ao-kernel-live-adapter-gate GitHub App policy service on operator-owned internal infrastructure without secret value exposure",
-      "use the repo-owned ao-release-gate GHCR image or container package to deploy or configure the ao-release-gate GitHub App check-run service on operator-owned internal infrastructure without secret value exposure",
-      "use deploy/internal-gate-host or equivalent operator-owned infrastructure as the no-paid-cloud default host bundle for both GPP-2 gate services",
-      "collect no-secret public HTTPS health evidence with scripts/internal_gate_host_health_probe.py after the internal gate host is deployed",
-      "configure hosted gate runtimes with internal vault secret ids rather than committed, echoed, or repository-stored secret values",
-      "document or build end-user onboarding paths that do not require users to self-host the GPP-2 policy service, vault, webhook secret, GitHub App private key, or Cloud Run project",
-      "design or implement a local AI review evidence gate that validates implementer AI plus independent reviewer AI evidence for operator-controlled local merges without changing branch protection or claiming production readiness",
-      "repeat protected workflow evidence collection from main after the policy service responds",
-      "keep live execution disabled until protected workflow evidence explicitly permits a later live run"
+      "collect cross-provider AI review evidence as the operator-controlled GPP-2B review discipline, where the implementer AI provider differs from the reviewer AI provider",
+      "record non-author GitHub code-owner approval as the GPP-2B mechanical merge gate without admin bypass or branch-protection mutation",
+      "produce local_gpp_gate operator evidence as preparatory local trust evidence only; it does not close GPP-2, widen support, or claim production readiness",
+      "maintain the ao-release-gate required-check mapping and the shadow/enforce conclusion-mode matrix",
+      "collect ao-release-gate enforce-mode success and failure evidence on real pull requests",
+      "cut branch protection or rulesets over to require the ao-release-gate status check only after enforce-mode evidence is captured, with admin bypass disallowed",
+      "record the AO-GATE-9 GPP status closeout only after enforce-mode evidence and the required-check cutover both exist",
+      "document end-user onboarding paths that do not require users to self-host any GPP-2 gate service, vault, webhook secret, GitHub App private key, or Cloud Run project",
+      "treat testai.acik.com/ao-gate, smee.io delivery, the deployment-protection callback path, and policy App slug reconciliation as deferred optional GPP-2C infrastructure, not active GPP-2B scope",
+      "keep support widening, production platform claim, and live adapter execution disallowed while GPP-2 stays blocked"
     ],
     "evidence_collected": [
       {

--- a/tests/test_gpp_next.py
+++ b/tests/test_gpp_next.py
@@ -745,3 +745,37 @@ def test_gpp_next_cli_json_output(capsys: Any) -> None:
     assert payload["current_wp"]["id"] == "GPP-2"
     assert payload["current_wp"]["status"] == "blocked"
     assert payload["blocked_wps"][0]["id"] == "GPP-2"
+
+
+def test_allowed_scope_reflects_no_testai_model() -> None:
+    """current_wp.allowed_scope describes the no-testai active GPP-2B model and
+    does not re-introduce pre-no-testai active hosting / callback scope."""
+    payload = json.loads(_status_path().read_text(encoding="utf-8"))
+    allowed_scope = payload["current_wp"]["allowed_scope"]
+    assert isinstance(allowed_scope, list) and allowed_scope
+    joined = " ".join(allowed_scope).lower()
+
+    # Pre-no-testai active hosting / testai-callback scope must not return.
+    # Covers every removed pre-no-testai allowed_scope item that carried
+    # active hosting / policy-service / health-probe / callback behavior.
+    for stale in (
+        "deploy or configure the ao-kernel-live-adapter-gate github app policy service",
+        "deploy or configure the ao-release-gate github app check-run service",
+        "no-paid-cloud default host bundle",
+        "internal_gate_host_health_probe",
+        "configure hosted gate runtimes",
+        "design or implement a local ai review evidence gate",
+        "repeat protected workflow evidence collection",
+    ):
+        assert stale not in joined, f"stale active hosting scope re-entered allowed_scope: {stale}"
+
+    # The no-testai active GPP-2B path must be present.
+    assert any("cross-provider ai review" in item.lower() for item in allowed_scope)
+    assert any("non-author github" in item.lower() for item in allowed_scope)
+    assert any("local_gpp_gate" in item.lower() for item in allowed_scope)
+    assert any(
+        "ao-release-gate enforce-mode" in item.lower() and "real pull request" in item.lower() for item in allowed_scope
+    )
+    assert any("deferred optional gpp-2c" in item.lower() and "testai" in item.lower() for item in allowed_scope)
+    # allowed_scope must not present GPP-2 as closed or promoted.
+    assert any("gpp-2 stays blocked" in item.lower() for item in allowed_scope)


### PR DESCRIPTION
## Summary

Follow-up to PR #586. The machine-readable GPP SSOT moved to the no-testai
model, but `current_wp.allowed_scope` in `gpp_status.v1.json` still carried
pre-no-testai active hosting / policy-service / testai language. This closes
that last drift.

- **`gpp_status.v1.json`** — `current_wp.allowed_scope` rewritten (9 stale items
  → 10 no-testai items): cross-provider AI review, non-author GitHub approval,
  `local_gpp_gate` preparatory evidence, `ao-release-gate` required-check
  mapping + enforce-mode evidence on real PRs, the conditional
  branch-protection cutover, the AO-GATE-9 closeout, the end-user self-host
  boundary, `testai` / smee / callback / policy-App-slug as deferred optional
  GPP-2C infrastructure, and the support/production/live-adapter guard.
- **`tests/test_gpp_next.py`** — new `test_allowed_scope_reflects_no_testai_model`
  drift guard: 7 stale active-hosting patterns must not re-enter
  `allowed_scope`; the no-testai model items must stay present.

## Scope / non-goals

JSON + test only. **No** human-readable docs, **no** runtime / webhook / GitHub
App / branch-protection / live-adapter change. `current_wp.status` stays
`blocked`; guard flags stay `false`; `exit_decision` and `evidence_collected`
unchanged.

## Cross-AI peer review

- Implementer: Claude (Anthropic)
- Reviewer: Codex (OpenAI, thread `019e5166`) — post-impl **REVISE → AGREE**
  (the drift-guard tuple was underinclusive; broadened from 4 to 7 patterns
  covering every removed stale item — absorbed).

## Test plan

- [x] `python3 -m json.tool gpp_status.v1.json` — valid
- [x] `python3 scripts/gpp_next.py` — GPP-2 `blocked`, guard flags `false`, no-testai `exit_decision`
- [x] `pytest tests/test_gpp_next.py` — 22/22 pass (incl. the new drift guard)
- [x] Negative test: injecting a stale hosting item fails the drift guard with an actionable message; revert restores 22/22
- [x] `ruff check tests/` clean; `git diff --check` clean
- [ ] Required CI checks green
- [ ] Non-author code-owner approval (`gladyatore-lab`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)