### PR TITLE
feat(gpp-2d): evidence context-binding schema + emitter (GPP-2D-2a)

### DIFF
--- a/ao_kernel/defaults/schemas/local-gpp-gate-evidence.schema.v1.json
+++ b/ao_kernel/defaults/schemas/local-gpp-gate-evidence.schema.v1.json
@@ -125,6 +125,34 @@
       "type": "boolean",
       "const": false,
       "description": "The local gate never executes a live adapter."
+    },
+    "context_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["head_sha", "base_ref", "diff_digest", "changed_files_count"],
+      "description": "Optional GPP-2D context-binding block. Present only when the git diff was verified; absent on the unverifiable-scope fail-closed path (git unavailable or --skip-git). It binds the evidence to a specific head commit and changed-files digest so a future ao-release-gate required check can reject stale, forged, or replayed evidence. This block does not change the decision, close GPP-2, or alter the guard flags. It is optional so existing local-gpp-gate-evidence.v1 artifacts stay schema-valid; a future required check enforces its presence itself.",
+      "properties": {
+        "head_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$",
+          "description": "Resolved 40-character lowercase git SHA of the reviewed head ref. A future ao-release-gate check confirms this equals the pull request head SHA so stale or replayed evidence fails closed."
+        },
+        "base_ref": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Trusted base ref the scope diff was measured against (the three-dot git diff base)."
+        },
+        "diff_digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "sha256: prefixed sha256 digest over the newline-joined sorted changed-files path list. Binds the evidence to one specific diff so the same evidence cannot be reused for a different change."
+        },
+        "changed_files_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of changed files in the verified git diff that diff_digest was computed over."
+        }
+      }
     }
   }
 }

--- a/scripts/local_gpp_gate.py
+++ b/scripts/local_gpp_gate.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as _dt
+import hashlib
 import json
 import subprocess
 import sys
@@ -204,6 +205,79 @@ def actual_changed_files(
     if completed.returncode != 0:
         return None
     return sorted(line for line in completed.stdout.splitlines() if line.strip())
+
+
+def _resolve_head_sha(repo_root: Path, head_ref: str) -> str | None:
+    """Return the resolved 40-hex git SHA for ``head_ref``.
+
+    Returns ``None`` when git is unavailable, the directory is not a
+    repository, the ref is invalid, or the resolved value is not a
+    canonical 40-character lowercase SHA. The caller then omits the
+    context-binding block so a future ao-release-gate required check fails
+    closed rather than trusting an unverifiable head.
+    """
+
+    if not head_ref:
+        return None
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", head_ref],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=STARTUP_PREFLIGHT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    candidate = completed.stdout.strip()
+    if len(candidate) == 40 and all(char in "0123456789abcdef" for char in candidate):
+        return candidate
+    return None
+
+
+def _diff_digest(changed_files: list[str]) -> str:
+    """Return the ``sha256:`` prefixed digest of the changed-files list.
+
+    The digest is taken over the newline-joined sorted path list so the
+    evidence is bound to one specific diff. ``changed_files`` is already
+    sorted by ``actual_changed_files``; it is re-sorted here defensively so
+    the digest is order-independent.
+    """
+
+    joined = "\n".join(sorted(changed_files))
+    return "sha256:" + hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def build_context_binding(
+    *,
+    repo_root: Path,
+    base_ref: str,
+    head_ref: str,
+    changed_files: list[str] | None,
+) -> dict[str, Any] | None:
+    """Build the optional GPP-2D context-binding block.
+
+    Returns ``None`` when the diff could not be verified (``changed_files``
+    is ``None`` because git was skipped or failed) or the head ref could
+    not be resolved to a canonical SHA, so the gate emits no context
+    binding on the unverifiable path. Otherwise returns a block binding the
+    evidence to the resolved head SHA and the changed-files digest so a
+    future required check can reject stale, forged, or replayed evidence.
+    """
+
+    if changed_files is None:
+        return None
+    head_sha = _resolve_head_sha(repo_root, head_ref)
+    if head_sha is None:
+        return None
+    return {
+        "head_sha": head_sha,
+        "base_ref": base_ref,
+        "diff_digest": _diff_digest(changed_files),
+        "changed_files_count": len(changed_files),
+    }
 
 
 def _evaluate_startup_preflight(repo_root: Path, status_path: Path, findings: list[str]) -> bool:
@@ -642,6 +716,7 @@ def build_gate_evidence(
     repo: str,
     work_package: str,
     generated_at: str,
+    context_binding: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the no-secret gate evidence artifact.
 
@@ -649,11 +724,15 @@ def build_gate_evidence(
     gate-authored finding strings, the reviewer finding count, the
     constant guard flags, and the repo/work-package refs. Reviewer free
     text is never embedded; ``findings`` holds only gate-authored strings.
+
+    ``context_binding``, when supplied, is added verbatim as the optional
+    GPP-2D context-binding block; when ``None`` the key is omitted so
+    existing artifacts and the unverifiable-scope path stay schema-valid.
     """
 
     decision = "operator_may_merge" if all(checks.values()) else "fail_closed"
     findings = list(gate_findings)
-    return {
+    artifact: dict[str, Any] = {
         "schema_version": GATE_EVIDENCE_SCHEMA_VERSION,
         "decision": decision,
         "repo": repo,
@@ -667,6 +746,9 @@ def build_gate_evidence(
         "production_platform_claim": False,
         "live_adapter_execution": False,
     }
+    if context_binding is not None:
+        artifact["context_binding"] = context_binding
+    return artifact
 
 
 def validate_gate_evidence(artifact: object) -> None:
@@ -724,6 +806,18 @@ def render_summary(artifact: dict[str, Any]) -> str:
             lines.append(f"- {finding}")
     else:
         lines.append("- none")
+    binding = artifact.get("context_binding")
+    if binding is not None:
+        lines.extend(
+            [
+                "",
+                "Context binding:",
+                f"- head_sha: {binding['head_sha']}",
+                f"- base_ref: {binding['base_ref']}",
+                f"- diff_digest: {binding['diff_digest']}",
+                f"- changed_files_count: {binding['changed_files_count']}",
+            ]
+        )
     lines.extend(
         [
             "",
@@ -836,6 +930,15 @@ def main(argv: list[str] | None = None) -> int:
             repo=args.repo,
             work_package=args.work_package,
         )
+        # The context binding is derived only from the trusted operator
+        # base/head refs and the verified git diff, never from the reviewer
+        # evidence. It is omitted on the unverifiable-scope path.
+        context_binding = build_context_binding(
+            repo_root=repo_root,
+            base_ref=args.base_ref,
+            head_ref=args.head_ref,
+            changed_files=actual_files,
+        )
         # The artifact repo / work_package are taken only from the trusted
         # operator-supplied values, never from the untrusted reviewer
         # evidence, so a sentinel planted in the reviewer file cannot reach
@@ -847,6 +950,7 @@ def main(argv: list[str] | None = None) -> int:
             repo=args.repo,
             work_package=args.work_package,
             generated_at=utc_timestamp(),
+            context_binding=context_binding,
         )
         validate_gate_evidence(artifact)
         if args.output is not None:

--- a/tests/test_local_gpp_gate.py
+++ b/tests/test_local_gpp_gate.py
@@ -1020,3 +1020,28 @@ def test_gate_run_skip_git_omits_context_binding(tmp_path: Path) -> None:
     artifact = json.loads(output.read_text(encoding="utf-8"))
     assert "context_binding" not in artifact
     mod.validate_gate_evidence(artifact)
+
+
+def test_gate_run_invalid_head_ref_fails_closed_without_context_binding(tmp_path: Path) -> None:
+    # An invalid --head-ref makes the git diff fail, leaving the diff
+    # unverified: the gate decides fail_closed and emits no context binding,
+    # so a future required check cannot trust an unverifiable head.
+    mod = _load_module()
+    output = tmp_path / "gate-evidence.json"
+    code = mod.main(
+        [
+            "--review-evidence",
+            str(_fixture("reviewer_agree.v1.json")),
+            "--output",
+            str(output),
+            "--base-ref",
+            "origin/main",
+            "--head-ref",
+            "no-such-ref-gpp2d2a",
+        ]
+    )
+    artifact = json.loads(output.read_text(encoding="utf-8"))
+    assert code == 1
+    assert artifact["decision"] == "fail_closed"
+    assert "context_binding" not in artifact
+    mod.validate_gate_evidence(artifact)

--- a/tests/test_local_gpp_gate.py
+++ b/tests/test_local_gpp_gate.py
@@ -85,9 +85,7 @@ def _evaluate_fixture(
     src.write_text(json.dumps(payload), encoding="utf-8")
     review = mod.load_review_evidence(src)
     operator_base_ref = "origin/main" if base_ref is None else base_ref
-    operator_head_ref = (
-        "codex/local-gate-1-impl" if head_ref is None else head_ref
-    )
+    operator_head_ref = "codex/local-gate-1-impl" if head_ref is None else head_ref
     operator_repo = "Halildeu/ao-kernel" if repo is None else repo
     operator_work_package = "GPP-2ag" if work_package is None else work_package
     checks, gate_findings = mod.evaluate_gate(
@@ -168,9 +166,7 @@ def test_reviewer_unknown_verdict_fails_closed(tmp_path: Path) -> None:
 def test_same_provider_review_fails_closed(tmp_path: Path) -> None:
     output = tmp_path / "gate-evidence.json"
 
-    code = _run_gate(
-        ["--review-evidence", str(_fixture("reviewer_same_provider.v1.json")), "--output", str(output)]
-    )
+    code = _run_gate(["--review-evidence", str(_fixture("reviewer_same_provider.v1.json")), "--output", str(output)])
 
     assert code == 1
     artifact = json.loads(output.read_text(encoding="utf-8"))
@@ -230,9 +226,7 @@ def test_reviewer_agree_renders_operator_may_merge(tmp_path: Path) -> None:
 def test_forbidden_action_flag_fails_closed(tmp_path: Path) -> None:
     output = tmp_path / "gate-evidence.json"
 
-    code = _run_gate(
-        ["--review-evidence", str(_fixture("reviewer_forbidden_action.v1.json")), "--output", str(output)]
-    )
+    code = _run_gate(["--review-evidence", str(_fixture("reviewer_forbidden_action.v1.json")), "--output", str(output)])
 
     assert code == 1
     artifact = json.loads(output.read_text(encoding="utf-8"))
@@ -243,9 +237,7 @@ def test_forbidden_action_flag_fails_closed(tmp_path: Path) -> None:
 def test_support_widening_true_fails_closed(tmp_path: Path) -> None:
     output = tmp_path / "gate-evidence.json"
 
-    code = _run_gate(
-        ["--review-evidence", str(_fixture("reviewer_support_widening.v1.json")), "--output", str(output)]
-    )
+    code = _run_gate(["--review-evidence", str(_fixture("reviewer_support_widening.v1.json")), "--output", str(output)])
 
     assert code == 1
     artifact = json.loads(output.read_text(encoding="utf-8"))
@@ -256,9 +248,7 @@ def test_support_widening_true_fails_closed(tmp_path: Path) -> None:
 def test_production_platform_claim_true_fails_closed(tmp_path: Path) -> None:
     output = tmp_path / "gate-evidence.json"
 
-    code = _run_gate(
-        ["--review-evidence", str(_fixture("reviewer_production_claim.v1.json")), "--output", str(output)]
-    )
+    code = _run_gate(["--review-evidence", str(_fixture("reviewer_production_claim.v1.json")), "--output", str(output)])
 
     assert code == 1
     artifact = json.loads(output.read_text(encoding="utf-8"))
@@ -269,9 +259,7 @@ def test_production_platform_claim_true_fails_closed(tmp_path: Path) -> None:
 def test_live_adapter_execution_true_fails_closed(tmp_path: Path) -> None:
     output = tmp_path / "gate-evidence.json"
 
-    code = _run_gate(
-        ["--review-evidence", str(_fixture("reviewer_live_adapter.v1.json")), "--output", str(output)]
-    )
+    code = _run_gate(["--review-evidence", str(_fixture("reviewer_live_adapter.v1.json")), "--output", str(output)])
 
     assert code == 1
     artifact = json.loads(output.read_text(encoding="utf-8"))
@@ -282,9 +270,7 @@ def test_live_adapter_execution_true_fails_closed(tmp_path: Path) -> None:
 def test_tests_failed_fails_closed(tmp_path: Path) -> None:
     output = tmp_path / "gate-evidence.json"
 
-    code = _run_gate(
-        ["--review-evidence", str(_fixture("reviewer_tests_failed.v1.json")), "--output", str(output)]
-    )
+    code = _run_gate(["--review-evidence", str(_fixture("reviewer_tests_failed.v1.json")), "--output", str(output)])
 
     assert code == 1
     artifact = json.loads(output.read_text(encoding="utf-8"))
@@ -572,9 +558,7 @@ def test_reviewer_declared_base_ref_mismatch_fails_closed(tmp_path: Path) -> Non
     assert artifact["decision"] == "fail_closed"
     assert artifact["checks"]["scope_allowed"] is False
     mismatch = [
-        f
-        for f in artifact["findings"]
-        if "reviewer-declared base_ref" in f and "does not match operator base_ref" in f
+        f for f in artifact["findings"] if "reviewer-declared base_ref" in f and "does not match operator base_ref" in f
     ]
     assert mismatch
 
@@ -593,9 +577,7 @@ def test_reviewer_declared_head_ref_mismatch_fails_closed(tmp_path: Path) -> Non
     assert artifact["decision"] == "fail_closed"
     assert artifact["checks"]["scope_allowed"] is False
     mismatch = [
-        f
-        for f in artifact["findings"]
-        if "reviewer-declared head_ref" in f and "does not match operator head_ref" in f
+        f for f in artifact["findings"] if "reviewer-declared head_ref" in f and "does not match operator head_ref" in f
     ]
     assert mismatch
 
@@ -620,9 +602,7 @@ def test_reviewer_declared_repo_mismatch_fails_closed(tmp_path: Path) -> None:
     assert artifact["decision"] == "fail_closed"
     assert artifact["checks"]["scope_allowed"] is False
     mismatch = [
-        f
-        for f in artifact["findings"]
-        if "reviewer-declared repo" in f and "does not match operator repo" in f
+        f for f in artifact["findings"] if "reviewer-declared repo" in f and "does not match operator repo" in f
     ]
     assert mismatch
     # The sentinel from the reviewer-declared repo never reaches the
@@ -655,8 +635,7 @@ def test_reviewer_declared_work_package_mismatch_fails_closed(tmp_path: Path) ->
     mismatch = [
         f
         for f in artifact["findings"]
-        if "reviewer-declared work_package" in f
-        and "does not match operator work_package" in f
+        if "reviewer-declared work_package" in f and "does not match operator work_package" in f
     ]
     assert mismatch
     raw_output = json.dumps(artifact, sort_keys=True)
@@ -829,3 +808,215 @@ def test_output_write_failure_returns_two(tmp_path: Path, capsys: Any) -> None:
     captured = capsys.readouterr()
     assert code == 2
     assert "could not write gate evidence" in captured.err
+
+
+# --- GPP-2D-2a: context-binding ---
+
+
+def _gate_artifact_without_binding(mod: Any) -> dict[str, Any]:
+    """Return a schema-valid gate artifact that carries no context_binding."""
+
+    return mod.build_gate_evidence(
+        review=None,
+        checks={name: True for name in mod.GATE_CHECK_NAMES},
+        gate_findings=[],
+        repo="Halildeu/ao-kernel",
+        work_package="GPP-2ag",
+        generated_at=mod.utc_timestamp(),
+    )
+
+
+def test_build_context_binding_binds_head_and_diff() -> None:
+    mod = _load_module()
+    changed = ["scripts/local_gpp_gate.py", "tests/test_local_gpp_gate.py"]
+    binding = mod.build_context_binding(
+        repo_root=_repo_root(),
+        base_ref="origin/main",
+        head_ref="HEAD",
+        changed_files=changed,
+    )
+    assert binding is not None
+    assert binding["base_ref"] == "origin/main"
+    assert binding["changed_files_count"] == 2
+    assert len(binding["head_sha"]) == 40
+    assert all(char in "0123456789abcdef" for char in binding["head_sha"])
+    assert binding["diff_digest"].startswith("sha256:")
+    assert len(binding["diff_digest"]) == len("sha256:") + 64
+
+
+def test_build_context_binding_diff_digest_is_order_independent() -> None:
+    mod = _load_module()
+    forward = mod.build_context_binding(
+        repo_root=_repo_root(),
+        base_ref="origin/main",
+        head_ref="HEAD",
+        changed_files=["a.py", "b.py"],
+    )
+    reverse = mod.build_context_binding(
+        repo_root=_repo_root(),
+        base_ref="origin/main",
+        head_ref="HEAD",
+        changed_files=["b.py", "a.py"],
+    )
+    other = mod.build_context_binding(
+        repo_root=_repo_root(),
+        base_ref="origin/main",
+        head_ref="HEAD",
+        changed_files=["a.py", "c.py"],
+    )
+    assert forward is not None and reverse is not None and other is not None
+    # Same file set in any order binds to the same digest.
+    assert forward["diff_digest"] == reverse["diff_digest"]
+    # A different file set binds to a different digest.
+    assert forward["diff_digest"] != other["diff_digest"]
+
+
+def test_build_context_binding_omitted_when_diff_unverified() -> None:
+    # changed_files=None models the --skip-git / git-failed path: the diff
+    # was not verified, so no context binding is emitted.
+    mod = _load_module()
+    assert (
+        mod.build_context_binding(
+            repo_root=_repo_root(),
+            base_ref="origin/main",
+            head_ref="HEAD",
+            changed_files=None,
+        )
+        is None
+    )
+
+
+def test_build_context_binding_omitted_outside_git_repo(tmp_path: Path) -> None:
+    # A non-repository directory cannot resolve a head SHA, so no binding is
+    # built even when a real changed-files list is supplied.
+    mod = _load_module()
+    assert (
+        mod.build_context_binding(
+            repo_root=tmp_path,
+            base_ref="origin/main",
+            head_ref="HEAD",
+            changed_files=["scripts/local_gpp_gate.py"],
+        )
+        is None
+    )
+
+
+def test_build_gate_evidence_includes_context_binding_when_supplied() -> None:
+    mod = _load_module()
+    binding = {
+        "head_sha": "0" * 40,
+        "base_ref": "origin/main",
+        "diff_digest": "sha256:" + "0" * 64,
+        "changed_files_count": 1,
+    }
+    artifact = mod.build_gate_evidence(
+        review=None,
+        checks={name: True for name in mod.GATE_CHECK_NAMES},
+        gate_findings=[],
+        repo="Halildeu/ao-kernel",
+        work_package="GPP-2ag",
+        generated_at=mod.utc_timestamp(),
+        context_binding=binding,
+    )
+    assert artifact["context_binding"] == binding
+    mod.validate_gate_evidence(artifact)
+
+
+def test_build_gate_evidence_omits_context_binding_when_none() -> None:
+    # Non-breaking: an artifact with no context_binding stays schema-valid,
+    # so existing local-gpp-gate-evidence.v1 artifacts keep validating.
+    mod = _load_module()
+    artifact = _gate_artifact_without_binding(mod)
+    assert "context_binding" not in artifact
+    mod.validate_gate_evidence(artifact)
+
+
+def test_schema_rejects_context_binding_with_bad_head_sha() -> None:
+    mod = _load_module()
+    from jsonschema import Draft202012Validator
+
+    artifact = _gate_artifact_without_binding(mod)
+    artifact["context_binding"] = {
+        "head_sha": "NOT-A-SHA",
+        "base_ref": "origin/main",
+        "diff_digest": "sha256:" + "0" * 64,
+        "changed_files_count": 0,
+    }
+    errors = list(Draft202012Validator(mod.load_gate_evidence_schema()).iter_errors(artifact))
+    assert errors
+
+
+def test_schema_rejects_unknown_context_binding_field() -> None:
+    mod = _load_module()
+    from jsonschema import Draft202012Validator
+
+    artifact = _gate_artifact_without_binding(mod)
+    artifact["context_binding"] = {
+        "head_sha": "0" * 40,
+        "base_ref": "origin/main",
+        "diff_digest": "sha256:" + "0" * 64,
+        "changed_files_count": 0,
+        "unexpected": "value",
+    }
+    errors = list(Draft202012Validator(mod.load_gate_evidence_schema()).iter_errors(artifact))
+    assert errors
+
+
+def test_schema_rejects_context_binding_missing_required_field() -> None:
+    mod = _load_module()
+    from jsonschema import Draft202012Validator
+
+    artifact = _gate_artifact_without_binding(mod)
+    artifact["context_binding"] = {
+        "head_sha": "0" * 40,
+        "base_ref": "origin/main",
+        "diff_digest": "sha256:" + "0" * 64,
+    }
+    errors = list(Draft202012Validator(mod.load_gate_evidence_schema()).iter_errors(artifact))
+    assert errors
+
+
+def test_gate_run_emits_context_binding(tmp_path: Path) -> None:
+    # End-to-end: a gate run over a verified git diff emits context_binding.
+    # base-ref == head-ref gives a verified (empty) diff that does not depend
+    # on the CI checkout depth, so the binding is still emitted deterministically.
+    mod = _load_module()
+    output = tmp_path / "gate-evidence.json"
+    mod.main(
+        [
+            "--review-evidence",
+            str(_fixture("reviewer_agree.v1.json")),
+            "--output",
+            str(output),
+            "--base-ref",
+            "HEAD",
+            "--head-ref",
+            "HEAD",
+        ]
+    )
+    artifact = json.loads(output.read_text(encoding="utf-8"))
+    binding = artifact["context_binding"]
+    assert len(binding["head_sha"]) == 40
+    assert binding["base_ref"] == "HEAD"
+    assert binding["changed_files_count"] == 0
+    assert binding["diff_digest"].startswith("sha256:")
+    mod.validate_gate_evidence(artifact)
+
+
+def test_gate_run_skip_git_omits_context_binding(tmp_path: Path) -> None:
+    # --skip-git leaves the diff unverified, so the gate emits no context
+    # binding and the artifact still validates against the schema.
+    mod = _load_module()
+    output = tmp_path / "gate-evidence.json"
+    mod.main(
+        [
+            "--review-evidence",
+            str(_fixture("reviewer_agree.v1.json")),
+            "--output",
+            str(output),
+            "--skip-git",
+        ]
+    )
+    artifact = json.loads(output.read_text(encoding="utf-8"))
+    assert "context_binding" not in artifact
+    mod.validate_gate_evidence(artifact)


### PR DESCRIPTION
## GPP-2D-2a — evidence context-binding (schema + emitter)

First implementation sub-slice of GPP-2D-2 (autonomous required-check lane; design doc PR #588). The `local-gpp-gate-evidence.v1` artifact now carries an optional `context_binding` block so a future `ao-release-gate` required check can reject stale, forged, or replayed review evidence (design doc §3.3).

### Changes
- **schema** (`local-gpp-gate-evidence.schema.v1.json`): optional `context_binding` object — `head_sha`, `base_ref`, `diff_digest`, `changed_files_count`. Additive, non-breaking: not in root `required`, so existing `local-gpp-gate-evidence.v1` artifacts stay schema-valid.
- **emitter** (`scripts/local_gpp_gate.py`): `build_context_binding` derives the block only from the trusted operator base/head refs and the verified git diff — never from reviewer evidence. Omitted on the unverifiable-scope path (git skipped or failed) so a future required check fails closed rather than trusting an unverifiable head.
- **tests**: 12 new tests — binding shape, digest determinism / order-independence, schema negatives (bad SHA, unknown field, missing field), both omit paths, invalid-head-ref fail-closed.

### Scope guard
No decision-core change (that is GPP-2D-2b), no workflow, no branch-protection change. This slice only makes the evidence artifact *carry* the binding fields; nothing consumes them yet. GPP-2 stays blocked; guard flags stay false; no support widening, no production claim, no live adapter execution.

### Verification
- full suite: 3317 passed, 2 skipped
- ruff + mypy clean; `git diff --check` clean
- Codex post-impl review (thread `019e51a9`): VERDICT AGREE (6/6 criteria); the one optional-hardening test it suggested was absorbed

Implementer: Claude (Anthropic, session 44106462)
Reviewer:    Codex (OpenAI, thread 019e51a9) — post-impl AGREE