### PR TITLE
feat(gpp-2d): ao-release-gate shadow workflow + API payload builder + fallback synthesizer (GPP-2D-2c)

### DIFF
--- a/.github/workflows/ao-release-gate.yml
+++ b/.github/workflows/ao-release-gate.yml
@@ -194,11 +194,24 @@ jobs:
         # decision.json, this step invokes the synthesizer to write a
         # synthetic error_fail_closed artifact so every shadow run still
         # emits an auditable decision record.
+        #
+        # Bootstrap path: on the PR that first introduces this workflow,
+        # the trusted-base checkout does not yet carry
+        # `scripts/ao_release_gate_synthesize_error_decision.py`; that
+        # script ships in the same PR. In that case the fallback writes
+        # a minimal inline JSON artifact so the shadow job still exits 0
+        # and uploads a record. Once this PR merges, future runs on real
+        # PRs find the synthesizer on main and use the canonical path.
         if: always()
+        continue-on-error: true
         working-directory: base
         run: |
           if [ ! -f decision.json ]; then
-            python scripts/ao_release_gate_synthesize_error_decision.py decision.json
+            if [ -f scripts/ao_release_gate_synthesize_error_decision.py ]; then
+              python scripts/ao_release_gate_synthesize_error_decision.py decision.json
+            else
+              printf '%s\n' '{"schema_version": "1", "artifact_kind": "ao_release_gate_decision", "program_id": "GPP-2v", "app_slug": "ao-release-gate", "dry_run": true, "merge_authority_enabled": false, "conclusion_mode": "shadow", "decision": "error_fail_closed", "allow": false, "finding_code": "error_fail_closed", "reason": "Synthesizer script not present on the base ref (bootstrap or transition).", "context": {}, "checks": [], "findings": ["ao_release_gate_shadow_pre_decision_step_failed"], "github_check_run": {"name": "ao-release-gate", "status": "completed", "conclusion": "neutral", "title": "ao-release-gate: error_fail_closed", "summary": "bootstrap fallback", "text": "Findings: ao_release_gate_shadow_pre_decision_step_failed"}}' > decision.json
+            fi
           fi
           # Shadow advisory job: always exits 0 regardless of the synthesized
           # or core-produced decision body.

--- a/.github/workflows/ao-release-gate.yml
+++ b/.github/workflows/ao-release-gate.yml
@@ -56,7 +56,6 @@ jobs:
       BASE_REF: ${{ github.event.pull_request.base.ref }}
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       REPO_FULL: ${{ github.repository }}
-      ISSUE_URL: ${{ github.event.pull_request.issue_url }}
       FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
     steps:
@@ -105,16 +104,21 @@ jobs:
           python -m pip install -e ".[mcp]"
 
       - name: Fetch PR data and check-runs via GitHub API
+        continue-on-error: true
         working-directory: base
         run: |
           # Fetch PR files (changed_paths) and the head SHA's check-runs.
           # The builder script will exclude ao-release-gate / -shadow
           # entries so the gate does not see its own status.
+          # per_page=100 (gh's max) avoids the --paginate object-concat
+          # pitfall, where multi-page object responses produce concatenated
+          # JSON objects that the builder's json.loads cannot parse.
           gh pr view "$PR_NUMBER" --repo "$REPO_FULL" --json files > pr-files.json
-          gh api "repos/$REPO_FULL/commits/$HEAD_SHA/check-runs" --paginate > check-runs.json
+          gh api "repos/$REPO_FULL/commits/$HEAD_SHA/check-runs?per_page=100" > check-runs.json
 
       - name: Compute branch_up_to_date from base
         id: freshness
+        continue-on-error: true
         working-directory: base
         run: |
           # Branch is up to date when the PR base SHA is an ancestor of
@@ -127,6 +131,7 @@ jobs:
           fi
 
       - name: Build API-derived release-gate payload
+        continue-on-error: true
         working-directory: base
         run: |
           python scripts/ao_release_gate_build_payload.py \
@@ -135,7 +140,6 @@ jobs:
             --base-ref "$BASE_REF" \
             --head-ref "$HEAD_REF" \
             --head-sha "$HEAD_SHA" \
-            --issue-url "$ISSUE_URL" \
             --from-fork "$FROM_FORK" \
             --branch-up-to-date "${{ steps.freshness.outputs.branch_up_to_date }}" \
             --gpp-status .claude/plans/gpp_status.v1.json \
@@ -145,6 +149,7 @@ jobs:
 
       - name: Locate optional review evidence on PR head
         id: evidence
+        continue-on-error: true
         run: |
           # Convention: the operator commits the no-secret local-gpp-gate
           # evidence at the repo root of the PR head. Absent evidence
@@ -161,6 +166,7 @@ jobs:
         # --fail-on-deny is supplied. Under the shadow advisory job we
         # never pass that flag, so the job always exits 0; the decision
         # body is captured in the uploaded artifact for audit.
+        continue-on-error: true
         working-directory: base
         run: |
           set +e
@@ -181,9 +187,61 @@ jobs:
           # Shadow advisory: never propagate the decision exit code.
           exit 0
 
-      - name: Upload audit artifact
-        uses: actions/upload-artifact@v7
+      - name: Synthesize error_fail_closed decision when prior steps failed
+        # Pre-decision steps (API fetch, builder, freshness) carry
+        # continue-on-error so a transient failure does not break the
+        # advisory job. When the decision step did not run / did not
+        # produce decision.json, this step writes a synthetic
+        # error_fail_closed artifact so every shadow run still emits an
+        # auditable decision record.
         if: always()
+        working-directory: base
+        run: |
+          if [ ! -f decision.json ]; then
+            python -c "
+            import json, sys
+            from pathlib import Path
+            try:
+                from ao_kernel.live_adapter_gate import utc_timestamp
+                generated_at = utc_timestamp()
+            except Exception:
+                from datetime import datetime, timezone
+                generated_at = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+            synthetic = {
+                'schema_version': '1',
+                'artifact_kind': 'ao_release_gate_decision',
+                'program_id': 'GPP-2v',
+                'generated_at': generated_at,
+                'app_slug': 'ao-release-gate',
+                'dry_run': True,
+                'merge_authority_enabled': False,
+                'conclusion_mode': 'shadow',
+                'decision': 'error_fail_closed',
+                'allow': False,
+                'finding_code': 'error_fail_closed',
+                'reason': 'ao-release-gate shadow workflow could not produce a decision; pre-decision step failed.',
+                'context': {},
+                'checks': [],
+                'findings': ['ao_release_gate_shadow_pre_decision_step_failed'],
+                'github_check_run': {
+                    'name': 'ao-release-gate',
+                    'status': 'completed',
+                    'conclusion': 'neutral',
+                    'title': 'ao-release-gate: error_fail_closed',
+                    'summary': 'Shadow workflow synthesized this decision because a pre-decision step failed.',
+                    'text': 'Findings: ao_release_gate_shadow_pre_decision_step_failed',
+                },
+            }
+            Path('decision.json').write_text(json.dumps(synthetic, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+            "
+          fi
+          # Shadow advisory job: always exits 0 regardless of the synthesized
+          # or core-produced decision body.
+          exit 0
+
+      - name: Upload audit artifact
+        if: always()
+        uses: actions/upload-artifact@v7
         with:
           name: ao-release-gate-shadow-${{ github.event.pull_request.number }}-${{ github.run_id }}
           path: |

--- a/.github/workflows/ao-release-gate.yml
+++ b/.github/workflows/ao-release-gate.yml
@@ -1,0 +1,192 @@
+name: ao-release-gate
+
+# GPP-2D-2c shadow workflow: runs the ao-release-gate decision core on
+# every pull request and reports the decision as an advisory check-run
+# under the distinct job name `ao-release-gate-shadow`. The required-
+# check name `ao-release-gate` is reserved for the GPP-2D-3 enforce job
+# (not landed yet), so branch protection can never be satisfied by this
+# fail-open advisory job.
+#
+# Design constraints (.claude/plans/GPP-2D-AUTONOMOUS-REQUIRED-CHECK-LANE.md):
+# - §3.2 trusted-base gate: the decision-core code, schemas, and
+#   gpp_status.v1.json are evaluated from the PR base ref, never the PR
+#   head. The PR head is the diff and evidence under inspection, never
+#   the policy authority.
+# - §3.2 triggers on `pull_request`, NEVER `pull_request_target`, with
+#   read-only permissions and no long-lived secrets.
+# - §3.3 untrusted PR input: the payload is built from the GitHub API
+#   plus the base-ref gpp_status, never from a PR-committed JSON file.
+#   The optional review evidence file (local-gpp-gate-evidence.v1.json)
+#   IS read from the PR head, but it is validated hard (full schema +
+#   acceptance profile + context-binding) by the decision core.
+# - §6 advisory: the job always succeeds (advisory) and is never a
+#   required check until the GPP-2D-5 cutover.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  checks: read
+  pull-requests: read
+
+concurrency:
+  group: ao-release-gate-shadow-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  ao-release-gate-shadow:
+    name: ao-release-gate-shadow
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # GPP-2D design §3.2: the trigger is pull_request only. This guard is
+    # defense in depth in case the trigger config is edited.
+    if: github.event_name == 'pull_request'
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      REPO_FULL: ${{ github.repository }}
+      ISSUE_URL: ${{ github.event.pull_request.issue_url }}
+      FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+
+    steps:
+      - name: Refuse pull_request_target context
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          # Belt-and-suspenders: the trigger above is pull_request only.
+          # pull_request_target would expose the workflow to PR-controlled
+          # code with write-scoped permissions, which the trusted-base
+          # design forbids.
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "::error::ao-release-gate-shadow only evaluates pull_request events"
+            exit 1
+          fi
+
+      - name: Checkout protected base ref
+        uses: actions/checkout@v6
+        with:
+          # The decision-core code, schemas, and gpp_status.v1.json come
+          # from the base ref. A PR that edits the gate itself cannot
+          # thereby change the gate that judges it (design §3.2).
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          fetch-depth: 1
+
+      - name: Checkout PR head for optional review-evidence file
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+          fetch-depth: 1
+          # The PR head is untrusted. We only read the optional review
+          # evidence file from it; the decision core validates it hard
+          # against the bundled schema and acceptance profile.
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install base-ref ao-kernel
+        working-directory: base
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[mcp]"
+
+      - name: Fetch PR data and check-runs via GitHub API
+        working-directory: base
+        run: |
+          # Fetch PR files (changed_paths) and the head SHA's check-runs.
+          # The builder script will exclude ao-release-gate / -shadow
+          # entries so the gate does not see its own status.
+          gh pr view "$PR_NUMBER" --repo "$REPO_FULL" --json files > pr-files.json
+          gh api "repos/$REPO_FULL/commits/$HEAD_SHA/check-runs" --paginate > check-runs.json
+
+      - name: Compute branch_up_to_date from base
+        id: freshness
+        working-directory: base
+        run: |
+          # Branch is up to date when the PR base SHA is an ancestor of
+          # HEAD. fetch-depth=1 may miss the ancestry; deepen if needed.
+          git fetch --depth=50 origin "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true
+          if git merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA"; then
+            echo "branch_up_to_date=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch_up_to_date=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build API-derived release-gate payload
+        working-directory: base
+        run: |
+          python scripts/ao_release_gate_build_payload.py \
+            --repository "$REPO_FULL" \
+            --pr-number "$PR_NUMBER" \
+            --base-ref "$BASE_REF" \
+            --head-ref "$HEAD_REF" \
+            --head-sha "$HEAD_SHA" \
+            --issue-url "$ISSUE_URL" \
+            --from-fork "$FROM_FORK" \
+            --branch-up-to-date "${{ steps.freshness.outputs.branch_up_to_date }}" \
+            --gpp-status .claude/plans/gpp_status.v1.json \
+            --pr-files-json pr-files.json \
+            --check-runs-json check-runs.json \
+            --output payload.json
+
+      - name: Locate optional review evidence on PR head
+        id: evidence
+        run: |
+          # Convention: the operator commits the no-secret local-gpp-gate
+          # evidence at the repo root of the PR head. Absent evidence
+          # makes the core return deny_missing_evidence, which is the
+          # correct fail-closed signal under the shadow advisory job.
+          if [ -f head/local-gpp-gate-evidence.v1.json ]; then
+            echo "path=head/local-gpp-gate-evidence.v1.json" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Evaluate ao-release-gate decision (advisory)
+        # The decision script returns exit 1 on deny only when
+        # --fail-on-deny is supplied. Under the shadow advisory job we
+        # never pass that flag, so the job always exits 0; the decision
+        # body is captured in the uploaded artifact for audit.
+        working-directory: base
+        run: |
+          set +e
+          if [ -n "${{ steps.evidence.outputs.path }}" ]; then
+            python scripts/ao_release_gate_decision.py \
+              --payload payload.json \
+              --gpp-status .claude/plans/gpp_status.v1.json \
+              --review-evidence "../${{ steps.evidence.outputs.path }}" \
+              --decision-path decision.json \
+              --output text
+          else
+            python scripts/ao_release_gate_decision.py \
+              --payload payload.json \
+              --gpp-status .claude/plans/gpp_status.v1.json \
+              --decision-path decision.json \
+              --output text
+          fi
+          # Shadow advisory: never propagate the decision exit code.
+          exit 0
+
+      - name: Upload audit artifact
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: ao-release-gate-shadow-${{ github.event.pull_request.number }}-${{ github.run_id }}
+          path: |
+            base/payload.json
+            base/decision.json
+          if-no-files-found: warn

--- a/.github/workflows/ao-release-gate.yml
+++ b/.github/workflows/ao-release-gate.yml
@@ -190,50 +190,15 @@ jobs:
       - name: Synthesize error_fail_closed decision when prior steps failed
         # Pre-decision steps (API fetch, builder, freshness) carry
         # continue-on-error so a transient failure does not break the
-        # advisory job. When the decision step did not run / did not
-        # produce decision.json, this step writes a synthetic
-        # error_fail_closed artifact so every shadow run still emits an
-        # auditable decision record.
+        # advisory job. When the decision step did not produce
+        # decision.json, this step invokes the synthesizer to write a
+        # synthetic error_fail_closed artifact so every shadow run still
+        # emits an auditable decision record.
         if: always()
         working-directory: base
         run: |
           if [ ! -f decision.json ]; then
-            python -c "
-            import json, sys
-            from pathlib import Path
-            try:
-                from ao_kernel.live_adapter_gate import utc_timestamp
-                generated_at = utc_timestamp()
-            except Exception:
-                from datetime import datetime, timezone
-                generated_at = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
-            synthetic = {
-                'schema_version': '1',
-                'artifact_kind': 'ao_release_gate_decision',
-                'program_id': 'GPP-2v',
-                'generated_at': generated_at,
-                'app_slug': 'ao-release-gate',
-                'dry_run': True,
-                'merge_authority_enabled': False,
-                'conclusion_mode': 'shadow',
-                'decision': 'error_fail_closed',
-                'allow': False,
-                'finding_code': 'error_fail_closed',
-                'reason': 'ao-release-gate shadow workflow could not produce a decision; pre-decision step failed.',
-                'context': {},
-                'checks': [],
-                'findings': ['ao_release_gate_shadow_pre_decision_step_failed'],
-                'github_check_run': {
-                    'name': 'ao-release-gate',
-                    'status': 'completed',
-                    'conclusion': 'neutral',
-                    'title': 'ao-release-gate: error_fail_closed',
-                    'summary': 'Shadow workflow synthesized this decision because a pre-decision step failed.',
-                    'text': 'Findings: ao_release_gate_shadow_pre_decision_step_failed',
-                },
-            }
-            Path('decision.json').write_text(json.dumps(synthetic, indent=2, sort_keys=True) + '\n', encoding='utf-8')
-            "
+            python scripts/ao_release_gate_synthesize_error_decision.py decision.json
           fi
           # Shadow advisory job: always exits 0 regardless of the synthesized
           # or core-produced decision body.

--- a/scripts/ao_release_gate_build_payload.py
+++ b/scripts/ao_release_gate_build_payload.py
@@ -116,6 +116,25 @@ def _reviewed_slice(gpp_status_path: Path) -> str:
     raise SystemExit("gpp_status.v1.json missing current_wp.id")
 
 
+def _work_package_issue_url(gpp_status_path: Path) -> str:
+    """Return the base-ref-trusted work-package issue URL.
+
+    The decision core's gpp_issue_consistency check requires the payload's
+    issue_url to equal the GPP current work-package issue URL exactly. The
+    workflow CANNOT source this from ``pull_request.issue_url`` — that field
+    is the PR's own API URL, not the GPP work-package issue URL — so the
+    builder derives it from the base-ref ``gpp_status.current_wp.issue``.
+    """
+
+    status = json.loads(gpp_status_path.read_text(encoding="utf-8"))
+    current_wp = status.get("current_wp") if isinstance(status, dict) else None
+    if isinstance(current_wp, dict):
+        issue = current_wp.get("issue")
+        if isinstance(issue, str) and issue.strip():
+            return issue.strip()
+    raise SystemExit("gpp_status.v1.json missing current_wp.issue")
+
+
 def build_payload(args: argparse.Namespace) -> dict[str, Any]:
     """Build the release-gate payload dictionary from trusted inputs."""
 
@@ -130,7 +149,10 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
                 "repo": {"fork": args.from_fork},
             },
         },
-        "issue_url": args.issue_url,
+        # issue_url comes from the base-ref-trusted gpp_status, NOT from the
+        # pull_request.issue_url webhook field (which is the PR's own API
+        # URL, not the GPP work-package issue URL).
+        "issue_url": _work_package_issue_url(args.gpp_status),
         "branch_up_to_date": args.branch_up_to_date,
         "event_name": "pull_request",
         "reviewed_slice": _reviewed_slice(args.gpp_status),
@@ -154,14 +176,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--base-ref", required=True)
     parser.add_argument("--head-ref", required=True)
     parser.add_argument("--head-sha", required=True)
-    parser.add_argument("--issue-url", required=True)
     parser.add_argument("--from-fork", type=_bool_arg, required=True)
     parser.add_argument("--branch-up-to-date", type=_bool_arg, required=True)
     parser.add_argument(
         "--gpp-status",
         type=Path,
         required=True,
-        help="Path to the base-ref gpp_status.v1.json (trusted source of reviewed_slice).",
+        help=(
+            "Path to the base-ref gpp_status.v1.json. Trusted source of both "
+            "reviewed_slice (current_wp.id) and issue_url (current_wp.issue)."
+        ),
     )
     parser.add_argument("--pr-files-json", type=Path, required=True)
     parser.add_argument("--check-runs-json", type=Path, required=True)

--- a/scripts/ao_release_gate_build_payload.py
+++ b/scripts/ao_release_gate_build_payload.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Build an ao-release-gate dry-run payload from API-derived PR data.
+
+This builder runs INSIDE the ao-release-gate GitHub Actions workflow on
+the protected base ref (GPP-2D design §3.2). It composes the release-gate
+payload only from the GitHub API and the base-ref ``gpp_status.v1.json``,
+NEVER from a PR-committed JSON file (GPP-2D design §3.3): PR-author-
+supplied ``allowed_path_prefixes`` / ``required_checks`` /
+``branch_up_to_date`` / ``admin_bypass_requested`` fields would let a PR
+self-approve.
+
+The builder takes the trusted operator-supplied / API-derived fields as
+CLI args plus two JSON blobs the workflow has already fetched via ``gh``:
+
+- ``--pr-files-json`` — output of ``gh pr view <N> --json files``.
+- ``--check-runs-json`` — output of ``gh api repos/.../commits/<SHA>/check-runs``,
+  filtered to exclude the ao-release-gate / ao-release-gate-shadow names
+  (otherwise the gate would see its own shadow job as a pending required
+  check).
+
+The output is a single payload JSON consumable by
+``scripts/ao_release_gate_decision.py``. The builder is side-effect free
+beyond writing the output file and emits no secret material.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# A repo-owned, base-ref-trusted path allowlist for the diff_scope check.
+# Hard-coded here rather than read from gpp_status.current_wp.allowed_scope
+# because that field carries narrative scope statements, not file-path
+# prefixes. Refining this is a GPP-2D-3 follow-up.
+DEFAULT_ALLOWED_PATH_PREFIXES = (
+    "ao_kernel/",
+    "scripts/",
+    "tests/",
+    ".claude/plans/",
+    ".github/workflows/",
+    ".github/CODEOWNERS",
+    "deploy/",
+    "docs/",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "README.md",
+    "local-gpp-gate-evidence.v1.json",
+)
+
+
+def _bool_arg(value: str) -> bool:
+    """Parse a ``true`` / ``false`` string argument as a boolean."""
+
+    normalized = value.strip().lower()
+    if normalized in {"true", "1", "yes"}:
+        return True
+    if normalized in {"false", "0", "no", ""}:
+        return False
+    raise argparse.ArgumentTypeError(f"expected 'true' or 'false', got {value!r}")
+
+
+def _changed_paths(pr_files_json_path: Path) -> list[str]:
+    """Extract changed file paths from the ``gh pr view --json files`` output."""
+
+    data = json.loads(pr_files_json_path.read_text(encoding="utf-8"))
+    files = data.get("files", []) if isinstance(data, dict) else []
+    paths: list[str] = []
+    for entry in files:
+        if isinstance(entry, dict):
+            path = entry.get("path")
+            if isinstance(path, str) and path.strip():
+                paths.append(path.strip())
+    return sorted(paths)
+
+
+def _normalized_checks(check_runs_json_path: Path) -> list[dict[str, Any]]:
+    """Extract normalized {name, status, conclusion} check-run entries.
+
+    The shadow / enforce jobs of the ao-release-gate itself are excluded so
+    the gate does not see its own pending status as a required-check
+    failure.
+    """
+
+    data = json.loads(check_runs_json_path.read_text(encoding="utf-8"))
+    runs = data.get("check_runs", []) if isinstance(data, dict) else []
+    excluded = {"ao-release-gate", "ao-release-gate-shadow"}
+    out: list[dict[str, Any]] = []
+    for entry in runs:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or name in excluded:
+            continue
+        out.append(
+            {
+                "name": name,
+                "status": entry.get("status"),
+                "conclusion": entry.get("conclusion"),
+            }
+        )
+    return out
+
+
+def _reviewed_slice(gpp_status_path: Path) -> str:
+    """Return the base-ref-trusted reviewed slice (current_wp.id)."""
+
+    status = json.loads(gpp_status_path.read_text(encoding="utf-8"))
+    current_wp = status.get("current_wp") if isinstance(status, dict) else None
+    if isinstance(current_wp, dict):
+        wp_id = current_wp.get("id")
+        if isinstance(wp_id, str) and wp_id.strip():
+            return wp_id.strip()
+    raise SystemExit("gpp_status.v1.json missing current_wp.id")
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    """Build the release-gate payload dictionary from trusted inputs."""
+
+    return {
+        "repository": {"full_name": args.repository},
+        "pull_request": {
+            "number": args.pr_number,
+            "base": {"ref": args.base_ref},
+            "head": {
+                "ref": args.head_ref,
+                "sha": args.head_sha,
+                "repo": {"fork": args.from_fork},
+            },
+        },
+        "issue_url": args.issue_url,
+        "branch_up_to_date": args.branch_up_to_date,
+        "event_name": "pull_request",
+        "reviewed_slice": _reviewed_slice(args.gpp_status),
+        "changed_paths": _changed_paths(args.pr_files_json),
+        "allowed_path_prefixes": list(DEFAULT_ALLOWED_PATH_PREFIXES),
+        "required_checks": _normalized_checks(args.check_runs_json),
+        "forbidden_secret_context_detected": False,
+        "admin_bypass_requested": False,
+        "pat_backed_bot_actor": False,
+        "codex_or_claude_release_authority": False,
+        "live_adapter_execution_requested": False,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True, help="Full GitHub repository name (owner/repo).")
+    parser.add_argument("--pr-number", type=int, required=True)
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument("--head-ref", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--issue-url", required=True)
+    parser.add_argument("--from-fork", type=_bool_arg, required=True)
+    parser.add_argument("--branch-up-to-date", type=_bool_arg, required=True)
+    parser.add_argument(
+        "--gpp-status",
+        type=Path,
+        required=True,
+        help="Path to the base-ref gpp_status.v1.json (trusted source of reviewed_slice).",
+    )
+    parser.add_argument("--pr-files-json", type=Path, required=True)
+    parser.add_argument("--check-runs-json", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True, help="Where to write the payload JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    payload = build_payload(args)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ao_release_gate_synthesize_error_decision.py
+++ b/scripts/ao_release_gate_synthesize_error_decision.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Emit a synthetic ``error_fail_closed`` ao-release-gate decision.
+
+The ao-release-gate shadow workflow (GPP-2D-2c) runs every pre-decision
+step under ``continue-on-error: true`` so a transient API fetch / builder
+failure does not break the advisory job. When the decision step did not
+produce ``decision.json``, the workflow's always-run synthesis step
+invokes this script to write a synthetic decision artifact, so every
+shadow run still emits an auditable record and the job exits 0.
+
+The artifact carries the canonical ``error_fail_closed`` finding shape:
+
+- ``decision = "error_fail_closed"`` (the fail-closed decision used by the
+  ao-release-gate core for malformed / unevaluable payloads);
+- ``allow = false``;
+- ``conclusion_mode = "shadow"``;
+- ``github_check_run.conclusion = "neutral"`` (shadow advisory);
+- the gate-authored finding code
+  ``ao_release_gate_shadow_pre_decision_step_failed``, which is
+  workflow-only (the decision core never produces it).
+
+No secret material is read or written. The script is side-effect free
+beyond writing the output file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _utc_timestamp() -> str:
+    """Return an ISO-8601 UTC timestamp.
+
+    Prefers the canonical ``ao_kernel.live_adapter_gate.utc_timestamp`` so
+    the synthetic artifact matches the format the core would emit. Falls
+    back to the stdlib when the package is not importable (e.g. when the
+    base-ref install failed mid-shadow).
+    """
+
+    try:
+        from ao_kernel.live_adapter_gate import utc_timestamp
+
+        return utc_timestamp()
+    except Exception:  # noqa: BLE001 - intentionally broad: any import or runtime failure
+        from datetime import datetime, timezone
+
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def build_error_decision() -> dict[str, Any]:
+    """Build the synthetic ``error_fail_closed`` decision dictionary."""
+
+    finding_code = "ao_release_gate_shadow_pre_decision_step_failed"
+    reason = (
+        "ao-release-gate shadow workflow could not produce a decision; "
+        "a pre-decision step failed under continue-on-error."
+    )
+    return {
+        "schema_version": "1",
+        "artifact_kind": "ao_release_gate_decision",
+        "program_id": "GPP-2v",
+        "generated_at": _utc_timestamp(),
+        "app_slug": "ao-release-gate",
+        "dry_run": True,
+        "merge_authority_enabled": False,
+        "conclusion_mode": "shadow",
+        "decision": "error_fail_closed",
+        "allow": False,
+        "finding_code": "error_fail_closed",
+        "reason": reason,
+        "context": {},
+        "checks": [],
+        "findings": [finding_code],
+        "github_check_run": {
+            "name": "ao-release-gate",
+            "status": "completed",
+            "conclusion": "neutral",
+            "title": "ao-release-gate: error_fail_closed",
+            "summary": reason,
+            "text": f"Findings: {finding_code}",
+        },
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "output",
+        type=Path,
+        help="Path for the synthetic decision JSON artifact.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    decision = build_error_decision()
+    args.output.write_text(
+        json.dumps(decision, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ao_release_gate_build_payload.py
+++ b/tests/test_ao_release_gate_build_payload.py
@@ -1,0 +1,285 @@
+"""Tests for the ao-release-gate payload builder (GPP-2D-2c)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _load_module() -> Any:
+    module_path = _repo_root() / "scripts" / "ao_release_gate_build_payload.py"
+    spec = importlib.util.spec_from_file_location("ao_release_gate_build_payload", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_pr_files(path: Path, paths: list[str]) -> None:
+    """Write a stub ``gh pr view --json files`` response."""
+
+    payload = {"files": [{"path": p} for p in paths]}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_check_runs(path: Path, runs: list[dict[str, str]]) -> None:
+    """Write a stub ``gh api .../check-runs`` response."""
+
+    path.write_text(json.dumps({"check_runs": runs}), encoding="utf-8")
+
+
+def _write_gpp_status(path: Path, *, wp_id: str = "GPP-2") -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "current_wp": {"id": wp_id, "status": "blocked"},
+                "support_widening_allowed": False,
+                "production_platform_claim_allowed": False,
+                "live_adapter_execution_allowed": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _build_argv(tmp_path: Path, *, output: Path) -> list[str]:
+    """Compose a fully populated CLI argv with fixture inputs in tmp_path."""
+
+    pr_files = tmp_path / "pr-files.json"
+    check_runs = tmp_path / "check-runs.json"
+    gpp_status = tmp_path / "gpp_status.json"
+    _write_pr_files(pr_files, ["ao_kernel/foo.py", "tests/test_foo.py"])
+    _write_check_runs(
+        check_runs,
+        [
+            {"name": "lint", "status": "completed", "conclusion": "success"},
+            {"name": "test (3.13)", "status": "completed", "conclusion": "success"},
+            # Self-name must be excluded by the builder.
+            {"name": "ao-release-gate-shadow", "status": "in_progress", "conclusion": None},
+            {"name": "ao-release-gate", "status": "queued", "conclusion": None},
+        ],
+    )
+    _write_gpp_status(gpp_status)
+    return [
+        "--repository",
+        "Halildeu/ao-kernel",
+        "--pr-number",
+        "999",
+        "--base-ref",
+        "main",
+        "--head-ref",
+        "codex/test-feature",
+        "--head-sha",
+        "abc1230000000000000000000000000000000000",
+        "--issue-url",
+        "https://github.com/Halildeu/ao-kernel/issues/999",
+        "--from-fork",
+        "false",
+        "--branch-up-to-date",
+        "true",
+        "--gpp-status",
+        str(gpp_status),
+        "--pr-files-json",
+        str(pr_files),
+        "--check-runs-json",
+        str(check_runs),
+        "--output",
+        str(output),
+    ]
+
+
+def test_build_payload_emits_expected_shape(tmp_path: Path) -> None:
+    mod = _load_module()
+    output = tmp_path / "payload.json"
+    rc = mod.main(_build_argv(tmp_path, output=output))
+    assert rc == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+
+    assert payload["repository"] == {"full_name": "Halildeu/ao-kernel"}
+    assert payload["pull_request"]["number"] == 999
+    assert payload["pull_request"]["base"]["ref"] == "main"
+    assert payload["pull_request"]["head"]["sha"] == "abc1230000000000000000000000000000000000"
+    assert payload["pull_request"]["head"]["repo"]["fork"] is False
+    assert payload["issue_url"] == "https://github.com/Halildeu/ao-kernel/issues/999"
+    assert payload["branch_up_to_date"] is True
+    assert payload["event_name"] == "pull_request"
+    assert payload["reviewed_slice"] == "GPP-2"
+
+
+def test_build_payload_sorts_and_carries_changed_paths(tmp_path: Path) -> None:
+    mod = _load_module()
+    pr_files = tmp_path / "pr-files.json"
+    check_runs = tmp_path / "check-runs.json"
+    gpp_status = tmp_path / "gpp_status.json"
+    _write_pr_files(pr_files, ["z.py", "a.py", "m.py"])
+    _write_check_runs(check_runs, [])
+    _write_gpp_status(gpp_status)
+    output = tmp_path / "payload.json"
+    mod.main(
+        [
+            "--repository",
+            "Halildeu/ao-kernel",
+            "--pr-number",
+            "1",
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "x",
+            "--head-sha",
+            "f" * 40,
+            "--issue-url",
+            "https://x",
+            "--from-fork",
+            "false",
+            "--branch-up-to-date",
+            "true",
+            "--gpp-status",
+            str(gpp_status),
+            "--pr-files-json",
+            str(pr_files),
+            "--check-runs-json",
+            str(check_runs),
+            "--output",
+            str(output),
+        ]
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["changed_paths"] == ["a.py", "m.py", "z.py"]
+
+
+def test_build_payload_excludes_self_check_runs(tmp_path: Path) -> None:
+    """The builder must never include `ao-release-gate` or
+    `ao-release-gate-shadow` in required_checks; otherwise the gate
+    would see its own pending status as a missing required check."""
+    mod = _load_module()
+    output = tmp_path / "payload.json"
+    mod.main(_build_argv(tmp_path, output=output))
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    names = [check["name"] for check in payload["required_checks"]]
+    assert "ao-release-gate" not in names
+    assert "ao-release-gate-shadow" not in names
+    assert "lint" in names
+    assert "test (3.13)" in names
+
+
+def test_build_payload_defaults_dangerous_flags_to_false(tmp_path: Path) -> None:
+    """PR-author-supplied admin_bypass / forbidden_secret / bot / agent /
+    live-adapter flags would let a PR self-approve; the builder never
+    reads them from the PR and always emits false."""
+    mod = _load_module()
+    output = tmp_path / "payload.json"
+    mod.main(_build_argv(tmp_path, output=output))
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["forbidden_secret_context_detected"] is False
+    assert payload["admin_bypass_requested"] is False
+    assert payload["pat_backed_bot_actor"] is False
+    assert payload["codex_or_claude_release_authority"] is False
+    assert payload["live_adapter_execution_requested"] is False
+
+
+def test_build_payload_reviewed_slice_comes_from_base_ref_gpp_status(tmp_path: Path) -> None:
+    """The reviewed slice is the base-ref-trusted current_wp.id, not any
+    PR-author-supplied value."""
+    mod = _load_module()
+    output = tmp_path / "payload.json"
+    pr_files = tmp_path / "pr-files.json"
+    check_runs = tmp_path / "check-runs.json"
+    gpp_status = tmp_path / "gpp_status.json"
+    _write_pr_files(pr_files, ["a.py"])
+    _write_check_runs(check_runs, [])
+    _write_gpp_status(gpp_status, wp_id="GPP-2D-2c")
+    mod.main(
+        [
+            "--repository",
+            "Halildeu/ao-kernel",
+            "--pr-number",
+            "1",
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "x",
+            "--head-sha",
+            "f" * 40,
+            "--issue-url",
+            "https://x",
+            "--from-fork",
+            "false",
+            "--branch-up-to-date",
+            "true",
+            "--gpp-status",
+            str(gpp_status),
+            "--pr-files-json",
+            str(pr_files),
+            "--check-runs-json",
+            str(check_runs),
+            "--output",
+            str(output),
+        ]
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["reviewed_slice"] == "GPP-2D-2c"
+
+
+def test_build_payload_allowed_path_prefixes_repo_owned_not_pr_supplied(tmp_path: Path) -> None:
+    """allowed_path_prefixes is fixed in the base-ref builder, never read
+    from the PR head or a PR-committed JSON. The set must include the
+    documented active surfaces."""
+    mod = _load_module()
+    output = tmp_path / "payload.json"
+    mod.main(_build_argv(tmp_path, output=output))
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    prefixes = payload["allowed_path_prefixes"]
+    assert "ao_kernel/" in prefixes
+    assert "scripts/" in prefixes
+    assert "tests/" in prefixes
+    assert ".claude/plans/" in prefixes
+    assert ".github/workflows/" in prefixes
+
+
+def test_build_payload_from_fork_is_carried(tmp_path: Path) -> None:
+    """A fork-context PR must surface from_fork=true so the core's
+    fork_boundary check fails closed."""
+    mod = _load_module()
+    output = tmp_path / "payload.json"
+    pr_files = tmp_path / "pr-files.json"
+    check_runs = tmp_path / "check-runs.json"
+    gpp_status = tmp_path / "gpp_status.json"
+    _write_pr_files(pr_files, ["a.py"])
+    _write_check_runs(check_runs, [])
+    _write_gpp_status(gpp_status)
+    mod.main(
+        [
+            "--repository",
+            "Halildeu/ao-kernel",
+            "--pr-number",
+            "1",
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "x",
+            "--head-sha",
+            "f" * 40,
+            "--issue-url",
+            "https://x",
+            "--from-fork",
+            "true",
+            "--branch-up-to-date",
+            "true",
+            "--gpp-status",
+            str(gpp_status),
+            "--pr-files-json",
+            str(pr_files),
+            "--check-runs-json",
+            str(check_runs),
+            "--output",
+            str(output),
+        ]
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["pull_request"]["head"]["repo"]["fork"] is True

--- a/tests/test_ao_release_gate_build_payload.py
+++ b/tests/test_ao_release_gate_build_payload.py
@@ -34,11 +34,16 @@ def _write_check_runs(path: Path, runs: list[dict[str, str]]) -> None:
     path.write_text(json.dumps({"check_runs": runs}), encoding="utf-8")
 
 
-def _write_gpp_status(path: Path, *, wp_id: str = "GPP-2") -> None:
+def _write_gpp_status(
+    path: Path,
+    *,
+    wp_id: str = "GPP-2",
+    issue: str = "https://github.com/Halildeu/ao-kernel/issues/539",
+) -> None:
     path.write_text(
         json.dumps(
             {
-                "current_wp": {"id": wp_id, "status": "blocked"},
+                "current_wp": {"id": wp_id, "status": "blocked", "issue": issue},
                 "support_widening_allowed": False,
                 "production_platform_claim_allowed": False,
                 "live_adapter_execution_allowed": False,
@@ -77,8 +82,6 @@ def _build_argv(tmp_path: Path, *, output: Path) -> list[str]:
         "codex/test-feature",
         "--head-sha",
         "abc1230000000000000000000000000000000000",
-        "--issue-url",
-        "https://github.com/Halildeu/ao-kernel/issues/999",
         "--from-fork",
         "false",
         "--branch-up-to-date",
@@ -106,7 +109,9 @@ def test_build_payload_emits_expected_shape(tmp_path: Path) -> None:
     assert payload["pull_request"]["base"]["ref"] == "main"
     assert payload["pull_request"]["head"]["sha"] == "abc1230000000000000000000000000000000000"
     assert payload["pull_request"]["head"]["repo"]["fork"] is False
-    assert payload["issue_url"] == "https://github.com/Halildeu/ao-kernel/issues/999"
+    # issue_url is derived from base-ref gpp_status.current_wp.issue,
+    # NOT from any workflow env var or PR-supplied field.
+    assert payload["issue_url"] == "https://github.com/Halildeu/ao-kernel/issues/539"
     assert payload["branch_up_to_date"] is True
     assert payload["event_name"] == "pull_request"
     assert payload["reviewed_slice"] == "GPP-2"
@@ -133,8 +138,6 @@ def test_build_payload_sorts_and_carries_changed_paths(tmp_path: Path) -> None:
             "x",
             "--head-sha",
             "f" * 40,
-            "--issue-url",
-            "https://x",
             "--from-fork",
             "false",
             "--branch-up-to-date",
@@ -206,8 +209,6 @@ def test_build_payload_reviewed_slice_comes_from_base_ref_gpp_status(tmp_path: P
             "x",
             "--head-sha",
             "f" * 40,
-            "--issue-url",
-            "https://x",
             "--from-fork",
             "false",
             "--branch-up-to-date",
@@ -265,8 +266,6 @@ def test_build_payload_from_fork_is_carried(tmp_path: Path) -> None:
             "x",
             "--head-sha",
             "f" * 40,
-            "--issue-url",
-            "https://x",
             "--from-fork",
             "true",
             "--branch-up-to-date",
@@ -283,3 +282,92 @@ def test_build_payload_from_fork_is_carried(tmp_path: Path) -> None:
     )
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert payload["pull_request"]["head"]["repo"]["fork"] is True
+
+
+def test_build_payload_issue_url_comes_from_base_ref_gpp_status(tmp_path: Path) -> None:
+    """The issue_url must be derived from base-ref gpp_status.current_wp.issue,
+    NOT from any PR webhook field. Otherwise the gpp_issue_consistency check
+    would systematically deny by comparing the PR's own API URL against the
+    GPP work-package issue URL.
+    """
+    mod = _load_module()
+    output = tmp_path / "payload.json"
+    pr_files = tmp_path / "pr-files.json"
+    check_runs = tmp_path / "check-runs.json"
+    gpp_status = tmp_path / "gpp_status.json"
+    _write_pr_files(pr_files, ["a.py"])
+    _write_check_runs(check_runs, [])
+    _write_gpp_status(gpp_status, issue="https://github.com/Halildeu/ao-kernel/issues/567")
+    mod.main(
+        [
+            "--repository",
+            "Halildeu/ao-kernel",
+            "--pr-number",
+            "1",
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "x",
+            "--head-sha",
+            "f" * 40,
+            "--from-fork",
+            "false",
+            "--branch-up-to-date",
+            "true",
+            "--gpp-status",
+            str(gpp_status),
+            "--pr-files-json",
+            str(pr_files),
+            "--check-runs-json",
+            str(check_runs),
+            "--output",
+            str(output),
+        ]
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["issue_url"] == "https://github.com/Halildeu/ao-kernel/issues/567"
+
+
+def test_build_payload_raises_when_gpp_status_missing_issue(tmp_path: Path) -> None:
+    """If the base-ref gpp_status.current_wp lacks an `issue` field, the
+    builder fails fast rather than silently emitting an empty issue_url."""
+    import pytest
+
+    mod = _load_module()
+    output = tmp_path / "payload.json"
+    pr_files = tmp_path / "pr-files.json"
+    check_runs = tmp_path / "check-runs.json"
+    gpp_status = tmp_path / "gpp_status.json"
+    _write_pr_files(pr_files, ["a.py"])
+    _write_check_runs(check_runs, [])
+    gpp_status.write_text(
+        json.dumps({"current_wp": {"id": "GPP-2", "status": "blocked"}}),
+        encoding="utf-8",
+    )
+    with pytest.raises(SystemExit):
+        mod.main(
+            [
+                "--repository",
+                "Halildeu/ao-kernel",
+                "--pr-number",
+                "1",
+                "--base-ref",
+                "main",
+                "--head-ref",
+                "x",
+                "--head-sha",
+                "f" * 40,
+                "--from-fork",
+                "false",
+                "--branch-up-to-date",
+                "true",
+                "--gpp-status",
+                str(gpp_status),
+                "--pr-files-json",
+                str(pr_files),
+                "--check-runs-json",
+                str(check_runs),
+                "--output",
+                str(output),
+            ]
+        )

--- a/tests/test_ao_release_gate_synthesize_error_decision.py
+++ b/tests/test_ao_release_gate_synthesize_error_decision.py
@@ -1,0 +1,90 @@
+"""Tests for the ao-release-gate shadow fallback synthesizer (GPP-2D-2c)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _load_module() -> Any:
+    module_path = _repo_root() / "scripts" / "ao_release_gate_synthesize_error_decision.py"
+    spec = importlib.util.spec_from_file_location("ao_release_gate_synthesize_error_decision", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_synthesizer_produces_error_fail_closed_decision(tmp_path: Path) -> None:
+    """The synthesizer always emits the canonical error_fail_closed shape."""
+    mod = _load_module()
+    output = tmp_path / "decision.json"
+    rc = mod.main([str(output)])
+    assert rc == 0
+    decision = json.loads(output.read_text(encoding="utf-8"))
+
+    assert decision["decision"] == "error_fail_closed"
+    assert decision["allow"] is False
+    assert decision["dry_run"] is True
+    assert decision["merge_authority_enabled"] is False
+    assert decision["conclusion_mode"] == "shadow"
+    assert decision["finding_code"] == "error_fail_closed"
+    assert decision["app_slug"] == "ao-release-gate"
+    assert decision["program_id"] == "GPP-2v"
+
+
+def test_synthesizer_carries_shadow_pre_decision_finding(tmp_path: Path) -> None:
+    """The synthesizer writes the workflow-only finding code that the
+    decision core never emits, so audit logs can identify shadow-fallback
+    runs distinctly from core-produced error_fail_closed decisions."""
+    mod = _load_module()
+    output = tmp_path / "decision.json"
+    mod.main([str(output)])
+    decision = json.loads(output.read_text(encoding="utf-8"))
+    assert "ao_release_gate_shadow_pre_decision_step_failed" in decision["findings"]
+
+
+def test_synthesizer_github_check_run_is_neutral_shadow_advisory(tmp_path: Path) -> None:
+    """The shadow advisory job posts no check-run, but the synthetic
+    artifact still carries a neutral conclusion so an operator reading
+    the artifact sees the shadow-advisory mapping rather than failure."""
+    mod = _load_module()
+    output = tmp_path / "decision.json"
+    mod.main([str(output)])
+    decision = json.loads(output.read_text(encoding="utf-8"))
+    check_run = decision["github_check_run"]
+    assert check_run["name"] == "ao-release-gate"
+    assert check_run["status"] == "completed"
+    assert check_run["conclusion"] == "neutral"
+
+
+def test_synthesizer_module_imports_and_builds_decision_cleanly() -> None:
+    """A workflow-runtime smoke check: the synthesizer module must import
+    without side effects and produce a well-formed decision when called
+    directly. If the file ever regresses into a Python syntax error or
+    a missing-field bug this would catch it before the shadow workflow
+    ships."""
+    mod = _load_module()
+    decision = mod.build_error_decision()
+    assert decision["decision"] == "error_fail_closed"
+    assert decision["allow"] is False
+    assert decision["github_check_run"]["conclusion"] == "neutral"
+
+
+def test_synthesizer_output_is_pretty_sorted_json(tmp_path: Path) -> None:
+    """The synthetic artifact uses canonical pretty/sorted JSON so audit
+    diffs over it are stable."""
+    mod = _load_module()
+    output = tmp_path / "decision.json"
+    mod.main([str(output)])
+    text = output.read_text(encoding="utf-8")
+    assert text.endswith("\n")
+    # Sorted keys: a representative key ordering check.
+    assert text.index('"allow"') < text.index('"decision"')
+    assert text.index('"decision"') < text.index('"findings"')

--- a/tests/test_ao_release_gate_workflow.py
+++ b/tests/test_ao_release_gate_workflow.py
@@ -181,14 +181,19 @@ def test_workflow_carries_continue_on_error_on_data_gathering_steps() -> None:
 
 def test_workflow_synthesizes_decision_when_prior_steps_fail() -> None:
     """When the decision step did not produce decision.json (because a
-    prior continue-on-error step failed), a synthesis step writes an
-    error_fail_closed decision so every shadow run still emits an
-    auditable record.
+    prior continue-on-error step failed), a synthesis step invokes the
+    repo-owned synthesizer script (no fragile inline Python) which writes
+    an error_fail_closed decision so every shadow run still emits an
+    auditable record. The synthesizer itself is unit-tested in
+    test_ao_release_gate_synthesize_error_decision.py.
     """
     text = _workflow_text()
     assert "Synthesize error_fail_closed decision when prior steps failed" in text
-    assert "error_fail_closed" in text
-    assert "ao_release_gate_shadow_pre_decision_step_failed" in text
+    # The workflow invokes the repo-owned synthesizer script; it must not
+    # carry inline `python -c` snippets that would IndentationError under
+    # YAML block-scalar indent stripping.
+    assert "scripts/ao_release_gate_synthesize_error_decision.py decision.json" in text
+    assert "python -c" not in text
 
 
 def test_workflow_does_not_forward_pull_request_issue_url() -> None:

--- a/tests/test_ao_release_gate_workflow.py
+++ b/tests/test_ao_release_gate_workflow.py
@@ -196,6 +196,29 @@ def test_workflow_synthesizes_decision_when_prior_steps_fail() -> None:
     assert "python -c" not in text
 
 
+def test_workflow_synthesis_step_has_bootstrap_fallback() -> None:
+    """The shadow workflow is itself a base-ref-trusted system; on the PR
+    that first introduces it the synthesizer script is not yet on the
+    base ref. The synthesis step must fall back to an inline JSON
+    artifact so the bootstrap PR still produces an audit record and the
+    job exits 0; subsequent PRs (after this one merges to main) find the
+    synthesizer on main and use the canonical path.
+    """
+    text = _workflow_text()
+    # The fallback branch exists.
+    assert "Synthesizer script not present on the base ref" in text
+    # The synthesis step itself carries continue-on-error so even an
+    # unexpected catastrophic fallback failure does not break the job.
+    synthesis_index = text.index("Synthesize error_fail_closed decision when prior steps failed")
+    upload_index = text.index("Upload audit artifact")
+    synthesis_block = text[synthesis_index:upload_index]
+    assert "continue-on-error: true" in synthesis_block, (
+        "synthesis step must carry continue-on-error as belt-and-suspenders"
+    )
+    # The bootstrap fallback still emits the workflow-only finding code.
+    assert "ao_release_gate_shadow_pre_decision_step_failed" in text
+
+
 def test_workflow_does_not_forward_pull_request_issue_url() -> None:
     """The pull_request webhook field `issue_url` is the PR's own API URL,
     NOT the GPP work-package issue URL. Forwarding it to the builder

--- a/tests/test_ao_release_gate_workflow.py
+++ b/tests/test_ao_release_gate_workflow.py
@@ -1,0 +1,151 @@
+"""Drift-guard for the ao-release-gate shadow workflow (GPP-2D-2c)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _workflow_text() -> str:
+    workflow = _repo_root() / ".github" / "workflows" / "ao-release-gate.yml"
+    return workflow.read_text(encoding="utf-8")
+
+
+def test_workflow_triggers_on_pull_request_never_pull_request_target() -> None:
+    """GPP-2D §3.2: the gate must trigger on pull_request only.
+
+    pull_request_target would expose the workflow to PR-controlled code
+    with write-scoped permissions and break the trusted-base design.
+    """
+    text = _workflow_text()
+    assert "on:\n  pull_request:" in text
+    assert "pull_request_target" not in text or "pull_request_target context" in text
+    # The defensive event-name guard must explicitly reject anything else.
+    assert "ao-release-gate-shadow only evaluates pull_request events" in text
+
+
+def test_workflow_permissions_are_read_only() -> None:
+    """GPP-2D §3.2: read-only permissions, no write scopes."""
+    text = _workflow_text()
+    assert "contents: read" in text
+    assert "checks: read" in text
+    assert "pull-requests: read" in text
+    # No write permissions anywhere in the job.
+    for write_scope in (
+        "contents: write",
+        "checks: write",
+        "pull-requests: write",
+        "issues: write",
+        "actions: write",
+    ):
+        assert write_scope not in text, f"unexpected write permission: {write_scope}"
+
+
+def test_workflow_job_uses_shadow_name_not_required_check_name() -> None:
+    """GPP-2D §3.4: the required-check name `ao-release-gate` is reserved
+    for the GPP-2D-3 enforce job. The shadow job runs under the distinct
+    name `ao-release-gate-shadow` so branch protection can never be
+    satisfied by this fail-open advisory job.
+    """
+    text = _workflow_text()
+    assert "name: ao-release-gate-shadow" in text
+    # The required-check name reservation must be explicitly documented.
+    assert "`ao-release-gate-shadow`" in text
+    assert "is reserved for the GPP-2D-3 enforce job" in text
+
+
+def test_workflow_checks_out_base_ref_for_gate_code() -> None:
+    """GPP-2D §3.2: the decision-core code, schemas, and gpp_status.v1.json
+    are evaluated from the base ref, not the PR head. A PR that edits the
+    gate cannot thereby change the gate that judges it.
+    """
+    text = _workflow_text()
+    # The base checkout must explicitly pin to the PR base SHA.
+    assert "ref: ${{ github.event.pull_request.base.sha }}" in text
+    assert "path: base" in text
+    # The script and gpp_status paths must be resolved from the base checkout.
+    assert "scripts/ao_release_gate_decision.py" in text
+    assert "scripts/ao_release_gate_build_payload.py" in text
+    assert ".claude/plans/gpp_status.v1.json" in text
+
+
+def test_workflow_builds_payload_from_api_not_pr_committed_json() -> None:
+    """GPP-2D §3.3: the release-gate payload is built by the workflow from
+    the GitHub API and the base-ref gpp_status, never from a PR-committed
+    JSON file. PR-author-supplied allowed_path_prefixes / required_checks
+    / branch_up_to_date / admin_bypass_requested fields would let a PR
+    self-approve.
+    """
+    text = _workflow_text()
+    assert "gh pr view" in text
+    assert "gh api" in text and "/check-runs" in text
+    # The builder script reads the API outputs and the base-ref gpp_status,
+    # not anything from the PR head checkout (other than the optional
+    # review-evidence file).
+    assert "--pr-files-json pr-files.json" in text
+    assert "--check-runs-json check-runs.json" in text
+    assert "--gpp-status .claude/plans/gpp_status.v1.json" in text
+    # The payload JSON must not be sourced from the PR head.
+    assert "head/payload.json" not in text
+
+
+def test_workflow_reads_review_evidence_only_from_pr_head_and_validates_via_core() -> None:
+    """GPP-2D §3.3: the review evidence is the only PR-head input. The
+    decision core validates it against the full schema + acceptance
+    profile + context-binding before trusting any field.
+    """
+    text = _workflow_text()
+    assert "head/local-gpp-gate-evidence.v1.json" in text
+    assert "--review-evidence" in text
+
+
+def test_workflow_is_advisory_never_propagates_deny_exit() -> None:
+    """GPP-2D §6 GPP-2D-2c: the shadow job runs and reports the decision
+    but always succeeds (advisory) and is never a required check until
+    the GPP-2D-5 cutover.
+    """
+    text = _workflow_text()
+    # The decision script must never be invoked WITH --fail-on-deny under
+    # the shadow advisory job. Comments may reference the flag to explain
+    # the design, but no actual invocation line carries it.
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        assert "--fail-on-deny" not in line, "shadow workflow must not invoke the decision script with --fail-on-deny"
+    # Explicit advisory contract: the decision step ends with `exit 0` so
+    # the job always succeeds regardless of the decision body.
+    assert "Shadow advisory" in text
+    assert "exit 0" in text
+
+
+def test_workflow_uses_only_github_token_no_long_lived_secrets() -> None:
+    """GPP-2D §7: no long-lived secret / PAT / PEM / webhook-secret value
+    in the workflow. Only the ephemeral GitHub Actions GITHUB_TOKEN is
+    used, with minimal read-only permissions.
+    """
+    text = _workflow_text()
+    assert "${{ github.token }}" in text
+    # No reference to any long-lived secret name.
+    for forbidden in (
+        "AO_GITHUB_APP_PRIVATE_KEY",
+        "AO_RELEASE_GATE_WEBHOOK_SECRET",
+        "GHCR_TOKEN",
+        "AO_CLAUDE_CODE_CLI_AUTH",
+        "secrets.PAT",
+        "secrets.PRIVATE_KEY",
+    ):
+        assert forbidden not in text, f"unexpected long-lived secret reference: {forbidden}"
+
+
+def test_workflow_uploads_decision_audit_artifact() -> None:
+    """Every shadow run uploads payload.json + decision.json so operators
+    can audit what the gate would have decided.
+    """
+    text = _workflow_text()
+    assert "actions/upload-artifact@v7" in text
+    assert "base/payload.json" in text
+    assert "base/decision.json" in text

--- a/tests/test_ao_release_gate_workflow.py
+++ b/tests/test_ao_release_gate_workflow.py
@@ -149,3 +149,58 @@ def test_workflow_uploads_decision_audit_artifact() -> None:
     assert "actions/upload-artifact@v7" in text
     assert "base/payload.json" in text
     assert "base/decision.json" in text
+
+
+def test_workflow_fetches_check_runs_per_page_not_paginate() -> None:
+    """The check-runs API endpoint returns an object, not an array; `gh api
+    --paginate` against an object endpoint concatenates page objects and
+    breaks `json.loads`. The workflow must fetch a single page with
+    per_page=100 (gh's max) instead.
+    """
+    text = _workflow_text()
+    assert "check-runs?per_page=100" in text
+    # No --paginate flag in the check-runs fetch line.
+    for line in text.splitlines():
+        if "/check-runs" in line and "gh api" in line:
+            assert "--paginate" not in line, "check-runs fetch must not use --paginate"
+
+
+def test_workflow_carries_continue_on_error_on_data_gathering_steps() -> None:
+    """The shadow advisory job must not fail when a pre-decision step
+    (API fetch, freshness, builder, evidence locator, decision) fails.
+    Every such step carries continue-on-error: true; the final synthesis
+    step runs on `if: always()` so an audit artifact is emitted even
+    when prior steps failed.
+    """
+    text = _workflow_text()
+    # At least the five pre-decision steps + the decision step carry the
+    # continue-on-error flag, so six occurrences is the minimum.
+    assert text.count("continue-on-error: true") >= 5
+    assert "if: always()" in text
+
+
+def test_workflow_synthesizes_decision_when_prior_steps_fail() -> None:
+    """When the decision step did not produce decision.json (because a
+    prior continue-on-error step failed), a synthesis step writes an
+    error_fail_closed decision so every shadow run still emits an
+    auditable record.
+    """
+    text = _workflow_text()
+    assert "Synthesize error_fail_closed decision when prior steps failed" in text
+    assert "error_fail_closed" in text
+    assert "ao_release_gate_shadow_pre_decision_step_failed" in text
+
+
+def test_workflow_does_not_forward_pull_request_issue_url() -> None:
+    """The pull_request webhook field `issue_url` is the PR's own API URL,
+    NOT the GPP work-package issue URL. Forwarding it to the builder
+    would make gpp_issue_consistency fail closed on every PR. The
+    builder must source issue_url from the base-ref
+    gpp_status.current_wp.issue instead.
+    """
+    text = _workflow_text()
+    # The builder receives no --issue-url argument.
+    assert "--issue-url" not in text
+    # The env var is not declared either.
+    assert "ISSUE_URL:" not in text
+    assert "github.event.pull_request.issue_url" not in text


### PR DESCRIPTION
## GPP-2D-2c — ao-release-gate shadow workflow

Final implementation sub-slice of GPP-2D-2 (autonomous required-check lane; design doc PR #588). Stands up the ao-release-gate decision core as a GitHub Actions advisory check-run on every pull request, under the distinct job name `ao-release-gate-shadow`. The required-check name `ao-release-gate` stays reserved for the GPP-2D-3 enforce job; this shadow job is never a required check.

**Stacked PR**: base = `codex/gpp2d-2b-decision-core-wiring` (PR #590). Will be retargeted to `main` after #589 → #590 merge train. Each layer touches disjoint files, so retargeted diffs stay clean.

### Changes

- **`.github/workflows/ao-release-gate.yml`**: `pull_request` trigger only (NEVER `pull_request_target`), read-only permissions (contents/checks/pull-requests: read), GITHUB_TOKEN-only (no long-lived secrets), per-PR concurrency. Trusted-base gate: checks out the PR base SHA for the decision-core code, schemas, and `gpp_status.v1.json`; the PR head is checked out only for the optional `local-gpp-gate-evidence.v1.json` file. Every pre-decision step + the decision step carries `continue-on-error: true`; the synthesis step runs on `if: always()` and writes a synthetic `error_fail_closed` decision (with the workflow-only finding `ao_release_gate_shadow_pre_decision_step_failed`) if `decision.json` is absent. Final step always `exit 0`. Uploads `payload.json + decision.json` as the audit artifact via `if: always()`.

- **`scripts/ao_release_gate_build_payload.py`**: composes the release-gate payload from API-fetched PR data (changed files via `gh pr view`, required-check status via `gh api check-runs?per_page=100`), workflow-provided context (head/base ref, head SHA, fork status, branch freshness), and the **base-ref-trusted** `reviewed_slice` (gpp_status.current_wp.id) and `issue_url` (gpp_status.current_wp.issue). Self-named check-runs (`ao-release-gate` / `ao-release-gate-shadow`) are filtered out of required_checks. The dangerous PR-author-supplied flags (admin_bypass_requested, forbidden_secret_context_detected, pat_backed_bot_actor, codex_or_claude_release_authority, live_adapter_execution_requested) are always `false`; the workflow never reads them from the PR. `allowed_path_prefixes` is a repo-owned, base-ref-trusted list.

- **`scripts/ao_release_gate_synthesize_error_decision.py`**: side-effect-free fallback synthesizer invoked by the workflow when the decision step did not produce `decision.json`. Emits the canonical `error_fail_closed` shape with the workflow-only finding `ao_release_gate_shadow_pre_decision_step_failed` and a neutral shadow check-run conclusion. Falls back to stdlib `datetime` when `ao_kernel` is not importable.

- **Tests** (3 new test files, 27 tests):
  - `tests/test_ao_release_gate_workflow.py` (15 drift-guards): trigger boundary, read-only permissions, shadow name vs required-check reservation, base-ref checkout, API-built payload, evidence-only PR head reading, advisory exit semantics (no `--fail-on-deny` on the invocation line), no long-lived secrets, audit artifact upload, `per_page=100` (no `--paginate` on check-runs), `continue-on-error: true` count, synthesis step + script invocation (no inline `python -c`), no `pull_request.issue_url` forwarding.
  - `tests/test_ao_release_gate_build_payload.py` (9 unit tests): payload shape, sorted changed_paths, self-check-run exclusion, dangerous-flag defaults, reviewed_slice + issue_url from base-ref gpp_status, missing-issue fail-fast, allowed_path_prefixes content, fork status passthrough.
  - `tests/test_ao_release_gate_synthesize_error_decision.py` (5 tests): canonical shape, workflow-only finding code, neutral shadow check-run, import+behavior smoke, sorted-pretty JSON.

### Codex post-impl review (cross-AI HARD RULE)

Plan-time AGREE was given on the design doc (#588). Post-impl thread `019e51e0` returned REVISE twice:

- **iter-1** (3 findings, all absorbed): (P1) `pull_request.issue_url` is the PR's API URL, not the GPP work-package issue URL → builder now derives `issue_url` from base-ref `gpp_status.current_wp.issue`. (P2) `gh api --paginate` against the check-runs object endpoint concatenates page objects and breaks `json.loads` → switched to `per_page=100` single page. (P2) Advisory always-success was only the decision step → all pre-decision steps now carry `continue-on-error: true` plus a synthesis step writes a synthetic `error_fail_closed` artifact when needed.

- **iter-2** (1 P1 finding, absorbed): the inline `python -c "..."` synthesis block had indented Python inside a YAML block scalar, which Python -c rejects with `IndentationError`. The advisory fallback would never have run. Fix: extracted the synthesizer to its own dedicated script (`scripts/ao_release_gate_synthesize_error_decision.py`) and added unit tests pinning the runtime shape.

- **iter-3**: VERDICT AGREE.

### Scope guard

No enforce-mode flip (GPP-2D-3), no branch-protection mutation (GPP-2D-5). The shadow job is always advisory; the required-check name `ao-release-gate` is reserved and not yet posted as a real required check. GPP-2 stays blocked; guard flags stay false; no support widening, no production claim, no live adapter execution.

### Verification

- Full suite: 3354 passed, 2 skipped
- ruff + mypy clean on my files
- YAML syntax valid; synthesizer script smoke OK
- Codex post-impl review (thread `019e51e0`): VERDICT AGREE after 2 absorb iterations

Implementer: Claude (Anthropic, session 44106462)
Reviewer:    Codex (OpenAI, thread 019e51e0) — post-impl AGREE after 2 REVISE iters