### PR TITLE
feat(gpp-2d): extend ao-release-gate allowed paths for runtime evidence files

### DIFF
--- a/scripts/ao_release_gate_build_payload.py
+++ b/scripts/ao_release_gate_build_payload.py
@@ -47,6 +47,15 @@ DEFAULT_ALLOWED_PATH_PREFIXES = (
     "AGENTS.md",
     "CLAUDE.md",
     "README.md",
+    # GPP-2D-3c bootstrap prerequisite: the ao-release-gate enforce
+    # job reads `local-ai-review-evidence.v1.json` from the PR head
+    # at the repo root and generates the head-bound
+    # `local-gpp-gate-evidence.v1.json` at CI runtime. The decision
+    # core's `diff_scope` check then requires every committed path
+    # to be in this allowlist. Both files live at the repo root, are
+    # cross-AI-review / local-gate only (never runtime adapter state),
+    # and never widen support or claim production readiness.
+    "local-ai-review-evidence.v1.json",
     "local-gpp-gate-evidence.v1.json",
 )
 

--- a/tests/test_ao_release_gate_build_payload.py
+++ b/tests/test_ao_release_gate_build_payload.py
@@ -394,6 +394,14 @@ def test_build_payload_allowed_path_prefixes_repo_owned_not_pr_supplied(tmp_path
     assert "tests/" in prefixes
     assert ".claude/plans/" in prefixes
     assert ".github/workflows/" in prefixes
+    # GPP-2D-3c bootstrap prerequisite: the ao-release-gate enforce
+    # job reads the raw reviewer evidence file committed at the repo
+    # head and generates the head-bound gate evidence file at CI
+    # runtime. The decision core's diff_scope check requires every
+    # committed path to be in this allowlist, so any PR that ships
+    # either file at the repo root must find it pinned here.
+    assert "local-ai-review-evidence.v1.json" in prefixes
+    assert "local-gpp-gate-evidence.v1.json" in prefixes
 
 
 def test_build_payload_from_fork_is_carried(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

GPP-2D-3c bootstrap prerequisite. Adds two repo-root JSON file
names to `DEFAULT_ALLOWED_PATH_PREFIXES` in
`scripts/ao_release_gate_build_payload.py` so the ao-release-gate
decision core's `diff_scope` check accepts:

* `local-ai-review-evidence.v1.json` — raw cross-AI reviewer
  evidence committed at the PR head
* `local-gpp-gate-evidence.v1.json` — head-bound runtime gate
  evidence file the enforce workflow generates at CI runtime

Without these entries, any PR that ships either file fails
`diff_scope: blocked (ao_release_gate_diff_out_of_scope)`. PR #599
itself surfaces this: Codex iter-5 returned AGREE on the
implementation, but the trusted-base copy of the builder on `main`
did not yet list these names.

## Test plan

- [x] `tests/test_ao_release_gate_build_payload.py::test_build_payload_allowed_path_prefixes_repo_owned_not_pr_supplied` extended to pin both new entries.
- [x] 11 build_payload tests pass locally.
- [x] Full suite: 3362 passed, 2 skipped.
- [x] ruff + git diff --check clean.

## Out of scope

- Branch protection mutation (GPP-2D-5 operator action).
- Real positive / negative enforce-mode evidence on live PRs (GPP-2D-4).
- The actual GPP-2D-3c workflow swap (PR #599).

## Hard stops

- GPP-2 stays blocked.
- support_widening_allowed, production_platform_claim_allowed, and
  live_adapter_execution_allowed all stay false.
- No admin bypass, no continue-on-error.
- Trusted-base discipline preserved: \`allowed_path_prefixes\` is
  fixed in the base-ref builder, never read from PR head or
  PR-committed JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)