### PR TITLE
docs(gpp-2d-5): negative-path verification probe (DO NOT MERGE)

### DIFF
--- a/.claude/plans/GPP-2D-5-VERIFICATION-NEGATIVE-PATH-PROBE.md
+++ b/.claude/plans/GPP-2D-5-VERIFICATION-NEGATIVE-PATH-PROBE.md
@@ -1,0 +1,34 @@
+# GPP-2D-5 Verification — Negative-Path Probe (DO NOT MERGE)
+
+> This PR is opened intentionally without committing the reviewer
+> evidence file `local-ai-review-evidence.v1.json` at the repo
+> root. It is the §3.3 negative-path verification for GPP-2D-5:
+> the `ao-release-gate` enforce gate must produce
+> `decision: deny_missing_evidence` on this PR, and the merge
+> button must be blocked by the now-required ruleset.
+>
+> Once the verification is recorded (in
+> `.claude/plans/GPP-2D-5-VERIFICATION-OUTCOMES.md`), this PR is
+> **closed without merging**.
+
+## Acceptance signals expected on this PR
+
+* `gh pr view <this PR> --json mergeStateStatus,statusCheckRollup,reviewDecision,mergeable`:
+    * `mergeStateStatus == "BLOCKED"` (or `"DIRTY"` if other signals
+      are still pending — block must be present in either case).
+    * `statusCheckRollup[]` includes an entry with
+      `name == "ao-release-gate"` whose `conclusion == "FAILURE"`.
+    * `reviewDecision` may be unset or APPROVED; the invariant we
+      are pinning is "merge is blocked by ao-release-gate", not
+      that no human approved.
+* UI: the "Merge pull request" button is greyed with the message
+  "Required statuses must pass before merging" or the ruleset
+  equivalent.
+* `gh pr merge <this PR> --repo Halildeu/ao-kernel --squash`
+  rejected with a required-status-check failure (non-zero exit).
+
+## Out of scope
+
+* Branch protection mutation by the agent.
+* Any commit that would silently merge this PR — explicit
+  `--admin` is forbidden and is not used here.


### PR DESCRIPTION
## DO NOT MERGE — GPP-2D-5 §3.3 negative-path verification probe

This PR intentionally ships **without** a reviewer evidence file
at the repo root. After the GPP-2D-5 ruleset cutover that just
made `ao-release-gate` a required status check on main, the
enforce gate must:

* produce `decision: deny_missing_evidence`
* fail the job (exit code 1)
* cause `mergeStateStatus` to be BLOCKED on this PR
* cause `gh pr merge --squash` to be rejected by the GitHub API

These signals are recorded in
`.claude/plans/GPP-2D-5-VERIFICATION-OUTCOMES.md` (follow-up PR)
and then this PR is **closed without merging**.

No reviewer evidence file. No branch-protection mutation. No
`--admin` merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)