### PR TITLE
docs(gpp-2d-5): iter-2 absorb follow-up for verification outcomes

### DIFF
--- a/.claude/plans/GPP-2D-5-VERIFICATION-OUTCOMES.md
+++ b/.claude/plans/GPP-2D-5-VERIFICATION-OUTCOMES.md
@@ -38,12 +38,140 @@ test (3.13) / coverage / typecheck / packaging-smoke). Its
 `enforce_admins.enabled` flag is `false` — this is a
 pre-existing surface that does NOT affect `ao-release-gate`'s
 enforcement (the gate is enforced by the new ruleset whose
-`bypass_actors == []`). Tightening the legacy `enforce_admins`
-flag is an optional later hardening slice; it is explicitly out
-of scope for GPP-2D-5.
+`bypass_actors == []`). If the legacy path were the only control
+this acceptance would NOT hold; this slice's acceptance relies
+explicitly on the ruleset path. Tightening the legacy
+`enforce_admins` flag is an optional later hardening slice; it
+is explicitly out of scope for GPP-2D-5.
 
 No `--admin` merge attempted. No other rule changed in the same
 save.
+
+### 1.1 Operator audit comment (replay reference)
+
+Per runbook §2.6, the operator pasted a structured audit block
+into PR #605 comments. **Operator audit comment URL**:
+[https://github.com/Halildeu/ao-kernel/pull/605#issuecomment-4529677096](https://github.com/Halildeu/ao-kernel/pull/605#issuecomment-4529677096)
+
+That comment carries every §2.6 required field as a table: UTC
+timestamp, actor (Halildeu, repo owner / admin), ruleset name
+("Protect main") + id (`16803733`), required checks BEFORE
+(legacy 7 contexts only) and AFTER (legacy 7 + ao-release-gate
+ruleset addition), selected check source (context, app_id 15368,
+app_slug github-actions, integration_id 15368), bypass actors
+BEFORE (none) and AFTER (`[]`), CODEOWNER review change record
+(unchanged — broad model preserved), screenshot replay path
+reference (this outcomes doc's §3.1 / §3.2 / §4 / §5 API + run
+URL trace), `Admin bypass attempted: false`, and `Other rule
+changes: none`.
+
+### 1.2 Raw ruleset state at cutover save (API replay)
+
+```bash
+gh api "repos/Halildeu/ao-kernel/rulesets/16803733"
+```
+
+```json
+{
+  "id": 16803733,
+  "name": "Protect main",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "Halildeu/ao-kernel",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["~DEFAULT_BRANCH"]
+    }
+  },
+  "rules": [
+    {"type": "deletion"},
+    {"type": "non_fast_forward"},
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "ao-release-gate",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [],
+  "current_user_can_bypass": "never"
+}
+```
+
+`integration_id 15368` is the GitHub Actions integration, so the
+required check is source-pinned to the workflow runner, not any
+external App. `current_user_can_bypass: "never"` confirms even
+the repo owner / admin viewing this API cannot bypass the rule.
+
+### 1.3 Legacy branch-protection raw state (unchanged, replay)
+
+```bash
+gh api "repos/Halildeu/ao-kernel/branches/main/protection"
+```
+
+```json
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "lint",
+      "test (3.11)",
+      "test (3.12)",
+      "test (3.13)",
+      "coverage",
+      "typecheck",
+      "packaging-smoke"
+    ],
+    "checks": [
+      {"context": "lint", "app_id": 15368},
+      {"context": "test (3.11)", "app_id": 15368},
+      {"context": "test (3.12)", "app_id": 15368},
+      {"context": "test (3.13)", "app_id": 15368},
+      {"context": "coverage", "app_id": 15368},
+      {"context": "typecheck", "app_id": 15368},
+      {"context": "packaging-smoke", "app_id": 15368}
+    ]
+  },
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true,
+    "require_last_push_approval": false,
+    "required_approving_review_count": 1
+  },
+  "required_signatures": { "enabled": false },
+  "enforce_admins": { "enabled": false },
+  "required_linear_history": { "enabled": false },
+  "allow_force_pushes": { "enabled": false },
+  "allow_deletions": { "enabled": false },
+  "required_conversation_resolution": { "enabled": false },
+  "lock_branch": { "enabled": false },
+  "allow_fork_syncing": { "enabled": false }
+}
+```
+
+Notes on this legacy state:
+
+* All 7 legacy CI required checks are themselves source-pinned to
+  `app_id: 15368` (GitHub Actions), so no source-collision risk
+  exists on the legacy path either.
+* `required_pull_request_reviews.require_code_owner_reviews:
+  true` with `required_approving_review_count: 1` is the
+  broad-CODEOWNERS reviewer rule the cutover slice intentionally
+  preserves. This is what gates the §3.4 positive-path PR's
+  merge button after `ao-release-gate` passes — exactly the
+  correct contract for GPP-2D-5.
+* `enforce_admins.enabled: false` is the pre-existing flag noted
+  in §1 — out of scope for this cutover, tracked as optional
+  later hardening.
 
 ## 2. Pre-cutover source-pin check (runbook §1 row 6)
 
@@ -122,6 +250,56 @@ Acceptance signals (all observed):
 PR #607 is closed without merging as part of this verification
 slice cleanup.
 
+### 4.1 PR #607 replay references
+
+* PR URL: https://github.com/Halildeu/ao-kernel/pull/607
+* Actions run URL: https://github.com/Halildeu/ao-kernel/actions/runs/26369184385
+* Audit artifact (run artifacts tab on the URL above): the run
+  uploaded the synthesizer fallback evidence + payload.json +
+  decision.json + local-gpp-gate.stdout.log on `if: always()`;
+  the runtime gate-evidence file (`local-gpp-gate-evidence.v1.json`)
+  was not produced because the reviewer evidence step gated the
+  workflow before it could write that file, so the artifact set
+  is the expected partial set for this denial code.
+* `gh pr merge` raw rejection output:
+  ```
+  X Pull request Halildeu/ao-kernel#607 is not mergeable:
+    the base branch policy prohibits the merge.
+  To have the pull request merged after all the requirements
+  have been met, add the --auto flag.
+  To use administrator privileges to immediately merge the
+  pull request, add the --admin flag.
+  ```
+  The `--admin` suggestion was NOT taken.
+* PR closure URL: https://github.com/Halildeu/ao-kernel/pull/607
+  (state: closed, branch deleted).
+
+#### 4.1.1 §3.3 Step 2 UI screenshot replay path
+
+Runbook §3.3 Step 2 calls for a UI screenshot of the negative-
+path PR's blocked merge panel. The probe PR was closed promptly
+as part of this slice's cleanup procedure (right after the
+acceptance signals in §4 were captured). The replay path that
+carries the **same acceptance signals** at the API layer is:
+
+* `gh pr view 607 --repo Halildeu/ao-kernel --json mergeStateStatus,statusCheckRollup` →
+  `mergeStateStatus: BLOCKED` + `statusCheckRollup[].ao-release-gate.conclusion: FAILURE`
+  (same information the "Some checks were not successful" panel
+  rendered visually).
+* `gh run view 26369184385 --repo Halildeu/ao-kernel` → the
+  `Evaluate ao-release-gate decision (enforce)` step output
+  recorded in §4 above (same information the run's UI page
+  renders visually).
+* The `gh pr merge` raw rejection text in §4.1 (same information
+  the greyed merge button conveyed visually).
+
+Reopening the probe PR purely for screenshot capture was
+deliberately not done — the closure was the correct cleanup,
+and the API + run URL + CLI text trace preserves the
+acceptance signals with higher fidelity than a screenshot
+would (the screenshot would be a rendered view of these same
+JSON fields).
+
 ## 5. Positive-path verification PR (runbook §3.4) — PR #608
 
 PR #608 ships a trivial doc plus a schema-valid
@@ -162,9 +340,44 @@ This is exactly the contract: the gate enforces but does not
 override the high-risk CODEOWNERS reviewer rule.
 
 PR #608 is closed without merging as part of this verification
-slice cleanup. (We do not merge the probe; the GPP-2D-5 runbook
-already merged in `cb47507`; this probe only proves the enforce
-gate now accepts well-formed evidence post-cutover.)
+slice cleanup.
+
+### 5.1 Controlled deviation from runbook §3.4 merge bullet
+
+Runbook §3.4 lists `gh pr merge --squash` working (or auto-merge
+enqueuing) as one of its acceptance signals. The post-cutover
+reality is narrower than that bullet because the legacy branch
+protection's broad `* @Halildeu @gladyatore-lab` CODEOWNERS
+model is **intentionally preserved this slice** (§1 row 7 in the
+runbook). With that preservation:
+
+* The `ao-release-gate` check on PR #608 passes ✅ (this is what
+  GPP-2D-5 is supposed to prove).
+* The merge button itself stays blocked because the legacy rule
+  still requires a code-owner approving review, and the PR
+  carries none.
+* This is **the correct contract** for GPP-2D-5: the gate now
+  enforces post-cutover, AND the high-risk CODEOWNERS rule
+  continues to gate human review.
+
+The real merge-smoke is GPP-2D-6's job — it runs after
+CODEOWNERS narrowing, demonstrates low-risk auto-merge, and
+re-checks that high-risk PRs still require human review. GPP-2D-5
+does not need (and does not claim) to merge the positive-path
+probe in this slice.
+
+### 5.2 PR #608 replay references
+
+* PR URL: https://github.com/Halildeu/ao-kernel/pull/608
+* Actions run URL: https://github.com/Halildeu/ao-kernel/actions/runs/26369236624
+* Specific job URL: https://github.com/Halildeu/ao-kernel/actions/runs/26369236624/job/77618585276
+  (the `Test / ao-release-gate (pull_request)` job, completed
+  SUCCESS in 21 seconds)
+* Audit artifact link (run artifacts tab on the URL above):
+  full 4-file set — `payload.json`, `decision.json`,
+  `local-gpp-gate-evidence.v1.json`, `local-gpp-gate.stdout.log`.
+* PR closure URL: https://github.com/Halildeu/ao-kernel/pull/608
+  (state: closed, branch deleted).
 
 ## 6. Coverage matrix
 

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -13,7 +13,7 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/gpp2d-5-verification-outcomes",
+    "head_ref": "refs/heads/codex/gpp2d-5-outcomes-iter2-followup",
     "changed_files": [
       ".claude/plans/GPP-2D-5-VERIFICATION-OUTCOMES.md",
       "local-ai-review-evidence.v1.json"
@@ -63,6 +63,14 @@
     {
       "name": "no_long_lived_secret",
       "status": "pass"
+    },
+    {
+      "name": "replay_references_complete",
+      "status": "pass"
+    },
+    {
+      "name": "controlled_deviation_documented",
+      "status": "pass"
     }
   ],
   "findings": [
@@ -73,6 +81,8 @@
     "Legacy branch-protection enforce_admins.enabled is false (pre-existing surface, not modified by this cutover). It does not affect ao-release-gate enforcement because the gate is the ruleset's responsibility and the ruleset has bypass_actors empty. Tightening the legacy enforce_admins flag is an explicit out-of-scope later hardening.",
     "PR scope is two files: the outcomes doc at .claude/plans/GPP-2D-5-VERIFICATION-OUTCOMES.md and this reviewer evidence file. No workflow / script / test / runtime / branch-protection / ruleset mutation in this PR; the cutover save was an operator UI action recorded in §1.",
     "Out-of-scope boundaries (§7) are explicit: GPP-2D-6 auto-merge smoke depends on CODEOWNERS narrowing first; GPP-2D-7 / AO-GATE-9 closeout is separate; legacy enforce_admins hardening is separate; probe PRs #607 and #608 are closed without merging; support_widening / production_platform_claim_allowed / live_adapter_execution_allowed stay false; no --admin merge.",
+    "Iter-1 absorb (Codex thread 019e5b49): the outcomes doc was enriched with the replay references runbook §3.5 demanded — §1.1 operator audit comment URL, §1.2 raw ruleset state JSON snapshot from gh api rulesets/16803733, §1.3 legacy branch-protection raw state, §4.1 PR #607 replay references (PR URL, Actions run URL, CLI rejection output text, audit artifact set), §5.1 controlled deviation from runbook §3.4 merge bullet (positive-path PR's blocked merge state is the broad-CODEOWNERS-preserved contract, not a deviation from the gate; merge-smoke remains GPP-2D-6), and §5.2 PR #608 replay references (PR URL, run URL, job URL, 4-file artifact set, closure URL). Each acceptance signal in §6 now traces to a replay-able link/snapshot.",
+    "Iter-2 absorb (Codex thread 019e5b4f): §1.1 placeholder replaced with the actual operator audit comment URL https://github.com/Halildeu/ao-kernel/pull/605#issuecomment-4529677096 (every §2.6 required field present as a table). §1.2 and §1.3 raw API outputs expanded to full JSON bodies, not normalized summaries (ruleset rules array + bypass_actors + current_user_can_bypass, plus the legacy required_status_checks.checks[].app_id pinning and the broad required_pull_request_reviews settings). §4.1.1 documents the §3.3 Step 2 UI screenshot replay path: probe PR was closed promptly as planned cleanup, and the API + Actions run URL + CLI rejection text trace preserves the same acceptance signals with higher fidelity than a screenshot would (screenshot is a rendered view of those JSON fields). Reopening probe PRs purely for screenshots was deliberately not done.",
     "GPP-2 stays blocked. With this outcomes file landed, the remaining work to close GPP-2 is GPP-2D-6 (auto-merge smoke + the CODEOWNERS narrowing it depends on) and GPP-2D-7 (AO-GATE-9 closeout)."
   ],
   "secrets_recorded": false,


### PR DESCRIPTION
## Summary

PR #609 squash-merged the iter-1-absorb version of the GPP-2D-5 verification outcomes doc as `9e87c4d` (squashed to `c0133c7`) **before** the Codex iter-2 absorb work landed. Iter-2 review (thread `019e5b4f`) returned REVISE with 2 blockers; iter-3 review (thread `019e5b5b`) gave AGREE on the worktree content and explicitly identified this follow-up PR pattern as the correct path forward.

This PR delivers the iter-2 absorb against current main.

## Changes

`.claude/plans/GPP-2D-5-VERIFICATION-OUTCOMES.md`:
- §1.1: placeholder → real operator audit comment URL (#605 issuecomment 4529677096)
- §1.2: normalized ruleset summary → full raw `gh api rulesets/16803733` JSON body
- §1.3: prose legacy branch-protection summary → full raw `gh api .../branches/main/protection` JSON body
- §4.1.1: new sub-section explicit §3.3 Step 2 UI screenshot replay path argument

`local-ai-review-evidence.v1.json`:
- `head_ref` updated to this follow-up branch
- 2 new `checks_considered` entries: `replay_references_complete`, `controlled_deviation_documented`
- Iter-2 absorb finding added

## Test plan

- [x] Schema validation: `local-ai-review-evidence.v1.json` schema-OK
- [x] Cross-AI review: iter-3 AGREE (worktree content), follow-up pattern validated
- [x] No workflow / script / test / runtime / branch-protection / ruleset mutation
- [x] Probe PRs #607 + #608 already closed
- [x] Operator audit comment posted to PR #605

## Out of scope

- GPP-2D-6 auto-merge smoke (CODEOWNERS narrowing prerequisite)
- GPP-2D-7 / AO-GATE-9 closeout
- Legacy `enforce_admins` hardening (pre-existing surface)

## Hard stops

- GPP-2 stays blocked
- `support_widening_allowed`, `production_platform_claim_allowed`, `live_adapter_execution_allowed` all stay false
- No `--admin` merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)