### PR TITLE
docs(gpp-2d-6): narrow CODEOWNERS and record auto-merge blockers

### DIFF
--- a/.claude/plans/GPP-2D-6-AUTOMERGE-SMOKE-RUNBOOK.md
+++ b/.claude/plans/GPP-2D-6-AUTOMERGE-SMOKE-RUNBOOK.md
@@ -1,10 +1,13 @@
 # GPP-2D-6 - Auto-Merge Smoke Runbook
 
-> Status: planned / verification contract only.
-> Work package: GPP-2 (still blocked).
+> Status: planned / partially hardened; smoke still blocked by repository
+> auto-merge and the legacy global required-review surface.
+> Work package: post-GPP-2 closeout hardening.
 > Parent lane: GPP-2D - Autonomous required-check lane.
-> This slice does not mutate branch protection, does not edit
-> `.github/CODEOWNERS`, does not enable auto-merge, and does not close GPP-2.
+> This runbook records the CODEOWNERS narrowing and legacy
+> `enforce_admins=true` hardening slice. It does not enable auto-merge, does
+> not relax the legacy global required-review setting, and does not reopen or
+> re-close GPP-2.
 
 ## 1. Purpose
 
@@ -22,63 +25,103 @@ High-risk PRs must still require human / CODEOWNERS review. AI output is
 evidence only; release authority remains the repo-owned `ao-release-gate`
 required check plus GitHub branch protection.
 
-## 2. Current CODEOWNERS state
+## 2. Current governance state
 
-The current `.github/CODEOWNERS` file starts with a broad default rule:
+The earlier `.github/CODEOWNERS` file started with a broad default rule:
 
 ```text
 * @Halildeu @gladyatore-lab
 ```
 
-That default is safe but blocks the GPP-2D-6 low-risk auto-merge smoke: every
-path has a code owner, so every PR remains human-review gated even when
-`ao-release-gate` succeeds.
+That default was safe but blocked the GPP-2D-6 low-risk auto-merge smoke: every
+path had a code owner, so every PR remained code-owner gated even when
+`ao-release-gate` succeeded.
 
-Therefore GPP-2D-6 cannot be honestly accepted until a separate, reviewed
-CODEOWNERS narrowing slice lands after the GPP-2D-5 cutover verification. The
-narrowing must remove the broad `*` default and keep explicit ownership only on
-the high-risk surface set.
+The GPP-2D-6 hardening slice narrows CODEOWNERS by removing the broad `*`
+default owner and keeping code-owner review on governance-sensitive surfaces:
 
-This runbook intentionally does not change CODEOWNERS. Weakening reviewer
-coverage before `ao-release-gate` is source-pinned as a required check would
-reduce governance before the mechanical gate is live.
+```text
+/.github/
+/AGENTS.md
+/CLAUDE.md
+/.claude/
+/ao_kernel/ao_release_gate*.py
+/scripts/ao_release_gate*.py
+/scripts/local_gpp_gate*.py
+/ao_kernel/defaults/schemas/*gate*.json
+/ao_kernel/defaults/policies/
+/deploy/
+```
 
-Short rule: Weakening reviewer coverage before `ao-release-gate` is source-pinned
-is forbidden.
+There is also a separate legacy branch-protection review gate. The live
+metadata check after the GPP-2D-6 hardening refresh showed:
+
+```text
+repository.autoMergeAllowed = false
+legacy_branch_protection.enforce_admins = true
+required_approving_review_count = 1
+require_code_owner_reviews = true
+dismiss_stale_reviews = true
+```
+
+This means the CODEOWNERS narrowing and `enforce_admins=true` tightening are
+necessary but still insufficient for the full GPP-2D-6 acceptance criterion.
+Removing the broad `*` owner can stop low-risk files from being code-owner
+matched, and `enforce_admins=true` makes the legacy surface stricter for admins;
+however `repository.autoMergeAllowed=false` prevents GitHub-native auto-merge,
+and a global `required_approving_review_count=1` still keeps low-risk PRs
+human-review gated.
+
+Therefore GPP-2D-6 cannot be honestly accepted until these conditions are true:
+
+1. GitHub-native auto-merge is enabled for the repository;
+2. the high-risk surface remains human-gated through an explicit, reviewed
+   governance mechanism; and
+3. the low-risk surface no longer has a global non-author review requirement.
+
+This runbook allows the CODEOWNERS narrowing only because `ao-release-gate` is
+already source-pinned as a required check and legacy `enforce_admins=true`
+hardening is active. It does not relax the global required-review setting.
+
+Short rule: weakening reviewer coverage is forbidden unless the replacement
+mechanical gate is already source-pinned, enforced, and verified.
 
 ## 3. Required ordering
 
-1. GPP-2D-5 runbook PR lands.
+1. GPP-2D-5 runbook PR lands. Done.
 2. Operator performs the GPP-2D-5 branch-protection / ruleset cutover:
    `ao-release-gate` required, source-pinned to GitHub Actions, admin bypass
-   disallowed.
+   disallowed. Done.
 
 Cutover invariant: admin bypass disallowed.
 3. Agent records GPP-2D-5 verification outcomes:
    required-check API evidence, admin-bypass-off evidence, negative-path PR
-   blocked by `ao-release-gate`, and positive-path PR allowed by the gate.
-4. A high-risk CODEOWNERS narrowing PR lands with non-author human approval.
-5. GPP-2D-6 auto-merge smoke runs.
-6. GPP-2D-7 / AO-GATE-9 closeout records the final GPP-2 state only after the
-   smoke evidence exists.
+   blocked by `ao-release-gate`, and positive-path PR allowed by the gate. Done.
+4. GPP-2D-7 / AO-GATE-9 closeout records GPP-2 as closed. Done; GPP-2D-6 is
+   now a post-closeout hardening slice, not a closeout prerequisite.
+5. CODEOWNERS narrowing lands and legacy `enforce_admins=true` is verified.
+6. Operator enables GitHub-native auto-merge for the repository and records
+   `repository.autoMergeAllowed=true`.
+7. Operator selects and applies the low-risk review model:
+   - either relax the legacy global review requirement while preserving a
+     high-risk human gate through CODEOWNERS / ruleset policy; or
+   - keep the legacy review requirement and record that full no-human
+     low-risk auto-merge is intentionally not enabled.
+8. GPP-2D-6 auto-merge smoke runs.
 
-Steps 1-3 must complete before any CODEOWNERS narrowing. Steps 1-5 must complete
-before GPP-2 closeout.
+Steps 1-5 are complete or in this hardening PR. Steps 6-8 remain before the
+smoke can be accepted.
 
 ## 4. CODEOWNERS narrowing target
 
-The first narrowing slice keeps code-owner review on the high-risk surface set
-from the GPP-2D design:
+The narrowing slice keeps code-owner review on the high-risk surface set from
+the GPP-2D design:
 
 ```text
 /.github/ @Halildeu @gladyatore-lab
 /AGENTS.md @Halildeu @gladyatore-lab
 /CLAUDE.md @Halildeu @gladyatore-lab
-/.claude/plans/gpp_status.v1.json @Halildeu @gladyatore-lab
-/.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md @Halildeu @gladyatore-lab
-/.claude/plans/AO-GATE-ROADMAP-TODO.md @Halildeu @gladyatore-lab
-/.claude/plans/GPP-* @Halildeu @gladyatore-lab
-/.claude/plans/AO-* @Halildeu @gladyatore-lab
+/.claude/ @Halildeu @gladyatore-lab
 /ao_kernel/ao_release_gate*.py @Halildeu @gladyatore-lab
 /scripts/ao_release_gate*.py @Halildeu @gladyatore-lab
 /scripts/local_gpp_gate*.py @Halildeu @gladyatore-lab
@@ -87,14 +130,18 @@ from the GPP-2D design:
 /deploy/ @Halildeu @gladyatore-lab
 ```
 
-The exact CODEOWNERS syntax is implemented in the future narrowing PR and must
-be reviewed as a high-risk governance change. The acceptance criterion is the
-behavior, not this draft text: low-risk paths are no longer code-owner-gated;
-the high-risk paths above still are.
+The CODEOWNERS syntax is implemented in this high-risk governance PR and must
+be reviewed by a non-author human reviewer. The acceptance criterion is the
+behavior: low-risk paths are no longer code-owner-gated; the high-risk paths
+above still are.
+
+Narrowing CODEOWNERS is not enough while the legacy branch protection still has
+`required_approving_review_count=1`. The smoke must verify the actual GitHub
+merge gate, not just the CODEOWNERS file contents.
 
 ## 5. Low-risk auto-merge smoke
 
-After the narrowing PR lands, open a low-risk smoke PR that changes only a path
+After this hardening PR lands, open a low-risk smoke PR that changes only a path
 outside the high-risk surface set. Example candidate:
 
 ```text
@@ -158,6 +205,11 @@ Required fields:
 UTC timestamp
 Repository and main head before smoke
 GPP-2D-5 verification evidence link
+GPP-2D-7 closeout evidence link
+Repository auto-merge setting before and after smoke
+Legacy branch-protection enforce_admins setting before smoke
+Legacy branch-protection review setting before smoke
+Operator review-model decision and resulting GitHub metadata
 CODEOWNERS narrowing PR link and merge SHA
 Low-risk PR link, check run IDs, auto-merge enabled timestamp, merge SHA
 High-risk PR link, code-owner block evidence, merge rejection / blocked status
@@ -166,7 +218,8 @@ Support widening: false
 Production platform claim: false
 Live adapter execution: false
 testai / smee dependency: false
-GPP-2 status after smoke: still blocked until GPP-2D-7 closeout
+GPP-2 status after smoke: remains closed; this slice is a post-closeout
+hardening record only
 ```
 
 ## 8. Stop conditions
@@ -175,7 +228,9 @@ Stop and do not continue to GPP-2D-7 if any of these are true:
 
 - `ao-release-gate` is not a source-pinned required check.
 - Admin bypass is enabled or a bypass actor exists.
-- The low-risk smoke still requires code-owner approval.
+- Repository auto-merge is disabled.
+- The low-risk smoke still requires code-owner approval or any global
+  non-author review approval.
 - The high-risk smoke does not require human / CODEOWNERS review.
 - Any merge uses `--admin`.
 - Any PR claims production readiness or widens support.
@@ -187,12 +242,16 @@ Stop and do not continue to GPP-2D-7 if any of these are true:
 
 ## 9. Relation to GPP-2D-7
 
-GPP-2D-7 may close GPP-2 only after:
+GPP-2D-7 already closed GPP-2 under the no-testai release-governance model.
+GPP-2D-6 is therefore a later hardening record, not a prerequisite for the
+current GPP-2 closeout. It may only be marked complete after:
 
 1. GPP-2D-5 verification outcomes are committed.
-2. CODEOWNERS narrowing is merged and reviewed as a high-risk change.
-3. GPP-2D-6 low-risk and high-risk smoke evidence is committed.
-4. `python3 scripts/gpp_next.py` is updated in the closeout slice to reflect the
-   new evidence.
+2. GPP-2D-7 closeout is committed.
+3. GitHub-native auto-merge is enabled by the operator.
+4. The selected review model is recorded and applied by the operator.
+5. CODEOWNERS narrowing and legacy `enforce_admins=true` hardening are merged
+   and reviewed as a high-risk governance change.
+6. GPP-2D-6 low-risk and high-risk smoke evidence is committed.
 
-Until then, GPP-2 remains `blocked`.
+Until then, GPP-2D-6 remains incomplete, but GPP-2 remains `closed`.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,19 @@
-# Default owner
-* @Halildeu @gladyatore-lab
+# Low-risk files intentionally have no default code owner. Release authority for
+# those paths is the repo-owned ao-release-gate required check plus GitHub branch
+# protection; CODEOWNERS remains focused on governance-sensitive surfaces.
 
-# Governance-sensitive surfaces
+# GitHub governance and workflow surfaces
 /.github/ @Halildeu @gladyatore-lab
-/.claude/ @Halildeu @gladyatore-lab
+
+# Agent and GPP governance surfaces
+/AGENTS.md @Halildeu @gladyatore-lab
 /CLAUDE.md @Halildeu @gladyatore-lab
+/.claude/ @Halildeu @gladyatore-lab
+
+# Release-gate runtime, policy, schema, and deployment surfaces
+/ao_kernel/ao_release_gate*.py @Halildeu @gladyatore-lab
+/scripts/ao_release_gate*.py @Halildeu @gladyatore-lab
+/scripts/local_gpp_gate*.py @Halildeu @gladyatore-lab
+/ao_kernel/defaults/schemas/*gate*.json @Halildeu @gladyatore-lab
 /ao_kernel/defaults/policies/ @Halildeu @gladyatore-lab
-/docs/ @Halildeu @gladyatore-lab
+/deploy/ @Halildeu @gladyatore-lab

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,74 +1,51 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "GOV-1",
+  "work_package": "GPP-2",
   "implementer": {
-    "agent": "claude",
-    "provider": "anthropic"
+    "agent": "codex",
+    "provider": "openai"
   },
   "reviewer": {
-    "agent": "codex",
-    "provider": "openai",
+    "agent": "claude",
+    "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/gov-1-roadmap-enrichment",
+    "head_ref": "refs/heads/codex/gpp2d6-readiness-correction",
     "changed_files": [
-      ".claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md",
-      ".claude/plans/PROGRAM-CHANGE-CONTROL.md",
-      ".claude/plans/_TEMPLATES/RETROSPECTIVE-TEMPLATE.md",
-      ".claude/plans/gpp_status.v1.json",
-      ".github/workflows/test.yml",
-      "docs/ROLLBACK-RUNBOOK.md",
+      ".claude/plans/GPP-2D-6-AUTOMERGE-SMOKE-RUNBOOK.md",
+      ".github/CODEOWNERS",
       "local-ai-review-evidence.v1.json",
-      "scripts/gpp_next.py",
-      "tests/test_ao_release_gate.py",
-      "tests/test_ao_release_gate_enforce_job.py",
-      "tests/test_gpp_next.py"
+      "tests/test_gpp2d6_automerge_contract.py"
     ]
   },
   "checks_considered": [
-    {"name": "tests", "status": "pass"},
-    {"name": "secret_scan", "status": "pass"},
-    {"name": "no_public_sdk_signature_change", "status": "pass"},
-    {"name": "no_branch_protection_mutation_by_agent", "status": "pass"},
-    {"name": "no_runtime_contract_change", "status": "pass"},
-    {"name": "guard_flags_unchanged", "status": "pass"},
-    {"name": "milestones_seven_canonical_ids", "status": "pass"},
-    {"name": "progress_estimates_milestone_and_wp_blocks", "status": "pass"},
-    {"name": "done_milestones_have_evidence_refs", "status": "pass"},
-    {"name": "aggregate_completion_sources_consistent", "status": "pass"},
-    {"name": "progress_output_renders_seven_milestones", "status": "pass"},
-    {"name": "text_output_includes_milestone_summary", "status": "pass"},
-    {"name": "status_md_milestones_section_timeline_free", "status": "pass"},
-    {"name": "cross_provider_verified", "status": "pass"},
-    {"name": "change_control_rules_complete", "status": "pass"},
-    {"name": "rollback_runbook_failure_mode_based", "status": "pass"},
-    {"name": "retrospective_template_five_questions", "status": "pass"},
-    {"name": "ao_release_gate_work_package_dynamic_binding", "status": "pass"},
-    {"name": "reviewed_slice_payload_binding", "status": "pass"}
+    {
+      "name": "tests",
+      "status": "pass"
+    },
+    {
+      "name": "secret_scan",
+      "status": "pass"
+    },
+    {
+      "name": "hard_boundary_compliance",
+      "status": "pass"
+    },
+    {
+      "name": "internal_consistency",
+      "status": "pass"
+    }
   ],
   "findings": [
-    "tests: pytest 3387 passed, 2 skipped in the full local test suite (~79s) including seven new GOV-1 drift guards.",
-    "secret_scan: no credential material, PEM, token, or webhook secret value appears in any changed file.",
-    "no_public_sdk_signature_change: ao_kernel package public SDK signatures unchanged; gpp_next.py extends CLI with --output progress and milestone summary in text output but preserves existing text and json modes.",
-    "no_branch_protection_mutation_by_agent: the agent does not call gh api on rulesets, branches/main/protection, or any settings endpoint in this PR.",
-    "no_runtime_contract_change: GOV-1 is docs/SSOT/script/test only; no runtime or schema-breaking change.",
-    "guard_flags_unchanged: support_widening_allowed=false, production_platform_claim_allowed=false, live_adapter_execution_allowed=false all preserved.",
-    "milestones_seven_canonical_ids: gpp_status.v1.json carries exactly seven milestones (M0..M6) with status in {done, pending}, gpp_slots, evidence_refs, and closed_at fields.",
-    "progress_estimates_milestone_and_wp_blocks: progress_estimates contains both milestones block (done_count=3, total_count=7, percent=43, next_milestone_id=M3) and wp_weighted block (38/50=76%, estimated=true).",
-    "done_milestones_have_evidence_refs: each done milestone references at least one existing path; closed_at is ISO-parseable.",
-    "aggregate_completion_sources_consistent: aggregate-aware test confirms GPP-2 satisfied by current_wp closed, GPP-2D by evidence_refs path, GPP-5 by completed_children {GPP-5a..d}, and atomic slots via completed_wps.",
-    "progress_output_renders_seven_milestones: scripts/gpp_next.py --output progress prints headline + seven milestone rows + next milestone label.",
-    "text_output_includes_milestone_summary: scripts/gpp_next.py default text output carries the two-line milestone summary before Blocked work packages.",
-    "status_md_milestones_section_timeline_free: STATUS.md introduces a new section 0 Milestones that contains the seven canonical IDs in a table and does not duplicate the global Date header inside the section.",
-    "cross_provider_verified: implementer claude (provider anthropic) differs from reviewer codex (provider openai); cross-AI peer review HARD RULE satisfied.",
-    "change_control_rules_complete: PROGRAM-CHANGE-CONTROL.md records 13 normative rules CC-1..CC-13 covering SSOT mutation, cross-AI review, non-author approval, no admin merge, AI-as-evidence, GPP-9 guard flag flip, ADR supersession, schema bump, branch ruleset mutation, archive tag, rollback, secret protection, and per-slice discipline.",
-    "rollback_runbook_failure_mode_based: ROLLBACK-RUNBOOK.md is failure-mode based with five scenarios (ruleset operator error, code regression, cross-machine recovery, closeout reversal, live execution mishap), each carrying Trigger, Owner, Forbidden, Steps, Evidence, and Supersession PR sections.",
-    "retrospective_template_five_questions: RETROSPECTIVE-TEMPLATE.md defines exactly five questions (worked, incomplete, learned, repeat pattern, retire anti-pattern) plus context header and cross-references; existing closeout records are left unchanged as terminal evidence per plan-time decision.",
-    "ao_release_gate_work_package_dynamic_binding: .github/workflows/test.yml no longer hardcodes the GPP-2 slice identifier as a literal CLI argument; a new Resolve reviewed work package step parses the reviewer-declared work_package, validates it against a strict format regex (uppercase + dash-separated identifier; no shell metacharacters), and passes it to local_gpp_gate.py through the REVIEW_WORK_PACKAGE env var. test_ao_release_gate_enforce_job.py pins the workflow shape + ordering (resolve before patch before local_gate before decision_core).",
-    "reviewed_slice_payload_binding: the same Resolve step also patches the runtime payload.json reviewed_slice field from the reviewer-declared work_package before decision-core evaluation. This keeps the binding-equality contract review_evidence.work_package == payload.reviewed_slice intact for any reviewed slice. test_release_gate_allows_reviewed_slice_distinct_from_current_wp_when_context_bound (new) pins this invariant alongside the existing test_release_gate_denies_when_reviewed_slice_mismatches negative case."
+    "CODEOWNERS narrowing is correct: broad default owner removed while governance, agent contract, release-gate runtime, local gate, policy, schema, and deploy surfaces retain explicit owners.",
+    "Runbook truthfully states GPP-2D-6 remains incomplete because repository auto-merge is disabled and the legacy global required-review setting remains active.",
+    "Legacy enforce_admins=true is recorded as tightening, not as bypass or smoke completion.",
+    "No production readiness, support widening, testai or smee reopening, or live adapter execution is claimed.",
+    "Tests pin CODEOWNERS narrowing, remaining blockers, hard stops, and post-closeout boundary.",
+    "No secrets or credentials in diff."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_gpp2d6_automerge_contract.py
+++ b/tests/test_gpp2d6_automerge_contract.py
@@ -8,23 +8,35 @@ DOC = ROOT / ".claude/plans/GPP-2D-6-AUTOMERGE-SMOKE-RUNBOOK.md"
 CODEOWNERS = ROOT / ".github/CODEOWNERS"
 
 
-def test_gpp2d6_records_current_broad_codeowners_as_blocking_low_risk_automerge() -> None:
+def test_gpp2d6_records_codeowners_narrowing_and_remaining_review_blockers() -> None:
     doc = DOC.read_text(encoding="utf-8")
     codeowners = CODEOWNERS.read_text(encoding="utf-8")
 
-    assert "* @Halildeu @gladyatore-lab" in codeowners
-    assert "safe but blocks the GPP-2D-6 low-risk auto-merge smoke" in doc
-    assert "This runbook intentionally does not change CODEOWNERS." in doc
-    assert "Weakening reviewer coverage before `ao-release-gate` is source-pinned" in doc
+    assert "* @Halildeu @gladyatore-lab" not in codeowners
+    assert "/.github/ @Halildeu @gladyatore-lab" in codeowners
+    assert "/.claude/ @Halildeu @gladyatore-lab" in codeowners
+    assert "/ao_kernel/ao_release_gate*.py @Halildeu @gladyatore-lab" in codeowners
+    assert "/scripts/local_gpp_gate*.py @Halildeu @gladyatore-lab" in codeowners
+    assert "/deploy/ @Halildeu @gladyatore-lab" in codeowners
+    assert "That default was safe but blocked the GPP-2D-6 low-risk auto-merge smoke" in doc
+    assert "CODEOWNERS narrowing and `enforce_admins=true` tightening are" in doc
+    assert "repository.autoMergeAllowed=false" in doc
+    assert "legacy_branch_protection.enforce_admins = true" in doc
+    assert "required_approving_review_count=1" in doc
+    assert "necessary but still insufficient" in doc
 
 
-def test_gpp2d6_requires_cutover_before_codeowners_narrowing() -> None:
+def test_gpp2d6_requires_cutover_and_operator_review_model_before_smoke() -> None:
     doc = DOC.read_text(encoding="utf-8")
 
     assert "GPP-2D-5 branch-protection / ruleset cutover" in doc
     assert "`ao-release-gate` required, source-pinned to GitHub Actions" in doc
     assert "admin bypass disallowed" in doc
-    assert "Steps 1-3 must complete before any CODEOWNERS narrowing." in doc
+    assert "GPP-2D-7 / AO-GATE-9 closeout records GPP-2 as closed. Done" in doc
+    assert "CODEOWNERS narrowing lands and legacy `enforce_admins=true` is verified." in doc
+    assert "Operator enables GitHub-native auto-merge" in doc
+    assert "Operator selects and applies the low-risk review model" in doc
+    assert "Steps 1-5 are complete or in this hardening PR. Steps 6-8 remain" in doc
 
 
 def test_gpp2d6_pins_low_risk_and_high_risk_smoke_acceptance() -> None:
@@ -46,4 +58,7 @@ def test_gpp2d6_keeps_hard_stops_and_gpp2_closeout_boundary() -> None:
     assert "Production platform claim: false" in doc
     assert "Live adapter execution: false" in doc
     assert "testai / smee dependency: false" in doc
-    assert "Until then, GPP-2 remains `blocked`." in doc
+    assert "Legacy branch-protection enforce_admins setting before smoke" in doc
+    assert "Repository auto-merge is disabled." in doc
+    assert "GPP-2 status after smoke: remains closed" in doc
+    assert "Until then, GPP-2D-6 remains incomplete, but GPP-2 remains `closed`." in doc


### PR DESCRIPTION
## Summary

GPP-2D-6 hardening slice. This PR now does two concrete things:

1. Narrows `.github/CODEOWNERS` by removing the broad `* @Halildeu @gladyatore-lab` default and keeping owners on governance-sensitive surfaces only.
2. Records the live legacy branch-protection hardening: `enforce_admins=true`.

This is still **not** the GPP-2D-6 auto-merge smoke itself. The runbook remains explicit that low-risk no-human auto-merge is still blocked because:

- `repository.autoMergeAllowed=false`
- legacy `required_approving_review_count=1`

## Boundaries

- No `--admin` merge.
- No production readiness claim.
- No support widening.
- No live adapter execution.
- No testai / smee / webhook callback reopening.
- GPP-2 remains `closed`; this is post-closeout hardening.

## Validation

- `gh api repos/Halildeu/ao-kernel/branches/main/protection --jq '.enforce_admins.enabled'` -> `true`
- Claude cross-provider review -> `AGREE`
- `pytest -q tests/test_gpp2d6_automerge_contract.py tests/test_gpp_next.py` -> `34 passed`
- `python3 scripts/gpp_next.py` -> GPP-2 `closed`, guard flags false
- `PYTHONPATH=. python3 scripts/local_gpp_gate.py ...` -> `decision=operator_may_merge`, findings none
- `git diff --check` -> clean

## Remaining before real GPP-2D-6 smoke

Operator must still enable GitHub-native repo auto-merge and apply a review model where low-risk PRs no longer require global non-author review while high-risk paths remain human-gated.
