### PR TITLE
feat(gpp-2d-6): add path-sensitive human-review gate

### DIFF
--- a/.claude/plans/GPP-2B-AO-RELEASE-GATE-REQUIRED-CHECK-MAPPING.md
+++ b/.claude/plans/GPP-2B-AO-RELEASE-GATE-REQUIRED-CHECK-MAPPING.md
@@ -53,8 +53,9 @@ stays `blocked`.
   `ao_kernel/ao_release_gate_service.py` + `ao_release_gate_runtime.py`.
 - A repo-owned GitHub App release gate. Consumes a PR-shaped GitHub payload
   plus the GPP status JSON. Emits an `ao-release-gate` GitHub check-run.
-- Twenty checks (GPP-2D-2b added `review_evidence` and
-  `review_evidence_context_bound` to the original eighteen);
+- Twenty-one checks (GPP-2D-2b added `review_evidence` and
+  `review_evidence_context_bound` to the original eighteen; GPP-2D-6b added
+  `path_sensitive_human_review`);
   `decision = allow_autonomous_merge` only when all pass, otherwise one of
   `deny_policy_violation`, `deny_missing_evidence`, `deny_stale_branch`,
   `deny_untrusted_context`, `error_fail_closed`.
@@ -68,7 +69,7 @@ stays `blocked`.
 
 ### 3.1 Check correspondence
 
-| Local gate check (8) | ao-release-gate check(s) (20) | Category |
+| Local gate check (8) | ao-release-gate check(s) (21) | Category |
 |---|---|---|
 | `startup_preflight_passed` | `payload_shape`, `repository` | A — evaluation context is structurally valid |
 | `gpp_status_checked` | `gpp_status`, `gpp_closed_boundaries` | A — GPP-2 blocked + support/production/live-adapter guards false |
@@ -77,7 +78,7 @@ stays `blocked`.
 | `secret_scan_passed` | `secret_boundary` | A — no secret material |
 | `forbidden_actions_absent` | `admin_bypass_boundary`, `bot_boundary`, `agent_authority_boundary`, `live_adapter_boundary` | A — no forbidden action / authority |
 | `reviewer_agree`, `cross_provider_verified` | `review_evidence` | A — cross-AI reviewer AGREE + cross-provider verdict consumed by ao-release-gate via the local-gpp-gate-evidence acceptance profile (GPP-2D-2b) |
-| *(none)* | `pull_request`, `issue_link`, `base_ref`, `branch_freshness`, `fork_boundary`, `event_boundary`, `gpp_issue_consistency`, `review_evidence_context_bound` | B — GitHub PR-context checks, ao-release-gate-only |
+| *(none)* | `pull_request`, `issue_link`, `base_ref`, `branch_freshness`, `fork_boundary`, `event_boundary`, `gpp_issue_consistency`, `review_evidence_context_bound`, `path_sensitive_human_review` | B — GitHub PR-context checks, ao-release-gate-only |
 
 - **Category A** — both gates verify the same governance condition from
   different vantage points (local repo state vs. GitHub PR payload). These are
@@ -90,7 +91,9 @@ stays `blocked`.
   issue URL against the current GPP work package, and
   `review_evidence_context_bound`, which binds the local-gate evidence to the
   PR head SHA, repository, reviewed slice, diff digest, and changed-files
-  count). The local gate has no PR payload and cannot perform these; they are
+  count, plus `path_sensitive_human_review`, which uses GitHub review metadata
+  to require current-head non-author approval only when high-risk paths
+  changed). The local gate has no PR payload and cannot perform these; they are
   inherently ao-release-gate-only and require no reconciliation.
 - **Category C** — historical: the cross-AI peer review verdict was previously
   unmappable (local-only) and tracked in §4 as the substantive gap. GPP-2D-2b
@@ -234,7 +237,7 @@ webhook/App configuration, no live adapter.
 | Slice | Scope | Gate |
 |---|---|---|
 | **GPP-2B-1** | This mapping record (this PR). | docs only |
-| **GPP-2B-2** | A machine-checkable mapping test pinning the §3.1 table to both gates' live check sets: every local-gate check (8, from `local-gpp-gate-evidence.schema.v1.json`) and every `ao-release-gate` check (20, from `build_ao_release_gate_decision` after GPP-2D-2b — originally 18 at GPP-2B-2 landing) must appear in the table with a documented counterpart or an explicit `local-only` marker, so the mapping cannot silently drift on either side. Implemented as `tests/test_gpp2b_mapping_drift_guard.py`. | docs + test |
+| **GPP-2B-2** | A machine-checkable mapping test pinning the §3.1 table to both gates' live check sets: every local-gate check (8, from `local-gpp-gate-evidence.schema.v1.json`) and every `ao-release-gate` check (21, from `build_ao_release_gate_decision` after GPP-2D-6b — originally 18 at GPP-2B-2 landing, then 20 after GPP-2D-2b) must appear in the table with a documented counterpart or an explicit `local-only` marker, so the mapping cannot silently drift on either side. Implemented as `tests/test_gpp2b_mapping_drift_guard.py`. | docs + test |
 | **GPP-2B-3** | Resolve the Category-C gap (§5) via Codex consultation; if Option 1 is selected, design the attested-review-evidence schema/contract. Historical scope was design only — no service wiring; subsequently wired in GPP-2D-2b. Resolved as Option 1 in §5.1; acceptance-profile schema `ao_kernel/defaults/schemas/ao-release-gate-review-evidence-input.schema.v1.json` + contract test `tests/test_gpp2b3_review_evidence_input_schema.py`. | docs + schema + test |
 | **GPP-2B-4** | Unit/schema-level conclusion-mapping test against the side-effect-free decision core: assert `build_ao_release_gate_decision(..., conclusion_mode=...)` maps decisions to GitHub conclusions correctly — `allow_autonomous_merge` → `success`; `deny_*` / `error_fail_closed` → `neutral` under `shadow` and `failure` under `enforce`. Pure in-process unit test; the hosted runtime mode is not changed, no check-run is posted to any PR, branch protection is untouched. Implemented as `tests/test_ao_release_gate.py::test_check_run_conclusion_mapping` (6 decisions x shadow/enforce). | docs + test |
 

--- a/.claude/plans/GPP-2D-6-AUTOMERGE-SMOKE-RUNBOOK.md
+++ b/.claude/plans/GPP-2D-6-AUTOMERGE-SMOKE-RUNBOOK.md
@@ -5,8 +5,9 @@
 > Work package: post-GPP-2 closeout hardening.
 > Parent lane: GPP-2D - Autonomous required-check lane.
 > This runbook records the CODEOWNERS narrowing and legacy
-> `enforce_admins=true` hardening slice. It does not enable auto-merge, does
-> not relax the legacy global required-review setting, and does not reopen or
+> `enforce_admins=true` hardening slice, plus the `ao-release-gate`
+> path-sensitive human-review gate. It does not enable auto-merge, does not
+> relax the legacy global required-review setting, and does not reopen or
 > re-close GPP-2.
 
 ## 1. Purpose
@@ -72,11 +73,26 @@ however `repository.autoMergeAllowed=false` prevents GitHub-native auto-merge,
 and a global `required_approving_review_count=1` still keeps low-risk PRs
 human-review gated.
 
+The GPP-2D-6b gate slice moves the high-risk human-review requirement into the
+repo-owned `ao-release-gate` required check:
+
+```text
+low-risk changed paths
+  -> AI review evidence + local_gpp_gate + CI + ao-release-gate can pass
+
+high-risk changed paths
+  -> ao-release-gate requires a current-head non-author APPROVED GitHub review
+```
+
+This lets the future low-risk lane remove the legacy global review requirement
+without losing the high-risk human gate. AI output remains evidence only; the
+required check is the release authority.
+
 Therefore GPP-2D-6 cannot be honestly accepted until these conditions are true:
 
 1. GitHub-native auto-merge is enabled for the repository;
-2. the high-risk surface remains human-gated through an explicit, reviewed
-   governance mechanism; and
+2. the high-risk surface remains human-gated through `ao-release-gate` and
+   CODEOWNERS / branch ruleset policy; and
 3. the low-risk surface no longer has a global non-author review requirement.
 
 This runbook allows the CODEOWNERS narrowing only because `ao-release-gate` is
@@ -100,16 +116,19 @@ Cutover invariant: admin bypass disallowed.
 4. GPP-2D-7 / AO-GATE-9 closeout records GPP-2 as closed. Done; GPP-2D-6 is
    now a post-closeout hardening slice, not a closeout prerequisite.
 5. CODEOWNERS narrowing lands and legacy `enforce_admins=true` is verified.
-6. Operator enables GitHub-native auto-merge for the repository and records
+6. `ao-release-gate` path-sensitive human-review enforcement lands: high-risk
+   paths require current-head non-author `APPROVED` GitHub review, while
+   low-risk paths do not.
+7. Operator enables GitHub-native auto-merge for the repository and records
    `repository.autoMergeAllowed=true`.
-7. Operator selects and applies the low-risk review model:
+8. Operator selects and applies the low-risk review model:
    - either relax the legacy global review requirement while preserving a
      high-risk human gate through CODEOWNERS / ruleset policy; or
    - keep the legacy review requirement and record that full no-human
      low-risk auto-merge is intentionally not enabled.
-8. GPP-2D-6 auto-merge smoke runs.
+9. GPP-2D-6 auto-merge smoke runs.
 
-Steps 1-5 are complete or in this hardening PR. Steps 6-8 remain before the
+Steps 1-6 are complete or in this hardening PR. Steps 7-9 remain before the
 smoke can be accepted.
 
 ## 4. CODEOWNERS narrowing target
@@ -149,6 +168,8 @@ docs/smoke/gpp2d6-low-risk-automerge-smoke.md
 ```
 
 The PR must include normal review evidence and must pass `ao-release-gate`.
+For low-risk paths, `ao-release-gate` must not require a human review when the
+AI evidence, local gate evidence, CI, and branch freshness checks pass.
 Then enable GitHub-native auto-merge:
 
 ```bash
@@ -159,10 +180,11 @@ Acceptance:
 
 1. `ao-release-gate` concludes `success`.
 2. Required CI checks are green.
-3. No non-author human review is required for the low-risk path.
-4. GitHub performs the merge after required checks pass.
-5. The merge is not performed with `--admin`.
-6. The evidence records the PR URL, merge SHA, relevant check run IDs, and the
+3. `ao-release-gate` records no high-risk changed paths.
+4. No non-author human review is required for the low-risk path.
+5. GitHub performs the merge after required checks pass.
+6. The merge is not performed with `--admin`.
+7. The evidence records the PR URL, merge SHA, relevant check run IDs, and the
    auto-merge timeline.
 
 ## 6. High-risk human-gate smoke
@@ -179,16 +201,21 @@ intended. The purpose is to prove the gate holds.
 
 Acceptance:
 
-1. `ao-release-gate` may pass if the evidence is valid.
-2. GitHub still reports a code-owner / required-review block.
-3. `gh pr view <HIGH_RISK_PR> --json mergeStateStatus,reviewDecision,statusCheckRollup`
+1. `ao-release-gate` fails with
+   `ao_release_gate_high_risk_human_review_missing` before a current-head
+   non-author approval exists.
+2. After a current-head non-author `APPROVED` GitHub review and a rerun,
+   `ao-release-gate` may pass if all other evidence is valid.
+3. GitHub still reports a code-owner / required-review block until that human
+   approval exists.
+4. `gh pr view <HIGH_RISK_PR> --json mergeStateStatus,reviewDecision,statusCheckRollup`
    shows the PR is not merge-ready without the required human approval.
-4. If `gh pr merge --auto --squash` is attempted before approval, GitHub must
+5. If `gh pr merge --auto --squash` is attempted before approval, GitHub must
    not auto-merge the PR.
 
 High-risk invariant: GitHub must not auto-merge the PR before required human
 approval.
-5. The smoke PR is closed or converted into a real reviewed governance PR after
+6. The smoke PR is closed or converted into a real reviewed governance PR after
    evidence capture.
 
 ## 7. Evidence artifact
@@ -252,6 +279,8 @@ current GPP-2 closeout. It may only be marked complete after:
 4. The selected review model is recorded and applied by the operator.
 5. CODEOWNERS narrowing and legacy `enforce_admins=true` hardening are merged
    and reviewed as a high-risk governance change.
-6. GPP-2D-6 low-risk and high-risk smoke evidence is committed.
+6. `ao-release-gate` path-sensitive high-risk human-review enforcement is
+   merged and reviewed as a high-risk governance change.
+7. GPP-2D-6 low-risk and high-risk smoke evidence is committed.
 
 Until then, GPP-2D-6 remains incomplete, but GPP-2 remains `closed`.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ on:
       - synchronize
       - ready_for_review
       - edited
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+      - dismissed
   workflow_dispatch:
     inputs:
       reason:
@@ -60,6 +65,10 @@ jobs:
                   fi
                   ;;
               esac
+              ;;
+            pull_request_review)
+              should_run=true
+              trigger_reason="pull_request_review:$EVENT_ACTION"
               ;;
           esac
 
@@ -348,7 +357,10 @@ jobs:
     # The fail-closed needs short-circuit below produces a `failure`
     # conclusion instead.
     if: |
-      always() && github.event_name == 'pull_request' && (
+      always() && (
+        github.event_name == 'pull_request' ||
+        github.event_name == 'pull_request_review'
+      ) && (
         needs.event-gate.outputs.should_run == 'true' ||
         needs.event-gate.result != 'success'
       )
@@ -376,8 +388,8 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-            echo "::error::ao-release-gate only evaluates pull_request events"
+          if [ "$EVENT_NAME" != "pull_request" ] && [ "$EVENT_NAME" != "pull_request_review" ]; then
+            echo "::error::ao-release-gate only evaluates pull_request or pull_request_review events"
             exit 1
           fi
 
@@ -428,6 +440,7 @@ jobs:
         working-directory: base
         run: |
           gh pr view "$PR_NUMBER" --repo "$REPO_FULL" --json files > pr-files.json
+          gh pr view "$PR_NUMBER" --repo "$REPO_FULL" --json reviews,author > pr-reviews.json
           gh api "repos/$REPO_FULL/commits/$HEAD_SHA/check-runs?per_page=100" > check-runs.json
 
       - name: Compute branch_up_to_date from base
@@ -465,6 +478,50 @@ jobs:
             --required-check policy-container-smoke \
             --required-check release-gate-container-smoke \
             --output payload.json
+
+      - name: Augment release-gate payload with PR review metadata
+        working-directory: base
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload_path = Path("payload.json")
+          payload = json.loads(payload_path.read_text(encoding="utf-8"))
+          review_payload = json.loads(Path("pr-reviews.json").read_text(encoding="utf-8"))
+
+          def normalized_string(value):
+              return value.strip() if isinstance(value, str) and value.strip() else None
+
+          author_payload = review_payload.get("author")
+          pr_author = None
+          if isinstance(author_payload, dict):
+              pr_author = normalized_string(author_payload.get("login"))
+
+          reviews = []
+          raw_reviews = review_payload.get("reviews")
+          if isinstance(raw_reviews, list):
+              for item in raw_reviews:
+                  if not isinstance(item, dict):
+                      continue
+                  reviewer = item.get("author")
+                  commit = item.get("commit")
+                  review = {
+                      "author": normalized_string(reviewer.get("login")) if isinstance(reviewer, dict) else None,
+                      "state": normalized_string(item.get("state")),
+                      "commit_oid": normalized_string(commit.get("oid")) if isinstance(commit, dict) else None,
+                  }
+                  if any(value is not None for value in review.values()):
+                      reviews.append(review)
+
+          pull_request = payload.setdefault("pull_request", {})
+          if isinstance(pull_request, dict) and pr_author is not None:
+              pull_request["author"] = {"login": pr_author}
+          payload["pr_author"] = pr_author
+          payload["human_reviews"] = reviews
+          payload["path_sensitive_human_review_enabled"] = True
+          payload_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          PY
 
       - name: Locate optional raw reviewer evidence on PR head
         id: reviewer

--- a/ao_kernel/ao_release_gate.py
+++ b/ao_kernel/ao_release_gate.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from fnmatch import fnmatch
 from importlib import resources
 from pathlib import Path
 from typing import Any, Literal, TypedDict, cast
@@ -27,6 +28,19 @@ EXPECTED_BASE_REF = "main"
 
 LOCAL_GATE_EVIDENCE_SCHEMA_NAME = "local-gpp-gate-evidence.schema.v1.json"
 REVIEW_EVIDENCE_ACCEPTANCE_SCHEMA_NAME = "ao-release-gate-review-evidence-input.schema.v1.json"
+
+HIGH_RISK_PATH_PATTERNS = (
+    ".github/**",
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".claude/**",
+    "ao_kernel/ao_release_gate*.py",
+    "scripts/ao_release_gate*.py",
+    "scripts/local_gpp_gate*.py",
+    "ao_kernel/defaults/schemas/*gate*.json",
+    "ao_kernel/defaults/policies/**",
+    "deploy/**",
+)
 
 
 def diff_digest(changed_paths: list[str]) -> str:
@@ -86,6 +100,14 @@ class AoReleaseGateInputCheck(TypedDict):
     conclusion: str | None
 
 
+class AoReleaseGateHumanReview(TypedDict):
+    """Normalized GitHub PR review metadata used by path-sensitive gating."""
+
+    author: str | None
+    state: str | None
+    commit_oid: str | None
+
+
 class AoReleaseGateCheck(TypedDict):
     """Single deterministic release-gate input check."""
 
@@ -104,12 +126,16 @@ class AoReleaseGateContext(TypedDict):
     base_ref: str | None
     head_ref: str | None
     head_sha: str | None
+    pr_author: str | None
     branch_up_to_date: bool | None
     from_fork: bool | None
     event_name: str | None
     changed_paths: list[str]
+    high_risk_changed_paths: list[str]
     allowed_path_prefixes: list[str]
     required_checks: list[AoReleaseGateInputCheck]
+    human_reviews: list[AoReleaseGateHumanReview]
+    path_sensitive_human_review_enabled: bool | None
     forbidden_secret_context_detected: bool | None
     admin_bypass_requested: bool | None
     pat_backed_bot_actor: bool | None
@@ -282,6 +308,24 @@ def _normalized_checks(payload: object) -> list[AoReleaseGateInputCheck]:
     return checks
 
 
+def _normalized_human_reviews(payload: object) -> list[AoReleaseGateHumanReview]:
+    """Normalize GitHub PR review objects from trusted API-derived payloads."""
+
+    reviews: list[AoReleaseGateHumanReview] = []
+    for item in _as_list(payload):
+        raw = _as_dict(item)
+        author = _as_dict(raw.get("author"))
+        commit = _as_dict(raw.get("commit"))
+        reviews.append(
+            {
+                "author": _first_string(author.get("login"), raw.get("author")),
+                "state": _first_string(raw.get("state")),
+                "commit_oid": _first_string(commit.get("oid"), raw.get("commit_oid")),
+            }
+        )
+    return reviews
+
+
 def _path_allowed(path: str, prefixes: list[str]) -> bool:
     """Return whether ``path`` is inside one explicit allowed path prefix."""
 
@@ -295,6 +339,63 @@ def _path_allowed(path: str, prefixes: list[str]) -> bool:
         elif path == prefix or path.startswith(f"{prefix}/"):
             return True
     return False
+
+
+def _path_matches_pattern(path: str, pattern: str) -> bool:
+    """Return whether ``path`` matches one CODEOWNERS-like high-risk pattern."""
+
+    normalized = pattern.strip().lstrip("/")
+    if not normalized:
+        return False
+    if normalized.endswith("/**"):
+        return path.startswith(normalized.removesuffix("**"))
+    if normalized.endswith("/"):
+        return path.startswith(normalized)
+    if any(char in normalized for char in "*?["):
+        return fnmatch(path, normalized)
+    return path == normalized or path.startswith(f"{normalized}/")
+
+
+def _high_risk_paths(changed_paths: list[str]) -> list[str]:
+    """Return changed paths that require a non-author human approval."""
+
+    return [
+        path
+        for path in changed_paths
+        if any(_path_matches_pattern(path, pattern) for pattern in HIGH_RISK_PATH_PATTERNS)
+    ]
+
+
+def _has_current_non_author_approval(context: AoReleaseGateContext) -> bool:
+    """Return whether a high-risk PR has a current-head non-author approval."""
+
+    author = context["pr_author"]
+    head_sha = context["head_sha"]
+    if author is None or head_sha is None:
+        return False
+    normalized_author = author.lower()
+    for review in context["human_reviews"]:
+        reviewer = review["author"]
+        state = (review["state"] or "").upper()
+        commit_oid = review["commit_oid"]
+        if reviewer is None or reviewer.lower() == normalized_author:
+            continue
+        if state != "APPROVED":
+            continue
+        if commit_oid != head_sha:
+            continue
+        return True
+    return False
+
+
+def _path_sensitive_human_review_satisfied(context: AoReleaseGateContext) -> bool:
+    """Return whether high-risk paths have required human approval."""
+
+    if context["path_sensitive_human_review_enabled"] is not True:
+        return True
+    if not context["high_risk_changed_paths"]:
+        return True
+    return _has_current_non_author_approval(context)
 
 
 def _required_checks_are_green(checks: list[AoReleaseGateInputCheck]) -> bool:
@@ -347,10 +448,16 @@ def extract_ao_release_gate_context(payload: object, gpp_status: object) -> AoRe
     base = _as_dict(pull_request.get("base"))
     head = _as_dict(pull_request.get("head"))
     head_repo = _as_dict(head.get("repo"))
+    pr_author = _first_string(
+        root.get("pr_author"),
+        service.get("pr_author"),
+        _as_dict(pull_request.get("author")).get("login"),
+    )
     changed_paths = _strings(root.get("changed_paths")) or _strings(service.get("changed_paths"))
     allowed_path_prefixes = _strings(root.get("allowed_path_prefixes")) or _strings(
         service.get("allowed_path_prefixes")
     )
+    human_reviews = _normalized_human_reviews(root.get("human_reviews") or root.get("reviews"))
     return {
         "repository": _first_string(
             repository.get("full_name"),
@@ -362,12 +469,19 @@ def extract_ao_release_gate_context(payload: object, gpp_status: object) -> AoRe
         "base_ref": _normalize_ref(_first_string(base.get("ref"), root.get("base_ref"), service.get("base_ref"))),
         "head_ref": _normalize_ref(_first_string(head.get("ref"), root.get("head_ref"), service.get("head_ref"))),
         "head_sha": _first_string(head.get("sha"), root.get("head_sha"), service.get("head_sha")),
+        "pr_author": pr_author,
         "branch_up_to_date": _first_bool(root.get("branch_up_to_date"), service.get("branch_up_to_date")),
         "from_fork": _first_bool(root.get("from_fork"), service.get("from_fork"), head_repo.get("fork")),
         "event_name": _first_string(root.get("event_name"), service.get("event_name")),
         "changed_paths": changed_paths,
+        "high_risk_changed_paths": _high_risk_paths(changed_paths),
         "allowed_path_prefixes": allowed_path_prefixes,
         "required_checks": _normalized_checks(root.get("required_checks") or root.get("checks")),
+        "human_reviews": human_reviews,
+        "path_sensitive_human_review_enabled": _first_bool(
+            root.get("path_sensitive_human_review_enabled"),
+            service.get("path_sensitive_human_review_enabled"),
+        ),
         "forbidden_secret_context_detected": _first_bool(
             root.get("forbidden_secret_context_detected"),
             service.get("forbidden_secret_context_detected"),
@@ -731,6 +845,18 @@ def build_ao_release_gate_decision(
             ),
             pass_detail="Changed paths are inside the explicit work-package allowlist.",
             blocked_detail="Changed paths or allowlist are missing, or a changed path is out of scope.",
+        ),
+        _check(
+            "path_sensitive_human_review",
+            _path_sensitive_human_review_satisfied(context),
+            finding_code="ao_release_gate_high_risk_human_review_missing",
+            pass_detail=(
+                "The path-sensitive human-review gate is inactive, no high-risk paths changed, "
+                "or a current-head non-author human approval exists for the high-risk surface."
+            ),
+            blocked_detail=(
+                "High-risk paths changed without a current-head non-author human approval."
+            ),
         ),
         _check(
             "secret_boundary",

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,130 +1,65 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "GPP-4c",
+  "work_package": "GPP-2D-6B",
   "implementer": {
-    "agent": "claude",
-    "provider": "anthropic"
+    "agent": "codex",
+    "provider": "openai"
   },
   "reviewer": {
-    "agent": "codex",
-    "provider": "openai",
+    "agent": "claude",
+    "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/gpp-4c-keep-operator-beta-infaz",
+    "head_ref": "refs/heads/codex/gpp2d6b-ai-path-gate",
     "changed_files": [
-      ".claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md",
-      ".claude/plans/GPP-4c-KEEP-OPERATOR-BETA-INFAZ.md",
-      ".claude/plans/gpp_status.v1.json",
-      "docs/KNOWN-BUGS.md",
-      "docs/PUBLIC-BETA.md",
-      "docs/SUPPORT-BOUNDARY.md",
+      ".claude/plans/GPP-2B-AO-RELEASE-GATE-REQUIRED-CHECK-MAPPING.md",
+      ".claude/plans/GPP-2D-6-AUTOMERGE-SMOKE-RUNBOOK.md",
+      ".github/workflows/test.yml",
+      "ao_kernel/ao_release_gate.py",
       "local-ai-review-evidence.v1.json",
-      "scripts/gp5_platform_claim_decision.py",
-      "tests/test_gpp_next.py",
-      "tests/test_local_gpp_gate.py"
+      "scripts/ao_release_gate_build_payload.py",
+      "tests/test_ao_release_gate.py",
+      "tests/test_ao_release_gate_build_payload.py",
+      "tests/test_ao_release_gate_enforce_job.py",
+      "tests/test_ao_release_gate_runtime.py",
+      "tests/test_ao_release_gate_service.py",
+      "tests/test_gpp2d6_automerge_contract.py"
     ]
   },
   "checks_considered": [
-    {
-      "name": "tests",
-      "status": "pass"
-    },
-    {
-      "name": "secret_scan",
-      "status": "pass"
-    },
-    {
-      "name": "no_public_sdk_signature_change",
-      "status": "pass"
-    },
-    {
-      "name": "no_branch_protection_mutation_by_agent",
-      "status": "pass"
-    },
-    {
-      "name": "guard_flags_unchanged",
-      "status": "pass"
-    },
-    {
-      "name": "gpp4_decision_executed_option_y_authoritative",
-      "status": "pass"
-    },
-    {
-      "name": "bc1_status_blocked_retained",
-      "status": "pass"
-    },
-    {
-      "name": "bc1_promotion_blockers_retained",
-      "status": "pass"
-    },
-    {
-      "name": "schema_version_v1_unchanged",
-      "status": "pass"
-    },
-    {
-      "name": "ssot_current_wp_gpp4c_closed",
-      "status": "pass"
-    },
-    {
-      "name": "ssot_gpp4b_closure_preserved_in_completed_wps",
-      "status": "pass"
-    },
-    {
-      "name": "ssot_gpp4c_not_in_completed_wps_this_slice",
-      "status": "pass"
-    },
-    {
-      "name": "ssot_wp_weighted_triple_pinned",
-      "status": "pass"
-    },
-    {
-      "name": "m4_milestone_done_three_evidence_refs",
-      "status": "pass"
-    },
-    {
-      "name": "docs_support_boundary_gpp4_synced",
-      "status": "pass"
-    },
-    {
-      "name": "docs_known_bugs_gpp4_synced",
-      "status": "pass"
-    },
-    {
-      "name": "docs_public_beta_gpp4_synced",
-      "status": "pass"
-    },
-    {
-      "name": "gpp4c_issue_anchor_present",
-      "status": "pass"
-    },
-    {
-      "name": "cross_provider_verified",
-      "status": "pass"
-    }
+    {"name": "tests", "status": "pass"},
+    {"name": "secret_scan", "status": "pass"},
+    {"name": "ruff", "status": "pass"},
+    {"name": "mypy", "status": "pass"},
+    {"name": "no_pull_request_target", "status": "pass"},
+    {"name": "no_branch_protection_mutation_by_agent", "status": "pass"},
+    {"name": "guard_flags_unchanged", "status": "pass"},
+    {"name": "low_risk_no_human_review_required", "status": "pass"},
+    {"name": "high_risk_current_head_non_author_approval_required", "status": "pass"},
+    {"name": "workflow_reruns_on_pull_request_review", "status": "pass"},
+    {"name": "trusted_base_payload_builder_bootstrap_compatible", "status": "pass"},
+    {"name": "gpp2b_mapping_updated_to_21_checks", "status": "pass"},
+    {"name": "gpp2d6_runbook_updated_for_path_sensitive_gate", "status": "pass"},
+    {"name": "cross_provider_verified", "status": "pass"}
   ],
   "findings": [
-    "tests: pytest tests/test_gpp_next.py + tests/test_local_gpp_gate.py 83 passed (~4.3s); full suite green.",
-    "secret_scan: no credential material in any changed file.",
-    "no_public_sdk_signature_change: ao_kernel public SDK signatures unchanged.",
-    "no_branch_protection_mutation_by_agent: no gh api on rulesets / branches/main/protection.",
-    "guard_flags_unchanged: support_widening_allowed=false, production_platform_claim_allowed=false, live_adapter_execution_allowed=false all preserved (CC-6).",
-    "gpp4_decision_executed_option_y_authoritative: GPP-4c executes the GPP-4b keep_operator_beta authoritative decision; new current_wp.exit_decision=gpp4_keep_operator_beta_executed_m4_closed_no_live_adapter_execution_no_support_widening_no_production_claim; record path .claude/plans/GPP-4c-KEEP-OPERATOR-BETA-INFAZ.md.",
-    "bc1_status_blocked_retained: scripts/gp5_platform_claim_decision.py BC-1 status='blocked' retained; only summary text and evidence list extended to cite the GPP-4 closure path (GPP-4a + GPP-4b + GPP-4c records).",
-    "bc1_promotion_blockers_retained: BC-1.blockers=['protected_live_adapter_gate_unattested'] retained; _promotion_blockers() global aggregator retains claude_code_cli_auth_operator_managed + kb001_claude_code_cli_operator_managed_auth + gh_cli_pr_live_write_not_production_promoted + repo_intelligence_context_handoff_not_runtime_auto_fed + kb002_gh_cli_pr_sandbox_only_live_write; no blocker removal under the keep_operator_beta authority.",
-    "schema_version_v1_unchanged: gp5-production-platform-claim-decision.schema.v1.json contract is untouched (no enum widening, no required-field change); BC-1.status='blocked' was already in the schema enum from the original GP-5.9 closeout. CC-8 enum-widening pattern does not apply here.",
-    "ssot_current_wp_gpp4c_closed: current_wp.id=GPP-4c, status=closed, issue=#625, exit_decision matches the executed string, record points to GPP-4c-KEEP-OPERATOR-BETA-INFAZ.md.",
-    "ssot_gpp4b_closure_preserved_in_completed_wps: GPP-4b entry present in completed_wps with decision=gpp4_keep_operator_beta_authoritative_no_live_adapter_execution_no_support_widening_no_production_claim, issue=#623, pr=#624, record path, closed_at=2026-05-25T12:44:16Z.",
-    "ssot_gpp4c_not_in_completed_wps_this_slice: GPP-4c is intentionally absent from completed_wps in this slice; current-closed accounting (closed_current_wp_count=1) per program convention; the next M5 opener slice migrates GPP-4c. Drift guard test_gpp_status_contract_keeps_support_widening_closed pins this invariant.",
-    "ssot_wp_weighted_triple_pinned: progress_estimates.wp_weighted shows completed_wps_count=43 (42 prior + GPP-4b moved into completed_wps), closed_current_wp_count=1 (GPP-4c current closed), completed_or_closed_count=44 = 43 + 1, estimated_total_wps=50, percent=88. Drift guard test_gpp_status_progress_estimates_present pins the triple.",
-    "m4_milestone_done_three_evidence_refs: milestones[M4].status=done with closed_at=2026-05-25T13:00:00Z and exactly three evidence_refs (GPP-4a + GPP-4b + GPP-4c record paths); progress_estimates.milestones done_count=5, percent=71, next_milestone_id=M5. Drift guard test_gpp_status_m4_done_three_evidence_refs pins the cardinality + path set.",
-    "docs_support_boundary_gpp4_synced: docs/SUPPORT-BOUNDARY.md GPP-3c paragrafının sonrasına GPP-4 closeout paragrafı eklendi; claude-code-cli lane Beta (operator-managed) tier korunur; Option X supersession requirement açıkça not edilmiş.",
-    "docs_known_bugs_gpp4_synced: docs/KNOWN-BUGS.md GP-5.9 closeout interpretation section'ından sonra yeni 'GPP-4 closeout interpretation' subsection eklendi; KB-001 kb001_claude_code_cli_operator_managed_auth blocker'ı retained, KB-002 operator-managed beta lane known bug olarak rename/remove yapılmadan korundu (Codex iter-1 wording correction absorb edildi).",
-    "docs_public_beta_gpp4_synced: docs/PUBLIC-BETA.md üç lokasyon update: claude-code-cli Beta row GP-3.6 + GP-4.5 + GPP-4 keep_operator_beta authoritative referansları aynı satırda; GPP-4a row trailing sentence GPP-4b decision record + GPP-4c infaz record path'lerine bağlandı; yeni GPP-4 closeout decision row Option X supersession requirement ile birlikte eklendi.",
-    "gpp4c_issue_anchor_present: GitHub issue #625 opened and pinned in current_wp.issue per PROGRAM-CHANGE-CONTROL.md CC-13.",
-    "cross_provider_verified: implementer claude (provider anthropic) differs from reviewer codex (provider openai); cross-AI peer review HARD RULE CC-2 satisfied. Codex thread 019e5f2f plan-time iter-1 PARTIAL (current_wp.status=closed vs completed_wps[].id=GPP-4c mutual exclusion + closed_current_wp_count=1 + BC-1 summary tightening + KB-002 wording clarification + Option X supersession guard) absorbed; plan-time iter-2 AGREE; post-impl iter-1 AGREE on commit 3e373b7 (no merge-blocker; 2 non-blocking hygiene notes absorbed in iter-2 commit)."
+    "tests: pytest 174 passed, 2 existing warnings on unrelated real-adapter usage/cost advisory tests.",
+    "secret_scan: no credential material recorded in the diff or in this evidence file.",
+    "ruff: ao_release_gate, payload builder tests, workflow contract tests, and GPP-2D-6 contract tests pass lint.",
+    "mypy: ao_kernel/ao_release_gate.py and scripts/ao_release_gate_build_payload.py pass static type checking.",
+    "no_pull_request_target: workflow adds pull_request_review but does not use pull_request_target or protected secrets.",
+    "no_branch_protection_mutation_by_agent: this slice changes repo-owned gate behavior only; it does not mutate GitHub branch protection or rulesets.",
+    "guard_flags_unchanged: live_adapter_execution=false, support_widening=false, and production_platform_claim=false remain the intended boundary.",
+    "low_risk_no_human_review_required: ao-release-gate passes path_sensitive_human_review when high_risk_changed_paths is empty.",
+    "high_risk_current_head_non_author_approval_required: high-risk paths fail closed with ao_release_gate_high_risk_human_review_missing until an APPROVED review from a non-author at the current head SHA exists.",
+    "workflow_reruns_on_pull_request_review: pull_request_review submitted/edited/dismissed events trigger the release gate so approval or dismissal is re-evaluated.",
+    "trusted_base_payload_builder_bootstrap_compatible: workflow does not pass new CLI flags to the protected base-ref payload builder; it augments payload.json with review metadata after the base builder step so the bootstrap PR can be evaluated by current main and future main can enforce the path-sensitive gate.",
+    "gpp2b_mapping_updated_to_21_checks: the required-check mapping table records path_sensitive_human_review as an ao-release-gate-only check.",
+    "gpp2d6_runbook_updated_for_path_sensitive_gate: the auto-merge runbook now requires this path-sensitive gate before low-risk auto-merge smoke.",
+    "cross_provider_verified: implementer codex (openai) differs from reviewer claude (anthropic); Claude returned VERDICT: AGREE with only non-blocking residual risks, and the username case comparison hardening was absorbed."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/ao_release_gate_build_payload.py
+++ b/scripts/ao_release_gate_build_payload.py
@@ -17,6 +17,10 @@ CLI args plus two JSON blobs the workflow has already fetched via ``gh``:
   filtered to exclude the ao-release-gate / ao-release-gate-shadow names
   (otherwise the gate would see its own shadow job as a pending required
   check).
+- ``--pr-reviews-json`` — output of ``gh pr view <N> --json reviews,author``.
+  The builder carries only reviewer login, state, and reviewed commit SHA so
+  the decision core can preserve human review for high-risk paths without
+  treating reviewer text as release authority.
 
 The output is a single payload JSON consumable by
 ``scripts/ao_release_gate_decision.py``. The builder is side-effect free
@@ -83,6 +87,39 @@ def _changed_paths(pr_files_json_path: Path) -> list[str]:
             if isinstance(path, str) and path.strip():
                 paths.append(path.strip())
     return sorted(paths)
+
+
+def _review_context(pr_reviews_json_path: Path | None) -> tuple[str | None, list[dict[str, Any]]]:
+    """Extract PR author and normalized reviews from ``gh pr view`` output."""
+
+    def normalized_string(value: object) -> str | None:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return None
+
+    if pr_reviews_json_path is None:
+        return None, []
+    data = json.loads(pr_reviews_json_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        return None, []
+    raw_author = data.get("author")
+    author = normalized_string(raw_author.get("login")) if isinstance(raw_author, dict) else None
+    reviews: list[dict[str, Any]] = []
+    for item in data.get("reviews", []):
+        if not isinstance(item, dict):
+            continue
+        raw_reviewer = item.get("author")
+        reviewer = normalized_string(raw_reviewer.get("login")) if isinstance(raw_reviewer, dict) else None
+        raw_commit = item.get("commit")
+        commit_oid = normalized_string(raw_commit.get("oid")) if isinstance(raw_commit, dict) else None
+        reviews.append(
+            {
+                "author": reviewer,
+                "state": normalized_string(item.get("state")),
+                "commit_oid": commit_oid,
+            }
+        )
+    return author if isinstance(author, str) else None, reviews
 
 
 def _check_run_sort_key(entry: dict[str, Any]) -> tuple[str, str, int]:
@@ -214,10 +251,12 @@ def _work_package_issue_url(gpp_status_path: Path) -> str:
 def build_payload(args: argparse.Namespace) -> dict[str, Any]:
     """Build the release-gate payload dictionary from trusted inputs."""
 
+    pr_author, human_reviews = _review_context(args.pr_reviews_json)
     return {
         "repository": {"full_name": args.repository},
         "pull_request": {
             "number": args.pr_number,
+            "author": {"login": pr_author} if pr_author is not None else {},
             "base": {"ref": args.base_ref},
             "head": {
                 "ref": args.head_ref,
@@ -234,6 +273,9 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
         "reviewed_slice": _reviewed_slice(args.gpp_status),
         "changed_paths": _changed_paths(args.pr_files_json),
         "allowed_path_prefixes": list(DEFAULT_ALLOWED_PATH_PREFIXES),
+        "pr_author": pr_author,
+        "human_reviews": human_reviews,
+        "path_sensitive_human_review_enabled": args.pr_reviews_json is not None,
         "required_checks": _normalized_checks(
             args.check_runs_json,
             required_checks_allowlist=list(args.required_check) if args.required_check else None,
@@ -268,6 +310,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--pr-files-json", type=Path, required=True)
     parser.add_argument("--check-runs-json", type=Path, required=True)
+    parser.add_argument(
+        "--pr-reviews-json",
+        type=Path,
+        default=None,
+        help=(
+            "Optional output of `gh pr view <N> --json reviews,author`. "
+            "When supplied, the payload carries only normalized review metadata "
+            "for the path-sensitive high-risk human gate."
+        ),
+    )
     parser.add_argument(
         "--required-check",
         action="append",

--- a/tests/test_ao_release_gate.py
+++ b/tests/test_ao_release_gate.py
@@ -108,6 +108,7 @@ def _allow_payload() -> dict[str, object]:
         "repository": {"full_name": "Halildeu/ao-kernel"},
         "pull_request": {
             "number": 539,
+            "author": {"login": "Halildeu"},
             "base": {"ref": "main"},
             "head": {
                 "ref": "codex/gpp-2v-release-gate-dry-run",
@@ -120,6 +121,15 @@ def _allow_payload() -> dict[str, object]:
         "event_name": "pull_request",
         "reviewed_slice": _ALLOW_REVIEWED_SLICE,
         "changed_paths": list(_ALLOW_CHANGED_PATHS),
+        "pr_author": "Halildeu",
+        "human_reviews": [
+            {
+                "author": "gladyatore-lab",
+                "state": "APPROVED",
+                "commit_oid": _ALLOW_HEAD_SHA,
+            }
+        ],
+        "path_sensitive_human_review_enabled": True,
         "allowed_path_prefixes": [
             "ao_kernel/",
             "scripts/",
@@ -176,6 +186,21 @@ def _missing_evidence_payload() -> dict[str, object]:
 def _policy_violation_payload() -> dict[str, object]:
     payload = _allow_payload()
     payload["admin_bypass_requested"] = True
+    return payload
+
+
+def _low_risk_payload() -> dict[str, object]:
+    payload = _allow_payload()
+    paths = ["docs/smoke/gpp2d6-low-risk-automerge-smoke.md"]
+    payload["changed_paths"] = paths
+    payload["human_reviews"] = []
+    payload["allowed_path_prefixes"] = ["docs/"]
+    return payload
+
+
+def _high_risk_without_review_payload() -> dict[str, object]:
+    payload = _allow_payload()
+    payload["human_reviews"] = []
     return payload
 
 
@@ -241,6 +266,75 @@ def test_release_gate_denies_policy_violations() -> None:
 
     assert decision["decision"] == DENY_POLICY_VIOLATION_DECISION
     assert "ao_release_gate_admin_bypass_requested" in decision["findings"]
+
+
+def test_release_gate_allows_low_risk_paths_without_human_review() -> None:
+    decision = build_ao_release_gate_decision(
+        _low_risk_payload(),
+        _gpp_status(),
+        review_evidence=_review_evidence(changed_paths=["docs/smoke/gpp2d6-low-risk-automerge-smoke.md"]),
+    )
+
+    assert decision["decision"] == ALLOW_AUTONOMOUS_MERGE_DECISION
+    assert decision["allow"] is True
+    assert decision["context"]["high_risk_changed_paths"] == []
+    assert _find_check(decision, "path_sensitive_human_review")["status"] == "pass"
+
+
+def test_release_gate_denies_high_risk_paths_without_current_non_author_review() -> None:
+    decision = build_ao_release_gate_decision(
+        _high_risk_without_review_payload(),
+        _gpp_status(),
+        review_evidence=_review_evidence(),
+    )
+
+    assert decision["decision"] == DENY_POLICY_VIOLATION_DECISION
+    assert "ao_release_gate_high_risk_human_review_missing" in decision["findings"]
+    assert _find_check(decision, "path_sensitive_human_review")["status"] == "blocked"
+    assert decision["context"]["high_risk_changed_paths"] == [
+        "ao_kernel/ao_release_gate.py",
+        "scripts/ao_release_gate_decision.py",
+        ".claude/plans/GPP-2v-AO-RELEASE-GATE-DRY-RUN-SCAFFOLD.md",
+    ]
+
+
+def test_release_gate_allows_legacy_payload_when_path_sensitive_gate_is_inactive() -> None:
+    payload = _high_risk_without_review_payload()
+    payload.pop("path_sensitive_human_review_enabled")
+
+    decision = build_ao_release_gate_decision(
+        payload,
+        _gpp_status(),
+        review_evidence=_review_evidence(),
+    )
+
+    assert decision["decision"] == ALLOW_AUTONOMOUS_MERGE_DECISION
+    assert _find_check(decision, "path_sensitive_human_review")["status"] == "pass"
+
+
+def test_release_gate_denies_high_risk_paths_when_review_is_stale_or_author_owned() -> None:
+    payload = _allow_payload()
+    payload["human_reviews"] = [
+        {
+            "author": "gladyatore-lab",
+            "state": "APPROVED",
+            "commit_oid": "f" * 40,
+        },
+        {
+            "author": "halildeu",
+            "state": "APPROVED",
+            "commit_oid": _ALLOW_HEAD_SHA,
+        },
+    ]
+
+    decision = build_ao_release_gate_decision(
+        payload,
+        _gpp_status(),
+        review_evidence=_review_evidence(),
+    )
+
+    assert decision["decision"] == DENY_POLICY_VIOLATION_DECISION
+    assert "ao_release_gate_high_risk_human_review_missing" in decision["findings"]
 
 
 def test_release_gate_denies_gpp_issue_mismatch_as_missing_evidence() -> None:

--- a/tests/test_ao_release_gate_build_payload.py
+++ b/tests/test_ao_release_gate_build_payload.py
@@ -34,6 +34,31 @@ def _write_check_runs(path: Path, runs: list[dict[str, str]]) -> None:
     path.write_text(json.dumps({"check_runs": runs}), encoding="utf-8")
 
 
+def _write_pr_reviews(path: Path) -> None:
+    """Write a stub ``gh pr view --json reviews,author`` response."""
+
+    path.write_text(
+        json.dumps(
+            {
+                "author": {"login": "Halildeu"},
+                "reviews": [
+                    {
+                        "author": {"login": "gladyatore-lab"},
+                        "state": "APPROVED",
+                        "commit": {"oid": "abc1230000000000000000000000000000000000"},
+                    },
+                    {
+                        "author": {"login": "gladyatore-lab"},
+                        "state": "DISMISSED",
+                        "commit": {"oid": "f" * 40},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def _write_gpp_status(
     path: Path,
     *,
@@ -58,6 +83,7 @@ def _build_argv(tmp_path: Path, *, output: Path) -> list[str]:
 
     pr_files = tmp_path / "pr-files.json"
     check_runs = tmp_path / "check-runs.json"
+    pr_reviews = tmp_path / "pr-reviews.json"
     gpp_status = tmp_path / "gpp_status.json"
     _write_pr_files(pr_files, ["ao_kernel/foo.py", "tests/test_foo.py"])
     _write_check_runs(
@@ -70,6 +96,7 @@ def _build_argv(tmp_path: Path, *, output: Path) -> list[str]:
             {"name": "ao-release-gate", "status": "queued", "conclusion": None},
         ],
     )
+    _write_pr_reviews(pr_reviews)
     _write_gpp_status(gpp_status)
     return [
         "--repository",
@@ -92,6 +119,8 @@ def _build_argv(tmp_path: Path, *, output: Path) -> list[str]:
         str(pr_files),
         "--check-runs-json",
         str(check_runs),
+        "--pr-reviews-json",
+        str(pr_reviews),
         "--output",
         str(output),
     ]
@@ -106,6 +135,7 @@ def test_build_payload_emits_expected_shape(tmp_path: Path) -> None:
 
     assert payload["repository"] == {"full_name": "Halildeu/ao-kernel"}
     assert payload["pull_request"]["number"] == 999
+    assert payload["pull_request"]["author"]["login"] == "Halildeu"
     assert payload["pull_request"]["base"]["ref"] == "main"
     assert payload["pull_request"]["head"]["sha"] == "abc1230000000000000000000000000000000000"
     assert payload["pull_request"]["head"]["repo"]["fork"] is False
@@ -115,6 +145,20 @@ def test_build_payload_emits_expected_shape(tmp_path: Path) -> None:
     assert payload["branch_up_to_date"] is True
     assert payload["event_name"] == "pull_request"
     assert payload["reviewed_slice"] == "GPP-2"
+    assert payload["pr_author"] == "Halildeu"
+    assert payload["human_reviews"] == [
+        {
+            "author": "gladyatore-lab",
+            "state": "APPROVED",
+            "commit_oid": "abc1230000000000000000000000000000000000",
+        },
+        {
+            "author": "gladyatore-lab",
+            "state": "DISMISSED",
+            "commit_oid": "f" * 40,
+        },
+    ]
+    assert payload["path_sensitive_human_review_enabled"] is True
 
 
 def test_build_payload_sorts_and_carries_changed_paths(tmp_path: Path) -> None:

--- a/tests/test_ao_release_gate_enforce_job.py
+++ b/tests/test_ao_release_gate_enforce_job.py
@@ -92,12 +92,16 @@ def test_enforce_job_is_present_under_reserved_required_check_name() -> None:
     assert "name: ao-release-gate-shadow" not in _test_workflow_text()
 
 
-def test_enforce_job_triggers_only_on_pull_request_never_pull_request_target() -> None:
+def test_enforce_job_triggers_on_pr_and_review_never_pull_request_target() -> None:
     block = _gate_job_block()
+    workflow = _test_workflow_text()
     stripped = _strip_yaml_comments(block)
     assert "github.event_name == 'pull_request'" in block
+    assert "github.event_name == 'pull_request_review'" in block
+    assert "pull_request_review:" in workflow
+    assert "pull_request_review:$EVENT_ACTION" in workflow
     assert "pull_request_target" not in stripped, "pull_request_target must not appear as a real trigger"
-    assert "ao-release-gate only evaluates pull_request events" in block
+    assert "ao-release-gate only evaluates pull_request or pull_request_review events" in block
 
 
 def test_enforce_job_permissions_are_read_only() -> None:
@@ -143,7 +147,9 @@ def test_enforce_job_runs_with_fail_closed_needs_short_circuit() -> None:
     and exits 1 with a fail-closed audit artifact when any one is not
     `success`."""
     block = _gate_job_block()
-    assert "always() && github.event_name == 'pull_request'" in block
+    assert "always() && (" in block
+    assert "github.event_name == 'pull_request'" in block
+    assert "github.event_name == 'pull_request_review'" in block
     assert "needs.event-gate.outputs.should_run == 'true'" in block
     assert "needs.event-gate.result != 'success'" in block
     assert "Fail closed if any required CI job did not succeed" in block
@@ -179,6 +185,16 @@ def test_enforce_job_builds_payload_from_api_not_pr_committed_json() -> None:
     assert "--check-runs-json check-runs.json" in block
     assert "--gpp-status .claude/plans/gpp_status.v1.json" in block
     assert "head/payload.json" not in block
+
+
+def test_enforce_job_augments_payload_with_review_metadata_after_base_builder() -> None:
+    block = _gate_job_block()
+    assert "gh pr view \"$PR_NUMBER\" --repo \"$REPO_FULL\" --json reviews,author > pr-reviews.json" in block
+    assert "Augment release-gate payload with PR review metadata" in block
+    assert "review_payload = json.loads(Path(\"pr-reviews.json\").read_text" in block
+    assert "payload[\"pr_author\"] = pr_author" in block
+    assert "payload[\"human_reviews\"] = reviews" in block
+    assert "payload[\"path_sensitive_human_review_enabled\"] = True" in block
 
 
 def test_enforce_job_reads_only_raw_reviewer_evidence_from_pr_head() -> None:

--- a/tests/test_ao_release_gate_runtime.py
+++ b/tests/test_ao_release_gate_runtime.py
@@ -72,6 +72,7 @@ def _allow_payload() -> dict[str, object]:
         "installation": {"id": 12345},
         "pull_request": {
             "number": 541,
+            "author": {"login": "Halildeu"},
             "base": {"ref": "main"},
             "head": {
                 "ref": "codex/gpp-2w-release-gate-service",
@@ -83,6 +84,15 @@ def _allow_payload() -> dict[str, object]:
         "branch_up_to_date": True,
         "event_name": "pull_request",
         "reviewed_slice": _ALLOW_REVIEWED_SLICE,
+        "pr_author": "Halildeu",
+        "human_reviews": [
+            {
+                "author": "gladyatore-lab",
+                "state": "APPROVED",
+                "commit_oid": _ALLOW_HEAD_SHA,
+            }
+        ],
+        "path_sensitive_human_review_enabled": True,
         "changed_paths": list(_ALLOW_CHANGED_PATHS),
         "allowed_path_prefixes": [
             "ao_kernel/",

--- a/tests/test_ao_release_gate_service.py
+++ b/tests/test_ao_release_gate_service.py
@@ -81,6 +81,7 @@ def _allow_payload() -> dict[str, object]:
         "repository": {"full_name": "Halildeu/ao-kernel"},
         "pull_request": {
             "number": 541,
+            "author": {"login": "Halildeu"},
             "base": {"ref": "main"},
             "head": {
                 "ref": "codex/gpp-2w-release-gate-service",
@@ -92,6 +93,15 @@ def _allow_payload() -> dict[str, object]:
         "branch_up_to_date": True,
         "event_name": "pull_request",
         "reviewed_slice": _ALLOW_REVIEWED_SLICE,
+        "pr_author": "Halildeu",
+        "human_reviews": [
+            {
+                "author": "gladyatore-lab",
+                "state": "APPROVED",
+                "commit_oid": _ALLOW_HEAD_SHA,
+            }
+        ],
+        "path_sensitive_human_review_enabled": True,
         "changed_paths": list(_ALLOW_CHANGED_PATHS),
         "allowed_path_prefixes": [
             "ao_kernel/",

--- a/tests/test_gpp2d6_automerge_contract.py
+++ b/tests/test_gpp2d6_automerge_contract.py
@@ -24,6 +24,8 @@ def test_gpp2d6_records_codeowners_narrowing_and_remaining_review_blockers() -> 
     assert "legacy_branch_protection.enforce_admins = true" in doc
     assert "required_approving_review_count=1" in doc
     assert "necessary but still insufficient" in doc
+    assert "GPP-2D-6b gate slice moves the high-risk human-review requirement" in doc
+    assert "ao-release-gate requires a current-head non-author APPROVED GitHub review" in doc
 
 
 def test_gpp2d6_requires_cutover_and_operator_review_model_before_smoke() -> None:
@@ -34,19 +36,25 @@ def test_gpp2d6_requires_cutover_and_operator_review_model_before_smoke() -> Non
     assert "admin bypass disallowed" in doc
     assert "GPP-2D-7 / AO-GATE-9 closeout records GPP-2 as closed. Done" in doc
     assert "CODEOWNERS narrowing lands and legacy `enforce_admins=true` is verified." in doc
+    assert "`ao-release-gate` path-sensitive human-review enforcement lands" in doc
     assert "Operator enables GitHub-native auto-merge" in doc
     assert "Operator selects and applies the low-risk review model" in doc
-    assert "Steps 1-5 are complete or in this hardening PR. Steps 6-8 remain" in doc
+    assert "Steps 1-6 are complete or in this hardening PR. Steps 7-9 remain" in doc
 
 
 def test_gpp2d6_pins_low_risk_and_high_risk_smoke_acceptance() -> None:
     doc = DOC.read_text(encoding="utf-8")
 
     assert "Low-risk auto-merge smoke" in doc
+    assert "For low-risk paths, `ao-release-gate` must not require a human review" in doc
+    assert "`ao-release-gate` records no high-risk changed paths." in doc
     assert "No non-author human review is required for the low-risk path." in doc
     assert "GitHub performs the merge after required checks pass." in doc
     assert "High-risk human-gate smoke" in doc
-    assert "GitHub still reports a code-owner / required-review block." in doc
+    assert "`ao-release-gate` fails with" in doc
+    assert "ao_release_gate_high_risk_human_review_missing" in doc
+    assert "current-head non-author `APPROVED` GitHub review" in doc
+    assert "GitHub still reports a code-owner / required-review block" in doc
     assert "must not auto-merge the PR" in doc
 
 


### PR DESCRIPTION
## Summary

Implements GPP-2D-6B: move high-risk human-review enforcement into the repo-owned `ao-release-gate` required-check path so the later low-risk auto-merge model does not depend on global manual review for every PR.

This PR adds a path-sensitive gate:
- Low-risk changed paths: `path_sensitive_human_review` passes without requiring GitHub human review.
- High-risk changed paths: `ao-release-gate` fails closed with `ao_release_gate_high_risk_human_review_missing` once `path_sensitive_human_review_enabled=true` and no current-head, non-author `APPROVED` GitHub review exists.
- The workflow stays bootstrap-compatible with protected base-ref code: it calls the base payload builder with existing args, then augments `payload.json` inline with `pr_author`, `human_reviews`, and `path_sensitive_human_review_enabled=true` from `gh pr view --json reviews,author`.
- Workflow reruns on `pull_request_review` submitted/edited/dismissed so approvals and dismissals are re-evaluated.

## Scope boundaries

- No branch protection or ruleset mutation.
- No `pull_request_target`.
- No protected secrets or secret material.
- No testai/smee/webhook-host work.
- No live adapter execution, support widening, or production platform claim.

## Validation

- `pytest -q tests/test_ao_release_gate_runtime.py tests/test_ao_release_gate_service.py tests/test_ao_release_gate.py tests/test_ao_release_gate_build_payload.py tests/test_ao_release_gate_enforce_job.py tests/test_gpp2d6_automerge_contract.py tests/test_gpp2b_mapping_drift_guard.py tests/test_gpp_next.py tests/test_local_gpp_gate.py` -> 174 passed, 2 existing warnings.
- `ruff check ao_kernel/ao_release_gate.py scripts/ao_release_gate_build_payload.py tests/test_ao_release_gate.py tests/test_ao_release_gate_build_payload.py tests/test_ao_release_gate_enforce_job.py tests/test_ao_release_gate_runtime.py tests/test_ao_release_gate_service.py tests/test_gpp2d6_automerge_contract.py` -> pass.
- `python3 -m mypy ao_kernel/ao_release_gate.py scripts/ao_release_gate_build_payload.py` -> pass.
- `git diff --check` -> pass.
- `PYTHONPATH=. python3 scripts/local_gpp_gate.py --repo Halildeu/ao-kernel --work-package GPP-2D-6B --base-ref refs/heads/main --head-ref refs/heads/codex/gpp2d6b-ai-path-gate --review-evidence local-ai-review-evidence.v1.json --output /tmp/gpp2d6b-local-gpp-gate-evidence.json` -> `decision=operator_may_merge`, 8/8 pass, `diff_digest=sha256:b3c14747c6f4cf4f1cb09de1f9b39da3b4ae51cb63703758b605579f98aeb6ff`, `changed_files_count=12`.

## Cross-AI review

Claude (Anthropic) reviewed the full diff adversarially and returned `VERDICT: AGREE`. After the bootstrap-compatible workflow fix, Claude re-reviewed and returned `VERDICT: AGREE` again. A non-blocking username case comparison suggestion was absorbed; string normalization was also tightened for empty review identities.

## Expected gate behavior

This PR intentionally touches high-risk paths (`.github/`, `.claude/`, `ao_kernel/ao_release_gate.py`, gate scripts). Current-base bootstrap compatibility means this PR can be evaluated by existing main. After merge, future high-risk PRs should fail closed until a current-head non-author approval exists, and the `pull_request_review` event should rerun the workflow after approval or dismissal.
