### PR TITLE
feat(ri-7.1): explicit operator authorization record + manifest 2-key flip

### DIFF
--- a/.claude/plans/RI-7-EVIDENCE-MANIFEST.v1.json
+++ b/.claude/plans/RI-7-EVIDENCE-MANIFEST.v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1",
   "artifact_kind": "ri7_evidence_manifest",
-  "explicit_operator_authorization": false,
-  "general_purpose_platform_claim_authorization": false,
+  "explicit_operator_authorization": true,
+  "general_purpose_platform_claim_authorization": true,
   "guardrail_hardening_matrix": true,
   "vector_backend_e2e_evidence": true,
   "scan_index_query_packaging_smoke": true,

--- a/.claude/plans/RI-7-REPO-INTELLIGENCE-TIER-PROMOTION-READINESS.md
+++ b/.claude/plans/RI-7-REPO-INTELLIGENCE-TIER-PROMOTION-READINESS.md
@@ -101,7 +101,7 @@ explicitly marked as independent.
 | ID | Status | Purpose | Required artifact | Exit decision |
 |---|---|---|---|---|
 | `RI-7.0` | ready for PR | Land the no-widening readiness gate and this tracking plan | `scripts/repo_intelligence_tier_promotion_readiness.py`, schema, tests, this plan | `ri7_readiness_gate_landed_blocked_no_support_widening` |
-| `RI-7.1` | pending | Record explicit operator authorization for the RI supersession and the general-purpose platform claim target | operator authorization record under `.claude/plans/` plus evidence manifest update | `ri7_operator_authorization_recorded_no_flag_flip` |
+| `RI-7.1` | pending | Record explicit operator authorization for the RI supersession and the general-purpose platform claim target | operator authorization record under `.claude/plans/` plus evidence manifest update | `ri7_operator_authorization_recorded_no_guard_flag_flip` |
 | `RI-7.2` | pending | Close repo-intelligence guardrail hardening matrix | matrix report covering AST/chunk edge cases, namespace isolation, stale vector cleanup, no-root-write, no-auto-feed, no-MCP exposure | `ri7_guardrail_hardening_matrix_ready` |
 | `RI-7.3` | pending | Prove configured vector backend E2E behavior | vector E2E evidence report for write, stale cleanup, namespace isolation, query hash/line validation, fail-closed missing backend/key | `ri7_vector_backend_e2e_ready` |
 | `RI-7.4` | pending | Prove wheel-installed scan/index/query behavior outside the source checkout | packaging smoke report from fresh venv / installed wheel | `ri7_scan_index_query_packaging_smoke_ready` |

--- a/.claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.md
+++ b/.claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.md
@@ -1,0 +1,135 @@
+# RI-7.1 — Explicit Operator Authorization Record
+
+**Status:** operator-bound authorization slice
+**Date:** 2026-05-27
+**Parent:** `RI-7-REPO-INTELLIGENCE-TIER-PROMOTION-READINESS.md`
+**B-path slice:** 2 of 8 (after slice-1 BC vocabulary fix, before RI-7.5 runtime semantics)
+**Authority:** explicit operator (`Halildeu`) GitHub PR review + commit trailer + cross-AI peer review
+**Decision:** `ri7_operator_authorization_recorded_no_guard_flag_flip`
+**Support impact:** none — guard flags stay false
+**Production platform claim:** false
+**Support widening:** false
+**Live adapter execution:** false
+
+## 1. Purpose
+
+RI-7.1 closes the readiness gate's **operator authorization** row by recording the named operator's explicit authorization for two independent semantics:
+
+1. **RI supersession authorization** — the operator authorizes the repo-intelligence subsystem (`ao-kernel repo scan`, `repo index`, `repo query`) to be evaluated as a contributor to a general-purpose production platform claim under the RI-7.x program. This authorization lets RI-7.5..RI-7.8 begin collecting evidence; it does NOT itself grant a production claim.
+2. **General-purpose platform claim target authorization** — the operator authorizes the general-purpose platform claim as the TARGET that RI-7.8c may evaluate (promote or non-promote). This is NOT the claim itself; the claim is granted only by RI-7.8c if its evidence chain passes.
+
+This slice flips the corresponding two manifest keys:
+
+- `explicit_operator_authorization`: false → true
+- `general_purpose_platform_claim_authorization`: false → true
+
+No other manifest keys are touched. The readiness gate continues to report `support_widening=false`, `production_platform_claim=false`, `live_adapter_execution=false` because this slice does not flip any guard flag.
+
+## 2. Authority Boundary
+
+GPP-9 remains closed under `gpp9_keep_narrow_stable_runtime_authoritative_program_closed_no_live_adapter_execution_no_support_widening_no_production_claim`. RI-7.1 does not change that authority; it only records the explicit operator authorization for downstream slices to evaluate against. The actual promotion decision belongs to RI-7.8c.
+
+Repo-intelligence remains Beta/experimental per `docs/PUBLIC-BETA.md` and `docs/SUPPORT-BOUNDARY.md`. No public boundary surface is edited by this slice.
+
+## 3. Authorization Record
+
+The operator authorizes by:
+
+1. **Commit identity** — the squash-merge commit author is `Halildeu` (the GitHub repo owner login pinned by schema `operator.github_login=const "Halildeu"`).
+2. **Commit trailers** in the squash commit:
+   - `Operator-Authorized-By: Halildeu`
+   - `Operator-Authorization-Scope: ri_supersession,general_purpose_platform_claim_target`
+   - `Operator-Authorization-At: <ISO 8601 UTC timestamp>`
+   - `No-Guard-Flag-Flip: support_widening=false,production_platform_claim=false,live_adapter_execution=false`
+3. **GitHub PR review approval** by `Halildeu` (non-author approval also accepted via path-sensitive review gate). The `ao-release-gate-review` required check enforces this.
+4. **Cross-AI peer review** (HARD RULE CC-2): implementer claude/anthropic; reviewer codex/openai. The `local-ai-review-evidence.v1.json` artifact records the cross-AI verdict; the schema accepts `REVISE` during the iter cycle and `AGREE` on the final commit. Final AGREE is pending until the iter loop completes; the same final verdict MUST land in both `local-ai-review-evidence.v1.json::reviewer.verdict` AND `RI-7.1-OPERATOR-AUTHORIZATION.v1.json::cross_ai_review_ref.final_verdict`. The invariant test `test_ri71_cross_ai_verdicts_match_review_evidence` enforces no drift between the two artifacts.
+
+The combination of these four signals constitutes the authority. None of them in isolation is sufficient.
+
+## 4. Schema-Backed Evidence Artifact
+
+`.claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.v1.json` validates against `ao_kernel/defaults/schemas/ri7-operator-authorization-evidence.schema.v1.json` (Draft 2020-12, strict, `additionalProperties=false` at every level).
+
+Required artifact fields (schema-pinned):
+
+- `schema_version` const `ri7-operator-authorization-evidence.v1`
+- `artifact_kind` const `ri7_operator_authorization_evidence`
+- `decision` const `ri7_operator_authorization_recorded_no_guard_flag_flip`
+- `operator.github_login` const `Halildeu`
+- `operator.authorization_timestamp` ISO 8601 date-time
+- `operator.no_secret_assertion` const true
+- `authorization_scope` array `[ri_supersession, general_purpose_platform_claim_target]`, exactly 2 unique items
+- `ri_supersession_authorized` const true
+- `general_purpose_platform_claim_target_authorized` const true
+- Guard flags (`support_widening`, `production_platform_claim`, `live_adapter_execution`) const false
+- `context_binding.repo` const `Halildeu/ao-kernel`
+- `context_binding.base_ref` const `refs/heads/main`
+- `context_binding.head_ref` const `refs/heads/codex/ri-7-1-operator-authorization`
+- `manifest_transition.before` and `manifest_transition.after` both pinned
+- `forbidden_change_audit.all_unchanged` const true with ≥8 protected surfaces enumerated
+- `cross_ai_review_ref.implementer_provider` const `anthropic`, `cross_ai_review_ref.reviewer_provider` const `openai`, `cross_ai_review_ref.final_verdict` const `AGREE`
+
+## 5. Manifest Flip
+
+`.claude/plans/RI-7-EVIDENCE-MANIFEST.v1.json` after this slice:
+
+```json
+{
+  "explicit_operator_authorization": true,
+  "general_purpose_platform_claim_authorization": true,
+  "operator_verified_runtime_semantics": false,
+  ...
+}
+```
+
+The remaining `operator_verified_runtime_semantics` blocker is owned by RI-7.5 (next slice).
+
+## 6. Forbidden-Change Audit
+
+`forbidden_change_audit.forbidden_surfaces` enumerates the protected surfaces this slice MUST NOT touch:
+
+- `.claude/plans/gpp_status.v1.json`
+- `scripts/gp5_platform_claim_decision.py`
+- `.github/workflows/`
+- `ao_kernel/mcp_server.py`
+- `ao_kernel/__init__.py`
+- `ao_kernel/defaults/policies/`
+- `docs/PUBLIC-BETA.md`
+- `docs/SUPPORT-BOUNDARY.md`
+- `docs/KNOWN-BUGS.md`
+
+Machine-enforced via the invariant test `test_ri71_forbidden_surfaces_actually_unchanged_in_diff` (CI fail-closed in PR context).
+
+## 7. Cross-AI Peer Review (HARD RULE CC-2)
+
+Implementer: claude/anthropic. Reviewer: codex/openai. The Codex MCP thread id is captured in `RI-7.1-OPERATOR-AUTHORIZATION.v1.json::cross_ai_review_ref.thread_id` (the `local-ai-review-evidence.v1.json` schema does not carry a separate cross-AI ref field — it records the reviewer verdict directly in `reviewer.verdict`). The same final verdict value lands in BOTH artifacts on the final commit: `local-ai-review-evidence.v1.json::reviewer.verdict` AND `RI-7.1-OPERATOR-AUTHORIZATION.v1.json::cross_ai_review_ref.final_verdict`. During the iter loop, both carry the interim verdict (`REVISE`); the cross-artifact equality is enforced by the invariant test `test_ri71_cross_ai_verdicts_match_review_evidence`. Final AGREE is pending until the iter loop completes.
+
+## 8. Definition Of Done
+
+RI-7.1 is complete when ALL of the items below are checked. Items marked `[pre-merge]` are verified by the agent before PR open; `[ci]` by the workflow; `[external]` by the operator/GitHub; `[post-merge]` by the squash-merge metadata after merge lands. None are marked as already done in this plan doc — production-grade tracking treats these as runtime gates, not authoring claims (Codex iter-1 absorb).
+
+1. `[pre-merge]` This plan exists and records the authority boundary, schema, manifest flip, forbidden-change audit, and cross-AI review pattern
+2. `[pre-merge]` Schema-backed evidence artifact validates against schema with zero errors
+3. `[pre-merge]` Manifest flip lands in the same PR
+4. `[pre-merge]` Invariant test suite passes locally (schema valid, evidence validates, manifest transition pinned, forbidden surfaces unchanged in `git diff` against base, plan doc structure, cross-AI verdicts match, no_secret_assertion required, timestamp pattern enforced, parent plan decision string match)
+5. `[external]` Cross-AI peer review final verdict = AGREE (recorded in both `local-ai-review-evidence.v1.json::reviewer.verdict` AND `RI-7.1-OPERATOR-AUTHORIZATION.v1.json::cross_ai_review_ref.final_verdict`; the invariant test asserts equality)
+6. `[ci]` CI fully green (all required checks pass)
+7. `[external]` Operator review approval landed via `ao-release-gate-review` required check
+8. `[post-merge]` Squash-merge commit carries the four authorization trailers
+9. `[post-merge]` Readiness gate output: `explicit_operator_authorization_missing` and `general_purpose_platform_claim_authorization_missing` blockers drop; `operator_verified_runtime_semantics_missing` remains (owned by RI-7.5)
+
+## 9. Non-Goals
+
+1. No guard flag flip (`support_widening`, `production_platform_claim`, `live_adapter_execution` all stay false)
+2. No production platform claim — that decision is in RI-7.8c
+3. No public boundary surface edit
+4. No `gpp_status.v1.json` or `scripts/gp5_platform_claim_decision.py` change
+5. No `.github/workflows/` change
+6. No MCP repo-intelligence tool exposure
+7. No context-compiler auto-feed
+8. No root authority file write
+9. Repo-intelligence Beta/experimental status remains unchanged
+
+## 10. Exit Decision
+
+`ri7_operator_authorization_recorded_no_guard_flag_flip`

--- a/.claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.v1.json
+++ b/.claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.v1.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "ri7-operator-authorization-evidence.v1",
+  "artifact_kind": "ri7_operator_authorization_evidence",
+  "decision": "ri7_operator_authorization_recorded_no_guard_flag_flip",
+  "operator": {
+    "github_login": "Halildeu",
+    "authorization_timestamp": "2026-05-27T16:11:43Z",
+    "no_secret_assertion": true
+  },
+  "authorization_scope": [
+    "ri_supersession",
+    "general_purpose_platform_claim_target"
+  ],
+  "ri_supersession_authorized": true,
+  "general_purpose_platform_claim_target_authorized": true,
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false,
+  "context_binding": {
+    "repo": "Halildeu/ao-kernel",
+    "base_ref": "refs/heads/main",
+    "head_ref": "refs/heads/codex/ri-7-1-operator-authorization",
+    "pr_number_hint": "tbd-after-open"
+  },
+  "manifest_transition": {
+    "before": {
+      "explicit_operator_authorization": false,
+      "general_purpose_platform_claim_authorization": false
+    },
+    "after": {
+      "explicit_operator_authorization": true,
+      "general_purpose_platform_claim_authorization": true
+    }
+  },
+  "forbidden_change_audit": {
+    "forbidden_surfaces": [
+      ".claude/plans/gpp_status.v1.json",
+      "scripts/gp5_platform_claim_decision.py",
+      ".github/workflows/",
+      "ao_kernel/mcp_server.py",
+      "ao_kernel/__init__.py",
+      "ao_kernel/defaults/policies/",
+      "docs/PUBLIC-BETA.md",
+      "docs/SUPPORT-BOUNDARY.md",
+      "docs/KNOWN-BUGS.md"
+    ],
+    "all_unchanged": true
+  },
+  "cross_ai_review_ref": {
+    "thread_id": "019e6a37-a9d1-7e73-8e90-4088353eb899",
+    "implementer_provider": "anthropic",
+    "reviewer_provider": "openai",
+    "final_verdict": "AGREE"
+  },
+  "notes": [
+    "RI-7.1 operator authorization slice \u2014 flips two manifest keys (explicit_operator_authorization + general_purpose_platform_claim_authorization) without flipping any guard flag. This authorization is the prerequisite that lets RI-7.5 (operator runtime semantics) and RI-7.8 (final promotion decision) begin collecting evidence; it is NOT the production claim itself.",
+    "Operator authority is established by FOUR concurrent signals (none alone is sufficient): commit identity Halildeu, commit trailers Operator-Authorized-By/Scope/At + No-Guard-Flag-Flip, GitHub PR review approval via ao-release-gate-review required check, cross-AI peer review final AGREE.",
+    "B-path slice 2 of 8 (Codex thread 019e691b iter-3 plan). Next slice: RI-7.5 operator runtime semantics (operator-bound observation + script-generated evidence)."
+  ]
+}

--- a/ao_kernel/defaults/schemas/ri7-operator-authorization-evidence.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ri7-operator-authorization-evidence.schema.v1.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:ri7-operator-authorization-evidence:v1",
+  "title": "RI-7.1 Operator Authorization Record Evidence",
+  "description": "Evidence artifact recording the explicit operator authorization for (a) the repo-intelligence supersession to a general-purpose production platform claim contributor surface, and (b) the GP-platform-claim target authorization that downstream RI-7.5 / RI-7.8 slices depend on. Operator-bound slice: the artifact is authoritative only when the named operator account signs the carrying PR via GitHub review approval AND the commit trailer set, AND a cross-AI peer review (HARD RULE CC-2) records the implementer/reviewer split. This artifact does NOT flip any guard flag (support_widening, production_platform_claim, live_adapter_execution) — it only authorizes the manifest keys explicit_operator_authorization=true + general_purpose_platform_claim_authorization=true so downstream slices can begin collecting evidence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "decision",
+    "operator",
+    "authorization_scope",
+    "ri_supersession_authorized",
+    "general_purpose_platform_claim_target_authorized",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution",
+    "context_binding",
+    "manifest_transition",
+    "forbidden_change_audit",
+    "cross_ai_review_ref"
+  ],
+  "properties": {
+    "schema_version": {"type": "string", "const": "ri7-operator-authorization-evidence.v1"},
+    "artifact_kind": {"type": "string", "const": "ri7_operator_authorization_evidence"},
+    "decision": {"type": "string", "const": "ri7_operator_authorization_recorded_no_guard_flag_flip"},
+    "operator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["github_login", "authorization_timestamp", "no_secret_assertion"],
+      "properties": {
+        "github_login": {
+          "type": "string",
+          "const": "Halildeu",
+          "description": "The single GitHub login authorized to sign this RI-7.1 operator authorization. Pinned to the repo owner; widening this requires an intentional schema migration PR with cross-AI review."
+        },
+        "authorization_timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+          "description": "ISO 8601 UTC timestamp of the operator's authorization. Pattern asserts the value at schema level even without a FormatChecker (Codex iter-1 absorb: format-only assertions are not enforced by jsonschema by default; the explicit regex closes that loophole). Must match the commit timestamp or fall within the same UTC day window the PR review was given on."
+        },
+        "no_secret_assertion": {
+          "type": "boolean",
+          "const": true,
+          "description": "The operator asserts no secret material has been added to this PR's diff (API keys, tokens, credentials). Reviewed by the local-ai-review-evidence secret_scan check. Codex iter-1 absorb: this field is required (was previously optional)."
+        }
+      }
+    },
+    "authorization_scope": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "type": "string",
+        "enum": [
+          "ri_supersession",
+          "general_purpose_platform_claim_target"
+        ]
+      },
+      "description": "The two manifest keys this authorization flips. Must be exactly these two; widening the scope requires an intentional schema migration PR."
+    },
+    "ri_supersession_authorized": {
+      "type": "boolean",
+      "const": true,
+      "description": "Operator authorizes the repo-intelligence subsystem (ao-kernel repo scan/index/query) to be evaluated as a contributor to a general-purpose production platform claim under the RI-7.x program. This is NOT a production claim itself; it is the authorization that lets RI-7.5..RI-7.8 collect evidence."
+    },
+    "general_purpose_platform_claim_target_authorized": {
+      "type": "boolean",
+      "const": true,
+      "description": "Operator authorizes the general-purpose platform claim as the TARGET that RI-7.8 may evaluate (promote or non-promote). This is NOT the claim itself; the claim is granted only by RI-7.8c if and when its evidence chain passes."
+    },
+    "support_widening": {"type": "boolean", "const": false},
+    "production_platform_claim": {"type": "boolean", "const": false},
+    "live_adapter_execution": {"type": "boolean", "const": false},
+    "context_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "base_ref", "head_ref", "pr_number_hint"],
+      "properties": {
+        "repo": {
+          "type": "string",
+          "const": "Halildeu/ao-kernel"
+        },
+        "base_ref": {
+          "type": "string",
+          "const": "refs/heads/main"
+        },
+        "head_ref": {
+          "type": "string",
+          "const": "refs/heads/codex/ri-7-1-operator-authorization"
+        },
+        "pr_number_hint": {
+          "type": "string",
+          "description": "PR number once known (the artifact may be authored before the PR is opened; final commit re-runs the cross-AI review evidence after the PR number lands)."
+        }
+      }
+    },
+    "manifest_transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["before", "after"],
+      "properties": {
+        "before": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["explicit_operator_authorization", "general_purpose_platform_claim_authorization"],
+          "properties": {
+            "explicit_operator_authorization": {"type": "boolean", "const": false},
+            "general_purpose_platform_claim_authorization": {"type": "boolean", "const": false}
+          }
+        },
+        "after": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["explicit_operator_authorization", "general_purpose_platform_claim_authorization"],
+          "properties": {
+            "explicit_operator_authorization": {"type": "boolean", "const": true},
+            "general_purpose_platform_claim_authorization": {"type": "boolean", "const": true}
+          }
+        }
+      }
+    },
+    "forbidden_change_audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["forbidden_surfaces", "all_unchanged"],
+      "properties": {
+        "forbidden_surfaces": {
+          "type": "array",
+          "minItems": 8,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "all_unchanged": {"type": "boolean", "const": true}
+      }
+    },
+    "cross_ai_review_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["thread_id", "implementer_provider", "reviewer_provider", "final_verdict"],
+      "properties": {
+        "thread_id": {"type": "string", "minLength": 1, "description": "Codex MCP thread id for the cross-AI peer review chain."},
+        "implementer_provider": {"type": "string", "const": "anthropic"},
+        "reviewer_provider": {"type": "string", "const": "openai"},
+        "final_verdict": {
+          "type": "string",
+          "enum": ["REVISE", "AGREE"],
+          "description": "Cross-AI peer review verdict. Codex iter-1 absorb: enum (not const) so the artifact can be committed with REVISE during the iter loop and re-committed with AGREE only after the actual AGREE is received. Invariant test `test_ri71_cross_ai_verdicts_match_review_evidence` asserts this field equals `local-ai-review-evidence.v1.json::reviewer.verdict` (no drift between the two artifacts). Final commit MUST land with AGREE; the local gate fail-closes on REVISE."
+        }
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    }
+  }
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,40 +1,210 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-8-SCOPE-INTRODUCER-DETECTION-FASTFOLLOW",
-  "implementer": {"agent": "claude", "provider": "anthropic"},
-  "reviewer": {"agent": "codex", "provider": "openai", "verdict": "AGREE"},
+  "work_package": "RI-7.1-OPERATOR-AUTHORIZATION",
+  "implementer": {
+    "agent": "claude",
+    "provider": "anthropic"
+  },
+  "reviewer": {
+    "agent": "codex",
+    "provider": "openai",
+    "verdict": "AGREE"
+  },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-8-scope-introducer-detection-fastfollow",
+    "head_ref": "refs/heads/codex/ri-7-1-operator-authorization",
     "changed_files": [
+      ".claude/plans/RI-7-EVIDENCE-MANIFEST.v1.json",
+      ".claude/plans/RI-7-REPO-INTELLIGENCE-TIER-PROMOTION-READINESS.md",
+      ".claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.md",
+      ".claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.v1.json",
+      "ao_kernel/defaults/schemas/ri7-operator-authorization-evidence.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_ao_ma_8_e2e_smoke.py"
+      "tests/test_ri7_operator_authorization_invariant.py"
     ]
   },
   "checks_considered": [
-    {"name": "tests", "status": "pass"},
-    {"name": "secret_scan", "status": "pass"},
-    {"name": "ao_ma_8_introducer_detection_added", "status": "pass"},
-    {"name": "test_skips_when_not_ao_ma_8_introducer", "status": "pass"},
-    {"name": "test_enforces_full_scope_on_ao_ma_8_introducer_pr", "status": "pass"},
-    {"name": "no_support_widening", "status": "pass"},
-    {"name": "no_production_platform_claim", "status": "pass"},
-    {"name": "no_live_adapter_execution", "status": "pass"},
-    {"name": "no_public_sdk_signature_change", "status": "pass"},
-    {"name": "no_branch_protection_mutation", "status": "pass"},
-    {"name": "no_workflow_change", "status": "pass"},
-    {"name": "no_schema_change", "status": "pass"},
-    {"name": "no_forbidden_surface_touched", "status": "pass"},
-    {"name": "cross_provider_verified", "status": "pass"}
+    {
+      "name": "tests",
+      "status": "pass"
+    },
+    {
+      "name": "secret_scan",
+      "status": "pass"
+    },
+    {
+      "name": "schema_draft_2020_12_valid",
+      "status": "pass"
+    },
+    {
+      "name": "schema_operator_github_login_const_halildeu",
+      "status": "pass"
+    },
+    {
+      "name": "schema_authorization_scope_exactly_two_unique_items",
+      "status": "pass"
+    },
+    {
+      "name": "schema_decision_const_no_guard_flag_flip",
+      "status": "pass"
+    },
+    {
+      "name": "schema_guard_flags_const_false",
+      "status": "pass"
+    },
+    {
+      "name": "schema_context_binding_repo_base_head_ref_const",
+      "status": "pass"
+    },
+    {
+      "name": "schema_manifest_transition_before_after_pinned",
+      "status": "pass"
+    },
+    {
+      "name": "schema_cross_ai_review_provider_split_const",
+      "status": "pass"
+    },
+    {
+      "name": "evidence_validates_against_schema",
+      "status": "pass"
+    },
+    {
+      "name": "evidence_operator_iso8601_timestamp",
+      "status": "pass"
+    },
+    {
+      "name": "evidence_no_secret_assertion_true",
+      "status": "pass"
+    },
+    {
+      "name": "manifest_explicit_operator_authorization_true",
+      "status": "pass"
+    },
+    {
+      "name": "manifest_general_purpose_platform_claim_authorization_true",
+      "status": "pass"
+    },
+    {
+      "name": "manifest_operator_verified_runtime_semantics_false_owned_by_ri75",
+      "status": "pass"
+    },
+    {
+      "name": "manifest_no_guard_flag_flip",
+      "status": "pass"
+    },
+    {
+      "name": "plan_doc_records_decision_authority_boundary_no_guard_flag_flip",
+      "status": "pass"
+    },
+    {
+      "name": "ri7_readiness_gate_drops_two_operator_blockers",
+      "status": "pass"
+    },
+    {
+      "name": "ri7_readiness_gate_remaining_blocker_only_operator_verified_runtime_semantics",
+      "status": "pass"
+    },
+    {
+      "name": "forbidden_change_audit_machine_enforced_git_diff",
+      "status": "pass"
+    },
+    {
+      "name": "no_support_widening",
+      "status": "pass"
+    },
+    {
+      "name": "no_production_platform_claim",
+      "status": "pass"
+    },
+    {
+      "name": "no_live_adapter_execution",
+      "status": "pass"
+    },
+    {
+      "name": "no_public_sdk_signature_change",
+      "status": "pass"
+    },
+    {
+      "name": "no_branch_protection_mutation",
+      "status": "pass"
+    },
+    {
+      "name": "no_workflow_change",
+      "status": "pass"
+    },
+    {
+      "name": "no_mcp_repo_intelligence_exposure",
+      "status": "pass"
+    },
+    {
+      "name": "no_context_compiler_auto_feed",
+      "status": "pass"
+    },
+    {
+      "name": "no_root_authority_write_change",
+      "status": "pass"
+    },
+    {
+      "name": "no_gp5_platform_claim_decision_change",
+      "status": "pass"
+    },
+    {
+      "name": "no_gpp_status_change",
+      "status": "pass"
+    },
+    {
+      "name": "no_public_boundary_doc_change",
+      "status": "pass"
+    },
+    {
+      "name": "cross_provider_verified",
+      "status": "pass"
+    },
+    {
+      "name": "schema_no_secret_assertion_required_iter1_absorb",
+      "status": "pass"
+    },
+    {
+      "name": "schema_timestamp_strict_utc_pattern_iter1_absorb",
+      "status": "pass"
+    },
+    {
+      "name": "schema_cross_ai_verdict_enum_revise_agree_iter1_absorb",
+      "status": "pass"
+    },
+    {
+      "name": "evidence_cross_ai_verdict_matches_review_evidence_iter1_absorb",
+      "status": "pass"
+    },
+    {
+      "name": "parent_plan_row_decision_string_synced_iter1_absorb",
+      "status": "pass"
+    },
+    {
+      "name": "plan_doc_dod_items_tagged_pre_merge_ci_external_post_merge_iter1_absorb",
+      "status": "pass"
+    },
+    {
+      "name": "negative_test_no_secret_assertion_omit_rejected",
+      "status": "pass"
+    },
+    {
+      "name": "negative_test_invalid_timestamp_rejected",
+      "status": "pass"
+    }
   ],
   "findings": [
-    "AO-MA-8 sistemik bug fast-follow per HARD RULE Governance / Sistemik Bug: the test_ao_ma_8_pr_scope_only_touches_allowlisted_files assertion introduced by PR #660 ran on every PR after AO-MA-8 landed and rejected any PR whose diff did not match AO-MA-8's specific scope — a category error. Fix detects the AO-MA-8 INTRODUCER PR by intersecting git diff with the four AO-MA-8-owned artifact paths (excluding the shared local-ai-review-evidence.v1.json); on non-introducer PRs the assertion skips, preserving the introducer's full-scope guarantee while unblocking every other PR.",
-    "Sistemik bug impact: blocks RI-7.1 (PR #661) and every future PR with this AO-MA-8 invariant. Sistemik fix prevents the cascading PR breakage that would otherwise require workarounds in every downstream slice.",
-    "Per HARD RULE Uzun Vadeli Kalıcı Çözüm + Governance / Sistemik Bug: separate fast-follow PR (not RI-7.1 inline patch) to avoid governance bypass; sistemik fix lands first, RI-7.1 rebases on it.",
-    "Diff scope: 2 files — tests/test_ao_ma_8_e2e_smoke.py (assertion + skip guard) + local-ai-review-evidence.v1.json (this artifact). No schema change. No public SDK signature change. No workflow / branch-protection mutation. Forbidden surfaces (gpp_status, gp5_platform_claim_decision, mcp_server, __init__, defaults/policies, PUBLIC-BETA, SUPPORT-BOUNDARY, KNOWN-BUGS) untouched.",
-    "Local verification: ruff check passes; pytest test_ao_ma_8_pr_scope_only_touches_allowlisted_files returns `1 skipped` when diff carries no AO-MA-8-specific path (correct behavior for non-introducer PR). Introducer-PR full-scope assertion still fires when synthetic diff includes AO-MA-8 paths.",
-    "Cross-AI peer review HARD RULE CC-2: implementer claude/anthropic differs from reviewer codex/openai. Sistemik bug fix is mechanically simple (one introducer-detection guard added before existing assertion); review verdict AGREE recorded directly without iter cycle. No interim REVISE needed for this scope."
+    "Iter-4 absorb COMPLETE; reviewer verdict received AGREE from Codex (thread 019e6a37). Final commit lands with reviewer.verdict=AGREE in this file AND cross_ai_review_ref.final_verdict=AGREE in RI-7.1-OPERATOR-AUTHORIZATION.v1.json; the invariant test_ri71_cross_ai_verdicts_match_review_evidence preserves cross-artifact equality. iter cycle: iter-1 REVISE (2 BLOCKER + 2 MEDIUM) \u2192 iter-2 REVISE (1 BLOCKER + 1 MEDIUM) \u2192 iter-3 REVISE (2 MEDIUM prose) \u2192 iter-4 AGREE merge-ready.",
+    "B-path slice 2 of 8: RI-7.1 operator authorization record. Codex thread 019e6a37-a9d1-7e73-8e90-4088353eb899 (slice-1 thread 019e691b expired post slice-1 merge). Reviewer verdict tracked iter-1 REVISE (4 findings) \u2192 iter-2 REVISE (2 findings) \u2192 iter-3 REVISE (2 MEDIUM prose drift) \u2192 iter-3 absorb in flight; final AGREE pending.",
+    "Schema strictness summary post-iter-1+iter-2 absorb: additionalProperties=false at every object level; schema_version + artifact_kind + decision const ri7_operator_authorization_recorded_no_guard_flag_flip; operator.github_login const Halildeu; operator.no_secret_assertion REQUIRED + const true (iter-1 BLOCKER absorb); operator.authorization_timestamp format=date-time + strict UTC pattern ^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z\\$ (iter-1 MEDIUM absorb); authorization_scope minItems=maxItems=2 + uniqueItems + enum [ri_supersession, general_purpose_platform_claim_target]; ri_supersession_authorized + general_purpose_platform_claim_target_authorized const true; guard flags const false; context_binding repo/base_ref/head_ref const; manifest_transition before/after const-pinned; forbidden_change_audit.all_unchanged const true + minItems=8 surfaces; cross_ai_review_ref implementer/reviewer provider const + final_verdict enum [REVISE, AGREE] (iter-1 BLOCKER absorb).",
+    "Authority signal model: 4 concurrent signals required (none alone sufficient): (1) commit identity Halildeu, (2) commit trailers Operator-Authorized-By/Scope/At + No-Guard-Flag-Flip, (3) GitHub PR approval via ao-release-gate-review required check, (4) cross-AI peer review final AGREE recorded in cross_ai_review_ref with cross-artifact equality enforced.",
+    "Invariant test suite (13 tests, post-iter-1 absorb +4): schema valid Draft 2020-12, evidence validates against schema, evidence records decision + Halildeu + ISO 8601 timestamp + no_secret_assertion + scope + 3-guard-false, manifest_transition before/after pinned, manifest flips both operator keys + operator_verified_runtime_semantics remains false, forbidden_change_audit 9 surfaces pinned, cross-AI provider split + verdict enum + thread_id, cross-artifact verdict equality (iter-1 absorb), parent plan row decision string matches (iter-1 absorb), no_secret_assertion required positive+negative (iter-1 absorb), invalid_timestamp rejected by schema pattern positive+negative (iter-1 absorb), plan doc decision/3-guards/Halildeu/Operator-Authorized-By, forbidden-diff invariant CI fail-closed in PR context.",
+    "Diff scope (7 files, iter-2 absorb): .claude/plans/RI-7-EVIDENCE-MANIFEST.v1.json (manifest 2-key flip), .claude/plans/RI-7-REPO-INTELLIGENCE-TIER-PROMOTION-READINESS.md (parent row decision string sync, iter-1 absorb), .claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.md (NEW plan doc, DoD tagged [pre-merge]/[ci]/[external]/[post-merge]), .claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.v1.json (NEW evidence), ao_kernel/defaults/schemas/ri7-operator-authorization-evidence.schema.v1.json (NEW schema), local-ai-review-evidence.v1.json (cross-AI evidence), tests/test_ri7_operator_authorization_invariant.py (NEW invariant tests).",
+    "Readiness gate output: 2 operator-bound blockers dropped (explicit_operator_authorization_missing + general_purpose_platform_claim_authorization_missing). Remaining 1 blocker: operator_verified_runtime_semantics_missing (RI-7.5 owner). Guard flags unchanged (all false).",
+    "Forbidden-change audit clean: gpp_status.v1.json, scripts/gp5_platform_claim_decision.py, .github/workflows/, ao_kernel/mcp_server.py, ao_kernel/__init__.py, ao_kernel/defaults/policies/, docs/PUBLIC-BETA.md, docs/SUPPORT-BOUNDARY.md, docs/KNOWN-BUGS.md \u2014 all untouched.",
+    "Local test run: 13 passed. ruff clean. Schema validates evidence with zero errors (Draft 2020-12). Review evidence validates against its schema with zero errors. Declared-vs-actual diff scope: 7=7 exact match (iter-2 absorb).",
+    "Cross-AI peer review HARD RULE CC-2: implementer claude/anthropic differs from reviewer codex/openai. Final AGREE pending; this file is committed with reviewer.verdict=REVISE during iter cycle; AGREE flip lands on final commit only after Codex returns AGREE. RI-7.1 evidence cross_ai_review_ref.final_verdict tracks the SAME value (cross-artifact equality enforced by test_ri71_cross_ai_verdicts_match_review_evidence)."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -21,7 +21,11 @@
       ".claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.v1.json",
       "ao_kernel/defaults/schemas/ri7-operator-authorization-evidence.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_ri7_operator_authorization_invariant.py"
+      "tests/test_ri7_cross_lane_production_matrix_invariant.py",
+      "tests/test_ri7_gp59_transition_plan_invariant.py",
+      "tests/test_ri7_guardrail_hardening_matrix_invariant.py",
+      "tests/test_ri7_operator_authorization_invariant.py",
+      "tests/test_ri7_scan_index_query_packaging_smoke_invariant.py"
     ]
   },
   "checks_considered": [
@@ -195,6 +199,7 @@
     }
   ],
   "findings": [
+    "Iter-5 absorb (post-impl gate CI signal): added 4 legacy invariant test files to changed_files after the operator-bound landing required loosening their state-at-landing pins (RI-7.2/7.4/7.6/7.7). Total scope now 11 files matching git diff exactly. The legacy loosening is documented per-test as the explicit RI-7.1 operator-bound landing absorb (each docstring previously pointed at this PR).",
     "Iter-4 absorb COMPLETE; reviewer verdict received AGREE from Codex (thread 019e6a37). Final commit lands with reviewer.verdict=AGREE in this file AND cross_ai_review_ref.final_verdict=AGREE in RI-7.1-OPERATOR-AUTHORIZATION.v1.json; the invariant test_ri71_cross_ai_verdicts_match_review_evidence preserves cross-artifact equality. iter cycle: iter-1 REVISE (2 BLOCKER + 2 MEDIUM) \u2192 iter-2 REVISE (1 BLOCKER + 1 MEDIUM) \u2192 iter-3 REVISE (2 MEDIUM prose) \u2192 iter-4 AGREE merge-ready.",
     "B-path slice 2 of 8: RI-7.1 operator authorization record. Codex thread 019e6a37-a9d1-7e73-8e90-4088353eb899 (slice-1 thread 019e691b expired post slice-1 merge). Reviewer verdict tracked iter-1 REVISE (4 findings) \u2192 iter-2 REVISE (2 findings) \u2192 iter-3 REVISE (2 MEDIUM prose drift) \u2192 iter-3 absorb in flight; final AGREE pending.",
     "Schema strictness summary post-iter-1+iter-2 absorb: additionalProperties=false at every object level; schema_version + artifact_kind + decision const ri7_operator_authorization_recorded_no_guard_flag_flip; operator.github_login const Halildeu; operator.no_secret_assertion REQUIRED + const true (iter-1 BLOCKER absorb); operator.authorization_timestamp format=date-time + strict UTC pattern ^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z\\$ (iter-1 MEDIUM absorb); authorization_scope minItems=maxItems=2 + uniqueItems + enum [ri_supersession, general_purpose_platform_claim_target]; ri_supersession_authorized + general_purpose_platform_claim_target_authorized const true; guard flags const false; context_binding repo/base_ref/head_ref const; manifest_transition before/after const-pinned; forbidden_change_audit.all_unchanged const true + minItems=8 surfaces; cross_ai_review_ref implementer/reviewer provider const + final_verdict enum [REVISE, AGREE] (iter-1 BLOCKER absorb).",

--- a/tests/test_ri7_cross_lane_production_matrix_invariant.py
+++ b/tests/test_ri7_cross_lane_production_matrix_invariant.py
@@ -101,8 +101,11 @@ def test_ri76_manifest_records_cross_lane_true_and_operator_bound_false() -> Non
     # scan_index_query_packaging_smoke, RI-7.7 gp59/support_boundary)
     # and may legitimately be True once those slices have also landed.
     for key in (
-        "explicit_operator_authorization",
-        "general_purpose_platform_claim_authorization",
+        # Codex iter-1 absorb (RI-7.1): explicit_operator_authorization and
+        # general_purpose_platform_claim_authorization are owned by the
+        # operator-bound RI-7.1 slice (PR #661); they may flip true once
+        # that slice lands. Only operator_verified_runtime_semantics
+        # (RI-7.5 owner) remains False at this PR's landing moment.
         "operator_verified_runtime_semantics",
     ):
         assert manifest[key] is False, key

--- a/tests/test_ri7_gp59_transition_plan_invariant.py
+++ b/tests/test_ri7_gp59_transition_plan_invariant.py
@@ -272,8 +272,11 @@ def test_ri77_manifest_flips_both_gp59_and_support_boundary_keys() -> None:
     # scan_index_query_packaging_smoke, RI-7.6 cross_lane) and may
     # legitimately be True once those slices have also landed.
     for key in (
-        "explicit_operator_authorization",
-        "general_purpose_platform_claim_authorization",
+        # Codex iter-1 absorb (RI-7.1): explicit_operator_authorization and
+        # general_purpose_platform_claim_authorization are owned by the
+        # operator-bound RI-7.1 slice (PR #661); they may flip true once
+        # that slice lands. Only operator_verified_runtime_semantics
+        # (RI-7.5 owner) remains False at this PR's landing moment.
         "operator_verified_runtime_semantics",
     ):
         assert manifest[key] is False, key

--- a/tests/test_ri7_guardrail_hardening_matrix_invariant.py
+++ b/tests/test_ri7_guardrail_hardening_matrix_invariant.py
@@ -174,8 +174,11 @@ def test_ri72_manifest_records_guardrail_hardening_matrix_true() -> None:
     # State-at-landing pin only — see docstring. Operator-bound landings
     # will revise this.
     for key in (
-        "explicit_operator_authorization",
-        "general_purpose_platform_claim_authorization",
+        # Codex iter-1 absorb (RI-7.1): explicit_operator_authorization and
+        # general_purpose_platform_claim_authorization are owned by the
+        # operator-bound RI-7.1 slice (PR #661); they may flip true once
+        # that slice lands. Only operator_verified_runtime_semantics
+        # (RI-7.5 owner) remains False at this PR's landing moment.
         "operator_verified_runtime_semantics",
     ):
         assert manifest[key] is False, key

--- a/tests/test_ri7_operator_authorization_invariant.py
+++ b/tests/test_ri7_operator_authorization_invariant.py
@@ -1,0 +1,332 @@
+"""Doc invariant test for RI-7.1 operator authorization record evidence.
+
+B-path slice 2 of 8 (after BC vocabulary fix slice-1, before RI-7.5 runtime
+semantics). Pins the operator authorization schema, evidence, manifest
+transition, forbidden-change audit, and cross-AI review reference.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PLAN_PATH = _REPO_ROOT / ".claude" / "plans" / "RI-7.1-OPERATOR-AUTHORIZATION.md"
+_EVIDENCE_PATH = _REPO_ROOT / ".claude" / "plans" / "RI-7.1-OPERATOR-AUTHORIZATION.v1.json"
+_SCHEMA_PATH = _REPO_ROOT / "ao_kernel" / "defaults" / "schemas" / "ri7-operator-authorization-evidence.schema.v1.json"
+_MANIFEST_PATH = _REPO_ROOT / ".claude" / "plans" / "RI-7-EVIDENCE-MANIFEST.v1.json"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"missing artifact: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_ri71_schema_is_valid_draft_2020_12() -> None:
+    schema = json.loads(_read(_SCHEMA_PATH))
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+
+def test_ri71_evidence_validates_against_schema() -> None:
+    schema = json.loads(_read(_SCHEMA_PATH))
+    evidence = json.loads(_read(_EVIDENCE_PATH))
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(evidence))
+    assert errors == [], [e.message for e in errors]
+
+
+def test_ri71_evidence_records_authorization_decision() -> None:
+    """The evidence artifact MUST record the no-guard-flag-flip decision,
+    the named operator Halildeu, both authorization scopes, and all
+    three guard flags as false.
+    """
+    evidence = json.loads(_read(_EVIDENCE_PATH))
+    assert evidence["artifact_kind"] == "ri7_operator_authorization_evidence"
+    assert evidence["decision"] == "ri7_operator_authorization_recorded_no_guard_flag_flip"
+
+    operator = evidence["operator"]
+    assert operator["github_login"] == "Halildeu"
+    assert operator["no_secret_assertion"] is True
+    # Authorization timestamp must parse as ISO 8601.
+    timestamp = operator["authorization_timestamp"]
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z", timestamp), (
+        f"authorization_timestamp not ISO 8601 UTC: {timestamp!r}"
+    )
+
+    assert set(evidence["authorization_scope"]) == {
+        "ri_supersession",
+        "general_purpose_platform_claim_target",
+    }
+    assert evidence["ri_supersession_authorized"] is True
+    assert evidence["general_purpose_platform_claim_target_authorized"] is True
+    assert evidence["support_widening"] is False
+    assert evidence["production_platform_claim"] is False
+    assert evidence["live_adapter_execution"] is False
+
+
+def test_ri71_evidence_records_manifest_transition() -> None:
+    evidence = json.loads(_read(_EVIDENCE_PATH))
+    transition = evidence["manifest_transition"]
+    assert transition["before"]["explicit_operator_authorization"] is False
+    assert transition["before"]["general_purpose_platform_claim_authorization"] is False
+    assert transition["after"]["explicit_operator_authorization"] is True
+    assert transition["after"]["general_purpose_platform_claim_authorization"] is True
+
+
+def test_ri71_manifest_flips_both_operator_keys_true() -> None:
+    """The committed manifest reflects the operator authorization. Both
+    `explicit_operator_authorization` and
+    `general_purpose_platform_claim_authorization` are true after this
+    slice; `operator_verified_runtime_semantics` remains false (RI-7.5
+    owner).
+    """
+    manifest = json.loads(_read(_MANIFEST_PATH))
+    assert manifest["artifact_kind"] == "ri7_evidence_manifest"
+    assert manifest["explicit_operator_authorization"] is True
+    assert manifest["general_purpose_platform_claim_authorization"] is True
+    assert manifest["operator_verified_runtime_semantics"] is False
+
+
+def test_ri71_evidence_records_forbidden_change_audit() -> None:
+    evidence = json.loads(_read(_EVIDENCE_PATH))
+    audit = evidence["forbidden_change_audit"]
+    assert audit["all_unchanged"] is True
+    surfaces = set(audit["forbidden_surfaces"])
+    for required_surface in (
+        ".claude/plans/gpp_status.v1.json",
+        "scripts/gp5_platform_claim_decision.py",
+        ".github/workflows/",
+        "ao_kernel/mcp_server.py",
+        "ao_kernel/__init__.py",
+        "ao_kernel/defaults/policies/",
+        "docs/PUBLIC-BETA.md",
+        "docs/SUPPORT-BOUNDARY.md",
+        "docs/KNOWN-BUGS.md",
+    ):
+        assert required_surface in surfaces, required_surface
+
+
+def test_ri71_cross_ai_review_provider_split_is_recorded() -> None:
+    evidence = json.loads(_read(_EVIDENCE_PATH))
+    ref = evidence["cross_ai_review_ref"]
+    assert ref["implementer_provider"] == "anthropic"
+    assert ref["reviewer_provider"] == "openai"
+    assert ref["implementer_provider"] != ref["reviewer_provider"]
+    # Codex iter-1 absorb: final_verdict can be REVISE during the iter
+    # cycle; the final commit MUST land with AGREE. The cross-artifact
+    # verdict equality test below enforces no drift between this
+    # artifact and `local-ai-review-evidence.v1.json`.
+    assert ref["final_verdict"] in {"REVISE", "AGREE"}
+    assert ref["thread_id"], "cross-AI review thread id MUST be recorded"
+
+
+def test_ri71_cross_ai_verdicts_match_review_evidence() -> None:
+    """Codex iter-1 absorb: the operator authorization evidence's
+    `cross_ai_review_ref.final_verdict` and the
+    `local-ai-review-evidence.v1.json::reviewer.verdict` MUST agree.
+    This prevents the 'AGREE pre-fill in one artifact, REVISE in the
+    other' inconsistency the iter-1 review identified as a BLOCKER.
+    """
+    evidence = json.loads(_read(_EVIDENCE_PATH))
+    review_path = _REPO_ROOT / "local-ai-review-evidence.v1.json"
+    review = json.loads(_read(review_path))
+
+    auth_verdict = evidence["cross_ai_review_ref"]["final_verdict"]
+    review_verdict = review["reviewer"]["verdict"]
+    assert auth_verdict == review_verdict, (
+        f"cross-AI verdict drift: RI-7.1 evidence carries {auth_verdict!r} "
+        f"but local-ai-review-evidence.v1.json carries {review_verdict!r}"
+    )
+
+
+def test_ri71_parent_plan_row_uses_same_decision_string() -> None:
+    """Codex iter-1 absorb: the RI-7 parent plan tracking table row for
+    RI-7.1 MUST cite the same exit decision string this artifact uses.
+    Drift here was the 'no_flag_flip vs no_guard_flag_flip' bug.
+    """
+    parent_path = _REPO_ROOT / ".claude" / "plans" / "RI-7-REPO-INTELLIGENCE-TIER-PROMOTION-READINESS.md"
+    parent_text = _read(parent_path)
+    evidence = json.loads(_read(_EVIDENCE_PATH))
+    decision = evidence["decision"]
+    assert decision == "ri7_operator_authorization_recorded_no_guard_flag_flip"
+    assert decision in parent_text, (
+        f"parent RI-7 plan does not cite the RI-7.1 decision string {decision!r}; "
+        "drift between parent tracking row and child artifact"
+    )
+
+
+def test_ri71_no_secret_assertion_is_schema_required() -> None:
+    """Codex iter-1 absorb: schema MUST require `operator.no_secret_assertion`
+    (previous version had it `const true` but optional, so an evidence
+    artifact could omit the assertion and still pass validation).
+    Negative test: removing the field must cause schema validation to
+    fail.
+    """
+    schema = json.loads(_read(_SCHEMA_PATH))
+    evidence = json.loads(_read(_EVIDENCE_PATH))
+    # Positive: current artifact has the field and validates.
+    assert "no_secret_assertion" in evidence["operator"]
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(evidence))
+    assert errors == [], [e.message for e in errors]
+
+    # Negative: removing the field must raise a validation error.
+    bad = json.loads(json.dumps(evidence))  # deep copy
+    del bad["operator"]["no_secret_assertion"]
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(bad))
+    assert errors, "schema accepted operator artifact without no_secret_assertion"
+
+
+def test_ri71_invalid_timestamp_is_rejected_by_schema_pattern() -> None:
+    """Codex iter-1 absorb: schema's `authorization_timestamp` carries a
+    strict ISO 8601 UTC pattern in addition to `format: date-time`,
+    because jsonschema's default validator does NOT enforce
+    `format`-only assertions. Negative test: a non-conformant timestamp
+    must be rejected.
+    """
+    schema = json.loads(_read(_SCHEMA_PATH))
+    evidence = json.loads(_read(_EVIDENCE_PATH))
+
+    bad = json.loads(json.dumps(evidence))
+    bad["operator"]["authorization_timestamp"] = "not-a-date"
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(bad))
+    assert errors, "schema accepted operator.authorization_timestamp='not-a-date'"
+
+    bad2 = json.loads(json.dumps(evidence))
+    bad2["operator"]["authorization_timestamp"] = "2026-05-27T16:00:00+00:00"  # non-UTC suffix
+    errors2 = list(jsonschema.Draft202012Validator(schema).iter_errors(bad2))
+    assert errors2, "schema accepted non-Z-suffixed authorization_timestamp"
+
+
+def test_ri71_plan_doc_records_decision_and_authority_boundary() -> None:
+    text = _read(_PLAN_PATH)
+    flat = " ".join(text.split())
+    assert "ri7_operator_authorization_recorded_no_guard_flag_flip" in flat
+    assert "support_widening" in flat
+    assert "production_platform_claim" in flat
+    assert "live_adapter_execution" in flat
+    assert "Halildeu" in flat
+    assert "Operator-Authorized-By" in flat
+
+
+# ----------------------------------------------------------------------
+# Forbidden-diff invariant (CI fail-closed in PR context).
+# Same pattern as PR #656 (B-path slice-1 inherits this).
+# ----------------------------------------------------------------------
+
+
+def _git(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(_REPO_ROOT),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def _in_ci() -> bool:
+    return os.environ.get("GITHUB_ACTIONS") == "true" or os.environ.get("CI") == "true"
+
+
+def _in_pr_context() -> bool:
+    if os.environ.get("GITHUB_EVENT_NAME") == "pull_request":
+        return True
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if event_path:
+        try:
+            event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+            if isinstance(event.get("pull_request"), dict):
+                return True
+        except (OSError, json.JSONDecodeError, KeyError):
+            return False
+    return False
+
+
+def _resolve_diff_base() -> tuple[str | None, str]:
+    """Multi-strategy diff base detection (see PR #656 invariant test for
+    full rationale)."""
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if event_path:
+        try:
+            event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+            pr = event.get("pull_request") or {}
+            base = pr.get("base") or {}
+            sha = base.get("sha")
+            base_ref_in_event = base.get("ref")
+            if isinstance(sha, str) and re.fullmatch(r"[0-9a-f]{40}", sha):
+                has = _git(["cat-file", "-e", sha])
+                if has.returncode != 0:
+                    _git(["fetch", "origin", sha, "--depth=1"])
+                    if base_ref_in_event and re.fullmatch(r"[A-Za-z0-9._/-]+", base_ref_in_event):
+                        _git(["fetch", "origin", base_ref_in_event, "--depth=1"])
+                    has = _git(["cat-file", "-e", sha])
+                if has.returncode == 0:
+                    return sha, "github_event_payload"
+        except (OSError, json.JSONDecodeError, KeyError):
+            pass
+
+    base_ref = os.environ.get("GITHUB_BASE_REF")
+    if base_ref and re.fullmatch(r"[A-Za-z0-9._/-]+", base_ref):
+        fetch_proc = _git(["fetch", "origin", base_ref, "--depth=1"])
+        if fetch_proc.returncode == 0:
+            mb = _git(["merge-base", "HEAD", "FETCH_HEAD"])
+            if mb.returncode == 0:
+                sha = mb.stdout.strip()
+                if re.fullmatch(r"[0-9a-f]{40}", sha):
+                    return sha, f"fetch:{base_ref}"
+
+    mb = _git(["merge-base", "HEAD", "origin/main"])
+    if mb.returncode == 0:
+        sha = mb.stdout.strip()
+        if re.fullmatch(r"[0-9a-f]{40}", sha):
+            return sha, "origin/main"
+
+    mb = _git(["merge-base", "HEAD", "main"])
+    if mb.returncode == 0:
+        sha = mb.stdout.strip()
+        if re.fullmatch(r"[0-9a-f]{40}", sha):
+            return sha, "local_main"
+
+    return None, "none"
+
+
+def test_ri71_forbidden_surfaces_actually_unchanged_in_diff() -> None:
+    """CI fail-closed in PR context: forbidden surfaces in the artifact
+    MUST not actually appear in `git diff --name-only base..HEAD`.
+    """
+    evidence = json.loads(_read(_EVIDENCE_PATH))
+    surfaces = evidence["forbidden_change_audit"]["forbidden_surfaces"]
+
+    base, source = _resolve_diff_base()
+    if base is None:
+        msg = "no PR diff base could be resolved"
+        if _in_ci() and _in_pr_context():
+            pytest.fail(f"forbidden-diff invariant cannot run in CI PR: {msg}")
+        pytest.skip(msg)
+
+    diff_proc = _git(["diff", "--name-only", f"{base}..HEAD"])
+    if diff_proc.returncode != 0:
+        msg = f"git diff against base ({source}={base!r}) failed: {diff_proc.stderr.strip() or 'unknown'}"
+        if _in_ci() and _in_pr_context():
+            pytest.fail(f"forbidden-diff invariant cannot run in CI PR: {msg}")
+        pytest.skip(msg)
+
+    changed_files = {line.strip() for line in diff_proc.stdout.splitlines() if line.strip()}
+    offenders: list[str] = []
+    for surface in surfaces:
+        if surface.endswith("/"):
+            offenders.extend(f for f in changed_files if f.startswith(surface))
+        else:
+            offenders.extend(f for f in changed_files if f == surface)
+
+    assert not offenders, (
+        f"forbidden surfaces touched (base source={source}): {sorted(offenders)}; "
+        f"forbidden_change_audit.all_unchanged=true is therefore false"
+    )

--- a/tests/test_ri7_scan_index_query_packaging_smoke_invariant.py
+++ b/tests/test_ri7_scan_index_query_packaging_smoke_invariant.py
@@ -85,8 +85,11 @@ def test_ri74_manifest_records_packaging_smoke_true_and_operator_bound_false() -
     # RI-7.7 gp59/support_boundary) and may legitimately be True once
     # those slices have also landed.
     for key in (
-        "explicit_operator_authorization",
-        "general_purpose_platform_claim_authorization",
+        # Codex iter-1 absorb (RI-7.1): explicit_operator_authorization and
+        # general_purpose_platform_claim_authorization are owned by the
+        # operator-bound RI-7.1 slice (PR #661); they may flip true once
+        # that slice lands. Only operator_verified_runtime_semantics
+        # (RI-7.5 owner) remains False at this PR's landing moment.
         "operator_verified_runtime_semantics",
     ):
         assert manifest[key] is False, key


### PR DESCRIPTION
## Summary

- **B-path slice 2 of 8** — operator-bound slice flipping two manifest keys (`explicit_operator_authorization` + `general_purpose_platform_claim_authorization`) without touching any guard flag.
- This authorization is the prerequisite that lets RI-7.5 + RI-7.8 collect evidence. It is **NOT** the production claim itself.
- Schema-backed evidence (Draft 2020-12 strict) with `operator.github_login=const Halildeu`, 4-signal authority model, manifest_transition before/after pinned, cross_ai_review_ref enum verdict [REVISE, AGREE], strict UTC timestamp pattern, machine-enforced forbidden-change audit (9 surfaces).

## Cross-AI peer review (HARD RULE CC-2)

Codex MCP thread `019e6a37-a9d1-7e73-8e90-4088353eb899`, 4-iter absorb cycle: iter-1 REVISE → iter-2 REVISE → iter-3 REVISE → **iter-4 AGREE / merge-ready**.

## Guard flag invariants (unchanged)

- `support_widening=false` (const)
- `production_platform_claim=false` (const)
- `live_adapter_execution=false` (const)

## Operator authority (4 concurrent signals)

1. Commit identity Halildeu
2. Commit trailers Operator-Authorized-By / Scope / At + No-Guard-Flag-Flip
3. GitHub PR approval via `ao-release-gate-review`
4. Cross-AI peer review final AGREE

## Test plan

- [x] `pytest test_ri7_operator_authorization_invariant.py` — 13 passed locally
- [x] `ruff check` — clean
- [x] Schema validates evidence — zero errors (Draft 2020-12)
- [x] Cross-artifact verdict equality (REVISE/REVISE → AGREE/AGREE flip)
- [x] Negative tests: no_secret_assertion omit + invalid timestamp → schema rejects
- [x] Readiness gate: 2 operator-bound blockers dropped, 1 remaining (RI-7.5)

## Forbidden-change audit (clean)

`gpp_status.v1.json`, `gp5_platform_claim_decision.py`, `.github/workflows/`, `mcp_server.py`, `__init__.py`, `defaults/policies/`, `docs/PUBLIC-BETA.md`, `docs/SUPPORT-BOUNDARY.md`, `docs/KNOWN-BUGS.md`, public SDK signatures, branch protection — all untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)