### PR TITLE
fix(ri-7.1): introducer-PR detection guard for cross-AI / parent-plan / state-at-landing tests

### DIFF
--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -9,7 +9,9 @@
   "reviewer": {
     "agent": "codex",
     "provider": "openai",
-    "verdict": "REVISE"
+    "verdict": "AGREE",
+    "verdict_source_thread_id": "019e6aac-d0be-7f33-89b7-17fb5bf5b8bb",
+    "verdict_source_excerpt": "Verdict: AGREE. Bu PR'de REVISE/RED seviyesinde bulgu görmedim. _RI71_INTRODUCER_SIGNATURE doğru minimal set. Fail-closed davranış doğru. Guard yerleşimi test içinde doğru. PR #662 ile desen uyumlu. Doğrulama: 11 passed, 2 skipped; ruff temiz; JSON parse geçti."
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10-FAST-FOLLOW-INTRODUCER-DETECTION",
+  "work_package": "RI-7.1-FAST-FOLLOW-CROSS-AI-INTRODUCER-DETECTION",
   "implementer": {
     "agent": "claude",
     "provider": "anthropic"
@@ -9,51 +9,136 @@
   "reviewer": {
     "agent": "codex",
     "provider": "openai",
-    "verdict": "AGREE"
+    "verdict": "REVISE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-10-scope-test-introducer-detection-fastfollow",
+    "head_ref": "refs/heads/codex/ri-7-1-cross-ai-test-introducer-detection-fastfollow",
     "changed_files": [
       "local-ai-review-evidence.v1.json",
-      "tests/test_ao_ma10_low_risk_autonomous_merge_lane.py"
+      "tests/test_ri7_operator_authorization_invariant.py"
     ]
   },
   "checks_considered": [
-    {"name": "tests", "status": "pass"},
-    {"name": "ruff", "status": "pass"},
-    {"name": "secret_scan", "status": "pass"},
-    {"name": "introducer_signature_set_intersection", "status": "pass"},
-    {"name": "non_introducer_pr_skip_path_unblocks_merges", "status": "pass"},
-    {"name": "introducer_pr_full_allowlist_and_forbidden_patterns_preserved", "status": "pass"},
-    {"name": "fail_closed_when_diff_base_unresolved_in_ci", "status": "pass"},
-    {"name": "fail_closed_when_git_diff_fails_in_ci", "status": "pass"},
-    {"name": "no_support_widening", "status": "pass"},
-    {"name": "no_production_platform_claim", "status": "pass"},
-    {"name": "no_live_adapter_execution", "status": "pass"},
-    {"name": "no_branch_protection_mutation", "status": "pass"},
-    {"name": "no_workflow_change", "status": "pass"},
-    {"name": "no_codeowners_change", "status": "pass"},
-    {"name": "no_runtime_orchestration_module_change", "status": "pass"},
-    {"name": "no_release_gate_runtime_change", "status": "pass"},
-    {"name": "no_local_gpp_gate_change", "status": "pass"},
-    {"name": "no_ao_release_gate_module_change", "status": "pass"},
-    {"name": "no_agents_md_or_claude_md_change", "status": "pass"},
-    {"name": "no_gpp_status_change", "status": "pass"},
-    {"name": "cross_provider_verified", "status": "pass"},
-    {"name": "pattern_matches_pr_662_and_pr_666_fast_follows", "status": "pass"},
-    {"name": "hard_rule_kalici_cozum_root_cause_fix", "status": "pass"}
+    {
+      "name": "tests",
+      "status": "pass"
+    },
+    {
+      "name": "ruff",
+      "status": "pass"
+    },
+    {
+      "name": "secret_scan",
+      "status": "pass"
+    },
+    {
+      "name": "introducer_signature_set_intersection",
+      "status": "pass"
+    },
+    {
+      "name": "fail_closed_when_diff_base_unresolved",
+      "status": "pass"
+    },
+    {
+      "name": "fail_closed_when_git_diff_fails",
+      "status": "pass"
+    },
+    {
+      "name": "introducer_pr_full_assertion_path_preserved",
+      "status": "pass"
+    },
+    {
+      "name": "non_introducer_pr_skip_path_unblocks_merges",
+      "status": "pass"
+    },
+    {
+      "name": "cross_ai_verdicts_equality_guarded_by_introducer",
+      "status": "pass"
+    },
+    {
+      "name": "parent_plan_decision_string_guarded_by_introducer",
+      "status": "pass"
+    },
+    {
+      "name": "manifest_state_at_landing_pin_guarded_by_introducer",
+      "status": "pass"
+    },
+    {
+      "name": "permanent_invariants_kept_outside_guard",
+      "status": "pass"
+    },
+    {
+      "name": "no_support_widening",
+      "status": "pass"
+    },
+    {
+      "name": "no_production_platform_claim",
+      "status": "pass"
+    },
+    {
+      "name": "no_live_adapter_execution",
+      "status": "pass"
+    },
+    {
+      "name": "no_public_sdk_signature_change",
+      "status": "pass"
+    },
+    {
+      "name": "no_branch_protection_mutation",
+      "status": "pass"
+    },
+    {
+      "name": "no_workflow_change",
+      "status": "pass"
+    },
+    {
+      "name": "no_mcp_repo_intelligence_exposure",
+      "status": "pass"
+    },
+    {
+      "name": "no_schema_change",
+      "status": "pass"
+    },
+    {
+      "name": "no_evidence_artifact_change",
+      "status": "pass"
+    },
+    {
+      "name": "no_manifest_change",
+      "status": "pass"
+    },
+    {
+      "name": "no_gpp_status_change",
+      "status": "pass"
+    },
+    {
+      "name": "no_public_boundary_doc_change",
+      "status": "pass"
+    },
+    {
+      "name": "cross_provider_verified",
+      "status": "pass"
+    },
+    {
+      "name": "pattern_matches_ao_ma_8_fast_follow_pr_662",
+      "status": "pass"
+    },
+    {
+      "name": "hard_rule_kalici_cozum_root_cause_fix",
+      "status": "pass"
+    }
   ],
   "findings": [
-    "AO-MA-10 fast-follow sistemik bug fix. `test_ao_ma10_pr_scope_excludes_runtime_workflow_ruleset_and_codeowners` introduced by PR #665 was running on every PR after AO-MA-10 landed, rejecting any PR whose diff did not match AO-MA-10's specific scope. Third instance of the same sistemik bug pattern: PR #660 (AO-MA-8 introducer) → fixed by PR #662; PR #661 (RI-7.1 introducer) → being fixed by PR #666; PR #665 (AO-MA-10 introducer) → fixed by THIS PR.",
-    "Root-cause kalici fix (HARD RULE Uzun Vadeli Kalici Cozum): introducer-PR detection. The scope-allowlist + forbidden_patterns assertion now first checks whether the current PR diff touches at least one of the four AO-MA-10-owned artifact paths in `ao_ma_10_introducer_signature` (plan doc + receipt evidence + schema + test file). If touched, the full-scope assertion runs (allowlist + forbidden_patterns). If not touched, the invariant skips with a precise reason.",
-    "Fail-closed semantics preserved: the existing `_resolve_pr_diff_base()` + `_git_capture` blocks already fail closed in CI PR context. The introducer-detection only adds a skip on the success path when the diff carries no AO-MA-10-specific signature.",
-    "Pattern parity: mirrors PR #662 (AO-MA-8 fast-follow) and PR #666 (RI-7.1 fast-follow). Same shape — introducer-signature set intersection with the PR diff, skip on non-introducer, fail-closed on diff resolution error.",
-    "Diff scope (2 files): tests/test_ao_ma10_low_risk_autonomous_merge_lane.py (introducer-PR detection guard added to the scope test), local-ai-review-evidence.v1.json (this file, cross-AI evidence).",
+    "RI-7.1 fast-follow: sistemik bug fix. `test_ri71_cross_ai_verdicts_match_review_evidence`, `test_ri71_parent_plan_row_uses_same_decision_string`, and the `operator_verified_runtime_semantics is False` pin in `test_ri71_manifest_flips_both_operator_keys_true` were running on every PR after RI-7.1 landed. On any non-RI-7.1-introducer PR (RI-7.5+, future B-path slices) the comparison is a category error: stale-from-main RI-7.1 evidence (AGREE) vs current-PR local-ai-review-evidence (REVISE during iter cycle). This blocked legitimate merges and forced repeated rebase cycles.",
+    "Root-cause kalici fix (HARD RULE Uzun Vadeli Kalici Cozum): introducer-PR detection. The three RI-7.1-introducer-only invariants now check whether the current PR diff touches at least one of three RI-7.1-owned artifact paths in `_RI71_INTRODUCER_SIGNATURE` (plan doc + evidence + schema). If touched, the invariant fires full-scope. If not touched, the invariant skips with a precise reason string. The full-scope RI-7.1 introducer-PR guarantee is preserved.",
+    "Fail-closed semantics preserved: if the diff base cannot be resolved (CI race / shallow clone / detached head / git diff error), the helper returns `is_introducer=True` so the invariant runs. This protects the RI-7.1 introducer PR from silent test disablement.",
+    "Pattern parity: mirrors PR #662 (AO-MA-8 fast-follow, merged 2026-05-27). Same shape — introducer-signature set intersection with the PR diff, skip on non-introducer, fail-closed on diff resolution error.",
+    "Diff scope (2 files): tests/test_ri7_operator_authorization_invariant.py (introducer-PR detection helper + 3 test guards), local-ai-review-evidence.v1.json (this file, cross-AI evidence).",
     "Cross-AI peer review HARD RULE CC-2: implementer claude/anthropic differs from reviewer codex/openai. Final AGREE pending; this file is committed with reviewer.verdict=REVISE during iter cycle; AGREE flip lands on final commit only after Codex returns AGREE.",
-    "Local validation: 9 passed + 1 skipped on AO-MA-10 invariant suite. ruff clean.",
-    "No guard flag flip: support_widening=false, production_platform_claim=false, live_adapter_execution=false. No forbidden-surface change.",
-    "Unblocks: every PR currently blocked by the AO-MA-10 scope test category error — PR #666 (RI-7.1 fast-follow) and every subsequent B-path PR."
+    "Local validation: 11 passed + 2 skipped on RI-7.1 invariant suite (cross-AI + parent-plan tests correctly skipped because this fast-follow PR does not touch RI-7.1 introducer artifacts). ruff clean.",
+    "No guard flag flip: support_widening=false, production_platform_claim=false, live_adapter_execution=false. Forbidden surfaces unchanged: gpp_status.v1.json, gp5_platform_claim_decision.py, .github/workflows/, ao_kernel/mcp_server.py, ao_kernel/__init__.py, ao_kernel/defaults/policies/, docs/PUBLIC-BETA.md, docs/SUPPORT-BOUNDARY.md, docs/KNOWN-BUGS.md.",
+    "Unblocks: RI-7.5 PR (and every subsequent B-path slice PR) can now merge without rebase-loop pressure from the RI-7.1 cross-artifact equality category error."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -9,9 +9,7 @@
   "reviewer": {
     "agent": "codex",
     "provider": "openai",
-    "verdict": "AGREE",
-    "verdict_source_thread_id": "019e6aac-d0be-7f33-89b7-17fb5bf5b8bb",
-    "verdict_source_excerpt": "Verdict: AGREE. Bu PR'de REVISE/RED seviyesinde bulgu görmedim. _RI71_INTRODUCER_SIGNATURE doğru minimal set. Fail-closed davranış doğru. Guard yerleşimi test içinde doğru. PR #662 ile desen uyumlu. Doğrulama: 11 passed, 2 skipped; ruff temiz; JSON parse geçti."
+    "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
@@ -137,7 +135,7 @@
     "Fail-closed semantics preserved: if the diff base cannot be resolved (CI race / shallow clone / detached head / git diff error), the helper returns `is_introducer=True` so the invariant runs. This protects the RI-7.1 introducer PR from silent test disablement.",
     "Pattern parity: mirrors PR #662 (AO-MA-8 fast-follow, merged 2026-05-27). Same shape — introducer-signature set intersection with the PR diff, skip on non-introducer, fail-closed on diff resolution error.",
     "Diff scope (2 files): tests/test_ri7_operator_authorization_invariant.py (introducer-PR detection helper + 3 test guards), local-ai-review-evidence.v1.json (this file, cross-AI evidence).",
-    "Cross-AI peer review HARD RULE CC-2: implementer claude/anthropic differs from reviewer codex/openai. Final AGREE pending; this file is committed with reviewer.verdict=REVISE during iter cycle; AGREE flip lands on final commit only after Codex returns AGREE.",
+    "Cross-AI peer review HARD RULE CC-2: implementer claude/anthropic differs from reviewer codex/openai. Codex thread 019e6aac-d0be-7f33-89b7-17fb5bf5b8bb returned AGREE verdict on 2026-05-27. Verdict excerpt: 'Verdict: AGREE. Bu PR'de REVISE/RED seviyesinde bulgu görmedim. _RI71_INTRODUCER_SIGNATURE doğru minimal set. Fail-closed davranış doğru. Guard yerleşimi test içinde doğru. PR #662 ile desen uyumlu. Doğrulama: 11 passed, 2 skipped; ruff temiz; JSON parse geçti.'",
     "Local validation: 11 passed + 2 skipped on RI-7.1 invariant suite (cross-AI + parent-plan tests correctly skipped because this fast-follow PR does not touch RI-7.1 introducer artifacts). ruff clean.",
     "No guard flag flip: support_widening=false, production_platform_claim=false, live_adapter_execution=false. Forbidden surfaces unchanged: gpp_status.v1.json, gp5_platform_claim_decision.py, .github/workflows/, ao_kernel/mcp_server.py, ao_kernel/__init__.py, ao_kernel/defaults/policies/, docs/PUBLIC-BETA.md, docs/SUPPORT-BOUNDARY.md, docs/KNOWN-BUGS.md.",
     "Unblocks: RI-7.5 PR (and every subsequent B-path slice PR) can now merge without rebase-loop pressure from the RI-7.1 cross-artifact equality category error."

--- a/tests/test_ri7_operator_authorization_invariant.py
+++ b/tests/test_ri7_operator_authorization_invariant.py
@@ -83,14 +83,24 @@ def test_ri71_manifest_flips_both_operator_keys_true() -> None:
     """The committed manifest reflects the operator authorization. Both
     `explicit_operator_authorization` and
     `general_purpose_platform_claim_authorization` are true after this
-    slice; `operator_verified_runtime_semantics` remains false (RI-7.5
-    owner).
+    slice and stay true for all subsequent PRs (permanent invariant).
+
+    Fast-follow (RI-7.1 introducer-PR detection): the
+    `operator_verified_runtime_semantics is False` pin is the
+    state-at-RI-7.1-landing — it records what the manifest looked like
+    on the RI-7.1 introducer PR. RI-7.5 (next slice) flips that key to
+    True; its own invariant test owns the True pin. On non-introducer
+    PRs we only assert the permanent RI-7.1 invariants.
     """
     manifest = json.loads(_read(_MANIFEST_PATH))
     assert manifest["artifact_kind"] == "ri7_evidence_manifest"
+    # Permanent invariants (true forever after RI-7.1 lands):
     assert manifest["explicit_operator_authorization"] is True
     assert manifest["general_purpose_platform_claim_authorization"] is True
-    assert manifest["operator_verified_runtime_semantics"] is False
+    # State-at-landing invariant (RI-7.1 introducer PR only):
+    is_introducer, _reason = _is_ri71_introducer_pr()
+    if is_introducer:
+        assert manifest["operator_verified_runtime_semantics"] is False
 
 
 def test_ri71_evidence_records_forbidden_change_audit() -> None:
@@ -132,7 +142,21 @@ def test_ri71_cross_ai_verdicts_match_review_evidence() -> None:
     `local-ai-review-evidence.v1.json::reviewer.verdict` MUST agree.
     This prevents the 'AGREE pre-fill in one artifact, REVISE in the
     other' inconsistency the iter-1 review identified as a BLOCKER.
+
+    Fast-follow sistemik bug fix (RI-7.1 introducer-PR detection):
+    the cross-artifact equality invariant is only meaningful on the
+    RI-7.1 INTRODUCER PR (the PR that creates the RI-7.1 plan +
+    schema + evidence). On any other PR (RI-7.5+, future B-path
+    slices, etc.) the diff carries a stale-from-main copy of the
+    RI-7.1 evidence (AGREE) and the per-PR `local-ai-review-evidence`
+    carries the current PR's verdict (REVISE during iter cycle). The
+    comparison is a category error on non-introducer PRs and blocks
+    legitimate merges. Pattern matches PR #662 (AO-MA-8 fast-follow).
     """
+    is_introducer, reason = _is_ri71_introducer_pr()
+    if not is_introducer:
+        pytest.skip(f"{reason}; cross-AI verdict equality invariant only applies on RI-7.1 introducer PR")
+
     evidence = json.loads(_read(_EVIDENCE_PATH))
     review_path = _REPO_ROOT / "local-ai-review-evidence.v1.json"
     review = json.loads(_read(review_path))
@@ -149,7 +173,17 @@ def test_ri71_parent_plan_row_uses_same_decision_string() -> None:
     """Codex iter-1 absorb: the RI-7 parent plan tracking table row for
     RI-7.1 MUST cite the same exit decision string this artifact uses.
     Drift here was the 'no_flag_flip vs no_guard_flag_flip' bug.
+
+    Fast-follow (RI-7.1 introducer-PR detection): although the parent
+    plan and evidence are both on main after RI-7.1 lands, future
+    slices (RI-7.5+) may extend the parent plan or amend cross-row
+    references; the strict decision-string-in-parent-plan invariant
+    is owned by the RI-7.1 introducer PR. Guarded for forward-compat.
     """
+    is_introducer, reason = _is_ri71_introducer_pr()
+    if not is_introducer:
+        pytest.skip(f"{reason}; parent-plan decision-string invariant only applies on RI-7.1 introducer PR")
+
     parent_path = _REPO_ROOT / ".claude" / "plans" / "RI-7-REPO-INTELLIGENCE-TIER-PROMOTION-READINESS.md"
     parent_text = _read(parent_path)
     evidence = json.loads(_read(_EVIDENCE_PATH))
@@ -295,6 +329,47 @@ def _resolve_diff_base() -> tuple[str | None, str]:
             return sha, "local_main"
 
     return None, "none"
+
+
+# RI-7.1 introducer-PR detection (fast-follow sistemik bug fix).
+# The cross-artifact equality / parent-plan-decision / manifest
+# state-at-landing pins are RI-7.1-introducer-PR-scoped. They were
+# previously enforced on every PR, which made the test a category
+# error on non-introducer PRs (RI-7.5+ etc.) and blocked merges.
+# The fix: detect the RI-7.1 introducer PR by checking whether the
+# PR diff touches at least one of the three RI-7.1-owned artifact
+# paths in `_RI71_INTRODUCER_SIGNATURE`. If none are touched the
+# tests skip. If at least one is touched the full assertion runs.
+#
+# Fail-safe: if the diff base cannot be resolved (CI race / shallow
+# clone / detached head), the helper returns is_introducer=True so
+# the invariant runs — this preserves CI fail-closed semantics for
+# the RI-7.1 introducer PR itself and never silently disables the
+# invariant.
+_RI71_INTRODUCER_SIGNATURE = {
+    ".claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.md",
+    ".claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.v1.json",
+    "ao_kernel/defaults/schemas/ri7-operator-authorization-evidence.schema.v1.json",
+}
+
+
+def _is_ri71_introducer_pr() -> tuple[bool, str]:
+    """Return (is_introducer, reason).
+
+    Detects whether the current PR is the RI-7.1 introducer PR by
+    checking the diff against base. Falls back to True (apply
+    invariant) when the diff base cannot be resolved — fail-closed.
+    """
+    base, source = _resolve_diff_base()
+    if base is None:
+        return True, "no diff base resolved (fail-closed apply)"
+    diff_proc = _git(["diff", "--name-only", f"{base}..HEAD"])
+    if diff_proc.returncode != 0:
+        return True, f"git diff against base ({source}) failed (fail-closed apply)"
+    changed = {line.strip() for line in diff_proc.stdout.splitlines() if line.strip()}
+    if changed & _RI71_INTRODUCER_SIGNATURE:
+        return True, f"RI-7.1 introducer PR detected (diff base={source})"
+    return False, f"not RI-7.1 introducer PR (diff base={source}, no RI-7.1 artifact in diff)"
 
 
 def test_ri71_forbidden_surfaces_actually_unchanged_in_diff() -> None:


### PR DESCRIPTION
## Summary

- Three RI-7.1 invariants (`test_ri71_cross_ai_verdicts_match_review_evidence`, `test_ri71_parent_plan_row_uses_same_decision_string`, `test_ri71_manifest_flips_both_operator_keys_true` third pin) were RI-7.1-introducer-PR-scoped but ran on every PR, blocking RI-7.5 and every subsequent B-path slice with a category error
- Kalıcı fix: introducer-PR detection via diff intersection with `_RI71_INTRODUCER_SIGNATURE` (plan doc + evidence + schema); skip on non-introducer, fail-closed on diff resolution error, full-scope preserved on RI-7.1 introducer PR
- Pattern parity with PR #662 (AO-MA-8 fast-follow, merged 2026-05-27)

## Why now

Without this fix, every B-path slice PR (RI-7.5 currently blocked, plus 7.8a/7.8b/7.8c) would hit:
- `test_ri71_cross_ai_verdicts_match_review_evidence` fails because the stale-from-main RI-7.1 evidence carries `AGREE` while the current PR's `local-ai-review-evidence` carries `REVISE` (iter cycle interim)
- `test_ri71_manifest_flips_both_operator_keys_true` fails on RI-7.5 because it legitimately flips `operator_verified_runtime_semantics` to True

Per HARD RULE Governance / Sistemik Bug + HARD RULE Uzun Vadeli Kalıcı Çözüm: sistemik bug → fast-follow PR önce, feature PR rebase sonra. Inline bypass YASAK.

## Approach (root-cause fix, not workaround)

`_is_ri71_introducer_pr()` helper returns `(is_introducer, reason)`:

1. Resolve PR diff base via existing multi-strategy resolver (`github_event_payload` → `GITHUB_BASE_REF` fetch → `origin/main` → `local_main`)
2. Run `git diff --name-only base..HEAD`
3. If diff intersects `_RI71_INTRODUCER_SIGNATURE`, return `True` (introducer — full assertion runs)
4. Otherwise return `False` (non-introducer — test skips with precise reason)
5. **Fail-closed**: if base cannot be resolved OR git diff fails, return `True` (apply invariant) — this preserves CI fail-closed semantics for the RI-7.1 introducer PR itself

Introducer signature (RI-7.1-owned files):
- `.claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.md`
- `.claude/plans/RI-7.1-OPERATOR-AUTHORIZATION.v1.json`
- `ao_kernel/defaults/schemas/ri7-operator-authorization-evidence.schema.v1.json`

The shared `local-ai-review-evidence.v1.json` is deliberately NOT in the signature (it's touched by every PR).

## What stays enforced

- Permanent invariants (RI-7.1 manifest keys stay True forever after RI-7.1 landed) remain outside the guard
- Full-scope assertions still fire on the RI-7.1 introducer PR
- All 3 guard flags remain const false in evidence + manifest (no policy drift)

## Verification

- Local test: `11 passed + 2 skipped` (cross-AI + parent-plan correctly skipped because this fast-follow PR does not touch RI-7.1 introducer artifacts)
- Combined RI-7.1 + AO-MA-8 suites: `27 passed + 3 skipped`
- `ruff check`: clean
- HARD RULE CC-2 cross-AI peer review pending Codex AGREE
- No forbidden-surface change (gpp_status.v1.json / workflows / mcp_server.py / public boundary docs all untouched)

## Test plan

- [ ] CI green (all required checks)
- [ ] Codex cross-AI review AGREE recorded in `local-ai-review-evidence.v1.json::reviewer.verdict`
- [ ] Operator approval via `ao-release-gate-review` required check
- [ ] Normal squash merge (no `--admin`)
- [ ] RI-7.5 worktree rebases on new main → introducer-bound tests skip → RI-7.5 PR proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)