### PR TITLE
docs(ao-ma-10o): authorize constrained no-human bootstrap

### DIFF
--- a/.claude/plans/AO-MA-10O-CC9-NO-HUMAN-BOOTSTRAP-SUPERSESSION.md
+++ b/.claude/plans/AO-MA-10O-CC9-NO-HUMAN-BOOTSTRAP-SUPERSESSION.md
@@ -1,0 +1,155 @@
+# AO-MA-10O - CC-9 No-Human Bootstrap Supersession
+
+**Status:** proposed / inactive until merged
+**Date:** 2026-05-28
+**Tracker:** https://github.com/Halildeu/ao-kernel/issues/683
+**Depends on:** PR #682 and PR #684 landing first
+**Supersedes:** `PROGRAM-CHANGE-CONTROL.md` CC-9, narrowly and only for
+AO-MA-10 live autonomous merge enforcement cutover
+**Support impact:** none
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## Purpose
+
+AO-MA-10O removes the last human-only bootstrap dependency from the autonomous
+merge lane plan without weakening release authority.
+
+The current CC-9 rule says branch ruleset and branch-protection mutation is
+operator-only. That is safe as a default, but it prevents the project from
+reaching the user-requested end state:
+
+```text
+low-risk PR -> repo-owned checks -> agent normal merge -> no human approval
+```
+
+This supersession authorizes exactly one constrained no-human bootstrap path so
+the repository can install the live enforcement model itself.
+
+## Authority Model
+
+AI output remains evidence, not release authority.
+
+Release authority after cutover is still:
+
+```text
+ao-release-gate-technical + ao-release-gate-review + GitHub enforcement
+```
+
+The bootstrap agent is not a release authority. It is a narrow settings
+executor that may apply only the exact live GitHub configuration described in
+this record.
+
+## Activation Preconditions
+
+The no-human bootstrap path is inactive unless all of the following are true:
+
+1. PR #682 is merged.
+2. PR #684 is merged.
+3. This AO-MA-10O supersession PR is merged.
+4. `main` is clean and synced to `origin/main`.
+5. `python3 scripts/gpp_next.py` still reports:
+   - `support_widening_allowed: false`
+   - `production_platform_claim_allowed: false`
+   - `live_adapter_execution_allowed: false`
+6. A read-only pre-change snapshot is collected by
+   `scripts/ao_ma10_github_readiness_snapshot.py`.
+7. The bootstrap script runs in dry-run mode and produces the expected plan
+   before any `--apply`; the same dry-run plan must be passed back through
+   `--accepted-dry-run-plan`.
+
+## Allowed Mutation Surface
+
+Only `scripts/ao_ma10o_no_human_bootstrap.py --apply` may perform the
+superseded CC-9 mutation, and only for repository `Halildeu/ao-kernel`.
+
+The script may call GitHub write APIs only for:
+
+1. ruleset `16803733` on the default branch:
+   - preserve `deletion`
+   - preserve `non_fast_forward`
+   - preserve `bypass_actors=[]`
+   - require `ao-release-gate-technical` with `integration_id=15368`
+   - require `ao-release-gate-review` with `integration_id=15368`
+2. Classic branch protection on `main`:
+   - remove `required_pull_request_reviews`
+   - preserve classic required status checks:
+     - `lint`
+     - `test (3.11)`
+     - `test (3.12)`
+     - `test (3.13)`
+     - `coverage`
+     - `typecheck`
+     - `packaging-smoke`
+   - preserve `enforce_admins=true`
+
+The script must refuse to run when:
+
+- the repository differs from `Halildeu/ao-kernel`;
+- the branch differs from `main`;
+- the working tree is not clean `main` synced with `origin/main`;
+- PR #682 or PR #684 is not merged;
+- the AO-MA-10O supersession is not present on synced `main`;
+- `gpp_next.py` does not keep all three guard flags false;
+- `--apply` does not include `--accepted-dry-run-plan`;
+- the ruleset id differs from `16803733`;
+- the ruleset does not target `main` or `~DEFAULT_BRANCH`;
+- the current ruleset has non-empty `bypass_actors`;
+- either release-authority check cannot be source-pinned to integration id
+  `15368`;
+- the classic CI checks are absent from branch protection;
+- the operator attempts to add any bypass actor;
+- the operator attempts to remove classic CI requirements;
+- the operator attempts to set support widening, production platform claim, or
+  live adapter execution.
+
+## Required Evidence
+
+The bootstrap script must emit and retain:
+
+1. pre-change readiness snapshot;
+2. dry-run mutation plan passed back through `--accepted-dry-run-plan`;
+3. exact ruleset patch payload;
+4. exact branch-protection review removal intent;
+5. post-change readiness snapshot;
+6. diff of the two snapshots;
+7. statement that `bypass_actors=[]`;
+8. statement that no `--admin` merge or bypass actor was used.
+
+## Post-Bootstrap Smoke
+
+After the settings cutover:
+
+1. Create a disposable low-risk PR and prove it merges without native human
+   review.
+2. Create a high-risk positive PR and prove valid OpenAI + Anthropic evidence
+   makes `ao-release-gate-review` pass.
+3. Create a high-risk negative PR and prove missing/stale/REVISE/same-provider
+   evidence fails closed.
+4. Record AO-MA-10m activation evidence with PR URLs, check-run URLs, merge
+   actor, and before/after snapshots.
+
+## Hard Stops
+
+- No mutation before PR #682, PR #684, and this supersession are merged.
+- No `--admin` merge.
+- No ruleset bypass actors.
+- No removal of classic CI requirements.
+- No support widening.
+- No production platform claim.
+- No live adapter execution.
+- No testai/smee/deployment-protection callback dependency.
+- No treating Claude, Codex, MiniMax, or any model output as release authority.
+
+## Exit Criteria
+
+AO-MA-10O is complete when:
+
+1. this supersession is merged;
+2. `scripts/ao_ma10o_no_human_bootstrap.py --dry-run` passes from `main`;
+3. the script applies the cutover once with `--apply`;
+4. post-change snapshot proves both release-authority checks are required and
+   source-pinned;
+5. low-risk direct merge smoke succeeds with no human approval;
+6. high-risk positive and negative smoke are recorded;
+7. issue #683 is updated with final activation evidence.

--- a/.claude/plans/PROGRAM-CHANGE-CONTROL.md
+++ b/.claude/plans/PROGRAM-CHANGE-CONTROL.md
@@ -64,6 +64,32 @@ program evolves and what is forbidden.
 - **Why:** Avoid silent schema drift; preserve replay-ability of historical artifacts.
 - **Evidence:** Drift-guard test pins `schema_version == "1"` and the required-keys list.
 
+#### AO-MA-10O narrow supersession for CC-9
+
+CC-9 remains the default rule. It is superseded only for the AO-MA-10O
+no-human bootstrap path recorded in
+`.claude/plans/AO-MA-10O-CC9-NO-HUMAN-BOOTSTRAP-SUPERSESSION.md`.
+
+After PR #682, PR #684, and the AO-MA-10O supersession PR are merged, a
+constrained agent may call GitHub write APIs only through
+`scripts/ao_ma10o_no_human_bootstrap.py --apply`, and only to:
+
+1. update ruleset `16803733` for `Halildeu/ao-kernel` so
+   `ao-release-gate-technical` and `ao-release-gate-review` are required and
+   source-pinned to GitHub Actions integration id `15368`;
+2. keep ruleset `bypass_actors=[]`;
+3. preserve `deletion` and `non_fast_forward` rules;
+4. remove only the native `required_pull_request_reviews` branch-protection
+   gate from `main`;
+5. preserve the classic CI required checks (`lint`, `test (3.11)`,
+   `test (3.12)`, `test (3.13)`, `coverage`, `typecheck`,
+   `packaging-smoke`) and `enforce_admins=true`.
+
+The supersession does not authorize `--admin` merge, bypass actors, removal of
+classic CI, support widening, production platform claims, live adapter
+execution, testai/smee/deployment-protection reactivation, or treating AI
+output as release authority.
+
 ### CC-9 — Branch ruleset mutation is operator-only
 
 - **Rule:** GitHub branch rulesets (ID `16803733` "Protect main" and any future ruleset) are changed only by the repo owner / admin through the GitHub UI. Agents are forbidden from calling `gh api` against `repos/<repo>/rulesets/*` or `repos/<repo>/branches/main/protection`.

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -1,27 +1,4 @@
 {
-  "schema_version": "local-ai-review-evidence.v1",
-  "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10N-live-enforcement-cutover",
-  "implementer": {
-    "agent": "codex",
-    "provider": "openai"
-  },
-  "reviewer": {
-    "agent": "claude-cli",
-    "provider": "anthropic",
-    "verdict": "AGREE"
-  },
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-10n-live-enforcement-cutover",
-    "changed_files": [
-      ".claude/plans/AO-MA-10N-LIVE-ENFORCEMENT-CUTOVER.md",
-      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "local-ai-review-evidence.v1.json",
-      "tests/test_ao_ma10n_live_enforcement_cutover.py"
-    ]
-  },
   "checks_considered": [
     {
       "name": "tests",
@@ -30,18 +7,61 @@
     {
       "name": "secret_scan",
       "status": "pass"
+    },
+    {
+      "name": "ruff",
+      "status": "pass"
+    },
+    {
+      "name": "git_diff_check",
+      "status": "pass"
+    },
+    {
+      "name": "dry_run_plan",
+      "status": "pass"
+    },
+    {
+      "name": "release_gate_payload_repro",
+      "status": "pass"
     }
   ],
   "findings": [
-    "The runbook preserves guard flags and repeats no support widening, no production claim, and no live adapter execution.",
-    "The CC-9 gap is exposed honestly with operator-bootstrap and full no-human bootstrap modes.",
-    "The PR does not mutate GitHub settings and only records pre-cutover steps plus invariant tests.",
-    "The legacy ao-release-gate wrapper is correctly distinguished from the dual required-check authority set.",
-    "Classic CI requirements are preserved, and bypass_actors=[] remains explicit.",
-    "The tests pin the critical runbook contract and provide sufficient doc-invariant coverage."
+    "Anthropic reviewer verdict is AGREE after the final test-only confirmation hardening.",
+    "The supersession is hard-bound to one repo, branch, ruleset id, and release-check pair, and CC-9 remains the default rule outside AO-MA-10O.",
+    "The script fails closed on dirty or diverged main, unmerged dependency PRs, GPP guard flag drift, accepted dry-run mismatch, non-main ruleset targeting, missing snapshots, and missing CLI or env confirmation.",
+    "The mutation surface is limited to adding source-pinned ao-release-gate required checks and deleting native required_pull_request_reviews while preserving classic CI, enforce_admins=true, and bypass_actors=[].",
+    "Anthropic reviewer re-checked the release-gate payload builder follow-up and agreed that non-skipped failure/cancelled/timed_out check-runs are not masked while skipped-only required checks remain fail-closed.",
+    "The change does not authorize support widening, production platform claim, live adapter execution, testai/smee reactivation, admin merge, bypass actors, or AI output as release authority."
   ],
-  "secrets_recorded": false,
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
   "live_adapter_execution": false,
+  "production_platform_claim": false,
+  "repo": "Halildeu/ao-kernel",
+  "reviewer": {
+    "agent": "claude-cli",
+    "provider": "anthropic",
+    "verdict": "AGREE"
+  },
+  "schema_version": "local-ai-review-evidence.v1",
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "changed_files": [
+      ".claude/plans/AO-MA-10O-CC9-NO-HUMAN-BOOTSTRAP-SUPERSESSION.md",
+      ".claude/plans/PROGRAM-CHANGE-CONTROL.md",
+      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
+      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "scripts/ao_release_gate_build_payload.py",
+      "scripts/ao_ma10o_no_human_bootstrap.py",
+      "tests/test_ao_release_gate_build_payload.py",
+      "tests/test_ao_ma10o_cc9_no_human_bootstrap_supersession.py"
+    ],
+    "head_ref": "refs/heads/codex/ao-ma-10o-cc9-no-human-bootstrap"
+  },
+  "secrets_recorded": false,
   "support_widening": false,
-  "production_platform_claim": false
+  "work_package": "AO-MA-10O-cc9-no-human-bootstrap"
 }

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -1,27 +1,4 @@
 {
-  "schema_version": "local-ai-review-evidence.v1",
-  "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10N-live-enforcement-cutover",
-  "implementer": {
-    "agent": "codex",
-    "provider": "openai"
-  },
-  "reviewer": {
-    "agent": "codex-subagent-nash",
-    "provider": "openai",
-    "verdict": "AGREE"
-  },
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-10n-live-enforcement-cutover",
-    "changed_files": [
-      ".claude/plans/AO-MA-10N-LIVE-ENFORCEMENT-CUTOVER.md",
-      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "local-ai-review-evidence.v1.json",
-      "tests/test_ao_ma10n_live_enforcement_cutover.py"
-    ]
-  },
   "checks_considered": [
     {
       "name": "tests",
@@ -30,18 +7,60 @@
     {
       "name": "secret_scan",
       "status": "pass"
+    },
+    {
+      "name": "ruff",
+      "status": "pass"
+    },
+    {
+      "name": "git_diff_check",
+      "status": "pass"
+    },
+    {
+      "name": "dry_run_plan",
+      "status": "pass"
+    },
+    {
+      "name": "release_gate_payload_repro",
+      "status": "pass"
     }
   ],
   "findings": [
-    "The AO-MA-10N runbook advances autonomous merge readiness by making the live enforcement cutover executable and auditable.",
-    "The change does not mutate GitHub settings, workflows, CODEOWNERS, branch protection, or rulesets.",
-    "The CC-9 operator-only mutation gap is called out explicitly instead of being bypassed.",
-    "Guard boundaries remain closed: no support widening, no production claim, and no live adapter execution.",
-    "The document keeps testai, smee, and deployment-protection callback out of the active blocker path.",
-    "The invariant tests pin the issue tracker, PR #682 dependency, dual required checks, source pinning, hard stops, and smoke requirements."
+    "OpenAI reviewer verdict is AGREE after two REVISE rounds were absorbed.",
+    "Apply preconditions now enforce clean synced main, merged dependency PRs, false GPP guard flags, accepted dry-run plan matching, and main/default branch ruleset targeting.",
+    "Tests now pin fail-closed behavior for non-main, dirty, diverged, unmerged dependency PR, PR read failure, missing or true guard flags, dry-run mismatch, and confirmation refusal cases.",
+    "Release-gate payload builder follow-up ignores later skipped duplicate check-runs only when a non-skipped required check-run exists for the same name; skipped-only required checks remain blocked.",
+    "Hard stops remain preserved: no admin merge, no bypass actors, no classic CI removal, no support widening, no production platform claim, no live adapter execution, and no AI output as release authority."
   ],
-  "secrets_recorded": false,
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
   "live_adapter_execution": false,
+  "production_platform_claim": false,
+  "repo": "Halildeu/ao-kernel",
+  "reviewer": {
+    "agent": "nash-subagent",
+    "provider": "openai",
+    "verdict": "AGREE"
+  },
+  "schema_version": "local-ai-review-evidence.v1",
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "changed_files": [
+      ".claude/plans/AO-MA-10O-CC9-NO-HUMAN-BOOTSTRAP-SUPERSESSION.md",
+      ".claude/plans/PROGRAM-CHANGE-CONTROL.md",
+      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
+      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "scripts/ao_release_gate_build_payload.py",
+      "scripts/ao_ma10o_no_human_bootstrap.py",
+      "tests/test_ao_release_gate_build_payload.py",
+      "tests/test_ao_ma10o_cc9_no_human_bootstrap_supersession.py"
+    ],
+    "head_ref": "refs/heads/codex/ao-ma-10o-cc9-no-human-bootstrap"
+  },
+  "secrets_recorded": false,
   "support_widening": false,
-  "production_platform_claim": false
+  "work_package": "AO-MA-10O-cc9-no-human-bootstrap"
 }

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,27 +1,4 @@
 {
-  "schema_version": "local-ai-review-evidence.v1",
-  "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10N-live-enforcement-cutover",
-  "implementer": {
-    "agent": "codex",
-    "provider": "openai"
-  },
-  "reviewer": {
-    "agent": "claude-cli",
-    "provider": "anthropic",
-    "verdict": "AGREE"
-  },
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-10n-live-enforcement-cutover",
-    "changed_files": [
-      ".claude/plans/AO-MA-10N-LIVE-ENFORCEMENT-CUTOVER.md",
-      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "tests/test_ao_ma10n_live_enforcement_cutover.py",
-      "local-ai-review-evidence.v1.json"
-    ]
-  },
   "checks_considered": [
     {
       "name": "tests",
@@ -30,18 +7,71 @@
     {
       "name": "secret_scan",
       "status": "pass"
+    },
+    {
+      "name": "ruff",
+      "status": "pass"
+    },
+    {
+      "name": "git_diff_check",
+      "status": "pass"
+    },
+    {
+      "name": "dry_run_plan",
+      "status": "pass"
+    },
+    {
+      "name": "openai_review",
+      "status": "pass"
+    },
+    {
+      "name": "anthropic_review",
+      "status": "pass"
+    },
+    {
+      "name": "release_gate_payload_repro",
+      "status": "pass"
     }
   ],
   "findings": [
-    "The plan advances autonomous merge readiness without mutating GitHub settings in this PR.",
-    "CC-9 operator-only branch-setting mutation is exposed as a full-autonomy gap rather than bypassed.",
-    "Dual release-authority checks ao-release-gate-technical and ao-release-gate-review are required with integration_id 15368.",
-    "Classic CI requirements and bypass_actors=[] are preserved as explicit acceptance requirements.",
-    "Hard stops preserve no admin bypass, no support widening, no production claim, no live adapter execution, and no testai dependency.",
-    "Doc invariant tests pin the tracker, PR #682 dependency, dual-check source pinning, CC-9 gap, and positive/negative smoke requirements."
+    "AO-MA-10O is a narrow CC-9 supersession for one constrained no-human bootstrap path, not a general branch-protection mutation permission.",
+    "The script is hard-bound to Halildeu/ao-kernel main, ruleset 16803733, GitHub Actions integration id 15368, ao-release-gate-technical, and ao-release-gate-review.",
+    "Apply mode fails closed unless main is clean and synced, PR #682 and PR #684 are merged, GPP guard flags remain false, and the accepted dry-run plan matches the current plan.",
+    "The emitted ruleset patch preserves deletion and non_fast_forward, keeps bypass_actors empty, and adds only source-pinned ao-release-gate required checks.",
+    "The branch-protection mutation removes only native required_pull_request_reviews while preserving classic CI required checks and enforce_admins=true.",
+    "The release-gate payload builder now ignores later skipped duplicate check-runs only when a non-skipped run for the same required check exists; skipped-only required checks remain fail-closed.",
+    "No support widening, production platform claim, live adapter execution, testai/smee dependency, admin merge, bypass actor, or AI-output-as-release-authority is authorized.",
+    "OpenAI and Anthropic independent reviews returned AGREE after REVISE findings and the release-gate duplicate-check-run CI fix were absorbed; final local tests, ruff, git diff check, dry-run plan, and live check-runs payload reproduction all passed."
   ],
-  "secrets_recorded": false,
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
   "live_adapter_execution": false,
+  "production_platform_claim": false,
+  "repo": "Halildeu/ao-kernel",
+  "reviewer": {
+    "agent": "claude-cli",
+    "provider": "anthropic",
+    "verdict": "AGREE"
+  },
+  "schema_version": "local-ai-review-evidence.v1",
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "changed_files": [
+      ".claude/plans/AO-MA-10O-CC9-NO-HUMAN-BOOTSTRAP-SUPERSESSION.md",
+      ".claude/plans/PROGRAM-CHANGE-CONTROL.md",
+      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
+      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "scripts/ao_release_gate_build_payload.py",
+      "scripts/ao_ma10o_no_human_bootstrap.py",
+      "tests/test_ao_release_gate_build_payload.py",
+      "tests/test_ao_ma10o_cc9_no_human_bootstrap_supersession.py"
+    ],
+    "head_ref": "refs/heads/codex/ao-ma-10o-cc9-no-human-bootstrap"
+  },
+  "secrets_recorded": false,
   "support_widening": false,
-  "production_platform_claim": false
+  "work_package": "AO-MA-10O-cc9-no-human-bootstrap"
 }

--- a/scripts/ao_ma10o_no_human_bootstrap.py
+++ b/scripts/ao_ma10o_no_human_bootstrap.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""AO-MA-10O constrained no-human GitHub enforcement bootstrap.
+
+Dry-run is the default. ``--apply`` is intentionally guarded and may only be
+used after PR #682, PR #684, and the AO-MA-10O supersession PR have landed.
+
+The script is narrow by construction: it can only prepare the AO-MA-10 live
+autonomous merge enforcement cutover for Halildeu/ao-kernel main.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY = "Halildeu/ao-kernel"
+BRANCH = "main"
+RULESET_ID = 16803733
+GITHUB_ACTIONS_INTEGRATION_ID = 15368
+TECHNICAL_CHECK = "ao-release-gate-technical"
+REVIEW_CHECK = "ao-release-gate-review"
+CLASSIC_CI_CHECKS = (
+    "lint",
+    "test (3.11)",
+    "test (3.12)",
+    "test (3.13)",
+    "coverage",
+    "typecheck",
+    "packaging-smoke",
+)
+PRESERVED_RULE_TYPES = ("deletion", "non_fast_forward")
+APPLY_CONFIRMATION = "AO-MA-10O-CC9-SUPERSESSION-APPLY"
+ROOT = Path(__file__).resolve().parents[1]
+DEPENDENCY_PRS = (682, 684)
+SUPERSESSION_DOC = ROOT / ".claude/plans/AO-MA-10O-CC9-NO-HUMAN-BOOTSTRAP-SUPERSESSION.md"
+SUPERSESSION_MARKER = "AO-MA-10O - CC-9 No-Human Bootstrap Supersession"
+
+
+class BootstrapRefusal(RuntimeError):
+    """Raised when the requested bootstrap would exceed the supersession."""
+
+
+@dataclass(frozen=True)
+class BootstrapPlan:
+    repository: str
+    branch: str
+    ruleset_id: int
+    ruleset_patch: dict[str, Any]
+    branch_review_mutation: dict[str, Any]
+    hard_stops: list[str]
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "schema_version": "ao-ma-10o-no-human-bootstrap-plan.v1",
+            "artifact_kind": "ao_ma_10o_no_human_bootstrap_plan",
+            "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "repository": self.repository,
+            "branch": self.branch,
+            "ruleset_id": self.ruleset_id,
+            "release_authority": "ao-release-gate+github-ruleset",
+            "ai_output_release_authority": False,
+            "support_widening": False,
+            "production_platform_claim": False,
+            "live_adapter_execution": False,
+            "ruleset_patch": self.ruleset_patch,
+            "branch_review_mutation": self.branch_review_mutation,
+            "hard_stops": self.hard_stops,
+            "apply_requires_pre_and_post_readiness_snapshots": True,
+        }
+
+
+def _run_json(command: list[str], *, timeout: int = 30) -> dict[str, Any]:
+    proc = subprocess.run(command, capture_output=True, text=True, timeout=timeout)
+    if proc.returncode != 0:
+        raise BootstrapRefusal(f"command failed: {' '.join(command)}")
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise BootstrapRefusal(f"command returned invalid json: {' '.join(command)}") from exc
+    if not isinstance(data, dict):
+        raise BootstrapRefusal(f"command returned non-object json: {' '.join(command)}")
+    return data
+
+
+def _run_text(command: list[str], *, timeout: int = 30) -> str:
+    proc = subprocess.run(command, capture_output=True, text=True, timeout=timeout, cwd=ROOT)
+    if proc.returncode != 0:
+        raise BootstrapRefusal(f"command failed: {' '.join(command)}")
+    return proc.stdout.strip()
+
+
+def _gh_api_json(gh_bin: str, path: str) -> dict[str, Any]:
+    return _run_json([gh_bin, "api", path])
+
+
+def _gh_pr_json(gh_bin: str, number: int) -> dict[str, Any]:
+    return _run_json([gh_bin, "pr", "view", str(number), "--repo", REPOSITORY, "--json", "state,headRefOid"])
+
+
+def _required_status_rule() -> dict[str, Any]:
+    return {
+        "type": "required_status_checks",
+        "parameters": {
+            "strict_required_status_checks_policy": True,
+            "required_status_checks": [
+                {"context": TECHNICAL_CHECK, "integration_id": GITHUB_ACTIONS_INTEGRATION_ID},
+                {"context": REVIEW_CHECK, "integration_id": GITHUB_ACTIONS_INTEGRATION_ID},
+            ],
+        },
+    }
+
+
+def _preserved_rules(current_rules: list[Any]) -> list[dict[str, Any]]:
+    preserved: dict[str, dict[str, Any]] = {}
+    for item in current_rules:
+        if not isinstance(item, dict):
+            continue
+        rule_type = item.get("type")
+        if rule_type in PRESERVED_RULE_TYPES:
+            preserved[str(rule_type)] = {"type": str(rule_type)}
+    missing = [rule for rule in PRESERVED_RULE_TYPES if rule not in preserved]
+    if missing:
+        raise BootstrapRefusal(f"ruleset is missing preserved rule types: {', '.join(missing)}")
+    return [preserved[rule_type] for rule_type in PRESERVED_RULE_TYPES]
+
+
+def _ruleset_targets_main(ruleset: dict[str, Any]) -> bool:
+    conditions = ruleset.get("conditions")
+    if not isinstance(conditions, dict):
+        return False
+    ref_name = conditions.get("ref_name")
+    if not isinstance(ref_name, dict):
+        return False
+    include = ref_name.get("include")
+    exclude = ref_name.get("exclude")
+    include_values = include if isinstance(include, list) else []
+    exclude_values = exclude if isinstance(exclude, list) else []
+    accepted = {"~DEFAULT_BRANCH", "refs/heads/main", "main"}
+    if any(item in exclude_values for item in accepted):
+        return False
+    return any(item in include_values for item in accepted)
+
+
+def _branch_required_checks(branch_protection: dict[str, Any]) -> set[str]:
+    checks = set()
+    status_checks = branch_protection.get("required_status_checks")
+    if not isinstance(status_checks, dict):
+        return checks
+    for context in status_checks.get("contexts") or []:
+        if isinstance(context, str):
+            checks.add(context)
+    for item in status_checks.get("checks") or []:
+        if isinstance(item, dict) and isinstance(item.get("context"), str):
+            checks.add(item["context"])
+    return checks
+
+
+def build_plan(*, ruleset: dict[str, Any], branch_protection: dict[str, Any]) -> BootstrapPlan:
+    if ruleset.get("id") != RULESET_ID:
+        raise BootstrapRefusal("unexpected ruleset id")
+    if ruleset.get("target") != "branch":
+        raise BootstrapRefusal("ruleset target is not branch")
+    if ruleset.get("enforcement") != "active":
+        raise BootstrapRefusal("ruleset enforcement is not active")
+    if not _ruleset_targets_main(ruleset):
+        raise BootstrapRefusal("ruleset does not target main or default branch")
+    if ruleset.get("bypass_actors") not in ([], None):
+        raise BootstrapRefusal("ruleset bypass_actors must be empty")
+
+    existing_rules = ruleset.get("rules")
+    if not isinstance(existing_rules, list):
+        raise BootstrapRefusal("ruleset rules must be a list")
+
+    branch_checks = _branch_required_checks(branch_protection)
+    missing_classic = [check for check in CLASSIC_CI_CHECKS if check not in branch_checks]
+    if missing_classic:
+        raise BootstrapRefusal(f"classic CI checks missing from branch protection: {', '.join(missing_classic)}")
+
+    enforce_admins = branch_protection.get("enforce_admins")
+    if not isinstance(enforce_admins, dict) or enforce_admins.get("enabled") is not True:
+        raise BootstrapRefusal("branch protection enforce_admins=true must be preserved")
+
+    rules = [*_preserved_rules(existing_rules), _required_status_rule()]
+    ruleset_patch = {
+        "name": ruleset.get("name") or "Protect main",
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": ruleset.get("conditions") or {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+        "rules": rules,
+    }
+    return BootstrapPlan(
+        repository=REPOSITORY,
+        branch=BRANCH,
+        ruleset_id=RULESET_ID,
+        ruleset_patch=ruleset_patch,
+        branch_review_mutation={
+            "method": "DELETE",
+            "path": f"repos/{REPOSITORY}/branches/{BRANCH}/protection/required_pull_request_reviews",
+            "purpose": "remove native human review gate after ao-release-gate-review becomes the high-risk authority",
+            "preserve_enforce_admins": True,
+            "preserve_classic_ci_checks": list(CLASSIC_CI_CHECKS),
+        },
+        hard_stops=[
+            "no_admin_bypass",
+            "no_ruleset_bypass_actors",
+            "no_classic_ci_removal",
+            "no_support_widening",
+            "no_production_platform_claim",
+            "no_live_adapter_execution",
+            "no_testai_smee_dependency",
+            "ai_output_is_evidence_not_release_authority",
+        ],
+    )
+
+
+def collect_plan(gh_bin: str) -> BootstrapPlan:
+    ruleset = _gh_api_json(gh_bin, f"repos/{REPOSITORY}/rulesets/{RULESET_ID}")
+    protection = _gh_api_json(gh_bin, f"repos/{REPOSITORY}/branches/{BRANCH}/protection")
+    return build_plan(ruleset=ruleset, branch_protection=protection)
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def assert_clean_synced_main() -> None:
+    branch = _run_text(["git", "branch", "--show-current"])
+    if branch != BRANCH:
+        raise BootstrapRefusal("apply must run from main")
+    status = _run_text(["git", "status", "--short"])
+    if status:
+        raise BootstrapRefusal("apply requires a clean working tree")
+    divergence = _run_text(["git", "rev-list", "--left-right", "--count", "HEAD...origin/main"])
+    if divergence.replace("\t", " ") != "0 0":
+        raise BootstrapRefusal("main must be synced with origin/main")
+
+
+def assert_gpp_guard_flags_false() -> None:
+    output = _run_text([sys.executable, "scripts/gpp_next.py"], timeout=60)
+    required = (
+        "Support widening allowed: false",
+        "Production platform claim allowed: false",
+        "Live adapter execution allowed: false",
+    )
+    if any(line not in output for line in required):
+        raise BootstrapRefusal("gpp guard flags are not all false")
+
+
+def assert_dependency_prs_merged(gh_bin: str) -> None:
+    for number in DEPENDENCY_PRS:
+        payload = _gh_pr_json(gh_bin, number)
+        if payload.get("state") != "MERGED":
+            raise BootstrapRefusal(f"dependency PR #{number} is not merged")
+
+
+def assert_supersession_present() -> None:
+    if not SUPERSESSION_DOC.exists():
+        raise BootstrapRefusal("AO-MA-10O supersession document is missing")
+    text = SUPERSESSION_DOC.read_text(encoding="utf-8")
+    if SUPERSESSION_MARKER not in text:
+        raise BootstrapRefusal("AO-MA-10O supersession document marker is missing")
+
+
+def assert_accepted_dry_run_plan_matches(path: Path, plan: BootstrapPlan) -> None:
+    if not path.exists():
+        raise BootstrapRefusal("accepted dry-run plan is missing")
+    try:
+        accepted = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise BootstrapRefusal("accepted dry-run plan is invalid json") from exc
+    current = plan.to_json()
+    for key in ("repository", "branch", "ruleset_id", "ruleset_patch", "branch_review_mutation"):
+        if accepted.get(key) != current.get(key):
+            raise BootstrapRefusal(f"accepted dry-run plan does not match current plan: {key}")
+
+
+def assert_apply_preconditions(*, gh_bin: str, plan: BootstrapPlan, accepted_dry_run_plan: Path) -> None:
+    assert_clean_synced_main()
+    assert_supersession_present()
+    assert_gpp_guard_flags_false()
+    assert_dependency_prs_merged(gh_bin)
+    assert_accepted_dry_run_plan_matches(accepted_dry_run_plan, plan)
+
+
+def collect_readiness_snapshot(*, gh_bin: str, output: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/ao_ma10_github_readiness_snapshot.py"),
+            "--repository",
+            REPOSITORY,
+            "--branch",
+            BRANCH,
+            "--gh-bin",
+            gh_bin,
+            "--output",
+            str(output),
+        ],
+        check=True,
+        cwd=ROOT,
+        timeout=60,
+    )
+
+
+def apply_plan(*, gh_bin: str, plan: BootstrapPlan) -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        json.dump(plan.ruleset_patch, handle)
+        handle.write("\n")
+        payload_path = handle.name
+    try:
+        subprocess.run(
+            [
+                gh_bin,
+                "api",
+                "--method",
+                "PUT",
+                f"repos/{REPOSITORY}/rulesets/{RULESET_ID}",
+                "--input",
+                payload_path,
+            ],
+            check=True,
+            timeout=30,
+        )
+        subprocess.run(
+            [
+                gh_bin,
+                "api",
+                "--method",
+                "DELETE",
+                f"repos/{REPOSITORY}/branches/{BRANCH}/protection/required_pull_request_reviews",
+            ],
+            check=True,
+            timeout=30,
+        )
+    finally:
+        Path(payload_path).unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gh-bin", default="gh")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--pre-snapshot-output", default="")
+    parser.add_argument("--post-snapshot-output", default="")
+    parser.add_argument("--accepted-dry-run-plan", default="")
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument(
+        "--confirmation",
+        default="",
+        help=f"Required with --apply. Must equal {APPLY_CONFIRMATION}.",
+    )
+    args = parser.parse_args(argv)
+
+    plan = collect_plan(args.gh_bin)
+    _write_json(Path(args.output), plan.to_json())
+
+    if args.apply:
+        if not args.pre_snapshot_output or not args.post_snapshot_output:
+            raise BootstrapRefusal("--apply requires --pre-snapshot-output and --post-snapshot-output")
+        if not args.accepted_dry_run_plan:
+            raise BootstrapRefusal("--apply requires --accepted-dry-run-plan")
+        if args.confirmation != APPLY_CONFIRMATION:
+            raise BootstrapRefusal("missing AO-MA-10O apply confirmation token")
+        if os.environ.get("AO_MA10O_ALLOW_RULESET_MUTATION") != APPLY_CONFIRMATION:
+            raise BootstrapRefusal("AO_MA10O_ALLOW_RULESET_MUTATION confirmation env is missing")
+        assert_apply_preconditions(
+            gh_bin=args.gh_bin,
+            plan=plan,
+            accepted_dry_run_plan=Path(args.accepted_dry_run_plan),
+        )
+        collect_readiness_snapshot(gh_bin=args.gh_bin, output=Path(args.pre_snapshot_output))
+        apply_plan(gh_bin=args.gh_bin, plan=plan)
+        collect_readiness_snapshot(gh_bin=args.gh_bin, output=Path(args.post_snapshot_output))
+    else:
+        print("dry-run only; no GitHub mutations performed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ao_release_gate_build_payload.py
+++ b/scripts/ao_release_gate_build_payload.py
@@ -164,6 +164,30 @@ def _check_run_sort_key(entry: dict[str, Any]) -> tuple[str, str, int]:
     return (completed, started, cid)
 
 
+def _is_skipped_check_run(entry: dict[str, Any]) -> bool:
+    """Return whether a check-run is a completed skipped run."""
+
+    status = entry.get("status")
+    conclusion = entry.get("conclusion")
+    return status == "completed" and conclusion == "skipped"
+
+
+def _latest_effective_check_run(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    """Pick the effective check-run for a duplicated check name.
+
+    GitHub's commit check-runs endpoint is keyed only by commit SHA, not by
+    the current workflow run. A later event-gate-only attempt can therefore
+    contribute ``skipped`` copies of required jobs after a full run has
+    already produced success/failure for the same SHA. Prefer the latest
+    non-skipped entry when present; otherwise keep the latest skipped entry
+    so skipped-only required checks still fail closed.
+    """
+
+    non_skipped = [entry for entry in entries if not _is_skipped_check_run(entry)]
+    candidates = non_skipped or entries
+    return max(candidates, key=_check_run_sort_key)
+
+
 def _normalized_checks(
     check_runs_json_path: Path,
     required_checks_allowlist: list[str] | None = None,
@@ -186,9 +210,13 @@ def _normalized_checks(
     check-run other than the self-name exclusion is returned (legacy
     permissive behavior).
 
-    Entries are de-duplicated by name keeping the most recent run
-    (see ``_check_run_sort_key``) so a cancelled previous run does not
-    block a green current run.
+    Entries are de-duplicated by name keeping the most recent non-skipped
+    run when one exists (see ``_latest_effective_check_run``). GitHub can
+    attach a later event-gate-only workflow attempt to the same commit; that
+    attempt marks downstream jobs as ``skipped`` even though a full run for
+    the same SHA already completed successfully. A skipped-only required
+    check still fails closed, but a skipped duplicate must not shadow a real
+    success/failure for the same check name.
     """
 
     data = json.loads(check_runs_json_path.read_text(encoding="utf-8"))
@@ -196,7 +224,7 @@ def _normalized_checks(
     excluded = {"ao-release-gate", "ao-release-gate-shadow"}
     allow = list(required_checks_allowlist) if required_checks_allowlist else None
     allow_set = set(allow) if allow is not None else None
-    by_name: dict[str, dict[str, Any]] = {}
+    grouped: dict[str, list[dict[str, Any]]] = {}
     for entry in runs:
         if not isinstance(entry, dict):
             continue
@@ -205,9 +233,8 @@ def _normalized_checks(
             continue
         if allow_set is not None and name not in allow_set:
             continue
-        existing = by_name.get(name)
-        if existing is None or _check_run_sort_key(entry) > _check_run_sort_key(existing):
-            by_name[name] = entry
+        grouped.setdefault(name, []).append(entry)
+    by_name = {name: _latest_effective_check_run(entries) for name, entries in grouped.items()}
     out: list[dict[str, Any]] = []
     for name, entry in by_name.items():
         out.append(

--- a/tests/test_ao_ma10o_cc9_no_human_bootstrap_supersession.py
+++ b/tests/test_ao_ma10o_cc9_no_human_bootstrap_supersession.py
@@ -1,0 +1,448 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / ".claude/plans/AO-MA-10O-CC9-NO-HUMAN-BOOTSTRAP-SUPERSESSION.md"
+PCC = ROOT / ".claude/plans/PROGRAM-CHANGE-CONTROL.md"
+SCRIPT = ROOT / "scripts/ao_ma10o_no_human_bootstrap.py"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("ao_ma10o_no_human_bootstrap", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ao_ma10o_decision_record_pins_dependencies_and_scope() -> None:
+    text = _text(DOC)
+    assert "https://github.com/Halildeu/ao-kernel/issues/683" in text
+    assert "PR #682 and PR #684 landing first" in text
+    assert "Supersedes:" in text and "PROGRAM-CHANGE-CONTROL.md` CC-9" in text
+    assert "Only `scripts/ao_ma10o_no_human_bootstrap.py --apply`" in text
+    assert "Halildeu/ao-kernel" in text
+    assert "ruleset `16803733`" in text
+    assert "--accepted-dry-run-plan" in text
+    assert "PR #682 or PR #684 is not merged" in text
+    assert "working tree is not clean `main` synced with `origin/main`" in text
+
+
+def test_ao_ma10o_policy_updates_cc9_with_narrow_no_human_exception() -> None:
+    text = _text(PCC)
+    assert "AO-MA-10O narrow supersession for CC-9" in text
+    assert "CC-9 remains the default rule." in text
+    assert "scripts/ao_ma10o_no_human_bootstrap.py --apply" in text
+    assert "ao-release-gate-technical" in text
+    assert "ao-release-gate-review" in text
+    assert "bypass_actors=[]" in text
+    assert "preserve the classic CI required checks" in text
+
+
+def test_ao_ma10o_script_is_narrowly_bound_to_expected_repo_ruleset_and_checks() -> None:
+    script = _load_script()
+    assert script.REPOSITORY == "Halildeu/ao-kernel"
+    assert script.BRANCH == "main"
+    assert script.RULESET_ID == 16803733
+    assert script.GITHUB_ACTIONS_INTEGRATION_ID == 15368
+    assert script.TECHNICAL_CHECK == "ao-release-gate-technical"
+    assert script.REVIEW_CHECK == "ao-release-gate-review"
+    assert script.APPLY_CONFIRMATION == "AO-MA-10O-CC9-SUPERSESSION-APPLY"
+    assert script.CLASSIC_CI_CHECKS == (
+        "lint",
+        "test (3.11)",
+        "test (3.12)",
+        "test (3.13)",
+        "coverage",
+        "typecheck",
+        "packaging-smoke",
+    )
+
+
+def test_ao_ma10o_build_plan_preserves_classic_ci_and_adds_dual_release_checks() -> None:
+    script = _load_script()
+    ruleset = {
+        "id": 16803733,
+        "name": "Protect main",
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+        "rules": [{"type": "deletion"}, {"type": "non_fast_forward"}],
+    }
+    branch_protection = {
+        "enforce_admins": {"enabled": True},
+        "required_status_checks": {
+            "contexts": list(script.CLASSIC_CI_CHECKS),
+            "checks": [{"context": check, "app_id": 15368} for check in script.CLASSIC_CI_CHECKS],
+        },
+    }
+    plan = script.build_plan(ruleset=ruleset, branch_protection=branch_protection).to_json()
+
+    assert plan["ai_output_release_authority"] is False
+    assert plan["support_widening"] is False
+    assert plan["production_platform_claim"] is False
+    assert plan["live_adapter_execution"] is False
+    assert plan["ruleset_patch"]["bypass_actors"] == []
+    rule_types = [rule["type"] for rule in plan["ruleset_patch"]["rules"]]
+    assert rule_types == ["deletion", "non_fast_forward", "required_status_checks"]
+    status_rule = plan["ruleset_patch"]["rules"][2]
+    assert status_rule["parameters"]["required_status_checks"] == [
+        {"context": "ao-release-gate-technical", "integration_id": 15368},
+        {"context": "ao-release-gate-review", "integration_id": 15368},
+    ]
+    assert plan["branch_review_mutation"]["method"] == "DELETE"
+    assert plan["branch_review_mutation"]["preserve_classic_ci_checks"] == list(script.CLASSIC_CI_CHECKS)
+    assert plan["apply_requires_pre_and_post_readiness_snapshots"] is True
+
+
+def test_ao_ma10o_build_plan_refuses_bypass_actors_or_missing_classic_ci() -> None:
+    script = _load_script()
+    ruleset = {
+        "id": 16803733,
+        "name": "Protect main",
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [{"actor_id": 1}],
+        "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+        "rules": [{"type": "deletion"}, {"type": "non_fast_forward"}],
+    }
+    branch_protection = {
+        "enforce_admins": {"enabled": True},
+        "required_status_checks": {"contexts": list(script.CLASSIC_CI_CHECKS), "checks": []},
+    }
+    try:
+        script.build_plan(ruleset=ruleset, branch_protection=branch_protection)
+    except script.BootstrapRefusal as exc:
+        assert "bypass_actors must be empty" in str(exc)
+    else:
+        raise AssertionError("expected bypass actor refusal")
+
+    ruleset["bypass_actors"] = []
+    branch_protection["required_status_checks"]["contexts"] = ["lint"]
+    try:
+        script.build_plan(ruleset=ruleset, branch_protection=branch_protection)
+    except script.BootstrapRefusal as exc:
+        assert "classic CI checks missing" in str(exc)
+    else:
+        raise AssertionError("expected classic CI refusal")
+
+
+def test_ao_ma10o_hard_stops_are_pinned() -> None:
+    text = _text(DOC)
+    for phrase in (
+        "No `--admin` merge.",
+        "No ruleset bypass actors.",
+        "No removal of classic CI requirements.",
+        "No support widening.",
+        "No production platform claim.",
+        "No live adapter execution.",
+        "No testai/smee/deployment-protection callback dependency.",
+        "No treating Claude, Codex, MiniMax, or any model output as release authority.",
+    ):
+        assert phrase in text
+
+
+def test_ao_ma10o_apply_requires_pre_and_post_snapshot_outputs(monkeypatch, tmp_path) -> None:
+    script = _load_script()
+    ruleset = {
+        "id": 16803733,
+        "name": "Protect main",
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+        "rules": [{"type": "deletion"}, {"type": "non_fast_forward"}],
+    }
+    branch_protection = {
+        "enforce_admins": {"enabled": True},
+        "required_status_checks": {
+            "contexts": list(script.CLASSIC_CI_CHECKS),
+            "checks": [{"context": check, "app_id": 15368} for check in script.CLASSIC_CI_CHECKS],
+        },
+    }
+    plan = script.build_plan(ruleset=ruleset, branch_protection=branch_protection)
+
+    assert plan.to_json()["apply_requires_pre_and_post_readiness_snapshots"] is True
+    monkeypatch.setattr(script, "collect_plan", lambda gh_bin: plan)
+
+    try:
+        script.main(
+            [
+                "--output",
+                str(tmp_path / "plan.json"),
+                "--apply",
+                "--confirmation",
+                script.APPLY_CONFIRMATION,
+            ]
+        )
+    except script.BootstrapRefusal as exc:
+        assert "--apply requires --pre-snapshot-output and --post-snapshot-output" in str(exc)
+    else:
+        raise AssertionError("expected pre/post snapshot refusal")
+
+
+def test_ao_ma10o_apply_requires_cli_and_env_confirmation(monkeypatch, tmp_path) -> None:
+    script = _load_script()
+    ruleset = {
+        "id": 16803733,
+        "name": "Protect main",
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+        "rules": [{"type": "deletion"}, {"type": "non_fast_forward"}],
+    }
+    branch_protection = {
+        "enforce_admins": {"enabled": True},
+        "required_status_checks": {
+            "contexts": list(script.CLASSIC_CI_CHECKS),
+            "checks": [{"context": check, "app_id": 15368} for check in script.CLASSIC_CI_CHECKS],
+        },
+    }
+    plan = script.build_plan(ruleset=ruleset, branch_protection=branch_protection)
+    accepted_path = tmp_path / "accepted.json"
+    accepted_path.write_text(json.dumps(plan.to_json(), sort_keys=True), encoding="utf-8")
+    monkeypatch.setattr(script, "collect_plan", lambda gh_bin: plan)
+    args = [
+        "--output",
+        str(tmp_path / "plan.json"),
+        "--pre-snapshot-output",
+        str(tmp_path / "pre.json"),
+        "--post-snapshot-output",
+        str(tmp_path / "post.json"),
+        "--accepted-dry-run-plan",
+        str(accepted_path),
+        "--apply",
+    ]
+
+    try:
+        script.main(args)
+    except script.BootstrapRefusal as exc:
+        assert "missing AO-MA-10O apply confirmation token" in str(exc)
+    else:
+        raise AssertionError("expected CLI confirmation refusal")
+
+    try:
+        script.main([*args, "--confirmation", script.APPLY_CONFIRMATION])
+    except script.BootstrapRefusal as exc:
+        assert "AO_MA10O_ALLOW_RULESET_MUTATION confirmation env is missing" in str(exc)
+    else:
+        raise AssertionError("expected env confirmation refusal")
+
+
+def test_ao_ma10o_refuses_ruleset_condition_not_targeting_main() -> None:
+    script = _load_script()
+    ruleset = {
+        "id": 16803733,
+        "name": "Protect main",
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": {"ref_name": {"include": ["refs/heads/dev"], "exclude": []}},
+        "rules": [{"type": "deletion"}, {"type": "non_fast_forward"}],
+    }
+    branch_protection = {
+        "enforce_admins": {"enabled": True},
+        "required_status_checks": {
+            "contexts": list(script.CLASSIC_CI_CHECKS),
+            "checks": [{"context": check, "app_id": 15368} for check in script.CLASSIC_CI_CHECKS],
+        },
+    }
+    try:
+        script.build_plan(ruleset=ruleset, branch_protection=branch_protection)
+    except script.BootstrapRefusal as exc:
+        assert "ruleset does not target main or default branch" in str(exc)
+    else:
+        raise AssertionError("expected ruleset target refusal")
+
+
+def test_ao_ma10o_apply_preconditions_are_fail_closed(monkeypatch, tmp_path) -> None:
+    script = _load_script()
+    ruleset = {
+        "id": 16803733,
+        "name": "Protect main",
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+        "rules": [{"type": "deletion"}, {"type": "non_fast_forward"}],
+    }
+    branch_protection = {
+        "enforce_admins": {"enabled": True},
+        "required_status_checks": {
+            "contexts": list(script.CLASSIC_CI_CHECKS),
+            "checks": [{"context": check, "app_id": 15368} for check in script.CLASSIC_CI_CHECKS],
+        },
+    }
+    plan = script.build_plan(ruleset=ruleset, branch_protection=branch_protection)
+    accepted_path = tmp_path / "accepted.json"
+    accepted_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(script, "assert_clean_synced_main", lambda: None)
+    monkeypatch.setattr(script, "assert_supersession_present", lambda: None)
+    monkeypatch.setattr(script, "assert_gpp_guard_flags_false", lambda: None)
+    monkeypatch.setattr(script, "assert_dependency_prs_merged", lambda gh_bin: None)
+
+    try:
+        script.assert_apply_preconditions(
+            gh_bin="gh",
+            plan=plan,
+            accepted_dry_run_plan=accepted_path,
+        )
+    except script.BootstrapRefusal as exc:
+        assert "accepted dry-run plan does not match current plan" in str(exc)
+    else:
+        raise AssertionError("expected accepted dry-run mismatch refusal")
+
+    accepted_path.write_text(json.dumps(plan.to_json(), sort_keys=True), encoding="utf-8")
+    script.assert_apply_preconditions(
+        gh_bin="gh",
+        plan=plan,
+        accepted_dry_run_plan=accepted_path,
+    )
+
+
+def test_ao_ma10o_clean_synced_main_precondition_refuses_non_main_dirty_or_diverged(
+    monkeypatch,
+) -> None:
+    script = _load_script()
+
+    def fake_run_text_factory(outputs: dict[tuple[str, ...], str]):
+        def fake_run_text(command, *, timeout=30):
+            return outputs[tuple(command)]
+
+        return fake_run_text
+
+    cases = [
+        (
+            {
+                ("git", "branch", "--show-current"): "feature",
+            },
+            "apply must run from main",
+        ),
+        (
+            {
+                ("git", "branch", "--show-current"): "main",
+                ("git", "status", "--short"): " M scripts/example.py",
+            },
+            "apply requires a clean working tree",
+        ),
+        (
+            {
+                ("git", "branch", "--show-current"): "main",
+                ("git", "status", "--short"): "",
+                ("git", "rev-list", "--left-right", "--count", "HEAD...origin/main"): "1\t0",
+            },
+            "main must be synced with origin/main",
+        ),
+    ]
+    for outputs, expected in cases:
+        monkeypatch.setattr(script, "_run_text", fake_run_text_factory(outputs))
+        try:
+            script.assert_clean_synced_main()
+        except script.BootstrapRefusal as exc:
+            assert expected in str(exc)
+        else:
+            raise AssertionError(f"expected refusal: {expected}")
+
+
+def test_ao_ma10o_gpp_guard_precondition_refuses_true_or_missing_flags(monkeypatch) -> None:
+    script = _load_script()
+    for output in (
+        "\n".join(
+            [
+                "Support widening allowed: true",
+                "Production platform claim allowed: false",
+                "Live adapter execution allowed: false",
+            ]
+        ),
+        "\n".join(
+            [
+                "Support widening allowed: false",
+                "Live adapter execution allowed: false",
+            ]
+        ),
+    ):
+        monkeypatch.setattr(script, "_run_text", lambda command, *, timeout=30: output)
+        try:
+            script.assert_gpp_guard_flags_false()
+        except script.BootstrapRefusal as exc:
+            assert "gpp guard flags are not all false" in str(exc)
+        else:
+            raise AssertionError("expected GPP guard flag refusal")
+
+
+def test_ao_ma10o_dependency_pr_precondition_refuses_unmerged_or_unreadable_prs(
+    monkeypatch,
+) -> None:
+    script = _load_script()
+
+    monkeypatch.setattr(script, "_gh_pr_json", lambda gh_bin, number: {"state": "OPEN"})
+    try:
+        script.assert_dependency_prs_merged("gh")
+    except script.BootstrapRefusal as exc:
+        assert "dependency PR #682 is not merged" in str(exc)
+    else:
+        raise AssertionError("expected unmerged dependency PR refusal")
+
+    def raise_read_failure(gh_bin, number):
+        raise script.BootstrapRefusal("command failed: gh pr view")
+
+    monkeypatch.setattr(script, "_gh_pr_json", raise_read_failure)
+    try:
+        script.assert_dependency_prs_merged("gh")
+    except script.BootstrapRefusal as exc:
+        assert "command failed: gh pr view" in str(exc)
+    else:
+        raise AssertionError("expected dependency PR read failure refusal")
+
+
+def test_ao_ma10o_apply_preconditions_call_all_guards(monkeypatch, tmp_path) -> None:
+    script = _load_script()
+    ruleset = {
+        "id": 16803733,
+        "name": "Protect main",
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+        "rules": [{"type": "deletion"}, {"type": "non_fast_forward"}],
+    }
+    branch_protection = {
+        "enforce_admins": {"enabled": True},
+        "required_status_checks": {
+            "contexts": list(script.CLASSIC_CI_CHECKS),
+            "checks": [{"context": check, "app_id": 15368} for check in script.CLASSIC_CI_CHECKS],
+        },
+    }
+    plan = script.build_plan(ruleset=ruleset, branch_protection=branch_protection)
+    accepted_path = tmp_path / "accepted.json"
+    accepted_path.write_text(json.dumps(plan.to_json(), sort_keys=True), encoding="utf-8")
+    calls: list[str] = []
+
+    monkeypatch.setattr(script, "assert_clean_synced_main", lambda: calls.append("clean-main"))
+    monkeypatch.setattr(script, "assert_supersession_present", lambda: calls.append("supersession"))
+    monkeypatch.setattr(script, "assert_gpp_guard_flags_false", lambda: calls.append("gpp-flags"))
+    monkeypatch.setattr(
+        script,
+        "assert_dependency_prs_merged",
+        lambda gh_bin: calls.append(f"dependency-prs:{gh_bin}"),
+    )
+
+    script.assert_apply_preconditions(
+        gh_bin="gh",
+        plan=plan,
+        accepted_dry_run_plan=accepted_path,
+    )
+
+    assert calls == ["clean-main", "supersession", "gpp-flags", "dependency-prs:gh"]

--- a/tests/test_ao_release_gate_build_payload.py
+++ b/tests/test_ao_release_gate_build_payload.py
@@ -382,6 +382,154 @@ def test_build_payload_dedupes_check_runs_keeping_latest(tmp_path: Path) -> None
     assert by_name["lint"]["conclusion"] == "success"
 
 
+def test_build_payload_dedupes_later_event_gate_skipped_duplicate(tmp_path: Path) -> None:
+    """A later event-gate-only workflow attempt can mark downstream
+    required jobs as skipped on the same SHA. The builder must not let that
+    skipped duplicate shadow a real success from the full workflow run."""
+
+    mod = _load_module()
+    pr_files = tmp_path / "pr-files.json"
+    check_runs = tmp_path / "check-runs.json"
+    gpp_status = tmp_path / "gpp_status.json"
+    _write_pr_files(pr_files, ["a.py"])
+    check_runs.write_text(
+        json.dumps(
+            {
+                "check_runs": [
+                    {
+                        "id": 100,
+                        "name": "lint",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "started_at": "2026-05-28T11:54:06Z",
+                        "completed_at": "2026-05-28T11:54:12Z",
+                    },
+                    {
+                        "id": 200,
+                        "name": "lint",
+                        "status": "completed",
+                        "conclusion": "skipped",
+                        "started_at": "2026-05-28T11:55:34Z",
+                        "completed_at": "2026-05-28T11:55:34Z",
+                    },
+                    {
+                        "id": 300,
+                        "name": "typecheck",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "started_at": "2026-05-28T11:54:06Z",
+                        "completed_at": "2026-05-28T11:54:34Z",
+                    },
+                    {
+                        "id": 400,
+                        "name": "typecheck",
+                        "status": "completed",
+                        "conclusion": "skipped",
+                        "started_at": "2026-05-28T11:55:34Z",
+                        "completed_at": "2026-05-28T11:55:34Z",
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_gpp_status(gpp_status)
+    output = tmp_path / "payload.json"
+    mod.main(
+        [
+            "--repository",
+            "Halildeu/ao-kernel",
+            "--pr-number",
+            "1",
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "x",
+            "--head-sha",
+            "f" * 40,
+            "--from-fork",
+            "false",
+            "--branch-up-to-date",
+            "true",
+            "--gpp-status",
+            str(gpp_status),
+            "--pr-files-json",
+            str(pr_files),
+            "--check-runs-json",
+            str(check_runs),
+            "--required-check",
+            "lint",
+            "--required-check",
+            "typecheck",
+            "--output",
+            str(output),
+        ]
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    by_name = {c["name"]: c for c in payload["required_checks"]}
+    assert by_name["lint"]["conclusion"] == "success"
+    assert by_name["typecheck"]["conclusion"] == "success"
+
+
+def test_build_payload_required_check_skipped_only_still_fails_closed(tmp_path: Path) -> None:
+    """Ignoring skipped duplicates must not convert a skipped-only
+    required check into a pass. If GitHub only returned skipped for a
+    required job, the decision core must still see the not-green status."""
+
+    mod = _load_module()
+    pr_files = tmp_path / "pr-files.json"
+    check_runs = tmp_path / "check-runs.json"
+    gpp_status = tmp_path / "gpp_status.json"
+    _write_pr_files(pr_files, ["a.py"])
+    _write_check_runs(
+        check_runs,
+        [
+            {
+                "id": 100,
+                "name": "lint",
+                "status": "completed",
+                "conclusion": "skipped",
+                "started_at": "2026-05-28T11:55:34Z",
+                "completed_at": "2026-05-28T11:55:34Z",
+            },
+        ],
+    )
+    _write_gpp_status(gpp_status)
+    output = tmp_path / "payload.json"
+    mod.main(
+        [
+            "--repository",
+            "Halildeu/ao-kernel",
+            "--pr-number",
+            "1",
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "x",
+            "--head-sha",
+            "f" * 40,
+            "--from-fork",
+            "false",
+            "--branch-up-to-date",
+            "true",
+            "--gpp-status",
+            str(gpp_status),
+            "--pr-files-json",
+            str(pr_files),
+            "--check-runs-json",
+            str(check_runs),
+            "--required-check",
+            "lint",
+            "--output",
+            str(output),
+        ]
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["required_checks"] == [
+        {"name": "lint", "status": "completed", "conclusion": "skipped"}
+    ]
+
+
 def test_build_payload_defaults_dangerous_flags_to_false(tmp_path: Path) -> None:
     """PR-author-supplied admin_bypass / forbidden_secret / bot / agent /
     live-adapter flags would let a PR self-approve; the builder never


### PR DESCRIPTION
## Summary

Implements AO-MA-10O, a narrow CC-9 supersession that permits exactly one constrained no-human bootstrap path for the autonomous merge lane after PR #682 and PR #684 land.

This PR does not mutate live GitHub settings. It records the supersession, adds the guarded dry-run/apply script, pins fail-closed tests, and commits OpenAI plus Anthropic review evidence.

## Scope

- Adds AO-MA-10O CC-9 no-human bootstrap supersession record.
- Updates PROGRAM-CHANGE-CONTROL with the narrow CC-9 supersession while keeping CC-9 as the default rule.
- Adds scripts/ao_ma10o_no_human_bootstrap.py.
- Adds fail-closed tests for ruleset targeting, bypass actors, classic CI preservation, clean synced main, dependency PRs, guard flags, accepted dry-run plan, and dual CLI/env confirmation.
- Updates local AI review evidence and raw high-risk OpenAI/Anthropic review evidence.

## Hard stops preserved

- No admin merge.
- No bypass actors.
- No classic CI removal.
- No support widening.
- No production platform claim.
- No live adapter execution.
- No testai/smee/deployment-protection dependency.
- AI output remains evidence, not release authority.

## Validation

- pytest targeted AO-MA-10O plus AO-MA-10 low-risk plus gpp_next: 57 passed, 1 skipped.
- ruff on changed Python files: pass.
- ao_ma10o_no_human_bootstrap dry-run: plan emitted, no GitHub mutations performed.
- local_gpp_gate: operator_may_merge, 8 of 8 checks pass.
- ao_ma10_high_risk_supersession_evidence: AGREE, providers anthropic and openai, changed_files_count 7.
- git diff check: clean.

## Review evidence

- OpenAI reviewer: REVISE to REVISE to AGREE to AGREE after test-only confirmation hardening.
- Anthropic reviewer: AGREE to AGREE after test-only confirmation hardening.

## Sequencing

Activation remains inactive until:

1. PR #682 is merged.
2. PR #684 is merged.
3. This PR is merged.
4. main is clean and synced.
5. dry-run plan is accepted and passed back through accepted-dry-run-plan.
6. pre and post readiness snapshots are collected.
