### PR TITLE
fix(ao-ma-10q): confirm dedicated merge actor readiness

### DIFF
--- a/.claude/plans/AO-MA-10A0-GITHUB-READINESS-SNAPSHOT.v1.json
+++ b/.claude/plans/AO-MA-10A0-GITHUB-READINESS-SNAPSHOT.v1.json
@@ -5,11 +5,11 @@
   "branch_protection": {
     "ao_release_gate_required_check_present": false,
     "ao_release_gate_source_pinned_to_actions": false,
-    "dismiss_stale_reviews": true,
+    "dismiss_stale_reviews": false,
     "enforce_admins": true,
     "present": true,
-    "require_code_owner_reviews": true,
-    "required_approving_review_count": 1,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0,
     "required_check_source_pins": [
       {
         "app_id": 15368,
@@ -62,7 +62,7 @@
     "present": true
   },
   "collection_errors": [],
-  "generated_at": "2026-05-28T10:03:15Z",
+  "generated_at": "2026-05-28T19:36:30Z",
   "guard_flags": {
     "live_adapter_execution": false,
     "production_platform_claim": false,
@@ -78,29 +78,27 @@
   "read_only": true,
   "readiness": {
     "blockers": [
-      "ao_release_gate_required_check_missing",
-      "legacy_required_review_blocks_low_risk_autonomy",
-      "merge_actor_admin_permission_observed"
+      "merge_actor_admin_permission_observed",
+      "unexpected_merge_actor"
     ],
     "decision": "blocked",
     "next_required_slice": "AO-MA-10a1 autonomous_merge_eligibility after blockers are resolved",
     "warnings": [
-      "repository_auto_merge_disabled_merge_agent_direct_mode_required",
       "some_nominal_low_risk_prefixes_still_codeowned"
     ]
   },
   "release_authority": "ao-release-gate+github-ruleset",
   "repository": "Halildeu/ao-kernel",
   "repository_settings": {
-    "auto_merge_allowed": false,
-    "delete_branch_on_merge": false,
+    "auto_merge_allowed": true,
+    "delete_branch_on_merge": true,
     "merge_commit_allowed": true,
     "rebase_merge_allowed": true,
     "squash_merge_allowed": true
   },
   "rulesets": {
-    "ao_release_gate_required_check_present": false,
-    "ao_release_gate_source_pinned_to_actions": false,
+    "ao_release_gate_required_check_present": true,
+    "ao_release_gate_source_pinned_to_actions": true,
     "bypass_actors_count": 0,
     "bypass_actors_empty": true,
     "default_branch_rulesets": [
@@ -111,13 +109,23 @@
         "name": "Protect main",
         "rule_types": [
           "deletion",
-          "non_fast_forward"
+          "non_fast_forward",
+          "required_status_checks"
         ],
         "source_type": "Repository",
         "target": "branch"
       }
     ],
-    "effective_required_checks": []
+    "effective_required_checks": [
+      {
+        "context": "ao-release-gate-technical",
+        "integration_id": 15368
+      },
+      {
+        "context": "ao-release-gate-review",
+        "integration_id": 15368
+      }
+    ]
   },
   "schema_version": "ao-ma-10-github-readiness-snapshot.v1",
   "snapshot_source": "github_api_read_only",

--- a/.claude/plans/AO-MA-10A1-AUTONOMOUS-MERGE-ELIGIBILITY.v1.json
+++ b/.claude/plans/AO-MA-10A1-AUTONOMOUS-MERGE-ELIGIBILITY.v1.json
@@ -14,32 +14,27 @@
   },
   "decision": {
     "blockers": [
-      "ao_release_gate_required_check_missing",
-      "ao_release_gate_review_required_check_missing",
-      "ao_release_gate_technical_required_check_missing",
       "dedicated_merge_actor_not_confirmed",
-      "legacy_code_owner_review_blocks_low_risk_autonomy",
-      "legacy_required_review_blocks_low_risk_autonomy",
       "merge_actor_admin_permission_observed",
-      "readiness_snapshot_not_ready"
+      "readiness_snapshot_not_ready",
+      "unexpected_merge_actor"
     ],
     "next_required_slice": "resolve_live_github_enforcement_blockers_before_AO-MA-10k_or_merge_agent_activation",
     "result": "blocked",
     "warnings": [
-      "repository_auto_merge_disabled_merge_agent_direct_mode_required",
       "some_nominal_low_risk_prefixes_still_codeowned"
     ]
   },
-  "generated_at": "2026-05-28T10:15:55Z",
+  "generated_at": "2026-05-28T19:36:30Z",
   "github_gate_requirements": {
-    "ao_release_gate_review_required_check_present": false,
-    "ao_release_gate_review_source_pinned_to_actions": false,
-    "ao_release_gate_technical_required_check_present": false,
-    "ao_release_gate_technical_source_pinned_to_actions": false,
+    "ao_release_gate_review_required_check_present": true,
+    "ao_release_gate_review_source_pinned_to_actions": true,
+    "ao_release_gate_technical_required_check_present": true,
+    "ao_release_gate_technical_source_pinned_to_actions": true,
     "dedicated_merge_actor_non_admin": false,
     "dedicated_merge_actor_without_admin_write": false,
-    "legacy_code_owner_review_disabled_for_low_risk": false,
-    "legacy_required_review_disabled_for_low_risk": false,
+    "legacy_code_owner_review_disabled_for_low_risk": true,
+    "legacy_required_review_disabled_for_low_risk": true,
     "ruleset_bypass_actors_empty": true
   },
   "guard_flags": {
@@ -52,13 +47,12 @@
   "readiness_source": {
     "artifact_kind": "ao_ma_10_github_readiness_snapshot",
     "blockers": [
-      "ao_release_gate_required_check_missing",
-      "legacy_required_review_blocks_low_risk_autonomy",
-      "merge_actor_admin_permission_observed"
+      "merge_actor_admin_permission_observed",
+      "unexpected_merge_actor"
     ],
     "branch": "main",
     "decision": "blocked",
-    "generated_at": "2026-05-28T10:03:15Z",
+    "generated_at": "2026-05-28T19:36:30Z",
     "repository": "Halildeu/ao-kernel",
     "schema_version": "ao-ma-10-github-readiness-snapshot.v1"
   },

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -21,20 +21,24 @@
       "status": "pass"
     },
     {
-      "name": "ao_ma10c_current_actor_fail_closed",
+      "name": "ao_ma10a0_dedicated_actor_confirmed_when_gladyatore_write_non_admin",
       "status": "pass"
     },
     {
-      "name": "merge_command_no_admin_or_auto",
+      "name": "ao_ma10a0_unexpected_non_admin_actor_fail_closed",
+      "status": "pass"
+    },
+    {
+      "name": "ao_ma10a1_unexpected_merge_actor_propagates",
       "status": "pass"
     }
   ],
   "findings": [
-    "Anthropic review: AO-MA-10c preserves the executor-not-authority boundary and keeps release authority with ao-release-gate plus GitHub ruleset.",
-    "Execute mode is locked behind explicit confirmation, fresh readiness, ready eligibility, passing live checks, and gladyatore-lab write/non-admin identity.",
-    "The current Halildeu/admin runtime is intentionally blocked and no merge command is attempted in that state.",
-    "The result schema captures blockers and command intent without storing secrets or widening support.",
-    "No live adapter execution, production platform claim, ruleset mutation, CODEOWNERS mutation, bypass actor, or admin merge path is introduced."
+    "Anthropic review: fail-closed for wrong actor is correct; viewer_login mismatch emits unexpected_merge_actor.",
+    "Dedicated actor confirmation requires login match, write permission, and non-admin viewer state, so no single-condition bypass is present.",
+    "Admin actor remains independently blocked by merge_actor_admin_permission_observed.",
+    "Schema and tests cover dedicated actor confirmed, wrong non-admin actor blocked, admin actor blocked, and eligibility propagation.",
+    "No mutation of rulesets, branch protection, CODEOWNERS, workflows, secrets, GitHub Apps, support tier, production claim, or live adapter execution is introduced."
   ],
   "implementer": {
     "agent": "codex",
@@ -52,21 +56,20 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.md",
-      ".claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.v1.json",
+      ".claude/plans/AO-MA-10A0-GITHUB-READINESS-SNAPSHOT.v1.json",
+      ".claude/plans/AO-MA-10A1-AUTONOMOUS-MERGE-ELIGIBILITY.v1.json",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/ao-ma-10c-merge-agent-result.schema.v1.json",
+      "ao_kernel/defaults/schemas/ao-ma-10-autonomous-merge-eligibility.schema.v1.json",
+      "ao_kernel/defaults/schemas/ao-ma-10-github-readiness-snapshot.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10c_merge_agent.py",
-      "tests/fixtures/ao_ma_10c/merge_agent.blocked_admin_actor.valid.json",
-      "tests/fixtures/ao_ma_10c/merge_agent.ready_dry_run.valid.json",
-      "tests/test_ao_ma10c_merge_agent.py",
-      "tests/test_ri78b_bc1_6c_fast_follow_invariant.py"
+      "scripts/ao_ma10_github_readiness_snapshot.py",
+      "tests/test_ao_ma10_autonomous_merge_eligibility.py",
+      "tests/test_ao_ma10_github_readiness_snapshot.py"
     ],
-    "head_ref": "refs/heads/codex/ao-ma-10c-merge-agent-executor"
+    "head_ref": "refs/heads/codex/ao-ma-10q-dedicated-actor-readiness"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-MA-10c"
+  "work_package": "AO-MA-10q"
 }

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -21,20 +21,24 @@
       "status": "pass"
     },
     {
-      "name": "ao_ma10c_current_actor_fail_closed",
+      "name": "ao_ma10a0_dedicated_actor_confirmed_when_gladyatore_write_non_admin",
       "status": "pass"
     },
     {
-      "name": "merge_command_no_admin_or_auto",
+      "name": "ao_ma10a0_unexpected_non_admin_actor_fail_closed",
+      "status": "pass"
+    },
+    {
+      "name": "ao_ma10a1_unexpected_merge_actor_propagates",
       "status": "pass"
     }
   ],
   "findings": [
-    "OpenAI review: AO-MA-10c correctly adds a fail-closed merge-agent executor without granting AI output release authority.",
-    "The executor is blocked under the current Halildeu/admin actor and requires the dedicated non-admin actor gladyatore-lab for execution.",
-    "The merge command builder is constrained to normal squash merge and tests assert no admin bypass or native auto-merge flag.",
-    "Schema and fixtures record dry-run, blocked-admin, command-attempt, mutation, required-check, and actor fields for later audit.",
-    "No support widening, production platform claim, live adapter execution, ruleset mutation, CODEOWNERS mutation, or bypass actor is introduced."
+    "OpenAI review: dedicated actor readiness was previously impossible because administration_write_absent_for_dedicated_actor was hardcoded false.",
+    "The patch computes that field from live GitHub actor evidence and keeps Halildeu/admin blocked.",
+    "unexpected_merge_actor is schema-pinned and propagated into AO-MA-10a1 eligibility blockers.",
+    "The refreshed A0/A1 artifacts correctly narrow live blockers to merge actor identity rather than stale required-check/review blockers.",
+    "The change is read-only and introduces no bypass, admin merge, support widening, production claim, or live adapter execution."
   ],
   "implementer": {
     "agent": "codex",
@@ -52,21 +56,20 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.md",
-      ".claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.v1.json",
+      ".claude/plans/AO-MA-10A0-GITHUB-READINESS-SNAPSHOT.v1.json",
+      ".claude/plans/AO-MA-10A1-AUTONOMOUS-MERGE-ELIGIBILITY.v1.json",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/ao-ma-10c-merge-agent-result.schema.v1.json",
+      "ao_kernel/defaults/schemas/ao-ma-10-autonomous-merge-eligibility.schema.v1.json",
+      "ao_kernel/defaults/schemas/ao-ma-10-github-readiness-snapshot.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10c_merge_agent.py",
-      "tests/fixtures/ao_ma_10c/merge_agent.blocked_admin_actor.valid.json",
-      "tests/fixtures/ao_ma_10c/merge_agent.ready_dry_run.valid.json",
-      "tests/test_ao_ma10c_merge_agent.py",
-      "tests/test_ri78b_bc1_6c_fast_follow_invariant.py"
+      "scripts/ao_ma10_github_readiness_snapshot.py",
+      "tests/test_ao_ma10_autonomous_merge_eligibility.py",
+      "tests/test_ao_ma10_github_readiness_snapshot.py"
     ],
-    "head_ref": "refs/heads/codex/ao-ma-10c-merge-agent-executor"
+    "head_ref": "refs/heads/codex/ao-ma-10q-dedicated-actor-readiness"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-MA-10c"
+  "work_package": "AO-MA-10q"
 }

--- a/ao_kernel/defaults/schemas/ao-ma-10-autonomous-merge-eligibility.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-ma-10-autonomous-merge-eligibility.schema.v1.json
@@ -211,7 +211,8 @@
               "ruleset_bypass_actors_present",
               "snapshot_mutated",
               "snapshot_not_read_only",
-              "ssot_live_required_check_drift_detected"
+              "ssot_live_required_check_drift_detected",
+              "unexpected_merge_actor"
             ]
           },
           "uniqueItems": true

--- a/ao_kernel/defaults/schemas/ao-ma-10-github-readiness-snapshot.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-ma-10-github-readiness-snapshot.schema.v1.json
@@ -239,6 +239,7 @@
               "ruleset_bypass_actors_present",
               "legacy_required_review_blocks_low_risk_autonomy",
               "merge_actor_admin_permission_observed",
+              "unexpected_merge_actor",
               "codeowners_broad_default_owner_present",
               "codeowners_governance_paths_not_fully_owned",
               "ssot_live_required_check_drift_detected"

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -21,20 +21,24 @@
       "status": "pass"
     },
     {
-      "name": "ao_ma10c_current_actor_fail_closed",
+      "name": "ao_ma10a0_dedicated_actor_confirmed_when_gladyatore_write_non_admin",
       "status": "pass"
     },
     {
-      "name": "merge_command_no_admin_or_auto",
+      "name": "ao_ma10a0_unexpected_non_admin_actor_fail_closed",
+      "status": "pass"
+    },
+    {
+      "name": "ao_ma10a1_unexpected_merge_actor_propagates",
       "status": "pass"
     }
   ],
   "findings": [
-    "AO-MA-10c adds a merge-agent dry-run/executor. It is an executor only; release authority remains ao-release-gate plus GitHub ruleset.",
-    "Dry-run is the default. Execute mode requires --execute plus confirmation literal AO-MA-10C-EXECUTE and all live gates passing.",
-    "The executor rejects the current Halildeu/admin actor and records merge_actor_admin_permission_observed instead of attempting a merge.",
-    "The only permitted command shape is gh pr merge <pr> --repo Halildeu/ao-kernel --squash --delete-branch. No admin bypass and no native auto-merge enablement are constructed.",
-    "Guard flags remain false: no support widening, no production platform claim, no live adapter execution."
+    "AO-MA-10q fixes the readiness snapshot so the dedicated merge actor can be confirmed instead of hardcoded false.",
+    "The dedicated actor condition is conjunctive: login gladyatore-lab, write permission, and viewerCanAdminister=false.",
+    "Wrong non-admin actors now fail closed with unexpected_merge_actor before eligibility or merge-agent activation.",
+    "Current live A0/A1 artifacts are refreshed: GitHub ruleset/review gates are ready, while active Halildeu/admin auth remains blocked.",
+    "No GitHub mutation, ruleset change, CODEOWNERS change, workflow change, live adapter execution, support widening, or production platform claim is introduced."
   ],
   "implementer": {
     "agent": "codex",
@@ -52,21 +56,20 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.md",
-      ".claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.v1.json",
+      ".claude/plans/AO-MA-10A0-GITHUB-READINESS-SNAPSHOT.v1.json",
+      ".claude/plans/AO-MA-10A1-AUTONOMOUS-MERGE-ELIGIBILITY.v1.json",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/ao-ma-10c-merge-agent-result.schema.v1.json",
+      "ao_kernel/defaults/schemas/ao-ma-10-autonomous-merge-eligibility.schema.v1.json",
+      "ao_kernel/defaults/schemas/ao-ma-10-github-readiness-snapshot.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10c_merge_agent.py",
-      "tests/fixtures/ao_ma_10c/merge_agent.blocked_admin_actor.valid.json",
-      "tests/fixtures/ao_ma_10c/merge_agent.ready_dry_run.valid.json",
-      "tests/test_ao_ma10c_merge_agent.py",
-      "tests/test_ri78b_bc1_6c_fast_follow_invariant.py"
+      "scripts/ao_ma10_github_readiness_snapshot.py",
+      "tests/test_ao_ma10_autonomous_merge_eligibility.py",
+      "tests/test_ao_ma10_github_readiness_snapshot.py"
     ],
-    "head_ref": "refs/heads/codex/ao-ma-10c-merge-agent-executor"
+    "head_ref": "refs/heads/codex/ao-ma-10q-dedicated-actor-readiness"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-MA-10c"
+  "work_package": "AO-MA-10q"
 }

--- a/scripts/ao_ma10_github_readiness_snapshot.py
+++ b/scripts/ao_ma10_github_readiness_snapshot.py
@@ -23,6 +23,7 @@ ARTIFACT_KIND = "ao_ma_10_github_readiness_snapshot"
 RELEASE_AUTHORITY = "ao-release-gate+github-ruleset"
 AO_RELEASE_GATE_REQUIRED_CHECKS = ("ao-release-gate-technical", "ao-release-gate-review")
 GITHUB_ACTIONS_APP_ID = 15368
+DEFAULT_DEDICATED_MERGE_ACTOR = "gladyatore-lab"
 
 
 def _run_json_with_error(command: list[str], label: str) -> tuple[dict[str, Any] | list[Any], str | None]:
@@ -290,6 +291,7 @@ def build_snapshot(
     rulesets: list[Any],
     branch_rules: list[Any],
     codeowners_text: str,
+    dedicated_merge_actor: str = DEFAULT_DEDICATED_MERGE_ACTOR,
     collection_errors: list[str] | None = None,
     ssot_required_check_claim_observed: bool = False,
     ssot_claim_source: str | None = None,
@@ -331,8 +333,17 @@ def build_snapshot(
         blockers.append("legacy_required_review_blocks_low_risk_autonomy")
 
     viewer_can_administer = bool(repo_info.get("viewerCanAdminister"))
+    actor_permission = viewer_permission or repo_info.get("viewerPermission")
+    actor_permission_normalized = str(actor_permission).lower() if actor_permission is not None else None
+    dedicated_actor_confirmed = (
+        viewer_login == dedicated_merge_actor
+        and actor_permission_normalized == "write"
+        and not viewer_can_administer
+    )
     if viewer_can_administer or viewer_permission == "admin":
         blockers.append("merge_actor_admin_permission_observed")
+    if viewer_login != dedicated_merge_actor:
+        blockers.append("unexpected_merge_actor")
 
     if not bool(repo_info.get("autoMergeAllowed")):
         warnings.append("repository_auto_merge_disabled_merge_agent_direct_mode_required")
@@ -377,9 +388,9 @@ def build_snapshot(
         },
         "merge_actor": {
             "login": viewer_login,
-            "permission": viewer_permission or repo_info.get("viewerPermission"),
+            "permission": actor_permission,
             "viewer_can_administer": viewer_can_administer,
-            "administration_write_absent_for_dedicated_actor": False,
+            "administration_write_absent_for_dedicated_actor": dedicated_actor_confirmed,
         },
         "branch_protection": {
             **normalized_bp,
@@ -407,7 +418,12 @@ def build_snapshot(
     }
 
 
-def collect_live_snapshot(repository: str, branch: str, gh_bin: str) -> dict[str, Any]:
+def collect_live_snapshot(
+    repository: str,
+    branch: str,
+    gh_bin: str,
+    dedicated_merge_actor: str = DEFAULT_DEDICATED_MERGE_ACTOR,
+) -> dict[str, Any]:
     collection_errors: list[str] = []
     repo_info, error = _repo_info_with_error(gh_bin, repository)
     if error:
@@ -462,6 +478,7 @@ def collect_live_snapshot(repository: str, branch: str, gh_bin: str) -> dict[str
         rulesets=detailed_rulesets,
         branch_rules=branch_rules if isinstance(branch_rules, list) else [],
         codeowners_text=codeowners,
+        dedicated_merge_actor=dedicated_merge_actor,
         collection_errors=collection_errors,
     )
 
@@ -471,6 +488,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--repository", default="Halildeu/ao-kernel")
     parser.add_argument("--branch", default="main")
     parser.add_argument("--gh-bin", default="gh")
+    parser.add_argument("--dedicated-merge-actor", default=DEFAULT_DEDICATED_MERGE_ACTOR)
     parser.add_argument(
         "--ssot-status-path",
         default=".claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md",
@@ -478,7 +496,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output", required=True)
     args = parser.parse_args(argv)
 
-    snapshot = collect_live_snapshot(args.repository, args.branch, args.gh_bin)
+    snapshot = collect_live_snapshot(args.repository, args.branch, args.gh_bin, args.dedicated_merge_actor)
     ssot_path = Path(args.ssot_status_path)
     ssot_claim_observed = _ssot_required_check_claim_observed(ssot_path)
     ssot_conflict = ssot_claim_observed and not snapshot["rulesets"]["ao_release_gate_source_pinned_to_actions"]

--- a/tests/test_ao_ma10_autonomous_merge_eligibility.py
+++ b/tests/test_ao_ma10_autonomous_merge_eligibility.py
@@ -45,6 +45,7 @@ def _ready_snapshot() -> dict[str, Any]:
     snapshot["readiness"]["warnings"] = ["repository_auto_merge_disabled_merge_agent_direct_mode_required"]
     snapshot["branch_protection"]["required_approving_review_count"] = 0
     snapshot["branch_protection"]["require_code_owner_reviews"] = False
+    snapshot["merge_actor"]["login"] = "gladyatore-lab"
     snapshot["merge_actor"]["permission"] = "write"
     snapshot["merge_actor"]["viewer_can_administer"] = False
     snapshot["merge_actor"]["administration_write_absent_for_dedicated_actor"] = True
@@ -101,12 +102,14 @@ def test_ao_ma10a1_current_snapshot_stays_blocked_with_live_blockers() -> None:
     Draft202012Validator(_schema()).validate(payload)
     blockers = set(payload["decision"]["blockers"])
     assert payload["decision"]["result"] == "blocked"
-    assert "ao_release_gate_required_check_missing" in blockers
-    assert "ao_release_gate_technical_required_check_missing" in blockers
-    assert "ao_release_gate_review_required_check_missing" in blockers
     assert "readiness_snapshot_not_ready" in blockers
-    assert "legacy_required_review_blocks_low_risk_autonomy" in blockers
     assert "merge_actor_admin_permission_observed" in blockers
+    assert "unexpected_merge_actor" in blockers
+    assert "dedicated_merge_actor_not_confirmed" in blockers
+    assert "ao_release_gate_required_check_missing" not in blockers
+    assert "ao_release_gate_technical_required_check_missing" not in blockers
+    assert "ao_release_gate_review_required_check_missing" not in blockers
+    assert "legacy_required_review_blocks_low_risk_autonomy" not in blockers
     assert "ssot_live_required_check_drift_detected" not in blockers
 
 
@@ -116,8 +119,11 @@ def test_ao_ma10a1_committed_evidence_records_current_fail_closed_state() -> Non
     assert payload["decision"]["result"] == "blocked"
     assert payload["read_only"] is True
     assert payload["mutations_performed"] is False
-    assert "ao_release_gate_technical_required_check_missing" in blockers
-    assert "ao_release_gate_review_required_check_missing" in blockers
+    assert "ao_release_gate_technical_required_check_missing" not in blockers
+    assert "ao_release_gate_review_required_check_missing" not in blockers
+    assert "merge_actor_admin_permission_observed" in blockers
+    assert "unexpected_merge_actor" in blockers
+    assert "dedicated_merge_actor_not_confirmed" in blockers
     assert "readiness_snapshot_not_ready" in blockers
 
 
@@ -219,6 +225,20 @@ def test_ao_ma10a1_blocks_admin_or_unconfirmed_merge_actor() -> None:
     snapshot["merge_actor"]["administration_write_absent_for_dedicated_actor"] = False
     payload = _eligibility(snapshot, ["tests/test_ao_ma10_autonomous_merge_eligibility.py"])
     assert "merge_actor_admin_permission_observed" in payload["decision"]["blockers"]
+    assert "dedicated_merge_actor_not_confirmed" in payload["decision"]["blockers"]
+
+
+def test_ao_ma10a1_propagates_unexpected_merge_actor_from_readiness_snapshot() -> None:
+    snapshot = _ready_snapshot()
+    snapshot["readiness"]["decision"] = "blocked"
+    snapshot["readiness"]["blockers"] = ["unexpected_merge_actor"]
+    snapshot["merge_actor"]["login"] = "some-other-writer"
+    snapshot["merge_actor"]["permission"] = "write"
+    snapshot["merge_actor"]["viewer_can_administer"] = False
+    snapshot["merge_actor"]["administration_write_absent_for_dedicated_actor"] = False
+    payload = _eligibility(snapshot, ["tests/test_ao_ma10_autonomous_merge_eligibility.py"])
+    assert "unexpected_merge_actor" in payload["decision"]["blockers"]
+    assert "readiness_snapshot_not_ready" in payload["decision"]["blockers"]
     assert "dedicated_merge_actor_not_confirmed" in payload["decision"]["blockers"]
 
 

--- a/tests/test_ao_ma10_github_readiness_snapshot.py
+++ b/tests/test_ao_ma10_github_readiness_snapshot.py
@@ -53,7 +53,7 @@ def _valid_ready_inputs() -> dict[str, Any]:
             "viewerCanAdminister": False,
             "viewerPermission": "WRITE",
         },
-        "viewer_login": "ao-merge-agent",
+        "viewer_login": "gladyatore-lab",
         "viewer_permission": "write",
         "branch_protection": {
             "required_pull_request_reviews": {
@@ -138,9 +138,10 @@ def test_ao_ma10a0_live_snapshot_records_current_blockers_without_mutation() -> 
     }
     assert snapshot["collection_errors"] == []
     blockers = set(snapshot["readiness"]["blockers"])
-    assert "ao_release_gate_required_check_missing" in blockers
-    assert "legacy_required_review_blocks_low_risk_autonomy" in blockers
     assert "merge_actor_admin_permission_observed" in blockers
+    assert "unexpected_merge_actor" in blockers
+    assert "ao_release_gate_required_check_missing" not in blockers
+    assert "legacy_required_review_blocks_low_risk_autonomy" not in blockers
     # Historical changelog/runbook wording does not count as a current SSOT
     # claim. AO-MA-10A0 should only report drift when the current status
     # section claims a live required-check shape that GitHub API contradicts.
@@ -162,9 +163,23 @@ def test_ao_ma10a0_ready_case_requires_source_pinned_release_gate_and_non_admin_
     assert snapshot["rulesets"]["ao_release_gate_required_check_present"] is True
     assert snapshot["rulesets"]["ao_release_gate_source_pinned_to_actions"] is True
     assert snapshot["merge_actor"]["viewer_can_administer"] is False
+    assert snapshot["merge_actor"]["administration_write_absent_for_dedicated_actor"] is True
     assert snapshot["readiness"]["decision"] == "ready_for_dry_run"
     assert snapshot["readiness"]["blockers"] == []
     assert "repository_auto_merge_disabled_merge_agent_direct_mode_required" in snapshot["readiness"]["warnings"]
+
+
+def test_ao_ma10a0_blocks_wrong_non_admin_merge_actor() -> None:
+    mod = _load_script_module()
+    inputs = _valid_ready_inputs()
+    inputs["viewer_login"] = "some-other-writer"
+    inputs["viewer_permission"] = "write"
+    inputs["repo_info"]["viewerCanAdminister"] = False
+    snapshot = mod.build_snapshot(**inputs)
+    assert snapshot["merge_actor"]["administration_write_absent_for_dedicated_actor"] is False
+    assert "unexpected_merge_actor" in snapshot["readiness"]["blockers"]
+    assert "merge_actor_admin_permission_observed" not in snapshot["readiness"]["blockers"]
+    assert snapshot["readiness"]["decision"] == "blocked"
 
 
 def test_ao_ma10a0_blocks_wrong_source_pin_even_when_check_name_matches() -> None:
@@ -271,6 +286,7 @@ def test_ao_ma10a0_blocks_admin_merge_actor() -> None:
     inputs["viewer_permission"] = "admin"
     snapshot = mod.build_snapshot(**inputs)
     assert "merge_actor_admin_permission_observed" in snapshot["readiness"]["blockers"]
+    assert snapshot["merge_actor"]["administration_write_absent_for_dedicated_actor"] is False
     assert snapshot["readiness"]["decision"] == "blocked"
 
 


### PR DESCRIPTION
## Summary

AO-MA-10q closes a readiness pipeline bug for no-human autonomous merge readiness: the dedicated merge actor confirmation was effectively hardcoded false, so the lane would stay blocked even after authenticating a non-admin/write actor.

This PR makes the merge actor check fail closed and explicit:

- expected dedicated actor defaults to `gladyatore-lab`
- wrong actor produces `unexpected_merge_actor`
- admin actor stays blocked via `merge_actor_admin_permission_observed`
- readiness only passes when viewer login matches the dedicated actor, permission is `write`, and administration is absent
- AO-MA-10A0/A1 live artifacts are regenerated against the current active actor (`Halildeu/admin`), so the current live state remains blocked until runtime credentials switch to the dedicated actor

## Why this matters

Native human approval/review gates are already removed from live GitHub rulesets, but full autonomy still needs a non-admin merge runtime identity. This patch ensures the readiness gate will become green when that identity is actually active, instead of remaining blocked due to a hardcoded false value.

## Validation

```text
python3 -m pytest -q tests/test_ao_ma10_github_readiness_snapshot.py tests/test_ao_ma10_autonomous_merge_eligibility.py tests/test_ao_ma10c_merge_agent.py tests/test_ao_ma10j_high_risk_supersession_evidence_builder.py
55 passed, 47 warnings

python3 -m ruff check scripts/ao_ma10_github_readiness_snapshot.py tests/test_ao_ma10_github_readiness_snapshot.py tests/test_ao_ma10_autonomous_merge_eligibility.py
All checks passed!

python3 -m mypy ao_kernel/
Success: no issues found in 257 source files

python3 scripts/local_gpp_gate.py --review-evidence local-ai-review-evidence.v1.json --repo Halildeu/ao-kernel --work-package AO-MA-10q --review-base-ref refs/heads/main --review-head-ref refs/heads/codex/ao-ma-10q-dedicated-actor-readiness --diff-base-ref origin/main --diff-head-ref HEAD
Decision: operator_may_merge
```

## Guardrails

- No support widening
- No production platform claim
- No live adapter execution
- No ruleset/branch-protection/CODEOWNERS/workflow mutation
- AI review remains evidence only; release authority remains repo-owned required checks + GitHub ruleset
