### PR TITLE
feat(ao-ma-10p): propagate dedicated gh runtime through smoke

### DIFF
--- a/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md
+++ b/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md
@@ -38,6 +38,17 @@ Execute mode requires:
 --execute --confirmation AO-MA-10L-EXECUTE
 ```
 
+The GitHub CLI runtime can be isolated with:
+
+```text
+--gh-bin <dedicated-gh-wrapper>
+```
+
+AO-MA-10l passes this value to every live GitHub read/write call, to the A0
+readiness snapshot collector, and to the AO-MA-10c merge-agent. This lets the
+smoke run under the dedicated non-admin merge actor without changing the
+operator's global `gh` login.
+
 Even in execute mode it stops before any GitHub write when A0/A1 is blocked.
 
 ## Live Blocker
@@ -51,8 +62,8 @@ merge_actor_admin_permission_observed
 dedicated_merge_actor_not_confirmed
 ```
 
-The smoke becomes runnable when the active `gh` runtime is authenticated as the
-dedicated non-admin merge actor:
+The smoke becomes runnable when the selected `gh` runtime is authenticated as
+the dedicated non-admin merge actor:
 
 ```text
 gladyatore-lab
@@ -73,10 +84,11 @@ When A0/A1 are ready and explicit confirmation is present, the orchestrator:
 5. refreshes A0/A1;
 6. delegates the actual merge to `scripts/ao_ma10c_merge_agent.py`.
 
-The only merge command still lives inside AO-MA-10c:
+The only merge command still lives inside AO-MA-10c and uses the same selected
+`--gh-bin` runtime:
 
 ```text
-gh pr merge <pr> --repo Halildeu/ao-kernel --squash --delete-branch
+<dedicated-gh-wrapper> pr merge <pr> --repo Halildeu/ao-kernel --squash --delete-branch
 ```
 
 AO-MA-10l never constructs an admin merge command and never mutates rulesets,

--- a/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json
+++ b/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json
@@ -11,6 +11,8 @@
   "live_adapter_execution": false,
   "default_mode": "read_only",
   "execute_confirmation": "AO-MA-10L-EXECUTE",
+  "supports_dedicated_gh_runtime": true,
+  "dedicated_gh_runtime_argument": "--gh-bin",
   "expected_actor": "gladyatore-lab",
   "blocks_before_github_write_when_a0_a1_blocked": true,
   "delegates_merge_to": "scripts/ao_ma10c_merge_agent.py",

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -5,16 +5,28 @@
       "status": "pass"
     },
     {
+      "name": "ruff",
+      "status": "pass"
+    },
+    {
+      "name": "mypy",
+      "status": "pass"
+    },
+    {
       "name": "secret_scan",
+      "status": "pass"
+    },
+    {
+      "name": "live_dry_run_fail_closed",
       "status": "pass"
     }
   ],
   "findings": [
-    "Claude/Anthropic review returned AGREE for AO-MA-10l autonomous smoke orchestrator.",
-    "Fail-closed behavior is preserved: A0/A1 blockers return before any GitHub branch, file, or PR write.",
-    "Execute mode requires AO-MA-10L-EXECUTE and delegates the actual merge to AO-MA-10c.",
-    "No admin merge, bypass actor, ruleset mutation, CODEOWNERS mutation, support widening, production platform claim, or live adapter execution is introduced.",
-    "Advisory only: merge_agent_result schema could be tightened later, and mid-flow GitHub API failure tests could be expanded."
+    "Claude/Anthropic review returned AGREE for AO-MA-10p dedicated gh runtime propagation.",
+    "Security boundary is preserved: gh_bin changes only the selected GitHub CLI runtime and does not change release authority.",
+    "Fail-closed behavior is preserved: execute still requires AO-MA-10L-EXECUTE and A0/A1 blockers return before GitHub writes.",
+    "Propagation is complete across A0 readiness collection, direct GitHub API/PR/check calls, and AO-MA-10c merge-agent delegation.",
+    "No admin merge, ruleset mutation, branch-protection mutation, CODEOWNERS mutation, support widening, production platform claim, or live adapter execution is introduced."
   ],
   "implementer": {
     "agent": "codex",
@@ -34,14 +46,13 @@
     "changed_files": [
       ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md",
       ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json",
-      "ao_kernel/defaults/schemas/ao-ma-10l-autonomous-smoke-result.schema.v1.json",
       "local-ai-review-evidence.v1.json",
       "scripts/ao_ma10l_autonomous_smoke.py",
       "tests/test_ao_ma10l_autonomous_smoke.py"
     ],
-    "head_ref": "refs/heads/codex/ao-ma10l-autonomous-smoke"
+    "head_ref": "refs/heads/codex/ao-ma10p-gh-bin-propagation"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-MA-10l"
+  "work_package": "AO-MA-10p"
 }

--- a/scripts/ao_ma10l_autonomous_smoke.py
+++ b/scripts/ao_ma10l_autonomous_smoke.py
@@ -164,6 +164,7 @@ def _collect_readiness(
     *,
     repo: str,
     expected_actor: str,
+    gh_bin: str,
     output: Path,
     runner: Runner,
 ) -> tuple[dict[str, Any], list[str]]:
@@ -174,6 +175,8 @@ def _collect_readiness(
         repo,
         "--dedicated-merge-actor",
         expected_actor,
+        "--gh-bin",
+        gh_bin,
         "--output",
         str(output),
     ]
@@ -276,6 +279,7 @@ def _parse_pr_number(value: str) -> int | None:
 def _create_disposable_pr(
     *,
     repo: str,
+    gh_bin: str,
     base_ref: str,
     branch: str,
     smoke_path: str,
@@ -286,7 +290,7 @@ def _create_disposable_pr(
 ) -> tuple[int | None, set[str]]:
     blockers: set[str] = set()
 
-    get_ref = ["gh", "api", f"repos/{repo}/git/ref/heads/{base_ref}"]
+    get_ref = [gh_bin, "api", f"repos/{repo}/git/ref/heads/{base_ref}"]
     _add_command(result, get_ref)
     ref_payload, error = _run_json(get_ref, runner)
     if error is not None or not isinstance(ref_payload, dict):
@@ -296,7 +300,7 @@ def _create_disposable_pr(
         return None, {"github_base_ref_sha_missing"}
 
     create_ref = [
-        "gh",
+        gh_bin,
         "api",
         f"repos/{repo}/git/refs",
         "--method",
@@ -328,7 +332,7 @@ def _create_disposable_pr(
         encoding="utf-8",
     )
     put_file = [
-        "gh",
+        gh_bin,
         "api",
         f"repos/{repo}/contents/{smoke_path}",
         "--method",
@@ -348,7 +352,7 @@ def _create_disposable_pr(
         "readiness and required checks pass."
     )
     create_pr = [
-        "gh",
+        gh_bin,
         "pr",
         "create",
         "--repo",
@@ -401,6 +405,7 @@ def _required_checks_passed(raw_checks: list[Any]) -> tuple[bool, list[dict[str,
 def _wait_for_required_checks(
     *,
     repo: str,
+    gh_bin: str,
     pr_number: int,
     runner: Runner,
     result: dict[str, Any],
@@ -411,7 +416,7 @@ def _wait_for_required_checks(
     last_failing: list[dict[str, Any]] = []
     while True:
         command = [
-            "gh",
+            gh_bin,
             "pr",
             "checks",
             str(pr_number),
@@ -441,6 +446,7 @@ def _wait_for_required_checks(
 def _run_merge_agent(
     *,
     repo: str,
+    gh_bin: str,
     pr_number: int,
     snapshot: Path,
     eligibility: Path,
@@ -453,6 +459,8 @@ def _run_merge_agent(
         "scripts/ao_ma10c_merge_agent.py",
         "--repo",
         repo,
+        "--gh-bin",
+        gh_bin,
         "--pr",
         str(pr_number),
         "--snapshot",
@@ -487,6 +495,7 @@ def run_smoke(
     repo: str,
     base_ref: str,
     expected_actor: str,
+    gh_bin: str,
     smoke_root: str,
     output: Path,
     execute: bool,
@@ -523,6 +532,7 @@ def run_smoke(
         snapshot, errors = _collect_readiness(
             repo=repo,
             expected_actor=expected_actor,
+            gh_bin=gh_bin,
             output=initial_snapshot_path,
             runner=runner,
         )
@@ -555,6 +565,7 @@ def run_smoke(
 
         pr_number, create_blockers = _create_disposable_pr(
             repo=repo,
+            gh_bin=gh_bin,
             base_ref=base_ref,
             branch=branch,
             smoke_path=smoke_path,
@@ -568,6 +579,7 @@ def run_smoke(
             blockers.update(
                 _wait_for_required_checks(
                     repo=repo,
+                    gh_bin=gh_bin,
                     pr_number=pr_number,
                     runner=runner,
                     result=result,
@@ -582,6 +594,7 @@ def run_smoke(
             final_snapshot, errors = _collect_readiness(
                 repo=repo,
                 expected_actor=expected_actor,
+                gh_bin=gh_bin,
                 output=final_snapshot_path,
                 runner=runner,
             )
@@ -609,6 +622,7 @@ def run_smoke(
                 merge_output = temp_dir / "merge-agent-result.json"
                 merge_result, merge_blockers = _run_merge_agent(
                     repo=repo,
+                    gh_bin=gh_bin,
                     pr_number=pr_number,
                     snapshot=final_snapshot_path,
                     eligibility=final_eligibility_path,
@@ -631,6 +645,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument("--base-ref", default=DEFAULT_BASE_REF)
     parser.add_argument("--expected-actor", default=DEFAULT_EXPECTED_ACTOR)
+    parser.add_argument(
+        "--gh-bin",
+        default="gh",
+        help="GitHub CLI binary or wrapper to use for every live GitHub call.",
+    )
     parser.add_argument("--smoke-root", default=DEFAULT_SMOKE_ROOT)
     parser.add_argument("--output", required=True)
     parser.add_argument("--execute", action="store_true")
@@ -644,6 +663,7 @@ def main(argv: list[str] | None = None) -> int:
         repo=args.repo,
         base_ref=args.base_ref,
         expected_actor=args.expected_actor,
+        gh_bin=args.gh_bin,
         smoke_root=args.smoke_root,
         output=Path(args.output),
         execute=args.execute,

--- a/tests/test_ao_ma10l_autonomous_smoke.py
+++ b/tests/test_ao_ma10l_autonomous_smoke.py
@@ -133,9 +133,10 @@ def _merge_agent_merged() -> dict[str, Any]:
 
 
 class FakeRunner:
-    def __init__(self, *, ready: bool = True, checks_pass: bool = True) -> None:
+    def __init__(self, *, ready: bool = True, checks_pass: bool = True, gh_bin: str = "gh") -> None:
         self.ready = ready
         self.checks_pass = checks_pass
+        self.gh_bin = gh_bin
         self.commands: list[list[str]] = []
 
     def __call__(self, command: list[str]) -> subprocess.CompletedProcess[str]:
@@ -150,15 +151,15 @@ class FakeRunner:
             payload = _ready_eligibility(changed_file) if self.ready else _blocked_eligibility(changed_file)
             output.write_text(json.dumps(payload), encoding="utf-8")
             return subprocess.CompletedProcess(command, 0 if self.ready else 1, json.dumps(payload), "")
-        if command[:3] == ["gh", "api", "repos/Halildeu/ao-kernel/git/ref/heads/main"]:
+        if command[:3] == [self.gh_bin, "api", "repos/Halildeu/ao-kernel/git/ref/heads/main"]:
             return subprocess.CompletedProcess(command, 0, json.dumps({"object": {"sha": "a" * 40}}), "")
-        if command[:3] == ["gh", "api", "repos/Halildeu/ao-kernel/git/refs"]:
+        if command[:3] == [self.gh_bin, "api", "repos/Halildeu/ao-kernel/git/refs"]:
             return subprocess.CompletedProcess(command, 0, json.dumps({"ref": "refs/heads/example"}), "")
-        if len(command) >= 3 and command[:2] == ["gh", "api"] and "/contents/" in command[2]:
+        if len(command) >= 3 and command[:2] == [self.gh_bin, "api"] and "/contents/" in command[2]:
             return subprocess.CompletedProcess(command, 0, json.dumps({"content": {"path": "docs/evidence/example.md"}}), "")
-        if command[:3] == ["gh", "pr", "create"]:
+        if command[:3] == [self.gh_bin, "pr", "create"]:
             return subprocess.CompletedProcess(command, 0, "https://github.com/Halildeu/ao-kernel/pull/999\n", "")
-        if command[:3] == ["gh", "pr", "checks"]:
+        if command[:3] == [self.gh_bin, "pr", "checks"]:
             checks = (
                 [
                     {"name": "ao-release-gate-technical", "bucket": "pass", "state": "SUCCESS"},
@@ -178,7 +179,14 @@ class FakeRunner:
         raise AssertionError(command)
 
 
-def _run_with_fake(tmp_path: Path, fake: FakeRunner, *, execute: bool = False, confirmation: str | None = None) -> dict[str, Any]:
+def _run_with_fake(
+    tmp_path: Path,
+    fake: FakeRunner,
+    *,
+    execute: bool = False,
+    confirmation: str | None = None,
+    gh_bin: str = "gh",
+) -> dict[str, Any]:
     mod = _load_script_module()
     output = tmp_path / "result.json"
     return cast(
@@ -187,6 +195,7 @@ def _run_with_fake(tmp_path: Path, fake: FakeRunner, *, execute: bool = False, c
             repo="Halildeu/ao-kernel",
             base_ref="main",
             expected_actor="gladyatore-lab",
+            gh_bin=gh_bin,
             smoke_root="docs/evidence/ao-ma-10l-autonomous-smoke",
             output=output,
             execute=execute,
@@ -264,6 +273,36 @@ def test_ao_ma10l_execute_success_creates_pr_and_delegates_merge_agent(tmp_path:
     assert merge_agent_commands
     assert "--execute" in merge_agent_commands[0]
     assert "--admin" not in merge_agent_commands[0]
+
+
+def test_ao_ma10l_propagates_custom_gh_bin_to_all_live_github_calls(tmp_path: Path) -> None:
+    fake = FakeRunner(ready=True, gh_bin="gh-dedicated")
+    result = _run_with_fake(
+        tmp_path,
+        fake,
+        execute=True,
+        confirmation="AO-MA-10L-EXECUTE",
+        gh_bin="gh-dedicated",
+    )
+    assert result["decision"]["result"] == "merged"
+
+    readiness_commands = [
+        command
+        for command in fake.commands
+        if len(command) > 1 and command[1].endswith("ao_ma10_github_readiness_snapshot.py")
+    ]
+    assert len(readiness_commands) == 2
+    assert all(command[command.index("--gh-bin") + 1] == "gh-dedicated" for command in readiness_commands)
+
+    live_gh_commands = [command for command in fake.commands if len(command) > 1 and command[1] in {"api", "pr"}]
+    assert live_gh_commands
+    assert all(command[0] == "gh-dedicated" for command in live_gh_commands)
+
+    merge_agent_commands = [
+        command for command in fake.commands if len(command) > 1 and command[1].endswith("ao_ma10c_merge_agent.py")
+    ]
+    assert merge_agent_commands
+    assert merge_agent_commands[0][merge_agent_commands[0].index("--gh-bin") + 1] == "gh-dedicated"
 
 
 def test_ao_ma10l_required_check_failure_blocks_before_merge_agent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds `--gh-bin` propagation to AO-MA-10l so the end-to-end autonomous smoke can run under an isolated dedicated non-admin GitHub actor runtime without changing the operator's global `gh` login.

## Scope

- `scripts/ao_ma10l_autonomous_smoke.py`
  - adds CLI/runtime `--gh-bin`
  - passes it to AO-MA-10a0 readiness collection
  - uses it for disposable PR branch/file/create/check GitHub calls
  - passes it to AO-MA-10c merge-agent
- AO-MA-10l plan + receipt updated to document dedicated runtime support
- root `local-ai-review-evidence.v1.json` updated for AO-MA-10p Claude/Anthropic AGREE
- tests assert all live GitHub calls and merge-agent delegation use the selected runtime

## Guardrails

- AI output remains evidence only, not release authority
- release authority remains `ao-release-gate+github-ruleset`
- no admin merge, ruleset mutation, branch-protection mutation, CODEOWNERS mutation
- no support widening, production platform claim, or live adapter execution
- execute still requires `AO-MA-10L-EXECUTE`
- live dry-run under current `Halildeu/admin` actor still blocks before mutation

## Validation

- `python3 -m pytest -q tests/test_ao_ma10l_autonomous_smoke.py` -> 8 passed
- `python3 -m pytest -q tests/test_ao_ma10l_autonomous_smoke.py tests/test_ao_ma10c_merge_agent.py tests/test_ao_ma10_autonomous_merge_eligibility.py tests/test_ao_ma10_github_readiness_snapshot.py` -> 60 passed
- `python3 -m ruff check scripts/ao_ma10l_autonomous_smoke.py tests/test_ao_ma10l_autonomous_smoke.py` -> pass
- `python3 -m mypy scripts/ao_ma10l_autonomous_smoke.py tests/test_ao_ma10l_autonomous_smoke.py` -> pass
- `python3 scripts/ao_ma10l_autonomous_smoke.py --gh-bin gh --output /tmp/ao-ma10p-current.json --format text` -> blocked, mutations_performed=false, expected current actor blockers
- Claude/Anthropic review -> AGREE, ready_to_merge=true
- `python3 scripts/local_gpp_gate.py ... --work-package AO-MA-10p` -> `operator_may_merge`