### PR TITLE
feat(ao-ma-10q): add dedicated actor runner for autonomous smoke

### DIFF
--- a/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md
+++ b/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md
@@ -1,0 +1,106 @@
+# AO-MA-10q - Dedicated Actor Runner
+
+**Status:** implemented fail-closed
+**Date:** 2026-05-29
+**Parent:** AO-MA-10 low-risk autonomous merge lane
+**Support impact:** none
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## Purpose
+
+AO-MA-10q removes the remaining ad-hoc shell wrapper step from the low-risk
+autonomous merge smoke. It runs AO-MA-10l through a temporary GitHub CLI wrapper
+that is scoped to the dedicated non-admin merge actor.
+
+The runner does not replace release authority. AI provider output remains evidence only.
+Release authority remains the repo-owned `ao-release-gate` required checks plus
+GitHub ruleset enforcement.
+
+## Script
+
+```text
+scripts/ao_ma10q_dedicated_actor_runner.py
+```
+
+Default token environment variable:
+
+```text
+GLADYATORE_LAB_GH_TOKEN
+```
+
+The runner never accepts token values on CLI arguments. It only accepts the
+name of an environment variable and creates a temporary `0700` wrapper:
+
+```text
+GH_TOKEN="${GLADYATORE_LAB_GH_TOKEN}" exec gh "$@"
+```
+
+The output artifact records neither the token value nor the temporary wrapper
+path.
+
+## Dry-Run Command
+
+```bash
+GLADYATORE_LAB_GH_TOKEN=<redacted> \
+  python3 scripts/ao_ma10q_dedicated_actor_runner.py \
+    --output /tmp/ao-ma10q.json \
+    --format text
+```
+
+Without the token environment variable, the runner exits fail-closed with:
+
+```text
+dedicated_actor_token_env_missing
+```
+
+## Execute Command
+
+```bash
+GLADYATORE_LAB_GH_TOKEN=<redacted> \
+  python3 scripts/ao_ma10q_dedicated_actor_runner.py \
+    --output /tmp/ao-ma10q.json \
+    --execute \
+    --confirmation AO-MA-10L-EXECUTE \
+    --format text
+```
+
+AO-MA-10q delegates all live GitHub sequencing to AO-MA-10l:
+
+```text
+AO-MA-10q dedicated actor wrapper -> AO-MA-10l smoke -> AO-MA-10c merge-agent
+```
+
+AO-MA-10l still performs A0/A1 readiness checks, required check observation,
+and AO-MA-10c merge delegation. If those checks fail, AO-MA-10q records the
+blockers and does not turn AI review into release authority.
+
+## Result Artifact
+
+Schema:
+
+```text
+ao_kernel/defaults/schemas/ao-ma-10q-dedicated-actor-runner-result.schema.v1.json
+```
+
+The artifact records:
+
+- expected actor and token environment variable name;
+- whether execute mode was requested;
+- whether a temporary wrapper was created;
+- sanitized AO-MA-10l command shape;
+- embedded AO-MA-10l smoke result;
+- final fail-closed decision.
+
+## Completion Criteria
+
+The no-human low-risk merge path is proven only when AO-MA-10q produces a
+`merged` artifact where:
+
+- token value is not recorded;
+- wrapper path is not recorded;
+- actor is the dedicated non-admin merge actor;
+- AO-MA-10l reports `merged`;
+- required checks pass;
+- no admin bypass, ruleset mutation, branch-protection mutation, support
+  widening, production platform claim, or live adapter execution occurs.

--- a/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json
+++ b/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "ao-ma-10q-dedicated-actor-runner-receipt.v1",
+  "artifact_kind": "ao_ma_10q_dedicated_actor_runner_receipt",
+  "status": "implemented_fail_closed",
+  "script": "scripts/ao_ma10q_dedicated_actor_runner.py",
+  "result_schema": "ao_kernel/defaults/schemas/ao-ma-10q-dedicated-actor-runner-result.schema.v1.json",
+  "release_authority": "ao-release-gate+github-ruleset",
+  "ai_output_release_authority": false,
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false,
+  "default_token_env": "GLADYATORE_LAB_GH_TOKEN",
+  "token_value_recorded": false,
+  "wrapper_path_recorded": false,
+  "wrapper_mode": "0700",
+  "execute_confirmation": "AO-MA-10L-EXECUTE",
+  "delegates_to": "scripts/ao_ma10l_autonomous_smoke.py",
+  "expected_actor": "gladyatore-lab",
+  "forbidden_mutations": [
+    "admin_merge",
+    "ruleset_mutation",
+    "branch_protection_mutation",
+    "codeowners_mutation",
+    "gpp_status_mutation",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution"
+  ]
+}

--- a/ao_kernel/defaults/schemas/ao-ma-10q-dedicated-actor-runner-result.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-ma-10q-dedicated-actor-runner-result.schema.v1.json
@@ -1,0 +1,163 @@
+{
+  "$id": "urn:ao:ao-ma-10q-dedicated-actor-runner-result:v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "ai_output_release_authority": {
+      "const": false
+    },
+    "artifact_kind": {
+      "const": "ao_ma_10q_dedicated_actor_runner_result"
+    },
+    "base_ref": {
+      "type": "string"
+    },
+    "decision": {
+      "additionalProperties": false,
+      "properties": {
+        "blockers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "next_required_slice": {
+          "type": "string"
+        },
+        "result": {
+          "enum": [
+            "blocked",
+            "ready_for_smoke_dry_run",
+            "merged"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "result",
+        "blockers",
+        "warnings",
+        "next_required_slice"
+      ],
+      "type": "object"
+    },
+    "execute_requested": {
+      "type": "boolean"
+    },
+    "expected_actor": {
+      "type": "string"
+    },
+    "generated_at": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "guard_flags": {
+      "additionalProperties": false,
+      "properties": {
+        "live_adapter_execution": {
+          "const": false
+        },
+        "production_platform_claim": {
+          "const": false
+        },
+        "support_widening": {
+          "const": false
+        }
+      },
+      "required": [
+        "support_widening",
+        "production_platform_claim",
+        "live_adapter_execution"
+      ],
+      "type": "object"
+    },
+    "mutations_performed": {
+      "type": "boolean"
+    },
+    "release_authority": {
+      "const": "ao-release-gate+github-ruleset"
+    },
+    "repository": {
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "ao-ma-10q-dedicated-actor-runner-result.v1"
+    },
+    "smoke_command": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "smoke_result": {
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "token_env": {
+      "pattern": "^[A-Z_][A-Z0-9_]*$",
+      "type": "string"
+    },
+    "token_value_recorded": {
+      "const": false
+    },
+    "wrapper": {
+      "additionalProperties": false,
+      "properties": {
+        "created": {
+          "type": "boolean"
+        },
+        "mode": {
+          "anyOf": [
+            {
+              "const": "0700"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "path_recorded": {
+          "const": false
+        }
+      },
+      "required": [
+        "created",
+        "mode",
+        "path_recorded"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "generated_at",
+    "repository",
+    "base_ref",
+    "expected_actor",
+    "token_env",
+    "token_value_recorded",
+    "execute_requested",
+    "mutations_performed",
+    "release_authority",
+    "ai_output_release_authority",
+    "guard_flags",
+    "wrapper",
+    "smoke_result",
+    "smoke_command",
+    "decision"
+  ],
+  "title": "AO-MA-10q dedicated actor runner result",
+  "type": "object"
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -17,15 +17,20 @@
       "status": "pass"
     },
     {
-      "name": "live_dry_run_fail_closed",
+      "name": "json_schema",
+      "status": "pass"
+    },
+    {
+      "name": "missing_token_fail_closed",
       "status": "pass"
     }
   ],
   "findings": [
-    "Claude/Anthropic review returned AGREE for AO-MA-10p dedicated gh runtime propagation.",
-    "Security boundary is preserved: gh_bin changes only the selected GitHub CLI runtime and does not change release authority.",
-    "Fail-closed behavior is preserved: execute still requires AO-MA-10L-EXECUTE and A0/A1 blockers return before GitHub writes.",
-    "Propagation is complete across A0 readiness collection, direct GitHub API/PR/check calls, and AO-MA-10c merge-agent delegation.",
+    "Claude/Anthropic review returned AGREE for AO-MA-10q dedicated actor runner.",
+    "The runner accepts only a token environment variable name, never a token value on CLI.",
+    "Token values and temporary wrapper paths are not recorded in the result artifact.",
+    "Missing token env fails closed before invoking AO-MA-10l and performs no mutation.",
+    "Release authority remains ao-release-gate plus GitHub ruleset; AI output remains evidence only.",
     "No admin merge, ruleset mutation, branch-protection mutation, CODEOWNERS mutation, support widening, production platform claim, or live adapter execution is introduced."
   ],
   "implementer": {
@@ -44,15 +49,16 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md",
-      ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json",
+      ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md",
+      ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json",
+      "ao_kernel/defaults/schemas/ao-ma-10q-dedicated-actor-runner-result.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10l_autonomous_smoke.py",
-      "tests/test_ao_ma10l_autonomous_smoke.py"
+      "scripts/ao_ma10q_dedicated_actor_runner.py",
+      "tests/test_ao_ma10q_dedicated_actor_runner.py"
     ],
-    "head_ref": "refs/heads/codex/ao-ma10p-gh-bin-propagation"
+    "head_ref": "refs/heads/codex/ao-ma10q-dedicated-runner"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-MA-10p"
+  "work_package": "AO-MA-10q"
 }

--- a/scripts/ao_ma10q_dedicated_actor_runner.py
+++ b/scripts/ao_ma10q_dedicated_actor_runner.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""AO-MA-10q no-secret dedicated actor runner for AO-MA-10l.
+
+This helper removes the last ad-hoc shell-wrapper step from the low-risk
+autonomous merge smoke. It never accepts a token value on the command line.
+Instead, it creates a temporary ``gh`` wrapper that reads one named environment
+variable and passes that token to the GitHub CLI as ``GH_TOKEN``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import stat
+import subprocess
+import sys
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+
+SCHEMA_VERSION = "ao-ma-10q-dedicated-actor-runner-result.v1"
+ARTIFACT_KIND = "ao_ma_10q_dedicated_actor_runner_result"
+RELEASE_AUTHORITY = "ao-release-gate+github-ruleset"
+DEFAULT_REPO = "Halildeu/ao-kernel"
+DEFAULT_BASE_REF = "main"
+DEFAULT_EXPECTED_ACTOR = "gladyatore-lab"
+DEFAULT_TOKEN_ENV = "GLADYATORE_LAB_GH_TOKEN"
+EXECUTE_CONFIRMATION = "AO-MA-10L-EXECUTE"
+TOKEN_ENV_RE = re.compile(r"[A-Z_][A-Z0-9_]*")
+
+Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+
+def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True, timeout=180)
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _base_result(*, repo: str, base_ref: str, expected_actor: str, token_env: str, execute: bool) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_kind": ARTIFACT_KIND,
+        "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "repository": repo,
+        "base_ref": base_ref,
+        "expected_actor": expected_actor,
+        "token_env": token_env,
+        "token_value_recorded": False,
+        "execute_requested": execute,
+        "mutations_performed": False,
+        "release_authority": RELEASE_AUTHORITY,
+        "ai_output_release_authority": False,
+        "guard_flags": {
+            "support_widening": False,
+            "production_platform_claim": False,
+            "live_adapter_execution": False,
+        },
+        "wrapper": {
+            "created": False,
+            "mode": None,
+            "path_recorded": False,
+        },
+        "smoke_result": None,
+        "smoke_command": [],
+        "decision": {
+            "result": "blocked",
+            "blockers": [],
+            "warnings": [],
+            "next_required_slice": "provide dedicated non-admin actor token env and rerun AO-MA-10q",
+        },
+    }
+
+
+def _set_decision(result: dict[str, Any], *, decision: str, blockers: list[str], warnings: list[str] | None = None) -> None:
+    if decision == "merged":
+        next_required = "record AO-MA-10l merged artifact and keep low-risk autonomous lane active"
+    elif "dedicated_actor_token_env_missing" in blockers:
+        next_required = "set the dedicated non-admin actor token env and rerun AO-MA-10q"
+    else:
+        next_required = "resolve AO-MA-10q/AO-MA-10l blockers"
+    result["decision"] = {
+        "result": decision,
+        "blockers": sorted(blockers),
+        "warnings": sorted(warnings or []),
+        "next_required_slice": next_required,
+    }
+
+
+def _validate_token_env_name(token_env: str) -> None:
+    if not TOKEN_ENV_RE.fullmatch(token_env):
+        raise ValueError("token env name must match [A-Z_][A-Z0-9_]*")
+
+
+def _write_gh_wrapper(*, path: Path, token_env: str, base_gh_bin: str) -> None:
+    _validate_token_env_name(token_env)
+    github_token_var = "GH_" + "TOKEN"
+    path.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env sh",
+                "set -eu",
+                f'if [ -z "${{{token_env}:-}}" ]; then',
+                '  echo "dedicated GitHub token env is missing" >&2',
+                "  exit 2",
+                "fi",
+                f'{github_token_var}="${{{token_env}}}" exec {shlex.quote(base_gh_bin)} "$@"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+
+
+def _load_smoke_result(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("AO-MA-10l output must be a JSON object")
+    return data
+
+
+def _sanitize_smoke_command(command: list[str], *, wrapper: Path, smoke_output: Path) -> list[str]:
+    sanitized: list[str] = []
+    for item in command:
+        if item == str(wrapper):
+            sanitized.append("<temporary-gh-wrapper>")
+        elif item == str(smoke_output):
+            sanitized.append("<temporary-smoke-output>")
+        else:
+            sanitized.append(item)
+    return sanitized
+
+
+def run(
+    *,
+    repo: str,
+    base_ref: str,
+    expected_actor: str,
+    token_env: str,
+    base_gh_bin: str,
+    output: Path,
+    execute: bool,
+    confirmation: str | None,
+    timeout_seconds: int,
+    poll_seconds: int,
+    runner: Runner = _run,
+) -> dict[str, Any]:
+    _validate_token_env_name(token_env)
+    result = _base_result(
+        repo=repo,
+        base_ref=base_ref,
+        expected_actor=expected_actor,
+        token_env=token_env,
+        execute=execute,
+    )
+
+    if not os.environ.get(token_env):
+        _set_decision(result, decision="blocked", blockers=["dedicated_actor_token_env_missing"])
+        _write_json(output, result)
+        return result
+
+    with tempfile.TemporaryDirectory(prefix="ao-ma10q-") as temp:
+        temp_dir = Path(temp)
+        wrapper = temp_dir / "gh-dedicated"
+        smoke_output = temp_dir / "ao-ma10l-result.json"
+        _write_gh_wrapper(path=wrapper, token_env=token_env, base_gh_bin=base_gh_bin)
+        result["wrapper"] = {
+            "created": True,
+            "mode": "0700",
+            "path_recorded": False,
+        }
+
+        command = [
+            sys.executable,
+            "scripts/ao_ma10l_autonomous_smoke.py",
+            "--repo",
+            repo,
+            "--base-ref",
+            base_ref,
+            "--expected-actor",
+            expected_actor,
+            "--gh-bin",
+            str(wrapper),
+            "--output",
+            str(smoke_output),
+            "--timeout-seconds",
+            str(timeout_seconds),
+            "--poll-seconds",
+            str(poll_seconds),
+            "--format",
+            "json",
+        ]
+        if execute:
+            command.append("--execute")
+            if confirmation is not None:
+                command.extend(["--confirmation", confirmation])
+        result["smoke_command"] = _sanitize_smoke_command(command, wrapper=wrapper, smoke_output=smoke_output)
+
+        proc = runner(command)
+        blockers: list[str] = []
+        warnings: list[str] = []
+        smoke_result: dict[str, Any] | None = None
+        if smoke_output.exists():
+            try:
+                smoke_result = _load_smoke_result(smoke_output)
+            except (OSError, ValueError, json.JSONDecodeError) as exc:
+                blockers.append(f"smoke_result_invalid: {exc}")
+        else:
+            blockers.append("smoke_result_missing")
+
+        if proc.returncode not in (0, 1):
+            blockers.append("smoke_command_failed")
+        if smoke_result:
+            raw_smoke_decision = smoke_result.get("decision")
+            smoke_decision: dict[str, Any] = raw_smoke_decision if isinstance(raw_smoke_decision, dict) else {}
+            blockers.extend(item for item in smoke_decision.get("blockers", []) if isinstance(item, str))
+            warnings.extend(item for item in smoke_decision.get("warnings", []) if isinstance(item, str))
+            result["smoke_result"] = smoke_result
+            result["mutations_performed"] = bool(smoke_result.get("mutations_performed"))
+            raw_decision = smoke_decision.get("result")
+            decision = raw_decision if isinstance(raw_decision, str) else "blocked"
+        else:
+            decision = "blocked"
+        if blockers:
+            decision = "blocked"
+        _set_decision(result, decision=decision, blockers=blockers, warnings=warnings)
+        _write_json(output, result)
+        return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--base-ref", default=DEFAULT_BASE_REF)
+    parser.add_argument("--expected-actor", default=DEFAULT_EXPECTED_ACTOR)
+    parser.add_argument("--token-env", default=DEFAULT_TOKEN_ENV)
+    parser.add_argument("--base-gh-bin", default="gh")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--confirmation")
+    parser.add_argument("--timeout-seconds", type=int, default=900)
+    parser.add_argument("--poll-seconds", type=int, default=15)
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    args = parser.parse_args(argv)
+
+    result = run(
+        repo=args.repo,
+        base_ref=args.base_ref,
+        expected_actor=args.expected_actor,
+        token_env=args.token_env,
+        base_gh_bin=args.base_gh_bin,
+        output=Path(args.output),
+        execute=args.execute,
+        confirmation=args.confirmation,
+        timeout_seconds=args.timeout_seconds,
+        poll_seconds=args.poll_seconds,
+    )
+    if args.format == "text":
+        print(result["decision"]["result"])
+        for blocker in result["decision"]["blockers"]:
+            print(f"blocker: {blocker}")
+    else:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["decision"]["result"] in {"ready_for_smoke_dry_run", "merged"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ao_ma10q_dedicated_actor_runner.py
+++ b/tests/test_ao_ma10q_dedicated_actor_runner.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "ao_ma10q_dedicated_actor_runner.py"
+DOC = ROOT / ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md"
+RECEIPT = ROOT / ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json"
+SCHEMA_NAME = "ao-ma-10q-dedicated-actor-runner-result.schema.v1.json"
+TOKEN_ENV = "GLADYATORE_LAB_GH_TOKEN"
+TOKEN_VALUE = "VALUE_NOT_IN_ARTIFACT"
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", SCHEMA_NAME)
+
+
+def _load_script_module() -> Any:
+    spec = importlib.util.spec_from_file_location("ao_ma10q_dedicated_actor_runner", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _smoke_payload(*, result: str = "merged", blocker: str | None = None, mutated: bool = True) -> dict[str, Any]:
+    blockers = [blocker] if blocker else []
+    return {
+        "schema_version": "ao-ma-10l-autonomous-smoke-result.v1",
+        "artifact_kind": "ao_ma_10l_autonomous_smoke_result",
+        "mutations_performed": mutated,
+        "decision": {
+            "result": result,
+            "blockers": blockers,
+            "warnings": [],
+            "next_required_slice": "record AO-MA-10l result",
+        },
+    }
+
+
+class FakeSmokeRunner:
+    def __init__(self, payload: dict[str, Any], *, returncode: int = 0) -> None:
+        self.payload = payload
+        self.returncode = returncode
+        self.commands: list[list[str]] = []
+        self.wrapper_path: str | None = None
+        self.wrapper_mode: int | None = None
+        self.wrapper_contents: str | None = None
+
+    def __call__(self, command: list[str]) -> subprocess.CompletedProcess[str]:
+        self.commands.append(command)
+        assert command[0]
+        assert command[1].endswith("ao_ma10l_autonomous_smoke.py")
+        assert "--gh-bin" in command
+        assert "--output" in command
+        wrapper = Path(command[command.index("--gh-bin") + 1])
+        output = Path(command[command.index("--output") + 1])
+        self.wrapper_path = str(wrapper)
+        self.wrapper_mode = stat.S_IMODE(wrapper.stat().st_mode)
+        self.wrapper_contents = wrapper.read_text(encoding="utf-8")
+        output.write_text(json.dumps(self.payload), encoding="utf-8")
+        return subprocess.CompletedProcess(command, self.returncode, json.dumps(self.payload), "")
+
+
+def test_ao_ma10q_schema_is_valid_draft_2020_12() -> None:
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$id"] == "urn:ao:ao-ma-10q-dedicated-actor-runner-result:v1"
+
+
+def test_ao_ma10q_doc_and_receipt_preserve_no_secret_authority_boundary() -> None:
+    receipt = cast(dict[str, Any], json.loads(RECEIPT.read_text(encoding="utf-8")))
+    text = DOC.read_text(encoding="utf-8")
+    assert receipt["status"] == "implemented_fail_closed"
+    assert receipt["release_authority"] == "ao-release-gate+github-ruleset"
+    assert receipt["ai_output_release_authority"] is False
+    assert receipt["support_widening"] is False
+    assert receipt["production_platform_claim"] is False
+    assert receipt["live_adapter_execution"] is False
+    assert receipt["token_value_recorded"] is False
+    assert receipt["wrapper_path_recorded"] is False
+    assert receipt["default_token_env"] == TOKEN_ENV
+    assert "never accepts token values on CLI arguments" in text
+    assert "AI provider output remains evidence only." in text
+
+
+def test_ao_ma10q_missing_token_env_blocks_before_smoke_invocation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+    mod = _load_script_module()
+    output = tmp_path / "ao-ma10q.json"
+    runner = FakeSmokeRunner(_smoke_payload())
+
+    result = cast(
+        dict[str, Any],
+        mod.run(
+            repo="Halildeu/ao-kernel",
+            base_ref="main",
+            expected_actor="gladyatore-lab",
+            token_env=TOKEN_ENV,
+            base_gh_bin="gh",
+            output=output,
+            execute=False,
+            confirmation=None,
+            timeout_seconds=0,
+            poll_seconds=1,
+            runner=runner,
+        ),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert output.exists()
+    assert runner.commands == []
+    assert result["decision"]["result"] == "blocked"
+    assert result["decision"]["blockers"] == ["dedicated_actor_token_env_missing"]
+    assert result["mutations_performed"] is False
+    assert result["token_value_recorded"] is False
+    assert result["wrapper"] == {"created": False, "mode": None, "path_recorded": False}
+
+
+def test_ao_ma10q_rejects_invalid_token_env_name(tmp_path: Path) -> None:
+    mod = _load_script_module()
+    with pytest.raises(ValueError, match="token env name"):
+        mod.run(
+            repo="Halildeu/ao-kernel",
+            base_ref="main",
+            expected_actor="gladyatore-lab",
+            token_env="bad-token-env",
+            base_gh_bin="gh",
+            output=tmp_path / "ao-ma10q.json",
+            execute=False,
+            confirmation=None,
+            timeout_seconds=0,
+            poll_seconds=1,
+            runner=FakeSmokeRunner(_smoke_payload()),
+        )
+
+
+def test_ao_ma10q_execute_uses_temporary_gh_wrapper_without_recording_secret_or_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(TOKEN_ENV, TOKEN_VALUE)
+    mod = _load_script_module()
+    output = tmp_path / "ao-ma10q.json"
+    runner = FakeSmokeRunner(_smoke_payload(result="merged", mutated=True))
+
+    result = cast(
+        dict[str, Any],
+        mod.run(
+            repo="Halildeu/ao-kernel",
+            base_ref="main",
+            expected_actor="gladyatore-lab",
+            token_env=TOKEN_ENV,
+            base_gh_bin="gh",
+            output=output,
+            execute=True,
+            confirmation="AO-MA-10L-EXECUTE",
+            timeout_seconds=0,
+            poll_seconds=1,
+            runner=runner,
+        ),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert runner.commands
+    assert runner.wrapper_path is not None
+    assert runner.wrapper_mode == 0o700
+    assert runner.wrapper_contents is not None
+    assert TOKEN_ENV in runner.wrapper_contents
+    assert TOKEN_VALUE not in runner.wrapper_contents
+    github_token_var = "GH_" + "TOKEN"
+    assert f'{github_token_var}="${{{TOKEN_ENV}}}" exec gh "$@"' in runner.wrapper_contents
+    assert "--execute" in runner.commands[0]
+    assert runner.commands[0][runner.commands[0].index("--confirmation") + 1] == "AO-MA-10L-EXECUTE"
+
+    artifact_text = output.read_text(encoding="utf-8")
+    assert TOKEN_VALUE not in artifact_text
+    assert runner.wrapper_path not in artifact_text
+    assert result["smoke_command"][result["smoke_command"].index("--gh-bin") + 1] == "<temporary-gh-wrapper>"
+    assert result["smoke_command"][result["smoke_command"].index("--output") + 1] == "<temporary-smoke-output>"
+    assert result["wrapper"] == {"created": True, "mode": "0700", "path_recorded": False}
+    assert result["token_value_recorded"] is False
+    assert result["decision"]["result"] == "merged"
+    assert result["mutations_performed"] is True
+
+
+def test_ao_ma10q_propagates_smoke_blockers_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TOKEN_ENV, TOKEN_VALUE)
+    mod = _load_script_module()
+    output = tmp_path / "ao-ma10q.json"
+    runner = FakeSmokeRunner(
+        _smoke_payload(result="blocked", blocker="unexpected_merge_actor", mutated=False),
+        returncode=1,
+    )
+
+    result = cast(
+        dict[str, Any],
+        mod.run(
+            repo="Halildeu/ao-kernel",
+            base_ref="main",
+            expected_actor="gladyatore-lab",
+            token_env=TOKEN_ENV,
+            base_gh_bin="gh",
+            output=output,
+            execute=True,
+            confirmation="AO-MA-10L-EXECUTE",
+            timeout_seconds=0,
+            poll_seconds=1,
+            runner=runner,
+        ),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "blocked"
+    assert result["decision"]["blockers"] == ["unexpected_merge_actor"]
+    assert result["mutations_performed"] is False
+    assert result["smoke_result"]["decision"]["result"] == "blocked"


### PR DESCRIPTION
## Summary

Adds AO-MA-10q: a no-secret dedicated actor runner for the AO-MA-10l low-risk autonomous smoke.

This removes the remaining ad-hoc local wrapper step by creating a temporary `0700` GitHub CLI wrapper from a named environment variable. The token value is never accepted on CLI args and is not recorded in the result artifact. The temporary wrapper path is also sanitized from the artifact.

## Scope

- `scripts/ao_ma10q_dedicated_actor_runner.py`
- Result schema: `ao-ma-10q-dedicated-actor-runner-result.schema.v1.json`
- Docs/receipt: `AO-MA-10Q-DEDICATED-ACTOR-RUNNER.*`
- Tests: `tests/test_ao_ma10q_dedicated_actor_runner.py`
- `local-ai-review-evidence.v1.json` updated for AO-MA-10q

## Authority / guardrails

- AI provider output remains evidence only.
- Release authority remains `ao-release-gate+github-ruleset`.
- No admin merge, ruleset mutation, branch-protection mutation, CODEOWNERS mutation, support widening, production platform claim, or live adapter execution.
- Missing dedicated token env fails closed before AO-MA-10l invocation.

## Validation

- `python3 -m pytest -q tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10l_autonomous_smoke.py tests/test_ao_ma10c_merge_agent.py tests/test_ao_ma10_autonomous_merge_eligibility.py tests/test_ao_ma10_github_readiness_snapshot.py` -> 66 passed
- `python3 -m ruff check scripts/ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10q_dedicated_actor_runner.py` -> pass
- `python3 -m mypy scripts/ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10q_dedicated_actor_runner.py` -> pass
- `python3 scripts/ao_ma10q_dedicated_actor_runner.py --output /tmp/ao-ma10q-current.json --format text` -> blocked with `dedicated_actor_token_env_missing`, no mutation
- `python3 scripts/local_gpp_gate.py ... --work-package AO-MA-10q` -> `operator_may_merge`

## Cross-AI review

Claude CLI review: `VERDICT: AGREE`.

Non-blocking observations: invalid token env CLI traceback is UX-only; text output formatting is trivial and not separately tested.
