### PR TITLE
feat(ao-ma-10): add dedicated actor credential doctor

### DIFF
--- a/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md
+++ b/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md
@@ -1,0 +1,74 @@
+# AO-MA-10r - Dedicated Actor Credential Doctor
+
+**Status:** implemented fail-closed
+**Date:** 2026-05-29
+**Parent:** AO-MA-10 low-risk autonomous merge lane
+**Support impact:** none
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## Purpose
+
+AO-MA-10r verifies the last credential prerequisite before AO-MA-10q executes
+the low-risk autonomous merge smoke. It proves that a named environment
+variable authenticates GitHub CLI as the expected dedicated non-admin merge
+actor.
+
+This is not release authority. Release authority remains the repo-owned
+`ao-release-gate` required checks plus GitHub ruleset enforcement.
+
+## Script
+
+```text
+scripts/ao_ma10r_dedicated_actor_credential_doctor.py
+```
+
+Default token environment variable:
+
+```text
+GLADYATORE_LAB_GH_TOKEN
+```
+
+The doctor never accepts token values as CLI arguments and never records token
+values, token prefixes, token hashes, or credential paths. It sets `GH_TOKEN`
+only inside the subprocess environment for read-only GitHub API calls.
+
+## Command
+
+```bash
+GLADYATORE_LAB_GH_TOKEN=<redacted> \
+  python3 scripts/ao_ma10r_dedicated_actor_credential_doctor.py \
+    --output /tmp/ao-ma10r.json \
+    --format text
+```
+
+Without the token environment variable, the doctor exits fail-closed with:
+
+```text
+dedicated_actor_token_env_missing
+```
+
+## Checks
+
+The doctor performs read-only checks:
+
+- `gh api user` -> actor identity is `gladyatore-lab`;
+- `gh api repos/Halildeu/ao-kernel` -> actor has write or maintain, but not
+  admin;
+- `gh api repos/Halildeu/ao-kernel/pulls?state=open&per_page=1` -> actor can
+  read pull-request state.
+
+## Completion Criteria
+
+AO-MA-10r is ready only when it emits `credential_ready` with:
+
+- `token_value_recorded=false`;
+- `mutations_performed=false`;
+- `actor.matches_expected=true`;
+- `repository_access.admin_permission_observed=false`;
+- `repository_access.can_merge_without_admin=true`;
+- `repository_access.can_read_pull_requests=true`;
+- all guard flags false.
+
+After AO-MA-10r passes, AO-MA-10q may be executed with the same token
+environment variable to collect the real no-human autonomous merge smoke.

--- a/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json
+++ b/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json
@@ -1,0 +1,19 @@
+{
+  "ai_output_release_authority": false,
+  "artifact_kind": "ao_ma_10r_dedicated_actor_credential_doctor_receipt",
+  "default_expected_actor": "gladyatore-lab",
+  "default_token_env": "GLADYATORE_LAB_GH_TOKEN",
+  "implemented_files": [
+    "scripts/ao_ma10r_dedicated_actor_credential_doctor.py",
+    "ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json",
+    "tests/test_ao_ma10r_dedicated_actor_credential_doctor.py"
+  ],
+  "live_adapter_execution": false,
+  "mutations_performed": false,
+  "production_platform_claim": false,
+  "release_authority": "ao-release-gate+github-ruleset",
+  "schema_version": "ao-ma-10r-dedicated-actor-credential-doctor-receipt.v1",
+  "status": "implemented_fail_closed",
+  "support_widening": false,
+  "token_value_recorded": false
+}

--- a/ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json
@@ -1,0 +1,193 @@
+{
+  "$id": "urn:ao:ao-ma-10r-dedicated-actor-credential-doctor-result:v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "actor": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "anyOf": [
+            { "type": "integer" },
+            { "type": "null" }
+          ]
+        },
+        "login": {
+          "anyOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ]
+        },
+        "matches_expected": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "login",
+        "id",
+        "matches_expected"
+      ],
+      "type": "object"
+    },
+    "ai_output_release_authority": {
+      "const": false
+    },
+    "artifact_kind": {
+      "const": "ao_ma_10r_dedicated_actor_credential_doctor_result"
+    },
+    "collection_errors": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "commands": {
+      "items": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "type": "array"
+    },
+    "decision": {
+      "additionalProperties": false,
+      "properties": {
+        "blockers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "next_required_slice": {
+          "type": "string"
+        },
+        "result": {
+          "enum": [
+            "blocked",
+            "credential_ready"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "result",
+        "blockers",
+        "warnings",
+        "next_required_slice"
+      ],
+      "type": "object"
+    },
+    "expected_actor": {
+      "type": "string"
+    },
+    "generated_at": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "guard_flags": {
+      "additionalProperties": false,
+      "properties": {
+        "live_adapter_execution": {
+          "const": false
+        },
+        "production_platform_claim": {
+          "const": false
+        },
+        "support_widening": {
+          "const": false
+        }
+      },
+      "required": [
+        "support_widening",
+        "production_platform_claim",
+        "live_adapter_execution"
+      ],
+      "type": "object"
+    },
+    "mutations_performed": {
+      "const": false
+    },
+    "release_authority": {
+      "const": "ao-release-gate+github-ruleset"
+    },
+    "repository": {
+      "type": "string"
+    },
+    "repository_access": {
+      "additionalProperties": false,
+      "properties": {
+        "admin_permission_observed": {
+          "type": "boolean"
+        },
+        "can_merge_without_admin": {
+          "type": "boolean"
+        },
+        "can_read_pull_requests": {
+          "type": "boolean"
+        },
+        "can_read_repository": {
+          "type": "boolean"
+        },
+        "permission_level": {
+          "anyOf": [
+            {
+              "enum": [
+                "none",
+                "read",
+                "triage",
+                "write",
+                "maintain",
+                "admin"
+              ]
+            },
+            { "type": "null" }
+          ]
+        }
+      },
+      "required": [
+        "permission_level",
+        "can_read_repository",
+        "can_read_pull_requests",
+        "can_merge_without_admin",
+        "admin_permission_observed"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "const": "ao-ma-10r-dedicated-actor-credential-doctor-result.v1"
+    },
+    "token_env": {
+      "pattern": "^[A-Z_][A-Z0-9_]*$",
+      "type": "string"
+    },
+    "token_value_recorded": {
+      "const": false
+    }
+  },
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "generated_at",
+    "repository",
+    "expected_actor",
+    "token_env",
+    "token_value_recorded",
+    "mutations_performed",
+    "release_authority",
+    "ai_output_release_authority",
+    "guard_flags",
+    "actor",
+    "repository_access",
+    "commands",
+    "collection_errors",
+    "decision"
+  ],
+  "title": "AO-MA-10r dedicated actor credential doctor result",
+  "type": "object"
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,29 +1,39 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "RI-7.8b-bc10-6a",
+  "work_package": "AO-MA-10R",
   "implementer": {
-    "agent": "claude",
-    "provider": "anthropic"
+    "agent": "codex",
+    "provider": "openai"
   },
   "reviewer": {
-    "agent": "codex-cli-reviewer",
-    "provider": "openai",
+    "agent": "claude-cli-reviewer",
+    "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ri-7-8b-bc10-6a-execution-window-authorization",
+    "head_ref": "refs/heads/codex/ao-ma10r-credential-doctor",
     "changed_files": [
-      ".claude/plans/RI-7.8b-bc10-6a-EXECUTION-WINDOW-AUTHORIZATION.v1.json",
-      "ao_kernel/defaults/schemas/ri7-8b-bc10-6a-execution-window-authorization-evidence.schema.v1.json",
+      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md",
+      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json",
+      "ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_ri78b_bc10_6a_execution_window_authorization_invariant.py"
+      "scripts/ao_ma10r_dedicated_actor_credential_doctor.py",
+      "tests/test_ao_ma10r_dedicated_actor_credential_doctor.py"
     ]
   },
   "checks_considered": [
     {
       "name": "tests",
+      "status": "pass"
+    },
+    {
+      "name": "ruff",
+      "status": "pass"
+    },
+    {
+      "name": "mypy",
       "status": "pass"
     },
     {
@@ -35,25 +45,17 @@
       "status": "pass"
     },
     {
-      "name": "sha256_digest_match",
-      "status": "pass"
-    },
-    {
       "name": "gpp_guard_flags_const_false",
       "status": "pass"
     }
   ],
   "findings": [
-    "Evidence validates against Draft 2020-12 schema with zero errors; schema enforces additionalProperties:false on all 13 nested objects and const-pinned guard flags (support_widening, production_platform_claim, live_adapter_execution).",
-    "SHA256 digests in ri78a_predecessor_ref + ri78b_bc1_6c_predecessor_ref + stale_replay_guard match the committed predecessor files at PR #673 (ri78a evidence) and PR #691 (bc1-6c-closure evidence + RI-7.8 submanifest post-flip).",
-    "GPP guard flags (support_widening_allowed, production_platform_claim_allowed, live_adapter_execution_allowed) remain const FALSE in current_gpp_guard_snapshot and top-level evidence fields. bc10-6a is authorization-only; no guard flag flip permitted.",
-    "Submanifest snapshot reflects post-#691 BC-1 landing state (bc1=true) and BC-10 not-yet-flipped state (bc10=false). submanifest_transition before==after enforces bc10-6a non-mutation contract.",
-    "planned_6b_authority_mode is pinned to manual_protected_environment with autonomous_trigger_allowed=false. bc10 6b activation MUST go through GitHub Environment required reviewers (unlike BC-1 6c-fast-follow autonomous pre-prod pattern) because bc10 involves REAL billable provider calls.",
-    "mutations_performed 7-key all-false invariant: runtime_modified, workflow_created, submanifest_mutated, gpp_status_mutated, provider_call_performed, secret_referenced, guard_flag_flipped all const false in schema and runtime evidence.",
-    "model_allowlist pinned to single-element [\"openai/gpt-4o-mini\"] with maxItems=1 + enum constraint. Per-call max_output_tokens cap ≤256; retries disabled; pre-call + post-call cost checks required.",
-    "Introducer-PR detection pattern (state-at-landing pin) applied to 11 git-diff-dependent tests; non-introducer branches skip with pytest.skip while structural invariants (schema valid, evidence validates, const pins) continue to enforce 6a state-at-landing on origin/main.",
-    "Secret boundary correct: secret_boundary=no_secret_material_no_credential_names_no_token_in_repo. No credential names, env var names, or token values present in any artifact. mutations_performed.secret_referenced=false enforces this at runtime.",
-    "Cross-AI peer review provider split: implementer=anthropic (claude), reviewer=openai (codex). Codex thread 019e70be-f4e3-77c2-bd3e-27a2e55b6eb6 iter-1 REVISE (bc10 must be 3-PR chain) + iter-2 REVISE (detailed absorb items: planned_6b_authority_mode, null workflow_content_sha256, schema path ri7-8b-bc10-6a-..., mutations_performed object) absorbed in this artifact."
+    "AO-MA-10r is fail-closed and no-secret: token values are accepted only via a named environment variable, never through CLI args, and token_value_recorded is schema-pinned false",
+    "The doctor performs read-only GitHub API checks only: user identity, repository permissions, and pull-request read access; no POST, merge, comment, ruleset, or branch-protection mutation is present",
+    "Permission semantics align with the low-risk autonomous merge model: write or maintain is merge-capable, admin is explicitly blocked, and read-only actors fail closed",
+    "Artifact schema is strict with additionalProperties=false and const-pinned release_authority, ai_output_release_authority=false, guard flags=false, and mutations_performed=false",
+    "Tests cover missing token, invalid env name, happy path, maintain path, wrong actor, admin actor, read-only actor, user API failure, repository API failure, and pull-request API failure",
+    "AO-MA-10r is correctly positioned as a prerequisite for AO-MA-10q execute smoke; it does not claim release authority or production readiness"
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/ao_ma10r_dedicated_actor_credential_doctor.py
+++ b/scripts/ao_ma10r_dedicated_actor_credential_doctor.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""AO-MA-10r no-secret dedicated merge actor credential doctor.
+
+This helper verifies that one named environment variable authenticates ``gh`` as
+the expected non-admin merge actor before AO-MA-10q is allowed to execute a live
+low-risk autonomous smoke. It performs read-only GitHub API calls and never
+accepts or records a token value.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+
+SCHEMA_VERSION = "ao-ma-10r-dedicated-actor-credential-doctor-result.v1"
+ARTIFACT_KIND = "ao_ma_10r_dedicated_actor_credential_doctor_result"
+RELEASE_AUTHORITY = "ao-release-gate+github-ruleset"
+DEFAULT_REPO = "Halildeu/ao-kernel"
+DEFAULT_EXPECTED_ACTOR = "gladyatore-lab"
+DEFAULT_TOKEN_ENV = "GLADYATORE_LAB_GH_TOKEN"
+TOKEN_ENV_RE = re.compile(r"[A-Z_][A-Z0-9_]*")
+WRITE_CAPABLE_LEVELS = {"write", "maintain"}
+
+Runner = Callable[[list[str], Mapping[str, str]], subprocess.CompletedProcess[str]]
+
+
+def _run(command: list[str], env: Mapping[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True, timeout=60, env=dict(env))
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _validate_token_env_name(token_env: str) -> None:
+    if not TOKEN_ENV_RE.fullmatch(token_env):
+        raise ValueError("token env name must match [A-Z_][A-Z0-9_]*")
+
+
+def _base_result(*, repo: str, expected_actor: str, token_env: str) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_kind": ARTIFACT_KIND,
+        "generated_at": _utc_now(),
+        "repository": repo,
+        "expected_actor": expected_actor,
+        "token_env": token_env,
+        "token_value_recorded": False,
+        "mutations_performed": False,
+        "release_authority": RELEASE_AUTHORITY,
+        "ai_output_release_authority": False,
+        "guard_flags": {
+            "support_widening": False,
+            "production_platform_claim": False,
+            "live_adapter_execution": False,
+        },
+        "actor": {
+            "login": None,
+            "id": None,
+            "matches_expected": False,
+        },
+        "repository_access": {
+            "permission_level": None,
+            "can_read_repository": False,
+            "can_read_pull_requests": False,
+            "can_merge_without_admin": False,
+            "admin_permission_observed": False,
+        },
+        "commands": [],
+        "collection_errors": [],
+        "decision": {
+            "result": "blocked",
+            "blockers": [],
+            "warnings": [],
+            "next_required_slice": "provide a dedicated non-admin actor token and rerun AO-MA-10r",
+        },
+    }
+
+
+def _redacted_command(command: list[str]) -> list[str]:
+    # Commands are static and never include token values, but keep a single
+    # helper so future command changes stay intentionally audited.
+    return list(command)
+
+
+def _run_json(
+    command: list[str],
+    *,
+    env: Mapping[str, str],
+    runner: Runner,
+    result: dict[str, Any],
+) -> tuple[dict[str, Any] | list[Any], str | None]:
+    result["commands"].append(_redacted_command(command))
+    proc = runner(command, env)
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or f"exit {proc.returncode}"
+        return {}, detail
+    if not proc.stdout.strip():
+        return {}, "empty response"
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {}, "invalid json response"
+    if not isinstance(payload, (dict, list)):
+        return {}, "json response must be object or array"
+    return payload, None
+
+
+def _permission_level(repo_payload: dict[str, Any]) -> str:
+    permissions = repo_payload.get("permissions")
+    if not isinstance(permissions, dict):
+        return "none"
+    if permissions.get("admin") is True:
+        return "admin"
+    if permissions.get("maintain") is True:
+        return "maintain"
+    if permissions.get("push") is True:
+        return "write"
+    if permissions.get("triage") is True:
+        return "triage"
+    if permissions.get("pull") is True:
+        return "read"
+    return "none"
+
+
+def _set_decision(result: dict[str, Any], blockers: set[str], warnings: set[str]) -> None:
+    if blockers:
+        decision = "blocked"
+        next_required = "resolve AO-MA-10r credential blockers before AO-MA-10q execute smoke"
+    else:
+        decision = "credential_ready"
+        next_required = "run AO-MA-10q execute smoke with the same dedicated actor token env"
+    result["decision"] = {
+        "result": decision,
+        "blockers": sorted(blockers),
+        "warnings": sorted(warnings),
+        "next_required_slice": next_required,
+    }
+
+
+def run(
+    *,
+    repo: str,
+    expected_actor: str,
+    token_env: str,
+    gh_bin: str,
+    output: Path,
+    runner: Runner = _run,
+) -> dict[str, Any]:
+    _validate_token_env_name(token_env)
+    result = _base_result(repo=repo, expected_actor=expected_actor, token_env=token_env)
+    blockers: set[str] = set()
+    warnings: set[str] = set()
+
+    token = os.environ.get(token_env)
+    if not token:
+        blockers.add("dedicated_actor_token_env_missing")
+        _set_decision(result, blockers, warnings)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return result
+
+    env = dict(os.environ)
+    github_token_var = "GH_" + "TOKEN"
+    env[github_token_var] = token
+
+    user_payload, error = _run_json([gh_bin, "api", "user"], env=env, runner=runner, result=result)
+    if error is not None or not isinstance(user_payload, dict):
+        blockers.add("github_user_read_failed")
+        result["collection_errors"].append(f"user: {error or 'invalid shape'}")
+        user_payload = {}
+
+    login = user_payload.get("login")
+    actor_id = user_payload.get("id")
+    login_value = login if isinstance(login, str) else None
+    actor_id_value = actor_id if isinstance(actor_id, int) else None
+    result["actor"] = {
+        "login": login_value,
+        "id": actor_id_value,
+        "matches_expected": login_value == expected_actor,
+    }
+    if login_value != expected_actor:
+        blockers.add("unexpected_merge_actor")
+
+    repo_payload, error = _run_json([gh_bin, "api", f"repos/{repo}"], env=env, runner=runner, result=result)
+    if error is not None or not isinstance(repo_payload, dict):
+        blockers.add("github_repository_read_failed")
+        result["collection_errors"].append(f"repository: {error or 'invalid shape'}")
+        repo_payload = {}
+
+    permission_level = _permission_level(repo_payload)
+    admin_permission_observed = permission_level == "admin"
+    can_merge_without_admin = permission_level in WRITE_CAPABLE_LEVELS
+    can_read_repository = permission_level in {"read", "triage", "write", "maintain", "admin"}
+    if admin_permission_observed:
+        blockers.add("merge_actor_admin_permission_observed")
+    if not can_merge_without_admin:
+        blockers.add("merge_actor_not_write_capable")
+    if not can_read_repository:
+        blockers.add("repository_read_permission_missing")
+
+    pulls_payload, error = _run_json(
+        [gh_bin, "api", f"repos/{repo}/pulls?state=open&per_page=1"],
+        env=env,
+        runner=runner,
+        result=result,
+    )
+    can_read_pulls = isinstance(pulls_payload, list) and error is None
+    if not can_read_pulls:
+        blockers.add("pull_request_read_failed")
+        result["collection_errors"].append(f"pulls: {error or 'invalid shape'}")
+
+    result["repository_access"] = {
+        "permission_level": permission_level,
+        "can_read_repository": can_read_repository,
+        "can_read_pull_requests": can_read_pulls,
+        "can_merge_without_admin": can_merge_without_admin,
+        "admin_permission_observed": admin_permission_observed,
+    }
+    _set_decision(result, blockers, warnings)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--expected-actor", default=DEFAULT_EXPECTED_ACTOR)
+    parser.add_argument("--token-env", default=DEFAULT_TOKEN_ENV)
+    parser.add_argument("--gh-bin", default="gh")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    args = parser.parse_args(argv)
+
+    result = run(
+        repo=args.repo,
+        expected_actor=args.expected_actor,
+        token_env=args.token_env,
+        gh_bin=args.gh_bin,
+        output=Path(args.output),
+    )
+
+    if args.format == "text":
+        print(result["decision"]["result"])
+        for blocker in result["decision"]["blockers"]:
+            print(f"blocker: {blocker}")
+    else:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["decision"]["result"] == "credential_ready" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ao_ma10r_dedicated_actor_credential_doctor.py
+++ b/tests/test_ao_ma10r_dedicated_actor_credential_doctor.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "ao_ma10r_dedicated_actor_credential_doctor.py"
+DOC = ROOT / ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md"
+RECEIPT = ROOT / ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json"
+SCHEMA_NAME = "ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json"
+TOKEN_ENV = "GLADYATORE_LAB_GH_TOKEN"
+TOKEN_VALUE = "VALUE_NOT_IN_ARTIFACT"
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", SCHEMA_NAME)
+
+
+def _load_script_module() -> Any:
+    spec = importlib.util.spec_from_file_location("ao_ma10r_dedicated_actor_credential_doctor", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeGitHubRunner:
+    def __init__(
+        self,
+        *,
+        login: str = "gladyatore-lab",
+        actor_id: int = 12345,
+        permissions: dict[str, bool] | None = None,
+        pulls: list[dict[str, Any]] | None = None,
+        fail_command_contains: str | None = None,
+    ) -> None:
+        self.login = login
+        self.actor_id = actor_id
+        self.permissions = permissions if permissions is not None else {"pull": True, "push": True, "admin": False}
+        self.pulls = [] if pulls is None else pulls
+        self.fail_command_contains = fail_command_contains
+        self.commands: list[list[str]] = []
+        self.envs: list[dict[str, str]] = []
+
+    def __call__(self, command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        self.commands.append(command)
+        self.envs.append(dict(env))
+        joined = " ".join(command)
+        if self.fail_command_contains and self.fail_command_contains in joined:
+            return subprocess.CompletedProcess(command, 1, "", "forced failure")
+        if command == ["gh", "api", "user"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"login": self.login, "id": self.actor_id}), "")
+        if command == ["gh", "api", "repos/Halildeu/ao-kernel"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"permissions": self.permissions}), "")
+        if command == ["gh", "api", "repos/Halildeu/ao-kernel/pulls?state=open&per_page=1"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps(self.pulls), "")
+        return subprocess.CompletedProcess(command, 1, "", f"unexpected command: {joined}")
+
+
+def _run_doctor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: FakeGitHubRunner,
+    *,
+    token_value: str | None = TOKEN_VALUE,
+    expected_actor: str = "gladyatore-lab",
+) -> dict[str, Any]:
+    if token_value is None:
+        monkeypatch.delenv(TOKEN_ENV, raising=False)
+    else:
+        monkeypatch.setenv(TOKEN_ENV, token_value)
+    mod = _load_script_module()
+    return cast(
+        dict[str, Any],
+        mod.run(
+            repo="Halildeu/ao-kernel",
+            expected_actor=expected_actor,
+            token_env=TOKEN_ENV,
+            gh_bin="gh",
+            output=tmp_path / "ao-ma10r.json",
+            runner=runner,
+        ),
+    )
+
+
+def test_ao_ma10r_schema_is_valid_draft_2020_12() -> None:
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$id"] == "urn:ao:ao-ma-10r-dedicated-actor-credential-doctor-result:v1"
+
+
+def test_ao_ma10r_doc_and_receipt_preserve_no_secret_authority_boundary() -> None:
+    receipt = cast(dict[str, Any], json.loads(RECEIPT.read_text(encoding="utf-8")))
+    text = DOC.read_text(encoding="utf-8")
+    assert receipt["status"] == "implemented_fail_closed"
+    assert receipt["release_authority"] == "ao-release-gate+github-ruleset"
+    assert receipt["ai_output_release_authority"] is False
+    assert receipt["support_widening"] is False
+    assert receipt["production_platform_claim"] is False
+    assert receipt["live_adapter_execution"] is False
+    assert receipt["token_value_recorded"] is False
+    assert receipt["default_token_env"] == TOKEN_ENV
+    assert "never accepts token values as CLI arguments" in text
+    assert "Release authority remains the repo-owned" in text
+
+
+def test_ao_ma10r_missing_token_env_blocks_before_github_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = FakeGitHubRunner()
+    result = _run_doctor(tmp_path, monkeypatch, runner, token_value=None)
+
+    Draft202012Validator(_schema()).validate(result)
+    assert runner.commands == []
+    assert result["decision"]["result"] == "blocked"
+    assert result["decision"]["blockers"] == ["dedicated_actor_token_env_missing"]
+    assert result["token_value_recorded"] is False
+    assert result["mutations_performed"] is False
+
+
+def test_ao_ma10r_rejects_invalid_token_env_name(tmp_path: Path) -> None:
+    mod = _load_script_module()
+    with pytest.raises(ValueError, match="token env name"):
+        mod.run(
+            repo="Halildeu/ao-kernel",
+            expected_actor="gladyatore-lab",
+            token_env="bad-token-env",
+            gh_bin="gh",
+            output=tmp_path / "ao-ma10r.json",
+            runner=FakeGitHubRunner(),
+        )
+
+
+def test_ao_ma10r_happy_path_ready_without_recording_secret_or_mutating(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = FakeGitHubRunner()
+    result = _run_doctor(tmp_path, monkeypatch, runner)
+
+    Draft202012Validator(_schema()).validate(result)
+    artifact_text = (tmp_path / "ao-ma10r.json").read_text(encoding="utf-8")
+    assert TOKEN_VALUE not in artifact_text
+    assert all(env.get("GH_TOKEN") == TOKEN_VALUE for env in runner.envs)
+    assert result["decision"]["result"] == "credential_ready"
+    assert result["decision"]["blockers"] == []
+    assert result["actor"] == {"login": "gladyatore-lab", "id": 12345, "matches_expected": True}
+    assert result["repository_access"]["permission_level"] == "write"
+    assert result["repository_access"]["can_merge_without_admin"] is True
+    assert result["repository_access"]["admin_permission_observed"] is False
+    assert result["repository_access"]["can_read_pull_requests"] is True
+    assert result["token_value_recorded"] is False
+    assert result["mutations_performed"] is False
+    assert result["commands"] == [
+        ["gh", "api", "user"],
+        ["gh", "api", "repos/Halildeu/ao-kernel"],
+        ["gh", "api", "repos/Halildeu/ao-kernel/pulls?state=open&per_page=1"],
+    ]
+
+
+def test_ao_ma10r_accepts_maintain_as_non_admin_merge_capable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result = _run_doctor(
+        tmp_path,
+        monkeypatch,
+        FakeGitHubRunner(permissions={"pull": True, "push": False, "maintain": True, "admin": False}),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "credential_ready"
+    assert result["repository_access"]["permission_level"] == "maintain"
+    assert result["repository_access"]["can_merge_without_admin"] is True
+    assert result["repository_access"]["admin_permission_observed"] is False
+
+
+def test_ao_ma10r_blocks_wrong_actor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _run_doctor(tmp_path, monkeypatch, FakeGitHubRunner(login="Halildeu"))
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "blocked"
+    assert "unexpected_merge_actor" in result["decision"]["blockers"]
+    assert result["actor"]["matches_expected"] is False
+
+
+def test_ao_ma10r_blocks_admin_actor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _run_doctor(
+        tmp_path,
+        monkeypatch,
+        FakeGitHubRunner(permissions={"pull": True, "push": True, "admin": True}),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "blocked"
+    assert "merge_actor_admin_permission_observed" in result["decision"]["blockers"]
+    assert result["repository_access"]["permission_level"] == "admin"
+
+
+def test_ao_ma10r_blocks_read_only_actor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _run_doctor(
+        tmp_path,
+        monkeypatch,
+        FakeGitHubRunner(permissions={"pull": True, "push": False, "admin": False}),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "blocked"
+    assert "merge_actor_not_write_capable" in result["decision"]["blockers"]
+    assert result["repository_access"]["permission_level"] == "read"
+
+
+def test_ao_ma10r_blocks_github_api_read_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _run_doctor(
+        tmp_path,
+        monkeypatch,
+        FakeGitHubRunner(fail_command_contains="pulls?state=open"),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "blocked"
+    assert "pull_request_read_failed" in result["decision"]["blockers"]
+    assert result["collection_errors"]
+    assert TOKEN_VALUE not in (tmp_path / "ao-ma10r.json").read_text(encoding="utf-8")
+
+
+def test_ao_ma10r_blocks_user_read_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _run_doctor(
+        tmp_path,
+        monkeypatch,
+        FakeGitHubRunner(fail_command_contains=" api user"),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "blocked"
+    assert "github_user_read_failed" in result["decision"]["blockers"]
+    assert "unexpected_merge_actor" in result["decision"]["blockers"]
+    assert any(item.startswith("user:") for item in result["collection_errors"])
+
+
+def test_ao_ma10r_blocks_repository_read_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _run_doctor(
+        tmp_path,
+        monkeypatch,
+        FakeGitHubRunner(fail_command_contains="repos/Halildeu/ao-kernel"),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "blocked"
+    assert "github_repository_read_failed" in result["decision"]["blockers"]
+    assert "repository_read_permission_missing" in result["decision"]["blockers"]
+    assert "merge_actor_not_write_capable" in result["decision"]["blockers"]
+    assert any(item.startswith("repository:") for item in result["collection_errors"])


### PR DESCRIPTION
## Summary

Adds AO-MA-10r, a no-secret/read-only credential doctor for the dedicated non-admin merge actor required before AO-MA-10q autonomous smoke can run.

This does not unblock autonomy by itself. It makes the current blocker mechanically testable and fail-closed:

- expected actor: gladyatore-lab
- token env: GLADYATORE_LAB_GH_TOKEN
- current no-token result: dedicated_actor_token_env_missing

## Scope

- New credential doctor script: scripts/ao_ma10r_dedicated_actor_credential_doctor.py
- Strict result schema with guard flags pinned false
- AO-MA-10r plan/receipt docs
- Local AI review evidence refreshed for AO-MA-10R
- Tests cover missing token, invalid env name, happy path, maintain/write permission, admin rejection, wrong actor, read-only actor, and GitHub API failure paths

## Validation

- bash .claude/scripts/ops.sh preflight: pass
- python3 scripts/gpp_next.py: program closed, next allowed actions still require dedicated actor authentication
- python3 scripts/local_gpp_gate.py ... --work-package AO-MA-10R: operator_may_merge
- python3 scripts/ao_ma10r_dedicated_actor_credential_doctor.py --output /tmp/ao-ma10r-current.json --format text: blocked / dedicated_actor_token_env_missing
- python3 -m pytest -q tests/test_ao_ma10r_dedicated_actor_credential_doctor.py tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10l_autonomous_smoke.py tests/test_ao_ma10c_merge_agent.py tests/test_ao_ma10_github_readiness_snapshot.py tests/test_ao_ma10_autonomous_merge_eligibility.py: 78 passed
- python3 -m ruff check scripts/ao_ma10r_dedicated_actor_credential_doctor.py tests/test_ao_ma10r_dedicated_actor_credential_doctor.py: pass
- python3 -m mypy scripts/ao_ma10r_dedicated_actor_credential_doctor.py: pass
- git diff --check: clean

## Guardrails

- token values are never accepted as CLI args and never recorded
- only read-only GitHub API calls are used
- no merge/comment/ruleset/branch-protection mutation
- release_authority remains ao-release-gate+github-ruleset
- AI output remains evidence, not release authority
- support_widening=false, production_platform_claim=false, live_adapter_execution=false

## Review

Claude review verdict: AGREE. Advisory gaps were absorbed with additional tests for maintain permission and user/repo/pulls API failure paths.