### PR TITLE
feat(ao-ma-10): add dedicated actor smoke workflow

### DIFF
--- a/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md
+++ b/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md
@@ -1,0 +1,77 @@
+# AO-MA-10s - Dedicated Actor Smoke Workflow
+
+**Parent:** AO-MA-10 low-risk autonomous merge lane
+
+**Status:** Implemented fail-closed
+
+**Workflow:** `.github/workflows/ao-ma10q-dedicated-actor-smoke.yml`
+
+## Purpose
+
+AO-MA-10s removes the remaining local-shell dependency from AO-MA-10q. The
+dedicated non-admin merge actor token is read from the GitHub repository secret
+`GLADYATORE_LAB_GH_TOKEN`, not from a local operator shell. A Codex or Claude
+operator may dispatch the workflow, but the merge authority remains the
+repo-owned `ao-release-gate` checks plus GitHub ruleset enforcement, and the
+merge actor must still be `gladyatore-lab`.
+
+This does not make the lane complete by itself. It makes the final smoke
+repeatable from GitHub Actions:
+
+```text
+workflow_dispatch -> AO-MA-10r credential doctor -> AO-MA-10q runner
+  -> AO-MA-10l disposable smoke -> AO-MA-10c merge-agent
+```
+
+## Safety Contract
+
+- trigger is `workflow_dispatch` only;
+- dispatch must run from `refs/heads/main`;
+- no `pull_request` or `pull_request_target` secret path is introduced;
+- workflow `GITHUB_TOKEN` has only `contents: read`;
+- the dedicated actor token is only bound as an environment variable;
+- token values are never echoed, printed, committed, or uploaded;
+- execute mode still requires `AO-MA-10L-EXECUTE`;
+- all evidence is uploaded as an Actions artifact;
+- guard flags stay false:
+  - `support_widening=false`
+  - `production_platform_claim=false`
+  - `live_adapter_execution=false`
+
+## Dispatch Modes
+
+Dry-run mode:
+
+```bash
+gh workflow run ao-ma10q-dedicated-actor-smoke.yml \
+  --repo Halildeu/ao-kernel \
+  --ref main \
+  -f mode=dry-run
+```
+
+Execute mode:
+
+```bash
+gh workflow run ao-ma10q-dedicated-actor-smoke.yml \
+  --repo Halildeu/ao-kernel \
+  --ref main \
+  -f mode=execute \
+  -f confirmation=AO-MA-10L-EXECUTE
+```
+
+## Completion Criteria
+
+AO-MA-10s is ready when the workflow exists, validates with tests, and fails
+closed if `GLADYATORE_LAB_GH_TOKEN` is not configured.
+
+The low-risk no-human merge lane is complete only when an execute-mode run
+produces:
+
+- AO-MA-10r `credential_ready`;
+- AO-MA-10q `merged`;
+- AO-MA-10l disposable PR merged;
+- AO-MA-10c merge-agent result `merged`;
+- live GitHub evidence that the merge actor is `gladyatore-lab`, not
+  `Halildeu`;
+- required `ao-release-gate-technical` and `ao-release-gate-review` checks
+  remain source-pinned and passing.

--- a/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json
+++ b/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json
@@ -1,0 +1,16 @@
+{
+  "artifact_kind": "ao_ma_10s_dedicated_actor_smoke_workflow_receipt",
+  "schema_version": "ao-ma-10s-dedicated-actor-smoke-workflow-receipt.v1",
+  "status": "implemented_fail_closed",
+  "workflow": ".github/workflows/ao-ma10q-dedicated-actor-smoke.yml",
+  "trigger": "workflow_dispatch_only",
+  "allowed_ref": "refs/heads/main",
+  "secret_env": "GLADYATORE_LAB_GH_TOKEN",
+  "token_value_recorded": false,
+  "release_authority": "ao-release-gate+github-ruleset",
+  "ai_output_release_authority": false,
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false,
+  "next_required_slice": "configure GLADYATORE_LAB_GH_TOKEN repository secret and dispatch AO-MA-10q smoke"
+}

--- a/.github/workflows/ao-ma10q-dedicated-actor-smoke.yml
+++ b/.github/workflows/ao-ma10q-dedicated-actor-smoke.yml
@@ -1,0 +1,130 @@
+name: AO-MA-10q Dedicated Actor Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "dry-run checks readiness; execute creates and merges the disposable smoke PR"
+        required: true
+        default: "dry-run"
+        type: choice
+        options:
+          - "dry-run"
+          - "execute"
+      confirmation:
+        description: "Required for execute mode: AO-MA-10L-EXECUTE"
+        required: false
+        type: string
+      timeout_seconds:
+        description: "Maximum seconds to wait for required checks on the disposable smoke PR"
+        required: true
+        default: "900"
+        type: string
+      poll_seconds:
+        description: "Polling interval for required checks on the disposable smoke PR"
+        required: true
+        default: "15"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ao-ma10q-dedicated-actor-smoke
+  cancel-in-progress: false
+
+jobs:
+  ao-ma10q-dedicated-actor-smoke:
+    name: ao-ma10q-dedicated-actor-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GLADYATORE_LAB_GH_TOKEN: ${{ secrets.GLADYATORE_LAB_GH_TOKEN }}
+      MODE: ${{ inputs.mode }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+      TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+      POLL_SECONDS: ${{ inputs.poll_seconds }}
+      EVIDENCE_DIR: .ao/evidence/ao-ma-10s
+    steps:
+      - name: Refuse non-main dispatch
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::AO-MA-10q smoke must be dispatched from refs/heads/main"
+            exit 1
+          fi
+
+      - name: Validate execute confirmation
+        run: |
+          set -euo pipefail
+          case "$MODE" in
+            dry-run)
+              ;;
+            execute)
+              if [ "$CONFIRMATION" != "AO-MA-10L-EXECUTE" ]; then
+                echo "::error::execute mode requires confirmation AO-MA-10L-EXECUTE"
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::mode must be dry-run or execute"
+              exit 1
+              ;;
+          esac
+
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install ao-kernel
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[mcp]"
+
+      - name: Run AO-MA-10r credential doctor and AO-MA-10q smoke
+        run: |
+          set -euo pipefail
+          mkdir -p "$EVIDENCE_DIR"
+
+          set +e
+          python scripts/ao_ma10r_dedicated_actor_credential_doctor.py \
+            --output "$EVIDENCE_DIR/ao-ma10r-credential-doctor-result.json" \
+            --format text
+          doctor_status=$?
+
+          q_args=(
+            --output "$EVIDENCE_DIR/ao-ma10q-dedicated-actor-runner-result.json"
+            --timeout-seconds "$TIMEOUT_SECONDS"
+            --poll-seconds "$POLL_SECONDS"
+            --format text
+          )
+          if [ "$MODE" = "execute" ]; then
+            q_args+=(--execute --confirmation "$CONFIRMATION")
+          fi
+
+          python scripts/ao_ma10q_dedicated_actor_runner.py "${q_args[@]}"
+          runner_status=$?
+          set -e
+
+          {
+            echo "mode=$MODE"
+            echo "doctor_status=$doctor_status"
+            echo "runner_status=$runner_status"
+          } > "$EVIDENCE_DIR/status.txt"
+
+          if [ "$doctor_status" -ne 0 ] || [ "$runner_status" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Upload AO-MA-10q smoke evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ao-ma10q-dedicated-actor-smoke-${{ github.run_id }}
+          path: .ao/evidence/ao-ma-10s/
+          if-no-files-found: error

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10R",
+  "work_package": "AO-MA-10S",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,14 +13,13 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10r-credential-doctor",
+    "head_ref": "refs/heads/codex/ao-ma10s-dedicated-actor-smoke-workflow",
     "changed_files": [
-      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md",
-      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json",
-      "ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json",
+      ".github/workflows/ao-ma10q-dedicated-actor-smoke.yml",
+      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md",
+      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10r_dedicated_actor_credential_doctor.py",
-      "tests/test_ao_ma10r_dedicated_actor_credential_doctor.py"
+      "tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py"
     ]
   },
   "checks_considered": [
@@ -33,15 +32,15 @@
       "status": "pass"
     },
     {
-      "name": "mypy",
-      "status": "pass"
-    },
-    {
-      "name": "secret_scan",
+      "name": "actionlint",
       "status": "pass"
     },
     {
       "name": "json_schema",
+      "status": "pass"
+    },
+    {
+      "name": "secret_scan",
       "status": "pass"
     },
     {
@@ -50,12 +49,14 @@
     }
   ],
   "findings": [
-    "AO-MA-10r is fail-closed and no-secret: token values are accepted only via a named environment variable, never through CLI args, and token_value_recorded is schema-pinned false",
-    "The doctor performs read-only GitHub API checks only: user identity, repository permissions, and pull-request read access; no POST, merge, comment, ruleset, or branch-protection mutation is present",
-    "Permission semantics align with the low-risk autonomous merge model: write or maintain is merge-capable, admin is explicitly blocked, and read-only actors fail closed",
-    "Artifact schema is strict with additionalProperties=false and const-pinned release_authority, ai_output_release_authority=false, guard flags=false, and mutations_performed=false",
-    "Tests cover missing token, invalid env name, happy path, maintain path, wrong actor, admin actor, read-only actor, user API failure, repository API failure, and pull-request API failure",
-    "AO-MA-10r is correctly positioned as a prerequisite for AO-MA-10q execute smoke; it does not claim release authority or production readiness"
+    "AO-MA-10s adds a workflow_dispatch-only GitHub Actions surface; no push, pull_request, pull_request_target, or schedule trigger is introduced",
+    "The workflow refuses non-main dispatches and keeps GITHUB_TOKEN permissions to contents:read only",
+    "GLADYATORE_LAB_GH_TOKEN is bound exactly once as a job environment variable from repository secrets; the shell never dereferences, echoes, prints, or uploads the token value",
+    "Execute mode requires the literal AO-MA-10L-EXECUTE confirmation before AO-MA-10q receives --execute",
+    "AO-MA-10r credential doctor runs before AO-MA-10q dedicated actor runner, preserving the fail-closed prerequisite order",
+    "Evidence upload uses if:always with if-no-files-found:error so blocked secret/readiness states remain observable as artifacts",
+    "The receipt and tests pin release_authority=ao-release-gate+github-ruleset, ai_output_release_authority=false, support_widening=false, production_platform_claim=false, and live_adapter_execution=false",
+    "Claude cross-provider review returned AGREE with no blockers; non-blocking observations confirmed set +e exit capture, non-overlapping concurrency, and timeout sizing"
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py
+++ b/tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "ao-ma10q-dedicated-actor-smoke.yml"
+DOC = ROOT / ".claude" / "plans" / "AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md"
+RECEIPT = ROOT / ".claude" / "plans" / "AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _strip_yaml_comments(text: str) -> str:
+    lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _run_step_blocks(text: str) -> list[str]:
+    blocks = re.split(r"\n      - name: ", text)
+    return blocks[1:]
+
+
+def test_ao_ma10s_workflow_is_dispatch_only_and_main_bound() -> None:
+    text = _workflow_text()
+    stripped = _strip_yaml_comments(text)
+    assert "workflow_dispatch:" in text
+    assert "\n  push:" not in stripped
+    assert "\n  pull_request:" not in stripped
+    assert "\n  pull_request_target:" not in stripped
+    assert "\n  schedule:" not in stripped
+    assert 'if [ "$GITHUB_REF" != "refs/heads/main" ]; then' in text
+    assert "AO-MA-10q smoke must be dispatched from refs/heads/main" in text
+
+
+def test_ao_ma10s_workflow_permissions_are_minimal() -> None:
+    text = _workflow_text()
+    assert "\npermissions:\n  contents: read\n" in text
+    forbidden = [
+        "contents: write",
+        "checks: write",
+        "pull-requests: write",
+        "issues: write",
+        "actions: write",
+        "deployments: write",
+    ]
+    for item in forbidden:
+        assert item not in text
+
+
+def test_ao_ma10s_secret_is_only_bound_as_env_and_not_echoed() -> None:
+    text = _workflow_text()
+    assert 'GLADYATORE_LAB_GH_TOKEN: ${{ secrets.GLADYATORE_LAB_GH_TOKEN }}' in text
+    assert text.count("${{ secrets.GLADYATORE_LAB_GH_TOKEN }}") == 1
+    shell_blocks = "\n".join(_run_step_blocks(text))
+    assert "$GLADYATORE_LAB_GH_TOKEN" not in shell_blocks
+    assert "${GLADYATORE_LAB_GH_TOKEN" not in shell_blocks
+    assert "set -x" not in shell_blocks
+    assert "env |" not in shell_blocks
+    assert "printenv" not in shell_blocks
+
+
+def test_ao_ma10s_workflow_runs_doctor_before_runner_and_uploads_artifacts() -> None:
+    text = _workflow_text()
+    doctor = "scripts/ao_ma10r_dedicated_actor_credential_doctor.py"
+    runner = "scripts/ao_ma10q_dedicated_actor_runner.py"
+    assert doctor in text
+    assert runner in text
+    assert text.index(doctor) < text.index(runner)
+    assert "ao-ma10r-credential-doctor-result.json" in text
+    assert "ao-ma10q-dedicated-actor-runner-result.json" in text
+    assert "actions/upload-artifact@v7" in text
+    assert "if: always()" in text
+    assert "if-no-files-found: error" in text
+
+
+def test_ao_ma10s_execute_mode_requires_confirmation() -> None:
+    text = _workflow_text()
+    assert "AO-MA-10L-EXECUTE" in text
+    assert 'if [ "$CONFIRMATION" != "AO-MA-10L-EXECUTE" ]; then' in text
+    assert 'q_args+=(--execute --confirmation "$CONFIRMATION")' in text
+
+
+def test_ao_ma10s_doc_and_receipt_preserve_authority_boundary() -> None:
+    doc = DOC.read_text(encoding="utf-8")
+    receipt = json.loads(RECEIPT.read_text(encoding="utf-8"))
+    assert receipt["status"] == "implemented_fail_closed"
+    assert receipt["trigger"] == "workflow_dispatch_only"
+    assert receipt["allowed_ref"] == "refs/heads/main"
+    assert receipt["secret_env"] == "GLADYATORE_LAB_GH_TOKEN"
+    assert receipt["token_value_recorded"] is False
+    assert receipt["release_authority"] == "ao-release-gate+github-ruleset"
+    assert receipt["ai_output_release_authority"] is False
+    assert receipt["support_widening"] is False
+    assert receipt["production_platform_claim"] is False
+    assert receipt["live_adapter_execution"] is False
+    assert "merge actor is `gladyatore-lab`, not" in doc


### PR DESCRIPTION
## Summary
- Adds AO-MA-10S workflow_dispatch-only GitHub Actions surface for the AO-MA-10q dedicated actor smoke.
- Moves the final no-human smoke from local env to repository secret `GLADYATORE_LAB_GH_TOKEN`, with fail-closed AO-MA-10r doctor evidence before the runner.
- Keeps release authority as `ao-release-gate+github-ruleset`; no support widening, production claim, or live adapter execution.

## Guardrails
- Trigger is `workflow_dispatch` only; no `push`, `pull_request`, `pull_request_target`, or schedule.
- Dispatch is main-bound (`refs/heads/main`) and execute mode requires literal confirmation `AO-MA-10L-EXECUTE`.
- `GITHUB_TOKEN` permissions are `contents: read` only.
- `GLADYATORE_LAB_GH_TOKEN` is bound from repository secrets as job env; shell does not dereference, echo, print, or upload token value.
- Evidence upload uses `if: always()` and `if-no-files-found: error` so missing-secret states are observable artifacts.

## Validation
- `python3 -m pytest -q tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10r_dedicated_actor_credential_doctor.py tests/test_local_gpp_gate.py` -> 80 passed
- `python3 -m ruff check tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py` -> pass
- `actionlint .github/workflows/ao-ma10q-dedicated-actor-smoke.yml` -> pass
- `python3 -m json.tool .claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json` -> pass
- `git diff --check HEAD` -> pass
- `scripts/local_gpp_gate.py` -> `operator_may_merge` (`diff_digest=sha256:327b1ce911dd5407643b7109d303f48e253acf1077b487492f81986c8b323da8`)
- Claude cross-provider review -> AGREE

## Full-autonomy boundary
This PR does not complete full no-human autonomy by itself. The remaining proof is configuring the `GLADYATORE_LAB_GH_TOKEN` repository secret and dispatching this workflow in execute mode so AO-MA-10q produces `merged` evidence with merge actor `gladyatore-lab`.
