### PR TITLE
feat(ao-ma-10): add dedicated actor secret bootstrap

### DIFF
--- a/.claude/plans/AO-MA-10T-DEDICATED-ACTOR-SECRET-BOOTSTRAP.md
+++ b/.claude/plans/AO-MA-10T-DEDICATED-ACTOR-SECRET-BOOTSTRAP.md
@@ -1,0 +1,74 @@
+# AO-MA-10T - Dedicated Actor Secret Bootstrap
+
+## Purpose
+
+AO-MA-10S moved the final low-risk no-human smoke into a main-only GitHub
+Actions workflow, but the live dry-run evidence still blocks on the missing
+`GLADYATORE_LAB_GH_TOKEN` repository secret. AO-MA-10T narrows that remaining
+operator contact to one no-secret command path:
+
+1. the dedicated actor token is provided to the agent process through one named
+   environment variable;
+2. the bootstrap script writes the repository secret with `gh secret set` via
+   stdin;
+3. the output artifact records metadata only;
+4. the next step is dispatching the already-main AO-MA-10S execute smoke.
+
+This does not make a PAT, admin account, or AI output release authority.
+Release authority remains `ao-release-gate+github-ruleset`.
+
+## Command
+
+Do not paste the token into chat, shell history, or a command-line flag. Put it
+in the process environment and run:
+
+```bash
+export GLADYATORE_LAB_GH_TOKEN='<dedicated gladyatore-lab fine-grained token>'
+
+python3 scripts/ao_ma10t_configure_dedicated_actor_secret.py \
+  --output .ao/evidence/ao-ma-10t/dedicated-actor-secret-bootstrap.json \
+  --execute \
+  --confirmation AO-MA-10T-CONFIGURE-SECRET \
+  --format text
+```
+
+The script passes the token to:
+
+```bash
+gh secret set GLADYATORE_LAB_GH_TOKEN --repo Halildeu/ao-kernel
+```
+
+through stdin. It does not put the token in argv or the evidence artifact.
+
+## Success Criteria
+
+- `decision.result == "secret_configured"`
+- `mutations_performed == true`
+- `token_value_recorded == false`
+- `secret_value_recorded == false`
+- `secret_metadata.name == "GLADYATORE_LAB_GH_TOKEN"`
+
+After success, dispatch AO-MA-10S:
+
+```bash
+gh workflow run 285224724 \
+  --repo Halildeu/ao-kernel \
+  --ref main \
+  -f mode=execute \
+  -f confirmation=AO-MA-10L-EXECUTE \
+  -f timeout_seconds=900 \
+  -f poll_seconds=10
+```
+
+The full no-human claim is still not complete until the AO-MA-10S artifact
+shows AO-MA-10q `merged` with merge actor `gladyatore-lab`.
+
+## Guardrails
+
+- No support widening.
+- No production platform claim.
+- No live adapter execution.
+- No admin bypass.
+- No token material in evidence, PR text, logs, or command-line flags.
+- `GITHUB_TOKEN`/admin credentials can configure infrastructure, but the smoke
+  merge actor must still be the dedicated non-admin actor.

--- a/.claude/plans/AO-MA-10T-DEDICATED-ACTOR-SECRET-BOOTSTRAP.v1.json
+++ b/.claude/plans/AO-MA-10T-DEDICATED-ACTOR-SECRET-BOOTSTRAP.v1.json
@@ -1,0 +1,18 @@
+{
+  "artifact_kind": "ao_ma_10t_dedicated_actor_secret_bootstrap_receipt",
+  "schema_version": "ao-ma-10t-dedicated-actor-secret-bootstrap-receipt.v1",
+  "status": "implemented_fail_closed",
+  "script": "scripts/ao_ma10t_configure_dedicated_actor_secret.py",
+  "repository": "Halildeu/ao-kernel",
+  "secret_name": "GLADYATORE_LAB_GH_TOKEN",
+  "source_token_env": "GLADYATORE_LAB_GH_TOKEN",
+  "token_value_recorded": false,
+  "secret_value_recorded": false,
+  "secret_transport": "stdin_to_gh_secret_set",
+  "release_authority": "ao-release-gate+github-ruleset",
+  "ai_output_release_authority": false,
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false,
+  "next_required_slice": "run AO-MA-10T with the dedicated actor token env, then dispatch AO-MA-10S execute smoke"
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10S",
+  "work_package": "AO-MA-10T",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,13 +13,13 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10s-dedicated-actor-smoke-workflow",
+    "head_ref": "refs/heads/codex/ao-ma10t-secret-bootstrap",
     "changed_files": [
-      ".github/workflows/ao-ma10q-dedicated-actor-smoke.yml",
-      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md",
-      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json",
+      ".claude/plans/AO-MA-10T-DEDICATED-ACTOR-SECRET-BOOTSTRAP.md",
+      ".claude/plans/AO-MA-10T-DEDICATED-ACTOR-SECRET-BOOTSTRAP.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py"
+      "scripts/ao_ma10t_configure_dedicated_actor_secret.py",
+      "tests/test_ao_ma10t_configure_dedicated_actor_secret.py"
     ]
   },
   "checks_considered": [
@@ -29,10 +29,6 @@
     },
     {
       "name": "ruff",
-      "status": "pass"
-    },
-    {
-      "name": "actionlint",
       "status": "pass"
     },
     {
@@ -46,17 +42,19 @@
     {
       "name": "gpp_guard_flags_const_false",
       "status": "pass"
+    },
+    {
+      "name": "claude_cross_provider_review",
+      "status": "pass"
     }
   ],
   "findings": [
-    "AO-MA-10s adds a workflow_dispatch-only GitHub Actions surface; no push, pull_request, pull_request_target, or schedule trigger is introduced",
-    "The workflow refuses non-main dispatches and keeps GITHUB_TOKEN permissions to contents:read only",
-    "GLADYATORE_LAB_GH_TOKEN is bound exactly once as a job environment variable from repository secrets; the shell never dereferences, echoes, prints, or uploads the token value",
-    "Execute mode requires the literal AO-MA-10L-EXECUTE confirmation before AO-MA-10q receives --execute",
-    "AO-MA-10r credential doctor runs before AO-MA-10q dedicated actor runner, preserving the fail-closed prerequisite order",
-    "Evidence upload uses if:always with if-no-files-found:error so blocked secret/readiness states remain observable as artifacts",
-    "The receipt and tests pin release_authority=ao-release-gate+github-ruleset, ai_output_release_authority=false, support_widening=false, production_platform_claim=false, and live_adapter_execution=false",
-    "Claude cross-provider review returned AGREE with no blockers; non-blocking observations confirmed set +e exit capture, non-overlapping concurrency, and timeout sizing"
+    "AO-MA-10t narrows the remaining dedicated actor token handoff to a no-secret bootstrap script that reads one named environment variable and writes the GitHub repository secret via gh secret set stdin",
+    "The token value is never placed in argv, command logs, receipt JSON, or the result artifact; tests assert the fake token is absent from serialized output and absent from every command list",
+    "The script is fail-closed for missing source env, missing execute flag, and wrong confirmation, with no GitHub mutation before all pre-mutation gates pass",
+    "Successful execution records only metadata: secret name plus created_at/updated_at presence booleans; no token hash or token-derived value is recorded",
+    "The receipt and script pin release_authority=ao-release-gate+github-ruleset, ai_output_release_authority=false, support_widening=false, production_platform_claim=false, and live_adapter_execution=false",
+    "Claude cross-provider review initially requested import-path hardening; importlib.util file-based loading was absorbed and the re-review returned AGREE"
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/ao_ma10t_configure_dedicated_actor_secret.py
+++ b/scripts/ao_ma10t_configure_dedicated_actor_secret.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Configure the AO-MA-10 dedicated actor repository secret without recording it.
+
+The full no-human merge smoke needs the ``GLADYATORE_LAB_GH_TOKEN`` repository
+secret so the main-only AO-MA-10S workflow can authenticate as the dedicated
+non-admin merge actor. This helper keeps the operator handoff bounded:
+
+* the token is read from one named environment variable;
+* the token is passed to ``gh secret set`` through stdin, never a CLI argument;
+* the output artifact records only metadata and guard flags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+
+SCHEMA_VERSION = "ao-ma-10t-dedicated-actor-secret-bootstrap-result.v1"
+ARTIFACT_KIND = "ao_ma_10t_dedicated_actor_secret_bootstrap_result"
+RELEASE_AUTHORITY = "ao-release-gate+github-ruleset"
+DEFAULT_REPO = "Halildeu/ao-kernel"
+DEFAULT_SECRET_NAME = "GLADYATORE_LAB_GH_TOKEN"
+DEFAULT_SOURCE_TOKEN_ENV = "GLADYATORE_LAB_GH_TOKEN"
+EXECUTE_CONFIRMATION = "AO-MA-10T-CONFIGURE-SECRET"
+ENV_RE = re.compile(r"[A-Z_][A-Z0-9_]*")
+
+Runner = Callable[[list[str], Mapping[str, str], str | None], subprocess.CompletedProcess[str]]
+
+
+def _run(command: list[str], env: Mapping[str, str], stdin: str | None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=dict(env),
+        input=stdin,
+    )
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _validate_env_name(name: str) -> None:
+    if not ENV_RE.fullmatch(name):
+        raise ValueError("environment variable name must match [A-Z_][A-Z0-9_]*")
+
+
+def _base_result(*, repo: str, secret_name: str, source_token_env: str, execute: bool) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_kind": ARTIFACT_KIND,
+        "generated_at": _utc_now(),
+        "repository": repo,
+        "secret_name": secret_name,
+        "source_token_env": source_token_env,
+        "execute_requested": execute,
+        "token_value_recorded": False,
+        "secret_value_recorded": False,
+        "mutations_performed": False,
+        "release_authority": RELEASE_AUTHORITY,
+        "ai_output_release_authority": False,
+        "guard_flags": {
+            "support_widening": False,
+            "production_platform_claim": False,
+            "live_adapter_execution": False,
+        },
+        "commands": [],
+        "secret_metadata": None,
+        "decision": {
+            "result": "blocked",
+            "blockers": [],
+            "warnings": [],
+            "next_required_slice": "provide the dedicated actor token env and rerun AO-MA-10T",
+        },
+    }
+
+
+def _set_decision(result: dict[str, Any], *, decision: str, blockers: set[str], warnings: set[str]) -> None:
+    if blockers:
+        next_required = "resolve AO-MA-10T credential/bootstrap blockers"
+    elif decision == "ready_to_configure":
+        next_required = "rerun AO-MA-10T with --execute and the confirmation string"
+    else:
+        next_required = "dispatch AO-MA-10S execute smoke from main"
+    result["decision"] = {
+        "result": "blocked" if blockers else decision,
+        "blockers": sorted(blockers),
+        "warnings": sorted(warnings),
+        "next_required_slice": next_required,
+    }
+
+
+def _write_json(path: Path, result: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _run_json(
+    command: list[str],
+    *,
+    env: Mapping[str, str],
+    runner: Runner,
+    result: dict[str, Any],
+    stdin: str | None = None,
+) -> tuple[dict[str, Any], str | None]:
+    result["commands"].append(list(command))
+    proc = runner(command, env, stdin)
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or f"exit {proc.returncode}"
+        return {}, detail
+    if not proc.stdout.strip():
+        return {}, None
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {}, "invalid json response"
+    if not isinstance(payload, dict):
+        return {}, "json response must be object"
+    return payload, None
+
+
+def run(
+    *,
+    repo: str,
+    secret_name: str,
+    source_token_env: str,
+    gh_bin: str,
+    output: Path,
+    execute: bool,
+    confirmation: str | None,
+    runner: Runner = _run,
+) -> dict[str, Any]:
+    _validate_env_name(secret_name)
+    _validate_env_name(source_token_env)
+    result = _base_result(
+        repo=repo,
+        secret_name=secret_name,
+        source_token_env=source_token_env,
+        execute=execute,
+    )
+    blockers: set[str] = set()
+    warnings: set[str] = set()
+
+    token = os.environ.get(source_token_env)
+    if not token:
+        blockers.add("source_token_env_missing")
+        _set_decision(result, decision="blocked", blockers=blockers, warnings=warnings)
+        _write_json(output, result)
+        return result
+
+    if not execute:
+        _set_decision(result, decision="ready_to_configure", blockers=blockers, warnings=warnings)
+        _write_json(output, result)
+        return result
+
+    if confirmation != EXECUTE_CONFIRMATION:
+        blockers.add("execute_confirmation_missing")
+        _set_decision(result, decision="blocked", blockers=blockers, warnings=warnings)
+        _write_json(output, result)
+        return result
+
+    env = dict(os.environ)
+    set_command = [gh_bin, "secret", "set", secret_name, "--repo", repo]
+    _, error = _run_json(set_command, env=env, runner=runner, result=result, stdin=token)
+    if error is not None:
+        blockers.add("gh_secret_set_failed")
+        result.setdefault("collection_errors", []).append(f"secret_set: {error}")
+    else:
+        result["mutations_performed"] = True
+
+    if not blockers:
+        metadata_command = [gh_bin, "api", f"repos/{repo}/actions/secrets/{secret_name}"]
+        metadata, error = _run_json(metadata_command, env=env, runner=runner, result=result)
+        if error is not None:
+            blockers.add("secret_metadata_read_failed")
+            result.setdefault("collection_errors", []).append(f"secret_metadata: {error}")
+        elif metadata.get("name") != secret_name:
+            blockers.add("secret_metadata_name_mismatch")
+            result["secret_metadata"] = {"name": metadata.get("name")}
+        else:
+            result["secret_metadata"] = {
+                "name": metadata.get("name"),
+                "created_at_present": isinstance(metadata.get("created_at"), str),
+                "updated_at_present": isinstance(metadata.get("updated_at"), str),
+            }
+
+    _set_decision(result, decision="secret_configured", blockers=blockers, warnings=warnings)
+    _write_json(output, result)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--secret-name", default=DEFAULT_SECRET_NAME)
+    parser.add_argument("--source-token-env", default=DEFAULT_SOURCE_TOKEN_ENV)
+    parser.add_argument("--gh-bin", default="gh")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--confirmation")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    args = parser.parse_args(argv)
+
+    result = run(
+        repo=args.repo,
+        secret_name=args.secret_name,
+        source_token_env=args.source_token_env,
+        gh_bin=args.gh_bin,
+        output=Path(args.output),
+        execute=args.execute,
+        confirmation=args.confirmation,
+    )
+    if args.format == "text":
+        print(result["decision"]["result"])
+        for blocker in result["decision"]["blockers"]:
+            print(f"blocker: {blocker}")
+    else:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["decision"]["result"] in {"ready_to_configure", "secret_configured"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ao_ma10t_configure_dedicated_actor_secret.py
+++ b/tests/test_ao_ma10t_configure_dedicated_actor_secret.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import importlib.util
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "ao_ma10t_configure_dedicated_actor_secret.py"
+SPEC = importlib.util.spec_from_file_location("ao_ma10t_configure_dedicated_actor_secret", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+bootstrap = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bootstrap)
+
+
+class FakeRunner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[str], str | None]] = []
+
+    def __call__(
+        self,
+        command: list[str],
+        env: Mapping[str, str],
+        stdin: str | None,
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append((list(command), stdin))
+        assert "token-secret-value" not in command
+        if command[:3] == ["gh", "secret", "set"]:
+            assert command == [
+                "gh",
+                "secret",
+                "set",
+                "GLADYATORE_LAB_GH_TOKEN",
+                "--repo",
+                "Halildeu/ao-kernel",
+            ]
+            assert stdin == "token-secret-value"
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command[:2] == ["gh", "api"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps(
+                    {
+                        "name": "GLADYATORE_LAB_GH_TOKEN",
+                        "created_at": "2026-05-29T00:00:00Z",
+                        "updated_at": "2026-05-29T00:00:00Z",
+                    }
+                ),
+                "",
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_missing_source_token_env_fails_closed_without_mutation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GLADYATORE_LAB_GH_TOKEN", raising=False)
+    output = tmp_path / "result.json"
+    runner = FakeRunner()
+
+    result = bootstrap.run(
+        repo="Halildeu/ao-kernel",
+        secret_name="GLADYATORE_LAB_GH_TOKEN",
+        source_token_env="GLADYATORE_LAB_GH_TOKEN",
+        gh_bin="gh",
+        output=output,
+        execute=True,
+        confirmation=bootstrap.EXECUTE_CONFIRMATION,
+        runner=runner,
+    )
+
+    assert result["decision"]["result"] == "blocked"
+    assert result["decision"]["blockers"] == ["source_token_env_missing"]
+    assert result["mutations_performed"] is False
+    assert result["token_value_recorded"] is False
+    assert runner.calls == []
+    assert read_json(output)["decision"]["result"] == "blocked"
+
+
+def test_source_token_without_execute_is_ready_to_configure_no_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GLADYATORE_LAB_GH_TOKEN", "token-secret-value")
+    output = tmp_path / "result.json"
+    runner = FakeRunner()
+
+    result = bootstrap.run(
+        repo="Halildeu/ao-kernel",
+        secret_name="GLADYATORE_LAB_GH_TOKEN",
+        source_token_env="GLADYATORE_LAB_GH_TOKEN",
+        gh_bin="gh",
+        output=output,
+        execute=False,
+        confirmation=None,
+        runner=runner,
+    )
+
+    assert result["decision"]["result"] == "ready_to_configure"
+    assert result["mutations_performed"] is False
+    assert runner.calls == []
+
+
+def test_execute_requires_literal_confirmation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GLADYATORE_LAB_GH_TOKEN", "token-secret-value")
+    output = tmp_path / "result.json"
+    runner = FakeRunner()
+
+    result = bootstrap.run(
+        repo="Halildeu/ao-kernel",
+        secret_name="GLADYATORE_LAB_GH_TOKEN",
+        source_token_env="GLADYATORE_LAB_GH_TOKEN",
+        gh_bin="gh",
+        output=output,
+        execute=True,
+        confirmation="wrong",
+        runner=runner,
+    )
+
+    assert result["decision"]["result"] == "blocked"
+    assert result["decision"]["blockers"] == ["execute_confirmation_missing"]
+    assert result["mutations_performed"] is False
+    assert runner.calls == []
+
+
+def test_execute_sets_secret_via_stdin_and_records_metadata_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GLADYATORE_LAB_GH_TOKEN", "token-secret-value")
+    output = tmp_path / "result.json"
+    runner = FakeRunner()
+
+    result = bootstrap.run(
+        repo="Halildeu/ao-kernel",
+        secret_name="GLADYATORE_LAB_GH_TOKEN",
+        source_token_env="GLADYATORE_LAB_GH_TOKEN",
+        gh_bin="gh",
+        output=output,
+        execute=True,
+        confirmation=bootstrap.EXECUTE_CONFIRMATION,
+        runner=runner,
+    )
+
+    assert result["decision"]["result"] == "secret_configured"
+    assert result["mutations_performed"] is True
+    assert result["token_value_recorded"] is False
+    assert result["secret_value_recorded"] is False
+    assert result["secret_metadata"] == {
+        "name": "GLADYATORE_LAB_GH_TOKEN",
+        "created_at_present": True,
+        "updated_at_present": True,
+    }
+    serialized = output.read_text(encoding="utf-8")
+    assert "token-secret-value" not in serialized
+    assert runner.calls[0][0] == [
+        "gh",
+        "secret",
+        "set",
+        "GLADYATORE_LAB_GH_TOKEN",
+        "--repo",
+        "Halildeu/ao-kernel",
+    ]
+    assert runner.calls[0][1] == "token-secret-value"
+    assert runner.calls[1][0] == [
+        "gh",
+        "api",
+        "repos/Halildeu/ao-kernel/actions/secrets/GLADYATORE_LAB_GH_TOKEN",
+    ]
+
+
+def test_invalid_env_names_are_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        bootstrap.run(
+            repo="Halildeu/ao-kernel",
+            secret_name="BAD-NAME",
+            source_token_env="GLADYATORE_LAB_GH_TOKEN",
+            gh_bin="gh",
+            output=tmp_path / "result.json",
+            execute=False,
+            confirmation=None,
+        )


### PR DESCRIPTION
## Summary
- Adds AO-MA-10T metadata-only bootstrap for configuring the `GLADYATORE_LAB_GH_TOKEN` repository secret.
- Reads the dedicated actor token from one named environment variable and passes it to `gh secret set` through stdin, never argv.
- Keeps release authority as `ao-release-gate+github-ruleset`; no support widening, production claim, or live adapter execution.

## Validation
- `python3 -m pytest -q tests/test_ao_ma10t_configure_dedicated_actor_secret.py tests/test_local_gpp_gate.py` -> 61 passed
- `python3 -m ruff check scripts/ao_ma10t_configure_dedicated_actor_secret.py tests/test_ao_ma10t_configure_dedicated_actor_secret.py` -> pass
- `python3 -m json.tool .claude/plans/AO-MA-10T-DEDICATED-ACTOR-SECRET-BOOTSTRAP.v1.json` -> pass
- `python3 -m json.tool local-ai-review-evidence.v1.json` -> pass
- `git diff --check` -> pass
- AO-MA-10T missing env smoke -> blocked / `source_token_env_missing`
- `PYTHONPATH=$PWD python3 scripts/local_gpp_gate.py ... --work-package AO-MA-10T` -> `operator_may_merge`, `diff_digest=sha256:c28f7b40496e9db5f4783a7804aafb69f89bae919946503dbc4d5f63d0f591c0`
- Claude cross-provider review -> REVISE import path -> absorbed -> AGREE

## Full-autonomy boundary
This PR still does not complete no-human autonomy. It makes the final credential handoff one safe command. Completion still requires setting a real non-admin `gladyatore-lab` token, dispatching AO-MA-10S execute mode, and observing AO-MA-10q `merged` evidence with merge actor `gladyatore-lab`.
