### PR TITLE
feat(ao-ma-10): split disposable PR producer token

### DIFF
--- a/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md
+++ b/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md
@@ -15,7 +15,7 @@ autonomous merge lane. The orchestrator does not replace release authority. It
 only sequences the already recorded authority chain:
 
 ```text
-AO-MA-10a0 readiness -> AO-MA-10a1 eligibility -> disposable PR ->
+AO-MA-10a0 readiness -> AO-MA-10a1 eligibility -> disposable PR producer ->
 required checks -> AO-MA-10c merge-agent
 ```
 
@@ -49,6 +49,20 @@ readiness snapshot collector, and to the AO-MA-10c merge-agent. This lets the
 smoke run under the dedicated non-admin merge actor without changing the
 operator's global `gh` login.
 
+AO-MA-10v adds an optional producer runtime:
+
+```text
+--producer-gh-bin <governance-or-producer-gh-wrapper>
+```
+
+When present, AO-MA-10l uses this runtime only for the disposable PR production
+steps: base-ref read, smoke branch create, low-risk file create, and PR create.
+Required-check polling and the final AO-MA-10c merge-agent still use
+`--gh-bin`, which must authenticate as the dedicated non-admin merge actor. This
+keeps branch/PR creation unblocked when a fine-grained non-admin actor token
+cannot create refs, while preserving release authority at the required checks
+plus non-admin merge actor boundary.
+
 Even in execute mode it stops before any GitHub write when A0/A1 is blocked.
 
 ## Live Blocker
@@ -75,10 +89,11 @@ admin: false
 
 When A0/A1 are ready and explicit confirmation is present, the orchestrator:
 
-1. creates a unique `codex/ao-ma10l-smoke-*` branch from `main`;
+1. creates a unique `codex/ao-ma10l-smoke-*` branch from `main` through the
+   selected PR producer runtime;
 2. creates one low-risk file under
    `docs/evidence/ao-ma-10l-autonomous-smoke/`;
-3. opens a disposable PR;
+3. opens a disposable PR through the selected PR producer runtime;
 4. waits for required checks, including `ao-release-gate-technical` and
    `ao-release-gate-review`;
 5. refreshes A0/A1;
@@ -106,6 +121,7 @@ ao_kernel/defaults/schemas/ao-ma-10l-autonomous-smoke-result.schema.v1.json
 The artifact records:
 
 - expected actor and branch;
+- PR producer role and allowed operations;
 - disposable smoke path;
 - A0/A1 decisions;
 - created PR metadata;
@@ -120,6 +136,7 @@ The low-risk autonomous lane is proven only when AO-MA-10l produces a `merged`
 artifact where:
 
 - actor is the dedicated non-admin merge actor;
+- any split PR producer is not treated as release authority;
 - A0 is `ready_for_dry_run`;
 - A1 is `ready_for_low_risk_dry_run`;
 - required checks pass;

--- a/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json
+++ b/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json
@@ -13,6 +13,15 @@
   "execute_confirmation": "AO-MA-10L-EXECUTE",
   "supports_dedicated_gh_runtime": true,
   "dedicated_gh_runtime_argument": "--gh-bin",
+  "supports_split_pr_producer_runtime": true,
+  "producer_gh_runtime_argument": "--producer-gh-bin",
+  "producer_release_authority": false,
+  "producer_allowed_operations": [
+    "base_ref_read",
+    "branch_create",
+    "file_create",
+    "pr_create"
+  ],
   "expected_actor": "gladyatore-lab",
   "blocks_before_github_write_when_a0_a1_blocked": true,
   "delegates_merge_to": "scripts/ao_ma10c_merge_agent.py",

--- a/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md
+++ b/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md
@@ -77,17 +77,24 @@ AO_GOVERNANCE_GH_TOKEN=<redacted> \
 AO-MA-10q delegates all live GitHub sequencing to AO-MA-10l:
 
 ```text
-AO-MA-10q dedicated actor wrapper + governance-read wrapper -> AO-MA-10l smoke -> AO-MA-10c merge-agent
+AO-MA-10q dedicated actor wrapper + governance/producer wrapper -> AO-MA-10l smoke -> AO-MA-10c merge-agent
 ```
 
 AO-MA-10l still performs A0/A1 readiness checks, required check observation,
 and AO-MA-10c merge delegation. If those checks fail, AO-MA-10q records the
 blockers and does not turn AI review into release authority.
 
-The governance wrapper is read-only from AO-MA-10l's perspective and is used
-only for branch-protection/ruleset readiness reads that fine-grained non-admin
-merge actor tokens cannot access. PR creation, check polling, and merge
-execution continue to use the dedicated actor wrapper.
+The governance wrapper has two bounded roles from AO-MA-10l's perspective:
+
+1. read-only branch-protection/ruleset readiness APIs that fine-grained
+   non-admin merge actor tokens cannot access;
+2. disposable low-risk PR production (`base_ref_read`, `branch_create`,
+   `file_create`, `pr_create`) when the dedicated non-admin actor token cannot
+   create refs.
+
+Required-check polling and merge execution continue to use the dedicated actor
+wrapper. The producer wrapper is not release authority and cannot satisfy the
+AO-MA-10c merge-agent actor assertion.
 
 ## Result Artifact
 
@@ -100,6 +107,7 @@ ao_kernel/defaults/schemas/ao-ma-10q-dedicated-actor-runner-result.schema.v1.jso
 The artifact records:
 
 - expected actor and token environment variable name;
+- producer token environment variable name and wrapper role;
 - whether execute mode was requested;
 - whether a temporary wrapper was created;
 - sanitized AO-MA-10l command shape;
@@ -114,6 +122,7 @@ The no-human low-risk merge path is proven only when AO-MA-10q produces a
 - token value is not recorded;
 - wrapper path is not recorded;
 - actor is the dedicated non-admin merge actor;
+- any split PR producer is not treated as release authority;
 - AO-MA-10l reports `merged`;
 - required checks pass;
 - no admin bypass, ruleset mutation, branch-protection mutation, support

--- a/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json
+++ b/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json
@@ -10,6 +10,14 @@
   "production_platform_claim": false,
   "live_adapter_execution": false,
   "default_token_env": "GLADYATORE_LAB_GH_TOKEN",
+  "default_producer_token_env": "AO_GOVERNANCE_GH_TOKEN",
+  "producer_release_authority": false,
+  "producer_allowed_operations": [
+    "base_ref_read",
+    "branch_create",
+    "file_create",
+    "pr_create"
+  ],
   "token_value_recorded": false,
   "wrapper_path_recorded": false,
   "wrapper_mode": "0700",

--- a/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md
+++ b/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md
@@ -11,9 +11,10 @@
 AO-MA-10s removes the remaining local-shell dependency from AO-MA-10q. The
 dedicated non-admin merge actor token is read from the GitHub repository secret
 `GLADYATORE_LAB_GH_TOKEN`, not from a local operator shell. The optional
-governance-read token is read from `AO_GOVERNANCE_GH_TOKEN` only for read-only
-branch-protection/ruleset readiness APIs that the non-admin merge actor cannot
-read. A Codex or Claude operator may dispatch the workflow, but the merge
+governance/producer token is read from `AO_GOVERNANCE_GH_TOKEN` for
+branch-protection/ruleset readiness APIs and for disposable low-risk PR
+production when the non-admin merge actor token cannot create refs. A Codex or
+Claude operator may dispatch the workflow, but the merge
 authority remains the repo-owned `ao-release-gate` checks plus GitHub ruleset
 enforcement, and the merge actor must still be `gladyatore-lab`.
 
@@ -32,8 +33,9 @@ workflow_dispatch -> AO-MA-10r credential doctor -> AO-MA-10q runner
 - no `pull_request` or `pull_request_target` secret path is introduced;
 - workflow `GITHUB_TOKEN` has only `contents: read`;
 - the dedicated actor token is only bound as an environment variable;
-- the governance token is only bound as an environment variable and is not used
-  for PR creation or merge execution;
+- the governance token is only bound as an environment variable and may be used
+  only for readiness reads plus disposable PR production;
+- merge execution remains bound to the dedicated non-admin merge actor token;
 - token values are never echoed, printed, committed, or uploaded;
 - execute mode still requires `AO-MA-10L-EXECUTE`;
 - all evidence is uploaded as an Actions artifact;

--- a/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json
+++ b/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json
@@ -3,6 +3,8 @@
   "allowed_ref": "refs/heads/main",
   "artifact_kind": "ao_ma_10s_dedicated_actor_smoke_workflow_receipt",
   "governance_secret_env": "AO_GOVERNANCE_GH_TOKEN",
+  "producer_secret_env": "AO_GOVERNANCE_GH_TOKEN",
+  "producer_release_authority": false,
   "live_adapter_execution": false,
   "next_required_slice": "configure GLADYATORE_LAB_GH_TOKEN and AO_GOVERNANCE_GH_TOKEN repository secrets and dispatch AO-MA-10q smoke",
   "production_platform_claim": false,

--- a/ao_kernel/defaults/schemas/ao-ma-10l-autonomous-smoke-result.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-ma-10l-autonomous-smoke-result.schema.v1.json
@@ -15,6 +15,7 @@
     "run_id",
     "branch",
     "smoke_path",
+    "pr_producer",
     "execute_requested",
     "mutations_performed",
     "release_authority",
@@ -38,6 +39,28 @@
     "run_id": { "type": "string", "minLength": 1 },
     "branch": { "type": "string", "pattern": "^codex/ao-ma10l-smoke-" },
     "smoke_path": { "type": "string", "pattern": "^docs/evidence/ao-ma-10l-autonomous-smoke/" },
+    "pr_producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "same_as_merge_actor", "release_authority", "allowed_operations"],
+      "properties": {
+        "role": { "type": "string", "enum": ["merge_actor", "governance_producer"] },
+        "same_as_merge_actor": { "type": "boolean" },
+        "release_authority": { "type": "boolean", "const": false },
+        "allowed_operations": {
+          "type": "array",
+          "prefixItems": [
+            { "type": "string", "const": "base_ref_read" },
+            { "type": "string", "const": "branch_create" },
+            { "type": "string", "const": "file_create" },
+            { "type": "string", "const": "pr_create" }
+          ],
+          "items": false,
+          "minItems": 4,
+          "maxItems": 4
+        }
+      }
+    },
     "execute_requested": { "type": "boolean" },
     "mutations_performed": { "type": "boolean" },
     "release_authority": { "type": "string", "const": "ao-release-gate+github-ruleset" },

--- a/ao_kernel/defaults/schemas/ao-ma-10q-dedicated-actor-runner-result.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-ma-10q-dedicated-actor-runner-result.schema.v1.json
@@ -79,6 +79,41 @@
     "mutations_performed": {
       "type": "boolean"
     },
+    "producer_token_env": {
+      "pattern": "^[A-Z_][A-Z0-9_]*$",
+      "type": "string"
+    },
+    "producer_wrapper": {
+      "additionalProperties": false,
+      "properties": {
+        "created": {
+          "type": "boolean"
+        },
+        "mode": {
+          "anyOf": [
+            {
+              "const": "0700"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "path_recorded": {
+          "const": false
+        },
+        "same_as_merge_actor_wrapper": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "created",
+        "mode",
+        "path_recorded",
+        "same_as_merge_actor_wrapper"
+      ],
+      "type": "object"
+    },
     "release_authority": {
       "const": "ao-release-gate+github-ruleset"
     },
@@ -147,6 +182,7 @@
     "base_ref",
     "expected_actor",
     "token_env",
+    "producer_token_env",
     "token_value_recorded",
     "execute_requested",
     "mutations_performed",
@@ -154,6 +190,7 @@
     "ai_output_release_authority",
     "guard_flags",
     "wrapper",
+    "producer_wrapper",
     "smoke_result",
     "smoke_command",
     "decision"

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10U",
+  "work_package": "AO-MA-10V",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -12,15 +12,18 @@
     "verdict": "AGREE"
   },
   "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10u-governance-token-split",
+    "base_ref": "origin/main",
+    "head_ref": "codex/ao-ma10v-producer-token-split",
     "changed_files": [
+      ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md",
+      ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json",
       ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md",
+      ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json",
       ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md",
       ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json",
-      ".github/workflows/ao-ma10q-dedicated-actor-smoke.yml",
+      "ao_kernel/defaults/schemas/ao-ma-10l-autonomous-smoke-result.schema.v1.json",
+      "ao_kernel/defaults/schemas/ao-ma-10q-dedicated-actor-runner-result.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10_github_readiness_snapshot.py",
       "scripts/ao_ma10l_autonomous_smoke.py",
       "scripts/ao_ma10q_dedicated_actor_runner.py",
       "tests/test_ao_ma10l_autonomous_smoke.py",
@@ -48,17 +51,19 @@
     {
       "name": "git_diff_check",
       "status": "pass"
+    },
+    {
+      "name": "cross_ai_review",
+      "status": "pass"
     }
   ],
   "findings": [
-    "AO_GOVERNANCE_GH_TOKEN is split from GLADYATORE_LAB_GH_TOKEN. Governance token is used for readiness snapshot reads; actor token remains responsible for PR create, check polling, and merge operations.",
-    "No --admin flag is introduced in the changed workflow or runner path. The dedicated actor remains non-admin release authority evidence, and GitHub ruleset plus ao-release-gate remain the enforcement surface.",
-    "Receipt and runner outputs preserve support_widening=false, production_platform_claim=false, live_adapter_execution=false, ai_output_release_authority=false, and token_value_recorded=false.",
-    "Workflow secrets are bound as environment variables only. The changed workflow and tests guard against echoing GLADYATORE_LAB_GH_TOKEN or AO_GOVERNANCE_GH_TOKEN values.",
-    "Governance wrapper creation is optional and gated on AO_GOVERNANCE_GH_TOKEN being present, so the existing actor-only path remains backward compatible while split-token readiness reads are available when the secret is configured.",
-    "Smoke command sanitization handles both temporary GitHub CLI wrappers and never records wrapper paths or token values in the emitted artifact.",
-    "collect_live_snapshot keeps branch-protection and ruleset reads on the governance gh wrapper while resolving viewer login and actor repository permission through the actor wrapper, including viewerPermission fallback when collaborator permission API is inaccessible to the fine-grained actor token.",
-    "Relevant tests passed locally: test_ao_ma10_github_readiness_snapshot.py, test_ao_ma10l_autonomous_smoke.py, test_ao_ma10q_dedicated_actor_runner.py, and test_ao_ma10s_dedicated_actor_smoke_workflow.py."
+    "Claude reviewer verdict AGREE. Blocking bulgu yok.",
+    "Producer token only creates the disposable branch, file, and PR. Required-check polling and AO-MA-10c merge-agent remain bound to the dedicated non-admin merge actor runtime.",
+    "pr_producer.release_authority is false and producer_wrapper.path_recorded is false in the emitted artifacts and schemas.",
+    "No new GitHub workflow trigger or GITHUB_TOKEN write permission is introduced; workflow remains workflow_dispatch only with contents read.",
+    "Backward compatibility is preserved because --producer-gh-bin is optional and defaults to --gh-bin.",
+    "Relevant validations passed locally: 35 AO-MA-10r/l/q/s tests, focused 23 AO-MA-10l/q/s tests, ruff on touched tests, compileall on touched scripts, JSON validation, and git diff check."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -12,8 +12,8 @@
     "verdict": "AGREE"
   },
   "scope_reviewed": {
-    "base_ref": "origin/main",
-    "head_ref": "codex/ao-ma10v-producer-token-split",
+    "base_ref": "refs/heads/main",
+    "head_ref": "refs/heads/codex/ao-ma10v-producer-token-split",
     "changed_files": [
       ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md",
       ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json",

--- a/scripts/ao_ma10l_autonomous_smoke.py
+++ b/scripts/ao_ma10l_autonomous_smoke.py
@@ -7,7 +7,7 @@ repo-owned evidence gates:
 
 1. AO-MA-10a0 live GitHub readiness snapshot.
 2. AO-MA-10a1 low-risk autonomous merge eligibility.
-3. A disposable low-risk PR created by the dedicated non-admin actor.
+3. A disposable low-risk PR created by the selected PR producer runtime.
 4. Live required-check pass observation.
 5. AO-MA-10c merge-agent execution.
 
@@ -101,6 +101,7 @@ def _result_template(
     smoke_path: str,
     execute: bool,
     generated_at: str,
+    producer_same_as_merge_actor: bool,
 ) -> dict[str, Any]:
     return {
         "schema_version": SCHEMA_VERSION,
@@ -112,6 +113,12 @@ def _result_template(
         "run_id": run_id,
         "branch": branch,
         "smoke_path": smoke_path,
+        "pr_producer": {
+            "role": "merge_actor" if producer_same_as_merge_actor else "governance_producer",
+            "same_as_merge_actor": producer_same_as_merge_actor,
+            "release_authority": False,
+            "allowed_operations": ["base_ref_read", "branch_create", "file_create", "pr_create"],
+        },
         "execute_requested": execute,
         "mutations_performed": False,
         "release_authority": RELEASE_AUTHORITY,
@@ -282,7 +289,7 @@ def _parse_pr_number(value: str) -> int | None:
 def _create_disposable_pr(
     *,
     repo: str,
-    gh_bin: str,
+    producer_gh_bin: str,
     base_ref: str,
     branch: str,
     smoke_path: str,
@@ -293,7 +300,7 @@ def _create_disposable_pr(
 ) -> tuple[int | None, set[str]]:
     blockers: set[str] = set()
 
-    get_ref = [gh_bin, "api", f"repos/{repo}/git/ref/heads/{base_ref}"]
+    get_ref = [producer_gh_bin, "api", f"repos/{repo}/git/ref/heads/{base_ref}"]
     _add_command(result, get_ref)
     ref_payload, error = _run_json(get_ref, runner)
     if error is not None or not isinstance(ref_payload, dict):
@@ -303,7 +310,7 @@ def _create_disposable_pr(
         return None, {"github_base_ref_sha_missing"}
 
     create_ref = [
-        gh_bin,
+        producer_gh_bin,
         "api",
         f"repos/{repo}/git/refs",
         "--method",
@@ -335,7 +342,7 @@ def _create_disposable_pr(
         encoding="utf-8",
     )
     put_file = [
-        gh_bin,
+        producer_gh_bin,
         "api",
         f"repos/{repo}/contents/{smoke_path}",
         "--method",
@@ -355,7 +362,7 @@ def _create_disposable_pr(
         "readiness and required checks pass."
     )
     create_pr = [
-        gh_bin,
+        producer_gh_bin,
         "pr",
         "create",
         "--repo",
@@ -500,6 +507,7 @@ def run_smoke(
     expected_actor: str,
     gh_bin: str,
     governance_gh_bin: str | None,
+    producer_gh_bin: str | None,
     smoke_root: str,
     output: Path,
     execute: bool,
@@ -513,6 +521,8 @@ def run_smoke(
     run_id = generated_at.replace("-", "").replace(":", "").replace("Z", "Z").replace("T", "-")
     branch = f"codex/ao-ma10l-smoke-{run_id.lower()}"
     smoke_path = f"{smoke_root.rstrip('/')}/ao-ma-10l-smoke-{run_id.lower()}.md"
+    effective_producer_gh_bin = producer_gh_bin or gh_bin
+    producer_same_as_merge_actor = effective_producer_gh_bin == gh_bin
     result = _result_template(
         repo=repo,
         base_ref=base_ref,
@@ -522,6 +532,7 @@ def run_smoke(
         smoke_path=smoke_path,
         execute=execute,
         generated_at=generated_at,
+        producer_same_as_merge_actor=producer_same_as_merge_actor,
     )
     blockers: set[str] = set()
     warnings: set[str] = set()
@@ -571,7 +582,7 @@ def run_smoke(
 
         pr_number, create_blockers = _create_disposable_pr(
             repo=repo,
-            gh_bin=gh_bin,
+            producer_gh_bin=effective_producer_gh_bin,
             base_ref=base_ref,
             branch=branch,
             smoke_path=smoke_path,
@@ -661,6 +672,13 @@ def main(argv: list[str] | None = None) -> int:
         "--governance-gh-bin",
         help="Optional GitHub CLI binary or wrapper for read-only governance API checks.",
     )
+    parser.add_argument(
+        "--producer-gh-bin",
+        help=(
+            "Optional GitHub CLI binary or wrapper for disposable branch/file/PR creation. "
+            "Defaults to --gh-bin so existing dedicated-actor-only runs remain unchanged."
+        ),
+    )
     parser.add_argument("--smoke-root", default=DEFAULT_SMOKE_ROOT)
     parser.add_argument("--output", required=True)
     parser.add_argument("--execute", action="store_true")
@@ -676,6 +694,7 @@ def main(argv: list[str] | None = None) -> int:
         expected_actor=args.expected_actor,
         gh_bin=args.gh_bin,
         governance_gh_bin=args.governance_gh_bin,
+        producer_gh_bin=args.producer_gh_bin,
         smoke_root=args.smoke_root,
         output=Path(args.output),
         execute=args.execute,

--- a/scripts/ao_ma10q_dedicated_actor_runner.py
+++ b/scripts/ao_ma10q_dedicated_actor_runner.py
@@ -55,6 +55,7 @@ def _base_result(*, repo: str, base_ref: str, expected_actor: str, token_env: st
         "base_ref": base_ref,
         "expected_actor": expected_actor,
         "token_env": token_env,
+        "producer_token_env": token_env,
         "token_value_recorded": False,
         "execute_requested": execute,
         "mutations_performed": False,
@@ -69,6 +70,12 @@ def _base_result(*, repo: str, base_ref: str, expected_actor: str, token_env: st
             "created": False,
             "mode": None,
             "path_recorded": False,
+        },
+        "producer_wrapper": {
+            "created": False,
+            "mode": None,
+            "path_recorded": False,
+            "same_as_merge_actor_wrapper": True,
         },
         "smoke_result": None,
         "smoke_command": [],
@@ -187,6 +194,13 @@ def run(
             "mode": "0700",
             "path_recorded": False,
         }
+        result["producer_token_env"] = governance_token_env if governance_wrapper_created else token_env
+        result["producer_wrapper"] = {
+            "created": governance_wrapper_created,
+            "mode": "0700" if governance_wrapper_created else None,
+            "path_recorded": False,
+            "same_as_merge_actor_wrapper": not governance_wrapper_created,
+        }
 
         command = [
             sys.executable,
@@ -210,6 +224,7 @@ def run(
         ]
         if governance_wrapper_created:
             command.extend(["--governance-gh-bin", str(governance_wrapper)])
+            command.extend(["--producer-gh-bin", str(governance_wrapper)])
         if execute:
             command.append("--execute")
             if confirmation is not None:

--- a/tests/test_ao_ma10l_autonomous_smoke.py
+++ b/tests/test_ao_ma10l_autonomous_smoke.py
@@ -133,10 +133,18 @@ def _merge_agent_merged() -> dict[str, Any]:
 
 
 class FakeRunner:
-    def __init__(self, *, ready: bool = True, checks_pass: bool = True, gh_bin: str = "gh") -> None:
+    def __init__(
+        self,
+        *,
+        ready: bool = True,
+        checks_pass: bool = True,
+        gh_bin: str = "gh",
+        producer_gh_bin: str | None = None,
+    ) -> None:
         self.ready = ready
         self.checks_pass = checks_pass
         self.gh_bin = gh_bin
+        self.producer_gh_bin = producer_gh_bin or gh_bin
         self.commands: list[list[str]] = []
 
     def __call__(self, command: list[str]) -> subprocess.CompletedProcess[str]:
@@ -151,13 +159,13 @@ class FakeRunner:
             payload = _ready_eligibility(changed_file) if self.ready else _blocked_eligibility(changed_file)
             output.write_text(json.dumps(payload), encoding="utf-8")
             return subprocess.CompletedProcess(command, 0 if self.ready else 1, json.dumps(payload), "")
-        if command[:3] == [self.gh_bin, "api", "repos/Halildeu/ao-kernel/git/ref/heads/main"]:
+        if command[:3] == [self.producer_gh_bin, "api", "repos/Halildeu/ao-kernel/git/ref/heads/main"]:
             return subprocess.CompletedProcess(command, 0, json.dumps({"object": {"sha": "a" * 40}}), "")
-        if command[:3] == [self.gh_bin, "api", "repos/Halildeu/ao-kernel/git/refs"]:
+        if command[:3] == [self.producer_gh_bin, "api", "repos/Halildeu/ao-kernel/git/refs"]:
             return subprocess.CompletedProcess(command, 0, json.dumps({"ref": "refs/heads/example"}), "")
-        if len(command) >= 3 and command[:2] == [self.gh_bin, "api"] and "/contents/" in command[2]:
+        if len(command) >= 3 and command[:2] == [self.producer_gh_bin, "api"] and "/contents/" in command[2]:
             return subprocess.CompletedProcess(command, 0, json.dumps({"content": {"path": "docs/evidence/example.md"}}), "")
-        if command[:3] == [self.gh_bin, "pr", "create"]:
+        if command[:3] == [self.producer_gh_bin, "pr", "create"]:
             return subprocess.CompletedProcess(command, 0, "https://github.com/Halildeu/ao-kernel/pull/999\n", "")
         if command[:3] == [self.gh_bin, "pr", "checks"]:
             checks = (
@@ -186,6 +194,8 @@ def _run_with_fake(
     execute: bool = False,
     confirmation: str | None = None,
     gh_bin: str = "gh",
+    governance_gh_bin: str | None = None,
+    producer_gh_bin: str | None = None,
 ) -> dict[str, Any]:
     mod = _load_script_module()
     output = tmp_path / "result.json"
@@ -196,7 +206,8 @@ def _run_with_fake(
             base_ref="main",
             expected_actor="gladyatore-lab",
             gh_bin=gh_bin,
-            governance_gh_bin=None,
+            governance_gh_bin=governance_gh_bin,
+            producer_gh_bin=producer_gh_bin,
             smoke_root="docs/evidence/ao-ma-10l-autonomous-smoke",
             output=output,
             execute=execute,
@@ -258,6 +269,12 @@ def test_ao_ma10l_ready_dry_run_has_no_mutations(tmp_path: Path) -> None:
     assert result["execute_requested"] is False
     assert result["mutations_performed"] is False
     assert result["smoke_path"].startswith("docs/evidence/ao-ma-10l-autonomous-smoke/")
+    assert result["pr_producer"] == {
+        "role": "merge_actor",
+        "same_as_merge_actor": True,
+        "release_authority": False,
+        "allowed_operations": ["base_ref_read", "branch_create", "file_create", "pr_create"],
+    }
 
 
 def test_ao_ma10l_execute_success_creates_pr_and_delegates_merge_agent(tmp_path: Path) -> None:
@@ -318,6 +335,7 @@ def test_ao_ma10l_uses_governance_gh_bin_only_for_readiness_snapshots(tmp_path: 
             expected_actor="gladyatore-lab",
             gh_bin="gh-dedicated",
             governance_gh_bin="gh-governance",
+            producer_gh_bin=None,
             smoke_root="docs/evidence/ao-ma-10l-autonomous-smoke",
             output=output,
             execute=True,
@@ -342,6 +360,46 @@ def test_ao_ma10l_uses_governance_gh_bin_only_for_readiness_snapshots(tmp_path: 
     live_gh_commands = [command for command in fake.commands if len(command) > 1 and command[1] in {"api", "pr"}]
     assert live_gh_commands
     assert all(command[0] == "gh-dedicated" for command in live_gh_commands)
+
+
+def test_ao_ma10l_can_split_disposable_pr_producer_from_merge_actor(tmp_path: Path) -> None:
+    fake = FakeRunner(ready=True, gh_bin="gh-dedicated", producer_gh_bin="gh-producer")
+    result = _run_with_fake(
+        tmp_path,
+        fake,
+        execute=True,
+        confirmation="AO-MA-10L-EXECUTE",
+        gh_bin="gh-dedicated",
+        governance_gh_bin="gh-governance",
+        producer_gh_bin="gh-producer",
+    )
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "merged"
+    assert result["pr_producer"]["role"] == "governance_producer"
+    assert result["pr_producer"]["same_as_merge_actor"] is False
+    assert result["pr_producer"]["release_authority"] is False
+
+    producer_commands = [
+        command
+        for command in fake.commands
+        if len(command) > 1
+        and command[0] == "gh-producer"
+        and (command[1] == "api" or command[:3] == ["gh-producer", "pr", "create"])
+    ]
+    assert producer_commands
+    assert all(
+        command[0] == "gh-producer"
+        for command in producer_commands
+        if command[1] == "api" or command[:3] == ["gh-producer", "pr", "create"]
+    )
+
+    check_commands = [command for command in fake.commands if command[:3] == ["gh-dedicated", "pr", "checks"]]
+    assert check_commands
+    merge_agent_commands = [
+        command for command in fake.commands if len(command) > 1 and command[1].endswith("ao_ma10c_merge_agent.py")
+    ]
+    assert merge_agent_commands
+    assert merge_agent_commands[0][merge_agent_commands[0].index("--gh-bin") + 1] == "gh-dedicated"
 
 
 def test_ao_ma10l_required_check_failure_blocks_before_merge_agent(tmp_path: Path) -> None:

--- a/tests/test_ao_ma10q_dedicated_actor_runner.py
+++ b/tests/test_ao_ma10q_dedicated_actor_runner.py
@@ -42,6 +42,12 @@ def _smoke_payload(*, result: str = "merged", blocker: str | None = None, mutate
         "schema_version": "ao-ma-10l-autonomous-smoke-result.v1",
         "artifact_kind": "ao_ma_10l_autonomous_smoke_result",
         "mutations_performed": mutated,
+        "pr_producer": {
+            "role": "governance_producer",
+            "same_as_merge_actor": False,
+            "release_authority": False,
+            "allowed_operations": ["base_ref_read", "branch_create", "file_create", "pr_create"],
+        },
         "decision": {
             "result": result,
             "blockers": blockers,
@@ -129,6 +135,13 @@ def test_ao_ma10q_missing_token_env_blocks_before_smoke_invocation(tmp_path: Pat
     assert result["mutations_performed"] is False
     assert result["token_value_recorded"] is False
     assert result["wrapper"] == {"created": False, "mode": None, "path_recorded": False}
+    assert result["producer_wrapper"] == {
+        "created": False,
+        "mode": None,
+        "path_recorded": False,
+        "same_as_merge_actor_wrapper": True,
+    }
+    assert result["producer_token_env"] == TOKEN_ENV
 
 
 def test_ao_ma10q_rejects_invalid_token_env_name(tmp_path: Path) -> None:
@@ -196,6 +209,13 @@ def test_ao_ma10q_execute_uses_temporary_gh_wrapper_without_recording_secret_or_
     assert result["smoke_command"][result["smoke_command"].index("--gh-bin") + 1] == "<temporary-gh-wrapper>"
     assert result["smoke_command"][result["smoke_command"].index("--output") + 1] == "<temporary-smoke-output>"
     assert result["wrapper"] == {"created": True, "mode": "0700", "path_recorded": False}
+    assert result["producer_wrapper"] == {
+        "created": False,
+        "mode": None,
+        "path_recorded": False,
+        "same_as_merge_actor_wrapper": True,
+    }
+    assert result["producer_token_env"] == TOKEN_ENV
     assert result["token_value_recorded"] is False
     assert result["decision"]["result"] == "merged"
     assert result["mutations_performed"] is True
@@ -230,11 +250,24 @@ def test_ao_ma10q_uses_optional_governance_wrapper_without_recording_secret_or_p
 
     Draft202012Validator(_schema()).validate(result)
     assert "--governance-gh-bin" in runner.commands[0]
+    assert "--producer-gh-bin" in runner.commands[0]
     assert runner.commands[0][runner.commands[0].index("--governance-gh-bin") + 1].startswith("/tmp/")
+    assert runner.commands[0][runner.commands[0].index("--producer-gh-bin") + 1].startswith("/tmp/")
+    assert (
+        runner.commands[0][runner.commands[0].index("--producer-gh-bin") + 1]
+        == runner.commands[0][runner.commands[0].index("--governance-gh-bin") + 1]
+    )
     artifact_text = output.read_text(encoding="utf-8")
     assert TOKEN_VALUE not in artifact_text
     assert GOVERNANCE_TOKEN_VALUE not in artifact_text
-    assert result["smoke_command"].count("<temporary-gh-wrapper>") == 2
+    assert result["smoke_command"].count("<temporary-gh-wrapper>") == 3
+    assert result["producer_token_env"] == GOVERNANCE_TOKEN_ENV
+    assert result["producer_wrapper"] == {
+        "created": True,
+        "mode": "0700",
+        "path_recorded": False,
+        "same_as_merge_actor_wrapper": False,
+    }
     assert result["decision"]["result"] == "merged"
 
 

--- a/tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py
+++ b/tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py
@@ -102,6 +102,8 @@ def test_ao_ma10s_doc_and_receipt_preserve_authority_boundary() -> None:
     assert receipt["allowed_ref"] == "refs/heads/main"
     assert receipt["secret_env"] == "GLADYATORE_LAB_GH_TOKEN"
     assert receipt["governance_secret_env"] == "AO_GOVERNANCE_GH_TOKEN"
+    assert receipt["producer_secret_env"] == "AO_GOVERNANCE_GH_TOKEN"
+    assert receipt["producer_release_authority"] is False
     assert receipt["token_value_recorded"] is False
     assert receipt["release_authority"] == "ao-release-gate+github-ruleset"
     assert receipt["ai_output_release_authority"] is False


### PR DESCRIPTION
## Summary

AO-MA-10S execute previously failed at disposable branch creation:

```text
github_branch_create_failed: gh: Resource not accessible by personal access token (HTTP 403)
```

The visible GitHub token permissions were already correct for the intended non-admin merge actor path. This PR therefore does **not** widen the merge/check authority. It splits the disposable PR producer from the dedicated merge actor:

- `GLADYATORE_LAB_GH_TOKEN` remains the dedicated actor for required-check polling and final merge-agent execution.
- `AO_GOVERNANCE_GH_TOKEN` may be used only as a bounded disposable producer for base-ref read, branch create, file create, and PR create.
- The producer is explicitly recorded as `release_authority=false`.

## Authority boundary

Release authority remains the repo-owned `ao-release-gate` required check plus GitHub branch protection/ruleset. AI outputs and producer-token activity are evidence/input only.

This PR does not:

- use or permit `--admin`
- change branch protection, rulesets, CODEOWNERS, or workflow trigger permissions
- broaden support scope
- claim production readiness
- enable live-adapter execution

## Changed behavior

- `scripts/ao_ma10l_autonomous_smoke.py` accepts optional `--producer-gh-bin`.
- Disposable PR production uses the producer wrapper when present.
- Required-check polling and merge-agent remain bound to the dedicated actor wrapper.
- `scripts/ao_ma10q_dedicated_actor_runner.py` passes governance wrapper as producer only when `AO_GOVERNANCE_GH_TOKEN` is available; otherwise it falls back to the dedicated actor wrapper.
- Result schemas now require structured producer evidence.

## Validation

```text
pytest -q tests/test_ao_ma10l_autonomous_smoke.py tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py
23 passed

pytest -q tests/test_ao_ma10r_dedicated_actor_credential_doctor.py tests/test_ao_ma10l_autonomous_smoke.py tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py
35 passed

python3 -m compileall -q scripts/ao_ma10l_autonomous_smoke.py scripts/ao_ma10q_dedicated_actor_runner.py
PASS

ruff check tests/test_ao_ma10l_autonomous_smoke.py tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py
PASS

python3 -m json.tool <changed receipts and schemas>
PASS

python3 scripts/gpp_next.py
GPP-9 closed; guard flags remain false

git diff --check / git diff --cached --check
PASS

gitleaks protect --staged --redact --no-banner
PASS: no leaks found in staged diff

python3 scripts/local_gpp_gate.py --review-evidence local-ai-review-evidence.v1.json --base-ref origin/main --head-ref codex/ao-ma10v-producer-token-split --work-package AO-MA-10V --output local-gpp-gate-evidence.v1.json
Decision: operator_may_merge
```

## Cross-AI review

- Lorentz subagent: AGREE, no blocking findings.
- Claude CLI diff review: AGREE, no blocking findings.

Both reviews confirmed that producer-token split does not loosen release authority: producer creates only disposable PR artifacts; dedicated actor and required check still own merge authority.
