### PR TITLE
fix(ao-ma-10): wait for initial required checks

### DIFF
--- a/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md
+++ b/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md
@@ -95,7 +95,9 @@ When A0/A1 are ready and explicit confirmation is present, the orchestrator:
    `docs/evidence/ao-ma-10l-autonomous-smoke/`;
 3. opens a disposable PR through the selected PR producer runtime;
 4. waits for required checks, including `ao-release-gate-technical` and
-   `ao-release-gate-review`;
+   `ao-release-gate-review`; GitHub's initial `no checks reported` response
+   immediately after PR creation is treated as transient inside the polling
+   window, but any timeout or real API/read failure remains fail-closed;
 5. refreshes A0/A1;
 6. delegates the actual merge to `scripts/ao_ma10c_merge_agent.py`.
 

--- a/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json
+++ b/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json
@@ -15,6 +15,8 @@
   "dedicated_gh_runtime_argument": "--gh-bin",
   "supports_split_pr_producer_runtime": true,
   "producer_gh_runtime_argument": "--producer-gh-bin",
+  "waits_for_initial_check_suite": true,
+  "initial_no_checks_reported_is_transient": true,
   "producer_release_authority": false,
   "producer_allowed_operations": [
     "base_ref_read",

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10V",
+  "work_package": "AO-MA-10W",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,22 +13,13 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10v-producer-token-split",
+    "head_ref": "refs/heads/codex/ao-ma10w-wait-for-initial-checks",
     "changed_files": [
       ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md",
       ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json",
-      ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md",
-      ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json",
-      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md",
-      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json",
-      "ao_kernel/defaults/schemas/ao-ma-10l-autonomous-smoke-result.schema.v1.json",
-      "ao_kernel/defaults/schemas/ao-ma-10q-dedicated-actor-runner-result.schema.v1.json",
       "local-ai-review-evidence.v1.json",
       "scripts/ao_ma10l_autonomous_smoke.py",
-      "scripts/ao_ma10q_dedicated_actor_runner.py",
-      "tests/test_ao_ma10l_autonomous_smoke.py",
-      "tests/test_ao_ma10q_dedicated_actor_runner.py",
-      "tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py"
+      "tests/test_ao_ma10l_autonomous_smoke.py"
     ]
   },
   "checks_considered": [
@@ -59,11 +50,11 @@
   ],
   "findings": [
     "Claude reviewer verdict AGREE. Blocking bulgu yok.",
-    "Producer token only creates the disposable branch, file, and PR. Required-check polling and AO-MA-10c merge-agent remain bound to the dedicated non-admin merge actor runtime.",
-    "pr_producer.release_authority is false and producer_wrapper.path_recorded is false in the emitted artifacts and schemas.",
-    "No new GitHub workflow trigger or GITHUB_TOKEN write permission is introduced; workflow remains workflow_dispatch only with contents read.",
-    "Backward compatibility is preserved because --producer-gh-bin is optional and defaults to --gh-bin.",
-    "Relevant validations passed locally: 35 AO-MA-10r/l/q/s tests, focused 23 AO-MA-10l/q/s tests, ruff on touched tests, compileall on touched scripts, JSON validation, and git diff check."
+    "The change addresses the AO-MA-10S execute race observed after PR #703: GitHub may initially return no checks reported before required check suites appear.",
+    "Only the specific no checks reported condition is retried inside the existing polling timeout; timeout, invalid payloads, and real GitHub API read failures still fail closed.",
+    "The new focused test exercises one transient no-checks response followed by a successful required-check observation and merge decision.",
+    "No branch-protection, ruleset, release authority, support tier, live adapter execution, or production platform claim change is introduced.",
+    "Relevant validations passed locally: focused AO-MA-10L tests, compileall on the touched script, JSON validation, local GPP gate, and git diff check."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/ao_ma10l_autonomous_smoke.py
+++ b/scripts/ao_ma10l_autonomous_smoke.py
@@ -412,6 +412,12 @@ def _required_checks_passed(raw_checks: list[Any]) -> tuple[bool, list[dict[str,
     return not failing, failing
 
 
+def _checks_not_reported_yet(error: str | None) -> bool:
+    """Return true for GitHub's transient post-PR check-suite delay."""
+
+    return isinstance(error, str) and "no checks reported" in error.lower()
+
+
 def _wait_for_required_checks(
     *,
     repo: str,
@@ -439,6 +445,14 @@ def _wait_for_required_checks(
         _add_command(result, command)
         checks_payload, error = _run_json(command, runner)
         if error is not None or not isinstance(checks_payload, list):
+            if (
+                _checks_not_reported_yet(error)
+                and timeout_seconds > 0
+                and time.monotonic() < deadline
+            ):
+                result["required_checks"] = {"observed": False, "all_passed": False, "failing": []}
+                time.sleep(max(1, poll_seconds))
+                continue
             result["required_checks"] = {"observed": True, "all_passed": False, "failing": []}
             return {f"github_required_checks_read_failed: {error or 'invalid shape'}"}
         passed, failing = _required_checks_passed(checks_payload)

--- a/tests/test_ao_ma10l_autonomous_smoke.py
+++ b/tests/test_ao_ma10l_autonomous_smoke.py
@@ -138,11 +138,13 @@ class FakeRunner:
         *,
         ready: bool = True,
         checks_pass: bool = True,
+        checks_transient_failures: int = 0,
         gh_bin: str = "gh",
         producer_gh_bin: str | None = None,
     ) -> None:
         self.ready = ready
         self.checks_pass = checks_pass
+        self.checks_transient_failures = checks_transient_failures
         self.gh_bin = gh_bin
         self.producer_gh_bin = producer_gh_bin or gh_bin
         self.commands: list[list[str]] = []
@@ -168,6 +170,14 @@ class FakeRunner:
         if command[:3] == [self.producer_gh_bin, "pr", "create"]:
             return subprocess.CompletedProcess(command, 0, "https://github.com/Halildeu/ao-kernel/pull/999\n", "")
         if command[:3] == [self.gh_bin, "pr", "checks"]:
+            if self.checks_transient_failures > 0:
+                self.checks_transient_failures -= 1
+                return subprocess.CompletedProcess(
+                    command,
+                    1,
+                    "",
+                    "no checks reported on the 'codex/ao-ma10l-smoke-example' branch",
+                )
             checks = (
                 [
                     {"name": "ao-release-gate-technical", "bucket": "pass", "state": "SUCCESS"},
@@ -400,6 +410,39 @@ def test_ao_ma10l_can_split_disposable_pr_producer_from_merge_actor(tmp_path: Pa
     ]
     assert merge_agent_commands
     assert merge_agent_commands[0][merge_agent_commands[0].index("--gh-bin") + 1] == "gh-dedicated"
+
+
+def test_ao_ma10l_waits_for_initial_required_checks_to_appear(tmp_path: Path) -> None:
+    fake = FakeRunner(ready=True, checks_transient_failures=1)
+    mod = _load_script_module()
+    monkeypatch_sleep = mod.time.sleep
+    mod.time.sleep = lambda _seconds: None
+    try:
+        result = cast(
+            dict[str, Any],
+            mod.run_smoke(
+                repo="Halildeu/ao-kernel",
+                base_ref="main",
+                expected_actor="gladyatore-lab",
+                gh_bin="gh",
+                governance_gh_bin=None,
+                producer_gh_bin=None,
+                smoke_root="docs/evidence/ao-ma-10l-autonomous-smoke",
+                output=tmp_path / "result.json",
+                execute=True,
+                confirmation="AO-MA-10L-EXECUTE",
+                timeout_seconds=5,
+                poll_seconds=1,
+                runner=fake,
+                now=datetime(2026, 5, 28, 21, 0, 0, tzinfo=UTC),
+            ),
+        )
+    finally:
+        mod.time.sleep = monkeypatch_sleep
+
+    assert result["decision"]["result"] == "merged"
+    check_commands = [command for command in fake.commands if command[:3] == ["gh", "pr", "checks"]]
+    assert len(check_commands) == 2
 
 
 def test_ao_ma10l_required_check_failure_blocks_before_merge_agent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Fixes the AO-MA-10S execute race observed after disposable PR #703 creation: GitHub can briefly return `no checks reported` before required check suites appear.
- Treats only that specific transient message as retryable inside the existing polling timeout.
- Keeps timeout, invalid JSON shape, and real GitHub API read failures fail-closed.

## Scope / guardrails
- No branch-protection or ruleset mutation.
- No release-authority change.
- No support widening, live adapter execution, or production platform claim.
- AI output remains evidence only; required checks and GitHub rules remain authority.

## Validation
- `pytest -q tests/test_ao_ma10l_autonomous_smoke.py` -> 11 passed.
- `python3 -m compileall -q scripts/ao_ma10l_autonomous_smoke.py` -> pass.
- `python3 -m json.tool .claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json >/dev/null` -> pass.
- `python3 -m json.tool local-ai-review-evidence.v1.json >/dev/null` -> pass.
- `git diff --check` -> clean.
- `gitleaks protect --staged --redact --no-banner` -> no leaks found.
- `scripts/local_gpp_gate.py` -> `operator_may_merge`, changed_files_count=5.
- Claude independent advisory review -> AGREE.

## Follow-up after merge
Rerun `ao-ma10q-dedicated-actor-smoke.yml` in execute mode from main and verify the dedicated non-admin actor can complete the real autonomous merge smoke.