### PR TITLE
fix(ao-ma-10): align runner timeout with smoke window

### DIFF
--- a/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md
+++ b/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md
@@ -84,6 +84,12 @@ AO-MA-10l still performs A0/A1 readiness checks, required check observation,
 and AO-MA-10c merge delegation. If those checks fail, AO-MA-10q records the
 blockers and does not turn AI review into release authority.
 
+AO-MA-10q gives the delegated AO-MA-10l subprocess the full AO-MA-10l polling
+window plus a bounded grace period: `timeout_seconds + max(60, poll_seconds * 4)`.
+A subprocess timeout is caught and recorded as a fail-closed
+`smoke_command_timeout` blocker so the workflow always uploads a diagnostic
+artifact instead of ending with an uncaught traceback.
+
 The governance wrapper has two bounded roles from AO-MA-10l's perspective:
 
 1. read-only branch-protection/ruleset readiness APIs that fine-grained

--- a/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json
+++ b/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json
@@ -21,6 +21,8 @@
   "token_value_recorded": false,
   "wrapper_path_recorded": false,
   "wrapper_mode": "0700",
+  "subprocess_timeout_aligned_with_smoke_timeout": true,
+  "subprocess_timeout_fail_closed_artifact": true,
   "execute_confirmation": "AO-MA-10L-EXECUTE",
   "delegates_to": "scripts/ao_ma10l_autonomous_smoke.py",
   "expected_actor": "gladyatore-lab",

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10W",
+  "work_package": "AO-MA-10X",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,13 +13,13 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10w-wait-for-initial-checks",
+    "head_ref": "refs/heads/codex/ao-ma10x-runner-timeout-alignment",
     "changed_files": [
-      ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md",
-      ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json",
+      ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md",
+      ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10l_autonomous_smoke.py",
-      "tests/test_ao_ma10l_autonomous_smoke.py"
+      "scripts/ao_ma10q_dedicated_actor_runner.py",
+      "tests/test_ao_ma10q_dedicated_actor_runner.py"
     ]
   },
   "checks_considered": [
@@ -50,11 +50,11 @@
   ],
   "findings": [
     "Claude reviewer verdict AGREE. Blocking bulgu yok.",
-    "The change addresses the AO-MA-10S execute race observed after PR #703: GitHub may initially return no checks reported before required check suites appear.",
-    "Only the specific no checks reported condition is retried inside the existing polling timeout; timeout, invalid payloads, and real GitHub API read failures still fail closed.",
-    "The new focused test exercises one transient no-checks response followed by a successful required-check observation and merge decision.",
+    "The change addresses the AO-MA-10S execute timeout observed after PR #705: AO-MA-10q gave the delegated AO-MA-10l subprocess only 180 seconds while AO-MA-10l was configured to poll for 900 seconds.",
+    "The delegated subprocess timeout now equals the AO-MA-10l polling timeout plus a bounded grace period, while disabled or short inner timeouts keep the previous 180 second floor.",
+    "subprocess.TimeoutExpired is caught and recorded as a fail-closed smoke_command_timeout blocker with an uploaded artifact instead of an uncaught traceback.",
     "No branch-protection, ruleset, release authority, support tier, live adapter execution, or production platform claim change is introduced.",
-    "Relevant validations passed locally: focused AO-MA-10L tests, compileall on the touched script, JSON validation, local GPP gate, and git diff check."
+    "Relevant validations passed locally: focused AO-MA-10Q tests, compileall on the touched script, JSON validation, local GPP gate, and git diff check."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/ao_ma10q_dedicated_actor_runner.py
+++ b/scripts/ao_ma10q_dedicated_actor_runner.py
@@ -20,7 +20,7 @@ import sys
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Protocol
 
 
 SCHEMA_VERSION = "ao-ma-10q-dedicated-actor-runner-result.v1"
@@ -33,12 +33,38 @@ DEFAULT_TOKEN_ENV = "GLADYATORE_LAB_GH_TOKEN"
 DEFAULT_GOVERNANCE_TOKEN_ENV = "AO_GOVERNANCE_GH_TOKEN"
 EXECUTE_CONFIRMATION = "AO-MA-10L-EXECUTE"
 TOKEN_ENV_RE = re.compile(r"[A-Z_][A-Z0-9_]*")
+MIN_SMOKE_SUBPROCESS_GRACE_SECONDS = 60
+SMOKE_SUBPROCESS_GRACE_POLLS = 4
 
-Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+class Runner(Protocol):
+    def __call__(self, command: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]: ...
 
 
-def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(command, capture_output=True, text=True, timeout=180)
+def _smoke_process_timeout(*, timeout_seconds: int, poll_seconds: int) -> int:
+    """Return the subprocess budget for the delegated AO-MA-10l smoke."""
+
+    if timeout_seconds <= 0:
+        return 180
+    grace_seconds = max(MIN_SMOKE_SUBPROCESS_GRACE_SECONDS, poll_seconds * SMOKE_SUBPROCESS_GRACE_POLLS)
+    return timeout_seconds + grace_seconds
+
+
+def _run(command: list[str], *, timeout: int = 180) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True, timeout=timeout)
+
+
+def _run_smoke_command(
+    runner: Runner,
+    command: list[str],
+    *,
+    timeout_seconds: int,
+    poll_seconds: int,
+) -> subprocess.CompletedProcess[str]:
+    return runner(
+        command,
+        timeout=_smoke_process_timeout(timeout_seconds=timeout_seconds, poll_seconds=poll_seconds),
+    )
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -234,10 +260,21 @@ def run(
             wrappers.append(governance_wrapper)
         result["smoke_command"] = _sanitize_smoke_command(command, wrappers=wrappers, smoke_output=smoke_output)
 
-        proc = runner(command)
         blockers: list[str] = []
         warnings: list[str] = []
         smoke_result: dict[str, Any] | None = None
+        try:
+            proc = _run_smoke_command(
+                runner,
+                command,
+                timeout_seconds=timeout_seconds,
+                poll_seconds=poll_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            blockers.append(f"smoke_command_timeout: {int(exc.timeout)}s")
+            _set_decision(result, decision="blocked", blockers=blockers, warnings=warnings)
+            _write_json(output, result)
+            return result
         if smoke_output.exists():
             try:
                 smoke_result = _load_smoke_result(smoke_output)

--- a/tests/test_ao_ma10q_dedicated_actor_runner.py
+++ b/tests/test_ao_ma10q_dedicated_actor_runner.py
@@ -62,12 +62,14 @@ class FakeSmokeRunner:
         self.payload = payload
         self.returncode = returncode
         self.commands: list[list[str]] = []
+        self.timeouts: list[int] = []
         self.wrapper_path: str | None = None
         self.wrapper_mode: int | None = None
         self.wrapper_contents: str | None = None
 
-    def __call__(self, command: list[str]) -> subprocess.CompletedProcess[str]:
+    def __call__(self, command: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
         self.commands.append(command)
+        self.timeouts.append(timeout)
         assert command[0]
         assert command[1].endswith("ao_ma10l_autonomous_smoke.py")
         assert "--gh-bin" in command
@@ -79,6 +81,18 @@ class FakeSmokeRunner:
         self.wrapper_contents = wrapper.read_text(encoding="utf-8")
         output.write_text(json.dumps(self.payload), encoding="utf-8")
         return subprocess.CompletedProcess(command, self.returncode, json.dumps(self.payload), "")
+
+
+class TimeoutSmokeRunner:
+    def __init__(self, timeout: int) -> None:
+        self.timeout = timeout
+        self.commands: list[list[str]] = []
+        self.timeouts: list[int] = []
+
+    def __call__(self, command: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+        self.commands.append(command)
+        self.timeouts.append(timeout)
+        raise subprocess.TimeoutExpired(command, timeout=self.timeout)
 
 
 def test_ao_ma10q_schema_is_valid_draft_2020_12() -> None:
@@ -218,6 +232,7 @@ def test_ao_ma10q_execute_uses_temporary_gh_wrapper_without_recording_secret_or_
     assert result["producer_token_env"] == TOKEN_ENV
     assert result["token_value_recorded"] is False
     assert result["decision"]["result"] == "merged"
+    assert runner.timeouts == [180]
     assert result["mutations_performed"] is True
 
 
@@ -269,6 +284,99 @@ def test_ao_ma10q_uses_optional_governance_wrapper_without_recording_secret_or_p
         "same_as_merge_actor_wrapper": False,
     }
     assert result["decision"]["result"] == "merged"
+    assert runner.timeouts == [180]
+
+
+def test_ao_ma10q_default_subprocess_timeout_exceeds_inner_smoke_window() -> None:
+    mod = _load_script_module()
+    assert mod._smoke_process_timeout(timeout_seconds=900, poll_seconds=15) == 960
+    assert mod._smoke_process_timeout(timeout_seconds=60, poll_seconds=30) == 180
+    assert mod._smoke_process_timeout(timeout_seconds=0, poll_seconds=1) == 180
+
+
+def test_ao_ma10q_catches_smoke_command_timeout_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(TOKEN_ENV, TOKEN_VALUE)
+    mod = _load_script_module()
+    output = tmp_path / "ao-ma10q.json"
+    runner = TimeoutSmokeRunner(timeout=321)
+
+    result = cast(
+        dict[str, Any],
+        mod.run(
+            repo="Halildeu/ao-kernel",
+            base_ref="main",
+            expected_actor="gladyatore-lab",
+            token_env=TOKEN_ENV,
+            governance_token_env=GOVERNANCE_TOKEN_ENV,
+            base_gh_bin="gh",
+            output=output,
+            execute=True,
+            confirmation="AO-MA-10L-EXECUTE",
+            timeout_seconds=900,
+            poll_seconds=15,
+            runner=runner,
+        ),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert output.exists()
+    assert runner.commands
+    assert runner.timeouts == [960]
+    assert result["decision"]["result"] == "blocked"
+    assert result["decision"]["blockers"] == ["smoke_command_timeout: 321s"]
+    assert result["smoke_result"] is None
+    assert result["mutations_performed"] is False
+    assert result["token_value_recorded"] is False
+
+
+def test_ao_ma10q_default_runner_applies_aligned_subprocess_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(TOKEN_ENV, TOKEN_VALUE)
+    mod = _load_script_module()
+    output = tmp_path / "ao-ma10q.json"
+    observed: dict[str, Any] = {}
+
+    def fake_subprocess_run(
+        command: list[str],
+        *,
+        capture_output: bool,
+        text: bool,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        observed["command"] = command
+        observed["capture_output"] = capture_output
+        observed["text"] = text
+        observed["timeout"] = timeout
+        raise subprocess.TimeoutExpired(command, timeout=timeout)
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
+
+    result = cast(
+        dict[str, Any],
+        mod.run(
+            repo="Halildeu/ao-kernel",
+            base_ref="main",
+            expected_actor="gladyatore-lab",
+            token_env=TOKEN_ENV,
+            governance_token_env=GOVERNANCE_TOKEN_ENV,
+            base_gh_bin="gh",
+            output=output,
+            execute=True,
+            confirmation="AO-MA-10L-EXECUTE",
+            timeout_seconds=900,
+            poll_seconds=15,
+        ),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert observed["timeout"] == 960
+    assert observed["capture_output"] is True
+    assert observed["text"] is True
+    assert result["decision"]["result"] == "blocked"
+    assert result["decision"]["blockers"] == ["smoke_command_timeout: 960s"]
 
 
 def test_ao_ma10q_propagates_smoke_blockers_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Fixes the second AO-MA-10S execute timing failure observed in run `26613464203`: AO-MA-10q killed delegated AO-MA-10l after a hardcoded 180s subprocess timeout while AO-MA-10l was configured to poll required checks for 900s.
- Passes a computed timeout to every runner call: `timeout_seconds + max(60, poll_seconds * 4)` with the existing 180s floor for disabled/short smoke windows.
- Catches `subprocess.TimeoutExpired` and writes a fail-closed JSON artifact with `smoke_command_timeout` instead of ending with an uncaught traceback.

## Scope / guardrails
- No branch-protection or ruleset mutation.
- No release-authority change.
- No support widening, live adapter execution, or production platform claim.
- AI output remains evidence only; required checks and GitHub rules remain authority.

## Validation
- `pytest -q tests/test_ao_ma10q_dedicated_actor_runner.py` -> 10 passed.
- `python3 -m compileall -q scripts/ao_ma10q_dedicated_actor_runner.py` -> pass.
- `python3 -m json.tool .claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json >/dev/null` -> pass.
- `python3 -m json.tool local-ai-review-evidence.v1.json >/dev/null` -> pass.
- `git diff --check` -> clean.
- `gitleaks protect --staged --redact --no-banner` -> no leaks found.
- `scripts/local_gpp_gate.py` -> `operator_may_merge`, changed_files_count=5.
- Claude independent review -> REVISE then AGREE after R1/R2 fixes.

## Follow-up after merge
Rerun `ao-ma10q-dedicated-actor-smoke.yml` in execute mode from main and verify the dedicated non-admin actor can complete the real autonomous merge smoke.