### PR TITLE
fix(ao-ma-10): ignore inherited stale review evidence

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -530,13 +530,31 @@ jobs:
 
       - name: Locate optional raw reviewer evidence on PR head
         id: reviewer
+        working-directory: base
         run: |
           # The reviewer schema (local-ai-review-evidence.schema.v1.json)
           # carries no head_sha, so the file is safe to commit on the PR
           # head: it does not create the head_sha self-reference fixed
           # point that a head-bound `local-gpp-gate-evidence.v1.json`
-          # would.
-          if [ -f head/local-ai-review-evidence.v1.json ]; then
+          # would. However, the root evidence file must also be part of
+          # the current PR diff. Otherwise a PR inherits stale evidence
+          # from the base branch and the gate may evaluate a previous PR's
+          # review as if it belonged to this one.
+          REVIEW_CHANGED="$(python - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("pr-files.json")
+          if not path.exists():
+              print("false")
+              raise SystemExit(0)
+          payload = json.loads(path.read_text(encoding="utf-8"))
+          files = payload.get("files", []) if isinstance(payload, dict) else []
+          paths = {entry.get("path") for entry in files if isinstance(entry, dict)}
+          print("true" if "local-ai-review-evidence.v1.json" in paths else "false")
+          PY
+          )"
+          if [ "$REVIEW_CHANGED" = "true" ] && [ -f ../head/local-ai-review-evidence.v1.json ]; then
             echo "path=head/local-ai-review-evidence.v1.json" >> "$GITHUB_OUTPUT"
           else
             echo "path=" >> "$GITHUB_OUTPUT"

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,25 +1,23 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10X",
+  "work_package": "AO-MA-10Y",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
   },
   "reviewer": {
-    "agent": "claude-code-reviewer",
+    "agent": "claude-cli-reviewer",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10x-runner-timeout-alignment",
+    "head_ref": "refs/heads/codex/ao-ma10y-stale-evidence-guard",
     "changed_files": [
-      ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md",
-      ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json",
+      ".github/workflows/test.yml",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10q_dedicated_actor_runner.py",
-      "tests/test_ao_ma10q_dedicated_actor_runner.py"
+      "tests/test_ao_release_gate_enforce_job.py"
     ]
   },
   "checks_considered": [
@@ -32,11 +30,7 @@
       "status": "pass"
     },
     {
-      "name": "json_schema",
-      "status": "pass"
-    },
-    {
-      "name": "ruff",
+      "name": "yaml_parse",
       "status": "pass"
     },
     {
@@ -49,12 +43,12 @@
     }
   ],
   "findings": [
-    "Claude reviewer verdict AGREE. Blocking bulgu yok.",
-    "The change addresses the AO-MA-10S execute timeout observed after PR #705: AO-MA-10q gave the delegated AO-MA-10l subprocess only 180 seconds while AO-MA-10l was configured to poll for 900 seconds.",
-    "The delegated subprocess timeout now equals the AO-MA-10l polling timeout plus a bounded grace period, while disabled or short inner timeouts keep the previous 180 second floor.",
-    "subprocess.TimeoutExpired is caught and recorded as a fail-closed smoke_command_timeout blocker with an uploaded artifact instead of an uncaught traceback.",
-    "No branch-protection, ruleset, release authority, support tier, live adapter execution, or production platform claim change is introduced.",
-    "Relevant validations passed locally: focused AO-MA-10Q tests, compileall on the touched script, JSON validation, local GPP gate, and git diff check."
+    "Claude reviewer verdict AGREE after the missing pr-files.json guard was added.",
+    "The workflow now accepts root local-ai-review-evidence.v1.json only when the file is part of the current PR file list and also exists in the head checkout.",
+    "Inherited root evidence from the base branch now yields an empty reviewer path, preventing stale evidence from being evaluated as current-PR evidence.",
+    "Legitimate PR-head reviewer evidence remains supported because a PR that adds or modifies local-ai-review-evidence.v1.json appears in pr-files.json and keeps the downstream head/... output contract.",
+    "Missing pr-files.json degrades to REVIEW_CHANGED=false and malformed pr-files.json remains fail-closed.",
+    "No branch-protection, ruleset, release authority, support tier, live adapter execution, or production platform claim change is introduced."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_ao_release_gate_enforce_job.py
+++ b/tests/test_ao_release_gate_enforce_job.py
@@ -213,6 +213,10 @@ def test_enforce_job_reads_only_head_sha_free_raw_reviewer_evidence_from_pr_head
     base code, never read directly from PR head."""
     block = _gate_job_block()
     assert "head/local-ai-review-evidence.v1.json" in block
+    assert "pr-files.json" in block
+    assert "if not path.exists()" in block
+    assert '"local-ai-review-evidence.v1.json" in paths' in block
+    assert '[ "$REVIEW_CHANGED" = "true" ]' in block
     assert "head/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json" in block
     assert "head/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json" in block
     # Head-bound evidence files must NOT be read from PR head.


### PR DESCRIPTION
## Summary

- Gate root `local-ai-review-evidence.v1.json` on PR-file membership before passing it to local_gpp_gate.
- Preserve the existing `head/...` downstream output contract while reading `pr-files.json` from the trusted base checkout.
- Rebind the root review evidence to AO-MA-10Y with a real Claude AGREE review.

## Why

AO-MA-10L disposable smoke PR #707 inherited a stale root review evidence file from base/main. The release gate correctly failed closed because the inherited file declared AO-MA-10X scope instead of the current PR scope. The workflow should not treat a base-inherited root evidence file as current-PR evidence unless that evidence file is actually part of the PR diff.

## Validation

- `pytest -q tests/test_ao_release_gate_enforce_job.py tests/test_ao_release_gate.py tests/test_ao_ma10l_autonomous_smoke.py` -> 112 passed
- `python3 - <<PY ... yaml.safe_load(.github/workflows/test.yml) ... PY` -> yaml-ok
- `python3 - <<PY ... Draft202012Validator(local-ai-review-evidence.schema.v1.json).validate(...) ... PY` -> review-evidence-schema-ok
- `gitleaks protect --staged --no-banner --redact` -> no leaks found
- `python3 scripts/local_gpp_gate.py ... --work-package AO-MA-10Y ...` -> `operator_may_merge`
- `python3 scripts/ao_ma10_high_risk_supersession_evidence.py ... --review-work-package AO-MA-10Y ...` -> `AGREE`, providers `anthropic/openai`, high-risk path `.github/workflows/test.yml`

## Review

- Codex subagent review: AGREE
- Claude CLI review: initial REVISE on missing `pr-files.json` guard; fix absorbed; final AGREE

## Guardrails

- No branch-protection or ruleset change
- No admin bypass
- No support widening
- No production platform claim
- No live adapter execution
