### PR TITLE
fix(ao-ma-10): skip unneeded high-risk supersession

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -716,17 +716,37 @@ jobs:
 
       - name: Locate optional high-risk raw reviewer evidence on PR head
         id: high_risk_reviewers
+        working-directory: base
         run: |
+          HIGH_RISK_CHANGED="$(python - <<'PY'
+          import json
+          from pathlib import Path
+
+          from ao_kernel.ao_release_gate import _high_risk_paths
+
+          payload = json.loads(Path("payload.json").read_text(encoding="utf-8"))
+          changed_paths = payload.get("changed_paths", [])
+          if not isinstance(changed_paths, list):
+              changed_paths = []
+          changed_paths = [path for path in changed_paths if isinstance(path, str)]
+          print("true" if _high_risk_paths(changed_paths) else "false")
+          PY
+          )"
+          if [ "$HIGH_RISK_CHANGED" != "true" ]; then
+            echo "openai_path=" >> "$GITHUB_OUTPUT"
+            echo "anthropic_path=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           OPENAI_PATH="head/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json"
           ANTHROPIC_PATH="head/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json"
-          if [ -f "$OPENAI_PATH" ] && [ -f "$ANTHROPIC_PATH" ]; then
-            if [ ! -f head/local-ai-review-evidence.v1.json ]; then
+          if [ -f "../$OPENAI_PATH" ] && [ -f "../$ANTHROPIC_PATH" ]; then
+            if [ ! -f ../head/local-ai-review-evidence.v1.json ]; then
               echo "::error::high-risk supersession raw reviews require root local-ai-review-evidence.v1.json for reviewed work-package binding"
               exit 1
             fi
             echo "openai_path=$OPENAI_PATH" >> "$GITHUB_OUTPUT"
             echo "anthropic_path=$ANTHROPIC_PATH" >> "$GITHUB_OUTPUT"
-          elif [ -f "$OPENAI_PATH" ] || [ -f "$ANTHROPIC_PATH" ]; then
+          elif [ -f "../$OPENAI_PATH" ] || [ -f "../$ANTHROPIC_PATH" ]; then
             echo "::error::high-risk supersession evidence requires both OpenAI and Anthropic raw reviewer files"
             exit 1
           else

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10Y",
+  "work_package": "AO-MA-10Z",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,7 +13,7 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10y-stale-evidence-guard",
+    "head_ref": "refs/heads/codex/ao-ma10z-skip-unneeded-high-risk-supersession",
     "changed_files": [
       ".github/workflows/test.yml",
       "local-ai-review-evidence.v1.json",
@@ -43,11 +43,11 @@
     }
   ],
   "findings": [
-    "Claude reviewer verdict AGREE after the missing pr-files.json guard was added.",
-    "The workflow now accepts root local-ai-review-evidence.v1.json only when the file is part of the current PR file list and also exists in the head checkout.",
-    "Inherited root evidence from the base branch now yields an empty reviewer path, preventing stale evidence from being evaluated as current-PR evidence.",
-    "Legitimate PR-head reviewer evidence remains supported because a PR that adds or modifies local-ai-review-evidence.v1.json appears in pr-files.json and keeps the downstream head/... output contract.",
-    "Missing pr-files.json degrades to REVIEW_CHANGED=false and malformed pr-files.json remains fail-closed.",
+    "Claude reviewer verdict AGREE. Blocking bulgu yok.",
+    "The workflow now computes current PR high-risk path presence from base/payload.json before locating inherited high-risk raw review files.",
+    "When current changed_paths has no high-risk paths, the workflow sets high-risk reviewer outputs empty and skips supersession generation.",
+    "High-risk behavior is preserved because PRs with high-risk changed paths still require the OpenAI and Anthropic raw review pair before generating supersession evidence.",
+    "Path handling remains consistent with working-directory base: payload.json is read from base and head file existence checks use ../head while downstream output values preserve the head/... contract.",
     "No branch-protection, ruleset, release authority, support tier, live adapter execution, or production platform claim change is introduced."
   ],
   "secrets_recorded": false,

--- a/tests/test_ao_release_gate_enforce_job.py
+++ b/tests/test_ao_release_gate_enforce_job.py
@@ -258,6 +258,10 @@ def test_enforce_job_generates_high_risk_supersession_evidence_at_runtime() -> N
 
     block = _gate_job_block()
     assert "Locate optional high-risk raw reviewer evidence on PR head" in block
+    assert "working-directory: base" in block
+    assert "payload.json" in block
+    assert "_high_risk_paths(changed_paths)" in block
+    assert '[ "$HIGH_RISK_CHANGED" != "true" ]' in block
     assert "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json" in block
     assert "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json" in block
     assert "high-risk supersession evidence requires both OpenAI and Anthropic raw reviewer files" in block


### PR DESCRIPTION
## Summary
- Fixes the AO-MA-10q smoke blocker exposed by PR #709 after #708 landed.
- The high-risk raw-review locator now reads the current PR payload changed_paths and uses the canonical _high_risk_paths classifier before emitting inherited raw-review paths.
- Low-risk PRs with no high-risk changed paths now leave high-risk review outputs empty, so supersession generation is skipped.
- High-risk PR behavior is preserved: high-risk changed paths still require the OpenAI + Anthropic raw review pair and supersession evidence.

## Evidence
- pytest -q tests/test_ao_release_gate_enforce_job.py tests/test_ao_release_gate.py tests/test_ao_ma10l_autonomous_smoke.py => 112 passed
- YAML parse: .github/workflows/test.yml OK
- git diff --check clean
- gitleaks protect --staged --no-banner --redact => no leaks
- local_gpp_gate AO-MA-10Z => operator_may_merge
- high-risk supersession evidence => AGREE, providers anthropic/openai, high-risk path .github/workflows/test.yml
- Claude CLI reviewer: AGREE
- Gauss subagent reviewer: AGREE

## Guardrails
- No branch-protection or ruleset mutation.
- No support widening, production platform claim, or live adapter execution.
- AI output remains evidence only; release authority stays ao-release-gate + GitHub ruleset.