### PR TITLE
fix(ao-ma-10ab): bind smoke producer to dedicated actor

### DIFF
--- a/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md
+++ b/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md
@@ -11,10 +11,10 @@
 AO-MA-10s removes the remaining local-shell dependency from AO-MA-10q. The
 dedicated non-admin merge actor token is read from the GitHub repository secret
 `GLADYATORE_LAB_GH_TOKEN`, not from a local operator shell. The optional
-governance/producer token is read from `AO_GOVERNANCE_GH_TOKEN` for
-branch-protection/ruleset readiness APIs and for disposable low-risk PR
-production when the non-admin merge actor token cannot create refs. A Codex or
-Claude operator may dispatch the workflow, but the merge
+governance token is read from `AO_GOVERNANCE_GH_TOKEN` for
+branch-protection/ruleset readiness APIs only. Disposable low-risk PR
+production and merge execution both stay bound to the dedicated non-admin actor
+token. A Codex or Claude operator may dispatch the workflow, but the merge
 authority remains the repo-owned `ao-release-gate` checks plus GitHub ruleset
 enforcement, and the merge actor must still be `gladyatore-lab`.
 
@@ -34,8 +34,11 @@ workflow_dispatch -> AO-MA-10r credential doctor -> AO-MA-10q runner
 - workflow `GITHUB_TOKEN` has only `contents: read`;
 - the dedicated actor token is only bound as an environment variable;
 - the governance token is only bound as an environment variable and may be used
-  only for readiness reads plus disposable PR production;
-- merge execution remains bound to the dedicated non-admin merge actor token;
+  only for readiness reads;
+- disposable PR production and merge execution remain bound to the dedicated
+  non-admin merge actor token;
+- AO-MA-10q fails closed if delegated AO-MA-10l evidence reports a producer
+  that is not the merge actor;
 - token values are never echoed, printed, committed, or uploaded;
 - execute mode still requires `AO-MA-10L-EXECUTE`;
 - all evidence is uploaded as an Actions artifact;

--- a/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json
+++ b/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json
@@ -3,7 +3,7 @@
   "allowed_ref": "refs/heads/main",
   "artifact_kind": "ao_ma_10s_dedicated_actor_smoke_workflow_receipt",
   "governance_secret_env": "AO_GOVERNANCE_GH_TOKEN",
-  "producer_secret_env": "AO_GOVERNANCE_GH_TOKEN",
+  "producer_secret_env": "GLADYATORE_LAB_GH_TOKEN",
   "producer_release_authority": false,
   "live_adapter_execution": false,
   "next_required_slice": "configure GLADYATORE_LAB_GH_TOKEN and AO_GOVERNANCE_GH_TOKEN repository secrets and dispatch AO-MA-10q smoke",

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10AA",
+  "work_package": "AO-MA-10AB",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,15 +13,14 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10aa-bind-autonomous-smoke-evidence",
+    "head_ref": "refs/heads/codex/ao-ma10ab-dedicated-producer-smoke",
     "changed_files": [
-      ".github/workflows/test.yml",
-      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/ao_release_gate.py",
+      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md",
+      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_ao_release_gate.py",
-      "tests/test_ao_release_gate_enforce_job.py"
+      "scripts/ao_ma10q_dedicated_actor_runner.py",
+      "tests/test_ao_ma10q_dedicated_actor_runner.py",
+      "tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py"
     ]
   },
   "checks_considered": [
@@ -51,11 +50,12 @@
     }
   ],
   "findings": [
-    "Claude reviewer verdict AGREE on the final AO-MA-10AA patch.",
-    "The no-review substitute is limited to explicit AO-MA-10l low-risk autonomous smoke requests by the dedicated gladyatore-lab actor.",
-    "Path validation rejects backslash, absolute path, empty segment, dot segment, dotdot segment, nested child path, non-markdown path, and non-smoke prefix.",
-    "Workflow detection requires every PR file to be changeType ADDED and a direct smoke markdown path before setting the autonomous request flag.",
-    "Ordinary PRs, high-risk PRs, non-dedicated actors, malformed AO-MA10 bundles, and authority-open bundles remain fail-closed.",
+    "Claude reviewer verdict AGREE on the final AO-MA-10AB patch.",
+    "The optional governance token remains limited to readiness and read-only GitHub API checks.",
+    "Disposable low-risk PR production is no longer routed through the governance wrapper when AO_GOVERNANCE_GH_TOKEN is present.",
+    "AO-MA-10q result metadata now records producer_token_env as GLADYATORE_LAB_GH_TOKEN and same_as_merge_actor_wrapper true.",
+    "AO-MA-10q fails closed if delegated AO-MA-10l evidence reports pr_producer.role other than merge_actor or same_as_merge_actor other than true.",
+    "Docs, receipt, and tests are aligned with the dedicated producer and merge actor boundary.",
     "No branch protection mutation, admin bypass, support widening, production platform claim, live adapter execution, or secret material is introduced."
   ],
   "secrets_recorded": false,

--- a/scripts/ao_ma10q_dedicated_actor_runner.py
+++ b/scripts/ao_ma10q_dedicated_actor_runner.py
@@ -220,12 +220,12 @@ def run(
             "mode": "0700",
             "path_recorded": False,
         }
-        result["producer_token_env"] = governance_token_env if governance_wrapper_created else token_env
+        result["producer_token_env"] = token_env
         result["producer_wrapper"] = {
-            "created": governance_wrapper_created,
-            "mode": "0700" if governance_wrapper_created else None,
+            "created": False,
+            "mode": None,
             "path_recorded": False,
-            "same_as_merge_actor_wrapper": not governance_wrapper_created,
+            "same_as_merge_actor_wrapper": True,
         }
 
         command = [
@@ -250,7 +250,6 @@ def run(
         ]
         if governance_wrapper_created:
             command.extend(["--governance-gh-bin", str(governance_wrapper)])
-            command.extend(["--producer-gh-bin", str(governance_wrapper)])
         if execute:
             command.append("--execute")
             if confirmation is not None:
@@ -286,6 +285,14 @@ def run(
         if proc.returncode not in (0, 1):
             blockers.append("smoke_command_failed")
         if smoke_result:
+            raw_pr_producer = smoke_result.get("pr_producer")
+            pr_producer: dict[str, Any] = raw_pr_producer if isinstance(raw_pr_producer, dict) else {}
+            producer_role = pr_producer.get("role")
+            producer_same_as_merge_actor = pr_producer.get("same_as_merge_actor")
+            if producer_role != "merge_actor":
+                blockers.append(f"producer_not_merge_actor: {producer_role}")
+            if producer_same_as_merge_actor is not True:
+                blockers.append("producer_not_same_as_merge_actor")
             raw_smoke_decision = smoke_result.get("decision")
             smoke_decision: dict[str, Any] = raw_smoke_decision if isinstance(raw_smoke_decision, dict) else {}
             blockers.extend(item for item in smoke_decision.get("blockers", []) if isinstance(item, str))

--- a/tests/test_ao_ma10q_dedicated_actor_runner.py
+++ b/tests/test_ao_ma10q_dedicated_actor_runner.py
@@ -36,15 +36,22 @@ def _load_script_module() -> Any:
     return module
 
 
-def _smoke_payload(*, result: str = "merged", blocker: str | None = None, mutated: bool = True) -> dict[str, Any]:
+def _smoke_payload(
+    *,
+    result: str = "merged",
+    blocker: str | None = None,
+    mutated: bool = True,
+    producer_role: str = "merge_actor",
+    producer_same_as_merge_actor: bool = True,
+) -> dict[str, Any]:
     blockers = [blocker] if blocker else []
     return {
         "schema_version": "ao-ma-10l-autonomous-smoke-result.v1",
         "artifact_kind": "ao_ma_10l_autonomous_smoke_result",
         "mutations_performed": mutated,
         "pr_producer": {
-            "role": "governance_producer",
-            "same_as_merge_actor": False,
+            "role": producer_role,
+            "same_as_merge_actor": producer_same_as_merge_actor,
             "release_authority": False,
             "allowed_operations": ["base_ref_read", "branch_create", "file_create", "pr_create"],
         },
@@ -265,26 +272,65 @@ def test_ao_ma10q_uses_optional_governance_wrapper_without_recording_secret_or_p
 
     Draft202012Validator(_schema()).validate(result)
     assert "--governance-gh-bin" in runner.commands[0]
-    assert "--producer-gh-bin" in runner.commands[0]
     assert runner.commands[0][runner.commands[0].index("--governance-gh-bin") + 1].startswith("/tmp/")
-    assert runner.commands[0][runner.commands[0].index("--producer-gh-bin") + 1].startswith("/tmp/")
-    assert (
-        runner.commands[0][runner.commands[0].index("--producer-gh-bin") + 1]
-        == runner.commands[0][runner.commands[0].index("--governance-gh-bin") + 1]
-    )
+    assert "--producer-gh-bin" not in runner.commands[0]
     artifact_text = output.read_text(encoding="utf-8")
     assert TOKEN_VALUE not in artifact_text
     assert GOVERNANCE_TOKEN_VALUE not in artifact_text
-    assert result["smoke_command"].count("<temporary-gh-wrapper>") == 3
-    assert result["producer_token_env"] == GOVERNANCE_TOKEN_ENV
+    assert result["smoke_command"].count("<temporary-gh-wrapper>") == 2
+    assert result["producer_token_env"] == TOKEN_ENV
     assert result["producer_wrapper"] == {
-        "created": True,
-        "mode": "0700",
+        "created": False,
+        "mode": None,
         "path_recorded": False,
-        "same_as_merge_actor_wrapper": False,
+        "same_as_merge_actor_wrapper": True,
     }
     assert result["decision"]["result"] == "merged"
     assert runner.timeouts == [180]
+
+
+def test_ao_ma10q_blocks_if_delegated_smoke_reports_governance_producer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(TOKEN_ENV, TOKEN_VALUE)
+    monkeypatch.setenv(GOVERNANCE_TOKEN_ENV, GOVERNANCE_TOKEN_VALUE)
+    mod = _load_script_module()
+    output = tmp_path / "ao-ma10q.json"
+    runner = FakeSmokeRunner(
+        _smoke_payload(
+            result="merged",
+            mutated=True,
+            producer_role="governance_producer",
+            producer_same_as_merge_actor=False,
+        )
+    )
+
+    result = cast(
+        dict[str, Any],
+        mod.run(
+            repo="Halildeu/ao-kernel",
+            base_ref="main",
+            expected_actor="gladyatore-lab",
+            token_env=TOKEN_ENV,
+            governance_token_env=GOVERNANCE_TOKEN_ENV,
+            base_gh_bin="gh",
+            output=output,
+            execute=True,
+            confirmation="AO-MA-10L-EXECUTE",
+            timeout_seconds=0,
+            poll_seconds=1,
+            runner=runner,
+        ),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert "--producer-gh-bin" not in runner.commands[0]
+    assert result["decision"]["result"] == "blocked"
+    assert result["decision"]["blockers"] == [
+        "producer_not_merge_actor: governance_producer",
+        "producer_not_same_as_merge_actor",
+    ]
+    assert result["mutations_performed"] is True
 
 
 def test_ao_ma10q_default_subprocess_timeout_exceeds_inner_smoke_window() -> None:

--- a/tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py
+++ b/tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py
@@ -102,7 +102,7 @@ def test_ao_ma10s_doc_and_receipt_preserve_authority_boundary() -> None:
     assert receipt["allowed_ref"] == "refs/heads/main"
     assert receipt["secret_env"] == "GLADYATORE_LAB_GH_TOKEN"
     assert receipt["governance_secret_env"] == "AO_GOVERNANCE_GH_TOKEN"
-    assert receipt["producer_secret_env"] == "AO_GOVERNANCE_GH_TOKEN"
+    assert receipt["producer_secret_env"] == "GLADYATORE_LAB_GH_TOKEN"
     assert receipt["producer_release_authority"] is False
     assert receipt["token_value_recorded"] is False
     assert receipt["release_authority"] == "ao-release-gate+github-ruleset"


### PR DESCRIPTION
## Summary

Fixes the AO-MA-10q smoke runner producer binding discovered by the failed diagnostic smoke PR #713.

The GitHub token permissions were already sufficient; the real blocker was that when `AO_GOVERNANCE_GH_TOKEN` existed, the runner passed the governance wrapper as both `--governance-gh-bin` and `--producer-gh-bin`, so disposable PR production happened as the governance actor instead of the dedicated `gladyatore-lab` actor.

## Changes

- Keep `AO_GOVERNANCE_GH_TOKEN` limited to readiness/read-only `--governance-gh-bin` use.
- Stop passing `--producer-gh-bin` from AO-MA-10q; AO-MA-10l defaults producer writes to the dedicated `--gh-bin` wrapper.
- Record `producer_token_env=GLADYATORE_LAB_GH_TOKEN` and `same_as_merge_actor_wrapper=true` in AO-MA-10q evidence.
- Fail closed if delegated AO-MA-10l evidence reports `pr_producer.role != "merge_actor"` or `pr_producer.same_as_merge_actor != true`.
- Align AO-MA-10S docs/receipt and tests with the dedicated producer boundary.

## Verification

- Claude CLI review: AGREE
- `pytest -q tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py tests/test_ao_ma10l_autonomous_smoke.py tests/test_local_gpp_gate.py` -> 84 passed
- `ruff check scripts/ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py` -> pass
- `mypy scripts/ao_ma10q_dedicated_actor_runner.py` -> pass
- `gitleaks protect --staged --no-banner --redact` -> no leaks
- `python3 scripts/local_gpp_gate.py ...` -> `operator_may_merge`

## Guardrails

- No branch protection mutation
- No admin bypass
- No support widening
- No production platform claim
- No live adapter execution
- No secret material recorded
