### PR TITLE
fix(ao-ma-10ac): prove dedicated token branch write readiness

### DIFF
--- a/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md
+++ b/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md
@@ -31,7 +31,12 @@ GLADYATORE_LAB_GH_TOKEN
 
 The doctor never accepts token values as CLI arguments and never records token
 values, token prefixes, token hashes, or credential paths. It sets `GH_TOKEN`
-only inside the subprocess environment for read-only GitHub API calls.
+only inside the subprocess environment for GitHub API calls.
+
+By default the doctor remains read-only. In execute-mode smoke runs the
+workflow passes `--branch-write-probe`, which creates and immediately deletes a
+temporary `codex/ao-ma10r-token-probe-*` branch. This proves the exact write
+path AO-MA-10l needs before the smoke attempts to create its disposable PR.
 
 ## Command
 
@@ -50,7 +55,7 @@ dedicated_actor_token_env_missing
 
 ## Checks
 
-The doctor performs read-only checks:
+The doctor always performs read-only checks:
 
 - `gh api user` -> actor identity is `gladyatore-lab`;
 - `gh api repos/Halildeu/ao-kernel` -> actor has write or maintain, but not
@@ -58,16 +63,29 @@ The doctor performs read-only checks:
 - `gh api repos/Halildeu/ao-kernel/pulls?state=open&per_page=1` -> actor can
   read pull-request state.
 
+With `--branch-write-probe`, the doctor additionally:
+
+- reads `refs/heads/main`;
+- creates a temporary `codex/ao-ma10r-token-probe-*` branch;
+- deletes that temporary branch;
+- fails closed with `branch_write_probe_create_failed`,
+  `branch_write_probe_base_ref_read_failed`, or
+  `branch_write_probe_cleanup_failed` if any step fails.
+
 ## Completion Criteria
 
 AO-MA-10r is ready only when it emits `credential_ready` with:
 
 - `token_value_recorded=false`;
-- `mutations_performed=false`;
+- `mutations_performed=false` for read-only mode, or `true` only when
+  `--branch-write-probe` successfully creates and deletes the temporary branch;
 - `actor.matches_expected=true`;
 - `repository_access.admin_permission_observed=false`;
 - `repository_access.can_merge_without_admin=true`;
 - `repository_access.can_read_pull_requests=true`;
+- `branch_write_probe.create_result=created` and
+  `branch_write_probe.delete_result=deleted` when execute mode requests the
+  branch-write probe;
 - all guard flags false.
 
 After AO-MA-10r passes, AO-MA-10q may be executed with the same token

--- a/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json
+++ b/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json
@@ -4,12 +4,13 @@
   "default_expected_actor": "gladyatore-lab",
   "default_token_env": "GLADYATORE_LAB_GH_TOKEN",
   "implemented_files": [
+    ".github/workflows/ao-ma10q-dedicated-actor-smoke.yml",
     "scripts/ao_ma10r_dedicated_actor_credential_doctor.py",
     "ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json",
     "tests/test_ao_ma10r_dedicated_actor_credential_doctor.py"
   ],
   "live_adapter_execution": false,
-  "mutations_performed": false,
+  "mutations_performed": "read_only_by_default_true_only_for_execute_mode_branch_write_probe",
   "production_platform_claim": false,
   "release_authority": "ao-release-gate+github-ruleset",
   "schema_version": "ao-ma-10r-dedicated-actor-credential-doctor-receipt.v1",

--- a/.github/workflows/ao-ma10q-dedicated-actor-smoke.yml
+++ b/.github/workflows/ao-ma10q-dedicated-actor-smoke.yml
@@ -93,10 +93,25 @@ jobs:
           mkdir -p "$EVIDENCE_DIR"
 
           set +e
-          python scripts/ao_ma10r_dedicated_actor_credential_doctor.py \
-            --output "$EVIDENCE_DIR/ao-ma10r-credential-doctor-result.json" \
+          doctor_args=(
+            --output "$EVIDENCE_DIR/ao-ma10r-credential-doctor-result.json"
             --format text
+          )
+          if [ "$MODE" = "execute" ]; then
+            doctor_args+=(--branch-write-probe)
+          fi
+          python scripts/ao_ma10r_dedicated_actor_credential_doctor.py "${doctor_args[@]}"
           doctor_status=$?
+          if [ "$doctor_status" -ne 0 ]; then
+            set -e
+            {
+              echo "mode=$MODE"
+              echo "doctor_status=$doctor_status"
+              echo "runner_status=skipped"
+              echo "runner_skipped_reason=doctor_failed"
+            } > "$EVIDENCE_DIR/status.txt"
+            exit 1
+          fi
 
           q_args=(
             --output "$EVIDENCE_DIR/ao-ma10q-dedicated-actor-runner-result.json"

--- a/ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json
@@ -41,6 +41,51 @@
       },
       "type": "array"
     },
+    "branch_write_probe": {
+      "additionalProperties": false,
+      "properties": {
+        "base_ref": {
+          "anyOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ]
+        },
+        "branch": {
+          "anyOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ]
+        },
+        "create_result": {
+          "enum": [
+            "not_requested",
+            "not_attempted",
+            "blocked",
+            "created",
+            "failed"
+          ]
+        },
+        "delete_result": {
+          "enum": [
+            "not_requested",
+            "not_attempted",
+            "deleted",
+            "failed"
+          ]
+        },
+        "requested": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "requested",
+        "branch",
+        "base_ref",
+        "create_result",
+        "delete_result"
+      ],
+      "type": "object"
+    },
     "commands": {
       "items": {
         "items": {
@@ -111,7 +156,7 @@
       "type": "object"
     },
     "mutations_performed": {
-      "const": false
+      "type": "boolean"
     },
     "release_authority": {
       "const": "ao-release-gate+github-ruleset"
@@ -182,6 +227,7 @@
     "release_authority",
     "ai_output_release_authority",
     "guard_flags",
+    "branch_write_probe",
     "actor",
     "repository_access",
     "commands",

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10AB",
+  "work_package": "AO-MA-10AC",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,13 +13,15 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10ab-dedicated-producer-smoke",
+    "head_ref": "refs/heads/codex/ao-ma10ac-credential-branch-probe",
     "changed_files": [
-      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md",
-      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json",
+      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md",
+      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json",
+      ".github/workflows/ao-ma10q-dedicated-actor-smoke.yml",
+      "ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10q_dedicated_actor_runner.py",
-      "tests/test_ao_ma10q_dedicated_actor_runner.py",
+      "scripts/ao_ma10r_dedicated_actor_credential_doctor.py",
+      "tests/test_ao_ma10r_dedicated_actor_credential_doctor.py",
       "tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py"
     ]
   },
@@ -41,7 +43,11 @@
       "status": "pass"
     },
     {
-      "name": "yaml_parse",
+      "name": "json_parse",
+      "status": "pass"
+    },
+    {
+      "name": "diff_check",
       "status": "pass"
     },
     {
@@ -50,12 +56,15 @@
     }
   ],
   "findings": [
-    "Claude reviewer verdict AGREE on the final AO-MA-10AB patch.",
-    "The optional governance token remains limited to readiness and read-only GitHub API checks.",
-    "Disposable low-risk PR production is no longer routed through the governance wrapper when AO_GOVERNANCE_GH_TOKEN is present.",
-    "AO-MA-10q result metadata now records producer_token_env as GLADYATORE_LAB_GH_TOKEN and same_as_merge_actor_wrapper true.",
-    "AO-MA-10q fails closed if delegated AO-MA-10l evidence reports pr_producer.role other than merge_actor or same_as_merge_actor other than true.",
-    "Docs, receipt, and tests are aligned with the dedicated producer and merge actor boundary.",
+    "Claude reviewer verdict AGREE on the AO-MA-10AC branch-write credential probe patch.",
+    "The patch catches the observed GitHub 403 branch-create failure earlier in the credential doctor by creating and deleting a temporary codex/ao-ma10r-token-probe-* branch only in execute mode.",
+    "The doctor remains read-only by default; workflow execute mode is the only path that passes --branch-write-probe.",
+    "Token values remain environment-only and are not accepted as CLI arguments or recorded in artifacts.",
+    "The branch-write probe fails closed for base-ref read failure, branch create failure, and cleanup failure.",
+    "The workflow now exits before invoking AO-MA-10q/AO-MA-10l when the credential doctor fails.",
+    "Claude advisory A1 for cleanup-failure coverage was absorbed with a dedicated test.",
+    "Claude follow-up advisory for base-ref read failure coverage was absorbed with a dedicated test.",
+    "Schema, docs, workflow wiring, and tests are aligned with the branch-write probe contract.",
     "No branch protection mutation, admin bypass, support widening, production platform claim, live adapter execution, or secret material is introduced."
   ],
   "secrets_recorded": false,

--- a/scripts/ao_ma10r_dedicated_actor_credential_doctor.py
+++ b/scripts/ao_ma10r_dedicated_actor_credential_doctor.py
@@ -24,8 +24,10 @@ SCHEMA_VERSION = "ao-ma-10r-dedicated-actor-credential-doctor-result.v1"
 ARTIFACT_KIND = "ao_ma_10r_dedicated_actor_credential_doctor_result"
 RELEASE_AUTHORITY = "ao-release-gate+github-ruleset"
 DEFAULT_REPO = "Halildeu/ao-kernel"
+DEFAULT_BASE_REF = "main"
 DEFAULT_EXPECTED_ACTOR = "gladyatore-lab"
 DEFAULT_TOKEN_ENV = "GLADYATORE_LAB_GH_TOKEN"
+BRANCH_PROBE_PREFIX = "codex/ao-ma10r-token-probe"
 TOKEN_ENV_RE = re.compile(r"[A-Z_][A-Z0-9_]*")
 WRITE_CAPABLE_LEVELS = {"write", "maintain"}
 
@@ -61,6 +63,13 @@ def _base_result(*, repo: str, expected_actor: str, token_env: str) -> dict[str,
             "support_widening": False,
             "production_platform_claim": False,
             "live_adapter_execution": False,
+        },
+        "branch_write_probe": {
+            "requested": False,
+            "branch": None,
+            "base_ref": None,
+            "create_result": "not_requested",
+            "delete_result": "not_requested",
         },
         "actor": {
             "login": None,
@@ -114,6 +123,20 @@ def _run_json(
     return payload, None
 
 
+def _run_status(
+    command: list[str],
+    *,
+    env: Mapping[str, str],
+    runner: Runner,
+    result: dict[str, Any],
+) -> str | None:
+    result["commands"].append(_redacted_command(command))
+    proc = runner(command, env)
+    if proc.returncode != 0:
+        return proc.stderr.strip() or proc.stdout.strip() or f"exit {proc.returncode}"
+    return None
+
+
 def _permission_level(repo_payload: dict[str, Any]) -> str:
     permissions = repo_payload.get("permissions")
     if not isinstance(permissions, dict):
@@ -146,13 +169,102 @@ def _set_decision(result: dict[str, Any], blockers: set[str], warnings: set[str]
     }
 
 
+def _run_branch_write_probe(
+    *,
+    repo: str,
+    base_ref: str,
+    gh_bin: str,
+    env: Mapping[str, str],
+    runner: Runner,
+    result: dict[str, Any],
+    blockers: set[str],
+) -> None:
+    branch = f"{BRANCH_PROBE_PREFIX}-{datetime.now(UTC).strftime('%Y%m%d%H%M%S%f')}"
+    probe = {
+        "requested": True,
+        "branch": branch,
+        "base_ref": base_ref,
+        "create_result": "not_attempted",
+        "delete_result": "not_attempted",
+    }
+    result["branch_write_probe"] = probe
+
+    base_payload, error = _run_json(
+        [gh_bin, "api", f"repos/{repo}/git/ref/heads/{base_ref}"],
+        env=env,
+        runner=runner,
+        result=result,
+    )
+    if error is not None or not isinstance(base_payload, dict):
+        blockers.add("branch_write_probe_base_ref_read_failed")
+        result["collection_errors"].append(f"branch_probe_base_ref: {error or 'invalid shape'}")
+        probe["create_result"] = "blocked"
+        probe["delete_result"] = "not_attempted"
+        return
+
+    object_payload = base_payload.get("object")
+    sha = object_payload.get("sha") if isinstance(object_payload, dict) else None
+    if not isinstance(sha, str) or not sha:
+        blockers.add("branch_write_probe_base_ref_read_failed")
+        result["collection_errors"].append("branch_probe_base_ref: missing object.sha")
+        probe["create_result"] = "blocked"
+        probe["delete_result"] = "not_attempted"
+        return
+
+    error = _run_status(
+        [
+            gh_bin,
+            "api",
+            f"repos/{repo}/git/refs",
+            "--method",
+            "POST",
+            "-f",
+            f"ref=refs/heads/{branch}",
+            "-f",
+            f"sha={sha}",
+        ],
+        env=env,
+        runner=runner,
+        result=result,
+    )
+    if error is not None:
+        blockers.add("branch_write_probe_create_failed")
+        result["collection_errors"].append(f"branch_probe_create: {error}")
+        probe["create_result"] = "failed"
+        probe["delete_result"] = "not_attempted"
+        return
+
+    result["mutations_performed"] = True
+    probe["create_result"] = "created"
+    error = _run_status(
+        [
+            gh_bin,
+            "api",
+            f"repos/{repo}/git/refs/heads/{branch}",
+            "--method",
+            "DELETE",
+        ],
+        env=env,
+        runner=runner,
+        result=result,
+    )
+    if error is not None:
+        blockers.add("branch_write_probe_cleanup_failed")
+        result["collection_errors"].append(f"branch_probe_delete: {error}")
+        probe["delete_result"] = "failed"
+        return
+    probe["delete_result"] = "deleted"
+
+
 def run(
     *,
     repo: str,
+    base_ref: str,
     expected_actor: str,
     token_env: str,
     gh_bin: str,
     output: Path,
+    branch_write_probe: bool,
     runner: Runner = _run,
 ) -> dict[str, Any]:
     _validate_token_env_name(token_env)
@@ -225,6 +337,16 @@ def run(
         "can_merge_without_admin": can_merge_without_admin,
         "admin_permission_observed": admin_permission_observed,
     }
+    if branch_write_probe and not blockers:
+        _run_branch_write_probe(
+            repo=repo,
+            base_ref=base_ref,
+            gh_bin=gh_bin,
+            env=env,
+            runner=runner,
+            result=result,
+            blockers=blockers,
+        )
     _set_decision(result, blockers, warnings)
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -234,19 +356,27 @@ def run(
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--base-ref", default=DEFAULT_BASE_REF)
     parser.add_argument("--expected-actor", default=DEFAULT_EXPECTED_ACTOR)
     parser.add_argument("--token-env", default=DEFAULT_TOKEN_ENV)
     parser.add_argument("--gh-bin", default="gh")
     parser.add_argument("--output", required=True)
+    parser.add_argument(
+        "--branch-write-probe",
+        action="store_true",
+        help="Create and delete a temporary branch to prove the token can perform the write path used by AO-MA-10l.",
+    )
     parser.add_argument("--format", choices=["json", "text"], default="json")
     args = parser.parse_args(argv)
 
     result = run(
         repo=args.repo,
+        base_ref=args.base_ref,
         expected_actor=args.expected_actor,
         token_env=args.token_env,
         gh_bin=args.gh_bin,
         output=Path(args.output),
+        branch_write_probe=args.branch_write_probe,
     )
 
     if args.format == "text":

--- a/tests/test_ao_ma10r_dedicated_actor_credential_doctor.py
+++ b/tests/test_ao_ma10r_dedicated_actor_credential_doctor.py
@@ -63,6 +63,17 @@ class FakeGitHubRunner:
             return subprocess.CompletedProcess(command, 0, json.dumps({"permissions": self.permissions}), "")
         if command == ["gh", "api", "repos/Halildeu/ao-kernel/pulls?state=open&per_page=1"]:
             return subprocess.CompletedProcess(command, 0, json.dumps(self.pulls), "")
+        if command == ["gh", "api", "repos/Halildeu/ao-kernel/git/ref/heads/main"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"object": {"sha": "abc123"}}), "")
+        if command[:5] == ["gh", "api", "repos/Halildeu/ao-kernel/git/refs", "--method", "POST"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"ref": command[6].removeprefix("ref=")}), "")
+        if (
+            len(command) == 5
+            and command[0:2] == ["gh", "api"]
+            and command[2].startswith("repos/Halildeu/ao-kernel/git/refs/heads/codex/ao-ma10r-token-probe-")
+            and command[3:] == ["--method", "DELETE"]
+        ):
+            return subprocess.CompletedProcess(command, 0, "", "")
         return subprocess.CompletedProcess(command, 1, "", f"unexpected command: {joined}")
 
 
@@ -73,6 +84,7 @@ def _run_doctor(
     *,
     token_value: str | None = TOKEN_VALUE,
     expected_actor: str = "gladyatore-lab",
+    branch_write_probe: bool = False,
 ) -> dict[str, Any]:
     if token_value is None:
         monkeypatch.delenv(TOKEN_ENV, raising=False)
@@ -83,10 +95,12 @@ def _run_doctor(
         dict[str, Any],
         mod.run(
             repo="Halildeu/ao-kernel",
+            base_ref="main",
             expected_actor=expected_actor,
             token_env=TOKEN_ENV,
             gh_bin="gh",
             output=tmp_path / "ao-ma10r.json",
+            branch_write_probe=branch_write_probe,
             runner=runner,
         ),
     )
@@ -108,9 +122,11 @@ def test_ao_ma10r_doc_and_receipt_preserve_no_secret_authority_boundary() -> Non
     assert receipt["production_platform_claim"] is False
     assert receipt["live_adapter_execution"] is False
     assert receipt["token_value_recorded"] is False
+    assert receipt["mutations_performed"] == "read_only_by_default_true_only_for_execute_mode_branch_write_probe"
     assert receipt["default_token_env"] == TOKEN_ENV
     assert "never accepts token values as CLI arguments" in text
     assert "Release authority remains the repo-owned" in text
+    assert "--branch-write-probe" in text
 
 
 def test_ao_ma10r_missing_token_env_blocks_before_github_calls(
@@ -132,10 +148,12 @@ def test_ao_ma10r_rejects_invalid_token_env_name(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="token env name"):
         mod.run(
             repo="Halildeu/ao-kernel",
+            base_ref="main",
             expected_actor="gladyatore-lab",
             token_env="bad-token-env",
             gh_bin="gh",
             output=tmp_path / "ao-ma10r.json",
+            branch_write_probe=False,
             runner=FakeGitHubRunner(),
         )
 
@@ -159,11 +177,100 @@ def test_ao_ma10r_happy_path_ready_without_recording_secret_or_mutating(
     assert result["repository_access"]["can_read_pull_requests"] is True
     assert result["token_value_recorded"] is False
     assert result["mutations_performed"] is False
+    assert result["branch_write_probe"] == {
+        "requested": False,
+        "branch": None,
+        "base_ref": None,
+        "create_result": "not_requested",
+        "delete_result": "not_requested",
+    }
     assert result["commands"] == [
         ["gh", "api", "user"],
         ["gh", "api", "repos/Halildeu/ao-kernel"],
         ["gh", "api", "repos/Halildeu/ao-kernel/pulls?state=open&per_page=1"],
     ]
+
+
+def test_ao_ma10r_branch_write_probe_creates_and_deletes_temp_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = FakeGitHubRunner()
+    result = _run_doctor(tmp_path, monkeypatch, runner, branch_write_probe=True)
+
+    Draft202012Validator(_schema()).validate(result)
+    artifact_text = (tmp_path / "ao-ma10r.json").read_text(encoding="utf-8")
+    assert TOKEN_VALUE not in artifact_text
+    assert result["decision"]["result"] == "credential_ready"
+    assert result["mutations_performed"] is True
+    probe = result["branch_write_probe"]
+    assert probe["requested"] is True
+    assert probe["base_ref"] == "main"
+    assert probe["branch"].startswith("codex/ao-ma10r-token-probe-")
+    assert probe["create_result"] == "created"
+    assert probe["delete_result"] == "deleted"
+    assert any(command[:3] == ["gh", "api", "repos/Halildeu/ao-kernel/git/refs"] for command in result["commands"])
+    assert any(
+        command[0:2] == ["gh", "api"]
+        and command[2].startswith("repos/Halildeu/ao-kernel/git/refs/heads/codex/ao-ma10r-token-probe-")
+        for command in result["commands"]
+    )
+
+
+def test_ao_ma10r_branch_write_probe_blocks_base_ref_read_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result = _run_doctor(
+        tmp_path,
+        monkeypatch,
+        FakeGitHubRunner(fail_command_contains="git/ref/heads/main"),
+        branch_write_probe=True,
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "blocked"
+    assert "branch_write_probe_base_ref_read_failed" in result["decision"]["blockers"]
+    assert result["mutations_performed"] is False
+    assert result["branch_write_probe"]["create_result"] == "blocked"
+    assert result["branch_write_probe"]["delete_result"] == "not_attempted"
+    assert any(item.startswith("branch_probe_base_ref:") for item in result["collection_errors"])
+
+
+def test_ao_ma10r_branch_write_probe_blocks_create_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result = _run_doctor(
+        tmp_path,
+        monkeypatch,
+        FakeGitHubRunner(fail_command_contains="git/refs --method POST"),
+        branch_write_probe=True,
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "blocked"
+    assert "branch_write_probe_create_failed" in result["decision"]["blockers"]
+    assert result["mutations_performed"] is False
+    assert result["branch_write_probe"]["create_result"] == "failed"
+    assert result["branch_write_probe"]["delete_result"] == "not_attempted"
+    assert any(item.startswith("branch_probe_create:") for item in result["collection_errors"])
+
+
+def test_ao_ma10r_branch_write_probe_blocks_cleanup_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result = _run_doctor(
+        tmp_path,
+        monkeypatch,
+        FakeGitHubRunner(fail_command_contains="git/refs/heads/codex/ao-ma10r-token-probe-"),
+        branch_write_probe=True,
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "blocked"
+    assert "branch_write_probe_cleanup_failed" in result["decision"]["blockers"]
+    assert result["mutations_performed"] is True
+    assert result["branch_write_probe"]["create_result"] == "created"
+    assert result["branch_write_probe"]["delete_result"] == "failed"
+    assert any(item.startswith("branch_probe_delete:") for item in result["collection_errors"])
 
 
 def test_ao_ma10r_accepts_maintain_as_non_admin_merge_capable(

--- a/tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py
+++ b/tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py
@@ -87,6 +87,16 @@ def test_ao_ma10s_workflow_runs_doctor_before_runner_and_uploads_artifacts() -> 
     assert "if-no-files-found: error" in text
 
 
+def test_ao_ma10s_workflow_skips_runner_when_doctor_fails() -> None:
+    text = _workflow_text()
+    guard = 'if [ "$doctor_status" -ne 0 ]; then'
+    runner = "scripts/ao_ma10q_dedicated_actor_runner.py"
+    assert guard in text
+    assert text.index(guard) < text.index(runner)
+    assert "runner_status=skipped" in text
+    assert "runner_skipped_reason=doctor_failed" in text
+
+
 def test_ao_ma10s_execute_mode_requires_confirmation() -> None:
     text = _workflow_text()
     assert "AO-MA-10L-EXECUTE" in text


### PR DESCRIPTION
## Summary
- add AO-MA-10r execute-mode branch-write probe that creates/deletes a temporary `codex/ao-ma10r-token-probe-*` branch
- wire AO-MA-10q smoke workflow to run the probe only in execute mode and stop before AO-MA-10q/AO-MA-10l if the doctor fails
- extend doctor schema/docs/tests and refresh local AI review evidence for AO-MA-10AC

## Why
The last live smoke proved the UI-visible token permissions were not enough: branch creation failed with `Resource not accessible by personal access token (HTTP 403)`. This patch makes that exact capability a pre-run credential check, so a bad dedicated token fails before the disposable PR producer runs.

## Validation
- `pytest -q tests/test_ao_ma10r_dedicated_actor_credential_doctor.py tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py tests/test_ao_ma10l_autonomous_smoke.py tests/test_local_gpp_gate.py` -> 101 passed
- `ruff check scripts/ao_ma10r_dedicated_actor_credential_doctor.py tests/test_ao_ma10r_dedicated_actor_credential_doctor.py tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py`
- `mypy scripts/ao_ma10r_dedicated_actor_credential_doctor.py`
- `gitleaks protect --staged --no-banner --redact`
- `python3 scripts/local_gpp_gate.py ... --work-package AO-MA-10AC` -> `operator_may_merge`

## Cross-AI review
- Claude CLI: AGREE; cleanup/base-ref advisories absorbed with tests
- Godel subagent: REVISE on workflow not stopping before runner; absorbed; re-review AGREE

## Guardrails
No branch protection mutation, admin bypass, support widening, production platform claim, live adapter execution, or secret material introduced.