### PR TITLE
fix(ao-ma-10): split producer branch probe from merge actor

### DIFF
--- a/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md
+++ b/.claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md
@@ -102,6 +102,12 @@ Required-check polling and merge execution continue to use the dedicated actor
 wrapper. The producer wrapper is not release authority and cannot satisfy the
 AO-MA-10c merge-agent actor assertion.
 
+AO-MA-10q accepts `pr_producer.role=governance_producer` only when the delegated
+AO-MA-10l artifact records `release_authority=false` and the bounded producer
+operation list is exactly `base_ref_read`, `branch_create`, `file_create`,
+`pr_create`. Any producer that claims release authority or expands operations
+fails closed.
+
 ## Result Artifact
 
 Schema:

--- a/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md
+++ b/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md
@@ -72,6 +72,18 @@ With `--branch-write-probe`, the doctor additionally:
   `branch_write_probe_base_ref_read_failed`, or
   `branch_write_probe_cleanup_failed` if any step fails.
 
+By default the branch-write probe uses the same dedicated merge actor token.
+When AO-MA-10q is running with a split disposable PR producer, pass:
+
+```text
+--branch-write-probe-token-env AO_GOVERNANCE_GH_TOKEN
+```
+
+That proves the producer token can create/delete the disposable smoke branch
+without making that producer release authority. The merge actor identity,
+required-check polling, and merge-agent execution remain bound to
+`GLADYATORE_LAB_GH_TOKEN`.
+
 ## Completion Criteria
 
 AO-MA-10r is ready only when it emits `credential_ready` with:
@@ -86,6 +98,8 @@ AO-MA-10r is ready only when it emits `credential_ready` with:
 - `branch_write_probe.create_result=created` and
   `branch_write_probe.delete_result=deleted` when execute mode requests the
   branch-write probe;
+- `branch_write_probe.token_role` is `merge_actor` for same-token probes or
+  `producer` for split disposable PR producer probes;
 - all guard flags false.
 
 After AO-MA-10r passes, AO-MA-10q may be executed with the same token

--- a/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json
+++ b/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json
@@ -3,6 +3,8 @@
   "artifact_kind": "ao_ma_10r_dedicated_actor_credential_doctor_receipt",
   "default_expected_actor": "gladyatore-lab",
   "default_token_env": "GLADYATORE_LAB_GH_TOKEN",
+  "default_branch_write_probe_token_env": "GLADYATORE_LAB_GH_TOKEN",
+  "split_producer_branch_write_probe_token_env": "AO_GOVERNANCE_GH_TOKEN",
   "implemented_files": [
     ".github/workflows/ao-ma10q-dedicated-actor-smoke.yml",
     "scripts/ao_ma10r_dedicated_actor_credential_doctor.py",

--- a/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md
+++ b/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md
@@ -11,10 +11,10 @@
 AO-MA-10s removes the remaining local-shell dependency from AO-MA-10q. The
 dedicated non-admin merge actor token is read from the GitHub repository secret
 `GLADYATORE_LAB_GH_TOKEN`, not from a local operator shell. The optional
-governance token is read from `AO_GOVERNANCE_GH_TOKEN` for
-branch-protection/ruleset readiness APIs only. Disposable low-risk PR
-production and merge execution both stay bound to the dedicated non-admin actor
-token. A Codex or Claude operator may dispatch the workflow, but the merge
+governance/producer token is read from `AO_GOVERNANCE_GH_TOKEN` for
+branch-protection/ruleset readiness APIs and disposable low-risk PR production.
+Merge execution stays bound to the dedicated non-admin actor token. A Codex or
+Claude operator may dispatch the workflow, but the merge
 authority remains the repo-owned `ao-release-gate` checks plus GitHub ruleset
 enforcement, and the merge actor must still be `gladyatore-lab`.
 
@@ -34,11 +34,13 @@ workflow_dispatch -> AO-MA-10r credential doctor -> AO-MA-10q runner
 - workflow `GITHUB_TOKEN` has only `contents: read`;
 - the dedicated actor token is only bound as an environment variable;
 - the governance token is only bound as an environment variable and may be used
-  only for readiness reads;
-- disposable PR production and merge execution remain bound to the dedicated
-  non-admin merge actor token;
+  only for readiness reads plus disposable PR production;
+- execute mode proves the disposable PR producer branch-write path with
+  `--branch-write-probe-token-env AO_GOVERNANCE_GH_TOKEN`;
+- merge execution remains bound to the dedicated non-admin merge actor token;
 - AO-MA-10q fails closed if delegated AO-MA-10l evidence reports a producer
-  that is not the merge actor;
+  that claims release authority or widens beyond the bounded producer
+  operations;
 - token values are never echoed, printed, committed, or uploaded;
 - execute mode still requires `AO-MA-10L-EXECUTE`;
 - all evidence is uploaded as an Actions artifact;

--- a/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json
+++ b/.claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json
@@ -3,7 +3,7 @@
   "allowed_ref": "refs/heads/main",
   "artifact_kind": "ao_ma_10s_dedicated_actor_smoke_workflow_receipt",
   "governance_secret_env": "AO_GOVERNANCE_GH_TOKEN",
-  "producer_secret_env": "GLADYATORE_LAB_GH_TOKEN",
+  "producer_secret_env": "AO_GOVERNANCE_GH_TOKEN",
   "producer_release_authority": false,
   "live_adapter_execution": false,
   "next_required_slice": "configure GLADYATORE_LAB_GH_TOKEN and AO_GOVERNANCE_GH_TOKEN repository secrets and dispatch AO-MA-10q smoke",

--- a/.github/workflows/ao-ma10q-dedicated-actor-smoke.yml
+++ b/.github/workflows/ao-ma10q-dedicated-actor-smoke.yml
@@ -99,6 +99,7 @@ jobs:
           )
           if [ "$MODE" = "execute" ]; then
             doctor_args+=(--branch-write-probe)
+            doctor_args+=(--branch-write-probe-token-env AO_GOVERNANCE_GH_TOKEN)
           fi
           python scripts/ao_ma10r_dedicated_actor_credential_doctor.py "${doctor_args[@]}"
           doctor_status=$?

--- a/ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json
@@ -56,6 +56,26 @@
             { "type": "null" }
           ]
         },
+        "token_env": {
+          "anyOf": [
+            {
+              "pattern": "^[A-Z_][A-Z0-9_]*$",
+              "type": "string"
+            },
+            { "type": "null" }
+          ]
+        },
+        "token_role": {
+          "anyOf": [
+            {
+              "enum": [
+                "merge_actor",
+                "producer"
+              ]
+            },
+            { "type": "null" }
+          ]
+        },
         "create_result": {
           "enum": [
             "not_requested",
@@ -79,6 +99,8 @@
       },
       "required": [
         "requested",
+        "token_env",
+        "token_role",
         "branch",
         "base_ref",
         "create_result",

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,30 +1,4 @@
 {
-  "schema_version": "local-ai-review-evidence.v1",
-  "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10AC",
-  "implementer": {
-    "agent": "codex",
-    "provider": "openai"
-  },
-  "reviewer": {
-    "agent": "claude-cli-reviewer",
-    "provider": "anthropic",
-    "verdict": "AGREE"
-  },
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10ac-credential-branch-probe",
-    "changed_files": [
-      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md",
-      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json",
-      ".github/workflows/ao-ma10q-dedicated-actor-smoke.yml",
-      "ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json",
-      "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10r_dedicated_actor_credential_doctor.py",
-      "tests/test_ao_ma10r_dedicated_actor_credential_doctor.py",
-      "tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py"
-    ]
-  },
   "checks_considered": [
     {
       "name": "tests",
@@ -56,19 +30,49 @@
     }
   ],
   "findings": [
-    "Claude reviewer verdict AGREE on the AO-MA-10AC branch-write credential probe patch.",
-    "The patch catches the observed GitHub 403 branch-create failure earlier in the credential doctor by creating and deleting a temporary codex/ao-ma10r-token-probe-* branch only in execute mode.",
-    "The doctor remains read-only by default; workflow execute mode is the only path that passes --branch-write-probe.",
+    "Claude reviewer verdict AGREE on PR #716 producer-branch-probe split.",
+    "The branch-write probe now uses AO_GOVERNANCE_GH_TOKEN as a literal token-env name for disposable branch/PR production, while actor identity checks still use GLADYATORE_LAB_GH_TOKEN.",
+    "Merge authority remains the dedicated actor path and release authority remains ao-release-gate plus GitHub ruleset.",
+    "The runner now fails closed when delegated pr_producer evidence contradicts the execution context.",
+    "Governance producer mode is accepted only when release_authority is false and allowed_operations exactly equals base_ref_read, branch_create, file_create, and pr_create.",
     "Token values remain environment-only and are not accepted as CLI arguments or recorded in artifacts.",
-    "The branch-write probe fails closed for base-ref read failure, branch create failure, and cleanup failure.",
-    "The workflow now exits before invoking AO-MA-10q/AO-MA-10l when the credential doctor fails.",
-    "Claude advisory A1 for cleanup-failure coverage was absorbed with a dedicated test.",
-    "Claude follow-up advisory for base-ref read failure coverage was absorbed with a dedicated test.",
-    "Schema, docs, workflow wiring, and tests are aligned with the branch-write probe contract.",
+    "The workflow passes --branch-write-probe-token-env AO_GOVERNANCE_GH_TOKEN as a literal env-var name, not a token value.",
+    "Schema, docs, workflow wiring, and tests are aligned with the split producer contract.",
     "No branch protection mutation, admin bypass, support widening, production platform claim, live adapter execution, or secret material is introduced."
   ],
-  "secrets_recorded": false,
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
   "live_adapter_execution": false,
+  "production_platform_claim": false,
+  "repo": "Halildeu/ao-kernel",
+  "reviewer": {
+    "agent": "claude-cli-reviewer",
+    "provider": "anthropic",
+    "verdict": "AGREE"
+  },
+  "schema_version": "local-ai-review-evidence.v1",
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "changed_files": [
+      ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md",
+      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md",
+      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json",
+      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md",
+      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json",
+      ".github/workflows/ao-ma10q-dedicated-actor-smoke.yml",
+      "ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "scripts/ao_ma10q_dedicated_actor_runner.py",
+      "scripts/ao_ma10r_dedicated_actor_credential_doctor.py",
+      "tests/test_ao_ma10q_dedicated_actor_runner.py",
+      "tests/test_ao_ma10r_dedicated_actor_credential_doctor.py",
+      "tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py"
+    ],
+    "head_ref": "refs/heads/codex/ao-ma10y-producer-probe"
+  },
+  "secrets_recorded": false,
   "support_widening": false,
-  "production_platform_claim": false
+  "work_package": "AO-MA-10Y"
 }

--- a/scripts/ao_ma10q_dedicated_actor_runner.py
+++ b/scripts/ao_ma10q_dedicated_actor_runner.py
@@ -220,12 +220,12 @@ def run(
             "mode": "0700",
             "path_recorded": False,
         }
-        result["producer_token_env"] = token_env
+        result["producer_token_env"] = governance_token_env if governance_wrapper_created else token_env
         result["producer_wrapper"] = {
-            "created": False,
-            "mode": None,
+            "created": governance_wrapper_created,
+            "mode": "0700" if governance_wrapper_created else None,
             "path_recorded": False,
-            "same_as_merge_actor_wrapper": True,
+            "same_as_merge_actor_wrapper": not governance_wrapper_created,
         }
 
         command = [
@@ -250,6 +250,7 @@ def run(
         ]
         if governance_wrapper_created:
             command.extend(["--governance-gh-bin", str(governance_wrapper)])
+            command.extend(["--producer-gh-bin", str(governance_wrapper)])
         if execute:
             command.append("--execute")
             if confirmation is not None:
@@ -289,10 +290,18 @@ def run(
             pr_producer: dict[str, Any] = raw_pr_producer if isinstance(raw_pr_producer, dict) else {}
             producer_role = pr_producer.get("role")
             producer_same_as_merge_actor = pr_producer.get("same_as_merge_actor")
-            if producer_role != "merge_actor":
-                blockers.append(f"producer_not_merge_actor: {producer_role}")
-            if producer_same_as_merge_actor is not True:
-                blockers.append("producer_not_same_as_merge_actor")
+            producer_release_authority = pr_producer.get("release_authority")
+            producer_allowed_operations = pr_producer.get("allowed_operations")
+            if producer_role not in {"merge_actor", "governance_producer"}:
+                blockers.append(f"producer_role_invalid: {producer_role}")
+            if producer_role == "merge_actor" and producer_same_as_merge_actor is not True:
+                blockers.append("producer_merge_actor_role_mismatch")
+            if producer_role == "governance_producer" and producer_same_as_merge_actor is not False:
+                blockers.append("producer_governance_role_mismatch")
+            if producer_release_authority is not False:
+                blockers.append("producer_release_authority_observed")
+            if producer_allowed_operations != ["base_ref_read", "branch_create", "file_create", "pr_create"]:
+                blockers.append("producer_allowed_operations_mismatch")
             raw_smoke_decision = smoke_result.get("decision")
             smoke_decision: dict[str, Any] = raw_smoke_decision if isinstance(raw_smoke_decision, dict) else {}
             blockers.extend(item for item in smoke_decision.get("blockers", []) if isinstance(item, str))

--- a/scripts/ao_ma10q_dedicated_actor_runner.py
+++ b/scripts/ao_ma10q_dedicated_actor_runner.py
@@ -292,8 +292,14 @@ def run(
             producer_same_as_merge_actor = pr_producer.get("same_as_merge_actor")
             producer_release_authority = pr_producer.get("release_authority")
             producer_allowed_operations = pr_producer.get("allowed_operations")
+            expected_producer_role = "governance_producer" if governance_wrapper_created else "merge_actor"
+            expected_same_as_merge_actor = not governance_wrapper_created
             if producer_role not in {"merge_actor", "governance_producer"}:
                 blockers.append(f"producer_role_invalid: {producer_role}")
+            if producer_role != expected_producer_role:
+                blockers.append("producer_role_execution_context_mismatch")
+            if producer_same_as_merge_actor is not expected_same_as_merge_actor:
+                blockers.append("producer_same_actor_execution_context_mismatch")
             if producer_role == "merge_actor" and producer_same_as_merge_actor is not True:
                 blockers.append("producer_merge_actor_role_mismatch")
             if producer_role == "governance_producer" and producer_same_as_merge_actor is not False:

--- a/scripts/ao_ma10r_dedicated_actor_credential_doctor.py
+++ b/scripts/ao_ma10r_dedicated_actor_credential_doctor.py
@@ -27,6 +27,7 @@ DEFAULT_REPO = "Halildeu/ao-kernel"
 DEFAULT_BASE_REF = "main"
 DEFAULT_EXPECTED_ACTOR = "gladyatore-lab"
 DEFAULT_TOKEN_ENV = "GLADYATORE_LAB_GH_TOKEN"
+DEFAULT_BRANCH_WRITE_PROBE_TOKEN_ENV = DEFAULT_TOKEN_ENV
 BRANCH_PROBE_PREFIX = "codex/ao-ma10r-token-probe"
 TOKEN_ENV_RE = re.compile(r"[A-Z_][A-Z0-9_]*")
 WRITE_CAPABLE_LEVELS = {"write", "maintain"}
@@ -66,6 +67,8 @@ def _base_result(*, repo: str, expected_actor: str, token_env: str) -> dict[str,
         },
         "branch_write_probe": {
             "requested": False,
+            "token_env": None,
+            "token_role": None,
             "branch": None,
             "base_ref": None,
             "create_result": "not_requested",
@@ -175,6 +178,8 @@ def _run_branch_write_probe(
     base_ref: str,
     gh_bin: str,
     env: Mapping[str, str],
+    probe_token_env: str,
+    probe_token_role: str,
     runner: Runner,
     result: dict[str, Any],
     blockers: set[str],
@@ -182,6 +187,8 @@ def _run_branch_write_probe(
     branch = f"{BRANCH_PROBE_PREFIX}-{datetime.now(UTC).strftime('%Y%m%d%H%M%S%f')}"
     probe = {
         "requested": True,
+        "token_env": probe_token_env,
+        "token_role": probe_token_role,
         "branch": branch,
         "base_ref": base_ref,
         "create_result": "not_attempted",
@@ -262,12 +269,15 @@ def run(
     base_ref: str,
     expected_actor: str,
     token_env: str,
+    branch_write_probe_token_env: str | None,
     gh_bin: str,
     output: Path,
     branch_write_probe: bool,
     runner: Runner = _run,
 ) -> dict[str, Any]:
     _validate_token_env_name(token_env)
+    effective_probe_token_env = branch_write_probe_token_env or token_env
+    _validate_token_env_name(effective_probe_token_env)
     result = _base_result(repo=repo, expected_actor=expected_actor, token_env=token_env)
     blockers: set[str] = set()
     warnings: set[str] = set()
@@ -338,15 +348,33 @@ def run(
         "admin_permission_observed": admin_permission_observed,
     }
     if branch_write_probe and not blockers:
-        _run_branch_write_probe(
-            repo=repo,
-            base_ref=base_ref,
-            gh_bin=gh_bin,
-            env=env,
-            runner=runner,
-            result=result,
-            blockers=blockers,
-        )
+        probe_token = os.environ.get(effective_probe_token_env)
+        probe_token_role = "merge_actor" if effective_probe_token_env == token_env else "producer"
+        if not probe_token:
+            blockers.add("branch_write_probe_token_env_missing")
+            result["branch_write_probe"] = {
+                "requested": True,
+                "token_env": effective_probe_token_env,
+                "token_role": probe_token_role,
+                "branch": None,
+                "base_ref": base_ref,
+                "create_result": "blocked",
+                "delete_result": "not_attempted",
+            }
+        else:
+            probe_env = dict(os.environ)
+            probe_env[github_token_var] = probe_token
+            _run_branch_write_probe(
+                repo=repo,
+                base_ref=base_ref,
+                gh_bin=gh_bin,
+                env=probe_env,
+                probe_token_env=effective_probe_token_env,
+                probe_token_role=probe_token_role,
+                runner=runner,
+                result=result,
+                blockers=blockers,
+            )
     _set_decision(result, blockers, warnings)
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -359,6 +387,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--base-ref", default=DEFAULT_BASE_REF)
     parser.add_argument("--expected-actor", default=DEFAULT_EXPECTED_ACTOR)
     parser.add_argument("--token-env", default=DEFAULT_TOKEN_ENV)
+    parser.add_argument(
+        "--branch-write-probe-token-env",
+        default=DEFAULT_BRANCH_WRITE_PROBE_TOKEN_ENV,
+        help=(
+            "Environment variable used only for the execute-mode branch-write probe. "
+            "Defaults to --token-env; set to AO_GOVERNANCE_GH_TOKEN when the "
+            "disposable PR producer is split from the dedicated merge actor."
+        ),
+    )
     parser.add_argument("--gh-bin", default="gh")
     parser.add_argument("--output", required=True)
     parser.add_argument(
@@ -374,6 +411,7 @@ def main(argv: list[str] | None = None) -> int:
         base_ref=args.base_ref,
         expected_actor=args.expected_actor,
         token_env=args.token_env,
+        branch_write_probe_token_env=args.branch_write_probe_token_env,
         gh_bin=args.gh_bin,
         output=Path(args.output),
         branch_write_probe=args.branch_write_probe,

--- a/tests/test_ao_ma10q_dedicated_actor_runner.py
+++ b/tests/test_ao_ma10q_dedicated_actor_runner.py
@@ -254,7 +254,14 @@ def test_ao_ma10q_uses_optional_governance_wrapper_without_recording_secret_or_p
     monkeypatch.setenv(GOVERNANCE_TOKEN_ENV, GOVERNANCE_TOKEN_VALUE)
     mod = _load_script_module()
     output = tmp_path / "ao-ma10q.json"
-    runner = FakeSmokeRunner(_smoke_payload(result="merged", mutated=True))
+    runner = FakeSmokeRunner(
+        _smoke_payload(
+            result="merged",
+            mutated=True,
+            producer_role="governance_producer",
+            producer_same_as_merge_actor=False,
+        )
+    )
 
     result = cast(
         dict[str, Any],
@@ -296,6 +303,45 @@ def test_ao_ma10q_uses_optional_governance_wrapper_without_recording_secret_or_p
     }
     assert result["decision"]["result"] == "merged"
     assert runner.timeouts == [180]
+
+
+def test_ao_ma10q_blocks_split_context_if_smoke_reports_merge_actor_producer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(TOKEN_ENV, TOKEN_VALUE)
+    monkeypatch.setenv(GOVERNANCE_TOKEN_ENV, GOVERNANCE_TOKEN_VALUE)
+    mod = _load_script_module()
+    output = tmp_path / "ao-ma10q.json"
+    runner = FakeSmokeRunner(_smoke_payload(result="merged", mutated=True))
+
+    result = cast(
+        dict[str, Any],
+        mod.run(
+            repo="Halildeu/ao-kernel",
+            base_ref="main",
+            expected_actor="gladyatore-lab",
+            token_env=TOKEN_ENV,
+            governance_token_env=GOVERNANCE_TOKEN_ENV,
+            base_gh_bin="gh",
+            output=output,
+            execute=True,
+            confirmation="AO-MA-10L-EXECUTE",
+            timeout_seconds=0,
+            poll_seconds=1,
+            runner=runner,
+        ),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["producer_token_env"] == GOVERNANCE_TOKEN_ENV
+    assert result["producer_wrapper"]["same_as_merge_actor_wrapper"] is False
+    assert result["smoke_result"]["pr_producer"]["role"] == "merge_actor"
+    assert result["decision"]["result"] == "blocked"
+    assert result["decision"]["blockers"] == [
+        "producer_role_execution_context_mismatch",
+        "producer_same_actor_execution_context_mismatch",
+    ]
+    assert result["mutations_performed"] is True
 
 
 def test_ao_ma10q_accepts_bounded_governance_producer_without_release_authority(

--- a/tests/test_ao_ma10q_dedicated_actor_runner.py
+++ b/tests/test_ao_ma10q_dedicated_actor_runner.py
@@ -43,6 +43,8 @@ def _smoke_payload(
     mutated: bool = True,
     producer_role: str = "merge_actor",
     producer_same_as_merge_actor: bool = True,
+    producer_release_authority: bool = False,
+    producer_allowed_operations: list[str] | None = None,
 ) -> dict[str, Any]:
     blockers = [blocker] if blocker else []
     return {
@@ -52,8 +54,10 @@ def _smoke_payload(
         "pr_producer": {
             "role": producer_role,
             "same_as_merge_actor": producer_same_as_merge_actor,
-            "release_authority": False,
-            "allowed_operations": ["base_ref_read", "branch_create", "file_create", "pr_create"],
+            "release_authority": producer_release_authority,
+            "allowed_operations": producer_allowed_operations
+            if producer_allowed_operations is not None
+            else ["base_ref_read", "branch_create", "file_create", "pr_create"],
         },
         "decision": {
             "result": result,
@@ -272,24 +276,29 @@ def test_ao_ma10q_uses_optional_governance_wrapper_without_recording_secret_or_p
 
     Draft202012Validator(_schema()).validate(result)
     assert "--governance-gh-bin" in runner.commands[0]
+    assert "--producer-gh-bin" in runner.commands[0]
     assert runner.commands[0][runner.commands[0].index("--governance-gh-bin") + 1].startswith("/tmp/")
-    assert "--producer-gh-bin" not in runner.commands[0]
+    assert runner.commands[0][runner.commands[0].index("--producer-gh-bin") + 1].startswith("/tmp/")
+    assert (
+        runner.commands[0][runner.commands[0].index("--producer-gh-bin") + 1]
+        == runner.commands[0][runner.commands[0].index("--governance-gh-bin") + 1]
+    )
     artifact_text = output.read_text(encoding="utf-8")
     assert TOKEN_VALUE not in artifact_text
     assert GOVERNANCE_TOKEN_VALUE not in artifact_text
-    assert result["smoke_command"].count("<temporary-gh-wrapper>") == 2
-    assert result["producer_token_env"] == TOKEN_ENV
+    assert result["smoke_command"].count("<temporary-gh-wrapper>") == 3
+    assert result["producer_token_env"] == GOVERNANCE_TOKEN_ENV
     assert result["producer_wrapper"] == {
-        "created": False,
-        "mode": None,
+        "created": True,
+        "mode": "0700",
         "path_recorded": False,
-        "same_as_merge_actor_wrapper": True,
+        "same_as_merge_actor_wrapper": False,
     }
     assert result["decision"]["result"] == "merged"
     assert runner.timeouts == [180]
 
 
-def test_ao_ma10q_blocks_if_delegated_smoke_reports_governance_producer(
+def test_ao_ma10q_accepts_bounded_governance_producer_without_release_authority(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv(TOKEN_ENV, TOKEN_VALUE)
@@ -324,12 +333,50 @@ def test_ao_ma10q_blocks_if_delegated_smoke_reports_governance_producer(
     )
 
     Draft202012Validator(_schema()).validate(result)
-    assert "--producer-gh-bin" not in runner.commands[0]
+    assert "--producer-gh-bin" in runner.commands[0]
+    assert result["decision"]["result"] == "merged"
+    assert result["decision"]["blockers"] == []
+    assert result["mutations_performed"] is True
+
+
+def test_ao_ma10q_blocks_if_split_producer_claims_release_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(TOKEN_ENV, TOKEN_VALUE)
+    monkeypatch.setenv(GOVERNANCE_TOKEN_ENV, GOVERNANCE_TOKEN_VALUE)
+    mod = _load_script_module()
+    output = tmp_path / "ao-ma10q.json"
+    runner = FakeSmokeRunner(
+        _smoke_payload(
+            result="merged",
+            mutated=True,
+            producer_role="governance_producer",
+            producer_same_as_merge_actor=False,
+            producer_release_authority=True,
+        )
+    )
+
+    result = cast(
+        dict[str, Any],
+        mod.run(
+            repo="Halildeu/ao-kernel",
+            base_ref="main",
+            expected_actor="gladyatore-lab",
+            token_env=TOKEN_ENV,
+            governance_token_env=GOVERNANCE_TOKEN_ENV,
+            base_gh_bin="gh",
+            output=output,
+            execute=True,
+            confirmation="AO-MA-10L-EXECUTE",
+            timeout_seconds=0,
+            poll_seconds=1,
+            runner=runner,
+        ),
+    )
+
+    Draft202012Validator(_schema()).validate(result)
     assert result["decision"]["result"] == "blocked"
-    assert result["decision"]["blockers"] == [
-        "producer_not_merge_actor: governance_producer",
-        "producer_not_same_as_merge_actor",
-    ]
+    assert result["decision"]["blockers"] == ["producer_release_authority_observed"]
     assert result["mutations_performed"] is True
 
 

--- a/tests/test_ao_ma10r_dedicated_actor_credential_doctor.py
+++ b/tests/test_ao_ma10r_dedicated_actor_credential_doctor.py
@@ -18,7 +18,9 @@ DOC = ROOT / ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md"
 RECEIPT = ROOT / ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json"
 SCHEMA_NAME = "ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json"
 TOKEN_ENV = "GLADYATORE_LAB_GH_TOKEN"
+PRODUCER_TOKEN_ENV = "AO_GOVERNANCE_GH_TOKEN"
 TOKEN_VALUE = "VALUE_NOT_IN_ARTIFACT"
+PRODUCER_TOKEN_VALUE = "PRODUCER_VALUE_NOT_IN_ARTIFACT"
 
 
 def _schema() -> dict[str, Any]:
@@ -83,13 +85,19 @@ def _run_doctor(
     runner: FakeGitHubRunner,
     *,
     token_value: str | None = TOKEN_VALUE,
+    producer_token_value: str | None = None,
     expected_actor: str = "gladyatore-lab",
     branch_write_probe: bool = False,
+    branch_write_probe_token_env: str | None = None,
 ) -> dict[str, Any]:
     if token_value is None:
         monkeypatch.delenv(TOKEN_ENV, raising=False)
     else:
         monkeypatch.setenv(TOKEN_ENV, token_value)
+    if producer_token_value is None:
+        monkeypatch.delenv(PRODUCER_TOKEN_ENV, raising=False)
+    else:
+        monkeypatch.setenv(PRODUCER_TOKEN_ENV, producer_token_value)
     mod = _load_script_module()
     return cast(
         dict[str, Any],
@@ -98,6 +106,7 @@ def _run_doctor(
             base_ref="main",
             expected_actor=expected_actor,
             token_env=TOKEN_ENV,
+            branch_write_probe_token_env=branch_write_probe_token_env,
             gh_bin="gh",
             output=tmp_path / "ao-ma10r.json",
             branch_write_probe=branch_write_probe,
@@ -124,9 +133,12 @@ def test_ao_ma10r_doc_and_receipt_preserve_no_secret_authority_boundary() -> Non
     assert receipt["token_value_recorded"] is False
     assert receipt["mutations_performed"] == "read_only_by_default_true_only_for_execute_mode_branch_write_probe"
     assert receipt["default_token_env"] == TOKEN_ENV
+    assert receipt["default_branch_write_probe_token_env"] == TOKEN_ENV
+    assert receipt["split_producer_branch_write_probe_token_env"] == PRODUCER_TOKEN_ENV
     assert "never accepts token values as CLI arguments" in text
     assert "Release authority remains the repo-owned" in text
     assert "--branch-write-probe" in text
+    assert "--branch-write-probe-token-env" in text
 
 
 def test_ao_ma10r_missing_token_env_blocks_before_github_calls(
@@ -151,6 +163,7 @@ def test_ao_ma10r_rejects_invalid_token_env_name(tmp_path: Path) -> None:
             base_ref="main",
             expected_actor="gladyatore-lab",
             token_env="bad-token-env",
+            branch_write_probe_token_env=None,
             gh_bin="gh",
             output=tmp_path / "ao-ma10r.json",
             branch_write_probe=False,
@@ -179,6 +192,8 @@ def test_ao_ma10r_happy_path_ready_without_recording_secret_or_mutating(
     assert result["mutations_performed"] is False
     assert result["branch_write_probe"] == {
         "requested": False,
+        "token_env": None,
+        "token_role": None,
         "branch": None,
         "base_ref": None,
         "create_result": "not_requested",
@@ -204,6 +219,8 @@ def test_ao_ma10r_branch_write_probe_creates_and_deletes_temp_branch(
     assert result["mutations_performed"] is True
     probe = result["branch_write_probe"]
     assert probe["requested"] is True
+    assert probe["token_env"] == TOKEN_ENV
+    assert probe["token_role"] == "merge_actor"
     assert probe["base_ref"] == "main"
     assert probe["branch"].startswith("codex/ao-ma10r-token-probe-")
     assert probe["create_result"] == "created"
@@ -214,6 +231,64 @@ def test_ao_ma10r_branch_write_probe_creates_and_deletes_temp_branch(
         and command[2].startswith("repos/Halildeu/ao-kernel/git/refs/heads/codex/ao-ma10r-token-probe-")
         for command in result["commands"]
     )
+    assert any(env.get("GH_TOKEN") == TOKEN_VALUE for env in runner.envs[-3:])
+
+
+def test_ao_ma10r_branch_write_probe_can_use_split_producer_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = FakeGitHubRunner()
+    result = _run_doctor(
+        tmp_path,
+        monkeypatch,
+        runner,
+        producer_token_value=PRODUCER_TOKEN_VALUE,
+        branch_write_probe=True,
+        branch_write_probe_token_env=PRODUCER_TOKEN_ENV,
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    artifact_text = (tmp_path / "ao-ma10r.json").read_text(encoding="utf-8")
+    assert TOKEN_VALUE not in artifact_text
+    assert PRODUCER_TOKEN_VALUE not in artifact_text
+    assert result["decision"]["result"] == "credential_ready"
+    assert result["mutations_performed"] is True
+    assert result["actor"]["login"] == "gladyatore-lab"
+    probe = result["branch_write_probe"]
+    assert probe["requested"] is True
+    assert probe["token_env"] == PRODUCER_TOKEN_ENV
+    assert probe["token_role"] == "producer"
+    assert probe["create_result"] == "created"
+    assert probe["delete_result"] == "deleted"
+    assert runner.envs[0].get("GH_TOKEN") == TOKEN_VALUE
+    assert any(env.get("GH_TOKEN") == PRODUCER_TOKEN_VALUE for env in runner.envs[-3:])
+
+
+def test_ao_ma10r_branch_write_probe_blocks_missing_split_producer_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = FakeGitHubRunner()
+    result = _run_doctor(
+        tmp_path,
+        monkeypatch,
+        runner,
+        branch_write_probe=True,
+        branch_write_probe_token_env=PRODUCER_TOKEN_ENV,
+    )
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "blocked"
+    assert result["decision"]["blockers"] == ["branch_write_probe_token_env_missing"]
+    assert result["mutations_performed"] is False
+    assert result["branch_write_probe"] == {
+        "requested": True,
+        "token_env": PRODUCER_TOKEN_ENV,
+        "token_role": "producer",
+        "branch": None,
+        "base_ref": "main",
+        "create_result": "blocked",
+        "delete_result": "not_attempted",
+    }
 
 
 def test_ao_ma10r_branch_write_probe_blocks_base_ref_read_failure(

--- a/tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py
+++ b/tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py
@@ -85,6 +85,7 @@ def test_ao_ma10s_workflow_runs_doctor_before_runner_and_uploads_artifacts() -> 
     assert "actions/upload-artifact@v7" in text
     assert "if: always()" in text
     assert "if-no-files-found: error" in text
+    assert "--branch-write-probe-token-env AO_GOVERNANCE_GH_TOKEN" in text
 
 
 def test_ao_ma10s_workflow_skips_runner_when_doctor_fails() -> None:
@@ -112,7 +113,7 @@ def test_ao_ma10s_doc_and_receipt_preserve_authority_boundary() -> None:
     assert receipt["allowed_ref"] == "refs/heads/main"
     assert receipt["secret_env"] == "GLADYATORE_LAB_GH_TOKEN"
     assert receipt["governance_secret_env"] == "AO_GOVERNANCE_GH_TOKEN"
-    assert receipt["producer_secret_env"] == "GLADYATORE_LAB_GH_TOKEN"
+    assert receipt["producer_secret_env"] == "AO_GOVERNANCE_GH_TOKEN"
     assert receipt["producer_release_authority"] is False
     assert receipt["token_value_recorded"] is False
     assert receipt["release_authority"] == "ao-release-gate+github-ruleset"


### PR DESCRIPTION
## Summary

This PR fixes the AO-MA-10Q execute-mode failure where the dedicated merge actor token was being used for the branch-write readiness probe.

The visible GitHub token permissions already looked correct, but the live API evidence was different: `POST /git/refs` returned 403 for the dedicated actor token. The correction is to use the governance/producer token for disposable branch/PR production capability while keeping merge authority unchanged.

## What changed

- `ao-ma10q-dedicated-actor-smoke.yml` now runs the credential doctor with:
  - dedicated actor token for actor/readiness identity
  - `AO_GOVERNANCE_GH_TOKEN` for branch-write probe only
- `ao_ma10r_dedicated_actor_credential_doctor.py` records branch probe token role/env metadata without recording token values.
- `ao_ma10q_dedicated_actor_runner.py` passes the governance wrapper as `--producer-gh-bin` and accepts `governance_producer` only when:
  - `release_authority=false`
  - `allowed_operations == ["base_ref_read", "branch_create", "file_create", "pr_create"]`
- Schema, receipts, docs, and tests were updated to describe the split.

## Security boundary

- Merge actor remains `gladyatore-lab` / `GLADYATORE_LAB_GH_TOKEN`.
- Release authority remains repo-owned `ao-release-gate` required check plus GitHub ruleset.
- Governance token is only a disposable PR producer/probe token.
- No token values are logged or persisted in artifacts.
- No support widening, production claim, or live adapter execution.

## Validation

- `pytest -q tests/test_ao_ma10r_dedicated_actor_credential_doctor.py tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10l_autonomous_smoke.py tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py` → 48 passed
- `ruff check ...` → pass
- `mypy scripts/ao_ma10r_dedicated_actor_credential_doctor.py scripts/ao_ma10q_dedicated_actor_runner.py scripts/ao_ma10l_autonomous_smoke.py` → pass
- JSON receipts/schema validate with `python3 -m json.tool`
- `git diff --check` → clean
- `gitleaks protect --staged --no-banner --redact` → no leaks

## Post-merge expected smoke

After this lands, rerun AO-MA-10Q execute smoke on `main`. Expected change:

- credential doctor `branch_write_probe.token_env == AO_GOVERNANCE_GH_TOKEN`
- `branch_write_probe.token_role == producer`
- branch create/delete succeeds using the producer token
- merge authority remains the dedicated actor path
