### PR TITLE
fix(ao-ma-10): make governance wrapper test tempdir portable

### DIFF
--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -13,14 +13,6 @@
       "status": "pass"
     },
     {
-      "name": "mypy",
-      "status": "pass"
-    },
-    {
-      "name": "json_parse",
-      "status": "pass"
-    },
-    {
       "name": "diff_check",
       "status": "pass"
     },
@@ -30,15 +22,11 @@
     }
   ],
   "findings": [
-    "Claude reviewer verdict AGREE on PR #716 producer-branch-probe split.",
-    "The branch-write probe now uses AO_GOVERNANCE_GH_TOKEN as a literal token-env name for disposable branch/PR production, while actor identity checks still use GLADYATORE_LAB_GH_TOKEN.",
-    "Merge authority remains the dedicated actor path and release authority remains ao-release-gate plus GitHub ruleset.",
-    "The runner now fails closed when delegated pr_producer evidence contradicts the execution context.",
-    "Governance producer mode is accepted only when release_authority is false and allowed_operations exactly equals base_ref_read, branch_create, file_create, and pr_create.",
-    "Token values remain environment-only and are not accepted as CLI arguments or recorded in artifacts.",
-    "The workflow passes --branch-write-probe-token-env AO_GOVERNANCE_GH_TOKEN as a literal env-var name, not a token value.",
-    "Schema, docs, workflow wiring, and tests are aligned with the split producer contract.",
-    "No branch protection mutation, admin bypass, support widening, production platform claim, live adapter execution, or secret material is introduced."
+    "Claude reviewer verdict AGREE on AO-MA-10Z Darwin tempdir portability fix.",
+    "The failing assertion assumed tempfile paths start with /tmp, which is false on macOS where temporary paths commonly resolve under /var/folders or /private/var/folders.",
+    "The test now asserts the generated wrapper basename is gh-governance and preserves the stronger invariant that --governance-gh-bin and --producer-gh-bin point to the same wrapper.",
+    "Path is already imported in the file, so the updated assertion introduces no missing import.",
+    "The patch changes only test assertions and does not change runtime behavior, workflow behavior, branch protection, release authority, support tier, production claim, live adapter execution, or secret handling."
   ],
   "implementer": {
     "agent": "codex",
@@ -56,23 +44,12 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md",
-      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md",
-      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json",
-      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md",
-      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json",
-      ".github/workflows/ao-ma10q-dedicated-actor-smoke.yml",
-      "ao_kernel/defaults/schemas/ao-ma-10r-dedicated-actor-credential-doctor-result.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10q_dedicated_actor_runner.py",
-      "scripts/ao_ma10r_dedicated_actor_credential_doctor.py",
-      "tests/test_ao_ma10q_dedicated_actor_runner.py",
-      "tests/test_ao_ma10r_dedicated_actor_credential_doctor.py",
-      "tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py"
+      "tests/test_ao_ma10q_dedicated_actor_runner.py"
     ],
-    "head_ref": "refs/heads/codex/ao-ma10y-producer-probe"
+    "head_ref": "refs/heads/codex/ao-ma10z-darwin-tempdir-test-fix"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-MA-10Y"
+  "work_package": "AO-MA-10Z"
 }

--- a/tests/test_ao_ma10q_dedicated_actor_runner.py
+++ b/tests/test_ao_ma10q_dedicated_actor_runner.py
@@ -284,11 +284,13 @@ def test_ao_ma10q_uses_optional_governance_wrapper_without_recording_secret_or_p
     Draft202012Validator(_schema()).validate(result)
     assert "--governance-gh-bin" in runner.commands[0]
     assert "--producer-gh-bin" in runner.commands[0]
-    assert runner.commands[0][runner.commands[0].index("--governance-gh-bin") + 1].startswith("/tmp/")
-    assert runner.commands[0][runner.commands[0].index("--producer-gh-bin") + 1].startswith("/tmp/")
+    governance_wrapper = runner.commands[0][runner.commands[0].index("--governance-gh-bin") + 1]
+    producer_wrapper = runner.commands[0][runner.commands[0].index("--producer-gh-bin") + 1]
+    assert Path(governance_wrapper).name == "gh-governance"
+    assert Path(producer_wrapper).name == "gh-governance"
     assert (
-        runner.commands[0][runner.commands[0].index("--producer-gh-bin") + 1]
-        == runner.commands[0][runner.commands[0].index("--governance-gh-bin") + 1]
+        producer_wrapper
+        == governance_wrapper
     )
     artifact_text = output.read_text(encoding="utf-8")
     assert TOKEN_VALUE not in artifact_text


### PR DESCRIPTION
## Summary

Fixes a post-merge local macOS test failure from PR #716. The test assumed temporary wrapper paths start with `/tmp/`; on macOS `tempfile.mkdtemp()` commonly resolves under `/var/folders` or `/private/var/folders`.

## Changes

- Replaces `/tmp/` prefix assertions with `Path(...).name == "gh-governance"`.
- Preserves the important invariant that `--governance-gh-bin` and `--producer-gh-bin` point to the same wrapper.
- Updates root `local-ai-review-evidence.v1.json` with Claude AGREE evidence for the one-file portability patch.

## Validation

- `pytest -q tests/test_ao_ma10q_dedicated_actor_runner.py` -> 13 passed
- `pytest -q tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_local_gpp_gate.py` -> 69 passed
- `ruff check tests/test_ao_ma10q_dedicated_actor_runner.py` -> pass
- `python3 -m json.tool local-ai-review-evidence.v1.json` -> pass
- `git diff --check` -> pass
- `gitleaks protect --staged --no-banner --redact` -> no leaks
- `python3 scripts/local_gpp_gate.py ... AO-MA-10Z ...` -> `operator_may_merge`

## Guardrails

No runtime behavior change, no branch protection change, no admin bypass, no support widening, no production platform claim, no live adapter execution, no secret material.