### PR TITLE
fix(ao-ma-10): wait for required checks discovery

### DIFF
--- a/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md
+++ b/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md
@@ -95,9 +95,10 @@ When A0/A1 are ready and explicit confirmation is present, the orchestrator:
    `docs/evidence/ao-ma-10l-autonomous-smoke/`;
 3. opens a disposable PR through the selected PR producer runtime;
 4. waits for required checks, including `ao-release-gate-technical` and
-   `ao-release-gate-review`; GitHub's initial `no checks reported` response
-   immediately after PR creation is treated as transient inside the polling
-   window, but any timeout or real API/read failure remains fail-closed;
+   `ao-release-gate-review`; GitHub's initial `no checks reported` or
+   `no required checks reported` response immediately after PR creation is
+   treated as transient inside the polling window, but any timeout or real
+   API/read failure remains fail-closed;
 5. refreshes A0/A1;
 6. delegates the actual merge to `scripts/ao_ma10c_merge_agent.py`.
 

--- a/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json
+++ b/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json
@@ -16,7 +16,10 @@
   "supports_split_pr_producer_runtime": true,
   "producer_gh_runtime_argument": "--producer-gh-bin",
   "waits_for_initial_check_suite": true,
-  "initial_no_checks_reported_is_transient": true,
+  "transient_check_discovery_errors": [
+    "no checks reported",
+    "no required checks reported"
+  ],
   "producer_release_authority": false,
   "producer_allowed_operations": [
     "base_ref_read",

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -13,6 +13,14 @@
       "status": "pass"
     },
     {
+      "name": "json_parse",
+      "status": "pass"
+    },
+    {
+      "name": "py_compile",
+      "status": "pass"
+    },
+    {
       "name": "diff_check",
       "status": "pass"
     },
@@ -22,11 +30,12 @@
     }
   ],
   "findings": [
-    "Claude reviewer verdict AGREE on AO-MA-10Z Darwin tempdir portability fix.",
-    "The failing assertion assumed tempfile paths start with /tmp, which is false on macOS where temporary paths commonly resolve under /var/folders or /private/var/folders.",
-    "The test now asserts the generated wrapper basename is gh-governance and preserves the stronger invariant that --governance-gh-bin and --producer-gh-bin point to the same wrapper.",
-    "Path is already imported in the file, so the updated assertion introduces no missing import.",
-    "The patch changes only test assertions and does not change runtime behavior, workflow behavior, branch protection, release authority, support tier, production claim, live adapter execution, or secret handling."
+    "Claude reviewer verdict REVISE, then AGREE after absorption.",
+    "The live execute smoke failed because GitHub initially returned 'no required checks reported' immediately after disposable PR creation.",
+    "AO-MA-10L now treats both 'no checks reported' and 'no required checks reported' as transient check-discovery strings inside the existing polling window.",
+    "The transient strings are represented in code as TRANSIENT_CHECK_DISCOVERY_ERRORS and in the receipt as transient_check_discovery_errors.",
+    "Parametrized tests cover both transient string variants; unrecognized errors, invalid payloads, and timeouts still fail closed.",
+    "No branch protection mutation, release authority change, support widening, production platform claim, live adapter execution, or secret material is introduced."
   ],
   "implementer": {
     "agent": "codex",
@@ -44,12 +53,15 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
+      ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md",
+      ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_ao_ma10q_dedicated_actor_runner.py"
+      "scripts/ao_ma10l_autonomous_smoke.py",
+      "tests/test_ao_ma10l_autonomous_smoke.py"
     ],
-    "head_ref": "refs/heads/codex/ao-ma10z-darwin-tempdir-test-fix"
+    "head_ref": "refs/heads/codex/ao-ma10aa-wait-initial-checks"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-MA-10Z"
+  "work_package": "AO-MA-10AA"
 }

--- a/scripts/ao_ma10l_autonomous_smoke.py
+++ b/scripts/ao_ma10l_autonomous_smoke.py
@@ -412,10 +412,19 @@ def _required_checks_passed(raw_checks: list[Any]) -> tuple[bool, list[dict[str,
     return not failing, failing
 
 
+TRANSIENT_CHECK_DISCOVERY_ERRORS = (
+    "no checks reported",
+    "no required checks reported",
+)
+
+
 def _checks_not_reported_yet(error: str | None) -> bool:
     """Return true for GitHub's transient post-PR check-suite delay."""
 
-    return isinstance(error, str) and "no checks reported" in error.lower()
+    if not isinstance(error, str):
+        return False
+    normalized = error.lower()
+    return any(fragment in normalized for fragment in TRANSIENT_CHECK_DISCOVERY_ERRORS)
 
 
 def _wait_for_required_checks(

--- a/tests/test_ao_ma10l_autonomous_smoke.py
+++ b/tests/test_ao_ma10l_autonomous_smoke.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 from jsonschema import Draft202012Validator
 
 from ao_kernel.config import load_default
@@ -139,12 +140,14 @@ class FakeRunner:
         ready: bool = True,
         checks_pass: bool = True,
         checks_transient_failures: int = 0,
+        checks_transient_error: str = "no checks reported on the 'codex/ao-ma10l-smoke-example' branch",
         gh_bin: str = "gh",
         producer_gh_bin: str | None = None,
     ) -> None:
         self.ready = ready
         self.checks_pass = checks_pass
         self.checks_transient_failures = checks_transient_failures
+        self.checks_transient_error = checks_transient_error
         self.gh_bin = gh_bin
         self.producer_gh_bin = producer_gh_bin or gh_bin
         self.commands: list[list[str]] = []
@@ -176,7 +179,7 @@ class FakeRunner:
                     command,
                     1,
                     "",
-                    "no checks reported on the 'codex/ao-ma10l-smoke-example' branch",
+                    self.checks_transient_error,
                 )
             checks = (
                 [
@@ -412,8 +415,15 @@ def test_ao_ma10l_can_split_disposable_pr_producer_from_merge_actor(tmp_path: Pa
     assert merge_agent_commands[0][merge_agent_commands[0].index("--gh-bin") + 1] == "gh-dedicated"
 
 
-def test_ao_ma10l_waits_for_initial_required_checks_to_appear(tmp_path: Path) -> None:
-    fake = FakeRunner(ready=True, checks_transient_failures=1)
+@pytest.mark.parametrize(
+    "transient_error",
+    [
+        "no checks reported on the 'codex/ao-ma10l-smoke-example' branch",
+        "no required checks reported on the 'codex/ao-ma10l-smoke-example' branch",
+    ],
+)
+def test_ao_ma10l_waits_for_initial_required_checks_to_appear(tmp_path: Path, transient_error: str) -> None:
+    fake = FakeRunner(ready=True, checks_transient_failures=1, checks_transient_error=transient_error)
     mod = _load_script_module()
     monkeypatch_sleep = mod.time.sleep
     mod.time.sleep = lambda _seconds: None


### PR DESCRIPTION
## Summary

Fixes the live AO-MA-10Q execute smoke blocker from run `26621299732`: after disposable PR creation, GitHub initially returned `no required checks reported ...`; the runner treated that as terminal instead of transient.

## Changes

- Models transient check discovery strings explicitly in `TRANSIENT_CHECK_DISCOVERY_ERRORS`.
- Retries both `no checks reported` and `no required checks reported` inside the existing polling window.
- Keeps unrecognized API/read errors, invalid payloads, and timeouts fail-closed.
- Adds parametrized tests for both transient messages.
- Updates AO-MA-10L markdown/receipt and root cross-provider review evidence.

## Validation

- `pytest -q tests/test_ao_ma10l_autonomous_smoke.py tests/test_ao_ma10q_dedicated_actor_runner.py` -> 25 passed
- `ruff check scripts/ao_ma10l_autonomous_smoke.py tests/test_ao_ma10l_autonomous_smoke.py` -> pass
- `python3 -m json.tool .claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json` -> pass
- `python3 -m py_compile scripts/ao_ma10l_autonomous_smoke.py` -> pass
- `git diff --check` -> pass
- `gitleaks protect --staged --no-banner --redact` -> no leaks
- `python3 scripts/local_gpp_gate.py ... AO-MA-10AA ...` -> `operator_may_merge`
- Claude review: REVISE -> AGREE after absorption

## Guardrails

No branch protection mutation, no release authority change, no support widening, no production platform claim, no live adapter execution, no secret material.