### PR TITLE
fix(ao-ma-10): harden merge-agent live-state reads

### DIFF
--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -30,11 +30,11 @@
     }
   ],
   "findings": [
-    "Live AO-MA-10q execute smoke reached disposable PR #720 and all normal required checks passed, but ao-release-gate denied because the split producer PR author was Halildeu while the narrow smoke exception only accepted gladyatore-lab.",
-    "AO-MA-10AB keeps merge authority with ao-release-gate plus GitHub ruleset and the dedicated non-admin merge actor; it only recognizes Halildeu as the operator-bound governance producer for direct one-file AO-MA-10l smoke PRs.",
-    "The exception remains gated by low_risk_autonomous_merge_requested=true, a valid boolean request flag, no high-risk paths, and every changed path being a direct docs/evidence/ao-ma-10l-autonomous-smoke/*.md file.",
-    "Unknown PR authors still fail closed and require local-gpp-gate review evidence; tests cover gladyatore-lab allow, Halildeu split-producer allow, and unknown-producer deny.",
-    "Claude CLI review returned AGREE and specifically found no fail-open risk, no support widening, no production claim, no live adapter execution, and no branch-protection mutation."
+    "Live AO-MA-10q execute smoke reached disposable PR #722 with credential_ready and all required checks passing, but AO-MA-10c blocked before merge because collaborator permission read returned the known fine-grained PAT 403 and GitHub mergeStateStatus was transiently UNSTABLE before later settling to CLEAN.",
+    "AO-MA-10AC keeps merge authority with ao-release-gate plus GitHub ruleset and the dedicated non-admin merge actor; it only hardens merge-agent live-state collection and does not add admin bypass, native auto-merge, support widening, production claim, or live adapter execution.",
+    "Repo permission fallback is now allowed only for the exact known fine-grained PAT 403 signature; unexpected permission-read failures such as HTTP 500 do not fallback, preserve collection_errors, and fail closed with github_api_read_failed plus merge_actor_not_write.",
+    "Transient mergeStateStatus UNKNOWN/UNSTABLE is retried before merge; non-transient blocked states break immediately, and exhausted transient states still fail closed with pr_merge_state_not_clean.",
+    "OpenAI subagent review first returned REVISE on an overly broad fallback, that finding was absorbed with negative tests, and re-review returned AGREE. Claude CLI reviewer also returned AGREE on the revised patch."
   ],
   "implementer": {
     "agent": "codex",
@@ -52,15 +52,13 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md",
-      ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json",
-      "ao_kernel/ao_release_gate.py",
       "local-ai-review-evidence.v1.json",
-      "tests/test_ao_release_gate.py"
+      "scripts/ao_ma10c_merge_agent.py",
+      "tests/test_ao_ma10c_merge_agent.py"
     ],
-    "head_ref": "refs/heads/codex/ao-ma10ab-split-producer-smoke-scope"
+    "head_ref": "refs/heads/codex/ao-ma10ac-merge-agent-live-state"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-MA-10AB"
+  "work_package": "AO-MA-10AC"
 }

--- a/scripts/ao_ma10c_merge_agent.py
+++ b/scripts/ao_ma10c_merge_agent.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable
@@ -23,8 +24,12 @@ RELEASE_AUTHORITY = "ao-release-gate+github-ruleset"
 DEFAULT_EXPECTED_ACTOR = "gladyatore-lab"
 DEFAULT_BASE_REF = "main"
 DEFAULT_MAX_SNAPSHOT_AGE_SECONDS = 300
+DEFAULT_MERGE_STATE_MAX_ATTEMPTS = 12
+DEFAULT_MERGE_STATE_POLL_SECONDS = 5
 EXECUTE_CONFIRMATION = "AO-MA-10C-EXECUTE"
 FORBIDDEN_ADMIN_FLAG = "--" "admin"
+READY_MERGE_STATES = {"CLEAN", "HAS_HOOKS"}
+TRANSIENT_MERGE_STATES = {"UNKNOWN", "UNSTABLE"}
 
 Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
 
@@ -64,6 +69,30 @@ def _json_command(command: list[str], runner: Runner) -> tuple[dict[str, Any] | 
     return parsed, None
 
 
+def _permission_from_repo_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    permissions = payload.get("permissions")
+    if not isinstance(permissions, dict):
+        return {}
+    if permissions.get("admin") is True:
+        return {"permission": "admin", "role_name": "admin"}
+    if permissions.get("maintain") is True:
+        return {"permission": "maintain", "role_name": "maintain"}
+    if permissions.get("push") is True:
+        return {"permission": "write", "role_name": "write"}
+    if permissions.get("triage") is True:
+        return {"permission": "triage", "role_name": "triage"}
+    if permissions.get("pull") is True:
+        return {"permission": "read", "role_name": "read"}
+    return {}
+
+
+def _permission_fallback_allowed(error: str | None) -> bool:
+    if not error:
+        return False
+    normalized = error.lower()
+    return "resource not accessible by personal access token" in normalized and "http 403" in normalized
+
+
 def _parse_time(value: Any) -> datetime | None:
     if not isinstance(value, str):
         return None
@@ -100,7 +129,15 @@ def merge_command(repo: str, pr_number: int, gh_bin: str = "gh") -> list[str]:
     ]
 
 
-def collect_live_github_state(*, repo: str, pr_number: int, gh_bin: str, runner: Runner = _run) -> dict[str, Any]:
+def collect_live_github_state(
+    *,
+    repo: str,
+    pr_number: int,
+    gh_bin: str,
+    runner: Runner = _run,
+    merge_state_max_attempts: int = DEFAULT_MERGE_STATE_MAX_ATTEMPTS,
+    merge_state_poll_seconds: int = DEFAULT_MERGE_STATE_POLL_SECONDS,
+) -> dict[str, Any]:
     """Collect live GitHub state needed immediately before a merge attempt."""
 
     collection_errors: list[str] = []
@@ -118,26 +155,45 @@ def collect_live_github_state(*, repo: str, pr_number: int, gh_bin: str, runner:
             runner,
         )
         if error is not None or not isinstance(permission_payload, dict):
-            collection_errors.append(f"permission: {error or 'invalid shape'}")
+            if not _permission_fallback_allowed(error):
+                collection_errors.append(f"permission: {error or 'invalid shape'}")
+            else:
+                repo_payload, repo_error = _json_command([gh_bin, "api", f"repos/{repo}"], runner)
+                if repo_error is not None or not isinstance(repo_payload, dict):
+                    collection_errors.append(f"permission: {error or 'invalid shape'}")
+                    collection_errors.append(f"repo_permission_fallback: {repo_error or 'invalid shape'}")
+                else:
+                    permission = _permission_from_repo_payload(repo_payload)
+                    if not permission:
+                        collection_errors.append("repo_permission_fallback: missing permissions")
         else:
             permission = permission_payload
 
-    pr_view, error = _json_command(
-        [
-            gh_bin,
-            "pr",
-            "view",
-            str(pr_number),
-            "--repo",
-            repo,
-            "--json",
-            "state,isDraft,baseRefName,headRefOid,mergeStateStatus",
-        ],
-        runner,
-    )
-    if error is not None or not isinstance(pr_view, dict):
-        collection_errors.append(f"pr_view: {error or 'invalid shape'}")
-        pr_view = {}
+    pr_view: dict[str, Any] = {}
+    attempts = max(1, merge_state_max_attempts)
+    for attempt in range(attempts):
+        payload, error = _json_command(
+            [
+                gh_bin,
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                repo,
+                "--json",
+                "state,isDraft,baseRefName,headRefOid,mergeStateStatus",
+            ],
+            runner,
+        )
+        if error is not None or not isinstance(payload, dict):
+            collection_errors.append(f"pr_view: {error or 'invalid shape'}")
+            pr_view = {}
+            break
+        pr_view = payload
+        merge_state = pr_view.get("mergeStateStatus")
+        if merge_state in READY_MERGE_STATES or merge_state not in TRANSIENT_MERGE_STATES or attempt == attempts - 1:
+            break
+        time.sleep(max(0, merge_state_poll_seconds))
 
     checks, error = _json_command(
         [
@@ -268,7 +324,7 @@ def build_result(
         blockers.add("pr_is_draft")
     if pr_view.get("baseRefName") != base_ref:
         blockers.add("pr_base_not_main")
-    if pr_view.get("mergeStateStatus") not in {"CLEAN", "HAS_HOOKS"}:
+    if pr_view.get("mergeStateStatus") not in READY_MERGE_STATES:
         blockers.add("pr_merge_state_not_clean")
 
     checks_ok, failing_checks = _checks_pass(required_checks_list)

--- a/tests/test_ao_ma10c_merge_agent.py
+++ b/tests/test_ao_ma10c_merge_agent.py
@@ -268,6 +268,145 @@ def test_ao_ma10c_collect_live_state_reads_only() -> None:
     assert " --method DELETE " not in flat
 
 
+def test_ao_ma10c_collect_live_state_falls_back_to_repo_permissions_when_collaborator_permission_403() -> None:
+    mod = _load_script_module()
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "api", "user"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"login": "gladyatore-lab"}), "")
+        if len(command) >= 3 and "/collaborators/" in command[2]:
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                "",
+                "gh: Resource not accessible by personal access token (HTTP 403)",
+            )
+        if command[:3] == ["gh", "api", "repos/Halildeu/ao-kernel"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps({"permissions": {"admin": False, "push": True, "pull": True}}),
+                "",
+            )
+        if command[:3] == ["gh", "pr", "view"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps(_ready_live_state()["pr_view"]), "")
+        if command[:3] == ["gh", "pr", "checks"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps(_ready_live_state()["required_checks"]), "")
+        raise AssertionError(command)
+
+    state = mod.collect_live_github_state(repo="Halildeu/ao-kernel", pr_number=123, gh_bin="gh", runner=fake_runner)
+
+    assert state["collection_errors"] == []
+    assert state["permission"]["permission"] == "write"
+    assert state["permission"]["role_name"] == "write"
+
+
+def test_ao_ma10c_collect_live_state_does_not_fallback_for_unexpected_permission_read_errors() -> None:
+    mod = _load_script_module()
+    repo_fallback_called = False
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        nonlocal repo_fallback_called
+        if command[:3] == ["gh", "api", "user"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"login": "gladyatore-lab"}), "")
+        if len(command) >= 3 and "/collaborators/" in command[2]:
+            return subprocess.CompletedProcess(command, 1, "", "gh: server error (HTTP 500)")
+        if command[:3] == ["gh", "api", "repos/Halildeu/ao-kernel"]:
+            repo_fallback_called = True
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps({"permissions": {"admin": False, "push": True, "pull": True}}),
+                "",
+            )
+        if command[:3] == ["gh", "pr", "view"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps(_ready_live_state()["pr_view"]), "")
+        if command[:3] == ["gh", "pr", "checks"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps(_ready_live_state()["required_checks"]), "")
+        raise AssertionError(command)
+
+    state = mod.collect_live_github_state(repo="Halildeu/ao-kernel", pr_number=123, gh_bin="gh", runner=fake_runner)
+    payload = _result(live_state=state)
+
+    assert repo_fallback_called is False
+    assert state["permission"] == {}
+    assert any("HTTP 500" in error for error in state["collection_errors"])
+    assert "github_api_read_failed" in payload["decision"]["blockers"]
+    assert "merge_actor_not_write" in payload["decision"]["blockers"]
+
+
+def test_ao_ma10c_collect_live_state_retries_transient_unstable_merge_state() -> None:
+    mod = _load_script_module()
+    pr_views = [
+        {
+            **_ready_live_state()["pr_view"],
+            "mergeStateStatus": "UNSTABLE",
+        },
+        _ready_live_state()["pr_view"],
+    ]
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "api", "user"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"login": "gladyatore-lab"}), "")
+        if len(command) >= 3 and "/collaborators/" in command[2]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"permission": "write"}), "")
+        if command[:3] == ["gh", "pr", "view"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps(pr_views.pop(0)), "")
+        if command[:3] == ["gh", "pr", "checks"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps(_ready_live_state()["required_checks"]), "")
+        raise AssertionError(command)
+
+    state = mod.collect_live_github_state(
+        repo="Halildeu/ao-kernel",
+        pr_number=123,
+        gh_bin="gh",
+        runner=fake_runner,
+        merge_state_max_attempts=2,
+        merge_state_poll_seconds=0,
+    )
+
+    assert state["collection_errors"] == []
+    assert state["pr_view"]["mergeStateStatus"] == "CLEAN"
+    assert pr_views == []
+
+
+def test_ao_ma10c_collect_live_state_blocks_when_transient_merge_state_never_settles() -> None:
+    mod = _load_script_module()
+    seen_pr_views = 0
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        nonlocal seen_pr_views
+        if command[:3] == ["gh", "api", "user"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"login": "gladyatore-lab"}), "")
+        if len(command) >= 3 and "/collaborators/" in command[2]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"permission": "write"}), "")
+        if command[:3] == ["gh", "pr", "view"]:
+            seen_pr_views += 1
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps({**_ready_live_state()["pr_view"], "mergeStateStatus": "UNSTABLE"}),
+                "",
+            )
+        if command[:3] == ["gh", "pr", "checks"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps(_ready_live_state()["required_checks"]), "")
+        raise AssertionError(command)
+
+    state = mod.collect_live_github_state(
+        repo="Halildeu/ao-kernel",
+        pr_number=123,
+        gh_bin="gh",
+        runner=fake_runner,
+        merge_state_max_attempts=2,
+        merge_state_poll_seconds=0,
+    )
+    payload = _result(live_state=state)
+
+    assert seen_pr_views == 2
+    assert state["pr_view"]["mergeStateStatus"] == "UNSTABLE"
+    assert "pr_merge_state_not_clean" in payload["decision"]["blockers"]
+
+
 def test_ao_ma10c_source_does_not_construct_admin_or_auto_merge() -> None:
     source = SCRIPT.read_text(encoding="utf-8")
     assert "--admin" not in source


### PR DESCRIPTION
## Summary
- Narrow AO-MA-10c repo-permission fallback to the known fine-grained PAT collaborator-permission 403 only.
- Keep unexpected permission-read failures fail-closed with collection_errors and merge_actor_not_write.
- Retry transient GitHub mergeStateStatus UNKNOWN/UNSTABLE before executing the dedicated actor merge, while preserving fail-closed behavior if it never settles.

## Live root cause
AO-MA-10q run 26622970512 reached disposable PR #722. Credential doctor was `credential_ready` and required checks including `ao-release-gate`, `ao-release-gate-review`, and `ao-release-gate-technical` passed. Merge-agent still blocked because collaborator permission self-check returned the known fine-grained PAT 403 and GitHub mergeStateStatus was transiently `UNSTABLE` before later settling to `CLEAN`.

## Validation
- `pytest -q tests/test_ao_ma10c_merge_agent.py tests/test_ao_ma10l_autonomous_smoke.py tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10r_dedicated_actor_credential_doctor.py tests/test_local_gpp_gate.py` -> 118 passed
- `ruff check scripts/ao_ma10c_merge_agent.py tests/test_ao_ma10c_merge_agent.py` -> pass
- `python3 -m py_compile scripts/ao_ma10c_merge_agent.py` -> pass
- `python3 -m json.tool local-ai-review-evidence.v1.json` -> pass
- `git diff --check` -> clean
- `gitleaks protect --staged --no-banner --redact` -> no leaks
- `scripts/local_gpp_gate.py` -> `operator_may_merge`, diff `sha256:0e6a03b7557f2bd301b4697d424f23d8894d4e5e447fcadd7e075ed1aaee4919`

## Cross-AI review
- OpenAI subagent: REVISE on broad fallback -> absorbed -> AGREE.
- Claude CLI reviewer: AGREE on revised patch.

## Guardrails
No admin bypass, no native auto-merge enablement, no branch protection mutation, no support widening, no production platform claim, no live adapter execution.