### PR TITLE
fix(ao-ma-10): use REST merge for dedicated actor

### DIFF
--- a/.claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.md
+++ b/.claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.md
@@ -56,14 +56,21 @@ It is dry-run by default. Execute mode requires:
 7. PR is open, not draft, base `main`, merge state clean
 8. all live required checks pass
 
-The only merge command it may construct is normal squash merge:
+The only merge command it may construct is the REST pull-request merge endpoint:
 
 ```text
-gh pr merge <pr> --repo Halildeu/ao-kernel --squash --delete-branch
+gh api repos/Halildeu/ao-kernel/pulls/<pr>/merge \
+  --method PUT \
+  -f merge_method=squash \
+  -f sha=<observed-head-sha>
 ```
 
-The executor must not construct admin bypass, bypass actors, ruleset mutation,
-or native auto-merge enablement.
+After a successful merge it may delete the same-repository PR head ref through
+the REST git-ref endpoint. Branch cleanup failure is warning-only; the merge
+result remains tied to the repo-owned required checks and GitHub ruleset.
+
+The executor must not construct admin bypass, bypass actors, GraphQL
+`mergePullRequest`, ruleset mutation, or native auto-merge enablement.
 
 ## Result Artifact
 
@@ -80,6 +87,7 @@ The artifact records:
 - live PR state
 - required-check status
 - merge command argv
+- branch delete argv/error when applicable
 - whether a merge command was attempted
 - whether mutation occurred
 - fail-closed blockers

--- a/.claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.v1.json
+++ b/.claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.v1.json
@@ -16,13 +16,14 @@
   "live_adapter_execution": false,
   "merge_command_shape": [
     "gh",
-    "pr",
-    "merge",
-    "<pr>",
-    "--repo",
-    "Halildeu/ao-kernel",
-    "--squash",
-    "--delete-branch"
+    "api",
+    "repos/Halildeu/ao-kernel/pulls/<pr>/merge",
+    "--method",
+    "PUT",
+    "-f",
+    "merge_method=squash",
+    "-f",
+    "sha=<observed-head-sha>"
   ],
   "mutates_github_rulesets": false,
   "native_auto_merge_enablement": false,

--- a/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md
+++ b/.claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md
@@ -118,7 +118,10 @@ The only merge command still lives inside AO-MA-10c and uses the same selected
 `--gh-bin` runtime:
 
 ```text
-<dedicated-gh-wrapper> pr merge <pr> --repo Halildeu/ao-kernel --squash --delete-branch
+<dedicated-gh-wrapper> api repos/Halildeu/ao-kernel/pulls/<pr>/merge \
+  --method PUT \
+  -f merge_method=squash \
+  -f sha=<observed-head-sha>
 ```
 
 AO-MA-10l never constructs an admin merge command and never mutates rulesets,

--- a/ao_kernel/defaults/schemas/ao-ma-10c-merge-agent-result.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-ma-10c-merge-agent-result.schema.v1.json
@@ -69,7 +69,9 @@
         "state": { "type": ["string", "null"] },
         "is_draft": { "type": ["boolean", "null"] },
         "base_ref": { "type": ["string", "null"] },
+        "head_ref": { "type": ["string", "null"] },
         "head_sha": { "type": ["string", "null"] },
+        "is_cross_repository": { "type": ["boolean", "null"] },
         "merge_state_status": { "type": ["string", "null"] }
       }
     },
@@ -94,6 +96,12 @@
       "items": { "type": "string" }
     },
     "merge_error": { "type": "string" },
+    "branch_delete_attempted": { "type": "boolean" },
+    "branch_delete_command_argv": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "branch_delete_error": { "type": "string" },
     "collection_errors": {
       "type": "array",
       "items": { "type": "string" }
@@ -123,6 +131,7 @@
               "merge_actor_not_write",
               "merge_command_failed",
               "pr_base_not_main",
+              "pr_head_sha_missing",
               "pr_is_draft",
               "pr_merge_state_not_clean",
               "pr_not_open",

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -30,11 +30,12 @@
     }
   ],
   "findings": [
-    "Live AO-MA-10q execute smoke reached disposable PR #722 with credential_ready and all required checks passing, but AO-MA-10c blocked before merge because collaborator permission read returned the known fine-grained PAT 403 and GitHub mergeStateStatus was transiently UNSTABLE before later settling to CLEAN.",
-    "AO-MA-10AC keeps merge authority with ao-release-gate plus GitHub ruleset and the dedicated non-admin merge actor; it only hardens merge-agent live-state collection and does not add admin bypass, native auto-merge, support widening, production claim, or live adapter execution.",
-    "Repo permission fallback is now allowed only for the exact known fine-grained PAT 403 signature; unexpected permission-read failures such as HTTP 500 do not fallback, preserve collection_errors, and fail closed with github_api_read_failed plus merge_actor_not_write.",
-    "Transient mergeStateStatus UNKNOWN/UNSTABLE is retried before merge; non-transient blocked states break immediately, and exhausted transient states still fail closed with pr_merge_state_not_clean.",
-    "OpenAI subagent review first returned REVISE on an overly broad fallback, that finding was absorbed with negative tests, and re-review returned AGREE. Claude CLI reviewer also returned AGREE on the revised patch."
+    "Live AO-MA-10q execute smoke reached disposable PR #724 with credential_ready, actual_actor gladyatore-lab, actor_permission write, mergeStateStatus CLEAN, and 16 required checks passing, but AO-MA-10c blocked because GitHub CLI gh pr merge used GraphQL mergePullRequest and returned Resource not accessible by personal access token.",
+    "AO-MA-10AD keeps merge authority with ao-release-gate plus GitHub ruleset and the dedicated non-admin merge actor; it only changes the final merge executor from gh pr merge GraphQL to REST PUT /pulls/{pr}/merge and does not add admin bypass, native auto-merge, support widening, production claim, or live adapter execution.",
+    "The REST merge command includes sha=headRefOid so a PR head change between readiness/check evidence and merge execution fails closed instead of merging an unobserved commit.",
+    "Branch cleanup is a separate REST git-ref DELETE attempted only for same-repository non-base head refs; branch delete failure is warning-only because a successful merge cannot be undone and artifact truth must remain merged.",
+    "OpenAI explorer independently recommended the same REST merge path and flagged head-sha and cross-repository delete guardrails; those guardrails were absorbed with tests.",
+    "Claude CLI reviewer returned VERDICT: AGREE on the REST merge patch; residual notes were non-blocking test/comment robustness observations only."
   ],
   "implementer": {
     "agent": "codex",
@@ -52,13 +53,19 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10c_merge_agent.py",
-      "tests/test_ao_ma10c_merge_agent.py"
-    ],
-    "head_ref": "refs/heads/codex/ao-ma10ac-merge-agent-live-state"
+        ".claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.md",
+        ".claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.v1.json",
+        ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md",
+        "ao_kernel/defaults/schemas/ao-ma-10c-merge-agent-result.schema.v1.json",
+        "local-ai-review-evidence.v1.json",
+        "scripts/ao_ma10c_merge_agent.py",
+        "tests/fixtures/ao_ma_10c/merge_agent.blocked_admin_actor.valid.json",
+        "tests/fixtures/ao_ma_10c/merge_agent.ready_dry_run.valid.json",
+        "tests/test_ao_ma10c_merge_agent.py"
+      ],
+      "head_ref": "refs/heads/codex/ao-ma10ad-rest-merge"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-MA-10AC"
+  "work_package": "AO-MA-10AD"
 }

--- a/scripts/ao_ma10c_merge_agent.py
+++ b/scripts/ao_ma10c_merge_agent.py
@@ -110,23 +110,80 @@ def _age_seconds(generated_at: Any, now: datetime) -> int | None:
 
 
 def merge_command(repo: str, pr_number: int, gh_bin: str = "gh") -> list[str]:
-    """Build the only permitted merge command.
+    """Build the only permitted merge command shape.
 
-    The command deliberately does not support admin bypass, bypass actors, or
-    native GitHub auto-merge enablement. It executes a normal squash merge after
-    required checks and rulesets are already green.
+    Fine-grained PATs can have repository write permission while GitHub's
+    GraphQL pull-request merge mutation remains unavailable to the GitHub CLI
+    PR merge path. The REST pull merge endpoint is the narrower operation this
+    actor needs after required checks and rulesets are already green.
     """
 
     return [
         gh_bin,
-        "pr",
-        "merge",
-        str(pr_number),
-        "--repo",
-        repo,
-        "--squash",
-        "--delete-branch",
+        "api",
+        f"repos/{repo}/pulls/{pr_number}/merge",
+        "--method",
+        "PUT",
+        "-f",
+        "merge_method=squash",
     ]
+
+
+def merge_command_with_sha(repo: str, pr_number: int, *, head_sha: str | None, gh_bin: str = "gh") -> list[str]:
+    command = merge_command(repo, pr_number, gh_bin=gh_bin)
+    if head_sha:
+        command.extend(["-f", f"sha={head_sha}"])
+    return command
+
+
+def branch_delete_command(repo: str, head_ref: str, gh_bin: str = "gh") -> list[str]:
+    return [
+        gh_bin,
+        "api",
+        f"repos/{repo}/git/refs/heads/{head_ref}",
+        "--method",
+        "DELETE",
+    ]
+
+
+def _safe_head_ref_for_delete(head_ref: Any, base_ref: str, *, is_cross_repository: bool) -> str | None:
+    if is_cross_repository:
+        return None
+    if not isinstance(head_ref, str) or not head_ref:
+        return None
+    if head_ref == base_ref or head_ref.startswith("refs/"):
+        return None
+    return head_ref
+
+
+def execute_merge(
+    *,
+    repo: str,
+    pr_number: int,
+    pr_view: dict[str, Any],
+    base_ref: str,
+    gh_bin: str,
+) -> tuple[int, str, int | None, str, list[str], list[str]]:
+    head_sha = pr_view.get("headRefOid") if isinstance(pr_view.get("headRefOid"), str) else None
+    merge_argv = merge_command_with_sha(repo, pr_number, head_sha=head_sha, gh_bin=gh_bin)
+    merge_proc = _run(merge_argv)
+    merge_error = merge_proc.stderr.strip() or merge_proc.stdout.strip()
+
+    delete_argv: list[str] = []
+    delete_exit_code: int | None = None
+    delete_error = ""
+    head_ref = _safe_head_ref_for_delete(
+        pr_view.get("headRefName"),
+        base_ref,
+        is_cross_repository=pr_view.get("isCrossRepository") is True,
+    )
+    if merge_proc.returncode == 0 and head_ref:
+        delete_argv = branch_delete_command(repo, head_ref, gh_bin=gh_bin)
+        delete_proc = _run(delete_argv)
+        delete_exit_code = delete_proc.returncode
+        delete_error = delete_proc.stderr.strip() or delete_proc.stdout.strip()
+
+    return merge_proc.returncode, merge_error, delete_exit_code, delete_error, merge_argv, delete_argv
 
 
 def collect_live_github_state(
@@ -181,7 +238,7 @@ def collect_live_github_state(
                 "--repo",
                 repo,
                 "--json",
-                "state,isDraft,baseRefName,headRefOid,mergeStateStatus",
+                "state,isDraft,baseRefName,headRefName,headRefOid,isCrossRepository,mergeStateStatus",
             ],
             runner,
         )
@@ -256,6 +313,9 @@ def build_result(
     confirmation: str | None = None,
     merge_exit_code: int | None = None,
     merge_stderr: str = "",
+    branch_delete_exit_code: int | None = None,
+    branch_delete_stderr: str = "",
+    branch_delete_command_argv: list[str] | None = None,
     gh_bin: str = "gh",
 ) -> dict[str, Any]:
     now = (now or datetime.now(UTC)).astimezone(UTC)
@@ -331,7 +391,19 @@ def build_result(
     if not checks_ok:
         blockers.add("required_checks_not_passed")
 
-    command = merge_command(repo, pr_number, gh_bin=gh_bin)
+    head_sha = pr_view.get("headRefOid") if isinstance(pr_view.get("headRefOid"), str) else None
+    if not head_sha:
+        blockers.add("pr_head_sha_missing")
+    command = merge_command_with_sha(repo, pr_number, head_sha=head_sha, gh_bin=gh_bin)
+    is_cross_repository = pr_view.get("isCrossRepository") is True
+    safe_head_ref = _safe_head_ref_for_delete(
+        pr_view.get("headRefName"),
+        base_ref,
+        is_cross_repository=is_cross_repository,
+    )
+    delete_command = branch_delete_command_argv
+    if delete_command is None:
+        delete_command = branch_delete_command(repo, safe_head_ref, gh_bin=gh_bin) if safe_head_ref else []
     if any(item == FORBIDDEN_ADMIN_FLAG for item in command):
         blockers.add("admin_merge_command_constructed")
 
@@ -341,6 +413,14 @@ def build_result(
     merge_attempted = bool(execute and not blockers)
     if merge_exit_code not in (None, 0):
         blockers.add("merge_command_failed")
+    if merge_exit_code == 0 and not delete_command:
+        warnings.add(
+            "branch_delete_skipped_cross_repository"
+            if is_cross_repository
+            else "branch_delete_skipped_no_safe_head_ref"
+        )
+    if merge_exit_code == 0 and branch_delete_exit_code not in (None, 0):
+        warnings.add("branch_delete_failed")
 
     if blockers:
         result = "blocked"
@@ -362,6 +442,7 @@ def build_result(
         "dry_run": not execute,
         "execute_requested": execute,
         "merge_command_attempted": merge_attempted,
+        "branch_delete_attempted": branch_delete_exit_code is not None,
         "mutations_performed": result == "merged",
         "release_authority": RELEASE_AUTHORITY,
         "ai_output_release_authority": False,
@@ -377,7 +458,9 @@ def build_result(
             "state": pr_view.get("state"),
             "is_draft": pr_view.get("isDraft"),
             "base_ref": pr_view.get("baseRefName"),
+            "head_ref": pr_view.get("headRefName"),
             "head_sha": pr_view.get("headRefOid"),
+            "is_cross_repository": pr_view.get("isCrossRepository"),
             "merge_state_status": pr_view.get("mergeStateStatus"),
         },
         "required_checks": {
@@ -387,6 +470,8 @@ def build_result(
         },
         "merge_command_argv": command,
         "merge_error": merge_stderr if merge_exit_code not in (None, 0) else "",
+        "branch_delete_command_argv": delete_command,
+        "branch_delete_error": branch_delete_stderr if branch_delete_exit_code not in (None, 0) else "",
         "collection_errors": collection_errors,
         "decision": {
             "result": result,
@@ -425,6 +510,9 @@ def main(argv: list[str] | None = None) -> int:
 
     merge_exit_code: int | None = None
     merge_stderr = ""
+    branch_delete_exit_code: int | None = None
+    branch_delete_stderr = ""
+    branch_delete_command_argv: list[str] = []
     preliminary = build_result(
         repo=args.repo,
         pr_number=args.pr,
@@ -440,9 +528,20 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     if args.execute and preliminary["decision"]["result"] != "blocked":
-        proc = _run(merge_command(args.repo, args.pr, gh_bin=args.gh_bin))
-        merge_exit_code = proc.returncode
-        merge_stderr = proc.stderr.strip() or proc.stdout.strip()
+        (
+            merge_exit_code,
+            merge_stderr,
+            branch_delete_exit_code,
+            branch_delete_stderr,
+            _merge_command_argv,
+            branch_delete_command_argv,
+        ) = execute_merge(
+            repo=args.repo,
+            pr_number=args.pr,
+            pr_view=_object(live_state.get("pr_view")),
+            base_ref=args.base_ref,
+            gh_bin=args.gh_bin,
+        )
 
     result = build_result(
         repo=args.repo,
@@ -457,6 +556,9 @@ def main(argv: list[str] | None = None) -> int:
         confirmation=args.confirmation,
         merge_exit_code=merge_exit_code,
         merge_stderr=merge_stderr,
+        branch_delete_exit_code=branch_delete_exit_code,
+        branch_delete_stderr=branch_delete_stderr,
+        branch_delete_command_argv=branch_delete_command_argv,
         gh_bin=args.gh_bin,
     )
 

--- a/tests/fixtures/ao_ma_10c/merge_agent.blocked_admin_actor.valid.json
+++ b/tests/fixtures/ao_ma_10c/merge_agent.blocked_admin_actor.valid.json
@@ -25,15 +25,25 @@
     "production_platform_claim": false,
     "support_widening": false
   },
+  "branch_delete_attempted": false,
+  "branch_delete_command_argv": [
+    "gh",
+    "api",
+    "repos/Halildeu/ao-kernel/git/refs/heads/codex/ao-ma10l-smoke-test",
+    "--method",
+    "DELETE"
+  ],
+  "branch_delete_error": "",
   "merge_command_argv": [
     "gh",
-    "pr",
-    "merge",
-    "123",
-    "--repo",
-    "Halildeu/ao-kernel",
-    "--squash",
-    "--delete-branch"
+    "api",
+    "repos/Halildeu/ao-kernel/pulls/123/merge",
+    "--method",
+    "PUT",
+    "-f",
+    "merge_method=squash",
+    "-f",
+    "sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   ],
   "merge_command_attempted": false,
   "merge_error": "",
@@ -41,7 +51,9 @@
   "pr_number": 123,
   "pr_state": {
     "base_ref": "main",
+    "head_ref": "codex/ao-ma10l-smoke-test",
     "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "is_cross_repository": false,
     "is_draft": false,
     "merge_state_status": "CLEAN",
     "state": "OPEN"

--- a/tests/fixtures/ao_ma_10c/merge_agent.ready_dry_run.valid.json
+++ b/tests/fixtures/ao_ma_10c/merge_agent.ready_dry_run.valid.json
@@ -21,15 +21,25 @@
     "production_platform_claim": false,
     "support_widening": false
   },
+  "branch_delete_attempted": false,
+  "branch_delete_command_argv": [
+    "gh",
+    "api",
+    "repos/Halildeu/ao-kernel/git/refs/heads/codex/ao-ma10l-smoke-test",
+    "--method",
+    "DELETE"
+  ],
+  "branch_delete_error": "",
   "merge_command_argv": [
     "gh",
-    "pr",
-    "merge",
-    "123",
-    "--repo",
-    "Halildeu/ao-kernel",
-    "--squash",
-    "--delete-branch"
+    "api",
+    "repos/Halildeu/ao-kernel/pulls/123/merge",
+    "--method",
+    "PUT",
+    "-f",
+    "merge_method=squash",
+    "-f",
+    "sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   ],
   "merge_command_attempted": false,
   "merge_error": "",
@@ -37,7 +47,9 @@
   "pr_number": 123,
   "pr_state": {
     "base_ref": "main",
+    "head_ref": "codex/ao-ma10l-smoke-test",
     "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "is_cross_repository": false,
     "is_draft": false,
     "merge_state_status": "CLEAN",
     "state": "OPEN"

--- a/tests/test_ao_ma10c_merge_agent.py
+++ b/tests/test_ao_ma10c_merge_agent.py
@@ -73,7 +73,9 @@ def _ready_live_state() -> dict[str, Any]:
             "state": "OPEN",
             "isDraft": False,
             "baseRefName": "main",
+            "headRefName": "codex/ao-ma10l-smoke-test",
             "headRefOid": "a" * 40,
+            "isCrossRepository": False,
             "mergeStateStatus": "CLEAN",
         },
         "required_checks": [
@@ -92,6 +94,8 @@ def _result(
     execute: bool = False,
     confirmation: str | None = None,
     merge_exit_code: int | None = None,
+    branch_delete_exit_code: int | None = None,
+    branch_delete_stderr: str = "",
 ) -> dict[str, Any]:
     mod = _load_script_module()
     now = datetime(2026, 5, 28, 21, 0, 0, tzinfo=UTC)
@@ -107,6 +111,8 @@ def _result(
             execute=execute,
             confirmation=confirmation,
             merge_exit_code=merge_exit_code,
+            branch_delete_exit_code=branch_delete_exit_code,
+            branch_delete_stderr=branch_delete_stderr,
         ),
     )
 
@@ -149,13 +155,21 @@ def test_ao_ma10c_ready_dry_run_does_not_attempt_merge() -> None:
     assert payload["mutations_performed"] is False
     assert payload["merge_command_argv"] == [
         "gh",
-        "pr",
-        "merge",
-        "123",
-        "--repo",
-        "Halildeu/ao-kernel",
-        "--squash",
-        "--delete-branch",
+        "api",
+        "repos/Halildeu/ao-kernel/pulls/123/merge",
+        "--method",
+        "PUT",
+        "-f",
+        "merge_method=squash",
+        "-f",
+        f"sha={'a' * 40}",
+    ]
+    assert payload["branch_delete_command_argv"] == [
+        "gh",
+        "api",
+        "repos/Halildeu/ao-kernel/git/refs/heads/codex/ao-ma10l-smoke-test",
+        "--method",
+        "DELETE",
     ]
     assert "--admin" not in payload["merge_command_argv"]
     assert "--auto" not in payload["merge_command_argv"]
@@ -179,6 +193,117 @@ def test_ao_ma10c_merge_command_failure_is_fail_closed() -> None:
     payload = _result(execute=True, confirmation="AO-MA-10C-EXECUTE", merge_exit_code=1)
     assert payload["decision"]["result"] == "blocked"
     assert "merge_command_failed" in payload["decision"]["blockers"]
+
+
+def test_ao_ma10c_branch_delete_failure_warns_without_undoing_merge_result() -> None:
+    payload = _result(
+        execute=True,
+        confirmation="AO-MA-10C-EXECUTE",
+        merge_exit_code=0,
+        branch_delete_exit_code=1,
+        branch_delete_stderr="delete failed",
+    )
+    assert payload["decision"]["result"] == "merged"
+    assert payload["branch_delete_attempted"] is True
+    assert payload["branch_delete_error"] == "delete failed"
+    assert "branch_delete_failed" in payload["decision"]["warnings"]
+
+
+def test_ao_ma10c_execute_blocks_when_pr_head_sha_is_missing() -> None:
+    live = _ready_live_state()
+    live["pr_view"]["headRefOid"] = None
+    payload = _result(live_state=live, execute=True, confirmation="AO-MA-10C-EXECUTE")
+
+    assert payload["decision"]["result"] == "blocked"
+    assert "pr_head_sha_missing" in payload["decision"]["blockers"]
+    assert payload["merge_command_attempted"] is False
+
+
+def test_ao_ma10c_execute_merge_uses_rest_merge_and_branch_delete(monkeypatch: Any) -> None:
+    mod = _load_script_module()
+    seen: list[list[str]] = []
+
+    def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        seen.append(command)
+        if command[:3] == ["gh", "api", "repos/Halildeu/ao-kernel/pulls/123/merge"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"merged": True}), "")
+        if command[:3] == ["gh", "api", "repos/Halildeu/ao-kernel/git/refs/heads/codex/ao-ma10l-smoke-test"]:
+            return subprocess.CompletedProcess(command, 0, "", "")
+        raise AssertionError(command)
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+    merge_exit, merge_error, delete_exit, delete_error, merge_argv, delete_argv = mod.execute_merge(
+        repo="Halildeu/ao-kernel",
+        pr_number=123,
+        pr_view=_ready_live_state()["pr_view"],
+        base_ref="main",
+        gh_bin="gh",
+    )
+
+    assert merge_exit == 0
+    assert merge_error
+    assert delete_exit == 0
+    assert delete_error == ""
+    assert merge_argv == [
+        "gh",
+        "api",
+        "repos/Halildeu/ao-kernel/pulls/123/merge",
+        "--method",
+        "PUT",
+        "-f",
+        "merge_method=squash",
+        "-f",
+        f"sha={'a' * 40}",
+    ]
+    assert delete_argv == [
+        "gh",
+        "api",
+        "repos/Halildeu/ao-kernel/git/refs/heads/codex/ao-ma10l-smoke-test",
+        "--method",
+        "DELETE",
+    ]
+    assert all("pr" not in command[:2] for command in seen)
+
+
+def test_ao_ma10c_execute_merge_failure_does_not_delete_branch(monkeypatch: Any) -> None:
+    mod = _load_script_module()
+    seen: list[list[str]] = []
+
+    def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        seen.append(command)
+        if command[:3] == ["gh", "api", "repos/Halildeu/ao-kernel/pulls/123/merge"]:
+            return subprocess.CompletedProcess(command, 1, "", "merge rejected")
+        raise AssertionError(command)
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+    merge_exit, merge_error, delete_exit, _delete_error, _merge_argv, delete_argv = mod.execute_merge(
+        repo="Halildeu/ao-kernel",
+        pr_number=123,
+        pr_view=_ready_live_state()["pr_view"],
+        base_ref="main",
+        gh_bin="gh",
+    )
+
+    assert merge_exit == 1
+    assert merge_error == "merge rejected"
+    assert delete_exit is None
+    assert delete_argv == []
+    assert len(seen) == 1
+
+
+def test_ao_ma10c_skips_branch_delete_for_cross_repository_pr() -> None:
+    live = _ready_live_state()
+    live["pr_view"]["isCrossRepository"] = True
+    payload = _result(
+        live_state=live,
+        execute=True,
+        confirmation="AO-MA-10C-EXECUTE",
+        merge_exit_code=0,
+    )
+
+    assert payload["decision"]["result"] == "merged"
+    assert payload["branch_delete_command_argv"] == []
+    assert "branch_delete_skipped_cross_repository" in payload["decision"]["warnings"]
 
 
 def test_ao_ma10c_blocks_current_admin_actor() -> None:
@@ -412,3 +537,5 @@ def test_ao_ma10c_source_does_not_construct_admin_or_auto_merge() -> None:
     assert "--admin" not in source
     assert "--auto" not in source
     assert "enablePullRequestAutoMerge" not in source
+    assert "mergePullRequest" not in source
+    assert '"pr",\n        "merge"' not in source


### PR DESCRIPTION
## Summary

Fixes the remaining AO-MA-10 dedicated actor execute-smoke blocker observed on run `26624083345` / PR #724:

- `gladyatore-lab` authenticated correctly
- actor permission was `write`
- PR merge state was `CLEAN`
- required checks were all passing (`16/16`)
- `gh pr merge` still failed through GitHub CLI GraphQL `mergePullRequest` with `Resource not accessible by personal access token`

This patch moves AO-MA-10c merge execution to the REST pull-request merge endpoint while keeping the same temporary `gh` wrapper token boundary.

## Changes

- Replace `gh pr merge --squash --delete-branch` command construction with:
  - `gh api repos/{repo}/pulls/{pr}/merge --method PUT -f merge_method=squash -f sha={headRefOid}`
- Add fail-closed `pr_head_sha_missing` blocker so an unobserved head commit cannot be merged.
- Add best-effort same-repo branch cleanup through REST git-ref DELETE after merge success.
- Treat branch delete failure as warning-only because a successful merge cannot be undone and artifact truth must remain `merged`.
- Skip branch delete for cross-repository PRs or unsafe/missing head refs.
- Extend AO-MA-10c result schema and fixtures for branch delete evidence fields.
- Update AO-MA-10c/AO-MA-10l docs to reflect the REST merge path.

## Validation

- `pytest -q tests/test_ao_ma10c_merge_agent.py` -> 24 passed
- `pytest -q tests/test_ao_ma10c_merge_agent.py tests/test_ao_ma10l_autonomous_smoke.py tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10r_dedicated_actor_credential_doctor.py tests/test_local_gpp_gate.py` -> 123 passed
- `ruff check scripts/ao_ma10c_merge_agent.py tests/test_ao_ma10c_merge_agent.py` -> pass
- `python3 -m py_compile scripts/ao_ma10c_merge_agent.py` -> pass
- `python3 -m json.tool` on schema, fixtures, receipt, review evidence -> pass
- `git diff --check` -> clean
- `gitleaks protect --staged --no-banner --redact` -> no leaks
- `python3 scripts/local_gpp_gate.py ... --work-package AO-MA-10AD` -> `operator_may_merge`

## Cross-AI review

- OpenAI explorer independently recommended REST `PUT /pulls/{pr}/merge` with `sha=headRefOid`, same-repo-only branch delete, and branch delete warning-only semantics.
- Claude CLI reviewer returned `VERDICT: AGREE`; residual notes were non-blocking test/comment robustness observations.

## Guardrails

- No admin bypass.
- No native auto-merge enablement.
- No ruleset or branch protection mutation.
- No support widening.
- No production platform claim.
- No live adapter execution.
- AI output remains evidence only; release authority remains `ao-release-gate+github-ruleset`.
