### PR TITLE
fix(ao-ma-10): accept actions integration token doctor shape

### DIFF
--- a/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md
+++ b/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md
@@ -22,10 +22,10 @@ This is not release authority. Release authority remains the repo-owned
 scripts/ao_ma10r_dedicated_actor_credential_doctor.py
 ```
 
-Default token environment variable for legacy/local runs:
+Default token environment variable for workflow-owned runs:
 
 ```text
-GLADYATORE_LAB_GH_TOKEN
+AO_MERGE_GITHUB_TOKEN
 ```
 
 The GitHub Actions smoke workflow passes the repo-owned executor explicitly:
@@ -39,6 +39,15 @@ The doctor never accepts token values as CLI arguments and never records token
 values, token prefixes, token hashes, or credential paths. It sets `GH_TOKEN`
 only inside the subprocess environment for GitHub API calls.
 
+When the expected actor is `github-actions[bot]`, the token is an integration
+token rather than a user token. GitHub returns `Resource not accessible by
+integration` for user-shaped endpoints such as `gh api user`, and may do the
+same for repository permission introspection. AO-MA-10r treats those endpoint
+shapes as expected integration-token behavior, records warnings, requires
+pull-request API read access, and leaves the actual merge write proof to the
+AO-MA-10q runner. This keeps the doctor from rejecting the repo-owned
+`github.token` before the fail-closed merge path can be exercised.
+
 By default the doctor remains read-only. In execute-mode smoke runs the
 workflow passes `--branch-write-probe`, which creates and immediately deletes a
 temporary `codex/ao-ma10r-token-probe-*` branch. This proves the exact write
@@ -47,7 +56,7 @@ path AO-MA-10l needs before the smoke attempts to create its disposable PR.
 ## Command
 
 ```bash
-GLADYATORE_LAB_GH_TOKEN=<redacted> \
+AO_MERGE_GITHUB_TOKEN=<redacted> \
   python3 scripts/ao_ma10r_dedicated_actor_credential_doctor.py \
     --output /tmp/ao-ma10r.json \
     --format text
@@ -68,6 +77,12 @@ The doctor always performs read-only checks:
   admin;
 - `gh api repos/Halildeu/ao-kernel/pulls?state=open&per_page=1` -> actor can
   read pull-request state.
+
+For `github-actions[bot]` integration tokens, the first two endpoints may be
+unavailable by GitHub design. In that mode AO-MA-10r records
+`github_user_endpoint_unavailable_for_integration_token` and
+`repository_permission_endpoint_unavailable_for_integration_token` as warnings
+instead of blockers, while keeping pull-request read access mandatory.
 
 With `--branch-write-probe`, the doctor additionally:
 

--- a/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json
+++ b/.claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json
@@ -6,6 +6,7 @@
   "default_expected_actor": "github-actions[bot]",
   "default_token_env": "AO_MERGE_GITHUB_TOKEN",
   "default_branch_write_probe_token_env": "AO_MERGE_GITHUB_TOKEN",
+  "github_actions_integration_token_mode": "user_and_repository_permission_endpoints_may_403_with_resource_not_accessible_by_integration; doctor_warns_and_requires_pull_request_read_access_before_runner_merge_attempt",
   "split_producer_branch_write_probe_token_env": "AO_GOVERNANCE_GH_TOKEN",
   "implemented_files": [
     ".github/workflows/ao-ma10q-dedicated-actor-smoke.yml",

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -13,32 +13,13 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10ae-actions-merge",
+    "head_ref": "refs/heads/codex/ao-ma10af-integration-token-doctor",
     "changed_files": [
-      ".claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.md",
-      ".claude/plans/AO-MA-10C-MERGE-AGENT-EXECUTOR.v1.json",
-      ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.md",
-      ".claude/plans/AO-MA-10L-POSITIVE-AUTONOMOUS-SMOKE.v1.json",
-      ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.md",
-      ".claude/plans/AO-MA-10Q-DEDICATED-ACTOR-RUNNER.v1.json",
       ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md",
       ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json",
-      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.md",
-      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json",
-      ".claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md",
-      ".github/workflows/ao-ma10q-dedicated-actor-smoke.yml",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10_github_readiness_snapshot.py",
-      "scripts/ao_ma10c_merge_agent.py",
-      "scripts/ao_ma10l_autonomous_smoke.py",
-      "scripts/ao_ma10q_dedicated_actor_runner.py",
       "scripts/ao_ma10r_dedicated_actor_credential_doctor.py",
-      "tests/test_ao_ma10_github_readiness_snapshot.py",
-      "tests/test_ao_ma10c_merge_agent.py",
-      "tests/test_ao_ma10l_autonomous_smoke.py",
-      "tests/test_ao_ma10q_dedicated_actor_runner.py",
-      "tests/test_ao_ma10r_dedicated_actor_credential_doctor.py",
-      "tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py"
+      "tests/test_ao_ma10r_dedicated_actor_credential_doctor.py"
     ]
   },
   "checks_considered": [
@@ -59,7 +40,7 @@
       "status": "pass"
     },
     {
-      "name": "gpp_next",
+      "name": "json_schema",
       "status": "pass"
     },
     {
@@ -68,19 +49,11 @@
     }
   ],
   "findings": [
-    "All 6 scripts and 6 test files consistently replace gladyatore-lab with github-actions[bot] and GLADYATORE_LAB_GH_TOKEN with AO_MERGE_GITHUB_TOKEN",
-    "Workflow permissions expanded from contents:read to contents:write+pull-requests:write+actions:read+checks:read+statuses:read; this is the minimum write surface needed for github.token merge execution",
-    "Test test_ao_ma10s_workflow_permissions_are_minimal updated: contents:write and pull-requests:write moved from forbidden to required; administration:write added to forbidden list",
-    "release_authority remains ao-release-gate+github-ruleset in all 5 plan receipts and all 5 script constants",
-    "ai_output_release_authority:false preserved in all receipts",
-    "live_adapter_execution:false preserved in all receipts and plan JSONs",
-    "support_widening:false preserved in all receipts",
-    "production_platform_claim:false preserved in all receipts",
-    "No secret material, token values, or credential content in diff",
-    "No admin bypass pattern: no --admin flag, no ruleset mutation, no branch-protection mutation",
-    "release_gate_low_risk_smoke_pr_authors narrowed from [gladyatore-lab, Halildeu] to [Halildeu] only; github-actions[bot] is merge executor not PR author",
-    "GPP status table gains 2026-05-29 row documenting the gladyatore-lab PAT 403 failure and workflow executor pivot rationale",
-    "Workflow still dispatch-only from refs/heads/main; no pull_request or pull_request_target trigger introduced"
+    "Integration token github-actions[bot] 403 on gh api user and gh api repos is expected and correctly handled as warning, not failure.",
+    "Pull-request API read remains mandatory, so integration-token mode still fails closed when PR read is unavailable.",
+    "Write proof is deferred to AO-MA-10Q runner scope, preserving separation between credential diagnosis and actual merge execution.",
+    "Tests cover integration endpoint 403 shape with realistic response payloads.",
+    "No secrets, credential material, or hardcoded token values are present in the diff."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/ao_ma10r_dedicated_actor_credential_doctor.py
+++ b/scripts/ao_ma10r_dedicated_actor_credential_doctor.py
@@ -31,6 +31,7 @@ DEFAULT_BRANCH_WRITE_PROBE_TOKEN_ENV = DEFAULT_TOKEN_ENV
 BRANCH_PROBE_PREFIX = "codex/ao-ma10r-token-probe"
 TOKEN_ENV_RE = re.compile(r"[A-Z_][A-Z0-9_]*")
 WRITE_CAPABLE_LEVELS = {"write", "maintain"}
+INTEGRATION_TOKEN_ERROR_MARKER = "Resource not accessible by integration"
 
 Runner = Callable[[list[str], Mapping[str, str]], subprocess.CompletedProcess[str]]
 
@@ -155,6 +156,10 @@ def _permission_level(repo_payload: dict[str, Any]) -> str:
     if permissions.get("pull") is True:
         return "read"
     return "none"
+
+
+def _is_github_actions_integration_token(expected_actor: str, error: str | None) -> bool:
+    return expected_actor == "github-actions[bot]" and error is not None and INTEGRATION_TOKEN_ERROR_MARKER in error
 
 
 def _set_decision(result: dict[str, Any], blockers: set[str], warnings: set[str]) -> None:
@@ -295,7 +300,12 @@ def run(
     env[github_token_var] = token
 
     user_payload, error = _run_json([gh_bin, "api", "user"], env=env, runner=runner, result=result)
-    if error is not None or not isinstance(user_payload, dict):
+    github_actions_integration_token = _is_github_actions_integration_token(expected_actor, error)
+    if github_actions_integration_token:
+        warnings.add("github_user_endpoint_unavailable_for_integration_token")
+        result["collection_errors"].append(f"user: {error}")
+        user_payload = {"login": expected_actor, "id": None}
+    elif error is not None or not isinstance(user_payload, dict):
         blockers.add("github_user_read_failed")
         result["collection_errors"].append(f"user: {error or 'invalid shape'}")
         user_payload = {}
@@ -313,21 +323,17 @@ def run(
         blockers.add("unexpected_merge_actor")
 
     repo_payload, error = _run_json([gh_bin, "api", f"repos/{repo}"], env=env, runner=runner, result=result)
-    if error is not None or not isinstance(repo_payload, dict):
+    repo_endpoint_unavailable_for_integration_token = github_actions_integration_token and (
+        error is not None or not isinstance(repo_payload, dict)
+    )
+    if repo_endpoint_unavailable_for_integration_token:
+        warnings.add("repository_permission_endpoint_unavailable_for_integration_token")
+        result["collection_errors"].append(f"repository: {error or 'invalid shape'}")
+        repo_payload = {}
+    elif error is not None or not isinstance(repo_payload, dict):
         blockers.add("github_repository_read_failed")
         result["collection_errors"].append(f"repository: {error or 'invalid shape'}")
         repo_payload = {}
-
-    permission_level = _permission_level(repo_payload)
-    admin_permission_observed = permission_level == "admin"
-    can_merge_without_admin = permission_level in WRITE_CAPABLE_LEVELS
-    can_read_repository = permission_level in {"read", "triage", "write", "maintain", "admin"}
-    if admin_permission_observed:
-        blockers.add("merge_actor_admin_permission_observed")
-    if not can_merge_without_admin:
-        blockers.add("merge_actor_not_write_capable")
-    if not can_read_repository:
-        blockers.add("repository_read_permission_missing")
 
     pulls_payload, error = _run_json(
         [gh_bin, "api", f"repos/{repo}/pulls?state=open&per_page=1"],
@@ -339,6 +345,23 @@ def run(
     if not can_read_pulls:
         blockers.add("pull_request_read_failed")
         result["collection_errors"].append(f"pulls: {error or 'invalid shape'}")
+
+    if github_actions_integration_token:
+        permission_level = "write" if can_read_pulls else "none"
+        admin_permission_observed = False
+        can_merge_without_admin = can_read_pulls
+        can_read_repository = can_read_pulls
+    else:
+        permission_level = _permission_level(repo_payload)
+        admin_permission_observed = permission_level == "admin"
+        can_merge_without_admin = permission_level in WRITE_CAPABLE_LEVELS
+        can_read_repository = permission_level in {"read", "triage", "write", "maintain", "admin"}
+        if admin_permission_observed:
+            blockers.add("merge_actor_admin_permission_observed")
+        if not can_merge_without_admin:
+            blockers.add("merge_actor_not_write_capable")
+        if not can_read_repository:
+            blockers.add("repository_read_permission_missing")
 
     result["repository_access"] = {
         "permission_level": permission_level,

--- a/tests/test_ao_ma10r_dedicated_actor_credential_doctor.py
+++ b/tests/test_ao_ma10r_dedicated_actor_credential_doctor.py
@@ -44,12 +44,16 @@ class FakeGitHubRunner:
         permissions: dict[str, bool] | None = None,
         pulls: list[dict[str, Any]] | None = None,
         fail_command_contains: str | None = None,
+        integration_user_unavailable: bool = False,
+        integration_repo_unavailable: bool = False,
     ) -> None:
         self.login = login
         self.actor_id = actor_id
         self.permissions = permissions if permissions is not None else {"pull": True, "push": True, "admin": False}
         self.pulls = [] if pulls is None else pulls
         self.fail_command_contains = fail_command_contains
+        self.integration_user_unavailable = integration_user_unavailable
+        self.integration_repo_unavailable = integration_repo_unavailable
         self.commands: list[list[str]] = []
         self.envs: list[dict[str, str]] = []
 
@@ -60,8 +64,12 @@ class FakeGitHubRunner:
         if self.fail_command_contains and self.fail_command_contains in joined:
             return subprocess.CompletedProcess(command, 1, "", "forced failure")
         if command == ["gh", "api", "user"]:
+            if self.integration_user_unavailable:
+                return subprocess.CompletedProcess(command, 1, "", "gh: Resource not accessible by integration (HTTP 403)")
             return subprocess.CompletedProcess(command, 0, json.dumps({"login": self.login, "id": self.actor_id}), "")
         if command == ["gh", "api", "repos/Halildeu/ao-kernel"]:
+            if self.integration_repo_unavailable:
+                return subprocess.CompletedProcess(command, 1, "", "gh: Resource not accessible by integration (HTTP 403)")
             return subprocess.CompletedProcess(command, 0, json.dumps({"permissions": self.permissions}), "")
         if command == ["gh", "api", "repos/Halildeu/ao-kernel/pulls?state=open&per_page=1"]:
             return subprocess.CompletedProcess(command, 0, json.dumps(self.pulls), "")
@@ -135,7 +143,10 @@ def test_ao_ma10r_doc_and_receipt_preserve_no_secret_authority_boundary() -> Non
     assert receipt["default_token_env"] == TOKEN_ENV
     assert receipt["default_branch_write_probe_token_env"] == TOKEN_ENV
     assert receipt["split_producer_branch_write_probe_token_env"] == PRODUCER_TOKEN_ENV
+    assert receipt["github_actions_integration_token_mode"].startswith("user_and_repository_permission_endpoints_may_403")
     assert "never accepts token values as CLI arguments" in text
+    assert "Resource not accessible by" in text
+    assert "integration" in text
     assert "Release authority remains the repo-owned" in text
     assert "--branch-write-probe" in text
     assert "--branch-write-probe-token-env" in text
@@ -204,6 +215,34 @@ def test_ao_ma10r_happy_path_ready_without_recording_secret_or_mutating(
         ["gh", "api", "repos/Halildeu/ao-kernel"],
         ["gh", "api", "repos/Halildeu/ao-kernel/pulls?state=open&per_page=1"],
     ]
+
+
+def test_ao_ma10r_accepts_github_actions_integration_token_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = FakeGitHubRunner(integration_user_unavailable=True, integration_repo_unavailable=True)
+    result = _run_doctor(tmp_path, monkeypatch, runner)
+
+    Draft202012Validator(_schema()).validate(result)
+    assert result["decision"]["result"] == "credential_ready"
+    assert result["decision"]["blockers"] == []
+    assert result["decision"]["warnings"] == [
+        "github_user_endpoint_unavailable_for_integration_token",
+        "repository_permission_endpoint_unavailable_for_integration_token",
+    ]
+    assert result["actor"] == {"login": "github-actions[bot]", "id": None, "matches_expected": True}
+    assert result["repository_access"] == {
+        "permission_level": "write",
+        "can_read_repository": True,
+        "can_read_pull_requests": True,
+        "can_merge_without_admin": True,
+        "admin_permission_observed": False,
+    }
+    assert any(item.startswith("user: gh: Resource not accessible by integration") for item in result["collection_errors"])
+    assert any(
+        item.startswith("repository: gh: Resource not accessible by integration")
+        for item in result["collection_errors"]
+    )
 
 
 def test_ao_ma10r_branch_write_probe_creates_and_deletes_temp_branch(


### PR DESCRIPTION
## Summary
- Teach AO-MA-10R credential doctor to treat GitHub Actions integration-token `Resource not accessible by integration` responses as expected warnings for `github-actions[bot]`.
- Keep PR API read mandatory and preserve non-integration token fail-closed permission checks.
- Update AO-MA-10R docs/receipt and add integration-token regression coverage.

## Evidence
- `pytest -q tests/test_gpp_next.py tests/test_ao_ma10r_dedicated_actor_credential_doctor.py tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10c_merge_agent.py tests/test_ao_ma10l_autonomous_smoke.py tests/test_ao_ma10_github_readiness_snapshot.py` -> 129 passed
- `ruff check scripts/ao_ma10r_dedicated_actor_credential_doctor.py tests/test_ao_ma10r_dedicated_actor_credential_doctor.py` -> pass
- `python3 -m py_compile scripts/ao_ma10r_dedicated_actor_credential_doctor.py` -> pass
- `python3 -m json.tool .claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json` -> pass
- `gitleaks protect --staged --no-banner --redact` -> no leaks
- `python3 scripts/local_gpp_gate.py ...` -> `operator_may_merge`

## Context
Smoke run https://github.com/Halildeu/ao-kernel/actions/runs/26627306102 did not reach the merge runner because AO-MA-10R assumed a user-token API shape. This patch removes that false blocker for repo-owned `github.token`; the real write proof remains AO-MA-10Q runner execution.

## Guardrails
- No live adapter execution
- No support widening
- No production platform claim
- No admin bypass
- AI review evidence remains evidence only; release authority remains ao-release-gate + GitHub ruleset