### PR TITLE
fix(ao-ma-10): accept actions integration token in readiness

### DIFF
--- a/ao_kernel/defaults/schemas/ao-ma-10-github-readiness-snapshot.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-ma-10-github-readiness-snapshot.schema.v1.json
@@ -253,7 +253,8 @@
             "type": "string",
             "enum": [
               "repository_auto_merge_disabled_merge_agent_direct_mode_required",
-              "some_nominal_low_risk_prefixes_still_codeowned"
+              "some_nominal_low_risk_prefixes_still_codeowned",
+              "github_user_endpoint_unavailable_for_integration_token"
             ]
           },
           "uniqueItems": true

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -13,13 +13,12 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10af-integration-token-doctor",
+    "head_ref": "refs/heads/codex/ao-ma10ag-readiness-integration-token",
     "changed_files": [
-      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.md",
-      ".claude/plans/AO-MA-10R-DEDICATED-ACTOR-CREDENTIAL-DOCTOR.v1.json",
+      "ao_kernel/defaults/schemas/ao-ma-10-github-readiness-snapshot.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10r_dedicated_actor_credential_doctor.py",
-      "tests/test_ao_ma10r_dedicated_actor_credential_doctor.py"
+      "scripts/ao_ma10_github_readiness_snapshot.py",
+      "tests/test_ao_ma10_github_readiness_snapshot.py"
     ]
   },
   "checks_considered": [
@@ -49,11 +48,12 @@
     }
   ],
   "findings": [
-    "Integration token github-actions[bot] 403 on gh api user and gh api repos is expected and correctly handled as warning, not failure.",
-    "Pull-request API read remains mandatory, so integration-token mode still fails closed when PR read is unavailable.",
-    "Write proof is deferred to AO-MA-10Q runner scope, preserving separation between credential diagnosis and actual merge execution.",
-    "Tests cover integration endpoint 403 shape with realistic response payloads.",
-    "No secrets, credential material, or hardcoded token values are present in the diff."
+    "Fail-closed behavior is preserved for non-integration-token GitHub API errors.",
+    "viewer_login is set to github-actions[bot] only for the exact integration-token marker.",
+    "collection_errors remains empty for the known integration-token user endpoint shape.",
+    "Schema warning enum is updated with github_user_endpoint_unavailable_for_integration_token.",
+    "Regression tests cover the new integration-token code path.",
+    "No secrets or sensitive data are present in the diff."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/ao_ma10_github_readiness_snapshot.py
+++ b/scripts/ao_ma10_github_readiness_snapshot.py
@@ -24,12 +24,14 @@ RELEASE_AUTHORITY = "ao-release-gate+github-ruleset"
 AO_RELEASE_GATE_REQUIRED_CHECKS = ("ao-release-gate-technical", "ao-release-gate-review")
 GITHUB_ACTIONS_APP_ID = 15368
 DEFAULT_DEDICATED_MERGE_ACTOR = "github-actions[bot]"
+INTEGRATION_TOKEN_ERROR_MARKER = "Resource not accessible by integration"
 
 
 def _run_json_with_error(command: list[str], label: str) -> tuple[dict[str, Any] | list[Any], str | None]:
     proc = subprocess.run(command, capture_output=True, text=True, timeout=30)
     if proc.returncode != 0:
-        return {}, f"{label}: command failed with exit {proc.returncode}"
+        detail = proc.stderr.strip() or proc.stdout.strip() or f"command failed with exit {proc.returncode}"
+        return {}, f"{label}: {detail}"
     if not proc.stdout.strip():
         return {}, f"{label}: empty response"
     try:
@@ -109,6 +111,14 @@ def _viewer_repo_permission_with_error(gh_bin: str, repository: str, login: str 
     if isinstance(data, dict) and isinstance(data.get("permission"), str):
         return data["permission"], None
     return None, "viewer_permission: missing permission"
+
+
+def _is_github_actions_integration_token(dedicated_merge_actor: str, error: str | None) -> bool:
+    return (
+        dedicated_merge_actor == DEFAULT_DEDICATED_MERGE_ACTOR
+        and error is not None
+        and INTEGRATION_TOKEN_ERROR_MARKER in error
+    )
 
 
 def _codeowners_text_with_error(gh_bin: str, repository: str, branch: str) -> tuple[str, str | None]:
@@ -293,6 +303,7 @@ def build_snapshot(
     codeowners_text: str,
     dedicated_merge_actor: str = DEFAULT_DEDICATED_MERGE_ACTOR,
     collection_errors: list[str] | None = None,
+    collection_warnings: list[str] | None = None,
     ssot_required_check_claim_observed: bool = False,
     ssot_claim_source: str | None = None,
 ) -> dict[str, Any]:
@@ -317,6 +328,7 @@ def build_snapshot(
     warnings: list[str] = []
 
     errors = collection_errors or []
+    warnings.extend(collection_warnings or [])
 
     if errors:
         blockers.append("github_api_read_failed")
@@ -439,7 +451,14 @@ def collect_live_snapshot(
 
     login, error = _viewer_login_with_error(actor_gh_bin)
     if error:
-        collection_errors.append(error)
+        if _is_github_actions_integration_token(dedicated_merge_actor, error):
+            login = dedicated_merge_actor
+            integration_warnings = ["github_user_endpoint_unavailable_for_integration_token"]
+        else:
+            integration_warnings = []
+            collection_errors.append(error)
+    else:
+        integration_warnings = []
     permission, error = _viewer_repo_permission_with_error(actor_gh_bin, repository, login)
     if error:
         fallback_permission = actor_repo_info.get("viewerPermission")
@@ -499,6 +518,7 @@ def collect_live_snapshot(
         codeowners_text=codeowners,
         dedicated_merge_actor=dedicated_merge_actor,
         collection_errors=collection_errors,
+        collection_warnings=integration_warnings,
     )
 
 

--- a/tests/test_ao_ma10_github_readiness_snapshot.py
+++ b/tests/test_ao_ma10_github_readiness_snapshot.py
@@ -353,6 +353,54 @@ def test_ao_ma10a0_collect_live_snapshot_records_repo_and_viewer_read_errors(mon
     assert snapshot["readiness"]["decision"] == "blocked"
 
 
+def test_ao_ma10a0_accepts_github_actions_integration_user_endpoint_shape(monkeypatch: Any) -> None:
+    mod = _load_script_module()
+    codeowners_text = _valid_ready_inputs()["codeowners_text"]
+    encoded_codeowners = base64.b64encode(codeowners_text.encode("utf-8")).decode("utf-8")
+
+    def fake_run_json_with_error(command: list[str], label: str) -> tuple[dict[str, Any] | list[Any], str | None]:
+        del command
+        if label == "repository":
+            return {"data": {"repository": _valid_ready_inputs()["repo_info"]}}, None
+        if label == "viewer_login":
+            return {}, "viewer_login: gh: Resource not accessible by integration (HTTP 403)"
+        if label == "viewer_permission":
+            return {}, "viewer_permission: gh: Not Found (HTTP 404)"
+        if label == "branch_protection":
+            return _valid_ready_inputs()["branch_protection"], None
+        if label == "rulesets":
+            return _valid_ready_inputs()["rulesets"], None
+        if label == "ruleset:16803733":
+            return _valid_ready_inputs()["rulesets"][0], None
+        if label == "branch_rules":
+            return _valid_ready_inputs()["branch_rules"], None
+        if label == "codeowners":
+            return {"content": encoded_codeowners}, None
+        raise AssertionError(f"unexpected label: {label}")
+
+    monkeypatch.setattr(mod, "_run_json_with_error", fake_run_json_with_error)
+    snapshot = mod.collect_live_snapshot(
+        "Halildeu/ao-kernel",
+        "main",
+        "gh-governance",
+        dedicated_merge_actor="github-actions[bot]",
+        actor_gh_bin="gh-dedicated",
+    )
+
+    Draft202012Validator(_schema()).validate(snapshot)
+    assert snapshot["collection_errors"] == []
+    assert snapshot["merge_actor"] == {
+        "login": "github-actions[bot]",
+        "permission": "write",
+        "viewer_can_administer": False,
+        "administration_write_absent_for_dedicated_actor": True,
+    }
+    assert "github_user_endpoint_unavailable_for_integration_token" in snapshot["readiness"]["warnings"]
+    assert "github_api_read_failed" not in snapshot["readiness"]["blockers"]
+    assert "unexpected_merge_actor" not in snapshot["readiness"]["blockers"]
+    assert snapshot["readiness"]["decision"] == "ready_for_dry_run"
+
+
 def test_ao_ma10a0_script_is_read_only_and_has_no_write_api_methods() -> None:
     source = SCRIPT.read_text(encoding="utf-8")
     forbidden_tokens = [


### PR DESCRIPTION
## Summary
- Teach AO-MA-10A0 readiness snapshot to accept the GitHub Actions integration-token user endpoint shape for `github-actions[bot]`.
- Preserve fail-closed behavior for ordinary GitHub API errors and keep actor write/non-admin checks based on repository viewer permission.
- Add readiness warning schema enum + regression coverage.

## Evidence
- `pytest -q tests/test_ao_ma10_github_readiness_snapshot.py tests/test_ao_ma10l_autonomous_smoke.py tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10r_dedicated_actor_credential_doctor.py tests/test_gpp_next.py` -> 99 passed
- `ruff check scripts/ao_ma10_github_readiness_snapshot.py tests/test_ao_ma10_github_readiness_snapshot.py` -> pass
- `python3 -m py_compile scripts/ao_ma10_github_readiness_snapshot.py` -> pass
- `python3 -m json.tool ao_kernel/defaults/schemas/ao-ma-10-github-readiness-snapshot.schema.v1.json` -> pass
- `gitleaks protect --staged --no-banner --redact` -> no leaks
- `python3 scripts/local_gpp_gate.py ...` -> `operator_may_merge`

## Context
After #728, AO-MA-10r doctor passed in smoke run https://github.com/Halildeu/ao-kernel/actions/runs/26628297586. The remaining blocker moved to AO-MA-10A0 readiness, which still treated `gh api user` integration-token 403 as a hard GitHub API read failure. This patch aligns readiness with the same GitHub Actions token model.

## Guardrails
- No live adapter execution
- No support widening
- No production platform claim
- No admin bypass
- AI evidence remains evidence only; release authority remains ao-release-gate + GitHub ruleset