### PR TITLE
fix(ao-ma-10): accept actions integration token in eligibility

### DIFF
--- a/ao_kernel/defaults/schemas/ao-ma-10-autonomous-merge-eligibility.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-ma-10-autonomous-merge-eligibility.schema.v1.json
@@ -222,6 +222,7 @@
           "items": {
             "type": "string",
             "enum": [
+              "github_user_endpoint_unavailable_for_integration_token",
               "repository_auto_merge_disabled_merge_agent_direct_mode_required",
               "some_nominal_low_risk_prefixes_still_codeowned"
             ]

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -13,12 +13,12 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10ag-readiness-integration-token",
+    "head_ref": "refs/heads/codex/ao-ma10ah-eligibility-integration-token",
     "changed_files": [
-      "ao_kernel/defaults/schemas/ao-ma-10-github-readiness-snapshot.schema.v1.json",
+      "ao_kernel/defaults/schemas/ao-ma-10-autonomous-merge-eligibility.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10_github_readiness_snapshot.py",
-      "tests/test_ao_ma10_github_readiness_snapshot.py"
+      "scripts/ao_ma10_autonomous_merge_eligibility.py",
+      "tests/test_ao_ma10_autonomous_merge_eligibility.py"
     ]
   },
   "checks_considered": [
@@ -31,15 +31,15 @@
       "status": "pass"
     },
     {
-      "name": "ruff",
+      "name": "schema_validation",
+      "status": "pass"
+    },
+    {
+      "name": "ruff_lint",
       "status": "pass"
     },
     {
       "name": "py_compile",
-      "status": "pass"
-    },
-    {
-      "name": "json_schema",
       "status": "pass"
     },
     {
@@ -48,11 +48,11 @@
     }
   ],
   "findings": [
-    "Fail-closed behavior is preserved for non-integration-token GitHub API errors.",
-    "viewer_login is set to github-actions[bot] only for the exact integration-token marker.",
-    "collection_errors remains empty for the known integration-token user endpoint shape.",
-    "Schema warning enum is updated with github_user_endpoint_unavailable_for_integration_token.",
-    "Regression tests cover the new integration-token code path.",
+    "The integration-token path is additive and preserves the existing administration_write_absent_for_dedicated_actor=true path.",
+    "The new path requires all four conditions: github_user_endpoint_unavailable_for_integration_token warning, github-actions[bot] actor, write permission, and viewer_can_administer=false.",
+    "Admin actors remain blocked independently through merge_actor_admin_permission_observed and cannot satisfy the integration-token helper.",
+    "Wrong actor, non-write permission, admin permission, and missing integration warning cases are covered by regression tests.",
+    "The warning enum change is additive and keeps existing eligibility payloads backward-compatible.",
     "No secrets or sensitive data are present in the diff."
   ],
   "secrets_recorded": false,

--- a/scripts/ao_ma10_autonomous_merge_eligibility.py
+++ b/scripts/ao_ma10_autonomous_merge_eligibility.py
@@ -34,6 +34,8 @@ SCHEMA_VERSION = "ao-ma-10-autonomous-merge-eligibility.v1"
 ARTIFACT_KIND = "ao_ma_10_autonomous_merge_eligibility"
 RELEASE_AUTHORITY = "ao-release-gate+github-ruleset"
 GITHUB_ACTIONS_APP_ID = 15368
+GITHUB_ACTIONS_BOT_LOGIN = "github-actions[bot]"
+INTEGRATION_TOKEN_WARNING = "github_user_endpoint_unavailable_for_integration_token"
 TECHNICAL_CHECK = RELEASE_GATE_TECHNICAL_CHECK_NAME
 REVIEW_CHECK = RELEASE_GATE_REVIEW_CHECK_NAME
 DEFAULT_PLAN_PATH = ".claude/plans/AO-MA-10-LOW-RISK-AUTONOMOUS-MERGE-LANE.v1.json"
@@ -129,6 +131,29 @@ def _snapshot_collection_blockers(snapshot: dict[str, Any]) -> list[str]:
 
 def _snapshot_warnings(snapshot: dict[str, Any]) -> list[str]:
     return _string_list(_object(snapshot.get("readiness")).get("warnings"))
+
+
+def _merge_actor_permission(merge_actor: dict[str, Any]) -> str:
+    permission = merge_actor.get("permission")
+    return permission.lower() if isinstance(permission, str) else ""
+
+
+def _github_actions_integration_actor_confirmed(merge_actor: dict[str, Any], warnings: set[str]) -> bool:
+    """Confirm the GitHub Actions integration-token actor without relying on /user.
+
+    GitHub's Actions integration token can return "Resource not accessible by
+    integration" for the normal user endpoint. A0 records that as a warning and
+    still captures repo permission and admin state through repository-scoped
+    endpoints. A1 may accept that shape only for the exact Actions bot with
+    write permission and explicit non-admin evidence.
+    """
+
+    return (
+        INTEGRATION_TOKEN_WARNING in warnings
+        and merge_actor.get("login") == GITHUB_ACTIONS_BOT_LOGIN
+        and _merge_actor_permission(merge_actor) == "write"
+        and merge_actor.get("viewer_can_administer") is False
+    )
 
 
 def _low_risk_evaluation(
@@ -234,9 +259,14 @@ def build_eligibility(
         blockers.add("legacy_required_review_blocks_low_risk_autonomy")
     if branch_protection.get("require_code_owner_reviews") is not False:
         blockers.add("legacy_code_owner_review_blocks_low_risk_autonomy")
-    if merge_actor.get("viewer_can_administer") is True or merge_actor.get("permission") == "admin":
+    dedicated_merge_actor_confirmed = (
+        merge_actor.get("administration_write_absent_for_dedicated_actor") is True
+        or _github_actions_integration_actor_confirmed(merge_actor, warnings)
+    )
+
+    if merge_actor.get("viewer_can_administer") is True or _merge_actor_permission(merge_actor) == "admin":
         blockers.add("merge_actor_admin_permission_observed")
-    if merge_actor.get("administration_write_absent_for_dedicated_actor") is not True:
+    if not dedicated_merge_actor_confirmed:
         blockers.add("dedicated_merge_actor_not_confirmed")
     if codeowners.get("broad_default_owner_absent") is not True:
         blockers.add("codeowners_broad_default_owner_present")
@@ -287,12 +317,9 @@ def build_eligibility(
             "legacy_code_owner_review_disabled_for_low_risk": branch_protection.get("require_code_owner_reviews")
             is False,
             "dedicated_merge_actor_non_admin": not (
-                merge_actor.get("viewer_can_administer") is True or merge_actor.get("permission") == "admin"
+                merge_actor.get("viewer_can_administer") is True or _merge_actor_permission(merge_actor) == "admin"
             ),
-            "dedicated_merge_actor_without_admin_write": merge_actor.get(
-                "administration_write_absent_for_dedicated_actor"
-            )
-            is True,
+            "dedicated_merge_actor_without_admin_write": dedicated_merge_actor_confirmed,
         },
         "decision": {
             "result": decision,

--- a/tests/test_ao_ma10_autonomous_merge_eligibility.py
+++ b/tests/test_ao_ma10_autonomous_merge_eligibility.py
@@ -64,6 +64,16 @@ def _ready_snapshot() -> dict[str, Any]:
     return snapshot
 
 
+def _actions_integration_snapshot() -> dict[str, Any]:
+    snapshot = _ready_snapshot()
+    snapshot["readiness"]["warnings"] = ["github_user_endpoint_unavailable_for_integration_token"]
+    snapshot["merge_actor"]["login"] = "github-actions[bot]"
+    snapshot["merge_actor"]["permission"] = "write"
+    snapshot["merge_actor"]["viewer_can_administer"] = False
+    snapshot["merge_actor"]["administration_write_absent_for_dedicated_actor"] = False
+    return snapshot
+
+
 def _eligibility(snapshot: dict[str, Any], changed_files: list[str]) -> dict[str, Any]:
     mod = _load_script_module()
     return cast(
@@ -150,6 +160,58 @@ def test_ao_ma10a1_ready_snapshot_and_low_risk_files_are_ready_for_dry_run() -> 
         "dedicated_merge_actor_non_admin": True,
         "dedicated_merge_actor_without_admin_write": True,
     }
+
+
+def test_ao_ma10a1_accepts_actions_integration_token_actor_shape() -> None:
+    payload = _eligibility(
+        _actions_integration_snapshot(),
+        ["tests/test_ao_ma10_autonomous_merge_eligibility.py"],
+    )
+    Draft202012Validator(_schema()).validate(payload)
+    assert payload["decision"]["result"] == "ready_for_low_risk_dry_run"
+    assert payload["decision"]["blockers"] == []
+    assert payload["decision"]["warnings"] == ["github_user_endpoint_unavailable_for_integration_token"]
+    assert payload["github_gate_requirements"]["dedicated_merge_actor_non_admin"] is True
+    assert payload["github_gate_requirements"]["dedicated_merge_actor_without_admin_write"] is True
+
+
+def test_ao_ma10a1_rejects_integration_warning_for_unexpected_actor() -> None:
+    snapshot = _actions_integration_snapshot()
+    snapshot["merge_actor"]["login"] = "some-other-writer"
+    payload = _eligibility(snapshot, ["tests/test_ao_ma10_autonomous_merge_eligibility.py"])
+    assert payload["decision"]["result"] == "blocked"
+    assert "dedicated_merge_actor_not_confirmed" in payload["decision"]["blockers"]
+    assert payload["github_gate_requirements"]["dedicated_merge_actor_without_admin_write"] is False
+
+
+def test_ao_ma10a1_rejects_actions_actor_shape_without_integration_warning() -> None:
+    snapshot = _actions_integration_snapshot()
+    snapshot["readiness"]["warnings"] = []
+    payload = _eligibility(snapshot, ["tests/test_ao_ma10_autonomous_merge_eligibility.py"])
+    assert payload["decision"]["result"] == "blocked"
+    assert "dedicated_merge_actor_not_confirmed" in payload["decision"]["blockers"]
+    assert payload["github_gate_requirements"]["dedicated_merge_actor_without_admin_write"] is False
+
+
+def test_ao_ma10a1_rejects_integration_warning_without_write_permission() -> None:
+    snapshot = _actions_integration_snapshot()
+    snapshot["merge_actor"]["permission"] = "read"
+    payload = _eligibility(snapshot, ["tests/test_ao_ma10_autonomous_merge_eligibility.py"])
+    assert payload["decision"]["result"] == "blocked"
+    assert "dedicated_merge_actor_not_confirmed" in payload["decision"]["blockers"]
+    assert payload["github_gate_requirements"]["dedicated_merge_actor_without_admin_write"] is False
+
+
+def test_ao_ma10a1_rejects_integration_warning_when_actor_can_administer() -> None:
+    snapshot = _actions_integration_snapshot()
+    snapshot["merge_actor"]["permission"] = "admin"
+    snapshot["merge_actor"]["viewer_can_administer"] = True
+    payload = _eligibility(snapshot, ["tests/test_ao_ma10_autonomous_merge_eligibility.py"])
+    assert payload["decision"]["result"] == "blocked"
+    assert "merge_actor_admin_permission_observed" in payload["decision"]["blockers"]
+    assert "dedicated_merge_actor_not_confirmed" in payload["decision"]["blockers"]
+    assert payload["github_gate_requirements"]["dedicated_merge_actor_non_admin"] is False
+    assert payload["github_gate_requirements"]["dedicated_merge_actor_without_admin_write"] is False
 
 
 def test_ao_ma10a1_blocks_missing_changed_files() -> None:


### PR DESCRIPTION
## Summary

AO-MA-10A1 now accepts the GitHub Actions integration-token actor shape only when the live readiness snapshot already reports the known integration-token `/user` limitation and the repo-scoped actor evidence is otherwise safe.

Accepted shape:
- `github_user_endpoint_unavailable_for_integration_token` warning is present
- `merge_actor.login == "github-actions[bot]"`
- `merge_actor.permission == "write"`
- `merge_actor.viewer_can_administer is false`

Fail-closed cases preserved/added:
- wrong actor
- non-write permission
- admin permission / `viewer_can_administer=true`
- missing integration-token warning
- readiness not ready / guard drift / required-check drift

## Validation

- `pytest -q tests/test_ao_ma10_autonomous_merge_eligibility.py` -> 22 passed
- `pytest -q tests/test_ao_ma10_autonomous_merge_eligibility.py tests/test_ao_ma10l_autonomous_smoke.py tests/test_ao_ma10q_dedicated_actor_runner.py tests/test_ao_ma10_github_readiness_snapshot.py tests/test_gpp_next.py` -> 102 passed
- `ruff check scripts/ao_ma10_autonomous_merge_eligibility.py tests/test_ao_ma10_autonomous_merge_eligibility.py` -> pass
- `python3 -m py_compile scripts/ao_ma10_autonomous_merge_eligibility.py` -> pass
- `python3 -m json.tool local-ai-review-evidence.v1.json` -> pass
- `python3 -m json.tool ao_kernel/defaults/schemas/ao-ma-10-autonomous-merge-eligibility.schema.v1.json` -> pass
- `git diff --check` -> pass
- `gitleaks protect --staged --no-banner --redact` -> no leaks

## Cross-provider review / local gate

Claude CLI reviewer verdict: `AGREE`.

Local gate:
- command used `PYTHONPATH=.` because the primary checkout currently has a macOS TCC permission issue and Python otherwise resolved `ao_kernel` from `/Users/halilkocoglu/Documents/ao-kernel`.
- decision: `operator_may_merge`
- diff digest: `sha256:08141a41c9dd26fd5caa95c8afb63bcb0dcf2719604c924d85bd19659550e6e4`
- head sha: `516f99515aa6db4a822507ad563608de90139686`

## Boundaries

- no admin bypass
- no branch protection mutation
- no support widening
- no production platform claim
- no live adapter execution
