### PR TITLE
docs(ao-ma1): sync post-cutover autonomy model

### DIFF
--- a/.claude/plans/AO-MA-1-MULTI-AGENT-ORCHESTRATION-DESIGN.md
+++ b/.claude/plans/AO-MA-1-MULTI-AGENT-ORCHESTRATION-DESIGN.md
@@ -160,9 +160,14 @@ AO-MA is an execution accelerator for GPP-2D, not a replacement for it.
 - AO-MA can produce implementer, reviewer, verifier, and integration evidence.
 - `local_gpp_gate` can validate that evidence as operator/process evidence.
 - `ao-release-gate` remains the deterministic merge authority.
-- Low-risk PRs may eventually auto-merge only after GPP-2D-5 branch-protection
-  cutover makes `ao-release-gate` required.
-- High-risk PRs remain CODEOWNERS / human-gated.
+- Low-risk autonomous merge is active only for eligible low-risk PRs after
+  AO-MA-10A0/A1 readiness evidence plus the accepted AO-MA-10q merged-smoke
+  evidence; the merge executor remains an executor, not release authority.
+- High-risk and governance-sensitive PRs remain fail-closed unless
+  `ao-release-gate` validates current, context-bound cross-provider
+  supersession evidence and GitHub ruleset requirements pass. Missing,
+  stale, same-provider, non-AGREE, or guard-violating evidence keeps the PR
+  blocked instead of falling back to model output as authority.
 - testai, smee.io, public webhooks, and deployment-protection callbacks are
   not required for this AO-MA path; they remain deferred optional GPP-2C
   infrastructure unless explicitly reactivated.
@@ -207,8 +212,9 @@ the relevant promotion gates.
 - No treating Codex, Claude, or any other model output as release authority.
 - No testai or public webhook dependency for the near-term AO-MA lane.
 - No testai.acik.com/ao-gate, smee.io, GitHub App webhook, or deployment-protection callback work in AO-MA-1.
-- No GPP-2 closeout until GPP-2D enforce evidence, branch-protection cutover,
-  auto-merge smoke, and AO-GATE-9 closeout are complete.
+- No reopening GPP-2, testai/smee callback topology, production tier promotion,
+  support widening, live adapter execution, or production platform claim from
+  an AO-MA slice without an explicit operator-bound supersession PR.
 
 If a future AO-MA slice touches GitHub Actions workflow design, the inherited
 GPP-2D boundary is: pull_request only, never pull_request_target; read-only

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10M",
+  "work_package": "AO-MA-1-POST-CUTOVER-SYNC",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,24 +13,11 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10m-autonomy-ssot-sync-v2",
+    "head_ref": "refs/heads/codex/ao-ma1-post-cutover-sync",
     "changed_files": [
       ".claude/plans/AO-MA-1-MULTI-AGENT-ORCHESTRATION-DESIGN.md",
-      ".claude/plans/AO-MA-10-LOW-RISK-AUTONOMOUS-MERGE-LANE.md",
-      ".claude/plans/AO-MA-10-LOW-RISK-AUTONOMOUS-MERGE-LANE.v1.json",
-      ".claude/plans/AO-MA-10S-DEDICATED-ACTOR-SMOKE-WORKFLOW.v1.json",
-      ".claude/plans/AO-MA-10T-DEDICATED-ACTOR-SECRET-BOOTSTRAP.md",
-      ".claude/plans/AO-MA-10T-DEDICATED-ACTOR-SECRET-BOOTSTRAP.v1.json",
-      ".claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md",
-      ".claude/plans/GPP-2D-6-AUTOMERGE-SMOKE-RUNBOOK.md",
-      ".claude/plans/gpp_status.v1.json",
-      "AGENTS.md",
-      "docs/evidence/ao-ma-10l-autonomous-smoke/ao-ma-10l-smoke-20260529-105127z.md",
       "local-ai-review-evidence.v1.json",
-      "tests/test_ao_ma10_low_risk_autonomous_merge_lane.py",
-      "tests/test_ao_ma1_design_invariants.py",
-      "tests/test_gpp2d6_automerge_contract.py",
-      "tests/test_gpp_next.py"
+      "tests/test_ao_ma1_design_invariants.py"
     ]
   },
   "checks_considered": [
@@ -53,21 +40,16 @@
     {
       "name": "evidence_consistency",
       "status": "pass"
-    },
-    {
-      "name": "gpp_next_alignment",
-      "status": "pass"
     }
   ],
   "findings": [
-    "Claude review verdict AGREE for AO-MA-10M after reviewing the full branch diff and focused test output. The review evidence file is included in scope because the local-gpp gate requires exact current-PR changed_files binding after this record is added.",
-    "Fresh focused tests passed: tests/test_gpp_next.py, tests/test_ao_ma1_design_invariants.py, tests/test_gpp2d6_automerge_contract.py, tests/test_ao_ma10_low_risk_autonomous_merge_lane.py, tests/test_ao_ma10s_dedicated_actor_smoke_workflow.py, and tests/test_ao_ma10t_configure_dedicated_actor_secret.py reported 63 passed and 1 skipped.",
-    "Guard flags remain closed: support_widening=false, production_platform_claim=false, and live_adapter_execution=false across gpp_status.v1.json, AO-MA-10 receipt JSON, AO-MA-10S JSON, AO-MA-10T JSON, evidence doc, and GPP-2D-6 runbook.",
-    "Scope stays in documentation, plan artifacts, evidence records, and invariant tests. No runtime code, workflow YAML, SDK signatures, schema mutations, branch-protection or ruleset mutation, or CODEOWNERS mutation is introduced.",
-    "AO-MA-10q evidence references are internally consistent: run 26633091281, PR #737, merge commit 15a1e2f, merge actor app/github-actions, doctor_status=0, runner_status=0, and decision=merged are represented as low-risk autonomous merge evidence.",
-    "gpp_next.py remains aligned with the recorded GPP-9 closure: 7/7 milestones done, all three guard flags false, no blocked work packages, and the autonomous GPP chain remains closed without support widening or production platform claim.",
-    "The diff treats AI output as evidence only. Release authority remains ao-release-gate plus the GitHub ruleset; high-risk governance remains consensus-gated and fail-closed.",
-    "No credential material, API keys, tokens, PEMs, or secret values were found in the diff. Token and secret names are referenced only as identifiers, without values."
+    "Claude review verdict AGREE for AO-MA-1-POST-CUTOVER-SYNC after reviewing the current diff and focused validation output.",
+    "Low-risk autonomous merge language is correctly scoped to eligible PRs with AO-MA-10A0/A1 plus AO-MA-10q merged-smoke evidence.",
+    "High-risk fail-closed language explicitly requires context-bound cross-provider supersession evidence and does not fall back to model output as authority.",
+    "Forbidden-action boundary remains explicit: GPP-2 reopening, support widening, live adapter execution, and production platform claim require an operator-bound supersession PR.",
+    "Focused validation passed: pytest -q tests/test_ao_ma1_design_invariants.py tests/test_gpp_next.py tests/test_ao_ma10_low_risk_autonomous_merge_lane.py reported 47 passed and 1 skipped; git diff --check was clean.",
+    "Scope is docs and invariant tests only. No workflow mutation, ruleset mutation, runtime change, CODEOWNERS change, support widening, production platform claim, or live adapter execution is introduced.",
+    "No credential material, API keys, tokens, PEMs, webhook secrets, Vault tokens, or other secret values were found in the diff."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_ao_ma1_design_invariants.py
+++ b/tests/test_ao_ma1_design_invariants.py
@@ -52,6 +52,12 @@ def test_ao_ma1_is_docs_only_and_keeps_gpp2_guards_closed() -> None:
     assert "AO-MA-1 is a design/docs-only slice" in text
     assert "AO-MA-1 originally kept GPP-2 `blocked`" in text
     assert "low-risk autonomous merge evidence accepted" in text
+    assert "Low-risk autonomous merge is active only for eligible low-risk PRs" in text
+    assert "AO-MA-10A0/A1 readiness evidence plus the accepted AO-MA-10q merged-smoke" in text
+    assert "High-risk and governance-sensitive PRs remain fail-closed" in text
+    assert "context-bound cross-provider" in text
+    assert "supersession evidence" in text
+    assert "blocked instead of falling back to model output as authority" in text
     assert "support_widening=false" in text
     assert "production_platform_claim=false" in text
     assert "live_adapter_execution=false" in text
@@ -61,10 +67,9 @@ def test_ao_ma1_is_docs_only_and_keeps_gpp2_guards_closed() -> None:
         "No testai.acik.com/ao-gate, smee.io, GitHub App webhook, or deployment-protection callback work in AO-MA-1."
         in text
     )
-    # GPP-2 closeout (AO-GATE-9) is recorded in completed_wps; AO-MA-1 stays
-    # docs-only and does not change the three guard flags. The active slice
-    # at this point in the program is GPP-3a (Faz 1 of GPP-3) which migrated
-    # current_wp away from GPP-2.
+    assert "No reopening GPP-2, testai/smee callback topology, production tier promotion" in text
+    # GPP-2 closeout (AO-GATE-9) and later GPP closure are recorded in the
+    # SSOT; AO-MA-1 stays docs-only and does not change the three guard flags.
     gpp2_entries = [item for item in status["completed_wps"] if item.get("id") == "GPP-2"]
     assert len(gpp2_entries) == 1
     assert "closed_at" in gpp2_entries[0]


### PR DESCRIPTION
## Summary

Synchronizes the AO-MA-1 orchestration design with the current post-cutover autonomy model:

- low-risk autonomous merge is active only for eligible PRs after AO-MA-10A0/A1 readiness plus accepted AO-MA-10q merged-smoke evidence;
- high-risk/governance-sensitive PRs remain fail-closed unless `ao-release-gate` validates current context-bound cross-provider supersession evidence and GitHub ruleset requirements pass;
- AO-MA slices may not reopen GPP-2, testai/smee callback topology, support widening, live adapter execution, or production platform claims without explicit operator-bound supersession.

This is docs + invariant test + review evidence only. No workflow, ruleset, runtime, CODEOWNERS, support, production-claim, or live-adapter change.

## Validation

- `pytest -q tests/test_ao_ma1_design_invariants.py tests/test_gpp_next.py tests/test_ao_ma10_low_risk_autonomous_merge_lane.py` -> 47 passed, 1 skipped
- `git diff --check` -> clean
- `local-ai-review-evidence.v1.json` validates against `local-ai-review-evidence.schema.v1.json`
- `PYTHONPATH=$PWD python3 scripts/local_gpp_gate.py --review-evidence local-ai-review-evidence.v1.json --output /tmp/local-gpp-gate-ao-ma1-post-cutover-sync.json --repo Halildeu/ao-kernel --work-package AO-MA-1-POST-CUTOVER-SYNC --base-ref refs/heads/main --head-ref refs/heads/codex/ao-ma1-post-cutover-sync --repo-root .` -> `operator_may_merge`, 8/8 checks pass

## Guardrails

- `support_widening=false`
- `production_platform_claim=false`
- `live_adapter_execution=false`
- AI output remains evidence, not release authority
- Release authority remains `ao-release-gate+github-ruleset`
