### PR TITLE
feat(test-quality-gate): add BLK-004 mock-return tautology rule

### DIFF
--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10U",
+  "work_package": "B1-BLK004",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,12 +13,11 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10-high-risk-review-producer",
+    "head_ref": "refs/heads/codex/b1-blk004-mock-tautology",
     "changed_files": [
-      ".claude/plans/AO-MA-10H-HIGH-RISK-SUPERSESSION-CONTRACT.md",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10_high_risk_raw_review_producer.py",
-      "tests/test_ao_ma10_high_risk_raw_review_producer.py"
+      "tests/conftest.py",
+      "tests/test_conftest_quality_gate.py"
     ]
   },
   "checks_considered": [
@@ -45,16 +44,20 @@
     {
       "name": "authority_boundary",
       "status": "pass"
+    },
+    {
+      "name": "cross_ai_review",
+      "status": "pass"
     }
   ],
   "findings": [
-    "Claude review verdict AGREE for AO-MA-10U after reviewing the staged diff and focused validation output.",
-    "The raw high-risk review producer keeps AI output as evidence only; ao-release-gate plus the GitHub ruleset remain release authority.",
-    "The script calls configured OpenAI and Anthropic reviewer commands, normalizes their output into local-ai-review-evidence.v1 files, and requires both providers.",
-    "Fail-closed behavior covers missing provider commands, non-AGREE verdicts, missing tests or secret_scan checks, low-risk diffs, forbidden findings, provider command failures, and secret-like stdout, stderr, diff, prompt, or evidence content.",
-    "Guard flags remain false: no support widening, no production platform claim, and no live adapter execution.",
-    "Focused validation passed: ruff check, mypy, pytest for the raw producer, ao_release_gate, and gpp_next reported 129 passing tests; git diff --check was clean.",
-    "No workflow mutation, ruleset mutation, CODEOWNERS change, branch protection mutation, admin bypass, credential material, or secret value is introduced."
+    "Claude reviewer returned AGREE for B1-BLK004 after reviewing the diff and focused validation output.",
+    "The change adds BLK-004 to block direct mock-return tautologies in tests, reducing false-green test evidence in autonomous agent workflows.",
+    "The implementation stays narrow: direct <mock>.<method>.return_value assignment followed by direct call equality or one-hop result equality in the same test function.",
+    "Codex added a hardening fix so unrelated mock behavioral assertions no longer downgrade BLK-004 to ADV-003; only behavioral signals tied to the same mock method can downgrade.",
+    "Focused validation passed: ruff check tests/conftest.py tests/test_conftest_quality_gate.py, mypy tests/conftest.py, and pytest -q tests/test_conftest_quality_gate.py with 22 passing tests.",
+    "The whole-suite dry-run forcing function asserts zero BLK-004 hits outside the quality-gate fixture file.",
+    "No workflow mutation, ruleset mutation, CODEOWNERS change, branch protection mutation, admin bypass, credential material, support widening, production platform claim, or live adapter execution is introduced."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,20 @@ tautological assertions, exception swallowing, and assertion-free tests.
 
 Rules:
     BLK-001: assert callable(x) — tautological, proves nothing
-    BLK-002: assert x is not None as sole assertion after import — tautological
+    BLK-002: assert True placeholder — proves nothing
     BLK-003: except ...: pass inside test function — hides failures
+    BLK-004: Mock return-value direct-echo tautology (same test function)
+             Detects narrow form: <var>.<method>.return_value = <expr>
+             followed by assert <var>.<method>(...) == <expr> OR
+             result = <var>.<method>(...); assert result == <expr>.
+             Behavioral signals (assert_called_*, call_count, etc.) in the
+             same function downgrade to advisory.
+             Out of scope (first release): patch(..., return_value=...),
+             patch.object, mocker.patch, AsyncMock, side_effect, service
+             pass-through (assert service.f(mock) == VALUE), and attribute
+             projection (assert result.id == VALUE). Future PRs.
     ADV-001: Test function with 0 assert statements — warning
+    ADV-002: sole assertion is 'is not None' — weak behavioral signal
 """
 
 from __future__ import annotations
@@ -17,6 +28,7 @@ import ast
 import json
 import os
 import warnings
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -26,7 +38,7 @@ import pytest
 
 
 @pytest.fixture()
-def tmp_workspace(tmp_path: Path):
+def tmp_workspace(tmp_path: Path) -> Generator[Path, None, None]:
     """Create a temporary .ao/ workspace and cd into it."""
     ws = tmp_path / ".ao"
     ws.mkdir()
@@ -34,11 +46,17 @@ def tmp_workspace(tmp_path: Path):
         (ws / d).mkdir()
     ws_json = ws / "workspace.json"
     import ao_kernel
-    ws_json.write_text(json.dumps({
-        "version": ao_kernel.__version__,
-        "created_at": "2026-01-01T00:00:00Z",
-        "kind": "ao-workspace",
-    }) + "\n")
+
+    ws_json.write_text(
+        json.dumps(
+            {
+                "version": ao_kernel.__version__,
+                "created_at": "2026-01-01T00:00:00Z",
+                "kind": "ao-workspace",
+            }
+        )
+        + "\n"
+    )
     old_cwd = os.getcwd()
     os.chdir(tmp_path)
     yield ws
@@ -46,7 +64,7 @@ def tmp_workspace(tmp_path: Path):
 
 
 @pytest.fixture()
-def empty_dir(tmp_path: Path):
+def empty_dir(tmp_path: Path) -> Generator[Path, None, None]:
     """cd into a temp dir with no workspace."""
     old_cwd = os.getcwd()
     os.chdir(tmp_path)
@@ -55,16 +73,21 @@ def empty_dir(tmp_path: Path):
 
 
 @pytest.fixture()
-def legacy_workspace(tmp_path: Path):
+def legacy_workspace(tmp_path: Path) -> Generator[Path, None, None]:
     """Create a legacy .cache/ws_customer_default workspace."""
     legacy = tmp_path / ".cache" / "ws_customer_default"
     legacy.mkdir(parents=True)
     ws_json = legacy / "workspace.json"
-    ws_json.write_text(json.dumps({
-        "version": "0.0.9",
-        "created_at": "2025-01-01T00:00:00Z",
-        "kind": "ao-workspace",
-    }) + "\n")
+    ws_json.write_text(
+        json.dumps(
+            {
+                "version": "0.0.9",
+                "created_at": "2025-01-01T00:00:00Z",
+                "kind": "ao-workspace",
+            }
+        )
+        + "\n"
+    )
     old_cwd = os.getcwd()
     os.chdir(tmp_path)
     yield legacy
@@ -77,19 +100,175 @@ def legacy_workspace(tmp_path: Path):
 class _TestQualityViolation:
     """A detected test quality violation."""
 
-    def __init__(self, file: str, func: str, rule: str, detail: str):
+    def __init__(self, file: str, func: str, rule: str, detail: str) -> None:
         self.file = file
         self.func = func
         self.rule = rule
         self.detail = detail
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"[{self.rule}] {self.file}::{self.func} — {self.detail}"
+
+
+# Method names that, when called or referenced inside a test function,
+# indicate the test verifies mock-call behavior beyond return-value echo.
+# Presence of any of these in the function downgrades BLK-004 → ADV-003.
+_BLK004_BEHAVIORAL_METHODS = frozenset(
+    {
+        "assert_called",
+        "assert_called_once",
+        "assert_called_with",
+        "assert_called_once_with",
+        "assert_any_call",
+        "assert_has_calls",
+        "assert_not_called",
+    }
+)
+_BLK004_BEHAVIORAL_ATTRS = frozenset(
+    {
+        "call_count",
+        "called",
+        "call_args",
+        "call_args_list",
+        "mock_calls",
+        "method_calls",
+    }
+)
+
+
+def _ast_eq(a: ast.AST, b: ast.AST) -> bool:
+    """Structural AST equality (location-insensitive)."""
+    return ast.dump(a, annotate_fields=True, include_attributes=False) == ast.dump(
+        b, annotate_fields=True, include_attributes=False
+    )
+
+
+def _blk004_method_key(expr: ast.AST) -> tuple[str, str] | None:
+    """Return ``(<mock_name>, <method>)`` for ``mock.method`` expressions."""
+    if isinstance(expr, ast.Attribute) and isinstance(expr.value, ast.Name):
+        return (expr.value.id, expr.attr)
+    return None
+
+
+def _blk004_scan(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    fname: str,
+    func_name: str,
+    violations: list[_TestQualityViolation],
+) -> None:
+    """Detect BLK-004 mock-return direct-echo tautology in a test function.
+
+    Narrow scope per Codex CNS-20260529-001:
+      - assignment form: ``<Name>.<attr>.return_value = <expr>``
+      - echo form A:     ``assert <Name>.<attr>(...) == <expr>``
+      - echo form B:     ``<result> = <Name>.<attr>(...); assert <result> == <expr>``
+      - BLK iff sole/primary outcome assertion is direct echo AND no
+        behavioral signals (assert_called_*, call_count, ...) present.
+      - Behavioral signals present → emit ADV-003 (advisory) instead.
+
+    Out of scope (first release): patch/patch.object/mocker.patch kwargs,
+    AsyncMock, side_effect, service pass-through, attribute projection.
+    """
+    # Pass 1: gather return_value assignments and result bindings.
+    # Use ast.dump of the return_expr as the canonical key, so AST structural
+    # equality decides matches.
+    return_value_map: dict[tuple[str, str], ast.expr] = {}
+    result_call_map: dict[str, tuple[str, str]] = {}
+
+    for stmt in ast.walk(node):
+        if not (isinstance(stmt, ast.Assign) and len(stmt.targets) == 1):
+            continue
+        tgt = stmt.targets[0]
+
+        # <name>.<attr>.return_value = <expr>
+        if (
+            isinstance(tgt, ast.Attribute)
+            and tgt.attr == "return_value"
+            and isinstance(tgt.value, ast.Attribute)
+            and isinstance(tgt.value.value, ast.Name)
+        ):
+            mock_name = tgt.value.value.id
+            method = tgt.value.attr
+            return_value_map[(mock_name, method)] = stmt.value
+
+        # <result> = <name>.<attr>(...)
+        if (
+            isinstance(tgt, ast.Name)
+            and isinstance(stmt.value, ast.Call)
+            and isinstance(stmt.value.func, ast.Attribute)
+            and isinstance(stmt.value.func.value, ast.Name)
+        ):
+            call_func = stmt.value.func
+            assert isinstance(call_func, ast.Attribute)  # narrows for mypy
+            call_recv = call_func.value
+            assert isinstance(call_recv, ast.Name)  # narrows for mypy
+            result_call_map[tgt.id] = (call_recv.id, call_func.attr)
+
+    if not return_value_map:
+        return
+
+    # Pass 2: behavioral signals tied to a specific mock method suppress
+    # BLK to ADV-003 for that method only. An unrelated mock assertion must
+    # not downgrade a direct-echo tautology.
+    behavioral_keys: set[tuple[str, str]] = set()
+    for stmt in ast.walk(node):
+        if (
+            isinstance(stmt, ast.Call)
+            and isinstance(stmt.func, ast.Attribute)
+            and stmt.func.attr in _BLK004_BEHAVIORAL_METHODS
+        ):
+            key = _blk004_method_key(stmt.func.value)
+            if key is not None:
+                behavioral_keys.add(key)
+        if isinstance(stmt, ast.Attribute) and stmt.attr in _BLK004_BEHAVIORAL_ATTRS:
+            key = _blk004_method_key(stmt.value)
+            if key is not None:
+                behavioral_keys.add(key)
+
+    # Pass 3: scan asserts for direct echo.
+    seen_keys: set[tuple[str, str]] = set()
+    for stmt in ast.walk(node):
+        if not isinstance(stmt, ast.Assert):
+            continue
+        test = stmt.test
+        if not (isinstance(test, ast.Compare) and len(test.ops) == 1 and isinstance(test.ops[0], ast.Eq)):
+            continue
+        lhs = test.left
+        rhs = test.comparators[0]
+
+        # Form A: assert <var>.<attr>(...) == <expr>
+        if isinstance(lhs, ast.Call) and isinstance(lhs.func, ast.Attribute) and isinstance(lhs.func.value, ast.Name):
+            key = (lhs.func.value.id, lhs.func.attr)
+            if key in return_value_map and _ast_eq(rhs, return_value_map[key]):
+                if key in seen_keys:
+                    continue
+                seen_keys.add(key)
+                rule, label = ("ADV-003", "advisory") if key in behavioral_keys else ("BLK-004", "blocking")
+                detail = (
+                    f"mock-return tautology ({label}): {key[0]}.{key[1]}.return_value "
+                    "was set to the same expression asserted via direct call"
+                )
+                violations.append(_TestQualityViolation(fname, func_name, rule, detail))
+                continue
+
+        # Form B: assert <result_name> == <expr> (result bound from mock call)
+        if isinstance(lhs, ast.Name) and lhs.id in result_call_map:
+            key = result_call_map[lhs.id]
+            if key in return_value_map and _ast_eq(rhs, return_value_map[key]):
+                if key in seen_keys:
+                    continue
+                seen_keys.add(key)
+                rule, label = ("ADV-003", "advisory") if key in behavioral_keys else ("BLK-004", "blocking")
+                detail = (
+                    f"mock-return tautology ({label}): {key[0]}.{key[1]}.return_value "
+                    f"was set to the same expression asserted via {lhs.id}"
+                )
+                violations.append(_TestQualityViolation(fname, func_name, rule, detail))
 
 
 def _scan_test_file(filepath: Path) -> list[_TestQualityViolation]:
     """Scan a test file for anti-patterns using AST analysis."""
-    violations = []
+    violations: list[_TestQualityViolation] = []
     try:
         source = filepath.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(filepath))
@@ -112,30 +291,54 @@ def _scan_test_file(filepath: Path) -> list[_TestQualityViolation]:
             if isinstance(child, ast.Assert) and isinstance(child.test, ast.Call):
                 call = child.test
                 if isinstance(call.func, ast.Name) and call.func.id == "callable":
-                    violations.append(_TestQualityViolation(
-                        fname, func_name, "BLK-001",
-                        "assert callable(x) is tautological — test actual behavior instead",
-                    ))
+                    violations.append(
+                        _TestQualityViolation(
+                            fname,
+                            func_name,
+                            "BLK-001",
+                            "assert callable(x) is tautological — test actual behavior instead",
+                        )
+                    )
 
         # BLK-002: assert True (placeholder — proves nothing)
         for child in ast.walk(node):
             if isinstance(child, ast.Assert):
                 test_val = child.test
                 if isinstance(test_val, ast.Constant) and test_val.value is True:
-                    violations.append(_TestQualityViolation(
-                        fname, func_name, "BLK-002",
-                        "assert True is a placeholder — assert actual behavior instead",
-                    ))
+                    violations.append(
+                        _TestQualityViolation(
+                            fname,
+                            func_name,
+                            "BLK-002",
+                            "assert True is a placeholder — assert actual behavior instead",
+                        )
+                    )
 
         # BLK-003: except ...: pass
         for child in ast.walk(node):
             if isinstance(child, ast.ExceptHandler):
-                if (len(child.body) == 1
-                        and isinstance(child.body[0], ast.Pass)):
-                    violations.append(_TestQualityViolation(
-                        fname, func_name, "BLK-003",
-                        "except: pass swallows test failures — use pytest.raises or handle explicitly",
-                    ))
+                if len(child.body) == 1 and isinstance(child.body[0], ast.Pass):
+                    violations.append(
+                        _TestQualityViolation(
+                            fname,
+                            func_name,
+                            "BLK-003",
+                            "except: pass swallows test failures — use pytest.raises or handle explicitly",
+                        )
+                    )
+
+        # BLK-004: Mock return-value direct-echo tautology
+        # Narrow scope (per Codex CNS-20260529-001 REVISE+impl-ready):
+        #   <Name>.<attr>.return_value = <expr>
+        # then either:
+        #   assert <Name>.<attr>(...) == <expr>   (form A: direct call)
+        #   <result> = <Name>.<attr>(...)
+        #   assert <result> == <expr>             (form B: one-hop via result)
+        # AST structural equality (ast.dump w/o attrs) decides match.
+        # Behavioral signals in same function downgrade BLK → ADV-003.
+        # Out of scope: patch/patch.object/mocker.patch, AsyncMock, side_effect,
+        # service pass-through, attribute projection. Future PRs.
+        _blk004_scan(node, fname, func_name, violations)
 
         # ADV-002: Weak single assertion (is not None, isinstance, len > 0)
         # Only triggers when it's the SOLE meaningful assertion in the test
@@ -143,15 +346,21 @@ def _scan_test_file(filepath: Path) -> list[_TestQualityViolation]:
         if len(assert_nodes) == 1:
             sole = assert_nodes[0]
             # assert x is not None
-            if (isinstance(sole.test, ast.Compare)
-                    and len(sole.test.ops) == 1
-                    and isinstance(sole.test.ops[0], ast.IsNot)
-                    and isinstance(sole.test.comparators[0], ast.Constant)
-                    and sole.test.comparators[0].value is None):
-                violations.append(_TestQualityViolation(
-                    fname, func_name, "ADV-002",
-                    "sole assertion is 'is not None' — add a behavioral assertion",
-                ))
+            if (
+                isinstance(sole.test, ast.Compare)
+                and len(sole.test.ops) == 1
+                and isinstance(sole.test.ops[0], ast.IsNot)
+                and isinstance(sole.test.comparators[0], ast.Constant)
+                and sole.test.comparators[0].value is None
+            ):
+                violations.append(
+                    _TestQualityViolation(
+                        fname,
+                        func_name,
+                        "ADV-002",
+                        "sole assertion is 'is not None' — add a behavioral assertion",
+                    )
+                )
 
         # ADV-001: No assertions at all
         has_assert = False
@@ -170,15 +379,19 @@ def _scan_test_file(filepath: Path) -> list[_TestQualityViolation]:
                     break
 
         if not has_assert:
-            violations.append(_TestQualityViolation(
-                fname, func_name, "ADV-001",
-                "test has no assertions — add assert or pytest.raises",
-            ))
+            violations.append(
+                _TestQualityViolation(
+                    fname,
+                    func_name,
+                    "ADV-001",
+                    "test has no assertions — add assert or pytest.raises",
+                )
+            )
 
     return violations
 
 
-def pytest_collect_file(parent, file_path):
+def pytest_collect_file(parent: object, file_path: Path) -> None:
     """Scan test files for quality violations during collection."""
     if not file_path.name.startswith("test_") or not file_path.suffix == ".py":
         return

--- a/tests/test_conftest_quality_gate.py
+++ b/tests/test_conftest_quality_gate.py
@@ -1,0 +1,352 @@
+"""Tests for the conftest.py test-quality gate AST scanner.
+
+Validates the scanner contract:
+    - BLK-001 (assert callable) — blocking
+    - BLK-002 (assert True) — blocking
+    - BLK-003 (except: pass in test) — blocking
+    - BLK-004 (mock-return direct-echo tautology) — blocking
+    - ADV-001 (no assertions) — advisory
+    - ADV-002 (sole 'is not None') — advisory
+    - ADV-003 (BLK-004 downgraded by behavioral signal) — advisory
+
+Fixtures are written to ``tmp_path`` to avoid pytest auto-collection of the
+sample sources as real tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Import the scanner directly from the conftest module; pytest discovery and
+# direct imports both resolve to the same module instance.
+from tests.conftest import (  # noqa: E402
+    _TestQualityViolation,
+    _scan_test_file,
+)
+
+
+def _scan_source(tmp_path: Path, source: str, filename: str = "snippet_test.py") -> list[_TestQualityViolation]:
+    p = tmp_path / filename
+    p.write_text(source, encoding="utf-8")
+    return _scan_test_file(p)
+
+
+def _rules(violations: list[_TestQualityViolation]) -> list[str]:
+    return [v.rule for v in violations]
+
+
+# ── BLK-001..003 regression ────────────────────────────────────────────
+
+
+def test_blk001_assert_callable(tmp_path: Path) -> None:
+    source = "def test_thing():\n    def f():\n        return 1\n    assert callable(f)\n"
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-001" in rules
+
+
+def test_blk002_assert_true(tmp_path: Path) -> None:
+    source = "def test_thing():\n    assert True\n"
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-002" in rules
+
+
+def test_blk003_except_pass(tmp_path: Path) -> None:
+    source = "def test_thing():\n    try:\n        raise ValueError(1)\n    except Exception:\n        pass\n"
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-003" in rules
+
+
+# ── BLK-004 positive (blocking) ────────────────────────────────────────
+
+
+def test_blk004_form_a_direct_call_literal_int(tmp_path: Path) -> None:
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 42\n"
+        "    assert m.method() == 42\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" in rules
+    assert "ADV-003" not in rules
+
+
+def test_blk004_form_a_with_arg(tmp_path: Path) -> None:
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 'alpha'\n"
+        "    assert m.method('ignored') == 'alpha'\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" in rules
+
+
+def test_blk004_form_b_via_result_binding(tmp_path: Path) -> None:
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 7\n"
+        "    result = m.method()\n"
+        "    assert result == 7\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" in rules
+
+
+def test_blk004_struct_equality_literal_string(tmp_path: Path) -> None:
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 'hello'\n"
+        "    assert m.method() == 'hello'\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" in rules
+
+
+# ── ADV-003 (BLK-004 downgraded by behavioral signal) ──────────────────
+
+
+def test_adv003_when_assert_called_present(tmp_path: Path) -> None:
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 42\n"
+        "    result = m.method('x')\n"
+        "    assert result == 42\n"
+        "    m.method.assert_called_once_with('x')\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "ADV-003" in rules
+    assert "BLK-004" not in rules
+
+
+def test_adv003_when_call_count_present(tmp_path: Path) -> None:
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 5\n"
+        "    m.method()\n"
+        "    m.method()\n"
+        "    assert m.method.call_count == 2\n"
+        "    assert m.method() == 5\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "ADV-003" in rules
+    assert "BLK-004" not in rules
+
+
+def test_blk004_unrelated_behavioral_signal_does_not_downgrade(tmp_path: Path) -> None:
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    other = Mock()\n"
+        "    m.method.return_value = 42\n"
+        "    assert m.method() == 42\n"
+        "    other.save.assert_called_once()\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" in rules
+    assert "ADV-003" not in rules
+
+
+# ── BLK-004 negative (out of scope, must NOT trigger) ─────────────────
+
+
+def test_blk004_negative_service_pass_through(tmp_path: Path) -> None:
+    # service pass-through: out of scope per Codex CNS-20260529-001
+    source = (
+        "from unittest.mock import Mock\n"
+        "def fetch(repo):\n"
+        "    return repo.get_user()\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.get_user.return_value = 42\n"
+        "    assert fetch(m) == 42\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" not in rules
+    assert "ADV-003" not in rules
+
+
+def test_blk004_negative_attribute_projection(tmp_path: Path) -> None:
+    # assert result.id == 42 (attribute projection): out of scope
+    source = (
+        "from unittest.mock import Mock\n"
+        "class _Obj:\n"
+        "    id = 42\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.get_user.return_value = _Obj()\n"
+        "    result = m.get_user()\n"
+        "    assert result.id == 42\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" not in rules
+
+
+def test_blk004_negative_patch_kwarg(tmp_path: Path) -> None:
+    # patch(..., return_value=...) kwargs: out of scope (future PR)
+    source = (
+        "from unittest.mock import patch\n"
+        "def test_thing():\n"
+        "    with patch('os.getpid', return_value=99) as p:\n"
+        "        assert p() == 99\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" not in rules
+
+
+def test_blk004_negative_side_effect(tmp_path: Path) -> None:
+    # side_effect is out of scope first release
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.side_effect = [1, 2, 3]\n"
+        "    assert m.method() == 1\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" not in rules
+
+
+def test_blk004_negative_cache_state_check(tmp_path: Path) -> None:
+    # mock return_value set, but assertion is on different state
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    cache = {}\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 42\n"
+        "    cache['x'] = m.method()\n"
+        "    assert len(cache) == 1\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" not in rules
+
+
+def test_blk004_negative_different_expr_compared(tmp_path: Path) -> None:
+    # return_value set to 42, but assert compares to 43 (mismatch)
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 42\n"
+        "    assert m.method() == 43\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" not in rules
+
+
+def test_blk004_negative_different_mock_var(tmp_path: Path) -> None:
+    # return_value on one mock, assertion on different mock call
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m1 = Mock()\n"
+        "    m2 = Mock()\n"
+        "    m1.method.return_value = 42\n"
+        "    m2.method.return_value = 99\n"
+        "    assert m2.method() == 99\n"
+        "    assert m1.method() == 42\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    # Both ARE BLK-004 in narrow scope; just verify per-mock not cross-mock
+    assert rules.count("BLK-004") == 2
+
+
+# ── Cross-function isolation ────────────────────────────────────────
+
+
+def test_blk004_does_not_cross_functions(tmp_path: Path) -> None:
+    # return_value set in fn A, asserted in fn B → must NOT fire
+    source = (
+        "from unittest.mock import Mock\n"
+        "_M = Mock()\n"
+        "_M.method.return_value = 42\n"
+        "def test_a():\n"
+        "    _M.method.return_value = 42\n"
+        "    _M.method()\n"
+        "    _M.method.assert_called()\n"
+        "def test_b():\n"
+        "    # different test function — return_value not set HERE\n"
+        "    assert _M.method() == 42\n"
+    )
+    rules_per_fn = _rules(_scan_source(tmp_path, source))
+    # test_a: return_value set + assert_called → ADV-003 may fire if direct echo
+    #         present; here no direct echo assertion in test_a.
+    # test_b: NO return_value assignment in this function → no BLK-004.
+    # Ensure test_b alone does NOT see BLK-004.
+    # We just assert that BLK-004 count <= 1 (only test_a if at all).
+    assert rules_per_fn.count("BLK-004") == 0
+
+
+# ── ADV-001, ADV-002 regression ────────────────────────────────────────
+
+
+def test_adv001_no_assertions(tmp_path: Path) -> None:
+    source = "def test_thing():\n    x = 1 + 1\n    pass\n"
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "ADV-001" in rules
+
+
+def test_adv002_sole_is_not_none(tmp_path: Path) -> None:
+    source = "def make_obj():\n    return 1\ndef test_thing():\n    obj = make_obj()\n    assert obj is not None\n"
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "ADV-002" in rules
+
+
+# ── Whole-suite dry-run audit ──────────────────────────────────────────
+
+
+def test_blk004_zero_hits_in_current_suite() -> None:
+    """Lock-in: BLK-004 must have 0 hits in the current tests/ tree.
+
+    This forcing function ensures the rule stays narrow. If a future PR
+    introduces a direct-echo mock tautology, this test fails first; that PR
+    must either fix the test or extend BLK-004 scope intentionally.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    tests_dir = repo_root / "tests"
+    blk004_hits: list[str] = []
+    for p in sorted(tests_dir.rglob("test_*.py")):
+        if p.name == "test_conftest_quality_gate.py":
+            # Skip THIS file — we intentionally include BLK-004 fixtures.
+            continue
+        for v in _scan_test_file(p):
+            if v.rule == "BLK-004":
+                blk004_hits.append(f"{p.name}::{v.func}")
+    assert blk004_hits == [], (
+        "BLK-004 violations introduced in current tests/ tree: "
+        f"{blk004_hits}. Either fix the test or extend the rule deliberately."
+    )
+
+
+# ── Negative: ensure self-fixtures don't leak into the rest of the suite ──
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "snippet_test.py",
+    ],
+)
+def test_fixture_files_isolated_to_tmp_path(tmp_path: Path, filename: str) -> None:
+    """Sanity: tmp_path fixture files don't get auto-collected by pytest."""
+    fixture_path = tmp_path / filename
+    fixture_path.write_text("def test_x():\n    assert True\n", encoding="utf-8")
+    # tmp_path is OUTSIDE tests/ — pytest_collect_file would not touch it
+    # during normal collection. Verify by direct file existence + scanning.
+    assert fixture_path.exists()
+    rules = _rules(_scan_test_file(fixture_path))
+    assert "BLK-002" in rules  # the assert True placeholder


### PR DESCRIPTION
## Summary
- add `BLK-004` to `tests/conftest.py` to block narrow mock-return direct-echo tautologies
- add regression tests for BLK-001/002/003, BLK-004 positive/negative cases, ADV-003 downgrade behavior, and whole-suite zero-hit forcing function
- harden ADV-003 downgrade so only behavioral signals tied to the same mock method can downgrade a BLK-004 finding
- add `local-ai-review-evidence.v1.json` for cross-provider review trace

## Autonomy / authority boundary
- This improves autonomous-agent safety by rejecting false-green tests where an agent only asserts the value it placed into a mock
- AI output remains evidence only
- `ao-release-gate` plus the GitHub ruleset remain release authority
- no workflow mutation, ruleset mutation, CODEOWNERS change, branch protection mutation, admin bypass, support widening, production platform claim, or live adapter execution

## Scope
Detects narrow first-release forms:
- `<var>.<method>.return_value = X` followed by `assert <var>.<method>(...) == X`
- `<result> = <var>.<method>(...)` followed by `assert <result> == X`

Out of scope for this PR:
- `patch(..., return_value=...)`, `patch.object`, `mocker.patch`, `AsyncMock`, `side_effect`, service pass-through, attribute projection

## Validation
- `ruff check tests/conftest.py tests/test_conftest_quality_gate.py` -> pass
- `mypy tests/conftest.py` -> pass
- `pytest -q tests/test_conftest_quality_gate.py` -> 22 passed
- `PYTHONPATH=$PWD python3 scripts/local_gpp_gate.py --review-evidence local-ai-review-evidence.v1.json --output /tmp/local-gpp-gate-b1-blk004.json --repo Halildeu/ao-kernel --work-package B1-BLK004 --base-ref refs/heads/main --head-ref refs/heads/codex/b1-blk004-mock-tautology --repo-root .` -> `operator_may_merge`

## Cross-AI review
- Plan-time consultation: Codex thread `019e73b3-b131-7240-a49a-e4de27cb29a9` / `CNS-20260529-001` -> REVISE + ready_for_impl, scope `A_NARROW + D_AUDIT_FIRST`
- Post-implementation review: Claude Code reviewer returned `AGREE` with no required changes after reviewing the final diff and validation output