### PR TITLE
test(blk004): harden mock-return tautology scanner

### DIFF
--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "B1-BLK004",
+  "work_package": "B1-BLK004-HARDENING",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,7 +13,7 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/b1-blk004-mock-tautology",
+    "head_ref": "refs/heads/codex/blk004-hardening-main",
     "changed_files": [
       "local-ai-review-evidence.v1.json",
       "tests/conftest.py",
@@ -51,12 +51,12 @@
     }
   ],
   "findings": [
-    "Claude reviewer returned AGREE for B1-BLK004 after reviewing the diff and focused validation output.",
-    "The change adds BLK-004 to block direct mock-return tautologies in tests, reducing false-green test evidence in autonomous agent workflows.",
-    "The implementation stays narrow: direct <mock>.<method>.return_value assignment followed by direct call equality or one-hop result equality in the same test function.",
-    "Codex added a hardening fix so unrelated mock behavioral assertions no longer downgrade BLK-004 to ADV-003; only behavioral signals tied to the same mock method can downgrade.",
-    "Focused validation passed: ruff check tests/conftest.py tests/test_conftest_quality_gate.py, mypy tests/conftest.py, and pytest -q tests/test_conftest_quality_gate.py with 22 passing tests.",
-    "The whole-suite dry-run forcing function asserts zero BLK-004 hits outside the quality-gate fixture file.",
+    "Claude reviewer returned AGREE for B1-BLK004-HARDENING after reviewing the staged diff and focused validation output.",
+    "The change hardens BLK-004 so nested helper function bodies cannot leak mock-return events into the outer test scan.",
+    "The implementation makes BLK-004 source-order aware: later return_value assignments win and result aliases are cleared when a variable is rebound.",
+    "Behavioral-signal downgrade is scoped to the same mock method key; unrelated mock behavior and bare call_count reads do not downgrade blocking direct echoes.",
+    "Focused validation passed: ruff check tests/conftest.py tests/test_conftest_quality_gate.py, mypy tests/conftest.py, pytest -q tests/test_conftest_quality_gate.py, and pytest -q tests/test_conftest_quality_gate.py tests/test_ao_ma10_high_risk_raw_review_producer.py.",
+    "The current-suite forcing function continues to assert zero BLK-004 hits outside the quality-gate fixture file.",
     "No workflow mutation, ruleset mutation, CODEOWNERS change, branch protection mutation, admin bypass, credential material, support widening, production platform claim, or live adapter execution is introduced."
   ],
   "secrets_recorded": false,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ import ast
 import json
 import os
 import warnings
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 from pathlib import Path
 
 import pytest
@@ -143,11 +143,62 @@ def _ast_eq(a: ast.AST, b: ast.AST) -> bool:
     )
 
 
-def _blk004_method_key(expr: ast.AST) -> tuple[str, str] | None:
-    """Return ``(<mock_name>, <method>)`` for ``mock.method`` expressions."""
-    if isinstance(expr, ast.Attribute) and isinstance(expr.value, ast.Name):
-        return (expr.value.id, expr.attr)
-    return None
+def _walk_outside_nested_scopes(node: ast.AST) -> Iterator[ast.AST]:
+    """Yield ``node`` and all descendants in source order without entering nested
+    function/lambda/class scopes.
+
+    This is a same-function precision boundary for BLK-004. A nested helper
+    inside ``def test_xxx`` should NOT contribute return-value assignments or
+    asserts to the outer test scan.
+    """
+    yield node
+    for child in ast.iter_child_nodes(node):
+        if isinstance(
+            child,
+            (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef),
+        ):
+            continue
+        yield from _walk_outside_nested_scopes(child)
+
+
+def _collect_behavioral_signal_keys(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> set[tuple[str, str]]:
+    """Return the set of ``(mock_name, method)`` keys that have a real
+    behavioral assertion in the test function body.
+
+    A behavioral signal is one of:
+      - a *call* to ``<var>.<method>.<assert_called_*>(...)``
+      - a behavioral attribute (``call_count``, ``called``, ``call_args``...)
+        appearing *inside an ``ast.Assert``* (or other check context — we
+        scope to Assert/Call comparison here for precision).
+
+    Bare expressions like ``_ = m.method.call_count`` outside an Assert do
+    NOT count, so a direct-echo BLK stays blocking. Unrelated mocks (different
+    ``(mock_name, method)`` key) also do NOT downgrade the targeted echo.
+    """
+    keys: set[tuple[str, str]] = set()
+    for child in _walk_outside_nested_scopes(node):
+        # Behavioral method call: <mock>.<method>.assert_called*(...)
+        if (
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Attribute)
+            and child.func.attr in _BLK004_BEHAVIORAL_METHODS
+            and isinstance(child.func.value, ast.Attribute)
+            and isinstance(child.func.value.value, ast.Name)
+        ):
+            keys.add((child.func.value.value.id, child.func.value.attr))
+        # Behavioral attr inside Assert: assert m.method.call_count == 2 etc.
+        if isinstance(child, ast.Assert):
+            for sub in ast.walk(child):
+                if (
+                    isinstance(sub, ast.Attribute)
+                    and sub.attr in _BLK004_BEHAVIORAL_ATTRS
+                    and isinstance(sub.value, ast.Attribute)
+                    and isinstance(sub.value.value, ast.Name)
+                ):
+                    keys.add((sub.value.value.id, sub.value.attr))
+    return keys
 
 
 def _blk004_scan(
@@ -158,112 +209,120 @@ def _blk004_scan(
 ) -> None:
     """Detect BLK-004 mock-return direct-echo tautology in a test function.
 
-    Narrow scope per Codex CNS-20260529-001:
+    Narrow scope per Codex CNS-20260529-001 (iter-1 REVISE absorbed):
       - assignment form: ``<Name>.<attr>.return_value = <expr>``
       - echo form A:     ``assert <Name>.<attr>(...) == <expr>``
       - echo form B:     ``<result> = <Name>.<attr>(...); assert <result> == <expr>``
-      - BLK iff sole/primary outcome assertion is direct echo AND no
-        behavioral signals (assert_called_*, call_count, ...) present.
-      - Behavioral signals present → emit ADV-003 (advisory) instead.
+      - BLK iff direct echo AND no per-key behavioral signal in the same
+        function.
+      - Per-key behavioral signal present → emit ADV-003 (advisory) instead.
 
     Out of scope (first release): patch/patch.object/mocker.patch kwargs,
     AsyncMock, side_effect, service pass-through, attribute projection.
+
+    Precision (Codex post-impl iter-2 BLOCKING fixes absorbed):
+      - Nested function/lambda/class bodies are pruned from the scan, so a
+        helper inside the test cannot leak return_value/assert events to the
+        outer scope.
+      - Statement order is preserved: ``return_value`` reassignments and
+        ``result = m.method()`` rebindings are evaluated in source order, so
+        a stale value or a reassigned ``result`` does not produce a hit.
+      - Behavioral-signal downgrade is per-``(mock_name, method)`` key.
+        Bare references like ``_ = m.method.call_count`` outside an Assert
+        do not demote a sibling direct echo.
     """
-    # Pass 1: gather return_value assignments and result bindings.
-    # Use ast.dump of the return_expr as the canonical key, so AST structural
-    # equality decides matches.
-    return_value_map: dict[tuple[str, str], ast.expr] = {}
-    result_call_map: dict[str, tuple[str, str]] = {}
+    # Pre-pass: collect per-key behavioral signals for the downgrade rule.
+    behavioral_keys = _collect_behavioral_signal_keys(node)
 
-    for stmt in ast.walk(node):
-        if not (isinstance(stmt, ast.Assign) and len(stmt.targets) == 1):
-            continue
-        tgt = stmt.targets[0]
-
-        # <name>.<attr>.return_value = <expr>
-        if (
-            isinstance(tgt, ast.Attribute)
-            and tgt.attr == "return_value"
-            and isinstance(tgt.value, ast.Attribute)
-            and isinstance(tgt.value.value, ast.Name)
-        ):
-            mock_name = tgt.value.value.id
-            method = tgt.value.attr
-            return_value_map[(mock_name, method)] = stmt.value
-
-        # <result> = <name>.<attr>(...)
-        if (
-            isinstance(tgt, ast.Name)
-            and isinstance(stmt.value, ast.Call)
-            and isinstance(stmt.value.func, ast.Attribute)
-            and isinstance(stmt.value.func.value, ast.Name)
-        ):
-            call_func = stmt.value.func
-            assert isinstance(call_func, ast.Attribute)  # narrows for mypy
-            call_recv = call_func.value
-            assert isinstance(call_recv, ast.Name)  # narrows for mypy
-            result_call_map[tgt.id] = (call_recv.id, call_func.attr)
-
-    if not return_value_map:
-        return
-
-    # Pass 2: behavioral signals tied to a specific mock method suppress
-    # BLK to ADV-003 for that method only. An unrelated mock assertion must
-    # not downgrade a direct-echo tautology.
-    behavioral_keys: set[tuple[str, str]] = set()
-    for stmt in ast.walk(node):
-        if (
-            isinstance(stmt, ast.Call)
-            and isinstance(stmt.func, ast.Attribute)
-            and stmt.func.attr in _BLK004_BEHAVIORAL_METHODS
-        ):
-            key = _blk004_method_key(stmt.func.value)
-            if key is not None:
-                behavioral_keys.add(key)
-        if isinstance(stmt, ast.Attribute) and stmt.attr in _BLK004_BEHAVIORAL_ATTRS:
-            key = _blk004_method_key(stmt.value)
-            if key is not None:
-                behavioral_keys.add(key)
-
-    # Pass 3: scan asserts for direct echo.
+    # Main pass: walk function body in source order, maintaining a
+    # point-in-time state of return_value bindings and result aliases.
+    return_value_state: dict[tuple[str, str], ast.expr] = {}
+    result_active: dict[str, tuple[str, str]] = {}
     seen_keys: set[tuple[str, str]] = set()
-    for stmt in ast.walk(node):
-        if not isinstance(stmt, ast.Assert):
-            continue
-        test = stmt.test
-        if not (isinstance(test, ast.Compare) and len(test.ops) == 1 and isinstance(test.ops[0], ast.Eq)):
-            continue
-        lhs = test.left
-        rhs = test.comparators[0]
 
-        # Form A: assert <var>.<attr>(...) == <expr>
-        if isinstance(lhs, ast.Call) and isinstance(lhs.func, ast.Attribute) and isinstance(lhs.func.value, ast.Name):
-            key = (lhs.func.value.id, lhs.func.attr)
-            if key in return_value_map and _ast_eq(rhs, return_value_map[key]):
-                if key in seen_keys:
-                    continue
-                seen_keys.add(key)
-                rule, label = ("ADV-003", "advisory") if key in behavioral_keys else ("BLK-004", "blocking")
-                detail = (
-                    f"mock-return tautology ({label}): {key[0]}.{key[1]}.return_value "
-                    "was set to the same expression asserted via direct call"
-                )
-                violations.append(_TestQualityViolation(fname, func_name, rule, detail))
-                continue
+    def _emit(key: tuple[str, str], via: str) -> None:
+        if key in seen_keys:
+            return
+        seen_keys.add(key)
+        has_beh = key in behavioral_keys
+        rule, label = ("ADV-003", "advisory") if has_beh else ("BLK-004", "blocking")
+        detail = (
+            f"mock-return tautology ({label}): "
+            f"{key[0]}.{key[1]}.return_value was set to the same expression "
+            f"asserted via {via}"
+        )
+        violations.append(_TestQualityViolation(fname, func_name, rule, detail))
 
-        # Form B: assert <result_name> == <expr> (result bound from mock call)
-        if isinstance(lhs, ast.Name) and lhs.id in result_call_map:
-            key = result_call_map[lhs.id]
-            if key in return_value_map and _ast_eq(rhs, return_value_map[key]):
-                if key in seen_keys:
-                    continue
-                seen_keys.add(key)
-                rule, label = ("ADV-003", "advisory") if key in behavioral_keys else ("BLK-004", "blocking")
-                detail = (
-                    f"mock-return tautology ({label}): {key[0]}.{key[1]}.return_value "
-                    f"was set to the same expression asserted via {lhs.id}"
-                )
-                violations.append(_TestQualityViolation(fname, func_name, rule, detail))
+    def _process(stmt: ast.AST) -> None:
+        # Order-aware: handle Assign FIRST so result alias updates before any
+        # nested Asserts in the same statement, then Assert.
+        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
+            tgt = stmt.targets[0]
+
+            # <var>.<attr>.return_value = <expr>
+            if (
+                isinstance(tgt, ast.Attribute)
+                and tgt.attr == "return_value"
+                and isinstance(tgt.value, ast.Attribute)
+                and isinstance(tgt.value.value, ast.Name)
+            ):
+                return_value_state[(tgt.value.value.id, tgt.value.attr)] = stmt.value
+                return
+
+            # <result> = <var>.<attr>(...)  → bind alias
+            # any other RHS → clear alias (Codex iter-2 finding #2)
+            if isinstance(tgt, ast.Name):
+                if (
+                    isinstance(stmt.value, ast.Call)
+                    and isinstance(stmt.value.func, ast.Attribute)
+                    and isinstance(stmt.value.func.value, ast.Name)
+                ):
+                    call_func = stmt.value.func
+                    call_recv = call_func.value
+                    assert isinstance(call_func, ast.Attribute)
+                    assert isinstance(call_recv, ast.Name)
+                    result_active[tgt.id] = (call_recv.id, call_func.attr)
+                else:
+                    result_active.pop(tgt.id, None)
+                return
+
+        if isinstance(stmt, ast.Assert):
+            test = stmt.test
+            if not (isinstance(test, ast.Compare) and len(test.ops) == 1 and isinstance(test.ops[0], ast.Eq)):
+                return
+            lhs = test.left
+            rhs = test.comparators[0]
+
+            # Form A: assert <var>.<attr>(...) == <expr>
+            if (
+                isinstance(lhs, ast.Call)
+                and isinstance(lhs.func, ast.Attribute)
+                and isinstance(lhs.func.value, ast.Name)
+            ):
+                key = (lhs.func.value.id, lhs.func.attr)
+                if key in return_value_state and _ast_eq(rhs, return_value_state[key]):
+                    _emit(key, "direct call")
+                    return
+
+            # Form B: assert <result_name> == <expr> (result currently aliased)
+            if isinstance(lhs, ast.Name) and lhs.id in result_active:
+                key = result_active[lhs.id]
+                if key in return_value_state and _ast_eq(rhs, return_value_state[key]):
+                    _emit(key, lhs.id)
+                    return
+
+    # Source-order body traversal (with nested-scope pruning).
+    for top in node.body:
+        if isinstance(
+            top,
+            (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef),
+        ):
+            continue
+        for sub in _walk_outside_nested_scopes(top):
+            _process(sub)
+
+
+# ── Test Quality Gate (Scanner Entrypoint) ──────────────────────────────
 
 
 def _scan_test_file(filepath: Path) -> list[_TestQualityViolation]:

--- a/tests/test_conftest_quality_gate.py
+++ b/tests/test_conftest_quality_gate.py
@@ -309,19 +309,168 @@ def test_adv002_sole_is_not_none(tmp_path: Path) -> None:
 # ── Whole-suite dry-run audit ──────────────────────────────────────────
 
 
+# ── Codex post-impl iter-2 BLOCKING fixes regression suite ──────────────
+
+
+def test_blk004_nested_helper_does_not_leak_to_outer(tmp_path: Path) -> None:
+    """A nested helper FunctionDef inside a test_* function must not leak its
+    return_value/assert events into the outer test scan (Codex iter-2 #1)."""
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_outer():\n"
+        "    def helper():\n"
+        "        m = Mock()\n"
+        "        m.method.return_value = 42\n"
+        "        assert m.method() == 42  # nested fn body, NOT a test_*\n"
+        "    helper()\n"
+        "    # outer has no return_value direct echo\n"
+        "    assert (1 + 1) == 2\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    # Helper does not start with test_, so it isn't itself scanned. The outer
+    # test_outer must not pick up BLK-004 from the nested body.
+    assert "BLK-004" not in rules
+    assert "ADV-003" not in rules
+
+
+def test_blk004_form_b_reassignment_clears_alias(tmp_path: Path) -> None:
+    """result = m.method() then result = X must clear the alias so a later
+    assert result == ... no longer counts as direct echo (Codex iter-2 #2)."""
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 42\n"
+        "    result = m.method()\n"
+        "    result = 99  # rebind to plain literal — alias cleared\n"
+        "    assert result == 99\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" not in rules
+
+
+def test_blk004_form_b_reassignment_then_stale_compare(tmp_path: Path) -> None:
+    """After result is rebound, asserting the OLD return_value must not BLK
+    (Codex iter-2 #2 stale-binding variant)."""
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 42\n"
+        "    result = m.method()\n"
+        "    result = compute()\n"  # noqa
+        "    assert result == 42\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" not in rules
+
+
+def test_blk004_multiple_return_values_latest_wins(tmp_path: Path) -> None:
+    """Source-order semantics: assert matches the CURRENT return_value
+    (Codex iter-2 #2 order-aware variant)."""
+    source_current = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 42\n"
+        "    m.method.return_value = 99\n"
+        "    assert m.method() == 99  # matches CURRENT value → BLK\n"
+    )
+    rules_current = _rules(_scan_source(tmp_path, source_current, "snip1_test.py"))
+    assert "BLK-004" in rules_current
+
+
+def test_blk004_stale_return_value_no_match(tmp_path: Path) -> None:
+    """Source-order semantics: assert against the OLD return_value must NOT BLK
+    (Codex iter-2 #2 order-aware variant)."""
+    source_stale = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 42\n"
+        "    m.method.return_value = 99\n"
+        "    assert m.method() == 42  # 42 stale → no BLK\n"
+    )
+    rules_stale = _rules(_scan_source(tmp_path, source_stale, "snip2_test.py"))
+    assert "BLK-004" not in rules_stale
+
+
+def test_blk004_bare_call_count_does_not_downgrade(tmp_path: Path) -> None:
+    """Bare reference to .call_count outside an Assert must NOT demote a
+    sibling direct echo (Codex iter-2 #3)."""
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 42\n"
+        "    _ = m.method.call_count  # bare access, NOT in an assertion\n"
+        "    assert m.method() == 42\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" in rules
+    assert "ADV-003" not in rules
+
+
+def test_blk004_unrelated_mock_behavioral_signal_does_not_downgrade(
+    tmp_path: Path,
+) -> None:
+    """A behavioral signal on a DIFFERENT (mock, method) key must not demote
+    a direct echo on this key (Codex iter-2 #3 per-key precision)."""
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m1 = Mock()\n"
+        "    m2 = Mock()\n"
+        "    m1.method.return_value = 42\n"
+        "    m2.other.assert_called_once()  # unrelated key\n"
+        "    assert m1.method() == 42\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "BLK-004" in rules
+    assert "ADV-003" not in rules
+
+
+def test_blk004_behavioral_signal_inside_assert_does_downgrade(
+    tmp_path: Path,
+) -> None:
+    """A behavioral attr referenced INSIDE an Assert for the SAME key DOES
+    demote the direct echo (Codex iter-2 #3 positive precision)."""
+    source = (
+        "from unittest.mock import Mock\n"
+        "def test_thing():\n"
+        "    m = Mock()\n"
+        "    m.method.return_value = 42\n"
+        "    m.method()\n"
+        "    m.method()\n"
+        "    assert m.method.call_count == 2  # in-Assert behavioral check\n"
+        "    assert m.method() == 42  # direct echo → ADV-003 (not BLK)\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "ADV-003" in rules
+    assert "BLK-004" not in rules
+
+
+# ── Forcing function: 0 BLK-004 hits in current tests/ tree ─────────────
+
+
 def test_blk004_zero_hits_in_current_suite() -> None:
     """Lock-in: BLK-004 must have 0 hits in the current tests/ tree.
 
     This forcing function ensures the rule stays narrow. If a future PR
     introduces a direct-echo mock tautology, this test fails first; that PR
     must either fix the test or extend BLK-004 scope intentionally.
+
+    Self-skip uses ``Path.resolve()`` (NOT basename) so that a future
+    ``tests/subdir/test_conftest_quality_gate.py`` is not silently skipped
+    (Codex iter-2 nit absorbed).
     """
-    repo_root = Path(__file__).resolve().parent.parent
+    self_path = Path(__file__).resolve()
+    repo_root = self_path.parent.parent
     tests_dir = repo_root / "tests"
     blk004_hits: list[str] = []
     for p in sorted(tests_dir.rglob("test_*.py")):
-        if p.name == "test_conftest_quality_gate.py":
-            # Skip THIS file — we intentionally include BLK-004 fixtures.
+        if p.resolve() == self_path:
+            # Skip THIS exact file — we intentionally include BLK-004 fixtures.
             continue
         for v in _scan_test_file(p):
             if v.rule == "BLK-004":


### PR DESCRIPTION
## Summary
- hardens BLK-004 mock-return tautology scanning for nested-scope isolation, source-order return_value semantics, result alias clearing, and per-key behavioral downgrade precision
- adds regression coverage for nested helpers, stale/rebound aliases, latest return_value matching, bare call_count access, unrelated mock behavior, and current-suite zero-hit forcing
- keeps scope to test-quality gate files + local review evidence only

## Validation
- `ruff check tests/conftest.py tests/test_conftest_quality_gate.py`
- `mypy tests/conftest.py`
- `pytest -q tests/test_conftest_quality_gate.py`
- `pytest -q tests/test_conftest_quality_gate.py tests/test_ao_ma10_high_risk_raw_review_producer.py`
- `git diff --cached --check`
- `PYTHONPATH=$PWD python3 scripts/local_gpp_gate.py --review-evidence local-ai-review-evidence.v1.json --output /tmp/local-gpp-gate-blk004-hardening.json --repo Halildeu/ao-kernel --work-package B1-BLK004-HARDENING --base-ref refs/heads/main --head-ref refs/heads/codex/blk004-hardening-main --repo-root .` -> `operator_may_merge`

## Review evidence
- Independent Claude review verdict: `AGREE`
- Release authority remains `ao-release-gate + GitHub ruleset`; AI output is evidence only.

## Guardrails
- no workflow mutation
- no ruleset / branch protection mutation
- no CODEOWNERS change
- no admin bypass
- no credential material
- no support widening
- no production platform claim
- no live adapter execution