### PR TITLE
ci(ao): add autonomous merge executor workflow

### DIFF
--- a/.github/workflows/ao-autonomous-merge-executor.yml
+++ b/.github/workflows/ao-autonomous-merge-executor.yml
@@ -1,0 +1,152 @@
+name: AO Autonomous Merge Executor
+
+on:
+  workflow_run:
+    workflows: ["Test"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to evaluate and merge after required checks pass"
+        required: true
+        type: string
+      confirmation:
+        description: "Required confirmation: AO-AUTONOMOUS-MERGE-EXECUTE"
+        required: true
+        type: string
+      event_head_sha:
+        description: "Optional expected PR head SHA; empty means use current live head"
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  pull-requests: write
+  statuses: read
+
+concurrency:
+  group: ao-autonomous-merge-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  autonomous-merge:
+    name: autonomous-merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      CONFIRMATION: AO-AUTONOMOUS-MERGE-EXECUTE
+    steps:
+      - name: Resolve target PR
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PR_NUMBER: ${{ inputs.pr_number || '' }}
+          DISPATCH_CONFIRMATION: ${{ inputs.confirmation || '' }}
+          DISPATCH_EVENT_HEAD_SHA: ${{ inputs.event_head_sha || '' }}
+        run: |
+          set -euo pipefail
+
+          should_run=false
+          pr_number=""
+          event_head_sha=""
+          reason="not-applicable"
+
+          case "$EVENT_NAME" in
+            workflow_run)
+              workflow_event="$(jq -r '.workflow_run.event // ""' "$GITHUB_EVENT_PATH")"
+              workflow_conclusion="$(jq -r '.workflow_run.conclusion // ""' "$GITHUB_EVENT_PATH")"
+              pr_count="$(jq '.workflow_run.pull_requests | length' "$GITHUB_EVENT_PATH")"
+
+              if [ "$workflow_event" = "pull_request" ] && [ "$workflow_conclusion" = "success" ] && [ "$pr_count" = "1" ]; then
+                pr_number="$(jq -r '.workflow_run.pull_requests[0].number' "$GITHUB_EVENT_PATH")"
+                event_head_sha="$(jq -r '.workflow_run.head_sha // ""' "$GITHUB_EVENT_PATH")"
+                should_run=true
+                reason="workflow_run:test-success"
+              else
+                reason="workflow_run:${workflow_event}:${workflow_conclusion}:pr_count_${pr_count}"
+              fi
+              ;;
+            workflow_dispatch)
+              if [ "$DISPATCH_CONFIRMATION" != "$CONFIRMATION" ]; then
+                echo "::error::workflow_dispatch requires confirmation $CONFIRMATION"
+                exit 1
+              fi
+              pr_number="$DISPATCH_PR_NUMBER"
+              event_head_sha="$DISPATCH_EVENT_HEAD_SHA"
+              should_run=true
+              reason="workflow_dispatch"
+              ;;
+            *)
+              reason="unsupported-event:$EVENT_NAME"
+              ;;
+          esac
+
+          if [ "$should_run" = "true" ]; then
+            if ! printf '%s' "$pr_number" | grep -Eq '^[0-9]+$'; then
+              echo "::error::Invalid PR number: $pr_number"
+              exit 1
+            fi
+            if [ -n "$event_head_sha" ] && ! printf '%s' "$event_head_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+              echo "::error::Invalid event head SHA"
+              exit 1
+            fi
+          fi
+
+          {
+            echo "should_run=$should_run"
+            echo "pr_number=$pr_number"
+            echo "event_head_sha=$event_head_sha"
+            echo "reason=$reason"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Explain target decision
+        env:
+          SHOULD_RUN: ${{ steps.target.outputs.should_run }}
+          REASON: ${{ steps.target.outputs.reason }}
+          PR_NUMBER: ${{ steps.target.outputs.pr_number }}
+          EVENT_HEAD_SHA: ${{ steps.target.outputs.event_head_sha }}
+        run: |
+          echo "should_run=$SHOULD_RUN"
+          echo "reason=$REASON"
+          echo "pr_number=$PR_NUMBER"
+          echo "event_head_sha=$EVENT_HEAD_SHA"
+
+      - uses: actions/checkout@v6
+        if: steps.target.outputs.should_run == 'true'
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Run fail-closed autonomous merge executor
+        if: steps.target.outputs.should_run == 'true'
+        env:
+          PR_NUMBER: ${{ steps.target.outputs.pr_number }}
+          EVENT_HEAD_SHA: ${{ steps.target.outputs.event_head_sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p .ao/evidence/ao-autonomous-merge
+
+          args=(
+            --repo "$GITHUB_REPOSITORY"
+            --pr "$PR_NUMBER"
+            --expected-actor "github-actions[bot]"
+            --output ".ao/evidence/ao-autonomous-merge/result.json"
+            --execute
+            --confirmation "$CONFIRMATION"
+            --format text
+          )
+          if [ -n "$EVENT_HEAD_SHA" ]; then
+            args+=(--event-head-sha "$EVENT_HEAD_SHA")
+          fi
+
+          python scripts/ao_autonomous_pr_merge_executor.py "${args[@]}"
+
+      - name: Upload merge evidence
+        if: always() && steps.target.outputs.should_run == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ao-autonomous-merge-${{ steps.target.outputs.pr_number }}-${{ github.run_id }}
+          path: .ao/evidence/ao-autonomous-merge/
+          if-no-files-found: warn

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -1,27 +1,26 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10AA",
+  "work_package": "AO-MA-10Y-AUTONOMOUS-MERGE-EXECUTOR",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
   },
   "reviewer": {
-    "agent": "claude-cli-reviewer",
+    "agent": "claude-sonnet-reviewer",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10aa-bind-autonomous-smoke-evidence",
+    "head_ref": "refs/heads/codex/ao-auto-merge-executor",
     "changed_files": [
-      ".github/workflows/test.yml",
+      ".github/workflows/ao-autonomous-merge-executor.yml",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/ao_release_gate.py",
       "local-ai-review-evidence.v1.json",
-      "tests/test_ao_release_gate.py",
-      "tests/test_ao_release_gate_enforce_job.py"
+      "scripts/ao_autonomous_pr_merge_executor.py",
+      "tests/test_ao_autonomous_pr_merge_executor.py"
     ]
   },
   "checks_considered": [
@@ -42,16 +41,17 @@
       "status": "pass"
     },
     {
-      "name": "yaml_parse",
+      "name": "actionlint",
       "status": "pass"
     }
   ],
   "findings": [
-    "Anthropic reviewer verdict AGREE on the final AO-MA-10AA patch.",
-    "Path validator covers backslash, absolute path, empty-segment, dot, dotdot, and nested-child vectors for the prefix-pinned scope.",
-    "Workflow and decision-core validation provide defense in depth; the request flag is computed from GitHub API response, not PR content.",
-    "Review-evidence and bundle checks only relax when explicit request, dedicated actor, non-empty paths, no high-risk paths, and every-path-valid conditions hold simultaneously.",
-    "Explicit malformed or authority-open AO-MA10 bundles still validate and fail even when smoke scope is active.",
+    "Anthropic reviewer verdict AGREE on the final AO-MA-10Y autonomous merge executor patch.",
+    "No direct GitHub Actions expression injection remains; values from events and dispatch inputs are routed through env vars and validated.",
+    "The workflow checks out github.event.repository.default_branch before running the executor, avoiding PR-head code execution with a write token.",
+    "The merge command uses gh api PUT /pulls/{number}/merge with merge_method=squash and sha guard; no admin flag is constructed.",
+    "The executor validates source-pinned ao-release-gate-technical and ao-release-gate-review check-runs from GitHub Actions app id 15368 before mutation.",
+    "The executor blocks stale head SHA, draft PRs, cross-repository PRs, non-main base, non-clean merge state, wrong actor, admin permission, failed required checks, and collection errors.",
     "No support widening, production platform claim, live adapter execution, admin bypass, branch protection mutation, or secret material is introduced."
   ],
   "secrets_recorded": false,

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -1,27 +1,26 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10AA",
+  "work_package": "AO-MA-10Y-AUTONOMOUS-MERGE-EXECUTOR",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
   },
   "reviewer": {
-    "agent": "codex-reviewer-godel",
+    "agent": "codex-reviewer-dewey",
     "provider": "openai",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma10aa-bind-autonomous-smoke-evidence",
+    "head_ref": "refs/heads/codex/ao-auto-merge-executor",
     "changed_files": [
-      ".github/workflows/test.yml",
+      ".github/workflows/ao-autonomous-merge-executor.yml",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/ao_release_gate.py",
       "local-ai-review-evidence.v1.json",
-      "tests/test_ao_release_gate.py",
-      "tests/test_ao_release_gate_enforce_job.py"
+      "scripts/ao_autonomous_pr_merge_executor.py",
+      "tests/test_ao_autonomous_pr_merge_executor.py"
     ]
   },
   "checks_considered": [
@@ -42,16 +41,17 @@
       "status": "pass"
     },
     {
-      "name": "yaml_parse",
+      "name": "actionlint",
       "status": "pass"
     }
   ],
   "findings": [
-    "OpenAI reviewer verdict AGREE after REVISE findings were absorbed.",
-    "Workflow detector now requires changeType ADDED and rejects renamed, deleted, changed, modified, missing changeType, dotdot, nested, absolute, and backslash paths.",
-    "Decision-core smoke helper now rejects dot, dotdot, empty segment, nested child, absolute, backslash, non-smoke, and non-markdown paths.",
-    "The bypass remains constrained by explicit request, dedicated gladyatore-lab actor, non-empty changed paths, no high-risk paths, and direct smoke markdown paths.",
-    "Adversarial probes passed for happy smoke, request false, non-dedicated actor, dotdot path, nested path, absolute path, backslash path, and non-md path.",
+    "OpenAI reviewer verdict AGREE after adversarial review of the autonomous merge executor patch.",
+    "The prior expression-injection, unpinned-checkout, stale-head, noop masking, and concurrency payload findings are absorbed.",
+    "The workflow routes untrusted values through env vars, pins checkout to the default branch, and validates PR number plus optional event_head_sha before invoking the executor.",
+    "The executor requires GitHub Actions actor identity, write permission, current main-base open PR, clean merge state, successful required checks, and source-pinned ao-release-gate checks.",
+    "The merge mutation is limited to gh api PUT /pulls/{number}/merge with squash and sha=headRefOid; branch delete is best-effort and never uses --admin.",
+    "Focused validation passed: actionlint, ruff, mypy, pytest -q tests/test_ao_autonomous_pr_merge_executor.py, and combined merge-agent/release-gate regression subset.",
     "No branch protection mutation, admin bypass, support widening, production platform claim, live adapter execution, or secret material is introduced."
   ],
   "secrets_recorded": false,

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,23 +1,26 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "B1-BLK004-HARDENING",
+  "work_package": "AO-MA-10Y-AUTONOMOUS-MERGE-EXECUTOR",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
   },
   "reviewer": {
-    "agent": "claude-code-reviewer",
+    "agent": "claude-sonnet-reviewer",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/blk004-hardening-main",
+    "head_ref": "refs/heads/codex/ao-auto-merge-executor",
     "changed_files": [
+      ".github/workflows/ao-autonomous-merge-executor.yml",
+      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
+      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/conftest.py",
-      "tests/test_conftest_quality_gate.py"
+      "scripts/ao_autonomous_pr_merge_executor.py",
+      "tests/test_ao_autonomous_pr_merge_executor.py"
     ]
   },
   "checks_considered": [
@@ -51,13 +54,14 @@
     }
   ],
   "findings": [
-    "Claude reviewer returned AGREE for B1-BLK004-HARDENING after reviewing the staged diff and focused validation output.",
-    "The change hardens BLK-004 so nested helper function bodies cannot leak mock-return events into the outer test scan.",
-    "The implementation makes BLK-004 source-order aware: later return_value assignments win and result aliases are cleared when a variable is rebound.",
-    "Behavioral-signal downgrade is scoped to the same mock method key; unrelated mock behavior and bare call_count reads do not downgrade blocking direct echoes.",
-    "Focused validation passed: ruff check tests/conftest.py tests/test_conftest_quality_gate.py, mypy tests/conftest.py, pytest -q tests/test_conftest_quality_gate.py, and pytest -q tests/test_conftest_quality_gate.py tests/test_ao_ma10_high_risk_raw_review_producer.py.",
-    "The current-suite forcing function continues to assert zero BLK-004 hits outside the quality-gate fixture file.",
-    "No workflow mutation, ruleset mutation, CODEOWNERS change, branch protection mutation, admin bypass, credential material, support widening, production platform claim, or live adapter execution is introduced."
+    "Claude reviewer returned AGREE for AO-MA-10Y-AUTONOMOUS-MERGE-EXECUTOR after reviewing the staged autonomous merge executor patch.",
+    "No direct GitHub Actions expression injection remains: GitHub event and dispatch values used in shell are routed through environment variables and validated before use.",
+    "The executor workflow checks out the default branch rather than PR head code, so the write token does not execute untrusted branch scripts.",
+    "The merge path uses the GitHub pull merge REST endpoint with merge_method=squash and sha=headRefOid; no admin merge flag or admin bypass is constructed.",
+    "The executor fails closed on stale event head SHA, non-main base, draft PR, cross-repository PR, non-clean merge state, missing required checks, wrong actor, admin permission, and missing source-pinned ao-release-gate checks.",
+    "Source-pinned release authority remains ao-release-gate plus GitHub ruleset: ao-release-gate-technical and ao-release-gate-review must be completed successfully from GitHub Actions app id 15368.",
+    "Focused validation passed: actionlint, ruff, mypy, pytest -q tests/test_ao_autonomous_pr_merge_executor.py, and the combined ao autonomous merge / merge-agent / release-gate regression subset.",
+    "No ruleset mutation, CODEOWNERS change, branch protection mutation, admin bypass, credential material, support widening, production platform claim, or live adapter execution is introduced."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/ao_autonomous_pr_merge_executor.py
+++ b/scripts/ao_autonomous_pr_merge_executor.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+"""Fail-closed autonomous PR merge executor.
+
+This executor is deliberately narrow: it is not release authority. It only
+executes the normal GitHub pull merge endpoint after GitHub reports that the
+repo-owned required checks have passed and the source-pinned ao-release-gate
+checks were produced by GitHub Actions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+
+SCHEMA_VERSION = "ao-autonomous-pr-merge-executor-result.v1"
+ARTIFACT_KIND = "ao_autonomous_pr_merge_executor_result"
+RELEASE_AUTHORITY = "ao-release-gate+github-ruleset"
+DEFAULT_REPO = "Halildeu/ao-kernel"
+DEFAULT_BASE_REF = "main"
+DEFAULT_EXPECTED_ACTOR = "github-actions[bot]"
+EXECUTE_CONFIRMATION = "AO-AUTONOMOUS-MERGE-EXECUTE"
+GITHUB_ACTIONS_APP_ID = 15368
+SOURCE_PINNED_REQUIRED_CHECKS = ("ao-release-gate-technical", "ao-release-gate-review")
+READY_MERGE_STATES = {"CLEAN", "HAS_HOOKS"}
+INTEGRATION_TOKEN_WARNING = "github_user_endpoint_unavailable_for_integration_token"
+FORBIDDEN_ADMIN_FLAG = "--" "admin"
+
+Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True, timeout=60)
+
+
+def _json_command(command: list[str], runner: Runner) -> tuple[dict[str, Any] | list[Any], str | None]:
+    proc = runner(command)
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or f"exit {proc.returncode}"
+        return {}, detail
+    if not proc.stdout.strip():
+        return {}, "empty response"
+    try:
+        parsed = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {}, "invalid json response"
+    if not isinstance(parsed, (dict, list)):
+        return {}, "json response must be object or array"
+    return parsed, None
+
+
+def _object(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _string_list(value: Any) -> list[str]:
+    return [item for item in value if isinstance(item, str)] if isinstance(value, list) else []
+
+
+def _is_actions_integration_error(expected_actor: str, error: str | None) -> bool:
+    return (
+        expected_actor == DEFAULT_EXPECTED_ACTOR
+        and error is not None
+        and "resource not accessible by integration" in error.lower()
+    )
+
+
+def _permission_from_repo_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    permissions = payload.get("permissions")
+    if not isinstance(permissions, dict):
+        return {}
+    if permissions.get("admin") is True:
+        return {"permission": "admin", "role_name": "admin"}
+    if permissions.get("maintain") is True:
+        return {"permission": "maintain", "role_name": "maintain"}
+    if permissions.get("push") is True:
+        return {"permission": "write", "role_name": "write"}
+    if permissions.get("triage") is True:
+        return {"permission": "triage", "role_name": "triage"}
+    if permissions.get("pull") is True:
+        return {"permission": "read", "role_name": "read"}
+    return {}
+
+
+def _safe_head_ref_for_delete(head_ref: Any, base_ref: str, *, is_cross_repository: bool) -> str | None:
+    if is_cross_repository:
+        return None
+    if not isinstance(head_ref, str) or not head_ref:
+        return None
+    if head_ref == base_ref or head_ref.startswith("refs/"):
+        return None
+    return head_ref
+
+
+def merge_command(repo: str, pr_number: int, *, head_sha: str, gh_bin: str = "gh") -> list[str]:
+    return [
+        gh_bin,
+        "api",
+        f"repos/{repo}/pulls/{pr_number}/merge",
+        "--method",
+        "PUT",
+        "-f",
+        "merge_method=squash",
+        "-f",
+        f"sha={head_sha}",
+    ]
+
+
+def branch_delete_command(repo: str, head_ref: str, gh_bin: str = "gh") -> list[str]:
+    return [gh_bin, "api", f"repos/{repo}/git/refs/heads/{head_ref}", "--method", "DELETE"]
+
+
+def collect_live_state(
+    *,
+    repo: str,
+    pr_number: int,
+    gh_bin: str,
+    expected_actor: str,
+    runner: Runner = _run,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    viewer, error = _json_command([gh_bin, "api", "user"], runner)
+    if error is not None or not isinstance(viewer, dict):
+        if _is_actions_integration_error(expected_actor, error):
+            viewer = {"login": expected_actor}
+            warnings.append(INTEGRATION_TOKEN_WARNING)
+        else:
+            errors.append(f"viewer: {error or 'invalid shape'}")
+            viewer = {}
+
+    login = _string(_object(viewer).get("login"))
+    permission: dict[str, Any] = {}
+    if login and login != expected_actor:
+        permission_payload, error = _json_command(
+            [gh_bin, "api", f"repos/{repo}/collaborators/{login}/permission"],
+            runner,
+        )
+        if error is None and isinstance(permission_payload, dict):
+            permission = permission_payload
+        else:
+            errors.append(f"permission: {error or 'invalid shape'}")
+    else:
+        repo_payload, error = _json_command([gh_bin, "api", f"repos/{repo}"], runner)
+        if error is None and isinstance(repo_payload, dict):
+            permission = _permission_from_repo_payload(repo_payload)
+        else:
+            errors.append(f"repo_permission: {error or 'invalid shape'}")
+
+    pr_view, error = _json_command(
+        [
+            gh_bin,
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            repo,
+            "--json",
+            "state,isDraft,baseRefName,headRefName,headRefOid,isCrossRepository,mergeStateStatus,mergedAt,url",
+        ],
+        runner,
+    )
+    if error is not None or not isinstance(pr_view, dict):
+        errors.append(f"pr_view: {error or 'invalid shape'}")
+        pr_view = {}
+
+    required_checks, error = _json_command(
+        [
+            gh_bin,
+            "pr",
+            "checks",
+            str(pr_number),
+            "--repo",
+            repo,
+            "--required",
+            "--json",
+            "name,bucket,state,link",
+        ],
+        runner,
+    )
+    if error is not None or not isinstance(required_checks, list):
+        errors.append(f"pr_checks: {error or 'invalid shape'}")
+        required_checks = []
+
+    head_sha = _string(_object(pr_view).get("headRefOid"))
+    check_runs: dict[str, Any] | list[Any] = {}
+    if head_sha:
+        check_runs, error = _json_command(
+            [gh_bin, "api", f"repos/{repo}/commits/{head_sha}/check-runs?per_page=100"],
+            runner,
+        )
+        if error is not None or not isinstance(check_runs, dict):
+            errors.append(f"check_runs: {error or 'invalid shape'}")
+            check_runs = {}
+
+    return {
+        "viewer": viewer,
+        "permission": permission,
+        "pr_view": pr_view,
+        "required_checks": required_checks,
+        "check_runs": check_runs,
+        "collection_errors": errors,
+        "collection_warnings": warnings,
+    }
+
+
+def _required_checks_pass(required_checks: list[Any]) -> tuple[bool, list[dict[str, Any]]]:
+    failing: list[dict[str, Any]] = []
+    for raw in required_checks:
+        item = raw if isinstance(raw, dict) else {}
+        if item.get("bucket") != "pass":
+            failing.append(
+                {
+                    "name": item.get("name"),
+                    "bucket": item.get("bucket"),
+                    "state": item.get("state"),
+                    "link": item.get("link"),
+                }
+            )
+    return not failing, failing
+
+
+def _source_pinned_release_gate_checks(check_runs_payload: dict[str, Any]) -> tuple[bool, list[dict[str, Any]]]:
+    check_runs = check_runs_payload.get("check_runs")
+    runs = check_runs if isinstance(check_runs, list) else []
+    observed: list[dict[str, Any]] = []
+    for required_name in SOURCE_PINNED_REQUIRED_CHECKS:
+        matches: list[dict[str, Any]] = []
+        for raw in runs:
+            run = raw if isinstance(raw, dict) else {}
+            if run.get("name") != required_name:
+                continue
+            app = _object(run.get("app"))
+            matches.append(
+                {
+                    "name": run.get("name"),
+                    "status": run.get("status"),
+                    "conclusion": run.get("conclusion"),
+                    "app_id": app.get("id"),
+                    "app_slug": app.get("slug"),
+                    "details_url": run.get("details_url"),
+                }
+            )
+        selected = next(
+            (
+                item
+                for item in matches
+                if item["app_id"] == GITHUB_ACTIONS_APP_ID
+                and item["status"] == "completed"
+                and item["conclusion"] == "success"
+            ),
+            None,
+        )
+        observed.append(selected or {"name": required_name, "matches": matches})
+    return all("app_id" in item for item in observed), observed
+
+
+def build_result(
+    *,
+    repo: str,
+    pr_number: int,
+    live_state: dict[str, Any],
+    expected_actor: str,
+    base_ref: str,
+    event_head_sha: str | None,
+    execute: bool,
+    confirmation: str | None,
+    merge_exit_code: int | None = None,
+    merge_error: str = "",
+    branch_delete_exit_code: int | None = None,
+    branch_delete_error: str = "",
+    branch_delete_command_argv: list[str] | None = None,
+    gh_bin: str = "gh",
+) -> dict[str, Any]:
+    blockers: set[str] = set()
+    warnings: set[str] = set(_string_list(live_state.get("collection_warnings")))
+    blockers.update(_string_list(live_state.get("collection_errors")))
+
+    viewer = _object(live_state.get("viewer"))
+    permission = _object(live_state.get("permission"))
+    pr_view = _object(live_state.get("pr_view"))
+    required_checks = live_state.get("required_checks")
+    required_checks_list = required_checks if isinstance(required_checks, list) else []
+    check_runs = _object(live_state.get("check_runs"))
+    collection_error_items = _string_list(live_state.get("collection_errors"))
+
+    actual_actor = _string(viewer.get("login"))
+    permission_name = _string(permission.get("permission")) or _string(permission.get("role_name"))
+
+    if actual_actor != expected_actor:
+        blockers.add("unexpected_merge_actor")
+    if permission_name == "admin" or permission.get("role_name") == "admin":
+        blockers.add("merge_actor_admin_permission_observed")
+    if permission_name != "write":
+        blockers.add("merge_actor_not_write")
+
+    pr_state = pr_view.get("state")
+    merged_at = _string(pr_view.get("mergedAt"))
+    if pr_state != "OPEN":
+        if pr_state == "MERGED" or merged_at:
+            warnings.add("pr_already_merged_noop")
+        else:
+            blockers.add("pr_not_open")
+    if pr_view.get("isDraft") is True:
+        blockers.add("pr_is_draft")
+    if pr_view.get("baseRefName") != base_ref:
+        blockers.add("pr_base_not_expected")
+    if pr_view.get("isCrossRepository") is True:
+        blockers.add("cross_repository_pr_not_supported")
+    if pr_view.get("mergeStateStatus") not in READY_MERGE_STATES and pr_state == "OPEN":
+        blockers.add("pr_merge_state_not_clean")
+
+    head_sha = _string(pr_view.get("headRefOid"))
+    if not head_sha:
+        blockers.add("pr_head_sha_missing")
+    if event_head_sha and head_sha and event_head_sha != head_sha:
+        blockers.add("event_head_sha_stale")
+
+    checks_ok, failing_checks = _required_checks_pass(required_checks_list)
+    if not checks_ok:
+        blockers.add("required_checks_not_passed")
+
+    source_pinned_ok, source_pinned_observed = _source_pinned_release_gate_checks(check_runs)
+    if not source_pinned_ok:
+        blockers.add("source_pinned_ao_release_gate_checks_not_success")
+
+    merge_argv = merge_command(repo, pr_number, head_sha=head_sha or "<missing-head-sha>", gh_bin=gh_bin)
+    if any(item == FORBIDDEN_ADMIN_FLAG for item in merge_argv):
+        blockers.add("admin_merge_command_constructed")
+    if execute and confirmation != EXECUTE_CONFIRMATION:
+        blockers.add("execute_confirmation_missing")
+
+    safe_head_ref = _safe_head_ref_for_delete(
+        pr_view.get("headRefName"),
+        base_ref,
+        is_cross_repository=pr_view.get("isCrossRepository") is True,
+    )
+    delete_argv = branch_delete_command_argv
+    if delete_argv is None:
+        delete_argv = branch_delete_command(repo, safe_head_ref, gh_bin=gh_bin) if safe_head_ref else []
+
+    merge_attempted = bool(execute and not blockers and pr_state == "OPEN")
+    if merge_exit_code not in (None, 0):
+        blockers.add("merge_command_failed")
+    if merge_exit_code == 0 and branch_delete_exit_code not in (None, 0):
+        warnings.add("branch_delete_failed")
+
+    if pr_state == "MERGED" or (merged_at and "pr_not_open" not in blockers):
+        result = "noop_already_merged"
+        for item in collection_error_items:
+            warnings.add(f"noop_collection_error:{item}")
+        blockers.clear()
+    elif blockers:
+        result = "blocked"
+    elif execute and merge_exit_code == 0:
+        result = "merged"
+    elif execute and merge_exit_code is None:
+        result = "ready_to_merge"
+    else:
+        result = "ready_for_merge_dry_run"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_kind": ARTIFACT_KIND,
+        "generated_at": _utc_now(),
+        "repository": repo,
+        "pr_number": pr_number,
+        "base_ref": base_ref,
+        "expected_actor": expected_actor,
+        "actual_actor": actual_actor,
+        "actor_permission": permission_name,
+        "event_head_sha": event_head_sha,
+        "dry_run": not execute,
+        "execute_requested": execute,
+        "merge_command_attempted": merge_attempted,
+        "branch_delete_attempted": branch_delete_exit_code is not None,
+        "mutations_performed": result == "merged",
+        "release_authority": RELEASE_AUTHORITY,
+        "ai_output_release_authority": False,
+        "guard_flags": {
+            "support_widening": False,
+            "production_platform_claim": False,
+            "live_adapter_execution": False,
+        },
+        "pr_state": {
+            "state": pr_view.get("state"),
+            "is_draft": pr_view.get("isDraft"),
+            "base_ref": pr_view.get("baseRefName"),
+            "head_ref": pr_view.get("headRefName"),
+            "head_sha": head_sha,
+            "is_cross_repository": pr_view.get("isCrossRepository"),
+            "merge_state_status": pr_view.get("mergeStateStatus"),
+            "merged_at": merged_at,
+        },
+        "required_checks": {
+            "total": len(required_checks_list),
+            "all_passed": checks_ok,
+            "failing": failing_checks,
+        },
+        "source_pinned_release_gate_checks": {
+            "required_app_id": GITHUB_ACTIONS_APP_ID,
+            "all_passed": source_pinned_ok,
+            "observed": source_pinned_observed,
+        },
+        "merge_command_argv": merge_argv,
+        "merge_error": merge_error if merge_exit_code not in (None, 0) else "",
+        "branch_delete_command_argv": delete_argv,
+        "branch_delete_error": branch_delete_error if branch_delete_exit_code not in (None, 0) else "",
+        "collection_errors": _string_list(live_state.get("collection_errors")),
+        "decision": {
+            "result": result,
+            "blockers": sorted(blockers),
+            "warnings": sorted(warnings),
+            "next_required_slice": (
+                "autonomous merge completed"
+                if result in {"merged", "noop_already_merged"}
+                else "wait for required checks and rerun autonomous merge executor"
+                if result == "blocked"
+                else "execute autonomous merge executor"
+            ),
+        },
+    }
+
+
+def execute_merge(
+    *,
+    repo: str,
+    pr_number: int,
+    pr_view: dict[str, Any],
+    base_ref: str,
+    gh_bin: str,
+    runner: Runner = _run,
+) -> tuple[int, str, int | None, str, list[str], list[str]]:
+    head_sha = _string(pr_view.get("headRefOid"))
+    if not head_sha:
+        return 1, "missing head sha", None, "", [], []
+    merge_argv = merge_command(repo, pr_number, head_sha=head_sha, gh_bin=gh_bin)
+    merge_proc = runner(merge_argv)
+    merge_error = merge_proc.stderr.strip() or merge_proc.stdout.strip()
+    delete_argv: list[str] = []
+    delete_exit_code: int | None = None
+    delete_error = ""
+    safe_head_ref = _safe_head_ref_for_delete(
+        pr_view.get("headRefName"),
+        base_ref,
+        is_cross_repository=pr_view.get("isCrossRepository") is True,
+    )
+    if merge_proc.returncode == 0 and safe_head_ref:
+        delete_argv = branch_delete_command(repo, safe_head_ref, gh_bin=gh_bin)
+        delete_proc = runner(delete_argv)
+        delete_exit_code = delete_proc.returncode
+        delete_error = delete_proc.stderr.strip() or delete_proc.stdout.strip()
+    return merge_proc.returncode, merge_error, delete_exit_code, delete_error, merge_argv, delete_argv
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--base-ref", default=DEFAULT_BASE_REF)
+    parser.add_argument("--expected-actor", default=DEFAULT_EXPECTED_ACTOR)
+    parser.add_argument("--event-head-sha")
+    parser.add_argument("--gh-bin", default="gh")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--confirmation")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    args = parser.parse_args(argv)
+
+    live_state = collect_live_state(
+        repo=args.repo,
+        pr_number=args.pr,
+        gh_bin=args.gh_bin,
+        expected_actor=args.expected_actor,
+    )
+    preliminary = build_result(
+        repo=args.repo,
+        pr_number=args.pr,
+        live_state=live_state,
+        expected_actor=args.expected_actor,
+        base_ref=args.base_ref,
+        event_head_sha=args.event_head_sha,
+        execute=args.execute,
+        confirmation=args.confirmation,
+        gh_bin=args.gh_bin,
+    )
+
+    merge_exit_code: int | None = None
+    merge_error = ""
+    branch_delete_exit_code: int | None = None
+    branch_delete_error = ""
+    branch_delete_argv: list[str] = []
+    if preliminary["decision"]["result"] == "ready_to_merge":
+        (
+            merge_exit_code,
+            merge_error,
+            branch_delete_exit_code,
+            branch_delete_error,
+            _merge_argv,
+            branch_delete_argv,
+        ) = execute_merge(
+            repo=args.repo,
+            pr_number=args.pr,
+            pr_view=_object(live_state.get("pr_view")),
+            base_ref=args.base_ref,
+            gh_bin=args.gh_bin,
+        )
+
+    result = build_result(
+        repo=args.repo,
+        pr_number=args.pr,
+        live_state=live_state,
+        expected_actor=args.expected_actor,
+        base_ref=args.base_ref,
+        event_head_sha=args.event_head_sha,
+        execute=args.execute,
+        confirmation=args.confirmation,
+        merge_exit_code=merge_exit_code,
+        merge_error=merge_error,
+        branch_delete_exit_code=branch_delete_exit_code,
+        branch_delete_error=branch_delete_error,
+        branch_delete_command_argv=branch_delete_argv,
+        gh_bin=args.gh_bin,
+    )
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.format == "text":
+        print(result["decision"]["result"])
+        for blocker in result["decision"]["blockers"]:
+            print(f"blocker: {blocker}")
+    else:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["decision"]["result"] in {"ready_for_merge_dry_run", "merged", "noop_already_merged"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ao_autonomous_pr_merge_executor.py
+++ b/tests/test_ao_autonomous_pr_merge_executor.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "ao_autonomous_pr_merge_executor.py"
+
+
+def _load_script_module() -> Any:
+    spec = importlib.util.spec_from_file_location("ao_autonomous_pr_merge_executor", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ready_live_state() -> dict[str, Any]:
+    return {
+        "viewer": {"login": "github-actions[bot]"},
+        "permission": {"permission": "write", "role_name": "write"},
+        "pr_view": {
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "main",
+            "headRefName": "codex/example",
+            "headRefOid": "a" * 40,
+            "isCrossRepository": False,
+            "mergeStateStatus": "CLEAN",
+            "mergedAt": None,
+            "url": "https://github.com/Halildeu/ao-kernel/pull/123",
+        },
+        "required_checks": [
+            {"name": "lint", "bucket": "pass", "state": "SUCCESS"},
+            {"name": "ao-release-gate-technical", "bucket": "pass", "state": "SUCCESS"},
+            {"name": "ao-release-gate-review", "bucket": "pass", "state": "SUCCESS"},
+        ],
+        "check_runs": {
+            "check_runs": [
+                {
+                    "name": "ao-release-gate-technical",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "app": {"id": 15368, "slug": "github-actions"},
+                    "details_url": "https://github.example/technical",
+                },
+                {
+                    "name": "ao-release-gate-review",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "app": {"id": 15368, "slug": "github-actions"},
+                    "details_url": "https://github.example/review",
+                },
+            ]
+        },
+        "collection_errors": [],
+        "collection_warnings": [],
+    }
+
+
+def _result(
+    live_state: dict[str, Any] | None = None,
+    *,
+    execute: bool = True,
+    confirmation: str | None = "AO-AUTONOMOUS-MERGE-EXECUTE",
+    event_head_sha: str | None = "a" * 40,
+    merge_exit_code: int | None = None,
+) -> dict[str, Any]:
+    mod = _load_script_module()
+    return mod.build_result(
+        repo="Halildeu/ao-kernel",
+        pr_number=123,
+        live_state=live_state or _ready_live_state(),
+        expected_actor="github-actions[bot]",
+        base_ref="main",
+        event_head_sha=event_head_sha,
+        execute=execute,
+        confirmation=confirmation,
+        merge_exit_code=merge_exit_code,
+    )
+
+
+def test_ready_executor_is_ready_to_merge_without_claiming_authority() -> None:
+    payload = _result()
+
+    assert payload["decision"]["result"] == "ready_to_merge"
+    assert payload["release_authority"] == "ao-release-gate+github-ruleset"
+    assert payload["ai_output_release_authority"] is False
+    assert payload["guard_flags"] == {
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+    }
+    assert payload["source_pinned_release_gate_checks"]["all_passed"] is True
+    assert "--admin" not in payload["merge_command_argv"]
+    assert payload["merge_command_argv"] == [
+        "gh",
+        "api",
+        "repos/Halildeu/ao-kernel/pulls/123/merge",
+        "--method",
+        "PUT",
+        "-f",
+        "merge_method=squash",
+        "-f",
+        f"sha={'a' * 40}",
+    ]
+
+
+def test_successful_merge_records_mutation_and_branch_delete_command() -> None:
+    payload = _result(merge_exit_code=0)
+
+    assert payload["decision"]["result"] == "merged"
+    assert payload["mutations_performed"] is True
+    assert payload["branch_delete_command_argv"] == [
+        "gh",
+        "api",
+        "repos/Halildeu/ao-kernel/git/refs/heads/codex/example",
+        "--method",
+        "DELETE",
+    ]
+
+
+def test_missing_source_pinned_release_gate_check_blocks() -> None:
+    live = _ready_live_state()
+    live["check_runs"]["check_runs"] = [
+        item for item in live["check_runs"]["check_runs"] if item["name"] != "ao-release-gate-review"
+    ]
+
+    payload = _result(live)
+
+    assert payload["decision"]["result"] == "blocked"
+    assert "source_pinned_ao_release_gate_checks_not_success" in payload["decision"]["blockers"]
+
+
+def test_wrong_release_gate_app_blocks_even_when_check_name_matches() -> None:
+    live = _ready_live_state()
+    live["check_runs"]["check_runs"][1]["app"] = {"id": 999999, "slug": "some-other-app"}
+
+    payload = _result(live)
+
+    assert payload["decision"]["result"] == "blocked"
+    assert "source_pinned_ao_release_gate_checks_not_success" in payload["decision"]["blockers"]
+
+
+def test_required_check_failure_blocks() -> None:
+    live = _ready_live_state()
+    live["required_checks"][0] = {"name": "lint", "bucket": "fail", "state": "FAILURE"}
+
+    payload = _result(live)
+
+    assert payload["decision"]["result"] == "blocked"
+    assert "required_checks_not_passed" in payload["decision"]["blockers"]
+
+
+def test_stale_workflow_run_head_sha_blocks() -> None:
+    payload = _result(event_head_sha="b" * 40)
+
+    assert payload["decision"]["result"] == "blocked"
+    assert "event_head_sha_stale" in payload["decision"]["blockers"]
+
+
+def test_admin_or_wrong_actor_blocks() -> None:
+    live = _ready_live_state()
+    live["viewer"] = {"login": "Halildeu"}
+    live["permission"] = {"permission": "admin", "role_name": "admin"}
+
+    payload = _result(live)
+
+    assert payload["decision"]["result"] == "blocked"
+    assert "unexpected_merge_actor" in payload["decision"]["blockers"]
+    assert "merge_actor_admin_permission_observed" in payload["decision"]["blockers"]
+
+
+def test_already_merged_pr_is_successful_noop() -> None:
+    live = _ready_live_state()
+    live["pr_view"]["state"] = "MERGED"
+    live["pr_view"]["mergedAt"] = "2026-05-29T14:00:00Z"
+    live["collection_errors"] = ["viewer: transient API failure"]
+
+    payload = _result(live)
+
+    assert payload["decision"]["result"] == "noop_already_merged"
+    assert payload["decision"]["blockers"] == []
+    assert "pr_already_merged_noop" in payload["decision"]["warnings"]
+    assert "noop_collection_error:viewer: transient API failure" in payload["decision"]["warnings"]
+    assert payload["mutations_performed"] is False
+
+
+def test_execute_merge_uses_rest_merge_and_safe_branch_delete() -> None:
+    mod = _load_script_module()
+    seen: list[list[str]] = []
+
+    def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        seen.append(command)
+        if command[:3] == ["gh", "api", "repos/Halildeu/ao-kernel/pulls/123/merge"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"merged": True}), "")
+        if command[:3] == ["gh", "api", "repos/Halildeu/ao-kernel/git/refs/heads/codex/example"]:
+            return subprocess.CompletedProcess(command, 0, "", "")
+        raise AssertionError(command)
+
+    merge_exit, merge_error, delete_exit, delete_error, merge_argv, delete_argv = mod.execute_merge(
+        repo="Halildeu/ao-kernel",
+        pr_number=123,
+        pr_view=_ready_live_state()["pr_view"],
+        base_ref="main",
+        gh_bin="gh",
+        runner=fake_run,
+    )
+
+    assert merge_exit == 0
+    assert merge_error
+    assert delete_exit == 0
+    assert delete_error == ""
+    assert merge_argv in seen
+    assert delete_argv in seen
+    assert "--admin" not in merge_argv


### PR DESCRIPTION
## Summary

Adds a default-branch-trusted autonomous PR merge executor for ordinary PRs whose repo-owned required checks already passed.

This closes the observed gap where PR #743 had green `ao-release-gate-*` checks but stayed open because no general workflow existed to execute the merge after the required checks passed.

## Scope

- New workflow: `.github/workflows/ao-autonomous-merge-executor.yml`
- New executor: `scripts/ao_autonomous_pr_merge_executor.py`
- New tests: `tests/test_ao_autonomous_pr_merge_executor.py`
- Current-scope review evidence: `local-ai-review-evidence.v1.json`
- High-risk raw reviewer evidence pair: `ao-ma-10-high-risk-reviews/{openai,anthropic}.local-ai-review-evidence.v1.json`

## Safety properties

- No `--admin` path is constructed.
- Workflow uses default branch checkout, not PR head script execution.
- Workflow values are passed through env vars and validated before shell use.
- Merge uses REST `PUT /pulls/{number}/merge` with `merge_method=squash` and `sha=<headRefOid>`.
- Blocks draft PRs, cross-repo PRs, non-main base, non-clean merge state, stale workflow_run head SHA, failed required checks, missing source-pinned release-gate checks, wrong actor, admin permission, and collection errors.
- Requires source-pinned `ao-release-gate-technical` and `ao-release-gate-review` check-runs from GitHub Actions app id `15368`.
- Evidence states `ai_output_release_authority=false`; release authority remains `ao-release-gate+github-ruleset`.
- Guard flags remain false: no support widening, no production platform claim, no live adapter execution.

## Cross-AI review

- OpenAI sub-agent review: `AGREE`, no blocking findings.
- Claude/Sonnet review: `AGREE`, no blocking findings.
- Claude non-blocking notes: mutable action version tags and per-run concurrency are accepted as non-blocking in this repo context; current repo already uses the same actions major tags, and merge safety is guarded by live head SHA + GitHub merge API `sha=`.

## Validation

```bash
actionlint .github/workflows/ao-autonomous-merge-executor.yml
ruff check scripts/ao_autonomous_pr_merge_executor.py tests/test_ao_autonomous_pr_merge_executor.py
mypy scripts/ao_autonomous_pr_merge_executor.py
pytest -q tests/test_ao_autonomous_pr_merge_executor.py tests/test_ao_ma10c_merge_agent.py tests/test_ao_release_gate.py::test_check_run_conclusion_mapping
python3 scripts/ao_ma10_high_risk_supersession_evidence.py \
  --repository Halildeu/ao-kernel \
  --review-work-package AO-MA-10Y-AUTONOMOUS-MERGE-EXECUTOR \
  --review-base-ref refs/heads/main \
  --review-head-ref refs/heads/codex/ao-auto-merge-executor \
  --diff-base-ref origin/main \
  --diff-head-ref HEAD \
  --repo-root . \
  --review-evidence ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json \
  --review-evidence ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json \
  --output /tmp/ao-auto-merge-high-risk-evidence.json
```

Results:

- `actionlint`: pass
- `ruff`: pass
- `mypy`: pass
- pytest subset: `42 passed`
- high-risk supersession local simulation: `AGREE`, changed_files_count `6`, high-risk path `.github/workflows/ao-autonomous-merge-executor.yml`

## Bootstrap note

This workflow is intentionally pinned to default-branch code for safety. That means it cannot securely self-bootstrap from this PR branch. Once this PR lands on `main`, future green PRs can be merged by the GitHub Actions executor instead of staying open with `autoMergeRequest=null`.
