### PR TITLE
fix(ao): normalize autonomous merge executor readiness

### DIFF
--- a/.github/workflows/ao-autonomous-merge-executor.yml
+++ b/.github/workflows/ao-autonomous-merge-executor.yml
@@ -37,6 +37,7 @@ jobs:
     timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}
+      AO_AUTONOMOUS_MERGE_TOKEN_SOURCE: github.token
       CONFIRMATION: AO-AUTONOMOUS-MERGE-EXECUTE
     steps:
       - name: Resolve target PR

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10Y-AUTONOMOUS-MERGE-EXECUTOR",
+  "work_package": "AO-MA-10Y-AUTONOMOUS-MERGE-EXECUTOR-FIX",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,11 +13,9 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-auto-merge-executor",
+    "head_ref": "refs/heads/codex/ao-auto-merge-executor-fix",
     "changed_files": [
       ".github/workflows/ao-autonomous-merge-executor.yml",
-      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
       "local-ai-review-evidence.v1.json",
       "scripts/ao_autonomous_pr_merge_executor.py",
       "tests/test_ao_autonomous_pr_merge_executor.py"
@@ -54,13 +52,14 @@
     }
   ],
   "findings": [
-    "Claude reviewer returned AGREE for AO-MA-10Y-AUTONOMOUS-MERGE-EXECUTOR after reviewing the staged autonomous merge executor patch.",
-    "No direct GitHub Actions expression injection remains: GitHub event and dispatch values used in shell are routed through environment variables and validated before use.",
-    "The executor workflow checks out the default branch rather than PR head code, so the write token does not execute untrusted branch scripts.",
-    "The merge path uses the GitHub pull merge REST endpoint with merge_method=squash and sha=headRefOid; no admin merge flag or admin bypass is constructed.",
-    "The executor fails closed on stale event head SHA, non-main base, draft PR, cross-repository PR, non-clean merge state, missing required checks, wrong actor, admin permission, and missing source-pinned ao-release-gate checks.",
-    "Source-pinned release authority remains ao-release-gate plus GitHub ruleset: ao-release-gate-technical and ao-release-gate-review must be completed successfully from GitHub Actions app id 15368.",
-    "Focused validation passed: actionlint, ruff, mypy, pytest -q tests/test_ao_autonomous_pr_merge_executor.py, and the combined ao autonomous merge / merge-agent / release-gate regression subset.",
+    "Claude reviewer returned AGREE for the v3 autonomous merge executor readiness fix after reviewing the staged patch.",
+    "The fix groups duplicate required check contexts by name so a current passing context wins over stale pending or skipped duplicates while real failing contexts still block.",
+    "The fix keeps source-pinned ao-release-gate checks authoritative and does not accept same-name checks from an untrusted integration.",
+    "The GitHub Actions integration token path now requires repo-owned workflow proof for synthetic github-actions identity, independent of whether a permissions probe reports write.",
+    "The workflow declares AO_AUTONOMOUS_MERGE_TOKEN_SOURCE=github.token plus contents and pull-requests write permissions, and the executor verifies the main-branch workflow provenance before accepting an unobservable integration-token permission path.",
+    "The executor still denies non-main base refs, draft PRs, cross-repository PRs, dirty merge states, admin actors, admin permissions, missing required checks, missing source-pinned release checks, and unverified synthetic integration identity.",
+    "Focused validation passed for actionlint, ruff, mypy, and pytest covering the autonomous executor, merge-agent, and release-gate conclusion mapping subset.",
+    "Claude v3 and OpenAI subagent v3 both returned AGREE after the identity-proof bypass concern was absorbed.",
     "No ruleset mutation, CODEOWNERS change, branch protection mutation, admin bypass, credential material, support widening, production platform claim, or live adapter execution is introduced."
   ],
   "secrets_recorded": false,

--- a/scripts/ao_autonomous_pr_merge_executor.py
+++ b/scripts/ao_autonomous_pr_merge_executor.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import re
 import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
@@ -28,6 +30,8 @@ GITHUB_ACTIONS_APP_ID = 15368
 SOURCE_PINNED_REQUIRED_CHECKS = ("ao-release-gate-technical", "ao-release-gate-review")
 READY_MERGE_STATES = {"CLEAN", "HAS_HOOKS"}
 INTEGRATION_TOKEN_WARNING = "github_user_endpoint_unavailable_for_integration_token"
+INTEGRATION_TOKEN_PERMISSION_WARNING = "github_actions_integration_token_permission_unobservable"
+REPO_OWNED_ACTIONS_TOKEN_WORKFLOW = ".github/workflows/ao-autonomous-merge-executor.yml"
 FORBIDDEN_ADMIN_FLAG = "--" "admin"
 
 Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
@@ -75,6 +79,47 @@ def _is_actions_integration_error(expected_actor: str, error: str | None) -> boo
         and error is not None
         and "resource not accessible by integration" in error.lower()
     )
+
+
+def _workflow_declares_github_token(path: Path) -> tuple[bool, list[str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return False, [f"workflow_file_read_failed:{exc.__class__.__name__}"]
+
+    checks = {
+        "gh_token_is_github_token": "GH_TOKEN: ${{ github.token }}" in text,
+        "contents_write_permission": re.search(r"(?m)^  contents: write$", text) is not None,
+        "pull_requests_write_permission": re.search(r"(?m)^  pull-requests: write$", text) is not None,
+        "no_admin_flag_literal": FORBIDDEN_ADMIN_FLAG not in text,
+    }
+    return all(checks.values()), [name for name, passed in checks.items() if not passed]
+
+
+def _repo_owned_actions_token_proof(repo: str) -> dict[str, Any]:
+    workflow_path = Path(REPO_OWNED_ACTIONS_TOKEN_WORKFLOW)
+    workflow_ok, workflow_failures = _workflow_declares_github_token(workflow_path)
+    expected_workflow_ref = f"{repo}/{REPO_OWNED_ACTIONS_TOKEN_WORKFLOW}@refs/heads/main"
+    checks = {
+        "github_actions": os.environ.get("GITHUB_ACTIONS") == "true",
+        "event": os.environ.get("GITHUB_EVENT_NAME") in {"workflow_run", "workflow_dispatch"},
+        "repository": os.environ.get("GITHUB_REPOSITORY") == repo,
+        "workflow_ref": os.environ.get("GITHUB_WORKFLOW_REF") == expected_workflow_ref,
+        "token_source": os.environ.get("AO_AUTONOMOUS_MERGE_TOKEN_SOURCE") == "github.token",
+        "workflow_declares_github_token": workflow_ok,
+    }
+    failures = [name for name, passed in checks.items() if not passed]
+    failures.extend(workflow_failures)
+    return {
+        "verified": not failures,
+        "workflow_ref": os.environ.get("GITHUB_WORKFLOW_REF"),
+        "expected_workflow_ref": expected_workflow_ref,
+        "event_name": os.environ.get("GITHUB_EVENT_NAME"),
+        "repository": os.environ.get("GITHUB_REPOSITORY"),
+        "token_source": os.environ.get("AO_AUTONOMOUS_MERGE_TOKEN_SOURCE"),
+        "workflow_file": REPO_OWNED_ACTIONS_TOKEN_WORKFLOW,
+        "failures": sorted(set(failures)),
+    }
 
 
 def _permission_from_repo_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -132,12 +177,14 @@ def collect_live_state(
 ) -> dict[str, Any]:
     errors: list[str] = []
     warnings: list[str] = []
+    repo_owned_actions_token: dict[str, Any] = {"verified": False, "failures": ["not_evaluated"]}
 
     viewer, error = _json_command([gh_bin, "api", "user"], runner)
     if error is not None or not isinstance(viewer, dict):
         if _is_actions_integration_error(expected_actor, error):
             viewer = {"login": expected_actor}
             warnings.append(INTEGRATION_TOKEN_WARNING)
+            repo_owned_actions_token = _repo_owned_actions_token_proof(repo)
         else:
             errors.append(f"viewer: {error or 'invalid shape'}")
             viewer = {}
@@ -212,24 +259,61 @@ def collect_live_state(
         "pr_view": pr_view,
         "required_checks": required_checks,
         "check_runs": check_runs,
+        "repo_owned_actions_token": repo_owned_actions_token,
         "collection_errors": errors,
         "collection_warnings": warnings,
     }
 
 
 def _required_checks_pass(required_checks: list[Any]) -> tuple[bool, list[dict[str, Any]]]:
-    failing: list[dict[str, Any]] = []
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    anonymous_index = 0
     for raw in required_checks:
         item = raw if isinstance(raw, dict) else {}
-        if item.get("bucket") != "pass":
+        name = _string(item.get("name"))
+        if not name:
+            anonymous_index += 1
+            name = f"<unnamed-{anonymous_index}>"
+        grouped.setdefault(name, []).append(item)
+
+    failing: list[dict[str, Any]] = []
+    for name, items in grouped.items():
+        buckets = {_string(item.get("bucket")) for item in items}
+        states = {_string(item.get("state")) for item in items}
+
+        if "fail" in buckets:
             failing.append(
                 {
-                    "name": item.get("name"),
-                    "bucket": item.get("bucket"),
-                    "state": item.get("state"),
-                    "link": item.get("link"),
+                    "name": name,
+                    "bucket": "fail",
+                    "state": sorted(str(state) for state in states if state is not None),
+                    "observed": items,
                 }
             )
+            continue
+
+        # GitHub can report duplicate required-check contexts for the same PR
+        # head while older workflow runs are still visible. One successful
+        # context is enough; pending duplicates should not override it.
+        if "pass" in buckets:
+            continue
+
+        # Skipped contexts from event-gate-only workflow runs are not release
+        # authority; source-pinned ao-release-gate check-runs and mergeState
+        # still have to pass before a merge can happen.
+        if buckets and buckets <= {"skipping"}:
+            continue
+
+        representative = items[0] if items else {}
+        failing.append(
+            {
+                "name": name,
+                "bucket": representative.get("bucket"),
+                "state": representative.get("state"),
+                "link": representative.get("link"),
+                "observed": items,
+            }
+        )
     return not failing, failing
 
 
@@ -296,15 +380,29 @@ def build_result(
     required_checks_list = required_checks if isinstance(required_checks, list) else []
     check_runs = _object(live_state.get("check_runs"))
     collection_error_items = _string_list(live_state.get("collection_errors"))
+    repo_owned_actions_token = _object(live_state.get("repo_owned_actions_token"))
 
     actual_actor = _string(viewer.get("login"))
     permission_name = _string(permission.get("permission")) or _string(permission.get("role_name"))
+    integration_actor_permission_unobservable = (
+        actual_actor == expected_actor
+        and INTEGRATION_TOKEN_WARNING in warnings
+        and permission_name is None
+    )
+    integration_actor_identity_synthetic = actual_actor == expected_actor and INTEGRATION_TOKEN_WARNING in warnings
+    repo_owned_actions_token_verified = repo_owned_actions_token.get("verified") is True
 
     if actual_actor != expected_actor:
         blockers.add("unexpected_merge_actor")
+    if integration_actor_identity_synthetic and not repo_owned_actions_token_verified:
+        blockers.add("merge_actor_identity_unverified")
     if permission_name == "admin" or permission.get("role_name") == "admin":
         blockers.add("merge_actor_admin_permission_observed")
-    if permission_name != "write":
+    if integration_actor_permission_unobservable and repo_owned_actions_token_verified:
+        warnings.add(INTEGRATION_TOKEN_PERMISSION_WARNING)
+    elif integration_actor_permission_unobservable:
+        blockers.add("merge_actor_permission_unobservable")
+    elif permission_name != "write":
         blockers.add("merge_actor_not_write")
 
     pr_state = pr_view.get("state")
@@ -390,6 +488,7 @@ def build_result(
         "mutations_performed": result == "merged",
         "release_authority": RELEASE_AUTHORITY,
         "ai_output_release_authority": False,
+        "repo_owned_actions_token": repo_owned_actions_token,
         "guard_flags": {
             "support_widening": False,
             "production_platform_claim": False,

--- a/tests/test_ao_autonomous_pr_merge_executor.py
+++ b/tests/test_ao_autonomous_pr_merge_executor.py
@@ -156,6 +156,87 @@ def test_required_check_failure_blocks() -> None:
     assert "required_checks_not_passed" in payload["decision"]["blockers"]
 
 
+def test_duplicate_required_checks_allow_pass_over_stale_pending_and_skipped() -> None:
+    live = _ready_live_state()
+    live["required_checks"] = [
+        {"name": "lint", "bucket": "skipping", "state": "SKIPPED", "link": "stale"},
+        {"name": "lint", "bucket": "pass", "state": "SUCCESS", "link": "current"},
+        {"name": "test (3.11)", "bucket": "pending", "state": "IN_PROGRESS", "link": "old-run"},
+        {"name": "test (3.11)", "bucket": "pass", "state": "SUCCESS", "link": "new-run"},
+        {"name": "ao-release-gate", "bucket": "skipping", "state": "SKIPPED", "link": "event-gate-only"},
+    ]
+
+    payload = _result(live)
+
+    assert payload["decision"]["result"] == "ready_to_merge"
+    assert payload["required_checks"]["all_passed"] is True
+    assert payload["required_checks"]["failing"] == []
+
+
+def test_pending_required_check_without_pass_still_blocks() -> None:
+    live = _ready_live_state()
+    live["required_checks"].append(
+        {"name": "test (3.13)", "bucket": "pending", "state": "IN_PROGRESS", "link": "current"}
+    )
+
+    payload = _result(live)
+
+    assert payload["decision"]["result"] == "blocked"
+    assert "required_checks_not_passed" in payload["decision"]["blockers"]
+    assert payload["required_checks"]["failing"][0]["name"] == "test (3.13)"
+
+
+def test_github_actions_integration_token_permission_gap_does_not_block() -> None:
+    live = _ready_live_state()
+    live["permission"] = {}
+    live["collection_warnings"] = ["github_user_endpoint_unavailable_for_integration_token"]
+    live["repo_owned_actions_token"] = {"verified": True, "failures": []}
+
+    payload = _result(live)
+
+    assert payload["decision"]["result"] == "ready_to_merge"
+    assert "merge_actor_not_write" not in payload["decision"]["blockers"]
+    assert "github_actions_integration_token_permission_unobservable" in payload["decision"]["warnings"]
+    assert payload["repo_owned_actions_token"]["verified"] is True
+
+
+def test_integration_token_permission_gap_without_repo_owned_proof_blocks() -> None:
+    live = _ready_live_state()
+    live["permission"] = {}
+    live["collection_warnings"] = ["github_user_endpoint_unavailable_for_integration_token"]
+    live["repo_owned_actions_token"] = {"verified": False, "failures": ["workflow_ref"]}
+
+    payload = _result(live)
+
+    assert payload["decision"]["result"] == "blocked"
+    assert "merge_actor_permission_unobservable" in payload["decision"]["blockers"]
+    assert "merge_actor_identity_unverified" in payload["decision"]["blockers"]
+    assert "merge_actor_not_write" not in payload["decision"]["blockers"]
+
+
+def test_integration_token_with_write_permission_still_requires_repo_owned_proof() -> None:
+    live = _ready_live_state()
+    live["permission"] = {"permission": "write", "role_name": "write"}
+    live["collection_warnings"] = ["github_user_endpoint_unavailable_for_integration_token"]
+    live["repo_owned_actions_token"] = {"verified": False, "failures": ["workflow_ref"]}
+
+    payload = _result(live)
+
+    assert payload["decision"]["result"] == "blocked"
+    assert "merge_actor_identity_unverified" in payload["decision"]["blockers"]
+    assert "merge_actor_not_write" not in payload["decision"]["blockers"]
+
+
+def test_required_check_failure_with_missing_state_blocks_without_type_error() -> None:
+    live = _ready_live_state()
+    live["required_checks"][0] = {"name": "lint", "bucket": "fail", "link": "failure-without-state"}
+
+    payload = _result(live)
+
+    assert payload["decision"]["result"] == "blocked"
+    assert "required_checks_not_passed" in payload["decision"]["blockers"]
+
+
 def test_stale_workflow_run_head_sha_blocks() -> None:
     payload = _result(event_head_sha="b" * 40)
 


### PR DESCRIPTION
## Summary

Fix the autonomous merge executor readiness logic discovered by smoke PR #745.

The first executor smoke correctly failed closed, but it exposed two live-GitHub mismatches:

1. `github-actions[bot]` integration-token permission can be unobservable through `gh api user`/repo permission introspection. The executor now keeps that as fail-closed unless it verifies the repo-owned `AO Autonomous Merge Executor` workflow context from `main`, confirms the workflow declares `GH_TOKEN: ${{ github.token }}`, and confirms the workflow has write permissions for contents and pull requests. Without that proof, the blocker is `merge_actor_permission_unobservable`.
2. `gh pr checks --required` can report duplicate required-check contexts from older/stale workflow runs. The executor now groups required checks by name: a real failure still blocks, a pass wins over stale pending/skipped duplicates, all-skipping event-gate-only contexts do not become release authority, and source-pinned `ao-release-gate-*` check-runs remain independently required by app id `15368`.

## Validation

- `python3 -m pytest -q tests/test_ao_autonomous_pr_merge_executor.py tests/test_ao_ma10c_merge_agent.py tests/test_ao_release_gate.py::test_check_run_conclusion_mapping` -> 47 passed
- `python3 -m ruff check scripts/ao_autonomous_pr_merge_executor.py tests/test_ao_autonomous_pr_merge_executor.py`
- `python3 -m mypy scripts/ao_autonomous_pr_merge_executor.py`
- `actionlint .github/workflows/ao-autonomous-merge-executor.yml`
- `git diff --check`

## Cross-AI review

- Claude CLI review v1: AGREE before permission hardening
- Sub-agent review v1: REVISE on unobservable integration-token permission
- v2 absorbs REVISE by making permission-unobservable fail-closed unless repo-owned workflow proof passes

## Guardrails

- No admin merge path
- No branch-protection mutation
- No support widening
- No production platform claim
- No live adapter execution
- AI output remains evidence only; release authority remains `ao-release-gate+github-ruleset`
