### PR TITLE
test(hyg-public-facade-gaps): cover critical fail-closed branches

### DIFF
--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "HYG-PUBLIC-FACADE-TEST-QUALITY-AUDIT",
+  "work_package": "HYG-PUBLIC-FACADE-GAPS",
   "implementer": {
     "agent": "claude",
     "provider": "anthropic"
@@ -13,10 +13,12 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/hyg-mutmut-coverage-audit",
+    "head_ref": "refs/heads/codex/hyg-public-facade-gaps",
     "changed_files": [
-      "docs/audits/PUBLIC-FACADE-TEST-QUALITY-AUDIT-2026-05-29.md",
-      "local-ai-review-evidence.v1.json"
+      "local-ai-review-evidence.v1.json",
+      "tests/test_config.py",
+      "tests/test_llm_facade.py",
+      "tests/test_tool_gateway.py"
     ]
   },
   "checks_considered": [
@@ -29,15 +31,11 @@
       "status": "pass"
     },
     {
-      "name": "doc_only_scope",
+      "name": "test_only_scope",
       "status": "pass"
     },
     {
-      "name": "no_fake_work_disclosure",
-      "status": "pass"
-    },
-    {
-      "name": "guard_flags_remain_false",
+      "name": "coverage_delta_recorded",
       "status": "pass"
     },
     {
@@ -45,18 +43,22 @@
       "status": "pass"
     },
     {
-      "name": "no_pyproject_or_workflow_mutation",
+      "name": "guard_flags_remain_false",
+      "status": "pass"
+    },
+    {
+      "name": "no_fake_work_already_covered_excluded",
       "status": "pass"
     }
   ],
   "findings": [
-    "Codex post-impl review returned AGREE for HYG-PUBLIC-FACADE-TEST-QUALITY-AUDIT after reviewing the doc-only diff and source-line consistency checks (Codex thread 019e74e6, CNS-20260529-002 Track 1, iter-3 AGREE + post-impl AGREE).",
-    "Diff surface is doc-only: adds the audit document and the consultation request artifact only; no tests, no pyproject or mutmut config change, no workflow, no guard flag, no gpp_status, no runtime module.",
-    "Mutmut failure disclosure is No-Fake-Work aligned: it records mutmut 3.5.0, local macOS and Python context, three observed failure classes, and avoids an upstream-defect claim without a minimal repro. No synthetic mutation result was fabricated.",
-    "The audit does not claim mutation coverage; it is framed as coverage-driven and states covered does not equal well asserted.",
-    "Critical-gap definition is narrow and applied consistently: fail-closed, input-validation, provider-guardrail, and policy branches are critical; defensive import and except fallbacks are recorded as intentionally_uncovered_or_unreachable.",
-    "Source-line spot checks match cited code: config.py non-object JSON errors, llm.py provider guardrail denial, tool_gateway.py strict policy type validation, governance.py provider and generic violation branches.",
-    "Coverage JSON and mutmut working directories were generated locally for extraction and were intentionally excluded from the committed diff.",
+    "Codex plan-time consultation (thread 019e7520) returned REVISE + ready_for_impl with add_missing_arcs_only scope: skip already-covered governance arcs, require coverage-delta, single combined PR.",
+    "Test-only diff: extends tests/test_config.py, tests/test_tool_gateway.py, tests/test_llm_facade.py. No ao_kernel runtime module, no pyproject, no workflow, no schema, no guard flag, no gpp_status change.",
+    "GAPS-01 config.py: adds non-object workspace.json (array + scalar), non-object override, and non-object bundled default (narrow importlib.resources monkeypatch, no real bundled file touched) fail-closed tests.",
+    "GAPS-02 tool_gateway.py: adds blocked_tools non-list / non-string entry, cycle_detection non-object, and max_identical_calls non-int / bool-rejected tests — closing the asymmetric gap where allowed_tools had validation tests but blocked_tools did not.",
+    "GAPS-03 llm.py: adds build_request provider-guardrails deny (PROVIDER_DISABLED + MODEL_NOT_ALLOWED) and allow paths using a tmp workspace override policy; no live provider call or network access.",
+    "Coverage delta recorded (full-suite before -> after, source 428b886): config.py 93.6%->97.9% (closed 115/145/164), tool_gateway.py 94.3%->97.8% (closed 119/122/143/151), llm.py 87.1%->91.6% (closed 104/105/110/111/114).",
+    "No-Fake-Work discipline applied: governance.py was deliberately excluded because its core violation codes are already covered and the remaining arcs are partial dispatch-branch completions; llm.py:115 except-pass import guard left intentionally uncovered.",
     "No secrets, API keys, tokens, credential material, webhook URLs, admin bypass, workflow mutation, ruleset mutation, CODEOWNERS change, support widening, production platform claim, or live adapter execution are introduced."
   ],
   "secrets_recorded": false,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,6 +46,7 @@ class TestLoadWorkspaceJson:
     def test_valid_workspace(self, tmp_workspace: Path):
         data = load_workspace_json(tmp_workspace)
         import ao_kernel
+
         assert data["version"] == ao_kernel.__version__
         assert data["kind"] == "ao-workspace"
 
@@ -61,6 +62,22 @@ class TestLoadWorkspaceJson:
     def test_missing_required_field(self, tmp_path: Path):
         (tmp_path / "workspace.json").write_text('{"version": "2.0.0"}')
         with pytest.raises(WorkspaceCorruptedError, match="missing required field"):
+            load_workspace_json(tmp_path)
+
+    def test_non_object_top_level_raises(self, tmp_path: Path):
+        # HYG-PUBLIC-FACADE-GAPS-01: workspace.json is valid JSON but its
+        # top-level value is not an object (a JSON array here). The loader
+        # must fail closed before the required-field scan. Covers the
+        # `not isinstance(data, dict)` fail-closed branch in
+        # load_workspace_json (config.py).
+        (tmp_path / "workspace.json").write_text("[1, 2, 3]")
+        with pytest.raises(WorkspaceCorruptedError, match="must be a JSON object"):
+            load_workspace_json(tmp_path)
+
+    def test_non_object_scalar_top_level_raises(self, tmp_path: Path):
+        # Same fail-closed branch, scalar top-level (a bare JSON number).
+        (tmp_path / "workspace.json").write_text("42")
+        with pytest.raises(WorkspaceCorruptedError, match="must be a JSON object"):
             load_workspace_json(tmp_path)
 
 
@@ -134,6 +151,35 @@ class TestLoadDefault:
         with pytest.raises(DefaultsNotFoundError):
             load_default("policies", "nonexistent_file.json")
 
+    def test_non_object_bundled_default_raises(self, monkeypatch):
+        # HYG-PUBLIC-FACADE-GAPS-01: pin the public contract that a bundled
+        # default whose top-level JSON is not an object fails closed with
+        # DefaultsNotFoundError. Bundled JSON files are all valid objects, so
+        # this branch is only reachable by faking the resource read. We patch
+        # the importlib.resources traversable chain (files(...).joinpath(...))
+        # to return a stub whose read_text yields a JSON array — never
+        # touching a real bundled file. Covers the `not isinstance(parsed,
+        # dict)` branch in load_default (config.py).
+        import ao_kernel.config as cfg
+
+        class _StubResource:
+            def read_text(self, encoding="utf-8"):
+                return "[1, 2, 3]"
+
+        class _StubTraversable:
+            def joinpath(self, _segment):
+                return self
+
+            def read_text(self, encoding="utf-8"):
+                return "[1, 2, 3]"
+
+        def _fake_files(_pkg):
+            return _StubTraversable()
+
+        monkeypatch.setattr(cfg, "files", _fake_files)
+        with pytest.raises(DefaultsNotFoundError, match="must be a JSON object"):
+            load_default("policies", "anything.json")
+
 
 class TestLoadWithOverride:
     def test_workspace_override_takes_precedence(self, tmp_workspace: Path):
@@ -153,3 +199,16 @@ class TestLoadWithOverride:
     def test_no_workspace(self):
         result = load_with_override("policies", "policy_autonomy.v1.json", workspace=None)
         assert isinstance(result, dict)
+
+    def test_override_non_object_raises(self, tmp_workspace: Path):
+        # HYG-PUBLIC-FACADE-GAPS-01: a workspace override file that parses as
+        # valid JSON but is not an object must fail closed with
+        # DefaultsNotFoundError, rather than returning a non-dict. Covers the
+        # `not isinstance(parsed, dict)` branch in load_with_override
+        # (config.py).
+        policy_dir = tmp_workspace / "policies"
+        policy_dir.mkdir(exist_ok=True)
+        (policy_dir / "policy_autonomy.v1.json").write_text("[1, 2, 3]")
+
+        with pytest.raises(DefaultsNotFoundError, match="Override must be a JSON object"):
+            load_with_override("policies", "policy_autonomy.v1.json", workspace=tmp_workspace)

--- a/tests/test_llm_facade.py
+++ b/tests/test_llm_facade.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import json
 
+import pytest
 
 
 class TestBuildRequest:
     def test_openai_request_has_required_fields(self):
         from ao_kernel.llm import build_request
+
         req = build_request(
-            provider_id="openai", model="gpt-4",
+            provider_id="openai",
+            model="gpt-4",
             messages=[{"role": "user", "content": "hello"}],
             base_url="https://api.openai.com/v1/chat/completions",
             api_key="sk-test",
@@ -24,8 +27,10 @@ class TestBuildRequest:
 
     def test_anthropic_request_has_required_fields(self):
         from ao_kernel.llm import build_request
+
         req = build_request(
-            provider_id="claude", model="claude-3-opus",
+            provider_id="claude",
+            model="claude-3-opus",
             messages=[{"role": "user", "content": "hi"}],
             base_url="https://api.anthropic.com/v1/messages",
             api_key="sk-ant-test",
@@ -38,18 +43,23 @@ class TestBuildRequest:
 
     def test_stream_flag_added_to_body(self):
         from ao_kernel.llm import build_request
+
         req = build_request(
-            provider_id="openai", model="gpt-4",
+            provider_id="openai",
+            model="gpt-4",
             messages=[{"role": "user", "content": "hi"}],
             base_url="https://api.openai.com/v1/chat/completions",
-            api_key="sk-test", stream=True,
+            api_key="sk-test",
+            stream=True,
         )
         assert req["body_json"]["stream"] is True
 
     def test_no_stream_flag_by_default(self):
         from ao_kernel.llm import build_request
+
         req = build_request(
-            provider_id="openai", model="gpt-4",
+            provider_id="openai",
+            model="gpt-4",
             messages=[{"role": "user", "content": "hi"}],
             base_url="https://api.openai.com/v1/chat/completions",
             api_key="sk-test",
@@ -58,11 +68,14 @@ class TestBuildRequest:
 
     def test_stream_with_tools_allowed(self):
         from ao_kernel.llm import build_request
+
         req = build_request(
-            provider_id="openai", model="gpt-4",
+            provider_id="openai",
+            model="gpt-4",
             messages=[{"role": "user", "content": "hi"}],
             base_url="https://api.openai.com/v1/chat/completions",
-            api_key="sk-test", stream=True,
+            api_key="sk-test",
+            stream=True,
             tools=[{"type": "function", "function": {"name": "test"}}],
         )
         assert req["body_json"]["stream"] is True
@@ -70,34 +83,121 @@ class TestBuildRequest:
 
     def test_google_stream_changes_endpoint(self):
         from ao_kernel.llm import build_request
+
         req = build_request(
-            provider_id="google", model="gemini-pro",
+            provider_id="google",
+            model="gemini-pro",
             messages=[{"role": "user", "content": "hi"}],
             base_url="https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent",
-            api_key="key-test", stream=True,
+            api_key="key-test",
+            stream=True,
         )
         assert "streamGenerateContent" in req["url"]
         assert "alt=sse" in req["url"]
 
     def test_temperature_and_max_tokens(self):
         from ao_kernel.llm import build_request
+
         req = build_request(
-            provider_id="openai", model="gpt-4",
+            provider_id="openai",
+            model="gpt-4",
             messages=[{"role": "user", "content": "hi"}],
             base_url="https://api.openai.com/v1/chat/completions",
-            api_key="sk-test", temperature=0.7, max_tokens=100,
+            api_key="sk-test",
+            temperature=0.7,
+            max_tokens=100,
         )
         assert req["body_json"]["temperature"] == 0.7
         assert req["body_json"]["max_tokens"] == 100
 
 
+class TestBuildRequestProviderGuardrails:
+    """HYG-PUBLIC-FACADE-GAPS-03: the provider-guardrails fail-closed branch
+    in build_request (llm.py) had no coverage. When a workspace ships an
+    explicit policy_llm_providers_guardrails.v1.json override that denies the
+    requested provider/model, build_request must raise ValueError; when the
+    policy allows it, build_request proceeds normally.
+
+    The tmp_workspace fixture creates ``.ao/policies/`` and chdirs into the
+    project, so ``workspace_root()`` resolves to that ``.ao`` directory and
+    build_request reads the override policy from ``.ao/policies/``. No live
+    provider call or network access occurs — build_request only constructs the
+    request dict.
+    """
+
+    def test_guardrails_deny_raises_value_error(self, tmp_workspace):
+        from ao_kernel.llm import build_request
+
+        # Disabled provider → PROVIDER_DISABLED violation → denied.
+        (tmp_workspace / "policies" / "policy_llm_providers_guardrails.v1.json").write_text(
+            json.dumps({"providers": {"openai": {"enabled": False}}})
+        )
+        with pytest.raises(ValueError, match="Provider guardrails denied"):
+            build_request(
+                provider_id="openai",
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                base_url="https://api.openai.com/v1/chat/completions",
+                api_key="sk-test",
+            )
+
+    def test_guardrails_model_not_allowed_raises(self, tmp_workspace):
+        from ao_kernel.llm import build_request
+
+        # Enabled provider but model not in allow_models → MODEL_NOT_ALLOWED.
+        (tmp_workspace / "policies" / "policy_llm_providers_guardrails.v1.json").write_text(
+            json.dumps({"providers": {"openai": {"enabled": True, "allow_models": ["gpt-4o-mini"]}}})
+        )
+        with pytest.raises(ValueError, match="Provider guardrails denied"):
+            build_request(
+                provider_id="openai",
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                base_url="https://api.openai.com/v1/chat/completions",
+                api_key="sk-test",
+            )
+
+    def test_guardrails_allow_proceeds(self, tmp_workspace):
+        from ao_kernel.llm import build_request
+
+        # Enabled provider + model in allow_models → no violation → builds.
+        (tmp_workspace / "policies" / "policy_llm_providers_guardrails.v1.json").write_text(
+            json.dumps({"providers": {"openai": {"enabled": True, "allow_models": ["gpt-4o"]}}})
+        )
+        req = build_request(
+            provider_id="openai",
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            base_url="https://api.openai.com/v1/chat/completions",
+            api_key="sk-test",
+        )
+        assert req["body_json"]["model"] == "gpt-4o"
+
+    def test_no_guardrails_policy_proceeds(self, tmp_workspace):
+        from ao_kernel.llm import build_request
+
+        # No guardrails policy file present → guardrails check is skipped,
+        # build_request proceeds (the `guardrails_path.exists()` False branch).
+        req = build_request(
+            provider_id="openai",
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            base_url="https://api.openai.com/v1/chat/completions",
+            api_key="sk-test",
+        )
+        assert req["body_json"]["model"] == "gpt-4o"
+
+
 class TestNormalizeResponse:
     def test_openai_text_extraction(self):
         from ao_kernel.llm import normalize_response
-        resp = json.dumps({
-            "choices": [{"message": {"content": "Hello world"}}],
-            "usage": {"prompt_tokens": 5, "completion_tokens": 2},
-        }).encode()
+
+        resp = json.dumps(
+            {
+                "choices": [{"message": {"content": "Hello world"}}],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 2},
+            }
+        ).encode()
         result = normalize_response(resp, provider_id="openai")
         assert result["text"] == "Hello world"
         assert result["usage"]["input_tokens"] == 5
@@ -106,21 +206,26 @@ class TestNormalizeResponse:
 
     def test_anthropic_text_extraction(self):
         from ao_kernel.llm import normalize_response
-        resp = json.dumps({
-            "content": [{"type": "text", "text": "Merhaba"}],
-            "usage": {"input_tokens": 10, "output_tokens": 3},
-        }).encode()
+
+        resp = json.dumps(
+            {
+                "content": [{"type": "text", "text": "Merhaba"}],
+                "usage": {"input_tokens": 10, "output_tokens": 3},
+            }
+        ).encode()
         result = normalize_response(resp, provider_id="claude")
         assert result["text"] == "Merhaba"
         assert result["usage"]["input_tokens"] == 10
 
     def test_empty_response_handling(self):
         from ao_kernel.llm import normalize_response
+
         result = normalize_response(b"", provider_id="openai")
         assert isinstance(result["text"], str)
 
     def test_malformed_json_response(self):
         from ao_kernel.llm import normalize_response
+
         result = normalize_response(b"not json at all", provider_id="openai")
         assert isinstance(result["text"], str)
 
@@ -128,16 +233,19 @@ class TestNormalizeResponse:
 class TestExtractText:
     def test_extracts_from_anthropic_format(self):
         from ao_kernel.llm import extract_text
+
         resp = json.dumps({"content": [{"type": "text", "text": "Test output"}]}).encode()
         assert extract_text(resp) == "Test output"
 
     def test_extracts_from_openai_format(self):
         from ao_kernel.llm import extract_text
+
         resp = json.dumps({"choices": [{"message": {"content": "OpenAI says"}}]}).encode()
         assert extract_text(resp) == "OpenAI says"
 
     def test_handles_empty_bytes(self):
         from ao_kernel.llm import extract_text
+
         result = extract_text(b"")
         assert isinstance(result, str)
 
@@ -145,6 +253,7 @@ class TestExtractText:
 class TestExtractUsage:
     def test_openai_usage(self):
         from ao_kernel.llm import extract_usage
+
         resp = json.dumps({"usage": {"prompt_tokens": 10, "completion_tokens": 20}}).encode()
         usage = extract_usage(resp)
         assert usage is not None
@@ -153,6 +262,7 @@ class TestExtractUsage:
 
     def test_no_usage_returns_none(self):
         from ao_kernel.llm import extract_usage
+
         usage = extract_usage(b'{"choices": []}')
         assert usage is None
 
@@ -160,6 +270,7 @@ class TestExtractUsage:
 class TestTokenCounting:
     def test_heuristic_returns_positive_int(self):
         from ao_kernel.llm import count_tokens_heuristic
+
         messages = [{"role": "user", "content": "Hello world, this is a test sentence."}]
         result = count_tokens_heuristic(messages)
         assert isinstance(result, int)
@@ -167,6 +278,7 @@ class TestTokenCounting:
 
     def test_heuristic_longer_text_more_tokens(self):
         from ao_kernel.llm import count_tokens_heuristic
+
         short = [{"role": "user", "content": "Hi"}]
         long = [{"role": "user", "content": "This is a much longer message with many words."}]
         assert count_tokens_heuristic(long) > count_tokens_heuristic(short)
@@ -175,12 +287,14 @@ class TestTokenCounting:
 class TestCircuitBreaker:
     def test_new_breaker_allows_requests(self):
         from ao_kernel.llm import get_circuit_breaker
+
         cb = get_circuit_breaker("facade_test_provider")
         allowed, reason = cb.allow_request()
         assert allowed is True
 
     def test_breaker_has_status(self):
         from ao_kernel.llm import get_circuit_breaker
+
         cb = get_circuit_breaker("facade_test_status")
         status = cb.status_dict()
         assert isinstance(status, dict)
@@ -190,6 +304,7 @@ class TestCircuitBreaker:
 class TestRateLimiter:
     def test_limiter_exists_and_acquires(self):
         from ao_kernel.llm import get_rate_limiter
+
         rl = get_rate_limiter("facade_test_rl")
         assert rl is not None
         assert hasattr(rl, "acquire")
@@ -198,6 +313,7 @@ class TestRateLimiter:
 class TestStreamTypes:
     def test_stream_event_dataclass(self):
         from ao_kernel.llm import StreamEvent
+
         evt = StreamEvent(event_type="text_delta", text="hello", index=0)
         assert evt.event_type == "text_delta"
         assert evt.text == "hello"
@@ -206,6 +322,7 @@ class TestStreamTypes:
 
     def test_stream_result_dataclass(self):
         from ao_kernel.llm import StreamResult
+
         result = StreamResult(status="OK", complete=True, text="done", finish_reason="stop")
         assert result.status == "OK"
         assert result.complete is True
@@ -213,6 +330,7 @@ class TestStreamTypes:
 
     def test_all_exports_count(self):
         from ao_kernel.llm import __all__
+
         assert len(__all__) == 16  # 14 original + build_request_with_context + process_response_with_context
 
 
@@ -245,6 +363,7 @@ class TestBuildRequestWithContext:
 
     def test_without_session_falls_back_to_plain_build(self):
         from ao_kernel.llm import build_request_with_context, build_request
+
         result = build_request_with_context(
             messages=[{"role": "user", "content": "Hello"}],
             provider_id="openai",

--- a/tests/test_tool_gateway.py
+++ b/tests/test_tool_gateway.py
@@ -271,6 +271,44 @@ class TestToolCallPolicyAbsorbV39B1:
         with pytest.raises(ValueError, match="allowed_tools must be list"):
             ToolCallPolicy.from_dict({"allowed_tools": "not_a_list"})
 
+    # HYG-PUBLIC-FACADE-GAPS-02: blocked_tools had no validation tests even
+    # though allowed_tools did — asymmetric coverage. These pin the
+    # blocked_tools strict-type branches (tool_gateway.py).
+    def test_from_dict_blocked_tools_non_list_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="blocked_tools must be list"):
+            ToolCallPolicy.from_dict({"blocked_tools": "not_a_list"})
+
+    def test_from_dict_blocked_tools_non_string_entry_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="blocked_tools entries must be str"):
+            ToolCallPolicy.from_dict({"blocked_tools": ["ok", 123]})
+
+    # HYG-PUBLIC-FACADE-GAPS-02: cycle_detection non-object and non-int
+    # max_identical_calls branches were uncovered (only .enabled non-bool
+    # and max_identical_calls < 1 were tested).
+    def test_from_dict_cycle_detection_non_dict_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="cycle_detection must be object"):
+            ToolCallPolicy.from_dict({"cycle_detection": "on"})
+
+    def test_from_dict_cycle_max_identical_non_int_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="cycle_detection.max_identical_calls must be int"):
+            ToolCallPolicy.from_dict({"cycle_detection": {"max_identical_calls": "2"}})
+
+    def test_from_dict_cycle_max_identical_bool_rejected_as_non_int(self):
+        # Strict: bool is a subclass of int but must NOT be accepted, mirroring
+        # the parser's isinstance(x, bool) rejection.
+        import pytest
+
+        with pytest.raises(ValueError, match="cycle_detection.max_identical_calls must be int"):
+            ToolCallPolicy.from_dict({"cycle_detection": {"max_identical_calls": True}})
+
     def test_from_dict_minimal_normalization_preserves_duplicates(self):
         # B1 normalization is intentionally minimal (list→tuple only).
         # No dedupe/sort/lowercase — that's B2's semantic layer.


### PR DESCRIPTION
Adds targeted tests for the critical fail-closed / input-validation branches flagged by the public-facade test-quality audit (PR #750). Test-only; no runtime module changes.

Plan-time consultation: Codex thread 019e7520 — REVISE + ready_for_impl. Absorbed: add_missing_arcs_only (skip already-covered governance arcs), coverage-delta required, single combined PR, config 145 monkeypatch, extend existing test files.

## Clusters

GAPS-01 config.py (corrupt-input fail-closed):
- workspace.json non-object top-level (array + scalar) -> WorkspaceCorruptedError
- workspace override non-object -> DefaultsNotFoundError
- bundled default non-object -> DefaultsNotFoundError (narrow importlib.resources monkeypatch; no real bundled file touched)

GAPS-02 tool_gateway.py (ToolCallPolicy strict-type validation):
- blocked_tools non-list / non-string entry -> ValueError (closes asymmetric gap; allowed_tools had these, blocked_tools did not)
- cycle_detection non-object -> ValueError
- cycle_detection.max_identical_calls non-int + bool-rejected-as-non-int

GAPS-03 llm.py (build_request provider-guardrails deny path):
- guardrails policy denies provider (PROVIDER_DISABLED) -> ValueError
- guardrails policy denies model (MODEL_NOT_ALLOWED) -> ValueError
- guardrails policy allows -> build proceeds
- no guardrails policy present -> build proceeds (skip branch)

## Coverage delta (full-suite before -> after, source 428b886)

| module | before | after | closed lines |
|---|---|---|---|
| config.py | 93.6% | 97.9% | 115, 145, 164 |
| tool_gateway.py | 94.3% | 97.8% | 119, 122, 143, 151 |
| llm.py | 87.1% | 91.6% | 104, 105, 110, 111, 114 |

## Out of scope (deliberate, No-Fake-Work + Codex add_missing_arcs_only)

- governance.py: core violation codes already covered; remaining arcs are partial dispatch-branch completions of unclear input mapping -> deferred to separate HYG-GOVERNANCE-ARC-COMPLETION analysis.
- llm.py:115 (except FileNotFoundError/ImportError: pass) — defensive import-guard, intentionally uncovered.

## Validation
- pytest (3 files): 122 passed
- ruff check + format: clean
- mypy: CI scope (ao_kernel/) unaffected (test-only)
- conftest BLK-004 forcing function: no trips

## Test plan
- [ ] Codex post-impl review AGREE
- [x] local-ai-review-evidence.v1.json (cross-provider)
- [ ] Non-author operator approval (if required)
- [ ] CI green + merge

Generated with Claude Code (https://claude.com/claude-code)