### PR TITLE
feat(ao-ma-4.5): add worker invocation (deterministic local worker + result emit)

### DIFF
--- a/.claude/plans/AO-MA-1-MULTI-AGENT-ORCHESTRATION-DESIGN.md
+++ b/.claude/plans/AO-MA-1-MULTI-AGENT-ORCHESTRATION-DESIGN.md
@@ -180,7 +180,7 @@ AO-MA is an execution accelerator for GPP-2D, not a replacement for it.
 | **AO-MA-2** | JSON Schemas for task graph, assignment, worker result, review verdict, verification report, and integration report. | schema + tests |
 | **AO-MA-3** | Local orchestrator CLI that reads SSOT and emits a task graph without spawning agents yet. | code + tests |
 | **AO-MA-4** | Parallel worktree runner with file ownership enforcement and conflict detection. | code + tests |
-| **AO-MA-4.5** | Worker invocation + result emit (LLM-driven; scope: write `worker_result.v1` per AO-MA-4 prepared worktree). Producer slice; not the integrator. | code + tests |
+| **AO-MA-4.5** | Worker invocation + result emit. **Implemented** as a deterministic local worker fixture (`ao-ma-worker-stub`) + `WorkerInvoker`: writes `worker_result.v1` per AO-MA-4 prepared worktree and bridges it into the base_dir consumption point. Live-LLM worker is deferred to an operator-bound GPP supersession (`live_adapter_execution=true`). Producer slice; not the integrator. See `.claude/plans/AO-MA-4.5-WORKER-INVOCATION.md`. | code + schema + tests |
 | **AO-MA-5** | Integrator policy: accept/reject/not_integratable worker outputs, conflict reports, operator-runnable assembly plan. NO remote write (no `git push`, no `gh pr create`). Depends on AO-MA-4.5 worker_result.v1 inputs + AO-MA-6 review_verdict.v1 + AO-MA-7 verification_report.v1; gracefully fails-closed (not_integratable) when those are missing. | code + tests |
 | **AO-MA-6** | Reviewer loop contract and bounded REVISE handling. | code + tests |
 | **AO-MA-7** | Verifier lane: GPP guard checks, secret scan, diff scope, and artifact hash reporting. | code + tests |

--- a/.claude/plans/AO-MA-4.5-WORKER-INVOCATION.md
+++ b/.claude/plans/AO-MA-4.5-WORKER-INVOCATION.md
@@ -1,0 +1,142 @@
+# AO-MA-4.5 — Worker Invocation (deterministic local worker fixture + result emit)
+
+**Status:** implemented (code + schema + tests). Closes the AO-MA dogfooding gap where AO-MA-4 prepared worktrees but no worker ever wrote `worker_result.v1`.
+**Date:** 2026-05-29
+**Parent:** AO-MA-1 §8 phased plan slice AO-MA-4.5
+**Cross-AI consultation:** Codex thread `019e74ef-06a2-7ac3-8cf7-d59d2ac9e27a` (iter-1 REVISE → iter-2 AGREE, `ready_for_impl=true`)
+**Support impact:** none
+**Production platform claim:** false
+**Live adapter execution:** false
+
+## 1. Why
+
+Before AO-MA-4.5, the AO-MA orchestration layer never spawned a worker. AO-MA-3
+emitted a task graph, AO-MA-4 prepared worktrees and recorded an
+`expected_worker_result_path` per worker, but the file at that path was never
+written by any runtime code — the real implementer work happened OUTSIDE
+ao-kernel (Claude Code / Codex under human direction). The pipeline could
+review/verify/integrate `worker_result.v1` artifacts but could not *produce*
+one. AO-MA-4.5 is the producer slice: it makes the orchestration layer drive a
+real worker and emit `worker_result.v1`, so the full chain
+`plan → spawn → invoke → review → verify → integrate` runs end-to-end on the
+repo's own machinery (dogfooding).
+
+## 2. Scope (v1) — deterministic local worker only
+
+AO-MA-4.5 v1 invokes a **pinned deterministic local worker fixture**, not a
+live LLM. This keeps `live_adapter_execution=false` (the GPP guard) honest:
+real LLM worker execution (e.g. `claude-code-cli`) requires a separate
+operator-bound GPP supersession with `live_adapter_execution=true` and is out
+of scope. The AO-MA-1 §8 row historically said "LLM-driven"; that remains the
+long-term intent, but the v1 acceptance carries **no live-LLM claim**.
+
+Files:
+
+1. `ao_kernel/fixtures/ao_ma_worker_stub.py` — deterministic worker fixture,
+   promoted from the AO-MA-8 in-file surrogate (`_emit_mock_worker_result`) to
+   a runtime module. Modifies one file from `declared_write_set` in the
+   prepared worktree, commits it, derives `head_sha` + `actual_changed_files`
+   from real git state, writes a schema-valid `worker_result.v1.json`
+   (`worker.provider="local"`).
+2. `ao_kernel/orchestration/worker_invoker.py` — `WorkerInvoker.invoke()`:
+   reads the AO-MA-4 `runner_report.v1.json`, invokes the pinned fixture for
+   each eligible worker (subprocess), validates the emitted `worker_result`,
+   bridges it into the base_dir consumption point, and emits a schema-valid
+   invocation report.
+3. `ao_kernel/defaults/schemas/ao-ma-worker-invocation-report.schema.v1.json` —
+   governance-grade invocation report schema (`additionalProperties:false`,
+   guard flags `const false`, `fixture_id` `const "ao-ma-worker-stub"`).
+4. `ao_kernel/orchestration/cli_handlers.py` + `ao_kernel/cli.py` —
+   `ao-kernel orchestration invoke --manifest <path>` (no `--adapter` flag).
+5. `tests/test_ao_ma_4_5_worker_invocation.py` — 26 tests (smoke + full chain +
+   negative + trust-boundary + worktree-gate + fixture/binding unit tests).
+
+## 3. Design decisions (Codex AGREE)
+
+- **Glue = orchestration-native (option B).** The invoker does NOT reuse
+  `executor.run_step`. That path owns its own worktree lifecycle (it would
+  bypass the AO-MA-4 worktree truth) and has no native AO-MA
+  `live_adapter_execution` gate. The invoker is a thin layer over the
+  runner_report truth.
+- **Producer = fixture writes worker_result, invoker does not synthesize it.**
+  `head_sha`, `actual_changed_files`, worker identity, and the no-secret
+  attestation come from the fixture's real git state — not mapped from an
+  adapter's stdout (which would be inventing provenance).
+- **No arbitrary adapter selection.** `invoke(fixture_id=...)` only accepts the
+  pinned `ao-ma-worker-stub`; a live adapter or `live_adapter_execution=true`
+  manifest is rejected fail-closed. The CLI exposes no adapter flag.
+- **Worker identity = `local`.** `worker_result.worker.provider="local"` is the
+  honest identity (a deterministic local fixture, not a live provider). The
+  assignment's planned `agent.provider` (AO-MA-3 metadata, default `anthropic`)
+  may differ — no AO-MA layer enforces equality (verified against
+  `integrator.py`, `reviewer.py`, `verifier.py`, `worker_runner.py`). A
+  regression test pins this so a future (incorrect) equality check cannot
+  silently break the chain.
+- **Eligible runner statuses = `prepared`, `skipped_existing_idempotent`.**
+  Every other status (e.g. `skipped_dry_run`, `failed_*`) is recorded as
+  `skipped_not_eligible`; the invoker writes no worker_result for it.
+
+## 4. Producer SSOT vs pipeline consumption — the bridge
+
+AO-MA-4 records `expected_worker_result_path = <worktree_root>/worker_result.v1.json`
+(the producer SSOT — the worker writes its result next to where it worked).
+But AO-MA-5/6/7 fail-closed on evidence paths **outside the manifest base_dir**
+(`<base_dir>/<task_graph_id>/…`) to preserve audit provenance
+(`integrator.py::_relativize`, `reviewer.py::_relativize`). A worktree —
+especially a realistic one parented outside the repo (`../ao-kernel-feat-X`) —
+is never under base_dir.
+
+Plan-time Codex AGREE did not surface this; it was found during
+implementation. The resolution keeps the AO-MA-4 SSOT intact and adds a
+**bridge**: after the fixture writes `worker_result.v1.json` at the worktree
+root, the invoker copies it to the canonical consumption point
+`<base_dir>/<task_graph_id>/workers/<task_id>/worker_result.v1.json` and records
+both paths in the invocation report (`worker_result_path` = worktree SSOT,
+`integrated_worker_result_path` = base_dir copy). The downstream chain consumes
+the bridged copy. This makes the chain work regardless of worktree location.
+
+This bridge is recorded for the post-impl cross-AI review: it is a small,
+SSOT-preserving addition to the AGREE'd plan (the worktree root remains the
+producer truth; the copy is the integration handoff), not a deviation from it.
+
+## 5. Known limitation
+
+- v1 worker is a deterministic local fixture; it does not perform real
+  implementation logic. `worker_result.tests_run` is empty and `known_gaps`
+  states the fixture nature explicitly.
+- The `worker_result.v1.json` written at the worktree root stays untracked.
+  Cleaning the worktree after AO-MA-4.5 is a separate operator step; AO-MA-4.5
+  makes no end-to-end lifecycle-clean claim.
+- Real LLM worker execution is deferred to a future slice gated by an
+  operator-bound GPP supersession (`live_adapter_execution=true`).
+
+## 6. Hard stops
+
+- No support widening; `support_widening=false`.
+- No production platform claim; `production_platform_claim=false`.
+- No live adapter execution; `live_adapter_execution=false`.
+- No GitHub write (no `git push`, no `gh pr create`).
+- No branch-protection / ruleset / workflow / CODEOWNERS mutation.
+- No `gpp_status.v1.json` mutation.
+- No executor coupling (orchestration-native invoker).
+
+## 7. Acceptance
+
+1. `ao-ma-worker-invocation-report.schema.v1.json` validates as Draft 2020-12.
+2. Layer 1 (smoke): `spawn → invoke` writes a schema-valid `worker_result.v1.json`
+   at the runner's expected path; guard flags closed; `actual_changed_files ⊆
+   declared_write_set`; `head_sha` is a real commit; invocation report
+   schema-valid + persisted.
+3. Layer 2 (full chain): `plan → spawn → invoke → review → verify → integrate`
+   reaches `IntegrationDecision.overall_status == "all_accepted"` with a
+   cross-provider chain (worker=local, reviewer=openai, verifier=tool), using
+   the runtime `WorkerInvoker.invoke()` (not the AO-MA-8 surrogate).
+4. Negatives: arbitrary adapter rejected; open `live_adapter_execution`
+   rejected; non-eligible runner status skipped.
+5. Trust boundary fail-closed: manifest envelope + runner_report manifest_sha256
+   + assignment_sha256 + assignment schema + cross-ref + worktree-root expected
+   path are all checked before the fixture runs; the emitted worker_result is
+   bound to this graph/task/base/branch before the bridge copy. Fixture rejects
+   absolute / traversal declared paths.
+6. 26 tests pass; ruff + mypy clean.
+7. Cross-provider post-impl review records AGREE.

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -2140,6 +2140,7 @@ def main(argv: list[str] | None = None) -> int:
         from ao_kernel.orchestration.cli_handlers import (
             cmd_orchestration_cleanup,
             cmd_orchestration_integrate,
+            cmd_orchestration_invoke,
             cmd_orchestration_plan,
             cmd_orchestration_review,
             cmd_orchestration_spawn,
@@ -2153,6 +2154,8 @@ def main(argv: list[str] | None = None) -> int:
             return cmd_orchestration_spawn(args)
         if orchestration_cmd == "cleanup":
             return cmd_orchestration_cleanup(args)
+        if orchestration_cmd == "invoke":
+            return cmd_orchestration_invoke(args)
         if orchestration_cmd == "integrate":
             return cmd_orchestration_integrate(args)
         if orchestration_cmd == "review":
@@ -2160,7 +2163,7 @@ def main(argv: list[str] | None = None) -> int:
         if orchestration_cmd == "verify":
             return cmd_orchestration_verify(args)
         print(
-            "Usage: ao-kernel orchestration {plan|spawn|cleanup|integrate|review|verify}",
+            "Usage: ao-kernel orchestration {plan|spawn|cleanup|invoke|integrate|review|verify}",
             file=sys.stderr,
         )
         return 1

--- a/ao_kernel/defaults/schemas/ao-ma-worker-invocation-report.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-ma-worker-invocation-report.schema.v1.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:ao-ma-worker-invocation-report:v1",
+  "title": "AO-MA Worker Invocation Report",
+  "description": "No-secret report artifact produced by the AO-MA-4.5 worker invoker. It records which prepared worktrees had a deterministic local worker fixture invoked, where each worker_result.v1.json was written, and the closed guard flags. The invoker only runs a pinned deterministic local worker fixture; it does NOT call live LLM adapters, does NOT widen support, and does NOT make a production platform claim. Real LLM worker execution requires a separate operator-bound GPP supersession with live_adapter_execution=true and is out of scope for v1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_graph_id",
+    "manifest_sha256",
+    "generated_at",
+    "fixture_id",
+    "invoked",
+    "guard_flags"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "ao-ma-worker-invocation-report.v1"
+    },
+    "task_graph_id": {
+      "type": "string",
+      "pattern": "^ao-ma-[a-z0-9][a-z0-9-]{2,80}$"
+    },
+    "manifest_sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "generated_at": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    },
+    "fixture_id": {
+      "type": "string",
+      "const": "ao-ma-worker-stub",
+      "description": "Pinned deterministic local worker fixture id. v1 does not allow arbitrary adapter selection; a live adapter (e.g. claude-code-cli) is rejected fail-closed."
+    },
+    "invoked": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/invocation_entry" }
+    },
+    "guard_flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["support_widening", "production_platform_claim", "live_adapter_execution"],
+      "properties": {
+        "support_widening": { "type": "boolean", "const": false },
+        "production_platform_claim": { "type": "boolean", "const": false },
+        "live_adapter_execution": { "type": "boolean", "const": false }
+      }
+    }
+  },
+  "$defs": {
+    "invocation_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "task_id",
+        "status",
+        "worker_result_path",
+        "integrated_worker_result_path",
+        "reason"
+      ],
+      "properties": {
+        "task_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]{1,80}$"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["invoked", "skipped_not_eligible", "failed"],
+          "description": "invoked: fixture ran and wrote a schema-valid worker_result.v1.json. skipped_not_eligible: runner_report entry status was not 'prepared' or 'skipped_existing_idempotent'. failed: fixture invocation or worker_result emission failed."
+        },
+        "worker_result_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path where the worker fixture wrote worker_result.v1.json (the runner's expected_worker_result_path SSOT, under the worktree root). Absolute by design; not constrained by the no-traversal relative path def."
+        },
+        "integrated_worker_result_path": {
+          "description": "Absolute path of the canonical copy the invoker placed under the manifest base_dir (<base_dir>/<task_graph_id>/workers/<task_id>/worker_result.v1.json) so AO-MA-5/6/7 can consume it (those layers fail-closed on evidence outside base_dir). Null when the worker was skipped or failed (no copy made). The worktree root remains the producer SSOT; this is the pipeline-consumption bridge.",
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/ao_kernel/fixtures/ao_ma_worker_stub.py
+++ b/ao_kernel/fixtures/ao_ma_worker_stub.py
@@ -1,0 +1,232 @@
+"""AO-MA-4.5 deterministic local worker fixture.
+
+Promoted from the AO-MA-8 e2e smoke in-file surrogate
+(``tests/test_ao_ma_8_e2e_smoke.py::_emit_mock_worker_result``) to a runtime
+module so the AO-MA-4.5 worker invoker can drive a real ``worker_result.v1``
+producer instead of a test-only helper.
+
+This fixture is a DETERMINISTIC LOCAL worker. It does NOT call any LLM, does
+NOT reach the network, and does NOT use a live adapter. It modifies one file
+from the assignment's ``declared_write_set`` inside the already-prepared
+worktree, commits it, derives ``head_sha`` + ``actual_changed_files`` from
+real git state, and writes a schema-valid ``worker_result.v1.json`` to the
+output path (the AO-MA-4 runner's ``expected_worker_result_path`` SSOT — the
+worktree root, not an artifact-dir shortcut).
+
+Invocation (matches the pinned ``WorkerInvoker`` command; no arbitrary adapter
+selection is offered in v1):
+
+    python3 -m ao_kernel.fixtures.ao_ma_worker_stub \
+        --assignment <agent_assignment-*.v1.json> \
+        --worktree <actual_worktree> \
+        --output <expected_worker_result_path>
+
+Identity: the emitted ``worker.provider`` is ``"local"`` — this fixture does
+not impersonate a live provider. The assignment's planned ``agent.provider``
+(AO-MA-3 metadata, default ``anthropic``) may differ; no AO-MA layer enforces
+equality between assignment provider and worker_result provider.
+
+Guard flags stay closed (``support_widening`` / ``production_platform_claim``
+/ ``live_adapter_execution`` all ``False``). Real LLM worker execution
+requires a separate operator-bound GPP supersession with
+``live_adapter_execution=true`` and is out of scope for AO-MA-4.5 v1.
+
+Lifecycle note: the emitted ``worker_result.v1.json`` lands in the worktree
+root and stays untracked (it is written AFTER the implementation commit so it
+never enters ``actual_changed_files``). Removing it / cleaning the worktree is
+a separate operator step; this fixture makes no end-to-end lifecycle-clean
+claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+FIXTURE_ID = "ao-ma-worker-stub"
+WORKER_PROVIDER = "local"
+
+_GUARD_KEYS = ("support_widening", "production_platform_claim", "live_adapter_execution")
+_CLOSED_GUARDS = {key: False for key in _GUARD_KEYS}
+
+
+class WorkerStubError(RuntimeError):
+    """Raised when the deterministic worker fixture cannot emit a worker_result."""
+
+
+def _run_git(worktree: Path, args: list[str]) -> str:
+    """Run ``git -C worktree <args>`` fail-closed and return stripped stdout."""
+
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(worktree), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.CalledProcessError, OSError, subprocess.TimeoutExpired) as exc:
+        raise WorkerStubError(f"git {args!r} failed in {worktree!s}: {exc}") from exc
+    return completed.stdout.strip()
+
+
+def _load_assignment(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise WorkerStubError(f"assignment not found: {path!s}")
+    try:
+        return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise WorkerStubError(f"failed to read assignment {path!s}: {exc}") from exc
+
+
+def emit_worker_result(*, assignment_path: Path, worktree: Path, output_path: Path) -> dict[str, Any]:
+    """Modify one declared file, commit, and write a schema-valid worker_result.v1.
+
+    Returns the worker_result dict written to ``output_path``. Fail-closed when
+    the assignment guard flags are open, the declared write set is empty, or the
+    worktree is missing.
+    """
+
+    assignment = _load_assignment(assignment_path)
+
+    # Guard: never run a worker under an open live-adapter / widening flag.
+    guard = assignment.get("guard_flags")
+    if not isinstance(guard, dict):
+        raise WorkerStubError("assignment guard_flags must be an object")
+    for key in _GUARD_KEYS:
+        if guard.get(key) is not False:
+            raise WorkerStubError(
+                f"assignment guard_flags.{key} must be the literal boolean False "
+                f"(got {guard.get(key)!r}); deterministic worker refuses an open guard"
+            )
+
+    try:
+        task_graph_id = assignment["task_graph_id"]
+        task_id = assignment["task_id"]
+        assignment_id = assignment["assignment_id"]
+        base_ref = assignment["base_ref"]
+        base_sha = assignment["base_sha"]
+        branch = assignment["branch"]
+    except KeyError as exc:
+        raise WorkerStubError(f"assignment missing required field: {exc}") from exc
+
+    declared = list(assignment.get("declared_write_set", []))
+    if not declared:
+        raise WorkerStubError("assignment declared_write_set is empty; nothing to implement")
+
+    worktree = worktree.resolve()
+    if not worktree.exists():
+        raise WorkerStubError(f"worktree does not exist: {worktree!s}")
+
+    # Defense-in-depth: the worktree must be the expected git checkout (on the
+    # assignment branch at base_sha HEAD) BEFORE any write. Standalone callers
+    # do not get the invoker's worktree gate, so the fixture self-verifies and
+    # refuses to write into a plain directory or a wrong branch / base.
+    head_before = _run_git(worktree, ["rev-parse", "HEAD"])
+    if head_before != base_sha:
+        raise WorkerStubError(f"worktree HEAD {head_before!r} != assignment base_sha {base_sha!r}; refusing write")
+    branch_now = _run_git(worktree, ["symbolic-ref", "--short", "HEAD"])
+    if branch_now != branch:
+        raise WorkerStubError(f"worktree branch {branch_now!r} != assignment branch {branch!r}; refusing write")
+
+    # 1. Modify the first declared file (create parent dirs / file if absent).
+    #    Path containment fail-closed BEFORE any write: a tampered assignment
+    #    must not drive an out-of-worktree write (e.g. '../outside.txt' or an
+    #    absolute path). Defense in depth — the fixture can be run standalone,
+    #    so it does not rely on the invoker's prior schema/containment checks.
+    target_rel = declared[0]
+    if target_rel.startswith("/") or ".." in Path(target_rel).parts or "\\" in target_rel:
+        raise WorkerStubError(
+            f"declared path {target_rel!r} is absolute or contains traversal components; refusing out-of-worktree write"
+        )
+    target_abs = (worktree / target_rel).resolve()
+    try:
+        target_abs.relative_to(worktree)
+    except ValueError as exc:
+        raise WorkerStubError(f"declared path {target_rel!r} escapes worktree {worktree!s}") from exc
+    target_abs.parent.mkdir(parents=True, exist_ok=True)
+    existing = target_abs.read_text(encoding="utf-8") if target_abs.exists() else ""
+    target_abs.write_text(existing + "\n# ao-ma-worker-stub deterministic change\n", encoding="utf-8")
+
+    # 2. Commit the implementation change (no --allow-empty).
+    _run_git(worktree, ["add", target_rel])
+    _run_git(worktree, ["commit", "-m", f"ao-ma-worker-stub: {task_id}"])
+
+    # 3. Derive head_sha + actual_changed_files from real git state.
+    head_sha = _run_git(worktree, ["rev-parse", "HEAD"])
+    actual_changed = [
+        line.strip()
+        for line in _run_git(worktree, ["diff", "--name-only", f"{base_sha}..HEAD"]).splitlines()
+        if line.strip()
+    ]
+
+    worker_result: dict[str, Any] = {
+        "schema_version": "ao-ma-worker-result.v1",
+        "task_graph_id": task_graph_id,
+        "task_id": task_id,
+        "assignment_id": assignment_id,
+        "worker": {
+            "agent_id": f"ao-ma-worker-stub-{task_id}"[:81],
+            "agent_type": "implementer",
+            "provider": WORKER_PROVIDER,
+            "session_id": f"ao-ma-4-5-{task_graph_id}",
+        },
+        "base_ref": base_ref,
+        "base_sha": base_sha,
+        "head_ref": branch,
+        "head_sha": head_sha,
+        "declared_write_set": declared,
+        "actual_changed_files": actual_changed,
+        "summary": f"ao-ma-worker-stub deterministic implementer for {task_id}",
+        "tests_run": [],
+        "known_gaps": ["deterministic local worker fixture; no real implementation logic"],
+        "no_secret_attestation": {"secrets_recorded": False},
+        "guard_flags": dict(_CLOSED_GUARDS),
+    }
+
+    # 4. Write worker_result AFTER the commit so it stays untracked in the
+    #    worktree root and never enters actual_changed_files. Atomic tmp+replace.
+    output_path = output_path.resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = output_path.parent / (output_path.name + ".tmp")
+    tmp.write_text(json.dumps(worker_result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(output_path)
+    return worker_result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ao_ma_worker_stub",
+        description=(
+            "Deterministic local worker fixture for AO-MA-4.5 worker invocation. "
+            "Modifies one declared file, commits, and emits a schema-valid "
+            "worker_result.v1.json. No LLM call, no network, no live adapter."
+        ),
+    )
+    parser.add_argument("--assignment", required=True, help="Path to agent_assignment-*.v1.json")
+    parser.add_argument("--worktree", required=True, help="Prepared worktree path (actual_worktree)")
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Where to write worker_result.v1.json (the runner's expected_worker_result_path)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        emit_worker_result(
+            assignment_path=Path(args.assignment).resolve(),
+            worktree=Path(args.worktree),
+            output_path=Path(args.output),
+        )
+    except WorkerStubError as exc:
+        print(f"ao-ma-worker-stub failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ao_kernel/orchestration/cli_handlers.py
+++ b/ao_kernel/orchestration/cli_handlers.py
@@ -35,6 +35,7 @@ from ao_kernel.orchestration.verifier import (
     Verifier,
     VerifierError,
 )
+from ao_kernel.orchestration.worker_invoker import WorkerInvocationError, WorkerInvoker
 from ao_kernel.orchestration.worker_runner import WorkerRunner, WorkerRunnerError
 
 
@@ -515,6 +516,30 @@ def add_orchestration_subparser(sub: argparse._SubParsersAction[argparse.Argumen
         help="Stdout summary format (default: text)",
     )
 
+    # AO-MA-4.5: invoke pinned deterministic local worker fixture per prepared worktree
+    invoke_p = orchestration_sub.add_parser(
+        "invoke",
+        help=(
+            "AO-MA-4.5 worker invocation v1: run the pinned deterministic local worker "
+            "fixture for each prepared runner_report worktree and emit "
+            "worker_invocation_report.v1.json. No arbitrary adapter selection, no live "
+            "adapter execution — a live adapter or open live_adapter_execution flag is "
+            "rejected fail-closed."
+        ),
+    )
+    invoke_p.add_argument("--manifest", required=True, help="Path to AO-MA-3 manifest.v1.json")
+    invoke_p.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repository root path (default: current working directory)",
+    )
+    invoke_p.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Stdout summary format (default: text)",
+    )
+
 
 def _parse_per_task_paths(raw: list[str] | None, kind: str) -> dict[str, Path]:
     """Parse repeated '--worker-result <task_id>=<path>' CLI args into a dict.
@@ -783,3 +808,45 @@ def cmd_orchestration_verify(args: argparse.Namespace) -> int:
         print(f"emitted to: {manifest_path.parent / 'workers' / args.task_id / 'verification_report.v1.json'}")
 
     return 1 if result.failed_checks else 0
+
+
+def cmd_orchestration_invoke(args: argparse.Namespace) -> int:
+    """Handle ``ao-kernel orchestration invoke`` (AO-MA-4.5 v1).
+
+    Runs the pinned deterministic local worker fixture for each eligible
+    runner_report worker entry (``prepared`` / ``skipped_existing_idempotent``)
+    and emits ``worker_invocation_report.v1.json``. There is no arbitrary
+    adapter selection and no live adapter execution; a live adapter or an open
+    ``live_adapter_execution`` flag is rejected fail-closed.
+
+    Exit codes:
+
+    - 0 — invocation report emitted; no worker entry failed
+    - 1 — invocation report emitted; at least one worker entry failed
+    - 2 — manifest not found / trust-boundary or fail-closed error
+    """
+
+    manifest_path = Path(args.manifest).resolve()
+    if not manifest_path.exists():
+        print(f"error: manifest not found: {manifest_path!s}", file=sys.stderr)
+        return 2
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else Path.cwd()
+    invoker = WorkerInvoker(repo_root=repo_root)
+    try:
+        report = invoker.invoke(manifest_path=manifest_path)
+    except WorkerInvocationError as exc:
+        print(f"orchestration invoke failed: {exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"task_graph_id: {report['task_graph_id']}")
+        print(f"fixture_id: {report['fixture_id']}")
+        print(f"invoked ({len(report['invoked'])}):")
+        for entry in report["invoked"]:
+            print(f"  - {entry['task_id']} [{entry['status']}] {entry['reason']}")
+
+    if any(entry["status"] == "failed" for entry in report["invoked"]):
+        return 1
+    return 0

--- a/ao_kernel/orchestration/worker_invoker.py
+++ b/ao_kernel/orchestration/worker_invoker.py
@@ -1,0 +1,530 @@
+"""AO-MA-4.5 worker invoker.
+
+Closes the AO-MA pipeline gap where AO-MA-4 prepared worktrees but no worker
+ever wrote ``worker_result.v1``. The invoker reads the AO-MA-4
+``runner_report.v1.json`` (the runner's truth) and, for each worker entry the
+runner actually prepared, invokes a PINNED deterministic local worker fixture
+inside that worktree. The fixture writes a schema-valid ``worker_result.v1.json``
+to the runner's ``expected_worker_result_path`` SSOT. The invoker then emits an
+``ao-ma-worker-invocation-report.v1.json``.
+
+Design boundaries (Codex thread 019e74ef AGREE):
+
+- It does NOT reuse ``executor.run_step``: that path owns its own worktree
+  lifecycle (it would bypass the AO-MA-4 worktree truth) and has no native
+  AO-MA ``live_adapter_execution`` gate.
+- It does NOT offer arbitrary adapter selection. v1 pins the
+  ``ao-ma-worker-stub`` deterministic local fixture; a live adapter (e.g.
+  ``claude-code-cli``) or an open ``live_adapter_execution`` flag is rejected
+  fail-closed. Real LLM worker execution requires a separate operator-bound
+  GPP supersession with ``live_adapter_execution=true`` and is out of scope.
+
+Eligible runner_report statuses: ``prepared`` and
+``skipped_existing_idempotent``. Every other status is recorded as
+``skipped_not_eligible`` (the runner already declined or skipped it).
+
+No GitHub write. No branch-protection / ruleset / workflow mutation.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from ao_kernel.fixtures.ao_ma_worker_stub import FIXTURE_ID as _STUB_FIXTURE_ID
+from ao_kernel.orchestration.runner_report_writer import sha256_of
+from ao_kernel.orchestration.worker_runner import WorkerRunnerError, _validate_manifest_envelope
+
+# Package root that contains the ``ao_kernel`` package (…/worker_invoker.py ->
+# orchestration -> ao_kernel -> <root>). Injected into the worker fixture
+# subprocess PYTHONPATH so the child imports the SAME ao_kernel as this
+# process — robust across installed, editable, and worktree layouts.
+_PKG_ROOT = Path(__file__).resolve().parent.parent.parent
+
+_SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "defaults" / "schemas"
+_RUNNER_REPORT_SCHEMA = "ao-ma-runner-report.schema.v1.json"
+_INVOCATION_REPORT_SCHEMA = "ao-ma-worker-invocation-report.schema.v1.json"
+_WORKER_RESULT_SCHEMA = "ao-ma-worker-result.schema.v1.json"
+_ASSIGNMENT_SCHEMA = "ao-ma-agent-assignment.schema.v1.json"
+
+PINNED_FIXTURE_ID = _STUB_FIXTURE_ID  # "ao-ma-worker-stub"
+_STUB_MODULE = "ao_kernel.fixtures.ao_ma_worker_stub"
+_ELIGIBLE_STATUSES = ("prepared", "skipped_existing_idempotent")
+_GUARD_KEYS = ("support_widening", "production_platform_claim", "live_adapter_execution")
+
+
+class WorkerInvocationError(RuntimeError):
+    """Raised when the worker invoker cannot run fail-closed."""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise WorkerInvocationError(f"file not found: {path!s}")
+    try:
+        return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise WorkerInvocationError(f"failed to read {path!s}: {exc}") from exc
+
+
+def _load_schema(name: str) -> dict[str, Any]:
+    try:
+        return cast(dict[str, Any], json.loads((_SCHEMAS_DIR / name).read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise WorkerInvocationError(f"bundled schema {name!r} could not be loaded: {exc}") from exc
+
+
+def _assert_closed_guards(guard_flags: Any, source: str) -> None:
+    """Fail-closed unless all three promotion guard flags are the literal False."""
+
+    if not isinstance(guard_flags, dict):
+        raise WorkerInvocationError(f"{source} guard_flags must be an object")
+    for key in _GUARD_KEYS:
+        if guard_flags.get(key) is not False:
+            raise WorkerInvocationError(
+                f"{source} guard_flags.{key} must be the literal boolean False "
+                f"(got {guard_flags.get(key)!r}); AO-MA-4.5 refuses an open guard "
+                f"(live adapter execution needs an operator-bound GPP supersession)"
+            )
+
+
+def _check_emitted_binding(
+    *,
+    emitted: dict[str, Any],
+    task_graph_id: str,
+    task_id: str,
+    base_sha: str,
+    branch: str,
+) -> str | None:
+    """Return an error string when the emitted worker_result does not bind to
+    THIS task graph / task / base / branch, else None. Prevents a schema-valid
+    but wrong-provenance payload from being reported as a successful invocation.
+    """
+
+    if emitted.get("task_graph_id") != task_graph_id:
+        return f"emitted worker_result task_graph_id {emitted.get('task_graph_id')!r} != {task_graph_id!r}"
+    if emitted.get("task_id") != task_id:
+        return f"emitted worker_result task_id {emitted.get('task_id')!r} != {task_id!r}"
+    if emitted.get("base_sha") != base_sha:
+        return f"emitted worker_result base_sha {emitted.get('base_sha')!r} != {base_sha!r}"
+    if emitted.get("head_ref") != branch:
+        return f"emitted worker_result head_ref {emitted.get('head_ref')!r} != assignment branch {branch!r}"
+    declared = set(emitted.get("declared_write_set", []))
+    actual = set(emitted.get("actual_changed_files", []))
+    if not actual.issubset(declared):
+        return (
+            f"emitted worker_result actual_changed_files {sorted(actual - declared)} not subset of declared_write_set"
+        )
+    return None
+
+
+@dataclass
+class WorkerInvoker:
+    """Invoke a pinned deterministic local worker fixture per prepared worktree."""
+
+    repo_root: Path
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.repo_root, Path):
+            raise WorkerInvocationError("repo_root must be a Path instance")
+        self.repo_root = self.repo_root.resolve()
+
+    def invoke(self, manifest_path: Path, *, fixture_id: str = PINNED_FIXTURE_ID) -> dict[str, Any]:
+        """Run the pinned worker fixture for each eligible runner_report entry.
+
+        Returns the emitted invocation report dict. Fail-closed when an
+        arbitrary adapter is requested, the manifest guard flags are open, the
+        runner_report is missing/invalid, or an emitted worker_result fails its
+        schema.
+        """
+
+        # 1. Pinned fixture only — v1 offers no arbitrary adapter selection.
+        if fixture_id != PINNED_FIXTURE_ID:
+            raise WorkerInvocationError(
+                f"AO-MA-4.5 v1 only invokes the pinned deterministic local worker fixture "
+                f"{PINNED_FIXTURE_ID!r}; arbitrary adapter {fixture_id!r} (e.g. a live "
+                f"claude-code-cli) is rejected fail-closed. Live adapter execution needs an "
+                f"operator-bound GPP supersession with live_adapter_execution=true."
+            )
+
+        manifest_path = manifest_path.resolve()
+        manifest = _load_json(manifest_path)
+
+        # 2. Manifest guard flags must be closed (defense in depth; this is the
+        #    fail-closed point for a live_adapter_execution=true manifest).
+        _assert_closed_guards(manifest.get("guard_flags"), manifest_path.name)
+
+        # 3. Manifest envelope integrity — mirror the AO-MA-4 runner trust gate
+        #    (schema_version, task_graph_id pattern, artifact sha256/size, single
+        #    task_graph entry, no traversal in artifact paths). The invoker drives
+        #    filesystem writes via the fixture, so it must not trust an unvalidated
+        #    manifest.
+        try:
+            _validate_manifest_envelope(manifest, manifest_path)
+        except WorkerRunnerError as exc:
+            raise WorkerInvocationError(f"manifest envelope invalid: {exc}") from exc
+
+        task_graph_id = manifest["task_graph_id"]
+        manifest_dir = manifest_path.parent
+
+        # 4. Load + schema-validate the AO-MA-4 runner_report (runner's truth).
+        runner_report_path = manifest_dir / "runner_report.v1.json"
+        runner_report = _load_json(runner_report_path)
+        try:
+            Draft202012Validator(_load_schema(_RUNNER_REPORT_SCHEMA)).validate(runner_report)
+        except ValidationError as exc:
+            raise WorkerInvocationError(f"{runner_report_path.name} fails runner-report schema: {exc.message}") from exc
+        if runner_report.get("task_graph_id") != task_graph_id:
+            raise WorkerInvocationError(
+                f"runner_report task_graph_id {runner_report.get('task_graph_id')!r} != "
+                f"manifest task_graph_id {task_graph_id!r}"
+            )
+
+        # 5. The runner_report must describe THIS manifest (no stale/tampered
+        #    report pointed at a different manifest's worktrees).
+        report_manifest_sha = runner_report.get("manifest_sha256")
+        actual_manifest_sha = sha256_of(manifest_path)
+        if report_manifest_sha != actual_manifest_sha:
+            raise WorkerInvocationError(
+                f"runner_report manifest_sha256 {report_manifest_sha!r} != on-disk manifest sha256 "
+                f"{actual_manifest_sha!r}; re-run AO-MA-4 spawn before invoke"
+            )
+        workers = runner_report.get("workers", [])
+        if not workers:
+            raise WorkerInvocationError("runner_report has no workers; nothing to invoke")
+        base_sha = runner_report["base_sha"]
+
+        worker_result_validator = Draft202012Validator(_load_schema(_WORKER_RESULT_SCHEMA))
+        assignment_validator = Draft202012Validator(_load_schema(_ASSIGNMENT_SCHEMA))
+        manifest_artifacts = {entry["path"]: entry for entry in manifest["artifacts"]}
+
+        # 6. Invoke the pinned fixture for each eligible worker entry.
+        invoked: list[dict[str, Any]] = []
+        for worker in workers:
+            invoked.append(
+                self._invoke_one(
+                    worker=worker,
+                    manifest_dir=manifest_dir,
+                    manifest_artifacts=manifest_artifacts,
+                    task_graph_id=task_graph_id,
+                    base_sha=base_sha,
+                    worker_result_validator=worker_result_validator,
+                    assignment_validator=assignment_validator,
+                )
+            )
+
+        # 5. Emit the schema-valid invocation report.
+        return self._emit_report(
+            manifest_dir=manifest_dir,
+            manifest_path=manifest_path,
+            task_graph_id=task_graph_id,
+            invoked=invoked,
+        )
+
+    def _invoke_one(
+        self,
+        *,
+        worker: dict[str, Any],
+        manifest_dir: Path,
+        manifest_artifacts: dict[str, Any],
+        task_graph_id: str,
+        base_sha: str,
+        worker_result_validator: Draft202012Validator,
+        assignment_validator: Draft202012Validator,
+    ) -> dict[str, Any]:
+        task_id = worker["task_id"]
+        status = worker["status"]
+        expected_path = Path(worker["expected_worker_result_path"])
+        base_entry = {
+            "task_id": task_id,
+            "worker_result_path": str(expected_path),
+            "integrated_worker_result_path": None,
+        }
+
+        if status not in _ELIGIBLE_STATUSES:
+            return {
+                **base_entry,
+                "status": "skipped_not_eligible",
+                "reason": f"runner_report status {status!r} is not prepared/skipped_existing_idempotent",
+            }
+
+        # Worker entry integrity BEFORE any subprocess / filesystem write: the
+        # assignment artifact must be inside the manifest dir, sha256-pinned by
+        # the runner report, schema-valid, cross-ref'd to this task graph / task /
+        # base, and the expected output path must be the worktree-root SSOT. A
+        # tampered runner_report / assignment must not drive an out-of-scope write.
+        try:
+            assignment = self._load_verified_assignment(
+                worker=worker,
+                manifest_dir=manifest_dir,
+                manifest_artifacts=manifest_artifacts,
+                task_graph_id=task_graph_id,
+                base_sha=base_sha,
+                expected_path=expected_path,
+                assignment_validator=assignment_validator,
+            )
+            # The worktree itself must be the AO-MA-4-prepared git checkout
+            # (same repo, expected branch + base HEAD) before any write — a
+            # tampered runner_report pointing actual_worktree at an arbitrary
+            # directory must not drive an out-of-scope write.
+            self._verify_worktree(
+                actual_worktree=Path(worker["actual_worktree"]),
+                base_sha=base_sha,
+                branch=worker["branch"],
+            )
+        except WorkerInvocationError as exc:
+            return {**base_entry, "status": "failed", "reason": f"worker entry integrity failed: {exc}"}
+
+        assignment_path = manifest_dir / worker["assignment_ref"]
+        actual_worktree = Path(worker["actual_worktree"])
+        cmd = [
+            sys.executable,
+            "-m",
+            _STUB_MODULE,
+            "--assignment",
+            str(assignment_path),
+            "--worktree",
+            str(actual_worktree),
+            "--output",
+            str(expected_path),
+        ]
+        env = dict(os.environ)
+        _existing_pp = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = str(_PKG_ROOT) + (os.pathsep + _existing_pp if _existing_pp else "")
+        try:
+            completed = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                cwd=str(self.repo_root),
+                env=env,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return {**base_entry, "status": "failed", "reason": f"fixture invocation error: {exc}"}
+
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip() or f"exit {completed.returncode}"
+            return {**base_entry, "status": "failed", "reason": f"fixture exited non-zero: {detail}"}
+
+        # Validate the emitted worker_result.v1.json fail-closed.
+        if not expected_path.exists():
+            return {
+                **base_entry,
+                "status": "failed",
+                "reason": "fixture exited 0 but no worker_result.v1.json at expected path",
+            }
+        try:
+            emitted = _load_json(expected_path)
+            worker_result_validator.validate(emitted)
+        except WorkerInvocationError as exc:
+            return {**base_entry, "status": "failed", "reason": f"emitted worker_result unreadable: {exc}"}
+        except ValidationError as exc:
+            return {**base_entry, "status": "failed", "reason": f"emitted worker_result fails schema: {exc.message}"}
+
+        # Emitted worker_result binding BEFORE bridge: schema-valid bytes from a
+        # DIFFERENT graph / task / base / branch must not be reported as a
+        # successful invocation for THIS task (false provenance). On mismatch ->
+        # failed, and the result is NOT bridged into the consumption point.
+        binding_error = _check_emitted_binding(
+            emitted=emitted,
+            task_graph_id=task_graph_id,
+            task_id=task_id,
+            base_sha=base_sha,
+            branch=assignment["branch"],
+        )
+        if binding_error:
+            return {**base_entry, "status": "failed", "reason": binding_error}
+
+        # Bridge: the worker fixture wrote worker_result.v1.json at the worktree
+        # root (AO-MA-4 producer SSOT), but AO-MA-5/6/7 consume evidence under
+        # the manifest base_dir and fail-closed on paths outside it (audit
+        # provenance). Copy the validated worker_result to the canonical
+        # consumption point so the downstream chain can integrate it regardless
+        # of where the worktree lives.
+        integrated_path = manifest_dir / "workers" / task_id / "worker_result.v1.json"
+        try:
+            integrated_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = integrated_path.parent / ".worker_result.v1.json.tmp"
+            tmp.write_text(json.dumps(emitted, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            tmp.replace(integrated_path)
+        except OSError as exc:
+            return {
+                **base_entry,
+                "status": "failed",
+                "reason": f"failed to bridge worker_result into base_dir consumption point: {exc}",
+            }
+
+        return {
+            **base_entry,
+            "integrated_worker_result_path": str(integrated_path),
+            "status": "invoked",
+            "reason": (
+                "pinned deterministic local worker fixture invoked; worker_result.v1.json "
+                "schema-valid and bridged to base_dir consumption point"
+            ),
+        }
+
+    def _load_verified_assignment(
+        self,
+        *,
+        worker: dict[str, Any],
+        manifest_dir: Path,
+        manifest_artifacts: dict[str, Any],
+        task_graph_id: str,
+        base_sha: str,
+        expected_path: Path,
+        assignment_validator: Draft202012Validator,
+    ) -> dict[str, Any]:
+        """Load + fully verify one worker's assignment, fail-closed.
+
+        Containment (assignment_ref inside manifest dir) + sha256 pin (matches
+        the runner_report) + schema + cross-ref (task_graph_id / task_id /
+        base_sha / branch) + worktree-root expected output path. Raises
+        WorkerInvocationError on any mismatch so a tampered runner_report /
+        assignment cannot drive an out-of-scope write.
+        """
+
+        assignment_ref = worker["assignment_ref"]
+        resolved_manifest_dir = manifest_dir.resolve()
+        assignment_path = (manifest_dir / assignment_ref).resolve()
+        try:
+            assignment_path.relative_to(resolved_manifest_dir)
+        except ValueError as exc:
+            raise WorkerInvocationError(
+                f"assignment_ref {assignment_ref!r} escapes manifest dir {resolved_manifest_dir!s}"
+            ) from exc
+        if not assignment_path.exists():
+            raise WorkerInvocationError(f"assignment not found: {assignment_path!s}")
+
+        # The assignment must be a DECLARED manifest artifact, and its sha256 must
+        # agree across the manifest, the runner_report, and the on-disk bytes. The
+        # runner_report is a tamperable on-disk artifact, so its assignment_sha256
+        # alone is not trusted — the manifest (envelope-validated above) anchors it.
+        manifest_entry = manifest_artifacts.get(assignment_ref)
+        if manifest_entry is None:
+            raise WorkerInvocationError(f"assignment_ref {assignment_ref!r} is not a declared manifest artifact")
+        actual_sha = sha256_of(assignment_path)
+        manifest_sha = manifest_entry.get("sha256")
+        runner_sha = worker.get("assignment_sha256")
+        if not (actual_sha == manifest_sha == runner_sha):
+            raise WorkerInvocationError(
+                f"assignment_sha256 mismatch for {assignment_ref!r}: on-disk {actual_sha!r}, "
+                f"manifest {manifest_sha!r}, runner_report {runner_sha!r}"
+            )
+
+        assignment = _load_json(assignment_path)
+        try:
+            assignment_validator.validate(assignment)
+        except ValidationError as exc:
+            raise WorkerInvocationError(f"assignment fails schema: {exc.message}") from exc
+
+        if assignment.get("task_graph_id") != task_graph_id:
+            raise WorkerInvocationError(
+                f"assignment task_graph_id {assignment.get('task_graph_id')!r} != {task_graph_id!r}"
+            )
+        if assignment.get("task_id") != worker["task_id"]:
+            raise WorkerInvocationError(
+                f"assignment task_id {assignment.get('task_id')!r} != runner task_id {worker['task_id']!r}"
+            )
+        if assignment.get("base_sha") != base_sha:
+            raise WorkerInvocationError(
+                f"assignment base_sha {assignment.get('base_sha')!r} != runner base_sha {base_sha!r}"
+            )
+        if assignment.get("branch") != worker["branch"]:
+            raise WorkerInvocationError(
+                f"assignment branch {assignment.get('branch')!r} != runner branch {worker['branch']!r}"
+            )
+
+        canonical_expected = (Path(worker["actual_worktree"]) / "worker_result.v1.json").resolve()
+        if expected_path.resolve() != canonical_expected:
+            raise WorkerInvocationError(
+                f"expected_worker_result_path {expected_path!s} is not the worktree-root SSOT {canonical_expected!s}"
+            )
+        return assignment
+
+    def _git_capture(self, worktree: Path, args: list[str]) -> tuple[int, str]:
+        try:
+            completed = subprocess.run(
+                ["git", "-C", str(worktree), *args],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise WorkerInvocationError(f"git {args!r} failed in {worktree!s}: {exc}") from exc
+        return completed.returncode, completed.stdout.strip()
+
+    def _verify_worktree(self, *, actual_worktree: Path, base_sha: str, branch: str) -> None:
+        """Fail-closed unless ``actual_worktree`` is the AO-MA-4-prepared git
+        worktree: a real worktree root, on the expected branch at ``base_sha``
+        HEAD, attached to the same repo as ``repo_root``. Prevents a tampered
+        runner_report from aiming the fixture's write at an arbitrary directory
+        or a foreign repository.
+        """
+
+        if not actual_worktree.exists():
+            raise WorkerInvocationError(f"actual_worktree does not exist: {actual_worktree!s}")
+        rc, toplevel = self._git_capture(actual_worktree, ["rev-parse", "--show-toplevel"])
+        if rc != 0:
+            raise WorkerInvocationError(f"actual_worktree {actual_worktree!s} is not a git worktree")
+        if Path(toplevel).resolve() != actual_worktree.resolve():
+            raise WorkerInvocationError(
+                f"actual_worktree {actual_worktree!s} is not a worktree root (toplevel={toplevel!r})"
+            )
+        rc, head = self._git_capture(actual_worktree, ["rev-parse", "HEAD"])
+        if rc != 0 or head != base_sha:
+            raise WorkerInvocationError(f"actual_worktree HEAD {head!r} != base_sha {base_sha!r}")
+        rc, observed_branch = self._git_capture(actual_worktree, ["symbolic-ref", "--short", "HEAD"])
+        if rc != 0 or observed_branch != branch:
+            raise WorkerInvocationError(f"actual_worktree branch {observed_branch!r} != expected {branch!r}")
+        # Same repo: the worktree's git-common-dir must match repo_root's.
+        rc, wt_common = self._git_capture(actual_worktree, ["rev-parse", "--git-common-dir"])
+        rc2, repo_common = self._git_capture(self.repo_root, ["rev-parse", "--git-common-dir"])
+        if rc != 0 or rc2 != 0:
+            raise WorkerInvocationError("failed to resolve git-common-dir for worktree containment")
+        wt_common_abs = Path(wt_common) if Path(wt_common).is_absolute() else (actual_worktree / wt_common)
+        repo_common_abs = Path(repo_common) if Path(repo_common).is_absolute() else (self.repo_root / repo_common)
+        if wt_common_abs.resolve() != repo_common_abs.resolve():
+            raise WorkerInvocationError(
+                f"actual_worktree git-common-dir {wt_common_abs!s} is not the same repo as repo_root "
+                f"{repo_common_abs!s}"
+            )
+
+    def _emit_report(
+        self,
+        *,
+        manifest_dir: Path,
+        manifest_path: Path,
+        task_graph_id: str,
+        invoked: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        report = {
+            "schema_version": "ao-ma-worker-invocation-report.v1",
+            "task_graph_id": task_graph_id,
+            "manifest_sha256": sha256_of(manifest_path),
+            "generated_at": _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "fixture_id": PINNED_FIXTURE_ID,
+            "invoked": invoked,
+            "guard_flags": {key: False for key in _GUARD_KEYS},
+        }
+        try:
+            Draft202012Validator(_load_schema(_INVOCATION_REPORT_SCHEMA)).validate(report)
+        except ValidationError as exc:
+            raise WorkerInvocationError(f"worker invocation report fails schema validation: {exc.message}") from exc
+
+        out_path = manifest_dir / "worker_invocation_report.v1.json"
+        tmp = manifest_dir / ".worker_invocation_report.v1.json.tmp"
+        tmp.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        tmp.replace(out_path)
+        return report

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "HYG-PUBLIC-CONTEXT-AUDIT",
+  "work_package": "AO-MA-4.5-WORKER-INVOCATION",
   "implementer": {
     "agent": "claude",
     "provider": "anthropic"
@@ -13,10 +13,17 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/hyg-public-context-audit",
+    "head_ref": "refs/heads/codex/ao-ma-4-5-worker-invocation",
     "changed_files": [
-      "docs/audits/PUBLIC-CONTEXT-TEST-QUALITY-AUDIT-2026-05-29.md",
-      "local-ai-review-evidence.v1.json"
+      ".claude/plans/AO-MA-1-MULTI-AGENT-ORCHESTRATION-DESIGN.md",
+      ".claude/plans/AO-MA-4.5-WORKER-INVOCATION.md",
+      "ao_kernel/cli.py",
+      "ao_kernel/defaults/schemas/ao-ma-worker-invocation-report.schema.v1.json",
+      "ao_kernel/fixtures/ao_ma_worker_stub.py",
+      "ao_kernel/orchestration/cli_handlers.py",
+      "ao_kernel/orchestration/worker_invoker.py",
+      "local-ai-review-evidence.v1.json",
+      "tests/test_ao_ma_4_5_worker_invocation.py"
     ]
   },
   "checks_considered": [
@@ -29,25 +36,29 @@
       "status": "pass"
     },
     {
-      "name": "doc_only_scope",
-      "status": "pass"
-    },
-    {
-      "name": "coverage_data_recorded",
+      "name": "coverage_gate",
       "status": "pass"
     },
     {
       "name": "guard_flags_remain_false",
       "status": "pass"
+    },
+    {
+      "name": "trust_boundary_fail_closed",
+      "status": "pass"
+    },
+    {
+      "name": "no_workflow_or_ruleset_mutation",
+      "status": "pass"
     }
   ],
   "findings": [
-    "Codex plan-time consultation (thread 019e7547) returned REVISE + ready_for_impl: audit-only, full 18-module table with actionable analysis on the 5 sub-85% modules, part-level external-vs-actionable classification, single doc-only PR.",
-    "Doc-only diff: adds docs/audits/PUBLIC-CONTEXT-TEST-QUALITY-AUDIT-2026-05-29.md. No ao_kernel/context runtime module, no tests, no pyproject, no workflow, no schema, no guard flag, no gpp_status change.",
-    "Coverage data recorded (full suite, head a124c3b, branch): 18 context/ modules, 1211 statements; 5 modules below 85% (semantic_retrieval 63.3%, checkpoint 79.2%, memory_tiers 80.0%, context_compiler 84.2%, session_lifecycle 84.6%).",
-    "Per Codex REVISE: low coverage on embedding/vector modules is classified part-level, not wholesale external. Provider HTTP (embed_text/semantic_search) and live pgvector are external_integration; cosine/cache/rerank/budget/config and fail-closed paths are actionable_offline; defensive logging fallbacks are intentionally_uncovered.",
-    "Audit is doc-only and proposes clustered follow-up test PRs (CONTEXT-GAPS-01/02/03 + optional pgvector integration lane); it does not add tests in this PR.",
-    "No secrets, API keys, tokens, credential material, webhook URLs, admin bypass, workflow mutation, ruleset mutation, CODEOWNERS change, support widening, production platform claim, or live adapter execution are introduced."
+    "Codex plan-time consultation (thread 019e74ef): iter-1 REVISE -> iter-2 AGREE (ready_for_impl=true). Scope pinned to a deterministic local worker fixture only; the live-LLM worker is deferred to an operator-bound GPP supersession, so live_adapter_execution stays false.",
+    "Codex post-impl review (thread 019e7522): iter-1 RED -> iter-2 RED -> iter-3 AGREE (ready_to_merge=true). Two security/governance blockers were found and closed: (1) a tampered runner_report actual_worktree could drive an out-of-scope filesystem write; (2) a schema-valid but wrong-provenance worker_result could be reported as a successful invocation.",
+    "AO-MA-4.5 adds the ao_ma_worker_stub deterministic local worker fixture plus WorkerInvoker, closing the AO-MA dogfooding gap where AO-MA-4 prepared worktrees but no worker ever wrote worker_result.v1.",
+    "Trust boundary is fail-closed before any filesystem write: manifest envelope + runner_report manifest_sha256 + assignment artifact triple-SHA binding (on-disk == manifest == runner_report) + assignment schema + cross-ref + worktree-root expected path + git worktree verification (toplevel / HEAD == base_sha / branch / same-repo common-dir). The fixture self-verifies the worktree and rejects absolute/traversal declared paths. The emitted worker_result is bound to this graph/task/base/branch before the bridge copy.",
+    "Full suite 4655 passed / 76 skipped, coverage 85.20%. ruff + mypy clean. 26 AO-MA-4.5 tests including out-of-repo worktree, foreign git repo, tampered assignment SHA, stale runner_report SHA, traversal declared path, and emitted-binding negatives.",
+    "No secrets, API keys, tokens, webhook URLs, admin bypass, workflow mutation, ruleset mutation, CODEOWNERS change, gpp_status mutation, support widening, production platform claim, or live adapter execution are introduced."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_ao_ma_4_5_worker_invocation.py
+++ b/tests/test_ao_ma_4_5_worker_invocation.py
@@ -1,0 +1,665 @@
+"""AO-MA-4.5 worker invocation tests.
+
+Codex thread `019e74ef` AGREE (ready_for_impl: true). Two acceptance layers:
+
+1. Unit/CLI smoke: ``spawn -> invoke`` writes a schema-valid
+   ``worker_result.v1.json`` at the runner's ``expected_worker_result_path``;
+   guard flags closed; ``actual_changed_files`` subset of declared write set;
+   the invocation report validates against its schema.
+2. Full dogfooding chain: ``plan -> spawn -> invoke -> review -> verify ->
+   integrate`` reaches ``IntegrationDecision.overall_status == "all_accepted"``
+   with a cross-provider chain (worker=local, reviewer=openai, verifier=tool).
+   This uses the runtime ``WorkerInvoker.invoke()``, NOT an in-file surrogate.
+
+Plus negative fail-closed cases: arbitrary adapter rejected, open
+``live_adapter_execution`` rejected, non-eligible runner status skipped.
+
+The worker fixture runs as a subprocess (``python -m
+ao_kernel.fixtures.ao_ma_worker_stub``); the suite is invoked with
+``PYTHONPATH`` pointed at this worktree so the subprocess imports the same
+``ao_kernel`` under test.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from ao_kernel.fixtures.ao_ma_worker_stub import WorkerStubError, emit_worker_result
+from ao_kernel.orchestration.integrator import Integrator
+from ao_kernel.orchestration.orchestrator import Orchestrator, SSOTPaths
+from ao_kernel.orchestration.reviewer import ReviewInputs, Reviewer
+from ao_kernel.orchestration.task_graph_builder import TaskSpec
+from ao_kernel.orchestration.verifier import VerificationInputs, Verifier
+from ao_kernel.orchestration.worker_invoker import (
+    PINNED_FIXTURE_ID,
+    WorkerInvocationError,
+    WorkerInvoker,
+    _check_emitted_binding,
+)
+from ao_kernel.orchestration.worker_runner import WorkerRunner
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_INVOCATION_SCHEMA_PATH = (
+    _REPO_ROOT / "ao_kernel" / "defaults" / "schemas" / "ao-ma-worker-invocation-report.schema.v1.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Test-harness git helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> str:
+    completed = subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True, timeout=30)
+    return completed.stdout.strip()
+
+
+def _git_init_repo(repo: Path) -> str:
+    _run(["git", "init", "--initial-branch=main", str(repo)])
+    _run(["git", "-C", str(repo), "config", "user.email", "test@example.com"])
+    _run(["git", "-C", str(repo), "config", "user.name", "test"])
+    (repo / "README.md").write_text("initial\n", encoding="utf-8")
+    (repo / "src").mkdir(parents=True, exist_ok=True)
+    (repo / "src" / "a.py").write_text("def a():\n    return 1\n", encoding="utf-8")
+    _run(["git", "-C", str(repo), "add", "README.md", "src/a.py"])
+    _run(["git", "-C", str(repo), "commit", "-m", "initial"])
+    sha = _run(["git", "-C", str(repo), "rev-parse", "HEAD"])
+    _run(["git", "-C", str(repo), "update-ref", "refs/remotes/origin/main", sha])
+    return sha
+
+
+def _write_synthetic_ssot(repo: Path) -> None:
+    (repo / "AGENTS.md").write_text("# AGENTS\nAO-MA-4.5 smoke synthetic SSOT.\n", encoding="utf-8")
+    plans_dir = repo / ".claude" / "plans"
+    plans_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": "gpp_status.v1",
+        "current_wp": {
+            "id": "AO-MA-4.5-smoke",
+            "support_widening_allowed": False,
+            "production_platform_claim_allowed": False,
+            "live_adapter_execution_allowed": False,
+        },
+        "support_widening_allowed": False,
+        "production_platform_claim_allowed": False,
+        "live_adapter_execution_allowed": False,
+    }
+    (plans_dir / "gpp_status.v1.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _build_manifest(repo: Path, base_sha: str, *, worktree_base: Path, dry_run: bool = False) -> dict[str, Any]:
+    """plan -> spawn; return a context dict with manifest_path + runner_report."""
+
+    ssot = SSOTPaths.default(repo)
+    orchestrator = Orchestrator(repo_root=repo, ssot=ssot, output_dir=None)
+    manifest = orchestrator.plan(
+        goal="AO-MA-4.5 worker invocation smoke",
+        declared_specs=[
+            TaskSpec(
+                task_id="task-001",
+                description="AO-MA-4.5 deterministic worker",
+                write_paths=["src/a.py"],
+                depends_on=[],
+            )
+        ],
+        base_sha=base_sha,
+        base_ref="refs/heads/main",
+        repo="Halildeu/ao-kernel",
+    )
+    task_graph_id = manifest["task_graph_id"]
+    manifest_path = repo / ".ao" / "orchestration" / task_graph_id / "manifest.v1.json"
+    runner = WorkerRunner(repo_root=repo, worktree_base=worktree_base, dry_run=dry_run)
+    runner_report = runner.spawn(manifest_path=manifest_path)
+    return {
+        "manifest": manifest,
+        "manifest_path": manifest_path,
+        "task_graph_id": task_graph_id,
+        "runner_report": runner_report,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Shared pipeline fixture: plan -> spawn -> invoke -> review -> verify -> integrate
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def chain(tmp_path_factory: pytest.TempPathFactory) -> Iterator[dict[str, Any]]:
+    tmp_path = tmp_path_factory.mktemp("ao_ma_4_5")
+    repo = tmp_path / "repo"
+    base_sha = _git_init_repo(repo)
+    _write_synthetic_ssot(repo)
+    # Worktrees live OUTSIDE repo_root (realistic: ../ao-kernel-feat-X). The
+    # invoker bridges each worktree-root worker_result into the manifest
+    # base_dir consumption point, so the downstream chain integrates it
+    # regardless of worktree location.
+    worktree_base = tmp_path / "worktrees"
+
+    built = _build_manifest(repo, base_sha, worktree_base=worktree_base)
+    manifest_path = built["manifest_path"]
+    task_id = "task-001"
+
+    # AO-MA-4.5: the real worker invoker writes worker_result.v1.json at the
+    # worktree root (producer SSOT) and bridges a copy into base_dir.
+    invoker = WorkerInvoker(repo_root=repo)
+    invocation_report = invoker.invoke(manifest_path=manifest_path)
+
+    worker_entry = next(w for w in built["runner_report"]["workers"] if w["task_id"] == task_id)
+    wr_path = Path(worker_entry["expected_worker_result_path"])  # worktree SSOT
+    integrated_path = Path(invocation_report["invoked"][0]["integrated_worker_result_path"])
+
+    # AO-MA-6: reviewer (worker=local, reviewer=openai)
+    diff_text = _run(["git", "-C", worker_entry["actual_worktree"], "diff", f"{base_sha}..HEAD"])
+    workers_dir = manifest_path.parent / "workers" / task_id
+    workers_dir.mkdir(parents=True, exist_ok=True)
+    pr_diff_path = workers_dir / "pr_diff.patch"
+    pr_diff_path.write_text(diff_text, encoding="utf-8")
+    findings_path = tmp_path / "findings.json"
+    findings_path.write_text(
+        json.dumps([{"severity": "info", "title": "AO-MA-4.5 smoke", "body": "no blockers"}]),
+        encoding="utf-8",
+    )
+    reviewer = Reviewer(repo_root=repo)
+    review_decision = reviewer.review(
+        ReviewInputs(
+            manifest_path=manifest_path,
+            task_id=task_id,
+            worker_result_paths={task_id: integrated_path},
+            reviewer_agent_id="codex-reviewer",
+            reviewer_provider="openai",
+            reviewer_session_id="ao-ma-4-5-reviewer",
+            verdict="AGREE",
+            findings_path=findings_path,
+            diff_path=pr_diff_path,
+        )
+    )
+
+    # AO-MA-7: verifier (verifier=tool)
+    verifier = Verifier(repo_root=repo)
+    verification_result = verifier.verify(
+        VerificationInputs(
+            manifest_path=manifest_path,
+            task_id=task_id,
+            worker_result_paths={task_id: integrated_path},
+            verifier_agent_id="verifier-tool",
+            verifier_provider="tool",
+            verifier_session_id="ao-ma-4-5-verifier",
+            review_verdict_path=workers_dir / "review_verdict.v1.json",
+            gpp_status_path=repo / ".claude" / "plans" / "gpp_status.v1.json",
+        )
+    )
+
+    # AO-MA-5: integrator
+    integrator = Integrator(
+        repo_root=repo,
+        integrator_agent_id="claude-integrator",
+        integrator_provider="anthropic",
+        integrator_session_id="ao-ma-4-5-integrator",
+    )
+    integration_decision = integrator.integrate(
+        manifest_path=manifest_path,
+        runner_report_path=None,
+        worker_result_paths={task_id: integrated_path},
+        review_verdict_paths={task_id: workers_dir / "review_verdict.v1.json"},
+        verification_report_paths={task_id: workers_dir / "verification_report.v1.json"},
+    )
+
+    yield {
+        "repo": repo,
+        "base_sha": base_sha,
+        "task_id": task_id,
+        "manifest_path": manifest_path,
+        "runner_report": built["runner_report"],
+        "invocation_report": invocation_report,
+        "worker_entry": worker_entry,
+        "wr_path": wr_path,
+        "integrated_path": integrated_path,
+        "review_decision": review_decision,
+        "verification_result": verification_result,
+        "integration_decision": integration_decision,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — unit/CLI smoke over the invoker output
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_emits_schema_valid_invocation_report(chain: dict[str, Any]) -> None:
+    schema = json.loads(_INVOCATION_SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(chain["invocation_report"])
+    report = chain["invocation_report"]
+    assert report["fixture_id"] == PINNED_FIXTURE_ID
+    assert len(report["invoked"]) == 1
+    assert report["invoked"][0]["status"] == "invoked"
+
+
+def test_invoke_writes_worker_result_at_expected_path(chain: dict[str, Any]) -> None:
+    wr_path = chain["wr_path"]
+    assert wr_path.exists(), f"worker_result.v1.json missing at expected path {wr_path}"
+    # Path matches the invocation report entry's worker_result_path SSOT
+    assert chain["invocation_report"]["invoked"][0]["worker_result_path"] == str(wr_path)
+
+
+def test_invoke_worker_result_is_schema_valid_and_local_provider(chain: dict[str, Any]) -> None:
+    wr = json.loads(chain["wr_path"].read_text(encoding="utf-8"))
+    schema_path = _REPO_ROOT / "ao_kernel" / "defaults" / "schemas" / "ao-ma-worker-result.schema.v1.json"
+    Draft202012Validator(json.loads(schema_path.read_text(encoding="utf-8"))).validate(wr)
+    assert wr["worker"]["provider"] == "local"
+    assert wr["worker"]["agent_type"] == "implementer"
+
+
+def test_invoke_actual_changed_files_subset_of_declared(chain: dict[str, Any]) -> None:
+    wr = json.loads(chain["wr_path"].read_text(encoding="utf-8"))
+    actual = set(wr["actual_changed_files"])
+    declared = set(wr["declared_write_set"])
+    assert actual, "deterministic worker produced no actual_changed_files"
+    assert actual.issubset(declared), f"actual {actual} not subset of declared {declared}"
+
+
+def test_invoke_worker_result_head_sha_is_real_commit(chain: dict[str, Any]) -> None:
+    wr = json.loads(chain["wr_path"].read_text(encoding="utf-8"))
+    actual_head = _run(["git", "-C", chain["worker_entry"]["actual_worktree"], "rev-parse", "HEAD"])
+    assert wr["head_sha"] == actual_head
+    assert wr["head_sha"] != chain["base_sha"], "head must differ from base after the worker commit"
+
+
+def test_invoke_guard_flags_closed(chain: dict[str, Any]) -> None:
+    for artifact in (chain["invocation_report"], json.loads(chain["wr_path"].read_text(encoding="utf-8"))):
+        gf = artifact["guard_flags"]
+        assert gf["support_widening"] is False
+        assert gf["production_platform_claim"] is False
+        assert gf["live_adapter_execution"] is False
+
+
+def test_invoke_bridges_worker_result_into_base_dir(chain: dict[str, Any]) -> None:
+    """The invoker bridges the worktree-root worker_result into the manifest
+    base_dir consumption point so AO-MA-5/6/7 can integrate it. The producer
+    SSOT (worktree root) and the bridged copy are distinct paths with identical
+    content, and the bridged copy lives under the manifest base_dir.
+    """
+
+    entry = chain["invocation_report"]["invoked"][0]
+    integrated = Path(entry["integrated_worker_result_path"])
+    base_dir = chain["manifest_path"].parent.parent
+    assert integrated.exists()
+    assert integrated != chain["wr_path"], "bridged copy must be distinct from the worktree SSOT path"
+    integrated.resolve().relative_to(base_dir.resolve())  # raises if outside base_dir
+    assert json.loads(integrated.read_text(encoding="utf-8")) == json.loads(
+        chain["wr_path"].read_text(encoding="utf-8")
+    ), "bridged worker_result content must equal the worktree SSOT content"
+
+
+def test_invoke_report_persisted_to_disk(chain: dict[str, Any]) -> None:
+    report_path = chain["manifest_path"].parent / "worker_invocation_report.v1.json"
+    assert report_path.exists()
+    persisted = json.loads(report_path.read_text(encoding="utf-8"))
+    assert persisted["schema_version"] == "ao-ma-worker-invocation-report.v1"
+    assert persisted["task_graph_id"] == chain["invocation_report"]["task_graph_id"]
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — full dogfooding chain reaches all_accepted
+# ---------------------------------------------------------------------------
+
+
+def test_full_chain_integration_all_accepted(chain: dict[str, Any]) -> None:
+    decision = chain["integration_decision"]
+    report = decision.report
+    assert decision.overall_status == "all_accepted", f"got {decision.overall_status!r}"
+    assert len(report["accepted_worker_results"]) == 1
+    assert report["rejected_worker_results"] == []
+    assert report["conflicts"] == []
+
+
+def test_full_chain_cross_provider_distinct(chain: dict[str, Any]) -> None:
+    wr = json.loads(chain["wr_path"].read_text(encoding="utf-8"))
+    reviewer_provider = chain["review_decision"].report["reviewer"]["provider"]
+    verifier_provider = chain["verification_result"].report["verifier"]["provider"]
+    providers = {wr["worker"]["provider"], reviewer_provider, verifier_provider}
+    assert wr["worker"]["provider"] == "local"
+    assert reviewer_provider == "openai"
+    assert verifier_provider == "tool"
+    assert len(providers) == 3, f"cross-provider chain not distinct: {providers}"
+
+
+def test_full_chain_assignment_provider_differs_from_worker_provider(chain: dict[str, Any]) -> None:
+    """Codex regression pin: assignment.agent.provider defaults to 'anthropic'
+    while worker_result.worker.provider is the honest 'local'; no AO-MA layer
+    enforces equality, so integration still reaches all_accepted. Guards the
+    chain if someone later adds an (incorrect) assignment-provider equality check.
+    """
+
+    manifest_dir = chain["manifest_path"].parent
+    assignment_files = sorted(manifest_dir.glob("agent_assignment-*.v1.json"))
+    assert assignment_files, "no agent_assignment artifact emitted by orchestrator"
+    assignment = json.loads(assignment_files[0].read_text(encoding="utf-8"))
+    wr = json.loads(chain["wr_path"].read_text(encoding="utf-8"))
+    assert assignment["agent"]["provider"] == "anthropic"
+    assert wr["worker"]["provider"] == "local"
+    assert chain["integration_decision"].overall_status == "all_accepted"
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — negative fail-closed cases
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_rejects_arbitrary_adapter(tmp_path: Path) -> None:
+    """fixture_id other than the pinned deterministic worker (e.g. a live
+    claude-code-cli) is rejected fail-closed before any manifest read.
+    """
+
+    invoker = WorkerInvoker(repo_root=tmp_path)
+    with pytest.raises(WorkerInvocationError, match="claude-code-cli"):
+        invoker.invoke(manifest_path=tmp_path / "manifest.v1.json", fixture_id="claude-code-cli")
+
+
+def test_invoke_rejects_open_live_adapter_execution_guard(tmp_path: Path) -> None:
+    """A manifest with live_adapter_execution=true is rejected fail-closed."""
+
+    manifest_path = tmp_path / "manifest.v1.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "ao-ma-orchestration-manifest.v1",
+                "task_graph_id": "ao-ma-20260529-abc1234",
+                "guard_flags": {
+                    "support_widening": False,
+                    "production_platform_claim": False,
+                    "live_adapter_execution": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    invoker = WorkerInvoker(repo_root=tmp_path)
+    with pytest.raises(WorkerInvocationError, match="live_adapter_execution"):
+        invoker.invoke(manifest_path=manifest_path)
+
+
+def test_invoke_skips_non_eligible_runner_status(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """A dry-run spawn yields status 'skipped_dry_run' (a real runner enum
+    value, not 'prepared'); the invoker records it as skipped_not_eligible and
+    does NOT write a worker_result.
+    """
+
+    tmp_path = tmp_path_factory.mktemp("ao_ma_4_5_dryrun")
+    repo = tmp_path / "repo"
+    base_sha = _git_init_repo(repo)
+    _write_synthetic_ssot(repo)
+    worktree_base = tmp_path / "worktrees"
+    built = _build_manifest(repo, base_sha, worktree_base=worktree_base, dry_run=True)
+
+    # Sanity: the runner reported a non-eligible status for dry-run.
+    statuses = {w["status"] for w in built["runner_report"]["workers"]}
+    assert statuses == {"skipped_dry_run"}, f"expected dry-run skip, got {statuses}"
+
+    invoker = WorkerInvoker(repo_root=repo)
+    report = invoker.invoke(manifest_path=built["manifest_path"])
+    assert len(report["invoked"]) == 1
+    entry = report["invoked"][0]
+    assert entry["status"] == "skipped_not_eligible"
+    assert not Path(entry["worker_result_path"]).exists(), "no worker_result should be written for a skip"
+
+
+# ---------------------------------------------------------------------------
+# Layer 4 — fixture core unit tests (direct emit_worker_result; the invoker
+# runs the fixture as a subprocess, so direct calls are needed to exercise and
+# measure the fixture's guard / error logic)
+# ---------------------------------------------------------------------------
+
+
+def _write_assignment(path: Path, *, base_sha: str, declared: list[str], guard: dict[str, bool] | None = None) -> None:
+    payload = {
+        "schema_version": "ao-ma-agent-assignment.v1",
+        "assignment_id": "ao-ma-4-5-task-001",
+        "task_graph_id": "ao-ma-20260529-abc1234",
+        "task_id": "task-001",
+        "agent": {
+            "agent_id": "planner-x",
+            "agent_type": "implementer",
+            "provider": "anthropic",
+            "session_id": "s1",
+        },
+        "base_ref": "refs/heads/main",
+        "base_sha": base_sha,
+        "branch": "codex/ao-ma-4-5-task-001",
+        "worktree": "worktrees/task-001",
+        "declared_write_set": declared,
+        "expected_output_artifact": "worker_result.v1.json",
+        "status": "pending",
+        "guard_flags": guard
+        or {"support_widening": False, "production_platform_claim": False, "live_adapter_execution": False},
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_worker_stub_emit_happy_path(tmp_path: Path) -> None:
+    wt = tmp_path / "wt"
+    base_sha = _git_init_repo(wt)
+    # The fixture's defense-in-depth git gate expects the worktree on the
+    # assignment branch at base_sha HEAD (as AO-MA-4 prepares it).
+    _run(["git", "-C", str(wt), "checkout", "-b", "codex/ao-ma-4-5-task-001"])
+    assignment_path = tmp_path / "assignment.json"
+    _write_assignment(assignment_path, base_sha=base_sha, declared=["src/a.py"])
+    out = tmp_path / "worker_result.v1.json"
+    result = emit_worker_result(assignment_path=assignment_path, worktree=wt, output_path=out)
+    assert out.exists()
+    schema_path = _REPO_ROOT / "ao_kernel" / "defaults" / "schemas" / "ao-ma-worker-result.schema.v1.json"
+    Draft202012Validator(json.loads(schema_path.read_text(encoding="utf-8"))).validate(result)
+    assert result["worker"]["provider"] == "local"
+    assert result["worker"]["agent_type"] == "implementer"
+    assert result["head_sha"] != base_sha
+    assert result["actual_changed_files"] == ["src/a.py"]
+    assert result["guard_flags"]["live_adapter_execution"] is False
+
+
+def test_worker_stub_rejects_open_live_adapter_guard(tmp_path: Path) -> None:
+    wt = tmp_path / "wt"
+    base_sha = _git_init_repo(wt)
+    assignment_path = tmp_path / "assignment.json"
+    _write_assignment(
+        assignment_path,
+        base_sha=base_sha,
+        declared=["src/a.py"],
+        guard={"support_widening": False, "production_platform_claim": False, "live_adapter_execution": True},
+    )
+    with pytest.raises(WorkerStubError, match="live_adapter_execution"):
+        emit_worker_result(assignment_path=assignment_path, worktree=wt, output_path=tmp_path / "o.json")
+    assert not (tmp_path / "o.json").exists()
+
+
+def test_worker_stub_rejects_empty_declared_write_set(tmp_path: Path) -> None:
+    wt = tmp_path / "wt"
+    base_sha = _git_init_repo(wt)
+    assignment_path = tmp_path / "assignment.json"
+    _write_assignment(assignment_path, base_sha=base_sha, declared=[])
+    with pytest.raises(WorkerStubError, match="declared_write_set"):
+        emit_worker_result(assignment_path=assignment_path, worktree=wt, output_path=tmp_path / "o.json")
+
+
+def test_worker_stub_rejects_missing_worktree(tmp_path: Path) -> None:
+    assignment_path = tmp_path / "assignment.json"
+    _write_assignment(assignment_path, base_sha="0" * 40, declared=["src/a.py"])
+    with pytest.raises(WorkerStubError, match="worktree"):
+        emit_worker_result(assignment_path=assignment_path, worktree=tmp_path / "nope", output_path=tmp_path / "o.json")
+
+
+def test_invoke_fails_when_runner_report_missing(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Valid manifest (envelope passes) but the runner_report.v1.json is absent
+    → fail-closed (the invoker is downstream of AO-MA-4 spawn).
+    """
+
+    tmp_path = tmp_path_factory.mktemp("ao_ma_4_5_norr")
+    repo = tmp_path / "repo"
+    base_sha = _git_init_repo(repo)
+    _write_synthetic_ssot(repo)
+    built = _build_manifest(repo, base_sha, worktree_base=tmp_path / "worktrees")
+    (built["manifest_path"].parent / "runner_report.v1.json").unlink()
+    with pytest.raises(WorkerInvocationError, match="not found"):
+        WorkerInvoker(repo_root=repo).invoke(manifest_path=built["manifest_path"])
+
+
+# ---------------------------------------------------------------------------
+# Layer 5 — trust boundary + emitted-binding fail-closed (Codex post-impl RED)
+# ---------------------------------------------------------------------------
+
+
+def test_worker_stub_rejects_traversal_declared_path(tmp_path: Path) -> None:
+    """A tampered assignment with a traversal declared path must NOT cause an
+    out-of-worktree write (the fixture self-defends even if called standalone).
+    """
+
+    wt = tmp_path / "wt"
+    base_sha = _git_init_repo(wt)
+    _run(["git", "-C", str(wt), "checkout", "-b", "codex/ao-ma-4-5-task-001"])
+    assignment_path = tmp_path / "assignment.json"
+    _write_assignment(assignment_path, base_sha=base_sha, declared=["../escape.txt"])
+    with pytest.raises(WorkerStubError, match="traversal|absolute|escape"):
+        emit_worker_result(assignment_path=assignment_path, worktree=wt, output_path=tmp_path / "o.json")
+    assert not (tmp_path / "escape.txt").exists(), "fixture wrote outside the worktree"
+
+
+def test_invoke_rejects_tampered_assignment_sha(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Mutating the assignment after spawn breaks its sha256 pin → the worker is
+    recorded failed and the fixture never runs.
+    """
+
+    tmp_path = tmp_path_factory.mktemp("ao_ma_4_5_sha")
+    repo = tmp_path / "repo"
+    base_sha = _git_init_repo(repo)
+    _write_synthetic_ssot(repo)
+    built = _build_manifest(repo, base_sha, worktree_base=tmp_path / "worktrees")
+    manifest_dir = built["manifest_path"].parent
+    assignment_file = next(manifest_dir.glob("agent_assignment-*.v1.json"))
+    # Tamper: append a byte so sha256 diverges from the runner_report pin.
+    assignment_file.write_text(assignment_file.read_text(encoding="utf-8") + " ", encoding="utf-8")
+
+    report = WorkerInvoker(repo_root=repo).invoke(manifest_path=built["manifest_path"])
+    entry = report["invoked"][0]
+    assert entry["status"] == "failed"
+    assert "assignment_sha256 mismatch" in entry["reason"]
+
+
+def test_invoke_rejects_stale_runner_report_manifest_sha(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """A runner_report whose manifest_sha256 does not match the on-disk manifest
+    is rejected fail-closed (stale/tampered report)."""
+
+    tmp_path = tmp_path_factory.mktemp("ao_ma_4_5_stale")
+    repo = tmp_path / "repo"
+    base_sha = _git_init_repo(repo)
+    _write_synthetic_ssot(repo)
+    built = _build_manifest(repo, base_sha, worktree_base=tmp_path / "worktrees")
+    runner_report_path = built["manifest_path"].parent / "runner_report.v1.json"
+    report = json.loads(runner_report_path.read_text(encoding="utf-8"))
+    report["manifest_sha256"] = "sha256:" + "0" * 64
+    runner_report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    with pytest.raises(WorkerInvocationError, match="manifest_sha256"):
+        WorkerInvoker(repo_root=repo).invoke(manifest_path=built["manifest_path"])
+
+
+def _binding_fixture() -> dict[str, Any]:
+    return {
+        "task_graph_id": "ao-ma-20260529-abc1234",
+        "task_id": "task-001",
+        "base_sha": "a" * 40,
+        "head_ref": "codex/ao-ma-4-5-task-001",
+        "declared_write_set": ["src/a.py"],
+        "actual_changed_files": ["src/a.py"],
+    }
+
+
+def test_check_emitted_binding_passes_on_full_match() -> None:
+    assert (
+        _check_emitted_binding(
+            emitted=_binding_fixture(),
+            task_graph_id="ao-ma-20260529-abc1234",
+            task_id="task-001",
+            base_sha="a" * 40,
+            branch="codex/ao-ma-4-5-task-001",
+        )
+        is None
+    )
+
+
+def test_check_emitted_binding_detects_wrong_graph_and_overlap() -> None:
+    wrong_graph = {**_binding_fixture(), "task_graph_id": "ao-ma-20260529-deadbee"}
+    assert _check_emitted_binding(
+        emitted=wrong_graph,
+        task_graph_id="ao-ma-20260529-abc1234",
+        task_id="task-001",
+        base_sha="a" * 40,
+        branch="codex/ao-ma-4-5-task-001",
+    )
+    overlap = {**_binding_fixture(), "actual_changed_files": ["src/evil.py"]}
+    assert _check_emitted_binding(
+        emitted=overlap,
+        task_graph_id="ao-ma-20260529-abc1234",
+        task_id="task-001",
+        base_sha="a" * 40,
+        branch="codex/ao-ma-4-5-task-001",
+    )
+
+
+def test_invoke_rejects_out_of_repo_worktree(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """A tampered runner_report pointing actual_worktree at a plain directory
+    outside the repo must NOT drive a write there: the worker is failed and the
+    outside directory stays empty.
+    """
+
+    tmp_path = tmp_path_factory.mktemp("ao_ma_4_5_oow")
+    repo = tmp_path / "repo"
+    base_sha = _git_init_repo(repo)
+    _write_synthetic_ssot(repo)
+    built = _build_manifest(repo, base_sha, worktree_base=tmp_path / "worktrees")
+    runner_report_path = built["manifest_path"].parent / "runner_report.v1.json"
+    report = json.loads(runner_report_path.read_text(encoding="utf-8"))
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    for w in report["workers"]:
+        w["actual_worktree"] = str(outside)
+        w["expected_worker_result_path"] = str(outside / "worker_result.v1.json")
+    runner_report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    invoke_report = WorkerInvoker(repo_root=repo).invoke(manifest_path=built["manifest_path"])
+    entry = invoke_report["invoked"][0]
+    assert entry["status"] == "failed"
+    assert "worker entry integrity failed" in entry["reason"]
+    assert list(outside.iterdir()) == [], "fixture wrote into the out-of-repo directory"
+
+
+def test_invoke_rejects_foreign_git_worktree(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """A tampered runner_report pointing actual_worktree at a DIFFERENT git repo
+    (not a worktree of repo_root) is rejected fail-closed.
+    """
+
+    tmp_path = tmp_path_factory.mktemp("ao_ma_4_5_foreign")
+    repo = tmp_path / "repo"
+    base_sha = _git_init_repo(repo)
+    _write_synthetic_ssot(repo)
+    built = _build_manifest(repo, base_sha, worktree_base=tmp_path / "worktrees")
+    foreign = tmp_path / "foreign"
+    _git_init_repo(foreign)  # independent repo, own HEAD / common-dir
+    runner_report_path = built["manifest_path"].parent / "runner_report.v1.json"
+    report = json.loads(runner_report_path.read_text(encoding="utf-8"))
+    for w in report["workers"]:
+        w["actual_worktree"] = str(foreign)
+        w["expected_worker_result_path"] = str(foreign / "worker_result.v1.json")
+    runner_report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    invoke_report = WorkerInvoker(repo_root=repo).invoke(manifest_path=built["manifest_path"])
+    entry = invoke_report["invoked"][0]
+    assert entry["status"] == "failed"
+    assert not (foreign / "worker_result.v1.json").exists()


### PR DESCRIPTION
## What

Closes the AO-MA dogfooding gap: AO-MA-4 prepared worktrees but no worker ever wrote `worker_result.v1`. The orchestration layer now drives a worker and emits the result, so `plan → spawn → invoke → review → verify → integrate` runs end-to-end on the repo's own machinery.

- **`ao_ma_worker_stub`** — deterministic local worker fixture (promoted from the AO-MA-8 in-file surrogate). Modifies one declared file in the prepared worktree, commits, derives `head_sha` + `actual_changed_files` from real git state, writes a schema-valid `worker_result.v1` (`worker.provider=local`).
- **`WorkerInvoker`** — reads the AO-MA-4 `runner_report`, invokes the pinned fixture per eligible worktree (subprocess), and bridges the validated `worker_result` into the manifest base_dir consumption point so AO-MA-5/6/7 (which fail-closed on evidence outside base_dir) can integrate it. Emits a schema-backed `worker_invocation_report.v1`.
- **`ao-ma-worker-invocation-report` schema** + `ao-kernel orchestration invoke` CLI.

## Guards / boundary

`live_adapter_execution` / `support_widening` / `production_platform_claim` stay closed. v1 invokes a deterministic local worker only — arbitrary adapter selection and a real LLM worker are rejected fail-closed; the latter is deferred to an operator-bound GPP supersession with `live_adapter_execution=true`.

Trust boundary is fail-closed before any filesystem write: manifest envelope + `runner_report.manifest_sha256` + assignment artifact triple-SHA binding (on-disk == manifest == runner_report) + assignment schema + cross-ref + worktree-root expected path + git worktree verification (toplevel / HEAD == base_sha / branch / same-repo common-dir). The fixture self-verifies the worktree (defense-in-depth) and rejects absolute/traversal declared paths. The emitted `worker_result` is bound to this graph/task/base/branch before the bridge copy (false-provenance guard).

## Tests

26 tests: spawn→invoke smoke, full chain → `all_accepted` (cross-provider local/openai/tool), and negatives (arbitrary adapter, open `live_adapter_execution`, non-eligible runner status, tampered assignment SHA, stale runner_report SHA, out-of-repo worktree, foreign git repo, traversal declared path, fixture/binding unit). Full suite: 4655 passed / 76 skipped, coverage 85.20%. ruff + mypy clean.

## Cross-AI review (HARD RULE)

- **Implementer:** Claude (Anthropic) — session worktree `codex/ao-ma-4-5-worker-invocation`
- **Reviewer:** Codex (OpenAI) — plan-time thread `019e74ef` (REVISE → AGREE) + post-impl thread `019e7522` (RED → RED → AGREE, `ready_to_merge=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)