### PR TITLE
docs(audit): add public-context-pipeline test-quality audit (coverage-driven)

### DIFF
--- a/docs/audits/PUBLIC-CONTEXT-TEST-QUALITY-AUDIT-2026-05-29.md
+++ b/docs/audits/PUBLIC-CONTEXT-TEST-QUALITY-AUDIT-2026-05-29.md
@@ -1,0 +1,150 @@
+# Public Context Pipeline Test-Quality Audit — 2026-05-29
+
+A **coverage-driven** test-quality audit for the `ao_kernel/context/` pipeline
+(the governed memory loop). Follows the same methodology as the public-facade
+audit (`docs/audits/PUBLIC-FACADE-TEST-QUALITY-AUDIT-2026-05-29.md`), which
+explicitly deferred `ao_kernel/context/` to this follow-up.
+
+> **Not a mutation-coverage audit.** Coverage measures execution, not
+> assertion strength. A covered branch is not necessarily a well-asserted
+> one. See §1.
+
+## 1. Methodology & limitations
+
+- **Instrument**: `coverage.py` branch coverage via `pytest-cov`, JSON report,
+  full suite.
+- **"Covered" ≠ "well asserted"**: high coverage is necessary, not sufficient.
+- **Classification labels** (assigned by source inspection, per Codex
+  CNS thread 019e7547 — part-level, not module-level):
+  - 🔴 **actionable_offline** — pure-Python / cache / config / selection /
+    rerank / fail-closed / corruption / budget logic that is testable
+    *without* a live provider or database.
+  - 🌐 **external_integration** — live provider HTTP (embeddings) or live
+    Postgres+pgvector backend; out of scope for offline unit tests, covered
+    only by optional integration evidence.
+  - ⚪ **intentionally_uncovered** — defensive fallback (`except: logging
+    .warning(...)`) where a test would assert little.
+- **Scope**: all 18 `ao_kernel/context/` modules in §2; §3 actionable analysis
+  concentrates on the 5 modules below 85%.
+
+## 2. Module coverage (full suite, head a124c3b, branch coverage)
+
+| Module | Cov % | Stmts | Miss | M.Branch | Tier |
+|---|---:|---:|---:|---:|---|
+| semantic_retrieval.py | 63.3% | 75 | 28 | 12 | 🔴+🌐 priority |
+| checkpoint.py | 79.2% | 59 | 9 | 7 | 🔴 fail-closed |
+| memory_tiers.py | 80.0% | 54 | 12 | 2 | 🔴 config/time |
+| context_compiler.py | 84.2% | 196 | 22 | 21 | 🔴 priority (blast radius) |
+| session_lifecycle.py | 84.6% | 37 | 6 | 0 | ⚪ mostly defensive |
+| vector_store_pgvector.py | 86.1% | 67 | 11 | 0 | 🌐 optional backend |
+| agent_coordination.py | 88.5% | 77 | 7 | 3 | watchlist |
+| canonical_store.py | 88.7% | 155 | 17 | 5 | watchlist |
+| vector_store.py | 88.9% | 39 | 5 | 0 | watchlist |
+| context_injector.py | 89.7% | 74 | 2 | 10 | watchlist |
+| memory_pipeline.py | 90.2% | 31 | 3 | 1 | ok |
+| vector_store_resolver.py | 90.3% | 85 | 7 | 4 | ok |
+| embedding_config.py | 92.4% | 56 | 4 | 1 | 🔴 config (offline) |
+| decision_extractor.py | 93.0% | 79 | 3 | 5 | ok |
+| profile_router.py | 98.3% | 42 | 0 | 1 | ok |
+| __init__.py | 100.0% | 9 | 0 | 0 | ok |
+| self_edit_memory.py | 100.0% | 37 | 0 | 0 | ok |
+| semantic_indexer.py | 100.0% | 39 | 0 | 0 | ok |
+
+Total: 1211 statements, 18 modules. Aggregate context/ coverage feeds the
+repo-wide 86.91% (full suite this run).
+
+## 3. Actionable gaps (5 low-coverage modules)
+
+Per Codex guidance, low coverage on embedding/vector modules is **not**
+wholesale "external dependency" — the offline paths are testable and remain
+actionable.
+
+### semantic_retrieval.py (63.3% — priority 1: lowest + boundary)
+
+| Lines | What | Tier | Suggested test |
+|---|---|---|---|
+| 50–73 | `embed_text`: build_embeddings_request + execute_http_request + non-OK status | 🌐 external | optional integration; offline: mock transport for status!=OK error path |
+| 99–115 | `embed_decision`: provider/model resolution + cache skip | 🔴 actionable | embedding cache hit/skip without re-embedding (no provider call) |
+| 123–125 | `decision["_embedding"]` cache write | 🔴 actionable | assert cache populated/reused |
+| 163–168 | `semantic_search` provider/model | 🌐 external | optional |
+| 192 | `return []` empty/non-list embedding skip | 🔴 actionable | empty query / non-list embedding → `[]` |
+
+### context_compiler.py (84.2% — priority 1: 196 stmt, largest blast radius)
+
+| Lines | What | Tier | Suggested test |
+|---|---|---|---|
+| 155 | `item.included = False` budget exclusion | 🔴 actionable | budget overflow → item excluded from compiled context |
+| 258 | `except Exception` telemetry fallback | ⚪ defensive | low value |
+| 338, 346 | relevance score constants (0.3 / 0.8) | 🔴 actionable | rerank scoring branches |
+| 397 | `content` list branch | 🔴 actionable | message content as list normalization |
+| 425–439 | semantic rerank `sim_map` build + sort | 🔴 actionable | rerank ordering with similarity map |
+
+### checkpoint.py (79.2% — fail-closed integrity)
+
+| Lines | What | Tier | Suggested test |
+|---|---|---|---|
+| 90, 102 | `raise CheckpointError(...)` | 🔴 actionable | corrupt/invalid checkpoint → CheckpointError |
+| 106 | `except (ValueError, TypeError)` | 🔴 actionable | malformed cursor parse |
+| 112 | `has_provider_cursor` resume metadata | 🔴 actionable | resume metadata flag set |
+| 147 | `except (json.JSONDecodeError, OSError)` | 🔴 actionable | corrupt checkpoint file fail-closed |
+
+### memory_tiers.py (80.0% — config / time edges)
+
+| Lines | What | Tier | Suggested test |
+|---|---|---|---|
+| 40–43 | `float(confidence)` coercion try | 🔴 actionable | non-numeric confidence coercion |
+| 94–112 | `load_default` + `datetime.now` + `except` | 🔴 actionable | tier config load + age computation edge |
+
+### session_lifecycle.py (84.6% — mostly defensive)
+
+| Lines | What | Tier | Suggested test |
+|---|---|---|---|
+| 89–91 | `except Exception: logging.warning("distillation failed")` | ⚪ defensive | low value |
+| 104–106 | `except Exception: logging.warning("promotion failed")` | ⚪ defensive | low value |
+
+session_lifecycle's misses are defensive logging fallbacks; its 84.6% is not
+a behavioral risk. Listed for completeness, not prioritized.
+
+## 4. Watchlist (85–90%, not prioritized)
+
+vector_store_pgvector.py (🌐 optional Postgres+pgvector backend — import guard
+/ dimension / namespace / mocked-connection paths testable; live DB E2E is a
+separate optional dependency lane), agent_coordination.py, canonical_store.py,
+vector_store.py, context_injector.py. These have adequate coverage; no
+critical fail-closed surface is currently uncovered.
+
+## 5. Run metadata (reproducibility)
+
+| Field | Value |
+|---|---|
+| Repo head SHA | `a124c3b` |
+| Date | 2026-05-29 |
+| OS | Darwin 25.5.0 arm64 |
+| Python | 3.13.6 |
+| coverage | 7.13.4 (branch) |
+| pytest-cov | 7.0.0 |
+| Command | `pytest tests/ --cov=ao_kernel.context --cov-branch --cov-report=json` |
+| Full suite | 4642 passed, 76 skipped, 141s |
+| Coverage JSON | generated locally; **not committed** (table above is the durable artifact) |
+
+## 6. Follow-up PR candidates (clustered)
+
+- **HYG-PUBLIC-CONTEXT-GAPS-01** — semantic_retrieval offline (cache skip,
+  empty/non-list embedding) + context_compiler rerank/budget/selection
+  branches (priority 1).
+- **HYG-PUBLIC-CONTEXT-GAPS-02** — checkpoint + session_lifecycle fail-closed:
+  CheckpointError raises, corrupt-file `OSError`/`JSONDecodeError`, resume
+  metadata. (session_lifecycle defensive logging excluded.)
+- **HYG-PUBLIC-CONTEXT-GAPS-03** — memory_tiers confidence coercion + tier
+  config/age edges + embedding_config env/policy precedence + secret repr
+  boundary.
+- **(optional) HYG-PUBLIC-CONTEXT-PGVECTOR-INTEGRATION** — pgvector mocked-unit
+  coverage + optional live-DB integration evidence (separate optional
+  dependency lane; not an offline unit-test cluster).
+
+## 7. Scope boundary (this audit PR)
+
+Doc-only. No `ao_kernel/context/*`, no `tests/*`, no `pyproject.toml`, no
+`.github/workflows/*`, no `gpp_status.v1.json`, no guard flag or
+support/production claim change. Coverage JSON generated locally and excluded
+from the committed diff.

--- a/docs/audits/PUBLIC-CONTEXT-TEST-QUALITY-AUDIT-2026-05-29.md
+++ b/docs/audits/PUBLIC-CONTEXT-TEST-QUALITY-AUDIT-2026-05-29.md
@@ -61,13 +61,19 @@ actionable.
 
 ### semantic_retrieval.py (63.3% — priority 1: lowest + boundary)
 
+Line classification corrected per Codex post-impl review (line-accurate):
+
 | Lines | What | Tier | Suggested test |
 |---|---|---|---|
 | 50–73 | `embed_text`: build_embeddings_request + execute_http_request + non-OK status | 🌐 external | optional integration; offline: mock transport for status!=OK error path |
 | 99–115 | `embed_decision`: provider/model resolution + cache skip | 🔴 actionable | embedding cache hit/skip without re-embedding (no provider call) |
 | 123–125 | `decision["_embedding"]` cache write | 🔴 actionable | assert cache populated/reused |
-| 163–168 | `semantic_search` provider/model | 🌐 external | optional |
-| 192 | `return []` empty/non-list embedding skip | 🔴 actionable | empty query / non-list embedding → `[]` |
+| 162–168 | `semantic_search` embedding_config precedence (provider/model/base_url/api_key resolve) | 🔴 actionable | embedding_config precedence resolution (offline, no provider call) |
+| 171–175 | `semantic_search` → `embed_text` live provider call | 🌐 external | optional integration; offline via mocked `embed_text` |
+| 177–178 | no query embedding → `[]` (deterministic fallback) | 🔴 actionable | empty/falsy query_embedding → `[]` |
+| 191–192 | no in-memory decisions → `[]` | 🔴 actionable | empty decisions list → `[]` |
+| 196–198 | missing / non-list `_embedding` → skip | 🔴 actionable | decision without list embedding is skipped |
+| 205–206 | similarity sort + `top_k` slice | 🔴 actionable | ordering by `_similarity` desc, top_k truncation |
 
 ### context_compiler.py (84.2% — priority 1: 196 stmt, largest blast radius)
 
@@ -75,18 +81,20 @@ actionable.
 |---|---|---|---|
 | 155 | `item.included = False` budget exclusion | 🔴 actionable | budget overflow → item excluded from compiled context |
 | 258 | `except Exception` telemetry fallback | ⚪ defensive | low value |
-| 338, 346 | relevance score constants (0.3 / 0.8) | 🔴 actionable | rerank scoring branches |
+| 338, 346 | `_recency_score` edge branches (empty timestamp → 0.3; <24h → 0.8) | 🔴 actionable | recency scoring edges (missing timestamp, fresh item) |
 | 397 | `content` list branch | 🔴 actionable | message content as list normalization |
-| 425–439 | semantic rerank `sim_map` build + sort | 🔴 actionable | rerank ordering with similarity map |
+| 425–436 | semantic rerank `sim_map` build + per-item score + sort | 🔴 actionable | rerank ordering with injected/stubbed similarity map |
+| 438–439 | `except Exception: pass` rerank fail-open | ⚪ defensive | non-critical; semantic search fail-open by design |
 
-### checkpoint.py (79.2% — fail-closed integrity)
+### checkpoint.py (79.2% — fail-closed integrity + resilience)
 
 | Lines | What | Tier | Suggested test |
 |---|---|---|---|
-| 90, 102 | `raise CheckpointError(...)` | 🔴 actionable | corrupt/invalid checkpoint → CheckpointError |
-| 106 | `except (ValueError, TypeError)` | 🔴 actionable | malformed cursor parse |
-| 112 | `has_provider_cursor` resume metadata | 🔴 actionable | resume metadata flag set |
-| 147 | `except (json.JSONDecodeError, OSError)` | 🔴 actionable | corrupt checkpoint file fail-closed |
+| 90 | missing `hashes.session_context_sha256` → `CheckpointError` | 🔴 actionable (fail-closed) | checkpoint without integrity hash → `CHECKPOINT_NO_HASH` |
+| 102 | expired `expires_at` with `fail_on_expired=True` → `CheckpointError` | 🔴 actionable (fail-closed) | expired checkpoint → `CHECKPOINT_EXPIRED` |
+| 106–107 | malformed `expires_at` parse → `except: pass` (allow resume) | 🔴 actionable (resilience) | unparseable expiry → resume still allowed (not fail-closed) |
+| 112 | `has_provider_cursor` resume metadata | 🔴 actionable | resume metadata flag set when cursor present |
+| 147 | `list_checkpoints` skips corrupt/unreadable entries (`json.JSONDecodeError`/`OSError`) | 🔴 actionable (resilience) | corrupt checkpoint file skipped without aborting the listing |
 
 ### memory_tiers.py (80.0% — config / time edges)
 
@@ -132,9 +140,13 @@ critical fail-closed surface is currently uncovered.
 - **HYG-PUBLIC-CONTEXT-GAPS-01** — semantic_retrieval offline (cache skip,
   empty/non-list embedding) + context_compiler rerank/budget/selection
   branches (priority 1).
-- **HYG-PUBLIC-CONTEXT-GAPS-02** — checkpoint + session_lifecycle fail-closed:
-  CheckpointError raises, corrupt-file `OSError`/`JSONDecodeError`, resume
-  metadata. (session_lifecycle defensive logging excluded.)
+- **HYG-PUBLIC-CONTEXT-GAPS-02** — checkpoint fail-closed + resilience:
+  `CHECKPOINT_NO_HASH` (missing integrity hash) and `CHECKPOINT_EXPIRED`
+  (expired with `fail_on_expired=True`) fail-closed raises; plus resilience
+  paths — malformed-`expires_at` allow-resume, `has_provider_cursor` metadata,
+  and `list_checkpoints` skip-on-corrupt. (session_lifecycle is NOT in this
+  cluster: its misses are defensive logging fallbacks, intentionally
+  uncovered, not fail-closed.)
 - **HYG-PUBLIC-CONTEXT-GAPS-03** — memory_tiers confidence coercion + tier
   config/age edges + embedding_config env/policy precedence + secret repr
   boundary.

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "HYG-PUBLIC-FACADE-GAPS",
+  "work_package": "HYG-PUBLIC-CONTEXT-AUDIT",
   "implementer": {
     "agent": "claude",
     "provider": "anthropic"
@@ -13,12 +13,10 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/hyg-public-facade-gaps",
+    "head_ref": "refs/heads/codex/hyg-public-context-audit",
     "changed_files": [
-      "local-ai-review-evidence.v1.json",
-      "tests/test_config.py",
-      "tests/test_llm_facade.py",
-      "tests/test_tool_gateway.py"
+      "docs/audits/PUBLIC-CONTEXT-TEST-QUALITY-AUDIT-2026-05-29.md",
+      "local-ai-review-evidence.v1.json"
     ]
   },
   "checks_considered": [
@@ -31,34 +29,24 @@
       "status": "pass"
     },
     {
-      "name": "test_only_scope",
+      "name": "doc_only_scope",
       "status": "pass"
     },
     {
-      "name": "coverage_delta_recorded",
-      "status": "pass"
-    },
-    {
-      "name": "no_runtime_code_changes",
+      "name": "coverage_data_recorded",
       "status": "pass"
     },
     {
       "name": "guard_flags_remain_false",
       "status": "pass"
-    },
-    {
-      "name": "no_fake_work_already_covered_excluded",
-      "status": "pass"
     }
   ],
   "findings": [
-    "Codex plan-time consultation (thread 019e7520) returned REVISE + ready_for_impl with add_missing_arcs_only scope: skip already-covered governance arcs, require coverage-delta, single combined PR.",
-    "Test-only diff: extends tests/test_config.py, tests/test_tool_gateway.py, tests/test_llm_facade.py. No ao_kernel runtime module, no pyproject, no workflow, no schema, no guard flag, no gpp_status change.",
-    "GAPS-01 config.py: adds non-object workspace.json (array + scalar), non-object override, and non-object bundled default (narrow importlib.resources monkeypatch, no real bundled file touched) fail-closed tests.",
-    "GAPS-02 tool_gateway.py: adds blocked_tools non-list / non-string entry, cycle_detection non-object, and max_identical_calls non-int / bool-rejected tests — closing the asymmetric gap where allowed_tools had validation tests but blocked_tools did not.",
-    "GAPS-03 llm.py: adds build_request provider-guardrails deny (PROVIDER_DISABLED + MODEL_NOT_ALLOWED) and allow paths using a tmp workspace override policy; no live provider call or network access.",
-    "Coverage delta recorded (full-suite before -> after, source 428b886): config.py 93.6%->97.9% (closed 115/145/164), tool_gateway.py 94.3%->97.8% (closed 119/122/143/151), llm.py 87.1%->91.6% (closed 104/105/110/111/114).",
-    "No-Fake-Work discipline applied: governance.py was deliberately excluded because its core violation codes are already covered and the remaining arcs are partial dispatch-branch completions; llm.py:115 except-pass import guard left intentionally uncovered.",
+    "Codex plan-time consultation (thread 019e7547) returned REVISE + ready_for_impl: audit-only, full 18-module table with actionable analysis on the 5 sub-85% modules, part-level external-vs-actionable classification, single doc-only PR.",
+    "Doc-only diff: adds docs/audits/PUBLIC-CONTEXT-TEST-QUALITY-AUDIT-2026-05-29.md. No ao_kernel/context runtime module, no tests, no pyproject, no workflow, no schema, no guard flag, no gpp_status change.",
+    "Coverage data recorded (full suite, head a124c3b, branch): 18 context/ modules, 1211 statements; 5 modules below 85% (semantic_retrieval 63.3%, checkpoint 79.2%, memory_tiers 80.0%, context_compiler 84.2%, session_lifecycle 84.6%).",
+    "Per Codex REVISE: low coverage on embedding/vector modules is classified part-level, not wholesale external. Provider HTTP (embed_text/semantic_search) and live pgvector are external_integration; cosine/cache/rerank/budget/config and fail-closed paths are actionable_offline; defensive logging fallbacks are intentionally_uncovered.",
+    "Audit is doc-only and proposes clustered follow-up test PRs (CONTEXT-GAPS-01/02/03 + optional pgvector integration lane); it does not add tests in this PR.",
     "No secrets, API keys, tokens, credential material, webhook URLs, admin bypass, workflow mutation, ruleset mutation, CODEOWNERS change, support widening, production platform claim, or live adapter execution are introduced."
   ],
   "secrets_recorded": false,


### PR DESCRIPTION
Coverage-driven test-quality audit for ao_kernel/context/ (governed memory loop) — the follow-up the public-facade audit (PR #750) deferred. Doc-only.

Plan-time: Codex thread 019e7547 REVISE+ready. Post-impl: 6 line-accuracy findings absorbed (iter-2) → AGREE.

## Coverage (full suite, head a124c3b, branch)
18 context/ modules, 1211 stmt. 5 below 85%: semantic_retrieval 63.3%, checkpoint 79.2%, memory_tiers 80.0%, context_compiler 84.2%, session_lifecycle 84.6%.

## Methodology (part-level classification, line-accurate)
- external_integration: embed_text/semantic_search provider HTTP, live pgvector
- actionable_offline: embedding_config precedence, cosine/cache, rerank sim_map/sort, recency edges, checkpoint fail-closed + resilience, memory_tiers config/time
- intentionally_uncovered: defensive logging fallbacks (session_lifecycle), rerank fail-open

## Follow-up clusters (§6)
- CONTEXT-GAPS-01: semantic_retrieval offline + context_compiler rerank/budget/recency
- CONTEXT-GAPS-02: checkpoint fail-closed (CHECKPOINT_NO_HASH, CHECKPOINT_EXPIRED) + resilience (malformed-expiry resume, list_checkpoints skip-on-corrupt). session_lifecycle NOT included (defensive logging, intentionally uncovered).
- CONTEXT-GAPS-03: memory_tiers + embedding_config
- optional pgvector integration lane

Doc-only. No runtime/test/pyproject/workflow/guard/gpp_status change.

Generated with Claude Code (https://claude.com/claude-code)