### PR TITLE
test(hyg-governance-arc): pin _check_rules public-facade dispatch

### DIFF
--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,32 +1,28 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "HYG-MUTATION-AUDIT-V2",
+  "work_package": "HYG-GOVERNANCE-ARC-COMPLETION",
   "implementer": { "agent": "claude", "provider": "anthropic" },
   "reviewer": { "agent": "codex", "provider": "openai", "verdict": "AGREE" },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/hyg-mutation-audit-v2",
-    "changed_files": [
-      "docs/audits/MUTATION-AUDIT-V2-2026-05-29.md",
-      "local-ai-review-evidence.v1.json"
-    ]
+    "head_ref": "refs/heads/codex/hyg-governance-arc-completion",
+    "changed_files": [ "local-ai-review-evidence.v1.json", "tests/test_governance.py" ]
   },
   "checks_considered": [
     { "name": "tests", "status": "pass" },
     { "name": "secret_scan", "status": "pass" },
-    { "name": "doc_only_scope", "status": "pass" },
-    { "name": "no_fabricated_score", "status": "pass" },
-    { "name": "isolated_venv_global_env_untouched", "status": "pass" },
+    { "name": "test_only_scope", "status": "pass" },
+    { "name": "coverage_delta_recorded", "status": "pass" },
+    { "name": "no_cosmetic_tests", "status": "pass" },
     { "name": "guard_flags_remain_false", "status": "pass" }
   ],
   "findings": [
-    "Codex plan-time consultation (thread 019e753e) returned REVISE + ready_for_impl: bounded audit-only mutation tool evaluation, mutmut 2.4.5 primary, isolated venv, 3 GAPS modules targeted, no fabricated score on tool failure.",
-    "Doc-only diff: adds docs/audits/MUTATION-AUDIT-V2-2026-05-29.md. No ao_kernel runtime, no tests, no pyproject mutmut-config change, no workflow, no guard flag, no gpp_status change.",
-    "mutmut 2.4.5 ran in an isolated /tmp venv; the repo's global mutmut 3.5.0 and the [dev] extra were left untouched. venv removed after run; .mutmut-cache not committed.",
-    "config.py is a trustworthy result: 78.3% (47/60 killed); the 13 survived mutants cluster on error-message string mutations that pytest.raises(match=substring) does not pin — a real, low-severity assertion-strength gap.",
-    "tool_gateway.py and llm.py reported 0 killed with high survived/suspicious counts; per No-Fake-Work this is documented as a mutmut-2.4.5 tool anomaly (lazy in-function imports in test_llm_facade prevent mutant injection; tool_gateway's large surface makes the selected-test runner produce 155 suspicious), NOT synthesized into a 0% mutation score.",
-    "Decision recorded: mutation testing is NOT adopted as a repo gate; it remains an opt-in diagnostic. Follow-ups proposed (HYG-MUTATION-CONFIG-HARDEN exact-message asserts; HYG-MUTATION-AUDIT-V3 reliable tooling via module-top imports / runner tuning / cosmic-ray).",
+    "Codex plan-time consultation (thread 019e7576) returned REVISE + small_test_pr: 2-4 named contract tests for the _check_rules public-facade dispatch, wildcard/generic/malformed arcs deliberately excluded as already-covered or cosmetic.",
+    "Test-only diff: appends TestCheckRulesDispatch (6 named contract tests) to tests/test_governance.py. No ao_kernel runtime, no pyproject, no workflow, no guard flag, no gpp_status change.",
+    "Tests pin _check_rules structural dispatch (governance.py) routing a policy dict to autonomy / tool-calling / provider-guardrails / generic checkers by structure — the public-facade path that existing helper-level tests did not exercise.",
+    "Coverage delta: governance.py dispatch lines 106 (autonomy extend) and 110 (tool-calling extend) were missing full-suite before; they are now covered by test_governance.py itself (no longer in the targeted missing list).",
+    "No-Fake-Work discipline: the wildcard allow_models=['*'] test already existed (test_wildcard_model_allows_any) and was NOT duplicated; generic complementary arcs (required/blocked/limits inverse directions) and malformed-policy fallthroughs (163-228) were deliberately excluded as cosmetic per Codex guidance.",
     "No secrets, API keys, tokens, credential material, webhook URLs, admin bypass, workflow mutation, ruleset mutation, CODEOWNERS change, support widening, production platform claim, or live adapter execution are introduced."
   ],
   "secrets_recorded": false,

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -278,3 +278,90 @@ class TestCheckProviderGuardrails:
         policy = {"providers": {"openai": {"enabled": True, "allow_models": ["*"]}}}
         violations = _check_provider_guardrails(policy, {"provider_id": "openai", "model": "any-model"})
         assert violations == []
+
+
+class TestCheckRulesDispatch:
+    """HYG-GOVERNANCE-ARC-COMPLETION: the public-facade dispatch in
+    _check_rules (governance.py) routes a policy dict to the right checker(s)
+    by structure. Existing tests exercise the helpers directly
+    (_check_autonomy / _check_tool_calling / _check_provider_guardrails), but
+    not the _check_rules dispatch itself (the autonomy/tool-calling extend
+    branches). These named contract tests pin that structural routing.
+
+    Per Codex thread 019e7576, wildcard allow_models, generic complementary
+    arcs, and malformed-policy fallthroughs are deliberately excluded
+    (already covered or cosmetic, No-Fake-Work).
+    """
+
+    def test_check_rules_dispatches_autonomy(self):
+        # Policy with intents+defaults.mode → _check_autonomy is dispatched and
+        # a mode mismatch surfaces through the public _check_rules path.
+        from ao_kernel.governance import _check_rules
+
+        policy = {
+            "intents": {"urn:core:deploy": {"mode": "human_review"}},
+            "defaults": {"mode": "human_review"},
+        }
+        violations = _check_rules(policy, {"intent": "urn:core:deploy", "mode": "full_auto"})
+        assert any("AUTONOMY_MODE_DENIED" in v for v in violations)
+
+    def test_check_rules_dispatches_tool_calling(self):
+        # Policy with blocked_tools (enabled) → _check_tool_calling dispatched;
+        # a blocked tool surfaces through _check_rules.
+        from ao_kernel.governance import _check_rules
+
+        policy = {"enabled": True, "blocked_tools": ["dangerous_tool"], "allowed_tools": []}
+        violations = _check_rules(policy, {"tool_name": "dangerous_tool"})
+        assert any("TOOL_BLOCKED" in v for v in violations)
+
+    def test_check_rules_dispatches_provider_guardrails(self):
+        # Policy with providers dict → _check_provider_guardrails dispatched;
+        # a disabled provider surfaces through _check_rules.
+        from ao_kernel.governance import _check_rules
+
+        policy = {"providers": {"openai": {"enabled": False}}}
+        violations = _check_rules(policy, {"provider_id": "openai", "model": "gpt-4"})
+        assert any("PROVIDER_DISABLED" in v for v in violations)
+
+    def test_check_rules_multi_type_policy_dispatches_all(self):
+        # A policy carrying multiple type markers dispatches to each checker;
+        # both an autonomy violation and a provider violation surface together.
+        from ao_kernel.governance import _check_rules
+
+        policy = {
+            "intents": {"urn:core:deploy": {"mode": "human_review"}},
+            "defaults": {"mode": "human_review"},
+            "providers": {"openai": {"enabled": False}},
+        }
+        violations = _check_rules(
+            policy,
+            {"intent": "urn:core:deploy", "mode": "full_auto", "provider_id": "openai", "model": "gpt-4"},
+        )
+        assert any("AUTONOMY_MODE_DENIED" in v for v in violations)
+        assert any("PROVIDER_DISABLED" in v for v in violations)
+
+    def test_check_rules_generic_always_runs(self):
+        # Generic rules (required_fields) run regardless of other type markers;
+        # a missing required field surfaces even with no autonomy/tool/provider
+        # markers present.
+        from ao_kernel.governance import _check_rules
+
+        policy = {"required_fields": ["intent"]}
+        violations = _check_rules(policy, {"action": "test"})
+        assert any("MISSING_REQUIRED_FIELD:intent" in v for v in violations)
+
+    def test_check_rules_clean_action_no_violation(self):
+        # A conforming action against a multi-type policy yields no violations
+        # (every dispatched checker passes).
+        from ao_kernel.governance import _check_rules
+
+        policy = {
+            "intents": {"urn:core:deploy": {"mode": "human_review"}},
+            "defaults": {"mode": "human_review"},
+            "providers": {"openai": {"enabled": True, "allow_models": ["gpt-4"]}},
+        }
+        violations = _check_rules(
+            policy,
+            {"intent": "urn:core:deploy", "mode": "human_review", "provider_id": "openai", "model": "gpt-4"},
+        )
+        assert violations == []


### PR DESCRIPTION
Adds TestCheckRulesDispatch (6 named contract tests) for the _check_rules public-facade dispatch in governance.py — routing a policy dict to autonomy/tool-calling/provider-guardrails/generic checkers by structure. Existing tests exercise helpers directly; they did not pin the _check_rules dispatch (autonomy/tool-calling extend branches, lines 106/110).

Plan-time: Codex thread 019e7576 (REVISE + small_test_pr). Scope = 2-4 named contract tests + meaningful edges; wildcard/generic/malformed arcs excluded.

## Coverage delta
governance.py lines 106 (autonomy extend) + 110 (tool-calling extend) were full-suite-missing before; now covered by test_governance.py.

## No-Fake-Work
- wildcard allow_models=['*'] test ALREADY existed (test_wildcard_model_allows_any) → NOT duplicated
- generic complementary arcs + malformed-policy fallthroughs (163-228) deliberately excluded as cosmetic per Codex (93%+ governance, core covered)

## Tests (6)
autonomy dispatch, tool-calling dispatch, provider-guardrails dispatch, multi-type dispatches-all, generic-always-runs, clean-action-no-violation.

Test-only. No runtime/pyproject/workflow/guard/gpp_status change.

## Test plan
- [ ] Codex post-impl review AGREE
- [x] local-ai-review-evidence (cross-provider)
- [ ] CI green + merge

Generated with Claude Code (https://claude.com/claude-code)