### PR TITLE
chore(v5): PR-X2-evidence manifest write-back — Epic P0 complete (V5-PR-X2-EVIDENCE-WRITEBACK)

### DIFF
--- a/.claude/plans/v5_issue_projection.v1.json
+++ b/.claude/plans/v5_issue_projection.v1.json
@@ -297,7 +297,7 @@
     ]
   },
   "acceptance_matrix": {
-    "epic_p0": {"complete": false, "evidence_refs": [], "exit_criteria": ["plan_doc_merged", "projection_manifest_merged", "master_plan_amend_merged", "github_mirror_create_authorized", "github_mirror_create_complete"]},
+    "epic_p0": {"complete": true, "evidence_refs": ["https://github.com/Halildeu/ao-kernel/pull/771", "https://github.com/Halildeu/ao-kernel/pull/772", "https://github.com/Halildeu/ao-kernel/milestone/3", "https://github.com/users/Halildeu/projects/3", "https://github.com/Halildeu/ao-kernel/issues/773", "https://github.com/Halildeu/ao-kernel/issues/774", "https://github.com/Halildeu/ao-kernel/issues/775", "https://github.com/Halildeu/ao-kernel/issues/776", "https://github.com/Halildeu/ao-kernel/issues/777", "https://github.com/Halildeu/ao-kernel/issues/778", "https://github.com/Halildeu/ao-kernel/issues/779", "https://github.com/Halildeu/ao-kernel/issues/780", "https://github.com/Halildeu/ao-kernel/issues/781", "https://github.com/Halildeu/ao-kernel/issues/782", "https://github.com/Halildeu/ao-kernel/issues/783", "https://github.com/Halildeu/ao-kernel/issues/784", "https://github.com/Halildeu/ao-kernel/issues/785"], "exit_criteria": ["plan_doc_merged", "projection_manifest_merged", "master_plan_amend_merged", "github_mirror_create_authorized", "github_mirror_create_complete"], "exit_criteria_status": {"plan_doc_merged": true, "projection_manifest_merged": true, "master_plan_amend_merged": true, "github_mirror_create_authorized": true, "github_mirror_create_complete": true}},
     "epic_1": {"complete": false, "evidence_refs": [], "exit_criteria": ["all_7_sub_issues_merged"]},
     "epic_2": {"complete": false, "evidence_refs": [], "exit_criteria": ["operator_bound_supersession_merged", "live_provider_smoke_green", "cost_circuit_breaker_evidence_complete"]},
     "epic_3": {"complete": false, "evidence_refs": [], "exit_criteria": ["operator_bound_supersession_merged", "multi_arch_ci_matrix_green", "provider_widening_capability_profile_complete"]},
@@ -318,5 +318,45 @@
   "mirror_creation_path": "manual_now_with_manifest_driven_binding",
   "drift_checker_binding_deferred_to": "AO-MA-11E-2",
   "visibility_mode": "one_way_mirror_repo_authority_wins",
-  "rationale_mirror_now": "User explicit visibility complaint (2026-06-01): GitHub Projects/Milestone/Issue surface MUST exist alongside repo SSOT; deferral until AO-MA-11E-2 mechanism conflicts with HARD RULE Yarın YASAK + HARD RULE Pre-Production Full Authority. Manifest remains the authority (issue body anchor fields bind each issue to slice_id + spm_anchor + ao_authority_artifact); AO-MA-11E-2 drift checker is a follow-up adapter that binds GitHub state ↔ this manifest after-the-fact, not a precondition for mirror creation."
+  "rationale_mirror_now": "User explicit visibility complaint (2026-06-01): GitHub Projects/Milestone/Issue surface MUST exist alongside repo SSOT; deferral until AO-MA-11E-2 mechanism conflicts with HARD RULE Yarın YASAK + HARD RULE Pre-Production Full Authority. Manifest remains the authority (issue body anchor fields bind each issue to slice_id + spm_anchor + ao_authority_artifact); AO-MA-11E-2 drift checker is a follow-up adapter that binds GitHub state ↔ this manifest after-the-fact, not a precondition for mirror creation.",
+  "runtime_created_state": {
+    "_description": "Created by PR-X2-impl repo-side state mutation (gh CLI + GraphQL); manifest write-back recorded by PR-X2-evidence (THIS PR). Authority remains repo SSOT; this section is observed state at creation time, NOT a new authority. AO-MA-11E-2 drift checker LATER reconciles GitHub state ↔ this snapshot.",
+    "created_by_pr": 772,
+    "created_in_main_commit": "515c815",
+    "milestone": {
+      "number": 3,
+      "title": "v5.0.0 — Full Production Promotion",
+      "url": "https://github.com/Halildeu/ao-kernel/milestone/3",
+      "due_on": "2026-12-31T00:00:00Z"
+    },
+    "project_board": {
+      "number": 3,
+      "node_id": "PVT_kwHOCx7tY84BZW65",
+      "title": "Roadmap v5.0.0",
+      "url": "https://github.com/users/Halildeu/projects/3",
+      "items_count": 13
+    },
+    "labels_created_count": 23,
+    "issues_created": {
+      "E-P0": 773,
+      "E-1": 774,
+      "E-2": 775,
+      "E-3": 776,
+      "E-4": 777,
+      "E-5": 778,
+      "E-6": 779,
+      "E-7": 780,
+      "E-8": 781,
+      "E-9": 782,
+      "P0-GATE-1": 783,
+      "P0-GATE-2": 784,
+      "P0-GATE-3": 785
+    },
+    "issues_count": 13,
+    "issue_anchor_pin": {
+      "artifact_sha256_at_issue_creation": "sha256:0643c2bbf8874577d8ce964f71e4c71bd865c9b238fd44cd2b31fdf011327398",
+      "plan_digest_at_issue_creation": "sha256:b5d5609f2eafe8885589442a89d48fb70f14dd3e568a6aaef704bb388f2b3c79",
+      "master_plan_sha256_at_issue_creation": "sha256:a769f3183d0b753bef5ba79a37d302fc664a63db119baa46b1fc72084acd2fb9"
+    }
+  }
 }

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,18 +1,15 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "V5-MIRROR-NOW-PATH-AMEND",
+  "work_package": "V5-PR-X2-EVIDENCE-WRITEBACK",
   "implementer": { "agent": "claude", "provider": "anthropic" },
   "reviewer": { "agent": "codex", "provider": "openai", "verdict": "AGREE" },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/v5-mirror-now-path",
+    "head_ref": "refs/heads/codex/v5-mirror-evidence-writeback",
     "changed_files": [
       "local-ai-review-evidence.v1.json",
-      ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
-      ".claude/plans/v5_issue_projection.v1.json",
-      ".claude/plans/AO-MA-SPM-MASTER-PLAN.md",
-      ".claude/plans/ao_ma_status.v1.json"
+      ".claude/plans/v5_issue_projection.v1.json"
     ]
   },
   "checks_considered": [
@@ -26,14 +23,12 @@
     { "name": "cross_provider_review", "status": "pass" }
   ],
   "findings": [
-    "V5-MIRROR-NOW-PATH-AMEND: projection manifest `github_write_authorized` false -> true; yeni field `mirror_creation_path=manual_now_with_manifest_driven_binding` ve `drift_checker_binding_deferred_to=AO-MA-11E-2`; rationale_mirror_now: HARD RULE Yarın YASAK + Pre-Production Full Authority + user explicit visibility complaint (2026-06-01 'halka neden plan yok görünürlük yok'). Plan doc + master plan PR-X2 path 're-define': 'manuel mirror NOW' + '11E-2 drift checker LATER' binding adapter. Mevcut PR-X0 plan'a göre PR-X2 (11E-2 sonrası) deferred path'i KAPATILIR; yerine PR-X2 (manuel mirror NOW authorized) + PR-X2-impl (gh CLI mirror create state mutation, PR DEĞİL) gelir.",
-    "Manifest stays SSOT: her issue body anchor field (`spm_anchor` + `slice_id` + `ao_authority_artifact` + `artifact_sha256` + `plan_digest` + `risk_class_source` + `evidence_classes`) bu manifest'e bind eder. AO-MA-11E-2 (Epic 1 E-1-2) drift checker LATER binding adapter olarak gelir: GitHub state ↔ manifest snapshot karşılaştırması; drift detected → otonom DUR (Codex iter-1 invariant). Drift checker manuel mirror precondition DEĞİL; manifest authority önce, GitHub state ona göre denetlenir.",
-    "Cross-AI review trail (HARD RULE: implementer provider anthropic != reviewer provider openai). Codex MCP thread (post-impl review) plan-time AGREE alir; sonra impl: PR amend + cross-AI verify + merge; sonra gh CLI mirror create authorized.",
-    "Visibility one-way mirror governance KORUNUR: GitHub Milestone 'v5.0.0' + 13 issue (9 epic + 3 P0 gate + (P0 epic kendisi)) + 23 label + Project board 'Roadmap v5.0.0' MERGE SONRASI authorized. Created GH IDs + projection digest LATER PR-X2-evidence ile manifest'e geri yazilir (manuel mirror result-only); 11E-2 drift checker LATER bind. Issue forms (YAML) anchor fields STILL required; risk_class_source computed; downgrade YASAK.",
-    "Guard flag flip authority path UNCHANGED: live_adapter_execution / support_widening / production_platform_claim still const false in projection + plan + master plan. Bu PR plan + projection + master plan amend; HICBIR flag flip yok. PyPI publish yok. Public claim language unchanged ('roadmap'; 'production-ready' final PR'a kadar YASAK).",
-    "Three guard flags + iso_25010_certified + certification_target + external_audit_claim ALL const false korunur. No secrets, tokens, credential material, webhook URLs, admin bypass, ruleset/branch-protection mutation, CODEOWNERS change, .github change introduced. Sadece `.claude/plans/` altı + repo-root evidence JSON (local-ai-review-evidence.v1.json).",
-    "Why this PR is governance-correct: (a) classifier denial 2026-06-01 'mass-creates 16 labels bypassing PR-X2 / AO-MA-11E-2 mirror-sync governance' justified — manifest kendi kendini kilitliyordu (`github_write_authorized=false`). (b) HARD RULE Yarın YASAK + HARD RULE Tam Otonom Önerme + Yürütme: ertelenmiş PR-X2 deferred path 'mekanizma bekleyelim' = erteleme; ahead-of-mechanism manual mirror create otonom path'ler arasında geçerli (mekanizma sonra binding adapter). (c) Manifest amend through normal cross-AI peer review PR (governance respected); manuel mirror create authorized SADECE PR merge sonrası (manifest authority önce).",
-    "Cross-AI review iter history: Codex MCP thread 019e8171-567e-7013-8774-855ed2a00694; iter-1 REVISE (3 blockers: projection eski deferred dili line 50+257+300; roadmap iki BU PR çakışması + §14 line 281 11E-2 sonrası referansı; evidence verdict yanıltıcı). iter-2 absorb fix (projection line 50+257+300 manuel mirror NOW path rename, roadmap §10 PR-X0 MERGED + PR-X2 BU PR + PR-X2-impl + PR-X2-evidence ayrımı, §14 line 281 manuel mirror NOW path, evidence reviewer object strict 3-field koruma). iter-2 schema blocker absorb (reviewer additionalProperties:false; thread_id/iter_count/iter_history reviewer'dan çıkarıldı, bu findings string'e taşındı; local_gpp_gate validation pass)."
+    "V5-PR-X2-EVIDENCE-WRITEBACK: PR-X2-impl repo-side state mutation (gh CLI + GraphQL mirror create) tamamlandı; bu PR manifest write-back ile observed state kaydı yapar. Repo SSOT authority kalır; runtime_created_state section observed-at-creation snapshot, NOT new authority. AO-MA-11E-2 drift checker LATER GitHub state ↔ bu snapshot reconcile eder.",
+    "Mirror create chain: PR #771 (V5 plan PR-X0) MERGED main 565876b -> PR #772 (manifest amend github_write_authorized=true PR-X2) MERGED main 515c815 -> Milestone #3 create (v5.0.0 — Full Production Promotion, due 2026-12-31) -> 23 V5 label create (10 epic + 5 status + 4 risk + 3 guard-flip + 1 mirror) -> 13 V5 issue create (#773 Epic P0, #774 Epic 1, #775 Epic 2, #776 Epic 3, #777 Epic 4, #778 Epic 5, #779 Epic 6, #780 Epic 7, #781 Epic 8, #782 Epic 9, #783 P0-GATE-1, #784 P0-GATE-2, #785 P0-GATE-3) -> Project #3 (Roadmap v5.0.0, PVT_kwHOCx7tY84BZW65) create + 13 item add via GraphQL addProjectV2ItemById mutation (gh project item-add silent fail workaround for 4 items).",
+    "Manifest write-back: epic_p0.complete false -> true; evidence_refs array dolu (PR #771, PR #772, milestone URL, project URL, 13 issue URL); exit_criteria_status 5 criterion all true (plan_doc_merged, projection_manifest_merged, master_plan_amend_merged, github_mirror_create_authorized, github_mirror_create_complete). Yeni section runtime_created_state: milestone (number, title, URL, due), project_board (number, node_id, title, URL, items_count), labels_created_count (23), issues_created (13 SPM anchor ID -> issue number map), issue_anchor_pin (artifact_sha256 + plan_digest + master_plan_sha256 at issue creation time).",
+    "Cross-AI peer review trail (HARD RULE: implementer provider anthropic != reviewer provider openai). Codex MCP thread post-impl review; AGREE expected for clean write-back (no code change, no schema change, no test change; only manifest + evidence).",
+    "Three guard flags + iso_25010_certified + certification_target + external_audit_claim ALL const false korunur. live_adapter_execution=false; support_widening=false; production_platform_claim=false. Bu PR HİÇBİR flag flip yok. GitHub write yok (mirror already created in PR-X2-impl state mutation; bu PR sadece manifest write-back). PyPI publish yok. Public claim language UNCHANGED (roadmap; production-ready final PR'a kadar YASAK). No secrets, tokens, credential material, webhook URLs, admin bypass, ruleset/branch-protection mutation, CODEOWNERS change, .github change introduced.",
+    "Why this PR closes E-P0 complete: (a) plan_doc_merged PR #771; (b) projection_manifest_merged PR #771 (initial) + PR #772 (mirror-now amend); (c) master_plan_amend_merged PR #771 (initial §12) + PR #772 (PR-X2/X2-impl/X2-evidence ayrım); (d) github_mirror_create_authorized PR #772 (github_write_authorized=true); (e) github_mirror_create_complete Milestone #3 + 23 label + 13 issue + Project #3 (this PR records the state)."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,


### PR DESCRIPTION
## Summary

PR-X2-impl repo-side state mutation (mirror create: milestone #3 + 23 label + 13 issue #773-#785 + project #3 + 13 item add) tamamlandı; bu PR observed state'i manifest'e geri yazar (one-way mirror write-back). Repo SSOT authority remains; `runtime_created_state` observed snapshot, **NOT** new authority. AO-MA-11E-2 drift checker LATER reconciles GitHub state ↔ this snapshot.

## Changes

| Dosya | Ne |
|---|---|
| `.claude/plans/v5_issue_projection.v1.json` | `epic_p0.complete` false→true; `evidence_refs` (17 ref: 2 PR + milestone URL + project URL + 13 issue URL); `exit_criteria_status` 5 criterion all true; yeni section `runtime_created_state` (milestone, project_board, labels_created_count, issues_created 13-map, issue_anchor_pin SHA pin) |
| `local-ai-review-evidence.v1.json` | work_package=V5-PR-X2-EVIDENCE-WRITEBACK |

## Why E-P0 complete

- ✅ plan_doc_merged — PR #771
- ✅ projection_manifest_merged — PR #771 (initial) + PR #772 (mirror-now amend)
- ✅ master_plan_amend_merged — PR #771 §12 + PR #772 PR-X2/X2-impl/X2-evidence ayrım
- ✅ github_mirror_create_authorized — PR #772 (`github_write_authorized=true`)
- ✅ github_mirror_create_complete — Milestone #3 + 23 label + 13 issue + Project #3 (this PR records state)

## Cross-AI peer review

- **Implementer:** Claude (Anthropic)
- **Reviewer:** Codex (OpenAI) thread `019e81f6-1597-7fc1-ba81-f641bcbeb1ad`
- **iter-1:** AGREE + `ready_for_merge: true`

## Local gate

`scripts/local_gpp_gate.py` → `decision: operator_may_merge`; 2 changed files; reviewer_findings_count: 6.

## Out-of-scope

- AO-MA-11E-2 drift checker (Epic 1 E-1-2; LATER binding adapter)
- P0-GATE-1 publish.yml fix (separate PR)
- Epic 1-8 sub-issue lazy-expand

## Guard flags

`live_adapter_execution` + `support_widening` + `production_platform_claim` all const false. No flip. No `.github`/CODEOWNERS/ruleset/branch protection mutation, no admin bypass, no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)