### PR TITLE
feat(ao-release-gate): RG-019e830d evidence finding taxonomy extension (V5 P0-4 unblock)

### DIFF
--- a/.claude/plans/RG-019E830D-EVIDENCE-FINDING-TAXONOMY.md
+++ b/.claude/plans/RG-019E830D-EVIDENCE-FINDING-TAXONOMY.md
@@ -175,7 +175,8 @@ yansıyor; type değişikliği yok. Decision JSON shape değişmiyor.
 
 ## 6. Acceptance
 
-- Local test: `pytest tests/test_ao_release_gate.py -x` (440+ pass).
+- Local test: `pytest tests/test_ao_release_gate.py -x` (111 pass).
+- Broader local: `pytest tests/ -k "release_gate or ao_ma10" -x` (440 pass + 2 skip).
 - Local lint: `ruff check ao_kernel/ tests/`.
 - Local type: `mypy ao_kernel/ scripts/ --ignore-missing-imports`.
 - Cross-AI post-impl review (Codex thread `019e830d` reply ile
@@ -209,7 +210,7 @@ ao-release-gate-review
 
 Codex iter-2 absorb: live ruleset bu turda sandbox/TMP/network kısıtı
 sebebiyle Codex tarafında doğrulanamadı. Merge öncesi operatör veya
-ao-release-gate-publish-check-runs.py kontrolü gerek.
+`scripts/ao_release_gate_publish_check_runs.py` kontrolü gerek.
 
 ## 7. Bağlantı
 

--- a/.claude/plans/RG-019E830D-EVIDENCE-FINDING-TAXONOMY.md
+++ b/.claude/plans/RG-019E830D-EVIDENCE-FINDING-TAXONOMY.md
@@ -1,0 +1,181 @@
+# RG-CONCLUSION-SEMANTICS 019e830d Extension — Evidence Finding Taxonomy
+
+**Status:** Implementing (codex/release-gate-review-evidence-action-required)
+**Codex thread:** `019e830d` (plan-time REVISE, `ready_for_impl: true`)
+**SSOT:** `ao_kernel/ao_release_gate.py` (`_REVIEW_ACTION_FINDINGS`)
+**Related plan:** `RG-CONCLUSION-SEMANTICS C-prime wrapper` (Codex thread `019e65c3`)
+
+## 1. Sorun (V5 P0-4 trigger)
+
+PR #764 (`fix/test-yml-required-no-event-gate` — required test.yml job'ları
+shadow-skip etmesini engelleyen küçük workflow düzeltmesi) `ao-release-gate`
+gate'inde iki bulgu ile reddedildi:
+
+- `ao_release_gate_review_evidence_not_accepting`
+- `ao_release_gate_review_evidence_context_unverifiable`
+
+İki bulgu da mevcut taksonomide `failure` sınıfına düşüyor (sadece
+`ao_release_gate_high_risk_human_review_missing` `review_action`).
+Sonuç: wrapper exit code 1 → required check kırmızı → merge bloklu.
+
+Functional/runtime/semantic kod değişikliği YOK; sadece CI workflow fix.
+GPP closeout (7/7 work package complete, üç guard flag const false,
+`keep_narrow_stable_runtime` kararı) sonrası yeni evidence üretimi
+beklenmiyor; operatör CODEOWNER review eksik. Bu durum kırmızı CI
+sinyaliyle değil, "operatör action required" sinyaliyle gösterilmeli.
+
+## 2. Codex iter-1 (plan-time)
+
+**Verdict:** `REVISE`, `ready_for_impl: true`.
+
+**Kabul edilenler:**
+
+- Fix yönü doğru — bu iki finding `review_action` sınıfına taşınmalı.
+- GPP closeout flag ile evidence skip ETME — gate boundary'sini fazla
+  gevşetir; GPP-9 closeout "support widening / production claim / live
+  adapter yok" demek; review authority ihtiyacını kaldırmaz.
+- Bypass riski sadece required-check topology drift ederse açılır.
+  `allow=false` kararı değişmez; sadece check-run conclusion + wrapper
+  exit code shift olur.
+
+**Reddedilenler:**
+
+- Daha derin refactor şu an gerekli değil.
+- "Closed GPP'de review_evidence skip" yanlış yönde.
+
+**Eklenen invariantlar:**
+
+1. `_unbound` (`review_evidence_context_unbound`) failure kalmalı —
+   forged / mismatched binding head SHA drift demek; review_action
+   değil.
+2. `_missing` (`review_evidence_missing`) failure kalmalı — artifact
+   YOK; procedural değil.
+3. `_schema_invalid` (`review_evidence_schema_invalid`) failure kalmalı
+   — broken artifact; procedural değil.
+4. Boundary violations review-action ile mixed olduğunda failure +
+   exit 1 kalmalı (`admin_bypass_requested`, `forbidden_secret_context`,
+   `live_adapter_execution_requested`, `gpp_boundary_open`,
+   `pat_backed_bot_actor`, `agent_release_authority`).
+5. `build_technical_check_run` `[not_accepting]` enforce → `success`
+   (was: `failure`).
+6. `build_review_check_run` `[not_accepting]` enforce → `action_required`
+   (was: `success`).
+7. CLI wrapper exit code testi faydalı olur (atlandı; future-follow-up;
+   gerçek Python-level wrapper_exit_code direct çağrı testleri kapsam
+   sağlıyor).
+
+## 3. Değişiklik scope
+
+### 3a. Source
+
+`ao_kernel/ao_release_gate.py`:
+
+- `_REVIEW_ACTION_FINDINGS` set'ine iki finding eklenir:
+  - `ao_release_gate_review_evidence_not_accepting`
+  - `ao_release_gate_review_evidence_context_unverifiable`
+- Set docstring'i procedural-evidence semantiğini açıklar.
+- `finding_conclusion_kind` docstring genişler (sibling evidence
+  failure'ları net listeler).
+- `wrapper_exit_code` docstring genişler (procedural vs structural
+  evidence failure ayrımı).
+- `RG-CONCLUSION-SEMANTICS` block comment "019e830d extension" ile
+  güncellenir.
+
+### 3b. Tests
+
+`tests/test_ao_release_gate.py`:
+
+- `TestFindingConclusionKind`:
+  - `test_review_missing_is_review_action` (mevcut, kalır)
+  - `test_review_evidence_not_accepting_is_review_action` (YENİ)
+  - `test_review_evidence_context_unverifiable_is_review_action` (YENİ)
+  - `test_branch_stale_is_stale` (mevcut, kalır)
+  - `test_real_violation_is_failure` (mevcut — iki finding listeden
+    çıkarıldı)
+  - `test_structural_evidence_defects_remain_failure` (YENİ — 3 finding)
+  - `test_boundary_violations_remain_failure` (YENİ — 6 finding)
+  - `test_none_finding_defaults_to_failure` (mevcut)
+  - `test_unknown_finding_defaults_to_failure` (mevcut)
+- `TestConclusionForFindings`:
+  - `test_any_failure_wins` (revize — `not_accepting` yerine
+    `forbidden_secret_context` boundary-violation kullan)
+  - `test_structural_evidence_failure_wins_over_procedural` (YENİ)
+  - `test_evidence_procedural_findings_are_action_required` (YENİ)
+  - `test_evidence_procedural_mixed_with_human_review_is_action_required`
+    (YENİ)
+- `TestWrapperExitCode`:
+  - `test_real_violation_returns_one` (revize — `forbidden_secret_context`)
+  - `test_structural_evidence_missing_returns_one` (YENİ)
+  - `test_structural_evidence_schema_invalid_returns_one` (YENİ)
+  - `test_structural_evidence_context_unbound_returns_one` (YENİ)
+  - `test_procedural_evidence_not_accepting_returns_zero` (YENİ)
+  - `test_procedural_evidence_context_unverifiable_returns_zero` (YENİ)
+  - `test_review_plus_procedural_evidence_returns_zero` (YENİ)
+  - `test_procedural_evidence_plus_violation_returns_one` (YENİ)
+  - `test_procedural_evidence_plus_structural_evidence_returns_one` (YENİ)
+  - `test_admin_bypass_violation_returns_one` (YENİ)
+- `TestBuildTechnicalCheckRun`:
+  - `test_real_violation_is_failure_in_enforce` (revize —
+    `forbidden_secret_context`)
+  - `test_structural_evidence_missing_is_failure_in_enforce` (YENİ)
+  - `test_procedural_evidence_alone_is_success_in_enforce` (YENİ — 2
+    finding)
+  - `test_review_plus_violation_is_failure_in_enforce` (revize —
+    boundary violation kullan)
+  - `test_procedural_plus_structural_evidence_is_failure_in_enforce`
+    (YENİ)
+  - `test_shadow_mode_neutral_for_blocker` (revize — `missing`)
+- `TestBuildReviewCheckRun`:
+  - `test_real_violation_ignored_in_review_check` (revize —
+    `forbidden_secret_context`)
+  - `test_structural_evidence_missing_ignored_in_review_check` (YENİ)
+  - `test_procedural_evidence_is_action_required_in_review_check` (YENİ)
+  - `test_procedural_evidence_is_neutral_in_review_check_shadow` (YENİ)
+
+### 3c. Workflow / Schema / Config
+
+YOK — finding code taksonomisi public API'ya zaten string olarak
+yansıyor; type değişikliği yok. Decision JSON shape değişmiyor.
+
+## 4. Out-of-scope
+
+- CLI wrapper exit code subprocess testi (Codex önerdi; mevcut
+  Python-level direct çağrı testleri taksonomi shift'i tam kapsadığı
+  için future-follow-up).
+- Mevcut PR #764 evidence dosyası eklemek (governance hijyeni; bu
+  PR'ın amacı taksonomi sertleştirme).
+- GPP closeout flag ile review_evidence skip (Codex reddetti; bypass
+  riski yüksek).
+
+## 5. Etki
+
+- **PR #764:** taksonomi merge sonrası kendi gate'i `action_required`
+  döner; wrapper exit 0; required check yeşil (CODEOWNER review veya
+  GitHub `require_code_owner_reviews` rule pasif olduğu için). Re-run
+  + merge.
+- **Gelecek high-risk PR'lar:** evidence dosyası eksik durumlar
+  "kırmızı CI" yerine "operatör action required" gösterir; doğru
+  semantik signal.
+- **Gerçek defects (missing artifact, schema invalid, forged binding):**
+  failure kalır; gate sertliği korunur.
+
+## 6. Acceptance
+
+- Local test: `pytest tests/test_ao_release_gate.py -x` (440+ pass).
+- Local lint: `ruff check ao_kernel/ tests/`.
+- Local type: `mypy ao_kernel/ scripts/ --ignore-missing-imports`.
+- Cross-AI post-impl review (Codex thread `019e830d` reply ile
+  `019df...` veya yeni thread).
+- PR squash mesajı: `Implementer: Anthropic Claude` /
+  `Reviewer: OpenAI Codex` audit trail.
+
+## 7. Bağlantı
+
+- `RG-CONCLUSION-SEMANTICS` C-prime wrapper (thread `019e65c3`) — bu
+  extension onun finding sub-classification'ını genişletir.
+- V5 P0-4 (PR #764 CI shadow-skip permanent fix) — bu fix unblock
+  eder; PR #764 ayrı concern.
+- HARD RULE — Uzun Vadeli Kalıcı Çözüm: review_evidence skip yerine
+  taksonomi düzeltme (Codex onayı ile).
+- HARD RULE — Cross-AI Peer Review: implementer Anthropic Claude;
+  reviewer OpenAI Codex.

--- a/.claude/plans/RG-019E830D-EVIDENCE-FINDING-TAXONOMY.md
+++ b/.claude/plans/RG-019E830D-EVIDENCE-FINDING-TAXONOMY.md
@@ -149,15 +149,29 @@ yansıyor; type değişikliği yok. Decision JSON shape değişmiyor.
 
 ## 5. Etki
 
-- **PR #764:** taksonomi merge sonrası kendi gate'i `action_required`
-  döner; wrapper exit 0; required check yeşil (CODEOWNER review veya
-  GitHub `require_code_owner_reviews` rule pasif olduğu için). Re-run
-  + merge.
-- **Gelecek high-risk PR'lar:** evidence dosyası eksik durumlar
+- **PR #764:** taksonomi merge sonrası kendi gate'i kırmızı CI üretmez:
+  - Legacy wrapper `ao-release-gate` artık kırmızı dönmez (exit 0).
+  - Yeni `ao-release-gate-technical` `success` döner (procedural findings
+    filtered out).
+  - Yeni `ao-release-gate-review` `action_required` döner — required
+    check ise merge **hâlâ bloklu**.
+  - Merge için: operatör CODEOWNER review submit eder, VEYA review
+    evidence file commit + accept edilir, VEYA context_unverifiable
+    sebebi external (network/eventual consistency) ise re-run.
+  - Otomatik "rerun + merge" YOK — `action_required` required check
+    satisfaction değildir.
+- **Gelecek high-risk PR'lar:** sadece `review_evidence_not_accepting`
+  veya `review_evidence_context_unverifiable` bulgusu olduğunda
   "kırmızı CI" yerine "operatör action required" gösterir; doğru
   semantik signal.
-- **Gerçek defects (missing artifact, schema invalid, forged binding):**
-  failure kalır; gate sertliği korunur.
+- **Structural evidence defects** (`review_evidence_missing`,
+  `review_evidence_schema_invalid`, `review_evidence_context_unbound`):
+  hâlâ failure; kırmızı CI; gate sertliği korunur. Bu durumda
+  evidence artifact'in kendisi bozuk veya yok — procedural değil,
+  defect; üretilmesi/düzeltilmesi gerek.
+- **Boundary violations** (admin bypass, secret context, live adapter,
+  GPP boundary open, PAT-backed bot, AI release authority):
+  taksonomi taraması dışında; failure kalır.
 
 ## 6. Acceptance
 
@@ -168,6 +182,34 @@ yansıyor; type değişikliği yok. Decision JSON shape değişmiyor.
   `019df...` veya yeni thread).
 - PR squash mesajı: `Implementer: Anthropic Claude` /
   `Reviewer: OpenAI Codex` audit trail.
+
+## 6.1. Required-check topology önkoşulu (operatör doğrulama)
+
+Bu fix'in güvenliği, GitHub branch protection / ruleset üzerinde şu
+iki check'in required + source-pinned olmasına bağlıdır:
+
+- `ao-release-gate-technical`
+- `ao-release-gate-review`
+
+Eğer sadece legacy wrapper `ao-release-gate` required ise, bu patch
+wrapper'ı yeşile çevirerek (review-action-only case) merge'i fazla
+gevşetebilir. Repo SSOT (ao-ma-10 dual source-pinned model) bu modeli
+destekliyor; ancak merge öncesi operatör live ruleset'i doğrulamalı:
+
+```bash
+gh api repos/Halildeu/ao-kernel/rules/branches/main \
+  --jq '.[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
+```
+
+Beklenen output (en az):
+```
+ao-release-gate-technical
+ao-release-gate-review
+```
+
+Codex iter-2 absorb: live ruleset bu turda sandbox/TMP/network kısıtı
+sebebiyle Codex tarafında doğrulanamadı. Merge öncesi operatör veya
+ao-release-gate-publish-check-runs.py kontrolü gerek.
 
 ## 7. Bağlantı
 

--- a/ao_kernel/ao_release_gate.py
+++ b/ao_kernel/ao_release_gate.py
@@ -1825,17 +1825,24 @@ def build_review_check_run(
 ) -> AoReleaseGateCheckRun:
     """Build the ``ao-release-gate-review`` check-run shape.
 
-    Review check covers only CODEOWNER review pending on the current PR
-    head. It deliberately ignores failure / stale findings; those are
-    published on the companion ``ao-release-gate-technical`` check.
+    Review check covers reviewer/operator-action signals on the current
+    PR head: a pending CODEOWNER review, OR a procedurally-fixable review
+    evidence finding (019e830d extension —
+    ``review_evidence_not_accepting`` and
+    ``review_evidence_context_unverifiable``). It deliberately ignores
+    failure / stale findings; those are published on the companion
+    ``ao-release-gate-technical`` check.
 
     Conclusion:
 
     - ``shadow`` mode: ``success`` when no review-action finding;
-      ``neutral`` when review pending.
+      ``neutral`` when any review-action finding is present.
     - ``enforce`` mode: ``success`` when no review-action finding;
-      ``action_required`` when CODEOWNER review missing (this conclusion
-      does NOT satisfy required status check; merge stays blocked).
+      ``action_required`` when any review-action finding (CODEOWNER review
+      missing OR procedural evidence finding). This conclusion does NOT
+      satisfy a required status check; merge stays blocked until the
+      operator/reviewer resolves it (submit CODEOWNER review, accept
+      evidence, or re-run when context becomes verifiable).
 
     Operator UI signal: ``action_required`` surfaces as "needs attention"
     rather than "failing", honoring the operator HARD RULE that approve
@@ -1844,10 +1851,14 @@ def build_review_check_run(
 
     review_findings = _findings_for_kind(findings, "review_action")
     summary = (
-        "CODEOWNER review pending on current head." if review_findings else "CODEOWNER review present or not required."
+        "Reviewer/operator action required on current head."
+        if review_findings
+        else "No reviewer/operator action required."
     )
     text = (
-        "Review findings: " + ", ".join(review_findings) if review_findings else "No review-pending findings recorded."
+        "Review-action findings: " + ", ".join(review_findings)
+        if review_findings
+        else "No review-action findings recorded."
     )
     conclusion: GithubCheckConclusion
     if not review_findings:

--- a/ao_kernel/ao_release_gate.py
+++ b/ao_kernel/ao_release_gate.py
@@ -88,9 +88,7 @@ def _load_ao_ma10_evidence_bundle_schema() -> dict[str, Any]:
 def _load_ao_ma10_high_risk_supersession_schema() -> dict[str, Any]:
     """Load the bundled AO-MA-10 high-risk supersession evidence schema."""
 
-    schema_path = resources.files("ao_kernel.defaults.schemas").joinpath(
-        AO_MA10_HIGH_RISK_SUPERSESSION_SCHEMA_NAME
-    )
+    schema_path = resources.files("ao_kernel.defaults.schemas").joinpath(AO_MA10_HIGH_RISK_SUPERSESSION_SCHEMA_NAME)
     return cast(dict[str, Any], json.loads(schema_path.read_text(encoding="utf-8")))
 
 
@@ -114,7 +112,8 @@ GithubCheckConclusion = Literal["success", "failure", "neutral", "action_require
 ConclusionMode = Literal["shadow", "enforce"]
 DEFAULT_CONCLUSION_MODE: ConclusionMode = "shadow"
 
-# RG-CONCLUSION-SEMANTICS (Codex thread 019e65c3 absorb):
+# RG-CONCLUSION-SEMANTICS (Codex thread 019e65c3 absorb +
+# 019e830d extension):
 # Finding codes are categorized by the *operator action shape* they imply.
 # The legacy single check-run `ao-release-gate` collapses everything to
 # success/failure, which mis-signals "operator approve missing" as a CI
@@ -124,14 +123,44 @@ DEFAULT_CONCLUSION_MODE: ConclusionMode = "shadow"
 # A C-prime wrapper preserves the legacy job's required check name while
 # shifting review-missing semantics off the failure axis (see
 # wrapper_exit_code below).
+#
+# 019e830d extension — the action_required category was broadened from
+# "human review missing" to "operator/reviewer evidence action required":
+# two evidence-acceptance findings (``review_evidence_not_accepting``
+# and ``review_evidence_context_unverifiable``) are procedural, not
+# defects, and now classify as review_action. Structural evidence
+# defects (missing artifact, schema invalid, context unbound/forged)
+# remain failure. The merge-blocking allow=false decision is unchanged;
+# only the surfaced check-run conclusion and wrapper exit code shift.
 FindingConclusionKind = Literal["failure", "review_action", "stale"]
 
 # Findings that map to GitHub Checks API `action_required` conclusion.
 # This conclusion does NOT satisfy a required status check, so merge is
 # still blocked — but the UI signal is "needs attention", not "failing".
+#
+# Semantically these are *procedural* blockers — operator must submit a
+# CODEOWNER review on the current PR head, OR supply review evidence
+# that the gate can verify. Not a code defect, not a governance
+# violation, not a structural input error.
+#
+# NOTE — only the two evidence-acceptance findings are taxonomized as
+# review_action:
+#   - ``review_evidence_not_accepting`` — evidence file exists/parses
+#     but the gate does not currently accept the evidence shape for
+#     this PR's head SHA (procedurally fixable via CODEOWNER review).
+#   - ``review_evidence_context_unverifiable`` — context binding could
+#     not be verified at evaluation time (network/GitHub eventual
+#     consistency; procedurally fixable via re-run or CODEOWNER review).
+#
+# Sibling evidence findings remain ``failure`` (real defects):
+#   - ``review_evidence_missing`` (no evidence file at all)
+#   - ``review_evidence_schema_invalid`` (broken artifact)
+#   - ``review_evidence_context_unbound`` (forged / mismatched binding)
 _REVIEW_ACTION_FINDINGS: frozenset[str] = frozenset(
     {
         "ao_release_gate_high_risk_human_review_missing",
+        "ao_release_gate_review_evidence_not_accepting",
+        "ao_release_gate_review_evidence_context_unverifiable",
     }
 )
 
@@ -157,13 +186,16 @@ def finding_conclusion_kind(finding_code: str | None) -> FindingConclusionKind:
 
     Three kinds:
 
-    - ``review_action`` — the operator needs to submit a CODEOWNER review
-      on the current PR head. The blocker is procedural, not a code or
-      governance defect.
+    - ``review_action`` — the operator must submit a CODEOWNER review on
+      the current PR head, OR the supplied review evidence requires
+      procedural follow-up (not-accepting shape, context unverifiable at
+      evaluation time). The blocker is procedural, not a code or
+      governance defect. See ``_REVIEW_ACTION_FINDINGS`` for the exact
+      finding set and the rationale for which evidence sub-codes count.
     - ``stale`` — the PR branch needs rebase/update. Not a code defect.
     - ``failure`` — everything else: real governance violation, structural
       input error, secret boundary, scope mismatch, fork/trust violation,
-      and so on.
+      missing/forged/schema-invalid evidence artifact, and so on.
 
     A finding code of ``None`` returns ``failure`` defensively so unknown
     blockers never silently map to success.
@@ -203,10 +235,11 @@ def conclusion_for_findings(findings: list[str]) -> GithubCheckConclusion:
 def wrapper_exit_code(decision: ReleaseGateDecisionValue, findings: list[str]) -> int:
     """C-prime compatibility wrapper for the legacy ao-release-gate job.
 
-    Returns 0 (success) when the gate would allow merge OR when the only
-    blocker is a pending CODEOWNER review on the current PR head. Returns
-    1 (failure) for any real violation, stale branch, or mixed blocker
-    set.
+    Returns 0 (success) when the gate would allow merge OR when every
+    blocker in the set is a review-action finding (pending CODEOWNER
+    review on the current PR head OR procedurally-fixable review evidence
+    finding). Returns 1 (failure) for any real violation, stale branch,
+    or mixed blocker set containing at least one non-review-action code.
 
     This function preserves the legacy ``ao-release-gate`` job's required
     status check name while shifting review-missing semantics off the
@@ -216,9 +249,14 @@ def wrapper_exit_code(decision: ReleaseGateDecisionValue, findings: list[str]) -
     ``require_code_owner_reviews`` branch protection rule, not by this
     wrapper.
 
-    Critical: the wrapper relaxes ONLY the lone-review-action case. A
+    Critical: the wrapper relaxes ONLY the all-review-action case. A
     review_action blocker mixed with any other blocker still returns 1.
-    Real governance violations are never softened.
+    Real governance violations are never softened. Procedurally-fixable
+    evidence findings (``review_evidence_not_accepting``,
+    ``review_evidence_context_unverifiable``) count as review_action;
+    structural evidence defects (``review_evidence_missing``,
+    ``review_evidence_schema_invalid``, ``review_evidence_context_unbound``)
+    remain ``failure``.
     """
 
     if decision == ALLOW_AUTONOMOUS_MERGE_DECISION:
@@ -557,7 +595,7 @@ def _is_ao_ma10_low_risk_autonomous_smoke_path(path: str) -> bool:
         return False
     if not path.startswith(AO_MA10_LOW_RISK_AUTONOMOUS_SMOKE_PREFIX):
         return False
-    relative = path[len(AO_MA10_LOW_RISK_AUTONOMOUS_SMOKE_PREFIX):]
+    relative = path[len(AO_MA10_LOW_RISK_AUTONOMOUS_SMOKE_PREFIX) :]
     return bool(relative) and "/" not in relative and relative.endswith(".md")
 
 
@@ -938,14 +976,8 @@ def _high_risk_supersession_authority_boundary_open(evidence: dict[str, Any]) ->
         if not isinstance(verdict, dict):
             continue
         if (
-            (
-                "release_authority" in verdict
-                and verdict.get("release_authority") != "ao-release-gate+github-ruleset"
-            )
-            or (
-                "ai_output_release_authority" in verdict
-                and verdict.get("ai_output_release_authority") is not False
-            )
+            ("release_authority" in verdict and verdict.get("release_authority") != "ao-release-gate+github-ruleset")
+            or ("ai_output_release_authority" in verdict and verdict.get("ai_output_release_authority") is not False)
             or ("secrets_recorded" in verdict and verdict.get("secrets_recorded") is not False)
             or ("support_widening" in verdict and verdict.get("support_widening") is not False)
             or ("production_platform_claim" in verdict and verdict.get("production_platform_claim") is not False)
@@ -1252,9 +1284,7 @@ def _evaluate_high_risk_supersession_checks(
         for provider_binding in provider_bindings
     )
     context_bound = (
-        binding is not None
-        and _high_risk_supersession_binding_matches(binding, context)
-        and provider_bindings_match
+        binding is not None and _high_risk_supersession_binding_matches(binding, context) and provider_bindings_match
     )
     context_check = (
         _pass(
@@ -1376,8 +1406,7 @@ def _evaluate_ao_ma10_evidence_bundle_checks(
             _pass(
                 "ao_ma10_authority_boundary",
                 detail=(
-                    "AO-MA-10l low-risk smoke keeps release authority with "
-                    "ao-release-gate plus the GitHub ruleset."
+                    "AO-MA-10l low-risk smoke keeps release authority with ao-release-gate plus the GitHub ruleset."
                 ),
             ),
         ]
@@ -1436,10 +1465,7 @@ def _evaluate_ao_ma10_evidence_bundle_checks(
             "production_platform_claim" in raw_guard_flags
             and raw_guard_flags.get("production_platform_claim") is not False
         )
-        or (
-            "live_adapter_execution" in raw_guard_flags
-            and raw_guard_flags.get("live_adapter_execution") is not False
-        )
+        or ("live_adapter_execution" in raw_guard_flags and raw_guard_flags.get("live_adapter_execution") is not False)
     )
     if authority_boundary_explicitly_open:
         return [
@@ -1582,17 +1608,13 @@ def _evaluate_ao_ma10_evidence_bundle_checks(
             authority_check,
         ]
 
-    repo_match = (
-        context["repository"] is not None and binding.get("repository_full_name") == context["repository"]
-    )
-    base_match = (
-        context["base_ref"] is not None
-        and _normalize_binding_ref(binding.get("base_ref")) == _normalize_binding_ref(context["base_ref"])
-    )
-    head_ref_match = (
-        context["head_ref"] is not None
-        and _normalize_binding_ref(binding.get("head_ref")) == _normalize_binding_ref(context["head_ref"])
-    )
+    repo_match = context["repository"] is not None and binding.get("repository_full_name") == context["repository"]
+    base_match = context["base_ref"] is not None and _normalize_binding_ref(
+        binding.get("base_ref")
+    ) == _normalize_binding_ref(context["base_ref"])
+    head_ref_match = context["head_ref"] is not None and _normalize_binding_ref(
+        binding.get("head_ref")
+    ) == _normalize_binding_ref(context["head_ref"])
     head_match = context["head_sha"] is not None and binding.get("head_sha") == context["head_sha"]
     digest_match = binding.get("diff_digest") == diff_digest(context["changed_paths"])
     count_match = binding.get("changed_files_count") == len(context["changed_paths"])
@@ -1890,12 +1912,10 @@ def build_ao_release_gate_decision(
 
     decision_generated_at = generated_at or utc_timestamp()
     context = extract_ao_release_gate_context(payload, gpp_status)
-    high_risk_supersession_checks, high_risk_supersession_valid = (
-        _evaluate_high_risk_supersession_checks(
-            high_risk_supersession_evidence,
-            context,
-            decision_generated_at=decision_generated_at,
-        )
+    high_risk_supersession_checks, high_risk_supersession_valid = _evaluate_high_risk_supersession_checks(
+        high_risk_supersession_evidence,
+        context,
+        decision_generated_at=decision_generated_at,
     )
     checks = [
         _check(
@@ -2008,9 +2028,7 @@ def build_ao_release_gate_decision(
         *high_risk_supersession_checks,
         _check(
             "path_sensitive_human_review",
-            _path_sensitive_human_review_satisfied(
-                context, high_risk_supersession_valid=high_risk_supersession_valid
-            ),
+            _path_sensitive_human_review_satisfied(context, high_risk_supersession_valid=high_risk_supersession_valid),
             finding_code="ao_release_gate_high_risk_human_review_missing",
             pass_detail=(
                 "The path-sensitive human-review gate is inactive, no high-risk paths changed, "

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,22 +1,17 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-11A-2-PLAN-APPROVAL-GATE",
+  "work_package": "RG-019E830D-EVIDENCE-FINDING-TAXONOMY-EXTENSION",
   "implementer": { "agent": "claude", "provider": "anthropic" },
   "reviewer": { "agent": "codex", "provider": "openai", "verdict": "AGREE" },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-11a-2-plan-approval-gate",
+    "head_ref": "refs/heads/codex/release-gate-review-evidence-action-required",
     "changed_files": [
-      ".claude/plans/AO-MA-11A-2-PLAN-APPROVAL-GATE.md",
-      ".github/workflows/ao-ma-11a-plan-approval.yml",
-      "ao_kernel/defaults/schemas/ao-ma-11a-2-plan-approval-gate-report.schema.v1.json",
+      ".claude/plans/RG-019E830D-EVIDENCE-FINDING-TAXONOMY.md",
+      "ao_kernel/ao_release_gate.py",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma11a2_plan_approval_gate.py",
-      "tests/test_ao_ma11a2_gate_cli.py",
-      "tests/test_ao_ma11a2_gate_report_schema_invariant.py",
-      "tests/test_ao_ma11a2_path_containment.py",
-      "tests/test_ao_ma11a2_workflow_invariant.py"
+      "tests/test_ao_release_gate.py"
     ]
   },
   "checks_considered": [
@@ -30,20 +25,12 @@
     { "name": "cross_provider_review", "status": "pass" }
   ],
   "findings": [
-    "AO-MA-11A-2-PLAN-APPROVAL-GATE: V5 Epic 1 E-1-1 sub-slice. 11A-1 (consensus + approval schema + validator + tests + plan) MERGED main; pure-policy core; 4-state gate_status lifecycle. Bu slice operator approval kapisi icin workflow + GitHub Environment wiring saglar. 11E-2b pattern (PR #789+#790) re-use disiplin.",
-    "Codex plan-time consensus thread 019e82cc: iter-1 REVISE (4 binding + 8 sub-decision) -> iter-2 REVISE (6 blocker) -> iter-3 AGREE + ready_for_impl=true. 4 binding: (1) plan_path + stale-main guard, (2) GitHub approval identity proof, (3) artifact-only kayit, (4) CLI canonical gate-report emitter. 6 iter-2 blocker: input count + 10-cond gate, validate+approve iki job, CLI stage order, API response shape + fixtures, bypass vs self-review separation, dispatch authority single model.",
-    "Two-job workflow (.github/workflows/ao-ma-11a-plan-approval.yml): validate (unprotected fail-fast; CLI validate-only call) + approve (environment-protected; 10-condition compound if; needs validate). All path/SHA/binding/consensus/api validation re-runs in approve job (validate output NOT trust source). Permissions minimum (contents:read + actions:read + deployments:read; NO contents:write). prevent_self_review defense in depth.",
-    "CLI 7-stage canonical emitter (scripts/ao_ma11a2_plan_approval_gate.py): path containment (absolute/.. reject + symlink-safe resolve.is_relative_to) -> raw SHA recompute (sha256 3 paths) -> plan binding (repo + base_ref refs/heads/main + base_sha == github.sha + plan_digest == sha256(plan_path)) -> validate_consensus_bundle (unanimous AGREE) -> GitHub approval review history fetch (5-retry backoff 2s; eventual consistency) -> construct approval.json from API response (Codex iter-2 §3 order; NOT validate_approval here) -> validate_approval FINAL stage (triple SHA-bind + AGREE). gh_api_caller DI; pure stdlib; no GitHub write at runtime.",
-    "Schema (ao-ma-11a-2-plan-approval-gate-report.schema.v1.json): Draft 2020-12 strict; additionalProperties:false root; 10 final_decision enum (after iter-2 +pre_flight_passed) + 6 approval_api_state enum + 5 stage pass flags + bypass 3-field (no_bypass_state_observed + self_review_rejected + required_reviewer_configured) + computed bypass_detected + environment_name const ao-ma-plan-approval + base_sha 40-hex + audit_url pattern github.com/.../actions/runs/<id>. allOf if/then: approved -> all 5 stages pass + bypass:false + approval_api_state=approved + login/at non-null.",
-    "Tests (47 PASS): test_ao_ma11a2_gate_cli.py (run_gate full happy path + stage fail-closed + parse_approval 4 API fixtures: happy/rejected/empty/wrong_environment + fetch_approvals retry + self_review_detected_marks_bypass + GateReport.compute_bypass 2 cases); test_ao_ma11a2_workflow_invariant.py (workflow_dispatch only + 7 required:true inputs + permissions no contents:write + 2-job + needs validate + environment + 10-cond compound if + preflight + artifact upload + no admin/ruleset); test_ao_ma11a2_gate_report_schema_invariant.py (Draft 2020-12 + enum pins + allOf approved invariants); test_ao_ma11a2_path_containment.py (absolute/.. reject + symlink escape). ruff + mypy strict clean.",
-    "Cross-AI peer review trail (HARD RULE: implementer provider anthropic != reviewer provider openai). Codex plan-time thread 019e82cc iter-3 AGREE absorbed. Post-impl review thread 019e82e4 iter-1+2+3 REVISE absorbed.",
-    "Three guard flags + iso_25010_certified + certification_target + external_audit_claim ALL const false korunur. live_adapter_execution=false; support_widening=false; production_platform_claim=false. Bu PR HICBIR flag flip yok. Workflow runtime'da NO contents:write (artifact-only emission); canli approval operator-bound (Environment required reviewer Halildeu). High-risk path (.github/workflows/) cross-AI provider-independent adversarial check ile pinli. No CODEOWNERS / ruleset / branch protection / admin / secrets / new .github push trigger.",
-    "Operator setup (post-merge): GitHub Settings -> Environments -> create ao-ma-plan-approval + required reviewer Halildeu + prevent_self_review:true + wait_timer:0. Dispatch model: agent gh CLI workflow_dispatch with 7 inputs (consensus bundle + approval request + plan + 3 SHA + confirmation); Halildeu Environment review UI'da approve. Post-merge first dispatch test acceptance: gate_report.json schema-valid + final_decision=approved + bypass_detected:false.",
-    "V5 Epic 1 E-1-1 sub-issue (#774 Epic 1 reference) — second E-1-X sub-slice landing (after E-1-2 11E-2a/b).",
-    "Codex post-impl iter-1 REVISE absorb (thread 019e82e4): (A) validate job `|| true` swallow + missing --validate-only flag fixed: CLI --validate-only stage 4 (env preflight) after stops short-circuiting; workflow validate job uses --validate-only; fail-fast (no `|| true`). (G) Schema approved invariant strengthened: approved → 3 bypass sub-fields (no_bypass_state_observed + self_review_rejected + required_reviewer_configured) all const true + stage_fail_reason const null (allOf if/then). (Evidence hygiene §3) reviewer.verdict pre-AGREE operational requirement: local_gpp_gate schema enum {AGREE/REVISE/BLOCK} only; verdict-less evidence triggers fail-closed; PENDING enum value missing in current schema. Workaround: implementer commits AGREE for gate-pass; Codex iter REVISE → evidence updated with iter-N absorb (this finding). Long-term fix: add PENDING enum to local-ai-review-evidence.schema (separate scope/slice).",
-    "Codex post-impl iter-2 REVISE absorb (validate_only schema collision): final_decision enum 9 → 10 (+pre_flight_passed); new allOf invariant for pre_flight_passed (path/SHA/binding/consensus pass + approval_validator_pass:false + approval_api_state:empty + null login/at + null fail_reason); CLI run_gate(validate_only=True) emits pre_flight_passed (NOT approved); to_exit_code() 0 for both approved + pre_flight_passed; tests +2 (validate_only invariant + schema enum).",
-    "Codex post-impl iter-3 REVISE absorb: pre_flight_passed schema invariant +required_reviewer_configured:true pin (env preflight pass kanıtı); CLI validate-only test assertion required_reviewer_configured eklendi; evidence güncel (10 enum + 47 PASS + iter-3 finding).",
-    "Test count: 47 PASS (assertion added to existing test; test count unchanged from iter-2) (+1 required_reviewer assertion in pre_flight_passed CLI test). ruff + mypy strict clean unchanged."
+    "RG-019E830D extension: PR #793 V5 P0-4 unblock — ao-release-gate finding taxonomy genişletildi. Iki evidence finding (review_evidence_not_accepting + review_evidence_context_unverifiable) failure → review_action (action_required Checks API conclusion) taşındı. Structural failures (missing, schema_invalid, context_unbound) failure pinlendi.",
+    "Codex plan-time thread 019e830d iter-1 REVISE + ready_for_impl=true: sibling evidence failure pinleme + boundary violation pinleme + dual check-run behavior + build_technical/review_check_run filtering + mixed-blocker rules. Plus operator action shape semantigi genisletildi (review_action = CODEOWNER review pending OR procedural evidence finding).",
+    "Codex post-impl review iter-1 REVISE -> iter-2 REVISE -> iter-3 AGREE (single P1 + 2 nit absorb chain): plan doc PR #764 effect rewritten (no rerun+merge bypass claim), structural evidence claim narrowed, build_review_check_run docstring + summary/text wording widened from CODEOWNER-only, required-check topology preflight section 6.1 added, 2 yeni invariant test (pr764_exact_procedural_pair + structural_pair).",
+    "Source changes: ao_kernel/ao_release_gate.py _REVIEW_ACTION_FINDINGS frozenset extended (3 finding) + docstring extensions (set + finding_conclusion_kind + wrapper_exit_code + RG-CONCLUSION-SEMANTICS block comment); tests/test_ao_release_gate.py 44 yeni + 6 mevcut revize; plan doc + audit nit fix.",
+    "Tests: 111 pass local in tests/test_ao_release_gate.py; 440 pass + 2 skip in tests/ -k 'release_gate or ao_ma10'; ruff + mypy --ignore-missing-imports clean.",
+    "Three guard flags + production claim + iso/audit claim ALL const false korunur. live_adapter_execution=false; support_widening=false; production_platform_claim=false. Bu PR HICBIR flag flip yok. Cross-AI peer review trail (HARD RULE implementer Anthropic Claude != reviewer OpenAI Codex; threads 019e830d plan-time + post-impl)."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_ao_release_gate.py
+++ b/tests/test_ao_release_gate.py
@@ -1526,6 +1526,27 @@ class TestWrapperExitCode:
             == 1
         )
 
+    def test_pr764_exact_procedural_pair_wrapper_zero(self) -> None:
+        # Codex 019e830d iter-2 absorb: PR #764's *exact* finding pair
+        # (not_accepting + context_unverifiable). Pins the regression
+        # signal at the wrapper boundary.
+        findings = [
+            "ao_release_gate_review_evidence_not_accepting",
+            "ao_release_gate_review_evidence_context_unverifiable",
+        ]
+        assert wrapper_exit_code(DENY_MISSING_EVIDENCE_DECISION, findings) == 0
+
+    def test_structural_pair_wrapper_one(self) -> None:
+        # Codex 019e830d iter-2 absorb: real decision-core often emits
+        # both structural and procedural findings in the same set
+        # (artifact missing AND context unverifiable). Wrapper must
+        # still fail closed when ANY blocker is structural failure.
+        findings = [
+            "ao_release_gate_review_evidence_missing",
+            "ao_release_gate_review_evidence_context_unverifiable",
+        ]
+        assert wrapper_exit_code(DENY_MISSING_EVIDENCE_DECISION, findings) == 1
+
     def test_stale_branch_returns_one(self) -> None:
         # Stale branch is not a review-action blocker; wrapper does not relax.
         assert (

--- a/tests/test_ao_release_gate.py
+++ b/tests/test_ao_release_gate.py
@@ -1248,19 +1248,56 @@ class TestFindingConclusionKind:
     def test_review_missing_is_review_action(self) -> None:
         assert finding_conclusion_kind("ao_release_gate_high_risk_human_review_missing") == "review_action"
 
+    def test_review_evidence_not_accepting_is_review_action(self) -> None:
+        # 019e830d extension: evidence not-accepting is procedural (operator
+        # CODEOWNER review can resolve it), not a code defect.
+        assert finding_conclusion_kind("ao_release_gate_review_evidence_not_accepting") == "review_action"
+
+    def test_review_evidence_context_unverifiable_is_review_action(self) -> None:
+        # 019e830d extension: context unverifiable means evaluation-time
+        # binding could not be verified (network / eventual consistency);
+        # procedurally fixable via re-run or CODEOWNER review.
+        assert finding_conclusion_kind("ao_release_gate_review_evidence_context_unverifiable") == "review_action"
+
     def test_branch_stale_is_stale(self) -> None:
         assert finding_conclusion_kind("ao_release_gate_branch_not_up_to_date") == "stale"
 
     def test_real_violation_is_failure(self) -> None:
         for code in (
-            "ao_release_gate_review_evidence_not_accepting",
-            "ao_release_gate_review_evidence_context_unverifiable",
             "ao_release_gate_wrong_repository",
             "ao_release_gate_untrusted_fork",
             "ao_release_gate_pull_request_target_context",
             "ao_release_gate_diff_scope_missing",
             "ao_release_gate_required_checks_not_green",
             "ao_release_gate_payload_not_object",
+        ):
+            assert finding_conclusion_kind(code) == "failure", code
+
+    def test_structural_evidence_defects_remain_failure(self) -> None:
+        # 019e830d extension invariant — sibling evidence findings are
+        # NOT review_action. These remain ``failure`` because they
+        # indicate a real artifact defect, not a procedural blocker:
+        #   - missing: no evidence file at all (operator did not supply)
+        #   - schema_invalid: artifact present but broken / malformed
+        #   - context_unbound: forged / mismatched binding (head SHA drift)
+        for code in (
+            "ao_release_gate_review_evidence_missing",
+            "ao_release_gate_review_evidence_schema_invalid",
+            "ao_release_gate_review_evidence_context_unbound",
+        ):
+            assert finding_conclusion_kind(code) == "failure", code
+
+    def test_boundary_violations_remain_failure(self) -> None:
+        # 019e830d extension pin — security / governance boundary
+        # violations must NEVER classify as review_action. These signal
+        # an active intent to bypass policy and are always real failures.
+        for code in (
+            "ao_release_gate_admin_bypass_requested",
+            "ao_release_gate_forbidden_secret_context",
+            "ao_release_gate_live_adapter_execution_requested",
+            "ao_release_gate_gpp_boundary_open",
+            "ao_release_gate_pat_backed_bot_actor",
+            "ao_release_gate_agent_release_authority",
         ):
             assert finding_conclusion_kind(code) == "failure", code
 
@@ -1285,7 +1322,49 @@ class TestConclusionForFindings:
         assert conclusion_for_findings(["ao_release_gate_branch_not_up_to_date"]) == "stale"
 
     def test_any_failure_wins(self) -> None:
-        # Real violation outranks pending action signals.
+        # Real violation outranks pending action signals. Uses a true
+        # boundary-violation failure code so the invariant survives the
+        # 019e830d extension (which moved two evidence findings out of
+        # failure). Picking ``forbidden_secret_context`` because it can
+        # never legitimately become review_action.
+        assert (
+            conclusion_for_findings(
+                [
+                    "ao_release_gate_high_risk_human_review_missing",
+                    "ao_release_gate_forbidden_secret_context",
+                ]
+            )
+            == "failure"
+        )
+
+    def test_structural_evidence_failure_wins_over_procedural(self) -> None:
+        # Pin 019e830d: structural evidence defect (``missing``) still
+        # outranks procedural evidence finding (``not_accepting``).
+        # Keeps the failure axis sharp — the gate does not soften when
+        # the artifact is fundamentally broken.
+        assert (
+            conclusion_for_findings(
+                [
+                    "ao_release_gate_review_evidence_not_accepting",
+                    "ao_release_gate_review_evidence_missing",
+                ]
+            )
+            == "failure"
+        )
+
+    def test_evidence_procedural_findings_are_action_required(self) -> None:
+        # 019e830d extension — the two procedural evidence findings, on
+        # their own, surface as action_required (operator/reviewer can
+        # resolve without code change).
+        for code in (
+            "ao_release_gate_review_evidence_not_accepting",
+            "ao_release_gate_review_evidence_context_unverifiable",
+        ):
+            assert conclusion_for_findings([code]) == "action_required", code
+
+    def test_evidence_procedural_mixed_with_human_review_is_action_required(self) -> None:
+        # Two review_action findings of different sub-shapes still map
+        # to action_required — review_action is monoidally closed.
         assert (
             conclusion_for_findings(
                 [
@@ -1293,7 +1372,7 @@ class TestConclusionForFindings:
                     "ao_release_gate_review_evidence_not_accepting",
                 ]
             )
-            == "failure"
+            == "action_required"
         )
 
     def test_review_plus_stale_no_failure_is_action_required(self) -> None:
@@ -1329,17 +1408,73 @@ class TestWrapperExitCode:
         )
 
     def test_real_violation_returns_one(self) -> None:
+        # Uses a true boundary-violation code so the invariant survives
+        # the 019e830d extension. ``forbidden_secret_context`` is a hard
+        # policy boundary — it can never become review_action.
+        assert (
+            wrapper_exit_code(
+                DENY_POLICY_VIOLATION_DECISION,
+                ["ao_release_gate_forbidden_secret_context"],
+            )
+            == 1
+        )
+
+    def test_structural_evidence_missing_returns_one(self) -> None:
+        # Pin 019e830d: missing evidence artifact is a real defect, not
+        # procedural. Wrapper still fails closed.
+        assert (
+            wrapper_exit_code(
+                DENY_MISSING_EVIDENCE_DECISION,
+                ["ao_release_gate_review_evidence_missing"],
+            )
+            == 1
+        )
+
+    def test_structural_evidence_schema_invalid_returns_one(self) -> None:
+        # Pin 019e830d: malformed evidence artifact is a real defect.
+        assert (
+            wrapper_exit_code(
+                DENY_MISSING_EVIDENCE_DECISION,
+                ["ao_release_gate_review_evidence_schema_invalid"],
+            )
+            == 1
+        )
+
+    def test_structural_evidence_context_unbound_returns_one(self) -> None:
+        # Pin 019e830d: forged / mismatched binding is a real defect
+        # (head SHA drift, evidence does not bind to current PR head).
+        assert (
+            wrapper_exit_code(
+                DENY_MISSING_EVIDENCE_DECISION,
+                ["ao_release_gate_review_evidence_context_unbound"],
+            )
+            == 1
+        )
+
+    def test_procedural_evidence_not_accepting_returns_zero(self) -> None:
+        # 019e830d extension — procedural evidence finding alone is
+        # softened by the wrapper (operator/reviewer can resolve).
         assert (
             wrapper_exit_code(
                 DENY_MISSING_EVIDENCE_DECISION,
                 ["ao_release_gate_review_evidence_not_accepting"],
             )
-            == 1
+            == 0
         )
 
-    def test_review_plus_violation_returns_one(self) -> None:
-        # Wrapper softens ONLY the lone review-action case. Mixed blocker
-        # set with any real violation still fails closed.
+    def test_procedural_evidence_context_unverifiable_returns_zero(self) -> None:
+        # 019e830d extension — context unverifiable is procedural.
+        assert (
+            wrapper_exit_code(
+                DENY_MISSING_EVIDENCE_DECISION,
+                ["ao_release_gate_review_evidence_context_unverifiable"],
+            )
+            == 0
+        )
+
+    def test_review_plus_procedural_evidence_returns_zero(self) -> None:
+        # 019e830d extension — two review_action findings of different
+        # sub-shapes still soften (wrapper relaxes all-review-action set).
         assert (
             wrapper_exit_code(
                 DENY_POLICY_VIOLATION_DECISION,
@@ -1347,6 +1482,46 @@ class TestWrapperExitCode:
                     "ao_release_gate_high_risk_human_review_missing",
                     "ao_release_gate_review_evidence_not_accepting",
                 ],
+            )
+            == 0
+        )
+
+    def test_procedural_evidence_plus_violation_returns_one(self) -> None:
+        # Critical pin — wrapper relaxes ONLY when EVERY blocker is
+        # review_action. A procedural evidence finding mixed with a
+        # real boundary violation still returns 1.
+        assert (
+            wrapper_exit_code(
+                DENY_POLICY_VIOLATION_DECISION,
+                [
+                    "ao_release_gate_review_evidence_not_accepting",
+                    "ao_release_gate_forbidden_secret_context",
+                ],
+            )
+            == 1
+        )
+
+    def test_procedural_evidence_plus_structural_evidence_returns_one(self) -> None:
+        # Pin — procedural evidence (review_action) mixed with structural
+        # evidence defect (failure) still returns 1. Wrapper never softens
+        # when ANY blocker is a real defect.
+        assert (
+            wrapper_exit_code(
+                DENY_MISSING_EVIDENCE_DECISION,
+                [
+                    "ao_release_gate_review_evidence_not_accepting",
+                    "ao_release_gate_review_evidence_missing",
+                ],
+            )
+            == 1
+        )
+
+    def test_admin_bypass_violation_returns_one(self) -> None:
+        # Pin — admin bypass request is always failure, never softened.
+        assert (
+            wrapper_exit_code(
+                DENY_POLICY_VIOLATION_DECISION,
+                ["ao_release_gate_admin_bypass_requested"],
             )
             == 1
         )
@@ -1397,12 +1572,36 @@ class TestBuildTechnicalCheckRun:
         assert cr["conclusion"] == "success"
 
     def test_real_violation_is_failure_in_enforce(self) -> None:
+        # Uses boundary-violation code so the invariant survives 019e830d.
         cr = build_technical_check_run(
-            DENY_MISSING_EVIDENCE_DECISION,
-            ["ao_release_gate_review_evidence_not_accepting"],
+            DENY_POLICY_VIOLATION_DECISION,
+            ["ao_release_gate_forbidden_secret_context"],
             conclusion_mode="enforce",
         )
         assert cr["conclusion"] == "failure"
+
+    def test_structural_evidence_missing_is_failure_in_enforce(self) -> None:
+        # Pin 019e830d — missing artifact is a real defect, not procedural.
+        cr = build_technical_check_run(
+            DENY_MISSING_EVIDENCE_DECISION,
+            ["ao_release_gate_review_evidence_missing"],
+            conclusion_mode="enforce",
+        )
+        assert cr["conclusion"] == "failure"
+
+    def test_procedural_evidence_alone_is_success_in_enforce(self) -> None:
+        # 019e830d extension — technical check ignores procedural
+        # evidence findings (they surface on the review check-run).
+        for code in (
+            "ao_release_gate_review_evidence_not_accepting",
+            "ao_release_gate_review_evidence_context_unverifiable",
+        ):
+            cr = build_technical_check_run(
+                DENY_MISSING_EVIDENCE_DECISION,
+                [code],
+                conclusion_mode="enforce",
+            )
+            assert cr["conclusion"] == "success", code
 
     def test_stale_only_is_stale_in_enforce(self) -> None:
         cr = build_technical_check_run(
@@ -1419,16 +1618,30 @@ class TestBuildTechnicalCheckRun:
             DENY_POLICY_VIOLATION_DECISION,
             [
                 "ao_release_gate_high_risk_human_review_missing",
+                "ao_release_gate_forbidden_secret_context",
+            ],
+            conclusion_mode="enforce",
+        )
+        assert cr["conclusion"] == "failure"
+
+    def test_procedural_plus_structural_evidence_is_failure_in_enforce(self) -> None:
+        # Pin 019e830d — procedural evidence (review_action, filtered)
+        # mixed with structural defect (failure) still surfaces failure.
+        cr = build_technical_check_run(
+            DENY_MISSING_EVIDENCE_DECISION,
+            [
                 "ao_release_gate_review_evidence_not_accepting",
+                "ao_release_gate_review_evidence_missing",
             ],
             conclusion_mode="enforce",
         )
         assert cr["conclusion"] == "failure"
 
     def test_shadow_mode_neutral_for_blocker(self) -> None:
+        # Shadow mode always neutralizes blockers, regardless of kind.
         cr = build_technical_check_run(
             DENY_MISSING_EVIDENCE_DECISION,
-            ["ao_release_gate_review_evidence_not_accepting"],
+            ["ao_release_gate_review_evidence_missing"],
             conclusion_mode="shadow",
         )
         assert cr["conclusion"] == "neutral"
@@ -1465,11 +1678,45 @@ class TestBuildReviewCheckRun:
         # Review check focuses only on review_action; a pure violation
         # set leaves it green (the technical check reports the failure).
         cr = build_review_check_run(
-            DENY_MISSING_EVIDENCE_DECISION,
-            ["ao_release_gate_review_evidence_not_accepting"],
+            DENY_POLICY_VIOLATION_DECISION,
+            ["ao_release_gate_forbidden_secret_context"],
             conclusion_mode="enforce",
         )
         assert cr["conclusion"] == "success"
+
+    def test_structural_evidence_missing_ignored_in_review_check(self) -> None:
+        # Pin 019e830d — structural evidence defect (failure) does not
+        # surface on the review check-run (technical check reports it).
+        cr = build_review_check_run(
+            DENY_MISSING_EVIDENCE_DECISION,
+            ["ao_release_gate_review_evidence_missing"],
+            conclusion_mode="enforce",
+        )
+        assert cr["conclusion"] == "success"
+
+    def test_procedural_evidence_is_action_required_in_review_check(self) -> None:
+        # 019e830d extension — procedural evidence findings surface on
+        # the review check-run as action_required (operator/reviewer
+        # action signal).
+        for code in (
+            "ao_release_gate_review_evidence_not_accepting",
+            "ao_release_gate_review_evidence_context_unverifiable",
+        ):
+            cr = build_review_check_run(
+                DENY_MISSING_EVIDENCE_DECISION,
+                [code],
+                conclusion_mode="enforce",
+            )
+            assert cr["conclusion"] == "action_required", code
+
+    def test_procedural_evidence_is_neutral_in_review_check_shadow(self) -> None:
+        # Pin — shadow mode neutralizes procedural findings too.
+        cr = build_review_check_run(
+            DENY_MISSING_EVIDENCE_DECISION,
+            ["ao_release_gate_review_evidence_not_accepting"],
+            conclusion_mode="shadow",
+        )
+        assert cr["conclusion"] == "neutral"
 
     def test_stale_branch_ignored_in_review_check(self) -> None:
         cr = build_review_check_run(


### PR DESCRIPTION
## Summary

PR #764 (and future similar high-risk PRs) blocked by 2 review_evidence
findings classified as `failure`. Semantically these are procedural
(operator/reviewer can resolve), not code defects. Surfaces as red CI
when it should be \`action_required\`.

This extension promotes two procedural evidence findings to
`review_action` while pinning structural evidence defects on the failure
axis:

| Finding code | Before | After | Why |
|---|---|---|---|
| `review_evidence_not_accepting` | failure | **review_action** | Procedural — operator CODEOWNER review resolves |
| `review_evidence_context_unverifiable` | failure | **review_action** | Procedural — network / eventual consistency, re-run resolves |
| `review_evidence_missing` | failure | failure (pinned) | Structural — no artifact at all |
| `review_evidence_schema_invalid` | failure | failure (pinned) | Structural — broken artifact |
| `review_evidence_context_unbound` | failure | failure (pinned) | Structural — forged / mismatched binding |

Boundary violations (admin_bypass, secret_context, live_adapter,
gpp_boundary, pat_backed_bot, agent_release_authority) remain failure
even when mixed with review_action findings.

`allow=false` decision unchanged; merge still blocked until CODEOWNER
review or evidence acceptance. Only check-run conclusion + wrapper exit
code shift.

## V5 P0-4 unblock

After merge: PR #764 re-run → \`ao-release-gate\` & \`ao-release-gate-technical\`
surface as `action_required` instead of `failure`; CODEOWNER review or
evidence file accept → merge.

## Codex plan-time consensus

- **Thread:** \`019e830d\`
- **Verdict:** REVISE + \`ready_for_impl: true\`
- **Absorb:** invariants 1-7 (sibling evidence failure pinning, boundary
  violation pinning, dual check-run behavior, mixed-blocker rules)
- **Reject:** "closed GPP'de review_evidence skip" (Codex: bypass riski
  yüksek)

## Test plan

- [x] \`pytest tests/test_ao_release_gate.py\` — 109 pass local
- [x] \`pytest tests/ -k "release_gate or ao_ma10"\` — 440 pass + 2 skip local
- [x] \`ruff check ao_kernel/ao_release_gate.py tests/test_ao_release_gate.py\` — clean
- [x] \`mypy ao_kernel/ao_release_gate.py\` — clean
- [x] Plan doc: \`.claude/plans/RG-019E830D-EVIDENCE-FINDING-TAXONOMY.md\`
- [ ] CI green
- [ ] Codex post-impl review (paralel başlatıldı)

## Audit

- **Implementer:** Anthropic Claude (session da2b8cec)
- **Reviewer:** OpenAI Codex (thread \`019e830d\`, plan-time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)