### PR TITLE
feat(epic-6-e6-5): CodeQL Security Analysis workflow (advisory baseline)

### DIFF
--- a/.claude/plans/EPIC-6-E6-5-CODEQL-WORKFLOW.md
+++ b/.claude/plans/EPIC-6-E6-5-CODEQL-WORKFLOW.md
@@ -1,0 +1,138 @@
+# Epic 6 E-6-5 — CodeQL Security Analysis Workflow
+
+**Status:** Implementing.
+**Codex thread:** `019e8350` (plan-time REVISE, `ready_for_impl: true`).
+**Slice:** E-6-5 (single PR — workflow + config + invariant tests +
+plan doc).
+
+## 1. Sorun
+
+V5 Epic 6 E-6-5 plan'da yazıyor: "CodeQL workflow (GitHub Advanced
+Security)". Mevcut `.github/workflows/`'ta CodeQL YOK; static security
+analysis baseline kurulmamış.
+
+Hedef: GitHub-native CodeQL static analysis workflow + scope config
++ shape invariant tests + governance disipliniyle plan dokümantasyonu.
+
+## 2. Codex iter-1 absorb (REVISE)
+
+| Konu | Codex bulgu | Absorb |
+|---|---|---|
+| Query packs | `security-extended,security-and-quality` baseline'da gürültü | Baseline `security-extended` only; `security-and-quality` follow-up |
+| Query source-of-truth | Workflow + config'te aynı `queries:` drift riski | Workflow'da `queries:` YOK; sadece `config-file:`; queries config'te |
+| `paths-ignore` syntax | Düz path string'ler nested match'i kaçırabilir | Glob form: `tests/**`, `ao_kernel/defaults/**`, `**/__pycache__/**`, `**/*.pyc` |
+| Timeout | `360 min` GitHub default — fazla geniş | `30 min` (Python CodeQL beklenen 5-15 min) |
+| Permissions | `pull-requests: read` eksik (PR scan future-proof) | Eklendi; `contents: write` ve `id-token: write` YOK |
+| Action versions | `init@v3`/`analyze@v3` doğru | Pin'li; `actions/checkout@v6` repo stiline uyumlu |
+| `setup-python` | Gereksiz (Python CodeQL build-less) | YOK |
+| `persist-credentials: false` | SARIF upload bozar mı? | HAYIR — upload `GITHUB_TOKEN` permissions'a dayanır |
+| `pull_request_target` | Fork PR token risk | YASAK + invariant test |
+| Required-check promotion | "yeşil = no alerts" yanlış semantik | Advisory baseline; required-check ayrı follow-up exit decision |
+
+## 3. Değişiklik scope
+
+### 3a. `.github/workflows/codeql.yml`
+- 4 trigger: `push` main, `pull_request` main, weekly `schedule` (Mon
+  03:17 UTC), `workflow_dispatch`.
+- Permissions: actions:read + contents:read + pull-requests:read +
+  security-events:write. NO contents:write, NO id-token:write.
+- Matrix: language `python` (fail-fast: false).
+- `timeout-minutes: 30`.
+- `actions/checkout@v6` + `persist-credentials: false`.
+- `github/codeql-action/init@v3` + `analyze@v3`.
+- `config-file: ./.github/codeql/codeql-config.yml` (queries source).
+- NO `queries:` inline in workflow (single source-of-truth in config).
+- NO `actions/setup-python` (Python CodeQL is build-less).
+
+### 3b. `.github/codeql/codeql-config.yml`
+- `disable-default-queries: false` (additive layering).
+- `queries: [security-extended]` (baseline only).
+- `paths: [ao_kernel, scripts]`.
+- `paths-ignore`: glob form `tests/**`, `ao_kernel/defaults/**`,
+  `**/__pycache__/**`, `**/*.pyc`.
+
+### 3c. `tests/test_codeql_workflow_shape.py`
+21 invariant tests, regex-free plain-text substring matching to
+avoid YAML 1.1 boolean trap on `on:` key:
+
+| Invariant | Test |
+|---|---|
+| Workflow file exists at canonical path | `test_codeql_workflow_exists_at_canonical_path` |
+| Workflow name pinned | `test_codeql_workflow_name_pinned` |
+| 4 trigger keys present | `test_codeql_workflow_triggers_include_push_pr_schedule_dispatch` |
+| Weekly low-traffic cron | `test_codeql_workflow_schedule_uses_weekly_low_traffic_cron` |
+| `pull_request_target` rejected | `test_codeql_workflow_rejects_pull_request_target` |
+| Minimum permissions set | `test_codeql_workflow_permissions_minimum_set` |
+| `contents: write` rejected | `test_codeql_workflow_rejects_contents_write` |
+| `id-token: write` rejected | `test_codeql_workflow_rejects_id_token_write` |
+| Checkout v6 + persist-credentials false | `test_codeql_workflow_uses_checkout_v6_no_persist_credentials` |
+| CodeQL action v3 init + analyze | `test_codeql_workflow_uses_codeql_action_v3` |
+| `setup-python` not used | `test_codeql_workflow_does_not_install_python_setup` |
+| Matrix language python | `test_codeql_workflow_matrix_pins_python` |
+| Timeout <= 30 min | `test_codeql_workflow_timeout_capped_at_30_minutes` |
+| Config file referenced | `test_codeql_workflow_references_config_file` |
+| Workflow does NOT inline queries | `test_codeql_workflow_does_not_inline_queries_key` |
+| Config file exists | `test_codeql_config_file_exists` |
+| security-extended query pack | `test_codeql_config_pins_security_extended_query_pack` |
+| security-and-quality deferred | `test_codeql_config_defers_security_and_quality_pack` |
+| Scope covers runtime code | `test_codeql_config_paths_scope_covers_runtime_code` |
+| paths-ignore glob covers noise | `test_codeql_config_paths_ignore_glob_covers_noise` |
+| Default queries enabled | `test_codeql_config_default_queries_remain_enabled` |
+
+### 3d. Plan doc — this file.
+
+## 4. Out-of-scope (E-6-5 follow-up slices)
+
+| Konu | Sonra |
+|---|---|
+| `security-and-quality` query pack | Initial baseline triage sonrası ayrı PR |
+| Required-check promotion | Ayrı follow-up exit decision (baseline + main runtime measurement + alert review sonrası) |
+| Custom query packs (ao-kernel'e özel) | Epic 6 follow-up — ao-kernel codebase için manual query yazımı |
+| GHAS code scanning enablement | Operator action — repo Settings → Code security and analysis → Default setup ya da Advanced; bu PR sadece workflow file ekler |
+| First-run runtime measurement | Post-merge — main'de ilk run sonrası ölçüm plan doc'a evidence olarak yazılacak |
+
+## 5. Risk + Mitigation
+
+| Risk | Mitigation |
+|---|---|
+| Fork PR token risk (security-events:write) | `pull_request_target` YASAK + invariant test |
+| Workflow `queries:` ile config drift | Single source-of-truth config file; workflow inline rejected by invariant |
+| `paths-ignore` nested match miss | Glob form `**` her path için |
+| Long CI runtime | 30-min cap (Python CodeQL build-less; expected 5-15 min) |
+| CodeQL alerts "passing" semantik karışıklığı | Plan doc + workflow yorum: "CodeQL green ≠ no alerts"; required-check promotion ayrı follow-up |
+| `setup-python` regression | Invariant test workflow'da setup-python kullanımını reject |
+| Action version drift | `@v3` + `@v6` pin'li; invariant test |
+
+## 6. Acceptance
+
+- ✅ `pytest tests/test_codeql_workflow_shape.py -x` → 21 pass local
+- ✅ `ruff check tests/test_codeql_workflow_shape.py` clean
+- ✅ Plan doc — this file
+- ⏳ Cross-AI post-impl review (Codex thread `019e8350` reply ile yeni iter)
+- ⏳ CI green (PR taksonomi extension gerek PR #793 merge sonrası)
+- ⏳ Squash merge audit trail: Implementer Anthropic Claude / Reviewer OpenAI Codex
+- ⏳ **Post-merge operator action**: GHAS code scanning enablement (Settings UI)
+- ⏳ **Post-merge measurement**: ilk main run runtime — plan doc'a evidence olarak ek
+
+## 7. Public claim discipline
+
+- "Production-ready" marketing claim YOK; CodeQL workflow advisory.
+- 3 guard flag (`support_widening`, `production_platform_claim`,
+  `live_adapter_execution`) `const false` korunur.
+- Bu PR HİÇBİR flag flip yok; sadece static analysis baseline.
+- "Security audited" / "SOC2 ready" public iddia YOK; SOC2 paketi
+  Epic 6 E-6-3 ayrı slice.
+
+## 8. Bağlantı
+
+- V5 Epic 6 plan: `V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md` §3 (Epic 6
+  Security + Compliance).
+- HARD RULE — Cross-AI Peer Review: implementer Anthropic Claude;
+  reviewer OpenAI Codex (thread `019e8350`).
+- HARD RULE — Uzun Vadeli Kalıcı Çözüm: baseline `security-extended`
+  only (gürültü kontrolü); config-file single source-of-truth;
+  required-check promotion ayrı exit decision (yanlış semantic
+  signal'i engelle).
+- HARD RULE — Continuous Autonomous Mode: PR #793 + PR #794 + PR #795
+  + bu PR autonomous merge chain'inde sıralı; her PR cross-AI peer
+  reviewed.

--- a/.claude/plans/EPIC-6-E6-5-CODEQL-WORKFLOW.md
+++ b/.claude/plans/EPIC-6-E6-5-CODEQL-WORKFLOW.md
@@ -52,7 +52,7 @@ Hedef: GitHub-native CodeQL static analysis workflow + scope config
   `**/__pycache__/**`, `**/*.pyc`.
 
 ### 3c. `tests/test_codeql_workflow_shape.py`
-21 invariant tests, regex-free plain-text substring matching to
+24 invariant tests, regex-free plain-text substring matching to
 avoid YAML 1.1 boolean trap on `on:` key:
 
 | Invariant | Test |

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,30 @@
+name: ao-kernel CodeQL config
+
+# V5 Epic 6 E-6-5 — single source-of-truth for CodeQL queries and
+# scoped paths. Codex 019e8350 absorb: workflow itself declares only
+# ``config-file`` so the queries list lives here and cannot drift.
+
+# Keep default-queries enabled so the security-extended pack
+# additively layers on top (not replacement).
+disable-default-queries: false
+
+queries:
+  # Baseline only — additive security-extended pack. The broader
+  # security-and-quality pack is deferred to a follow-up slice once
+  # the initial alert baseline is triaged (Codex 019e8350 absorb).
+  - uses: security-extended
+
+paths:
+  - ao_kernel
+  - scripts
+
+# Codex 019e8350 absorb: ``paths-ignore`` uses glob form for nested
+# match safety. Tests are excluded so reviewer false-positive load
+# stays controllable; packaged defaults under ``ao_kernel/defaults``
+# are excluded because the scanner would flag data-only JSON/text
+# files (no executable code paths).
+paths-ignore:
+  - "tests/**"
+  - "ao_kernel/defaults/**"
+  - "**/__pycache__/**"
+  - "**/*.pyc"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,65 @@
+name: CodeQL Security Analysis
+
+# V5 Epic 6 E-6-5 — CodeQL static analysis (Codex 019e8350 absorb).
+#
+# This workflow runs CodeQL queries against Python source. It is
+# **advisory** for the V5.0.0 release; alerts are reviewed but the
+# check does NOT block merges via branch protection in this slice.
+# A follow-up exit decision will evaluate promoting the workflow to
+# a required status check once the alert baseline stabilizes.
+#
+# Reasoning (Codex 019e8350 absorb):
+# - CodeQL workflow green ≠ "no alerts"; it only means the analysis
+#   pipeline + SARIF upload succeeded. Required-check promotion
+#   requires explicit operator decision per Epic 6 governance.
+# - Queries pinned to ``security-extended`` baseline only. The
+#   broader ``security-and-quality`` pack is deferred to a follow-up
+#   slice once the initial baseline is triaged.
+# - Single query source-of-truth: workflow specifies only
+#   ``config-file``; ``.github/codeql/codeql-config.yml`` owns the
+#   queries list. This avoids drift between two declarations.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Monday 03:17 UTC (06:17 İstanbul most of the year).
+    # Low-traffic window to avoid contention with active PR runs.
+    - cron: "17 3 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    # Codex 019e8350 absorb: 30 min cap (was: GitHub default 360).
+    # Python CodeQL build-less; expected runtime 5-15 min.
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **V5 Epic 6 E-6-5 CodeQL advisory baseline**: added a
+  GitHub-native CodeQL Security Analysis workflow plus explicit
+  CodeQL config for Python source scanning, with minimum Actions
+  permissions, no pull_request_target, no setup-python step, no
+  explicit secret usage, build-less PR merge-result analysis, and
+  advisory-only semantics.
 - **V5 Epic 6 E-6-2 vulnerability scanning baseline**: added the
   advisory Dependabot and Trivy filesystem scanning baseline with
   minimum GitHub Actions permissions, exact Trivy action pinning,

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -1,26 +1,28 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-918-release-gate-codeql-config-scope",
+  "work_package": "AO-MA-796-codeql-workflow",
   "implementer": {
-    "agent": "codex-gpt-5-release-gate-codeql-config-scope",
+    "agent": "codex-gpt-5-codeql-workflow-rebase-integrator",
     "provider": "openai"
   },
   "reviewer": {
-    "agent": "claude-code-independent-reviewer-codeql-config-scope",
+    "agent": "claude-code-independent-reviewer-pr796-codeql-final",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-release-gate-codeql-config-scope",
+    "head_ref": "refs/heads/codex/epic-6-e6-5-codeql-workflow",
     "changed_files": [
+      ".claude/plans/EPIC-6-E6-5-CODEQL-WORKFLOW.md",
+      ".github/codeql/codeql-config.yml",
+      ".github/workflows/codeql.yml",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_release_gate_build_payload.py",
-      "tests/test_ao_release_gate_build_payload.py"
+      "tests/test_codeql_workflow_shape.py"
     ]
   },
   "checks_considered": [
@@ -33,56 +35,60 @@
       "status": "pass"
     },
     {
-      "name": "exact_path_not_prefix_widening",
+      "name": "advisory_only_no_required_check_promotion",
       "status": "pass"
     },
     {
-      "name": "generic_github_prefix_absent",
+      "name": "no_pull_request_target",
       "status": "pass"
     },
     {
-      "name": "generic_codeql_prefix_absent",
+      "name": "no_explicit_secrets",
       "status": "pass"
     },
     {
-      "name": "workflow_governance_unchanged",
+      "name": "minimum_permissions",
       "status": "pass"
     },
     {
-      "name": "codeowners_governance_unchanged",
+      "name": "no_contents_write",
       "status": "pass"
     },
     {
-      "name": "ruleset_governance_unchanged",
+      "name": "no_id_token_write",
       "status": "pass"
     },
     {
-      "name": "branch_protection_unchanged",
+      "name": "no_setup_python",
       "status": "pass"
     },
     {
-      "name": "live_adapter_gate_unchanged",
+      "name": "config_security_extended_only",
       "status": "pass"
     },
     {
-      "name": "support_widening_claim_unchanged",
+      "name": "scoped_paths_and_ignores",
       "status": "pass"
     },
     {
-      "name": "production_platform_claim_unchanged",
+      "name": "invariant_tests_cover_shape",
       "status": "pass"
     },
     {
-      "name": "changelog_accuracy",
+      "name": "changelog_records_baseline",
+      "status": "pass"
+    },
+    {
+      "name": "guard_flags_const_false",
       "status": "pass"
     }
   ],
   "findings": [
-    "Claude AGREE: exact path .github/codeql/codeql-config.yml added; no generic .github/** or .github/codeql/** widening.",
-    "Claude AGREE: test asserts exact path present and confirms .github/codeql/ plus .github/ are absent from prefixes.",
-    "Claude AGREE: changelog note accurately describes scope and explicitly lists surfaces not widened.",
-    "Claude AGREE: no workflow, CODEOWNERS, ruleset, branch-protection, runtime, live-adapter, support-widening, or production-claim surfaces touched.",
-    "Claude AGREE: pattern mirrors the existing exact-path .github/dependabot.yml precedent."
+    "Claude AGREE: workflow is explicitly advisory-only and required-check promotion is out of scope.",
+    "Claude AGREE: pull_request_target is absent and pinned by invariant tests.",
+    "Claude AGREE: no secrets.X expressions, no contents: write, no id-token: write, no setup-python, and minimum permissions are present.",
+    "Claude AGREE: config is single source-of-truth for queries, security-extended only, with scoped paths and glob-form ignores.",
+    "Claude AGREE: changelog records the advisory baseline and no runtime/live-adapter/support-widening/production-claim/branch-protection/ruleset/CODEOWNERS mutation exists."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -1,26 +1,28 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-918-release-gate-codeql-config-scope",
+  "work_package": "AO-MA-796-codeql-workflow",
   "implementer": {
-    "agent": "codex-gpt-5-release-gate-codeql-config-scope",
+    "agent": "codex-gpt-5-codeql-workflow-rebase-integrator",
     "provider": "openai"
   },
   "reviewer": {
-    "agent": "openai-subagent-independent-reviewer-codeql-config-scope",
+    "agent": "openai-subagent-independent-reviewer-pr796-codeql-final",
     "provider": "openai",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-release-gate-codeql-config-scope",
+    "head_ref": "refs/heads/codex/epic-6-e6-5-codeql-workflow",
     "changed_files": [
+      ".claude/plans/EPIC-6-E6-5-CODEQL-WORKFLOW.md",
+      ".github/codeql/codeql-config.yml",
+      ".github/workflows/codeql.yml",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_release_gate_build_payload.py",
-      "tests/test_ao_release_gate_build_payload.py"
+      "tests/test_codeql_workflow_shape.py"
     ]
   },
   "checks_considered": [
@@ -33,23 +35,47 @@
       "status": "pass"
     },
     {
-      "name": "exact_path_not_prefix_widening",
+      "name": "advisory_only_no_required_check_promotion",
       "status": "pass"
     },
     {
-      "name": "generic_github_prefix_absent",
+      "name": "no_pull_request_target",
       "status": "pass"
     },
     {
-      "name": "generic_codeql_prefix_absent",
+      "name": "no_explicit_secrets",
       "status": "pass"
     },
     {
-      "name": "release_gate_diff_scope_regression",
+      "name": "minimum_permissions",
       "status": "pass"
     },
     {
-      "name": "changelog_discipline",
+      "name": "no_contents_write",
+      "status": "pass"
+    },
+    {
+      "name": "no_id_token_write",
+      "status": "pass"
+    },
+    {
+      "name": "no_setup_python",
+      "status": "pass"
+    },
+    {
+      "name": "config_security_extended_only",
+      "status": "pass"
+    },
+    {
+      "name": "scoped_paths_and_ignores",
+      "status": "pass"
+    },
+    {
+      "name": "invariant_tests_cover_shape",
+      "status": "pass"
+    },
+    {
+      "name": "changelog_records_baseline",
       "status": "pass"
     },
     {
@@ -58,11 +84,11 @@
     }
   ],
   "findings": [
-    "OpenAI independent review returned AGREE for the exact .github/codeql/codeql-config.yml release-gate scope fix.",
-    "The patch adds only an exact CodeQL config path, not a generic .github/codeql/ or .github/ prefix.",
-    "The invariant test asserts exact path presence and absence of both generic directory prefixes.",
-    "The change does not alter workflows, CODEOWNERS, rulesets, branch protection, runtime adapter code, support-widening authority, production-platform claims, or live adapter execution.",
-    "The changelog note accurately describes the reviewed CodeQL advisory baseline scope and no-widening boundary."
+    "OpenAI independent review returned AGREE for the inspected CodeQL advisory baseline slice.",
+    "The workflow is advisory/static-analysis only and does not use pull_request_target, explicit secrets, contents: write, id-token: write, or setup-python.",
+    "The CodeQL config declares security-extended only, keeps default queries enabled, and scopes paths/ignores to ao_kernel, scripts, tests/defaults/pycache/pyc boundaries.",
+    "Invariant tests cover workflow/config shape, no extra write permissions, no explicit secrets, and PR merge-result checkout semantics.",
+    "The changelog records the advisory baseline without overclaiming, and the only review note about plan-doc test-count drift was corrected before final evidence."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,26 +1,28 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-918-release-gate-codeql-config-scope",
+  "work_package": "AO-MA-796-codeql-workflow",
   "implementer": {
-    "agent": "codex-gpt-5-release-gate-codeql-config-scope",
+    "agent": "codex-gpt-5-codeql-workflow-rebase-integrator",
     "provider": "openai"
   },
   "reviewer": {
-    "agent": "claude-code-independent-reviewer-codeql-config-scope",
+    "agent": "claude-code-independent-reviewer-pr796-codeql-final",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-release-gate-codeql-config-scope",
+    "head_ref": "refs/heads/codex/epic-6-e6-5-codeql-workflow",
     "changed_files": [
+      ".claude/plans/EPIC-6-E6-5-CODEQL-WORKFLOW.md",
+      ".github/codeql/codeql-config.yml",
+      ".github/workflows/codeql.yml",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_release_gate_build_payload.py",
-      "tests/test_ao_release_gate_build_payload.py"
+      "tests/test_codeql_workflow_shape.py"
     ]
   },
   "checks_considered": [
@@ -33,55 +35,60 @@
       "status": "pass"
     },
     {
-      "name": "exact_path_not_prefix_widening",
+      "name": "advisory_only_no_required_check_promotion",
       "status": "pass"
     },
     {
-      "name": "generic_github_prefix_absent",
+      "name": "no_pull_request_target",
       "status": "pass"
     },
     {
-      "name": "generic_codeql_prefix_absent",
+      "name": "no_explicit_secrets",
       "status": "pass"
     },
     {
-      "name": "workflow_governance_unchanged",
+      "name": "minimum_permissions",
       "status": "pass"
     },
     {
-      "name": "codeowners_governance_unchanged",
+      "name": "no_contents_write",
       "status": "pass"
     },
     {
-      "name": "ruleset_governance_unchanged",
+      "name": "no_id_token_write",
       "status": "pass"
     },
     {
-      "name": "branch_protection_unchanged",
+      "name": "no_setup_python",
       "status": "pass"
     },
     {
-      "name": "live_adapter_gate_unchanged",
+      "name": "config_security_extended_only",
       "status": "pass"
     },
     {
-      "name": "support_widening_claim_unchanged",
+      "name": "scoped_paths_and_ignores",
       "status": "pass"
     },
     {
-      "name": "production_platform_claim_unchanged",
+      "name": "invariant_tests_cover_shape",
       "status": "pass"
     },
     {
-      "name": "changelog_discipline",
+      "name": "changelog_records_baseline",
+      "status": "pass"
+    },
+    {
+      "name": "guard_flags_const_false",
       "status": "pass"
     }
   ],
   "findings": [
-    "Claude AGREE: exact path .github/codeql/codeql-config.yml was added, not a generic .github/codeql/ or .github/ prefix.",
-    "Claude AGREE: the invariant test asserts exact path presence and rejects both .github/codeql/ and .github/ prefix leakage.",
-    "Claude AGREE: workflow, CODEOWNERS, ruleset, branch-protection, runtime, live-adapter, support-widening, and production-claim surfaces are untouched.",
-    "Focused local verification passed: tests/test_ao_release_gate_build_payload.py plus the closed dry-run decision smoke test, compileall, git diff --check, and a no-match secret-pattern scan."
+    "Claude AGREE: CodeQL workflow is advisory-only and does not promote branch-protection required checks in this slice.",
+    "Claude AGREE: workflow excludes pull_request_target, explicit secrets.X references, contents: write, id-token: write, and setup-python.",
+    "Claude AGREE: CodeQL config is the single query source-of-truth, uses security-extended only, scopes paths to ao_kernel and scripts, and ignores tests/defaults/pycache/pyc noise.",
+    "Claude AGREE: 24 invariant tests pin workflow/config shape, including PR merge-result checkout semantics and no extra write permissions.",
+    "OpenAI reviewer AGREE: no runtime, live-adapter, support-widening, production-claim, branch-protection, ruleset, or CODEOWNERS mutation; doc drift on invariant count was corrected before final evidence."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_codeql_workflow_shape.py
+++ b/tests/test_codeql_workflow_shape.py
@@ -216,3 +216,52 @@ def test_codeql_config_default_queries_remain_enabled() -> None:
     """Default queries provide essential security checks; we layer
     security-extended ON TOP (not as replacement)."""
     assert "disable-default-queries: false" in _config_text()
+
+
+def test_codeql_workflow_does_not_reference_secrets() -> None:
+    """Codex iter-2 absorb — workflow MUST NOT reference any
+    ``secrets.X`` token expressions. CodeQL SARIF upload relies
+    on default ``GITHUB_TOKEN`` permissions; explicit secrets
+    grow the surface unnecessarily.
+    """
+    assert "secrets." not in _workflow_text(), (
+        "workflow must not reference any secrets.X expression (CodeQL uses default GITHUB_TOKEN)"
+    )
+
+
+def test_codeql_workflow_no_extra_write_permissions() -> None:
+    """Codex iter-2 absorb — only ``security-events: write`` is
+    allowed; future drift adding ``packages: write``,
+    ``checks: write``, ``deployments: write``, ``id-token: write``,
+    etc. MUST be caught by this single regression pin.
+    """
+    text = _workflow_text()
+    forbidden_writes = [
+        "packages: write",
+        "checks: write",
+        "deployments: write",
+        "id-token: write",
+        "pages: write",
+        "issues: write",
+        "discussions: write",
+        "statuses: write",
+        "repository-projects: write",
+    ]
+    leaked = [w for w in forbidden_writes if w in text]
+    assert not leaked, f"workflow declares forbidden *: write permissions: {leaked}"
+
+
+def test_codeql_workflow_uses_default_pr_checkout_strategy() -> None:
+    """Codex iter-2 absorb — CodeQL analyzes the PR merge result by
+    default; explicit head-SHA / head-ref checkout bypasses that
+    semantic and would let an attacker hide changes in the merge
+    commit. Pin: workflow MUST NOT use any of these refs.
+    """
+    text = _workflow_text()
+    forbidden_ref_patterns = [
+        "github.event.pull_request.head.sha",
+        "github.event.pull_request.head.ref",
+        "github.head_ref",
+    ]
+    leaked = [p for p in forbidden_ref_patterns if p in text]
+    assert not leaked, f"workflow overrides default PR checkout (CodeQL must analyze merge result, not head): {leaked}"

--- a/tests/test_codeql_workflow_shape.py
+++ b/tests/test_codeql_workflow_shape.py
@@ -1,0 +1,218 @@
+"""Shape invariants for the CodeQL Security Analysis workflow.
+
+V5 Epic 6 E-6-5 (Codex 019e8350 absorb) — pins:
+
+- workflow file exists at canonical path
+- trigger set: push main + PR main + weekly schedule + manual dispatch
+- ``pull_request_target`` MUST NOT appear (Codex 019e8350 absorb —
+  fork PR token risk)
+- permissions: minimum + ``security-events: write`` + ``pull-requests:
+  read``; ``contents: write`` MUST NOT appear (write-side bypass)
+- ``actions/checkout@v6`` + ``persist-credentials: false``
+- ``github/codeql-action/init@v3`` + ``analyze@v3``
+- language ``python`` declared in the matrix
+- ``timeout-minutes`` <= 30 (Codex 019e8350 absorb — was 360 default)
+- ``config-file: ./.github/codeql/codeql-config.yml`` referenced
+- workflow does NOT inline ``queries:`` (single source-of-truth lives
+  in the config file)
+- config file exists at canonical path
+- ``security-extended`` query pack pinned in config
+- ``security-and-quality`` query pack NOT present yet (deferred to a
+  follow-up slice once baseline is triaged)
+- ``paths-ignore`` covers tests + defaults + pycache + .pyc
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _workflow_path() -> Path:
+    return _repo_root() / ".github" / "workflows" / "codeql.yml"
+
+
+def _config_path() -> Path:
+    return _repo_root() / ".github" / "codeql" / "codeql-config.yml"
+
+
+def _workflow_text() -> str:
+    return _workflow_path().read_text(encoding="utf-8")
+
+
+def _config_text() -> str:
+    return _config_path().read_text(encoding="utf-8")
+
+
+# ── Workflow file existence + identity ──────────────────────────────
+
+
+def test_codeql_workflow_exists_at_canonical_path() -> None:
+    assert _workflow_path().exists(), ".github/workflows/codeql.yml must exist (V5 Epic 6 E-6-5)"
+
+
+def test_codeql_workflow_name_pinned() -> None:
+    assert "name: CodeQL Security Analysis" in _workflow_text()
+
+
+# ── Trigger set ──────────────────────────────────────────────────────
+
+
+def test_codeql_workflow_triggers_include_push_pr_schedule_dispatch() -> None:
+    text = _workflow_text()
+    # Each trigger appears as a YAML key (regex-free; substring is
+    # sufficient because the file is hand-authored).
+    assert "  push:\n    branches: [main]" in text, "push main trigger missing"
+    assert "  pull_request:\n    branches: [main]" in text, "PR main trigger missing"
+    assert "  schedule:" in text, "schedule trigger missing"
+    assert "  workflow_dispatch:" in text, "workflow_dispatch trigger missing"
+
+
+def test_codeql_workflow_schedule_uses_weekly_low_traffic_cron() -> None:
+    text = _workflow_text()
+    # Codex 019e8350 absorb — Monday 03:17 UTC weekly. Pin exactly
+    # so accidental cron drift (e.g. hourly) is rejected.
+    assert '"17 3 * * 1"' in text, "schedule cron must be weekly Mon 03:17 UTC"
+
+
+def test_codeql_workflow_rejects_pull_request_target() -> None:
+    """Codex 019e8350 absorb — pull_request_target is a known fork
+    PR token risk surface and must NEVER appear in the CodeQL
+    workflow.
+    """
+    assert "pull_request_target" not in _workflow_text(), "pull_request_target MUST NOT appear (fork-PR token risk)"
+
+
+# ── Permissions ──────────────────────────────────────────────────────
+
+
+def test_codeql_workflow_permissions_minimum_set() -> None:
+    text = _workflow_text()
+    assert "actions: read" in text
+    assert "contents: read" in text
+    assert "pull-requests: read" in text
+    assert "security-events: write" in text
+
+
+def test_codeql_workflow_rejects_contents_write() -> None:
+    """contents: write would allow code mutation — write-side bypass
+    surface. Must NOT appear (Codex 019e8350 absorb)."""
+    assert "contents: write" not in _workflow_text()
+
+
+def test_codeql_workflow_rejects_id_token_write() -> None:
+    """id-token: write is unnecessary for CodeQL SARIF upload and
+    would expand the OIDC surface (Codex 019e8350 absorb)."""
+    assert "id-token: write" not in _workflow_text()
+
+
+# ── Action versions + checkout hardening ─────────────────────────────
+
+
+def test_codeql_workflow_uses_checkout_v6_no_persist_credentials() -> None:
+    text = _workflow_text()
+    assert "uses: actions/checkout@v6" in text
+    assert "persist-credentials: false" in text
+
+
+def test_codeql_workflow_uses_codeql_action_v3() -> None:
+    text = _workflow_text()
+    assert "uses: github/codeql-action/init@v3" in text
+    assert "uses: github/codeql-action/analyze@v3" in text
+
+
+def test_codeql_workflow_does_not_install_python_setup() -> None:
+    """Codex 019e8350 absorb — CodeQL Python is build-less; setup-python
+    is unnecessary and grows the runtime/network failure surface.
+    """
+    assert "uses: actions/setup-python" not in _workflow_text()
+
+
+# ── Matrix + timeout ─────────────────────────────────────────────────
+
+
+def test_codeql_workflow_matrix_pins_python() -> None:
+    text = _workflow_text()
+    assert "language: [python]" in text
+
+
+def test_codeql_workflow_timeout_capped_at_30_minutes() -> None:
+    """Codex 019e8350 absorb — was GitHub default 360 min; we cap
+    at 30 (Python CodeQL expected 5-15 min)."""
+    text = _workflow_text()
+    assert "timeout-minutes: 30" in text, "timeout-minutes must be 30 (not 360 default)"
+    assert "timeout-minutes: 360" not in text, "stale 360-min default must NOT appear"
+
+
+# ── Single-source-of-truth config file ───────────────────────────────
+
+
+def test_codeql_workflow_references_config_file() -> None:
+    text = _workflow_text()
+    assert "config-file: ./.github/codeql/codeql-config.yml" in text
+
+
+def test_codeql_workflow_does_not_inline_queries_key() -> None:
+    """Codex 019e8350 absorb — queries: must live only in the config
+    file (single source-of-truth). Workflow inlining creates drift.
+    """
+    text = _workflow_text()
+    # ``queries:`` as a top-level workflow key must NOT appear under
+    # the init step (config-file is the only declaration).
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if line.strip().startswith("queries:"):
+            # Only legitimate ``queries:`` location is inside the
+            # config file, not this workflow file.
+            raise AssertionError(
+                f"workflow inlines queries on line {i + 1}: {line!r}; queries belong in config file only"
+            )
+
+
+# ── Config file shape ────────────────────────────────────────────────
+
+
+def test_codeql_config_file_exists() -> None:
+    assert _config_path().exists(), ".github/codeql/codeql-config.yml must exist"
+
+
+def test_codeql_config_pins_security_extended_query_pack() -> None:
+    assert "uses: security-extended" in _config_text(), "security-extended query pack must be declared"
+
+
+def test_codeql_config_defers_security_and_quality_pack() -> None:
+    """V5 Epic 6 E-6-5 baseline (Codex 019e8350 absorb) — the broader
+    security-and-quality pack is OUT of this slice and ships only
+    after the initial alert baseline is triaged. Match only the
+    ``uses:`` declaration form (comments referencing the pack name
+    are allowed for documentation context).
+    """
+    assert "uses: security-and-quality" not in _config_text(), (
+        "security-and-quality query pack is deferred; must NOT be declared via 'uses:' yet"
+    )
+
+
+def test_codeql_config_paths_scope_covers_runtime_code() -> None:
+    text = _config_text()
+    assert "  - ao_kernel" in text, "ao_kernel must be in scanned paths"
+    assert "  - scripts" in text, "scripts must be in scanned paths"
+
+
+def test_codeql_config_paths_ignore_glob_covers_noise() -> None:
+    text = _config_text()
+    for ignore in (
+        '"tests/**"',
+        '"ao_kernel/defaults/**"',
+        '"**/__pycache__/**"',
+        '"**/*.pyc"',
+    ):
+        assert ignore in text, f"paths-ignore must include {ignore}"
+
+
+def test_codeql_config_default_queries_remain_enabled() -> None:
+    """Default queries provide essential security checks; we layer
+    security-extended ON TOP (not as replacement)."""
+    assert "disable-default-queries: false" in _config_text()


### PR DESCRIPTION
## Summary

V5 Epic 6 E-6-5 — GitHub-native CodeQL static analysis (Codex thread
\`019e8350\` plan-time REVISE + ready_for_impl absorbed).

## Files

| Path | Role |
|---|---|
| \`.github/workflows/codeql.yml\` | 4 trigger workflow (push/PR/weekly schedule/dispatch) |
| \`.github/codeql/codeql-config.yml\` | Single source-of-truth queries + path scope |
| \`tests/test_codeql_workflow_shape.py\` | 21 invariant tests (regex-free) |
| \`.claude/plans/EPIC-6-E6-5-CODEQL-WORKFLOW.md\` | Plan doc |

## Advisory baseline

**Workflow runs on push/PR/schedule but is NOT a required status
check.** Promotion to required requires (separate slice):

1. GHAS code scanning enablement (operator UI)
2. First main run runtime measurement
3. Initial alert baseline triage
4. Explicit operator decision

## Codex iter-1 absorb (10 revize)

- security-extended baseline only (security-and-quality deferred)
- Workflow does NOT inline queries (single source-of-truth in config)
- paths-ignore glob form
- timeout-minutes: 30 (was: 360 default)
- pull-requests: read; \`pull_request_target\` rejected
- No setup-python (Python CodeQL is build-less)
- contents: write rejected, id-token: write rejected

## Tests

21 invariant tests pass local, ruff clean.

## Audit

- **Implementer:** Anthropic Claude (session da2b8cec)
- **Reviewer:** OpenAI Codex (plan-time \`019e8350\`, post-impl pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)