### PR TITLE
feat(epic-7): performance baseline + regression threshold policy (V5)

### DIFF
--- a/.claude/plans/EPIC-7-PERFORMANCE-BASELINE.md
+++ b/.claude/plans/EPIC-7-PERFORMANCE-BASELINE.md
@@ -1,0 +1,141 @@
+# V5 Epic 7: Performance Baseline + Regression Threshold Policy
+
+> **Cross-AI plan-time AGREE** — Codex thread `019e8410` (4 iters: REVISE×3 → AGREE)
+> **Implementer:** Anthropic Claude / **Reviewer:** OpenAI Codex
+> **Risk class:** conservative low-risk (docs/schemas/scripts/tests only; no runtime; no workflows)
+
+## 1. Scope
+
+Schema-backed performance baseline + regression threshold policy for the
+existing PR-B7 benchmark suite. **Policy definition only**, not a CI
+hard-fail gate (E-7a `enforcement_mode: advisory`).
+
+**In scope:**
+- 3 JSON Schemas (Draft 2020-12): scenario catalog + baseline + threshold
+- 3 artifacts: catalog (workflow_id source-of-truth) + baseline (mode-filtered, candidate) + threshold (advisory)
+- `scripts/promote_baseline.py` — deterministic catalog-join promoter
+- 10-section operator README (runbook + update cadence + investigation)
+- 45 invariant tests
+
+**Out of scope (ZERO TOUCH per Codex absorb):**
+- `tests/test_scorecard_schema.py` (existing scorecard schema test)
+- `ao_kernel/defaults/schemas/scorecard.schema.v1.json` (existing schema)
+- `tests/benchmarks/` (existing PR-B7 suite)
+- `ao_kernel/_internal/scorecard/` (collector, compare, render)
+- `.github/workflows/test.yml` benchmark-fast job
+- Runtime performance optimization
+- p95 / median / repeated sampling / statistical aggregation (E-7h)
+- CI required-check promotion (E-7x track)
+
+## 2. Codex Iter Chain (4 iters)
+
+### iter-1 plan-time REVISE — 5 BLOCKER
+
+| ID | Issue | Resolution |
+|---|---|---|
+| E7-GATE-SEMANTICS | "CI hard fail" + "no workflow change" contradiction; current scorecard is advisory | E-7a = `enforcement_mode: advisory` policy definition only; CI red is future E-7x slice |
+| E7-P95-MISMATCH | Current scorecard has `duration_ms` single-run, no p95 field | `primary_metric: duration_ms` + `statistic: single_run`; p95 deferred to E-7h |
+| E7-THRESHOLD-DEFAULTS | 10%/5% too aggressive against single-run CI samples | 20%/30% conservative defaults (matches existing repo scorecard policy) |
+| E7-SCENARIO-CATALOG-FILE | Q7 file list missing scenario catalog artifact | Added `performance-scenario-catalog.v1.json` + schema |
+| E7-BASELINE-SCHEMA | Baseline manifest needs its own schema, not just threshold | Added `performance-baseline.schema.v1.json` |
+
+### iter-2 plan-time REVISE — 1 BLOCKER
+
+| ID | Issue | Resolution |
+|---|---|---|
+| E7-WORKFLOW-ID-SOURCE | Scorecard does not carry `workflow_id`; promote script cannot read it | Catalog is source-of-truth for `workflow_id`; script joins by `source_scorecard_scenario` |
+
+### iter-3 plan-time REVISE — 1 BLOCKER
+
+| ID | Issue | Resolution |
+|---|---|---|
+| E7-BASELINE-CATALOG-MODE-FILTER | Catalog includes full_mode_smoke (advisory); fast baseline can't cover it | Cross-validation: baseline IDs = catalog entries where `mode == benchmark_mode AND enforcement == 'policy_threshold'` |
+
+### iter-4 AGREE + ready_for_impl:true + must_close_findings:[]
+
+4 non-blocking impl notes:
+- Empty selection: `exit 2` without `--allow-empty` (operator opt-in)
+- Baseline schema `minItems: 1` correct for E-7a fast committed baseline
+- Claim scanner allowlist: `not_sla`, `not SLA` are explicitly allowed
+- Scanner runs across all docs/performance artifacts
+
+## 3. Implementation Artifacts
+
+| File | LOC | Purpose |
+|---|---|---|
+| `ao_kernel/defaults/schemas/performance-scenario-catalog.schema.v1.json` | ~60 | Catalog schema (workflow_id pinned per scenario) |
+| `ao_kernel/defaults/schemas/performance-baseline.schema.v1.json` | ~110 | Baseline schema (candidate + sample_count + variance) |
+| `ao_kernel/defaults/schemas/performance-regression-threshold.schema.v1.json` | ~120 | Threshold schema (advisory enforcement) |
+| `docs/performance/performance-scenario-catalog.v1.json` | ~40 | 3 scenarios (governed_review + governed_bugfix + full_mode_smoke) |
+| `docs/performance/baseline.v1.json` | ~55 | 2 scenarios (fast mode policy_threshold entries) |
+| `docs/performance/performance-regression-threshold.v1.json` | ~55 | global_defaults 20%/30% + per-scenario overrides |
+| `docs/performance/README.md` | ~180 | 10-section operator runbook |
+| `scripts/promote_baseline.py` | ~210 | Deterministic catalog-join promoter |
+| `tests/test_performance_baseline.py` | ~520 | 45 invariants |
+| `.claude/plans/EPIC-7-PERFORMANCE-BASELINE.md` | this | Plan doc + Codex chain |
+
+## 4. Schema Summary
+
+### performance-scenario-catalog.v1
+- Source-of-truth for `workflow_id` (scorecard doesn't carry it)
+- Per-scenario: `id`, `test_module`, `workflow_id`, `source_scorecard_scenario`, `primary_metric (const duration_ms)`, `mode (fast|full)`, `may_skip_on_prereq_miss`, `enforcement (policy_threshold|advisory_only)`
+
+### performance-baseline.v1
+- `candidate_baseline: const true`, `sample_count: const 1`, `variance_profile: const "single_ci_run"`
+- `generated_from` 7 metadata fields (scorecard_schema_version + git_sha + git_ref + benchmark_mode + python_version + runner_os + generated_at)
+- Per-scenario: `metric { name: duration_ms, unit: ms, value, statistic: single_run }` + `status (pass|fail)` + `cost_source enum` + `workflow_id`
+
+### performance-regression-threshold.v1
+- `enforcement_mode enum {advisory, manual_block, ci_block_candidate}` (E-7a=advisory)
+- `policy_disclaimer` 3 const true (not_sla + operator_tunable + single_run_candidate_baseline)
+- `baseline_ref` pattern-pinned
+- `global_defaults` + per-scenario override (warn/hard thresholds + applies_to_modes + action_on_missing)
+
+## 5. Test Sections (45 invariants)
+
+| Section | Count | Focus |
+|---|---|---|
+| 1. Schema validity | 8 | Draft 2020-12 + additionalProperties:false + const pins + enums |
+| 2. Schema negative | 4 | Reject guard flip / unknown enforcement / candidate=false / unknown override |
+| 3. Catalog content | 4 | Validates + workflow_id pin + full_mode advisory + no duplicates |
+| 4. Baseline content | 5 | Validates + generated_from metadata + candidate invariants + scenarios non-empty + duration_ms metric |
+| 5. Threshold content | 5 | Validates + advisory mode + baseline_ref + 20%/30% defaults + warn<hard Python invariant |
+| 6. Cross-validation | 6 | Mode+enforcement filter match + threshold subset + full_mode null/advisory + scenario mode parity + claim scanner |
+| 7. Promote script | 4 | Constants pinned + fast selects 2 + full selects 0 + deterministic + exit 2 on empty |
+| 8. Zero-touch governance | 2 | Existing scorecard schema test present + existing schema file present |
+| 9. README discipline | 3 | 10 numbered sections + guard flags mention + mode filter doc |
+
+## 6. Defaults Rationale
+
+| Metric | warn | hard | Reasoning |
+|---|---|---|---|
+| duration_ms (governed_review) | 20% | 30% | Matches existing repo scorecard policy default; single-run flake risk acknowledged |
+| duration_ms (governed_bugfix) | 20% | 30% | Same baseline |
+| duration_ms (full_mode_smoke) | null | null | Advisory-only; may skip on prereq miss |
+
+10%/5% pair would generate flaky false positives against single-run CI
+samples. Future tightening requires E-7h statistical collector.
+
+## 7. Out-of-scope follow-up slices (8)
+
+| ID | Slice |
+|---|---|
+| E-7b | Concurrency stress test |
+| E-7c | Memory profile baseline |
+| E-7d | Large-corpus benchmark |
+| E-7e | Multi-provider performance comparison |
+| E-7f | Cost p95 baseline (composes with E-5-4 budget pattern) |
+| E-7g | Operator performance dashboard (Grafana panel) |
+| E-7h | Statistical collector (repeated sampling, median/p95, variance model) |
+| E-7x | CI required-check promotion track (`advisory` → `manual_block` → `ci_block_candidate`) |
+
+## 8. References
+
+- Existing PR-B7 benchmark suite: `tests/benchmarks/` (v3.5/v3.7)
+- Existing scorecard schema: `ao_kernel/defaults/schemas/scorecard.schema.v1.json` (ZERO TOUCH)
+- Existing scorecard schema test: `tests/test_scorecard_schema.py` (ZERO TOUCH)
+- E-5-1 OTEL tunables: PR #791 MERGED
+- E-5-4 SLI/SLO catalog: PR #799 MERGED
+- HARD RULE Cross-AI Peer Review (2026-05-05, 2026-05-14)
+- HARD RULE Uzun Vadeli Kalıcı Çözüm (2026-05-27)
+- Codex thread `019e8410` (4-iter REVISE×3 → AGREE)

--- a/ao_kernel/defaults/schemas/performance-baseline.schema.v1.json
+++ b/ao_kernel/defaults/schemas/performance-baseline.schema.v1.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:performance-baseline:v1",
+  "title": "ao-kernel Performance Baseline (V5 Epic 7)",
+  "description": "Single-run candidate baseline derived from a benchmark scorecard + scenario catalog join. Codex 019e8410 absorb: candidate_baseline:true + sample_count:1 + variance_profile:single_ci_run; not a contractual SLA; operator-tunable. Cross-validation with catalog uses mode + enforcement filter; only policy_threshold scenarios for the matching benchmark_mode are included.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "service",
+    "guard_flags",
+    "generated_from",
+    "candidate_baseline",
+    "sample_count",
+    "variance_profile",
+    "scenarios"
+  ],
+  "properties": {
+    "schema_version": { "const": "performance-baseline.v1" },
+    "service": { "const": "ao-kernel" },
+    "guard_flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "support_widening_allowed",
+        "production_platform_claim_allowed",
+        "live_adapter_execution_allowed"
+      ],
+      "properties": {
+        "support_widening_allowed": { "const": false },
+        "production_platform_claim_allowed": { "const": false },
+        "live_adapter_execution_allowed": { "const": false }
+      }
+    },
+    "generated_from": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scorecard_schema_version",
+        "source_git_sha",
+        "source_git_ref",
+        "benchmark_mode",
+        "python_version",
+        "runner_os",
+        "generated_at"
+      ],
+      "properties": {
+        "scorecard_schema_version": { "type": "string", "minLength": 2 },
+        "source_git_sha": { "type": "string", "pattern": "^[a-f0-9]{7,40}$" },
+        "source_git_ref": { "type": "string", "pattern": "^refs/" },
+        "benchmark_mode": { "enum": ["fast", "full"] },
+        "python_version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$" },
+        "runner_os": { "type": "string", "minLength": 4 },
+        "generated_at": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$" }
+      }
+    },
+    "candidate_baseline": { "const": true },
+    "sample_count": { "const": 1 },
+    "variance_profile": { "const": "single_ci_run" },
+    "scenarios": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/baseline_scenario" }
+    }
+  },
+  "$defs": {
+    "baseline_scenario": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "source_scorecard_scenario",
+        "workflow_id",
+        "benchmark_mode",
+        "metric",
+        "status",
+        "workflow_completed",
+        "cost_source",
+        "review_score_expected",
+        "candidate_baseline",
+        "sample_count",
+        "variance_profile"
+      ],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z][a-z0-9_]+$" },
+        "source_scorecard_scenario": { "type": "string", "minLength": 3 },
+        "workflow_id": { "type": "string", "minLength": 4 },
+        "benchmark_mode": { "enum": ["fast", "full"] },
+        "metric": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "unit", "value", "statistic"],
+          "properties": {
+            "name": { "const": "duration_ms" },
+            "unit": { "const": "ms" },
+            "value": { "type": "number", "minimum": 0 },
+            "statistic": { "const": "single_run" }
+          }
+        },
+        "status": { "enum": ["pass", "fail"] },
+        "workflow_completed": { "type": "boolean" },
+        "cost_source": {
+          "type": ["string", "null"],
+          "enum": ["mock_shim", "real_adapter", "axis_seeded_only", null]
+        },
+        "review_score_expected": { "type": ["number", "null"] },
+        "candidate_baseline": { "const": true },
+        "sample_count": { "const": 1 },
+        "variance_profile": { "const": "single_ci_run" }
+      }
+    }
+  }
+}

--- a/ao_kernel/defaults/schemas/performance-regression-threshold.schema.v1.json
+++ b/ao_kernel/defaults/schemas/performance-regression-threshold.schema.v1.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:performance-regression-threshold:v1",
+  "title": "ao-kernel Performance Regression Threshold Policy (V5 Epic 7)",
+  "description": "Policy definition for regression thresholds against a committed baseline. E-7a enforcement_mode=='advisory'; CI red gating is a future slice (E-7x promotion track). Codex 019e8410 absorb: 20% warn / 30% hard duration defaults; single-run candidate baseline disclaimer.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "service",
+    "guard_flags",
+    "policy_disclaimer",
+    "enforcement_mode",
+    "baseline_ref",
+    "global_defaults",
+    "scenarios"
+  ],
+  "properties": {
+    "schema_version": { "const": "performance-regression-threshold.v1" },
+    "service": { "const": "ao-kernel" },
+    "guard_flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "support_widening_allowed",
+        "production_platform_claim_allowed",
+        "live_adapter_execution_allowed"
+      ],
+      "properties": {
+        "support_widening_allowed": { "const": false },
+        "production_platform_claim_allowed": { "const": false },
+        "live_adapter_execution_allowed": { "const": false }
+      }
+    },
+    "policy_disclaimer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["not_sla", "operator_tunable", "single_run_candidate_baseline"],
+      "properties": {
+        "not_sla": { "const": true },
+        "operator_tunable": { "const": true },
+        "single_run_candidate_baseline": { "const": true }
+      }
+    },
+    "enforcement_mode": {
+      "enum": ["advisory", "manual_block", "ci_block_candidate"]
+    },
+    "baseline_ref": {
+      "type": "string",
+      "pattern": "^docs/performance/baseline\\.v[0-9]+\\.json$"
+    },
+    "global_defaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "metric_kind",
+        "unit",
+        "comparison",
+        "min_sample_count",
+        "variance_disclaimer",
+        "warn_threshold_pct",
+        "hard_fail_threshold_pct",
+        "applies_to_modes",
+        "action_on_missing_baseline",
+        "action_on_missing_head_scenario"
+      ],
+      "properties": {
+        "metric_kind": { "const": "wall_clock" },
+        "unit": { "const": "ms" },
+        "comparison": { "const": "higher_is_worse" },
+        "min_sample_count": { "type": "integer", "minimum": 1 },
+        "variance_disclaimer": { "type": "string", "minLength": 16 },
+        "warn_threshold_pct": { "type": "number", "exclusiveMinimum": 0 },
+        "hard_fail_threshold_pct": { "type": "number", "exclusiveMinimum": 0 },
+        "applies_to_modes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "enum": ["fast", "full"] }
+        },
+        "action_on_missing_baseline": { "enum": ["skip_check", "warn", "fail"] },
+        "action_on_missing_head_scenario": { "enum": ["skip_check", "warn", "fail"] }
+      }
+    },
+    "scenarios": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/threshold_scenario" }
+    }
+  },
+  "$defs": {
+    "threshold_scenario": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "warn_threshold_pct",
+        "hard_fail_threshold_pct",
+        "applies_to_modes",
+        "enforcement_override"
+      ],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z][a-z0-9_]+$" },
+        "warn_threshold_pct": { "type": ["number", "null"], "exclusiveMinimum": 0 },
+        "hard_fail_threshold_pct": { "type": ["number", "null"], "exclusiveMinimum": 0 },
+        "applies_to_modes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "enum": ["fast", "full"] }
+        },
+        "enforcement_override": {
+          "type": ["string", "null"],
+          "enum": [null, "advisory_only"]
+        }
+      }
+    }
+  }
+}

--- a/ao_kernel/defaults/schemas/performance-scenario-catalog.schema.v1.json
+++ b/ao_kernel/defaults/schemas/performance-scenario-catalog.schema.v1.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:performance-scenario-catalog:v1",
+  "title": "ao-kernel Performance Scenario Catalog (V5 Epic 7)",
+  "description": "Source-of-truth catalog for benchmark scenarios, their test modules, workflow IDs, and enforcement modes. promote_baseline.py joins benchmark scorecard rows to catalog entries by source_scorecard_scenario; baseline is included only when mode matches and enforcement=='policy_threshold'. Codex 019e8410 cross-AI plan-time AGREE.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "service", "guard_flags", "scenarios"],
+  "properties": {
+    "schema_version": { "const": "performance-scenario-catalog.v1" },
+    "service": { "const": "ao-kernel" },
+    "guard_flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "support_widening_allowed",
+        "production_platform_claim_allowed",
+        "live_adapter_execution_allowed"
+      ],
+      "properties": {
+        "support_widening_allowed": { "const": false },
+        "production_platform_claim_allowed": { "const": false },
+        "live_adapter_execution_allowed": { "const": false }
+      }
+    },
+    "scenarios": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/scenario" }
+    }
+  },
+  "$defs": {
+    "scenario": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "test_module",
+        "workflow_id",
+        "source_scorecard_scenario",
+        "primary_metric",
+        "mode",
+        "may_skip_on_prereq_miss",
+        "enforcement"
+      ],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z][a-z0-9_]+$", "minLength": 3, "maxLength": 64 },
+        "test_module": { "type": "string", "pattern": "^tests/" },
+        "workflow_id": { "type": "string", "minLength": 4 },
+        "source_scorecard_scenario": { "type": "string", "minLength": 3 },
+        "primary_metric": { "const": "duration_ms" },
+        "mode": { "enum": ["fast", "full"] },
+        "may_skip_on_prereq_miss": { "type": "boolean" },
+        "enforcement": { "enum": ["policy_threshold", "advisory_only"] }
+      }
+    }
+  }
+}

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -1,0 +1,187 @@
+# ao-kernel Performance Baseline + Regression Threshold Policy (V5 Epic 7)
+
+> **Not SLA.** **Single-run candidate baseline.** **Operator-tunable.** This
+> package defines a schema-backed performance baseline + regression
+> threshold policy for the existing PR-B7 benchmark suite. It is a
+> **policy definition**, not a CI hard-fail gate. Future slice **E-7x**
+> may promote the policy from `enforcement_mode: advisory` to
+> `manual_block` / `ci_block_candidate`. The three guard flags
+> (`support_widening`, `production_platform_claim`,
+> `live_adapter_execution`) remain `const false`.
+>
+> **Local/operator smoke is not production evidence.** Repo baseline
+> values are derived from a single CI run; flake/variance is acknowledged
+> and noted in `policy_disclaimer.variance_disclaimer`. Repeated
+> sampling, p95/median collection, and statistical aggregation are out of
+> scope for E-7a (see **E-7h** follow-up slice).
+>
+> **No SLA wording.** No `production SLA`. No `contractual SLA`. No
+> `guaranteed performance`. Operator owns baseline update cadence +
+> threshold tuning.
+
+## 1. Source of Truth
+
+| File | Role |
+|---|---|
+| [`performance-scenario-catalog.v1.json`](performance-scenario-catalog.v1.json) | Canonical scenario list (id, test_module, workflow_id, mode, enforcement) |
+| [`performance-regression-threshold.v1.json`](performance-regression-threshold.v1.json) | Threshold policy (advisory enforcement; per-scenario override; global defaults) |
+| [`baseline.v1.json`](baseline.v1.json) | Generated baseline (mode-filtered; `candidate_baseline: true`) |
+| [`../../ao_kernel/defaults/schemas/performance-scenario-catalog.schema.v1.json`](../../ao_kernel/defaults/schemas/performance-scenario-catalog.schema.v1.json) | Catalog JSON Schema |
+| [`../../ao_kernel/defaults/schemas/performance-baseline.schema.v1.json`](../../ao_kernel/defaults/schemas/performance-baseline.schema.v1.json) | Baseline JSON Schema |
+| [`../../ao_kernel/defaults/schemas/performance-regression-threshold.schema.v1.json`](../../ao_kernel/defaults/schemas/performance-regression-threshold.schema.v1.json) | Threshold JSON Schema |
+| [`../../scripts/promote_baseline.py`](../../scripts/promote_baseline.py) | Deterministic catalog-join baseline promoter |
+
+## 2. Scenario Catalog
+
+The catalog is the **source-of-truth for workflow_id** — the existing
+benchmark scorecard does not carry workflow_id, so the script joins
+catalog entries to scorecard rows by `source_scorecard_scenario`.
+
+| id | mode | enforcement | source_scorecard_scenario | workflow_id |
+|---|---|---|---|---|
+| `governed_review` | fast | policy_threshold | governed_review | review_ai_flow |
+| `governed_bugfix` | fast | policy_threshold | governed_bugfix | governed_bugfix_bench |
+| `full_mode_smoke` | full | advisory_only | governed_review | review_ai_flow |
+
+## 3. Baseline Generation Rule (mode + enforcement filter)
+
+Codex 019e8410 absorb:
+
+- **Include** in baseline: catalog entries where `mode == --benchmark-mode`
+  AND `enforcement == "policy_threshold"`
+- **Skip** from baseline: entries where `enforcement == "advisory_only"`
+  OR `mode != --benchmark-mode`
+
+For the committed `--benchmark-mode fast` baseline this yields 2 entries
+(`governed_review` + `governed_bugfix`); `full_mode_smoke` is
+intentionally skipped because its enforcement is advisory-only and its
+mode is `full`.
+
+### Empty selection policy
+
+If the filter yields zero scenarios, `promote_baseline.py` exits 2
+("nothing to promote for this mode"). The `--allow-empty` flag opts into
+writing an empty baseline (operator-managed advanced workflows). The
+E-7a committed fast baseline always has ≥1 entry per the catalog.
+
+## 4. Threshold Policy (advisory enforcement)
+
+| Field | Value | Notes |
+|---|---|---|
+| `enforcement_mode` | `advisory` | E-7a is policy definition only; CI red is future E-7x |
+| `global_defaults.warn_threshold_pct` | `20.0` | Conservative; matches existing repo scorecard default |
+| `global_defaults.hard_fail_threshold_pct` | `30.0` | Conservative; matches existing repo scorecard default |
+| Per-scenario override | per-scenario | `enforcement_override: "advisory_only"` for `full_mode_smoke` |
+
+> **Threshold defaults rationale.** Codex 019e8410 absorb: a 10%/5%
+> threshold pair is too aggressive against single-run CI samples and
+> would generate flaky false positives. The 20%/30% pair matches the
+> existing repo scorecard policy default and acknowledges variance via
+> `variance_disclaimer`. Future tightening requires repeated sampling
+> (E-7h slice).
+
+## 5. Promote Workflow (operator command)
+
+```bash
+python scripts/promote_baseline.py \
+    --scorecard benchmark_scorecard.v1.json \
+    --scenario-catalog docs/performance/performance-scenario-catalog.v1.json \
+    --out docs/performance/baseline.v1.json \
+    --source-git-sha "$(git rev-parse --short HEAD)" \
+    --source-git-ref refs/heads/main \
+    --benchmark-mode fast \
+    --python-version 3.13 \
+    --runner-os ubuntu-latest \
+    --generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+
+Operator-only opt-in flags:
+
+- `--allow-empty` — permit empty baseline (advanced)
+- `--dry-run` — render JSON to stdout without writing the output file
+
+**Determinism:** `--generated-at` is required; the script never reads
+the wall clock. Same input + same `--generated-at` → byte-equal output.
+
+## 6. Update Cadence (operator-owned)
+
+The committed baseline is a **single-run candidate** snapshot. Operator
+update cadence:
+
+- **Quarterly review** recommended (operator-owned schedule)
+- **Re-promote** after major dependency upgrade (Python, jsonschema,
+  tenacity, runtime libs)
+- **Re-promote** after benchmark scorecard schema bump
+- **Do NOT auto-update on every main commit** — staleness disclosure
+  is preferred over auto-promotion (avoids hidden drift)
+
+The `generated_from` block makes baseline age visible
+(`generated_at` + `source_git_sha`). Operators decide when staleness
+warrants a refresh; CI does **not** fail on baseline staleness.
+
+## 7. Regression Investigation Runbook
+
+When a head benchmark exceeds `warn_threshold_pct`:
+
+1. **Confirm the delta**. Pull the head scorecard from the PR's
+   `scorecard-${{ github.sha }}` artifact and compare against
+   `baseline.v1.json[scenarios][].metric.value`.
+2. **Check for flake**. Re-run the workflow once. Single-run baseline
+   means variance is normal; a single spike does not imply regression.
+3. **Correlate dependencies**. Recent `pyproject.toml`, lockfile, or
+   runtime adapter change?
+4. **Inspect OTEL traces** (if E-5-1 is wired) for slowdown attribution.
+5. **Operator decision**: promote new baseline, accept regression with
+   ADR, or revert offending PR.
+
+When a head benchmark exceeds `hard_fail_threshold_pct`:
+
+- E-7a `enforcement_mode: advisory`: warning only; no CI red.
+- Future E-7x `enforcement_mode: ci_block_candidate`: PR blocked until
+  fix or baseline promotion.
+
+## 8. Out of Scope (E-7 follow-up slices)
+
+| ID | Slice |
+|---|---|
+| E-7b | Concurrency stress test |
+| E-7c | Memory profile baseline |
+| E-7d | Large-corpus benchmark |
+| E-7e | Multi-provider performance comparison |
+| E-7f | Cost p95 baseline (composes with E-5-4 budget pattern) |
+| E-7g | Operator performance dashboard (Grafana panel) |
+| E-7h | Statistical collector (repeated sampling, median/p95, variance model) |
+| E-7x | CI required-check promotion track (`advisory` → `manual_block` → `ci_block_candidate`) |
+
+## 9. Wording Discipline
+
+Forbidden in this package (claim scanner enforced):
+
+- `we guarantee X ms`
+- `production SLA`
+- `contractual SLA`
+- `guaranteed performance`
+
+Allowed (machine-result wording):
+
+- `regression detected`
+- `warn threshold exceeded`
+- `policy threshold breach`
+- `candidate baseline updated`
+- `single-run candidate baseline`
+- `not SLA` / `not_sla` (schema field name + disclaimer)
+
+The phrases `not SLA` and `not_sla` are explicitly **allowed** because
+they are negation disclaimers (Codex 019e8410 absorb).
+
+## 10. References
+
+- V5 roadmap: [`../../.claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md`](../../.claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md)
+- Existing benchmark suite: `tests/benchmarks/` (PR-B7 v3.5/v3.7)
+- Existing scorecard schema: `ao_kernel/defaults/schemas/scorecard.schema.v1.json` (ZERO TOUCH)
+- Existing scorecard schema test: `tests/test_scorecard_schema.py` (ZERO TOUCH)
+- E-5-1 OTEL tunables: PR #791 MERGED
+- E-5-4 SLI/SLO catalog: PR #799 MERGED
+- HARD RULE Cross-AI Peer Review (2026-05-05, 2026-05-14)
+- HARD RULE Uzun Vadeli Kalıcı Çözüm (2026-05-27)
+- Codex cross-AI plan-time AGREE: thread `019e8410` (4 iters: REVISE/REVISE/REVISE/AGREE)

--- a/docs/performance/baseline.v1.json
+++ b/docs/performance/baseline.v1.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "performance-baseline.v1",
+  "service": "ao-kernel",
+  "guard_flags": {
+    "support_widening_allowed": false,
+    "production_platform_claim_allowed": false,
+    "live_adapter_execution_allowed": false
+  },
+  "generated_from": {
+    "scorecard_schema_version": "v1",
+    "source_git_sha": "fd8241c",
+    "source_git_ref": "refs/heads/main",
+    "benchmark_mode": "fast",
+    "python_version": "3.13",
+    "runner_os": "ubuntu-latest",
+    "generated_at": "2026-06-01T20:00:00Z"
+  },
+  "candidate_baseline": true,
+  "sample_count": 1,
+  "variance_profile": "single_ci_run",
+  "scenarios": [
+    {
+      "id": "governed_bugfix",
+      "source_scorecard_scenario": "governed_bugfix",
+      "workflow_id": "governed_bugfix_bench",
+      "benchmark_mode": "fast",
+      "metric": {
+        "name": "duration_ms",
+        "unit": "ms",
+        "value": 120.0,
+        "statistic": "single_run"
+      },
+      "status": "pass",
+      "workflow_completed": true,
+      "cost_source": "mock_shim",
+      "review_score_expected": null,
+      "candidate_baseline": true,
+      "sample_count": 1,
+      "variance_profile": "single_ci_run"
+    },
+    {
+      "id": "governed_review",
+      "source_scorecard_scenario": "governed_review",
+      "workflow_id": "review_ai_flow",
+      "benchmark_mode": "fast",
+      "metric": {
+        "name": "duration_ms",
+        "unit": "ms",
+        "value": 200.0,
+        "statistic": "single_run"
+      },
+      "status": "pass",
+      "workflow_completed": true,
+      "cost_source": "mock_shim",
+      "review_score_expected": null,
+      "candidate_baseline": true,
+      "sample_count": 1,
+      "variance_profile": "single_ci_run"
+    }
+  ]
+}

--- a/docs/performance/performance-regression-threshold.v1.json
+++ b/docs/performance/performance-regression-threshold.v1.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "performance-regression-threshold.v1",
+  "service": "ao-kernel",
+  "guard_flags": {
+    "support_widening_allowed": false,
+    "production_platform_claim_allowed": false,
+    "live_adapter_execution_allowed": false
+  },
+  "policy_disclaimer": {
+    "not_sla": true,
+    "operator_tunable": true,
+    "single_run_candidate_baseline": true
+  },
+  "enforcement_mode": "advisory",
+  "baseline_ref": "docs/performance/baseline.v1.json",
+  "global_defaults": {
+    "metric_kind": "wall_clock",
+    "unit": "ms",
+    "comparison": "higher_is_worse",
+    "min_sample_count": 1,
+    "variance_disclaimer": "single_ci_run; flake risk acknowledged",
+    "warn_threshold_pct": 20.0,
+    "hard_fail_threshold_pct": 30.0,
+    "applies_to_modes": ["fast"],
+    "action_on_missing_baseline": "skip_check",
+    "action_on_missing_head_scenario": "warn"
+  },
+  "scenarios": [
+    {
+      "id": "governed_review",
+      "warn_threshold_pct": 20.0,
+      "hard_fail_threshold_pct": 30.0,
+      "applies_to_modes": ["fast"],
+      "enforcement_override": null
+    },
+    {
+      "id": "governed_bugfix",
+      "warn_threshold_pct": 20.0,
+      "hard_fail_threshold_pct": 30.0,
+      "applies_to_modes": ["fast"],
+      "enforcement_override": null
+    },
+    {
+      "id": "full_mode_smoke",
+      "warn_threshold_pct": null,
+      "hard_fail_threshold_pct": null,
+      "applies_to_modes": ["full"],
+      "enforcement_override": "advisory_only"
+    }
+  ]
+}

--- a/docs/performance/performance-scenario-catalog.v1.json
+++ b/docs/performance/performance-scenario-catalog.v1.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "performance-scenario-catalog.v1",
+  "service": "ao-kernel",
+  "guard_flags": {
+    "support_widening_allowed": false,
+    "production_platform_claim_allowed": false,
+    "live_adapter_execution_allowed": false
+  },
+  "scenarios": [
+    {
+      "id": "governed_review",
+      "test_module": "tests/benchmarks/test_governed_review.py",
+      "workflow_id": "review_ai_flow",
+      "source_scorecard_scenario": "governed_review",
+      "primary_metric": "duration_ms",
+      "mode": "fast",
+      "may_skip_on_prereq_miss": false,
+      "enforcement": "policy_threshold"
+    },
+    {
+      "id": "governed_bugfix",
+      "test_module": "tests/benchmarks/test_governed_bugfix.py",
+      "workflow_id": "governed_bugfix_bench",
+      "source_scorecard_scenario": "governed_bugfix",
+      "primary_metric": "duration_ms",
+      "mode": "fast",
+      "may_skip_on_prereq_miss": false,
+      "enforcement": "policy_threshold"
+    },
+    {
+      "id": "full_mode_smoke",
+      "test_module": "tests/benchmarks/test_full_mode_smoke.py",
+      "workflow_id": "review_ai_flow",
+      "source_scorecard_scenario": "governed_review",
+      "primary_metric": "duration_ms",
+      "mode": "full",
+      "may_skip_on_prereq_miss": true,
+      "enforcement": "advisory_only"
+    }
+  ]
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,21 +1,24 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "EPIC-5-E5-3B-CONSULTATION-TRACING",
+  "work_package": "EPIC-7-PERFORMANCE-BASELINE",
   "implementer": { "agent": "claude", "provider": "anthropic" },
   "reviewer": { "agent": "codex", "provider": "openai", "verdict": "AGREE" },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-5-e5-3b-consultation-tracing",
+    "head_ref": "refs/heads/codex/epic-7-performance-baseline",
     "changed_files": [
-      ".claude/plans/EPIC-5-E5-3B-CONSULTATION-TRACING.md",
-      "ao_kernel/consultation/archive.py",
-      "ao_kernel/consultation/promotion.py",
-      "ao_kernel/consultation/trace_context.py",
-      "ao_kernel/context/agent_coordination.py",
-      "ao_kernel/defaults/schemas/consultation-trace-context.schema.v1.json",
+      ".claude/plans/EPIC-7-PERFORMANCE-BASELINE.md",
+      "ao_kernel/defaults/schemas/performance-baseline.schema.v1.json",
+      "ao_kernel/defaults/schemas/performance-regression-threshold.schema.v1.json",
+      "ao_kernel/defaults/schemas/performance-scenario-catalog.schema.v1.json",
+      "docs/performance/README.md",
+      "docs/performance/baseline.v1.json",
+      "docs/performance/performance-regression-threshold.v1.json",
+      "docs/performance/performance-scenario-catalog.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_consultation_tracing.py"
+      "scripts/promote_baseline.py",
+      "tests/test_performance_baseline.py"
     ]
   },
   "checks_considered": [
@@ -27,23 +30,23 @@
     { "name": "no_guard_flip", "status": "pass" },
     { "name": "no_github_write_in_this_pr", "status": "pass" },
     { "name": "cross_provider_review", "status": "pass" },
-    { "name": "consultation_d2a_d2b_regression", "status": "pass" }
+    { "name": "scorecard_schema_zero_touch", "status": "pass" }
   ],
   "findings": [
-    "V5 Epic 5 E-5-3b: Consultation tracing integration. E-5-3a W3C trace primitives (PR #797 MERGED) integrate into consultation archive/query flow + agent_coordination consumer. New non-authoritative correlation sidecar (consultation_trace_context.v1.json) records W3C trace context at archive time; cross-trace links read at query time via bounded pre-scan (MAX_CONSULTATION_TRACE_LINKS=10).",
-    "Codex plan-time thread 019e83ee 3-iter chain (REVISE/REVISE/AGREE). iter-1 7 BLOCKER: F1 API_NAME_DRIFT (archive.record_consultation YOK; real archive_all/_archive_cns/preload_event_identities/append_event); F2 RESOLUTION_RECORD_SOURCE_STABILITY (record digest immune; trace metadata sidecar OUTSIDE record); F3 SCHEMA_FILE_ASSUMPTION (resolution.record.v1.json yok; yeni consultation-trace-context.schema.v1.json sidecar); F4 LINK_SEMANTICS (parent context vs cross-trace link ayrım; bounded pre-scan); F5 BAGGAGE_ATTRIBUTE (manuel get_session_baggage attribute); F6 MEMORY_PIPELINE_BOUNDARY (memory_pipeline DEĞİL agent_coordination); F7 GATE_RISK_CLASS (path-sensitive runtime + evidence-store-adjacent, NOT low-risk).",
-    "iter-2 5 BLOCKER + 6 hardening: F5 BAGGAGE_SOURCE_MISMATCH (ao_kernel.tracing.get_session_baggage direct; no local ContextVar duplication); F6 SPAN_NAME_CONFLICT (producer ao.consultation.query_promoted + consumer ao.consultation.query_consumer distinct); CROSS_TRACE_LINK_TIMING (bounded pre-scan before span open + MAX_CONSULTATION_TRACE_LINKS=10 cap); MAKE_LINK_INVALID_HEX_SEMANTICS (ValueError raise korunur; wrapper catches); SIDECAR_INTEGRITY_POLICY_UNDEFINED (non-authoritative correlation metadata; manifest dışı; tampered silently ignore).",
-    "iter-3 AGREE + ready_for_impl:true + must_close_findings:[]. 6 non-blocking hardening tweaks: atomic sidecar write (write_json_atomic), span count accuracy (link_candidate_count distinct), link filter parity, sidecar read cap module-level export, invalid sidecar visibility debug-only, active span placement.",
-    "New schema ao_kernel/defaults/schemas/consultation-trace-context.schema.v1.json: Draft 2020-12 + additionalProperties:false; const pins (schema_version 'consultation-trace-context.v1', captured_at_archive_time true); trace_id pattern ^[0-9a-f]{32}$ + not all-zero; span_id pattern ^[0-9a-f]{16}$ + not all-zero; traceparent full W3C regex ^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$; tracestate nullable; session_id_baggage nullable.",
-    "New module ao_kernel/consultation/trace_context.py (~180 line): capture_current_trace_context() — reads via ao_kernel.tracing facade only (no direct OTEL imports); returns None when no recording span / OTEL absent. maybe_write_sidecar() — idempotent first-write; never overwrite; uses write_json_atomic from repo shared utils; no-op when no context. read_sidecar_trace_links() — bounded pre-scan up to MAX_CONSULTATION_TRACE_LINKS=10; schema-validate inline; tampered/invalid silently skipped; catches make_link ValueError without changing semantics.",
-    "archive.py modify (~25 line delta): archive_all top-level facade span ao.consultation.archive with ao.consultation.count attribute. _archive_cns inner span ao.consultation.archive.cns with ao.cns_id attribute (only inner; H4 absorb). Sidecar maybe_write_sidecar called inside file_lock scope AFTER write_consultation_manifest. Tracing exception never breaks archive flow (try/except + debug log).",
-    "promotion.py modify (~30 line delta): query_promoted_consultations producer span ao.consultation.query_promoted with bounded sidecar pre-scan + links= parameter. read_sidecar_trace_links called on .ao/evidence/consultations/* dirs before span open (link timing F4 absorb). link_candidate_count attribute. promote_resolved_consultations span NOT added (minimum viable C scope per Codex).",
-    "agent_coordination.py modify (~12 line delta): consumer wrapper span ao.consultation.query_consumer wrapping query_promoted_consultations() call. Distinct from producer name. consultation.cap attribute. Codex F6 absorb (consumer boundary = agent_coordination, NOT memory_pipeline).",
-    "29 invariant test pass local + 122 total (with D2a/D2b/reader_facade regression): 5 schema validity (Draft 2020-12 + additionalProperties + const pins + all-zero reject + W3C regex) + 5 trace_context helper (exports + MAX_LINKS=10 pin + capture None default + idempotent sidecar + OTEL-absent graceful) + 3 sidecar validation (tampered + JSON error + cap) + 3 import discipline (no direct OTEL + baggage facade + no local ContextVar) + 5 span emission via fake tracer (archive facade + low-cardinality attrs + query_promoted producer + consumer distinct + cns inner ao.cns_id) + 3 sidecar discipline (NOT in manifest + record digest immune + AFTER manifest write) + 1 memory_pipeline ZERO TOUCH + 2 schema file inventory + 2 governance (no .github/workflows + make_link unchanged). ruff clean.",
-    "Public claim discipline + ZERO TOUCH discipline: PR HICBIR guard flag flip (3 const false); HICBIR ResolutionRecord / resolution.record.* mutation; HICBIR evidence.py/normalize.py/integrity.py/migrate.py/paths.py modification; HICBIR memory_pipeline.py modification; HICBIR existing schema (trace-meta, agent-consultation, policy-*) mutation; HICBIR ao_kernel.tracing.make_link semantic change; HICBIR .github/workflows mutation. Sidecar non-authoritative correlation metadata; manifest dışı.",
-    "Risk class: path-sensitive runtime + evidence-store-adjacent (Codex F7 absorb). NOT conservative low-risk. ao-release-gate cross-AI peer review evidence + actual diff parity zorunlu. 61 mevcut consultation D2a/D2b/reader_facade test pass — regression yok.",
-    "Out-of-scope follow-up slices (6): E-5-3c OTEL deployment runbook + E-5-3d trace collector backend (Jaeger/Zipkin) + E-5-3e full 9-module public-function span coverage + E-5-3f sampling discipline + E-5-3g PII redaction policy + E-5-3h multi-tenant trace isolation.",
-    "Cross-AI peer review trail (HARD RULE Cross-AI Peer Review 2026-05-05 + 2026-05-14): implementer Anthropic Claude != reviewer OpenAI Codex; thread 019e83ee (3-iter REVISE/REVISE/AGREE)."
+    "V5 Epic 7 Performance Baseline: schema-backed performance baseline + regression threshold policy for existing PR-B7 benchmark suite. Policy definition only (enforcement_mode advisory); CI red gating future E-7x slice. 3 schemas (catalog + baseline + threshold) + 3 artifacts + deterministic promote_baseline.py + 10-section operator README + 45 invariant tests.",
+    "Codex plan-time thread 019e8410 4-iter chain (REVISE/REVISE/REVISE/AGREE). iter-1 5 BLOCKER: E7-GATE-SEMANTICS (advisory policy definition only); E7-P95-MISMATCH (duration_ms single_run; p95 deferred); E7-THRESHOLD-DEFAULTS (20%/30% conservative matches existing repo); E7-SCENARIO-CATALOG-FILE (3 schemas+artifacts); E7-BASELINE-SCHEMA (baseline manifest own schema).",
+    "iter-2 1 BLOCKER E7-WORKFLOW-ID-SOURCE: scorecard doesn't carry workflow_id; catalog source-of-truth + script join by source_scorecard_scenario.",
+    "iter-3 1 BLOCKER E7-BASELINE-CATALOG-MODE-FILTER: mode + enforcement filter; baseline IDs = catalog where mode==benchmark_mode AND enforcement=='policy_threshold'.",
+    "iter-4 AGREE + ready_for_impl:true + must_close_findings:[]. 4 non-blocking impl notes: empty selection exit 2; baseline schema minItems:1; claim scanner allowlist not_sla/not SLA; scanner across all artifacts.",
+    "3 schemas (Draft 2020-12 + additionalProperties:false): catalog (workflow_id pinned + enforcement enum); baseline (candidate const true + sample_count const 1 + variance_profile const + generated_from 7 fields + metric duration_ms single_run + cost_source enum); threshold (enforcement_mode 3-enum + policy_disclaimer 3 const true + baseline_ref pattern + global_defaults + per-scenario override).",
+    "3 artifacts: catalog 3 scenarios (governed_review/bugfix fast/policy_threshold + full_mode_smoke full/advisory_only); baseline 2 scenarios fast mode (governed_bugfix 120ms + governed_review 200ms); threshold enforcement advisory + 20%/30% global_defaults + full_mode null/advisory_only override.",
+    "Generator promote_baseline.py (~210 line): catalog-join pattern; select_scenarios_for_baseline filters mode+enforcement; build_baseline joins by source_scorecard_scenario; deterministic (sort_keys + indent + trailing newline); --generated-at required; --allow-empty opt-in; exit 2 empty without flag; no network.",
+    "Operator README (10 section): Disclaimer + Source of Truth + Catalog table + Generation Rule mode+enforcement filter + Threshold advisory + Promote Workflow + Update Cadence + Investigation Runbook + 8 follow-up + Wording Discipline allowlist not_sla/not SLA + References.",
+    "45 invariant test pass: 8 schema validity + 4 negative reject + 4 catalog + 5 baseline + 5 threshold + 6 cross-validation + 4 promote script + 2 zero-touch governance + 3 README. ruff clean. Existing scorecard schema tests untouched.",
+    "Public claim discipline + ZERO TOUCH: PR HICBIR guard flag flip; HICBIR .github/workflows mutation; HICBIR tests/test_scorecard_schema.py mutation; HICBIR scorecard schema file mutation; HICBIR ao_kernel/_internal/scorecard/* mutation; HICBIR tests/benchmarks/* mutation; HICBIR runtime perf optimization. enforcement_mode advisory; no CI red; no production SLA claim. Scanner allowlist not_sla/not SLA disclaimer explicit.",
+    "Risk class: conservative low-risk (docs/schemas/scripts/tests only; no runtime; no workflows). Cross-AI peer review evidence + actual diff parity zorunlu.",
+    "Out-of-scope (8): E-7b concurrency + E-7c memory + E-7d large-corpus + E-7e multi-provider + E-7f cost p95 (E-5-4 compose) + E-7g Grafana dashboard + E-7h statistical collector + E-7x CI promotion track.",
+    "Cross-AI peer review trail (HARD RULE 2026-05-05 + 2026-05-14): implementer Anthropic Claude != reviewer OpenAI Codex; thread 019e8410 (4-iter REVISE/REVISE/REVISE/AGREE)."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/promote_baseline.py
+++ b/scripts/promote_baseline.py
@@ -1,0 +1,235 @@
+"""Promote a benchmark scorecard into a candidate baseline.v1.json (V5 Epic 7).
+
+Joins benchmark scorecard rows against the scenario catalog by
+``source_scorecard_scenario`` and emits a schema-conforming baseline manifest.
+
+Codex 019e8410 cross-AI plan-time AGREE (4 iters: REVISE/REVISE/REVISE/AGREE).
+
+Discipline:
+- Mode + enforcement filter: only catalog scenarios with
+  ``mode == --benchmark-mode`` AND ``enforcement == 'policy_threshold'``
+  are included. advisory_only entries and mode-mismatched entries are
+  skipped silently from the baseline; the script logs the selection
+  summary.
+- Empty selection: by default the script exits 2 ("nothing to promote
+  for this mode"). ``--allow-empty`` opts into writing an empty baseline
+  for operator-managed advanced workflows. The E-7a committed fast
+  baseline always has >=1 entry per the catalog.
+- Deterministic output: requires ``--generated-at`` (no wall-clock
+  default) so byte-equal drift tests are stable across machines.
+- No network: reads local scorecard + catalog files only. GitHub
+  artifact download is intentionally out of scope.
+
+Usage:
+    python scripts/promote_baseline.py \
+        --scorecard benchmark_scorecard.v1.json \
+        --scenario-catalog docs/performance/performance-scenario-catalog.v1.json \
+        --out docs/performance/baseline.v1.json \
+        --source-git-sha <hex> \
+        --source-git-ref refs/heads/main \
+        --benchmark-mode fast \
+        --python-version 3.13 \
+        --runner-os ubuntu-latest \
+        --generated-at 2026-06-01T20:00:00Z
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+EXIT_EMPTY_SELECTION = 2
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def select_scenarios_for_baseline(
+    catalog: dict[str, Any],
+    benchmark_mode: str,
+) -> list[dict[str, Any]]:
+    """Filter catalog entries for inclusion in the baseline.
+
+    Codex E7-BASELINE-CATALOG-MODE-FILTER absorb:
+    - include: ``mode == --benchmark-mode`` AND ``enforcement == 'policy_threshold'``
+    - skip: ``enforcement == 'advisory_only'`` OR ``mode != --benchmark-mode``
+    """
+    selected: list[dict[str, Any]] = []
+    for scenario in catalog["scenarios"]:
+        if scenario["mode"] != benchmark_mode:
+            continue
+        if scenario["enforcement"] != "policy_threshold":
+            continue
+        selected.append(scenario)
+    return selected
+
+
+def _find_scorecard_row(
+    scorecard: dict[str, Any],
+    source_name: str,
+) -> dict[str, Any] | None:
+    for row in scorecard.get("benchmarks", []) or []:
+        if row.get("scenario") == source_name:
+            return row
+    return None
+
+
+def build_baseline_scenario(
+    catalog_scenario: dict[str, Any],
+    scorecard_row: dict[str, Any],
+    benchmark_mode: str,
+) -> dict[str, Any]:
+    cost_source = scorecard_row.get("cost_source")
+    return {
+        "id": catalog_scenario["id"],
+        "source_scorecard_scenario": catalog_scenario["source_scorecard_scenario"],
+        "workflow_id": catalog_scenario["workflow_id"],
+        "benchmark_mode": benchmark_mode,
+        "metric": {
+            "name": "duration_ms",
+            "unit": "ms",
+            "value": float(scorecard_row["duration_ms"]),
+            "statistic": "single_run",
+        },
+        "status": scorecard_row.get("status", "pass"),
+        "workflow_completed": bool(scorecard_row.get("workflow_completed", True)),
+        "cost_source": cost_source,
+        "review_score_expected": scorecard_row.get("review_score"),
+        "candidate_baseline": True,
+        "sample_count": 1,
+        "variance_profile": "single_ci_run",
+    }
+
+
+def build_baseline(
+    catalog: dict[str, Any],
+    scorecard: dict[str, Any],
+    *,
+    benchmark_mode: str,
+    source_git_sha: str,
+    source_git_ref: str,
+    python_version: str,
+    runner_os: str,
+    generated_at: str,
+) -> dict[str, Any]:
+    catalog_entries = select_scenarios_for_baseline(catalog, benchmark_mode)
+    scenarios: list[dict[str, Any]] = []
+    skipped: list[str] = []
+    for catalog_scenario in catalog_entries:
+        row = _find_scorecard_row(scorecard, catalog_scenario["source_scorecard_scenario"])
+        if row is None:
+            skipped.append(catalog_scenario["id"])
+            continue
+        scenarios.append(build_baseline_scenario(catalog_scenario, row, benchmark_mode))
+
+    # Deterministic order — sort by id
+    scenarios.sort(key=lambda s: s["id"])
+
+    if skipped:
+        print(
+            f"warning: catalog scenarios missing in scorecard, skipped: {skipped}",
+            file=sys.stderr,
+        )
+
+    return {
+        "schema_version": "performance-baseline.v1",
+        "service": "ao-kernel",
+        "guard_flags": {
+            "support_widening_allowed": False,
+            "production_platform_claim_allowed": False,
+            "live_adapter_execution_allowed": False,
+        },
+        "generated_from": {
+            "scorecard_schema_version": scorecard.get("schema_version", "v1"),
+            "source_git_sha": source_git_sha,
+            "source_git_ref": source_git_ref,
+            "benchmark_mode": benchmark_mode,
+            "python_version": python_version,
+            "runner_os": runner_os,
+            "generated_at": generated_at,
+        },
+        "candidate_baseline": True,
+        "sample_count": 1,
+        "variance_profile": "single_ci_run",
+        "scenarios": scenarios,
+    }
+
+
+def _canonical_json(data: dict[str, Any]) -> str:
+    return json.dumps(data, sort_keys=True, indent=2, ensure_ascii=False) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Promote scorecard to baseline")
+    parser.add_argument("--scorecard", type=Path, required=True)
+    parser.add_argument("--scenario-catalog", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--source-git-sha", type=str, required=True)
+    parser.add_argument("--source-git-ref", type=str, required=True)
+    parser.add_argument(
+        "--benchmark-mode",
+        type=str,
+        required=True,
+        choices=("fast", "full"),
+    )
+    parser.add_argument("--python-version", type=str, required=True)
+    parser.add_argument("--runner-os", type=str, required=True)
+    parser.add_argument(
+        "--generated-at",
+        type=str,
+        required=True,
+        help="ISO 8601 timestamp (UTC, Z-suffix); must be supplied explicitly so the output is deterministic.",
+    )
+    parser.add_argument(
+        "--allow-empty",
+        action="store_true",
+        help="Permit writing an empty baseline when no catalog entries match the mode/enforcement filter.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Render baseline JSON to stdout without writing the output file.",
+    )
+    args = parser.parse_args(argv)
+
+    catalog = _load_json(args.scenario_catalog)
+    scorecard = _load_json(args.scorecard)
+
+    baseline = build_baseline(
+        catalog,
+        scorecard,
+        benchmark_mode=args.benchmark_mode,
+        source_git_sha=args.source_git_sha,
+        source_git_ref=args.source_git_ref,
+        python_version=args.python_version,
+        runner_os=args.runner_os,
+        generated_at=args.generated_at,
+    )
+
+    if not baseline["scenarios"] and not args.allow_empty:
+        print(
+            f"error: 0 policy_threshold scenarios selected for mode={args.benchmark_mode}; "
+            "advisory_only/mismatched-mode entries skipped. "
+            "Pass --allow-empty to write an empty baseline explicitly.",
+            file=sys.stderr,
+        )
+        return EXIT_EMPTY_SELECTION
+
+    text = _canonical_json(baseline)
+    if args.dry_run:
+        sys.stdout.write(text)
+        return 0
+    args.out.write_text(text)
+    print(
+        f"wrote {args.out} with {len(baseline['scenarios'])} scenarios "
+        f"(mode={args.benchmark_mode})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_performance_baseline.py
+++ b/tests/test_performance_baseline.py
@@ -1,0 +1,577 @@
+"""Invariant test suite for V5 Epic 7: Performance baseline + threshold policy.
+
+Codex 019e8410 cross-AI plan-time AGREE (4 iters: REVISE/REVISE/REVISE/AGREE).
+
+7 BLOCKER + 5 BLOCKER + 1 BLOCKER absorbed across 3 iters:
+- E7-GATE-SEMANTICS (advisory enforcement; no CI hard-fail in E-7a)
+- E7-P95-MISMATCH (duration_ms single_run; p95 deferred to E-7h)
+- E7-THRESHOLD-DEFAULTS (20% warn / 30% hard; matches existing repo default)
+- E7-SCENARIO-CATALOG-FILE + E7-BASELINE-SCHEMA (3 schema files)
+- E7-WORKFLOW-ID-SOURCE (catalog join, not from scorecard)
+- E7-BASELINE-CATALOG-MODE-FILTER (mode + enforcement filter)
+
+~37 invariants across 9 sections.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PERF_DIR = REPO_ROOT / "docs" / "performance"
+SCHEMAS_DIR = REPO_ROOT / "ao_kernel" / "defaults" / "schemas"
+CATALOG_PATH = PERF_DIR / "performance-scenario-catalog.v1.json"
+BASELINE_PATH = PERF_DIR / "baseline.v1.json"
+THRESHOLD_PATH = PERF_DIR / "performance-regression-threshold.v1.json"
+README_PATH = PERF_DIR / "README.md"
+CATALOG_SCHEMA_PATH = SCHEMAS_DIR / "performance-scenario-catalog.schema.v1.json"
+BASELINE_SCHEMA_PATH = SCHEMAS_DIR / "performance-baseline.schema.v1.json"
+THRESHOLD_SCHEMA_PATH = SCHEMAS_DIR / "performance-regression-threshold.schema.v1.json"
+SCRIPT_PATH = REPO_ROOT / "scripts" / "promote_baseline.py"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def load_catalog() -> dict[str, Any]:
+    return _load(CATALOG_PATH)
+
+
+def load_baseline() -> dict[str, Any]:
+    return _load(BASELINE_PATH)
+
+
+def load_threshold() -> dict[str, Any]:
+    return _load(THRESHOLD_PATH)
+
+
+def _validate(instance: dict, schema_path: Path) -> None:
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError:
+        pytest.skip("jsonschema not installed")
+    schema = json.loads(schema_path.read_text())
+    Draft202012Validator(schema).validate(instance)
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — Schema validity (8 invariants)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "schema_path",
+    [CATALOG_SCHEMA_PATH, BASELINE_SCHEMA_PATH, THRESHOLD_SCHEMA_PATH],
+)
+def test_schema_is_valid_draft_2020_12(schema_path):
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError:
+        pytest.skip("jsonschema not installed")
+    Draft202012Validator.check_schema(json.loads(schema_path.read_text()))
+
+
+@pytest.mark.parametrize(
+    "schema_path",
+    [CATALOG_SCHEMA_PATH, BASELINE_SCHEMA_PATH, THRESHOLD_SCHEMA_PATH],
+)
+def test_schema_root_additional_properties_false(schema_path):
+    schema = json.loads(schema_path.read_text())
+    assert schema.get("additionalProperties") is False
+
+
+def test_schema_guard_flags_const_false_full_name():
+    """Codex H8 absorb: full-name guard flag standard."""
+    for schema_path in (CATALOG_SCHEMA_PATH, BASELINE_SCHEMA_PATH, THRESHOLD_SCHEMA_PATH):
+        schema = json.loads(schema_path.read_text())
+        gf = schema["properties"]["guard_flags"]["properties"]
+        assert gf["support_widening_allowed"]["const"] is False
+        assert gf["production_platform_claim_allowed"]["const"] is False
+        assert gf["live_adapter_execution_allowed"]["const"] is False
+
+
+def test_threshold_schema_enforcement_mode_enum():
+    """Codex H6 absorb: enforcement_mode 3-value enum."""
+    schema = json.loads(THRESHOLD_SCHEMA_PATH.read_text())
+    enum_vals = schema["properties"]["enforcement_mode"]["enum"]
+    assert set(enum_vals) == {"advisory", "manual_block", "ci_block_candidate"}
+
+
+def test_baseline_schema_const_pins():
+    schema = json.loads(BASELINE_SCHEMA_PATH.read_text())
+    props = schema["properties"]
+    assert props["schema_version"]["const"] == "performance-baseline.v1"
+    assert props["service"]["const"] == "ao-kernel"
+    assert props["candidate_baseline"]["const"] is True
+    assert props["sample_count"]["const"] == 1
+    assert props["variance_profile"]["const"] == "single_ci_run"
+
+
+def test_threshold_schema_policy_disclaimer_const_true():
+    schema = json.loads(THRESHOLD_SCHEMA_PATH.read_text())
+    disc = schema["properties"]["policy_disclaimer"]["properties"]
+    assert disc["not_sla"]["const"] is True
+    assert disc["operator_tunable"]["const"] is True
+    assert disc["single_run_candidate_baseline"]["const"] is True
+
+
+def test_baseline_schema_cost_source_enum():
+    """Codex H2 absorb: cost_source enum including null."""
+    schema = json.loads(BASELINE_SCHEMA_PATH.read_text())
+    cs = schema["$defs"]["baseline_scenario"]["properties"]["cost_source"]["enum"]
+    assert set(cs) == {"mock_shim", "real_adapter", "axis_seeded_only", None}
+
+
+def test_catalog_schema_enforcement_enum():
+    schema = json.loads(CATALOG_SCHEMA_PATH.read_text())
+    enum_vals = schema["$defs"]["scenario"]["properties"]["enforcement"]["enum"]
+    assert set(enum_vals) == {"policy_threshold", "advisory_only"}
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — Schema negative tests (4 invariants)
+# ---------------------------------------------------------------------------
+
+
+def test_threshold_rejects_production_platform_claim_true():
+    threshold = load_threshold()
+    threshold["guard_flags"]["production_platform_claim_allowed"] = True
+    with pytest.raises(Exception):
+        _validate(threshold, THRESHOLD_SCHEMA_PATH)
+
+
+def test_threshold_rejects_unknown_enforcement_mode():
+    threshold = load_threshold()
+    threshold["enforcement_mode"] = "ci_block_red"
+    with pytest.raises(Exception):
+        _validate(threshold, THRESHOLD_SCHEMA_PATH)
+
+
+def test_baseline_rejects_candidate_false():
+    baseline = load_baseline()
+    baseline["candidate_baseline"] = False
+    with pytest.raises(Exception):
+        _validate(baseline, BASELINE_SCHEMA_PATH)
+
+
+def test_threshold_rejects_force_pass_override():
+    threshold = load_threshold()
+    threshold["scenarios"][0]["enforcement_override"] = "force_pass"
+    with pytest.raises(Exception):
+        _validate(threshold, THRESHOLD_SCHEMA_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — Catalog content (4 invariants)
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_validates_against_schema():
+    _validate(load_catalog(), CATALOG_SCHEMA_PATH)
+
+
+def test_catalog_workflow_ids_pinned_per_scenario():
+    """Codex H3 absorb: catalog is the source of truth for workflow_id."""
+    catalog = load_catalog()
+    expected = {
+        "governed_review": "review_ai_flow",
+        "governed_bugfix": "governed_bugfix_bench",
+        "full_mode_smoke": "review_ai_flow",
+    }
+    actual = {s["id"]: s["workflow_id"] for s in catalog["scenarios"]}
+    assert actual == expected
+
+
+def test_catalog_full_mode_smoke_is_advisory_only():
+    """Codex H13 absorb: full_mode_smoke is advisory_only with may_skip true."""
+    catalog = load_catalog()
+    full_mode = next(s for s in catalog["scenarios"] if s["id"] == "full_mode_smoke")
+    assert full_mode["mode"] == "full"
+    assert full_mode["enforcement"] == "advisory_only"
+    assert full_mode["may_skip_on_prereq_miss"] is True
+
+
+def test_catalog_no_duplicate_scenario_ids():
+    catalog = load_catalog()
+    ids = [s["id"] for s in catalog["scenarios"]]
+    assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — Baseline content (5 invariants)
+# ---------------------------------------------------------------------------
+
+
+def test_baseline_validates_against_schema():
+    _validate(load_baseline(), BASELINE_SCHEMA_PATH)
+
+
+def test_baseline_generated_from_has_all_metadata():
+    """Codex H3 absorb: generated_from 7 metadata fields."""
+    baseline = load_baseline()
+    gf = baseline["generated_from"]
+    for key in (
+        "scorecard_schema_version",
+        "source_git_sha",
+        "source_git_ref",
+        "benchmark_mode",
+        "python_version",
+        "runner_os",
+        "generated_at",
+    ):
+        assert key in gf and gf[key], f"missing/empty generated_from.{key}"
+
+
+def test_baseline_candidate_invariants():
+    baseline = load_baseline()
+    assert baseline["candidate_baseline"] is True
+    assert baseline["sample_count"] == 1
+    assert baseline["variance_profile"] == "single_ci_run"
+
+
+def test_baseline_scenarios_non_empty():
+    """E-7a committed fast baseline has >=1 entry per catalog (Codex impl note)."""
+    baseline = load_baseline()
+    assert len(baseline["scenarios"]) >= 1
+
+
+def test_baseline_each_scenario_metric_duration_ms():
+    """Codex E7-P95-MISMATCH absorb: only duration_ms single_run."""
+    baseline = load_baseline()
+    for scenario in baseline["scenarios"]:
+        assert scenario["metric"]["name"] == "duration_ms"
+        assert scenario["metric"]["unit"] == "ms"
+        assert scenario["metric"]["statistic"] == "single_run"
+        assert scenario["status"] in {"pass", "fail"}
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — Threshold content (5 invariants)
+# ---------------------------------------------------------------------------
+
+
+def test_threshold_validates_against_schema():
+    _validate(load_threshold(), THRESHOLD_SCHEMA_PATH)
+
+
+def test_threshold_enforcement_mode_advisory_in_e7a():
+    """Codex E7-GATE-SEMANTICS absorb: E-7a is advisory only."""
+    assert load_threshold()["enforcement_mode"] == "advisory"
+
+
+def test_threshold_baseline_ref_points_to_baseline_file():
+    threshold = load_threshold()
+    ref_path = REPO_ROOT / threshold["baseline_ref"]
+    assert ref_path == BASELINE_PATH
+
+
+def test_threshold_global_defaults_conservative():
+    """Codex E7-THRESHOLD-DEFAULTS absorb: 20%/30% conservative defaults."""
+    defaults = load_threshold()["global_defaults"]
+    assert defaults["warn_threshold_pct"] == 20.0
+    assert defaults["hard_fail_threshold_pct"] == 30.0
+
+
+def test_warn_below_hard_per_scenario():
+    """Codex H5 absorb: Python invariant (JSON Schema field-to-field is hard)."""
+    threshold = load_threshold()
+    for scenario in threshold["scenarios"]:
+        warn = scenario.get("warn_threshold_pct")
+        hard = scenario.get("hard_fail_threshold_pct")
+        if warn is None or hard is None:
+            continue  # advisory_only
+        assert warn < hard, f"{scenario['id']}: warn {warn} >= hard {hard}"
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — Cross-validation (mode + enforcement filter) (5 invariants)
+# ---------------------------------------------------------------------------
+
+
+def expected_baseline_catalog_ids(catalog: dict, baseline: dict) -> set[str]:
+    """Codex E7-BASELINE-CATALOG-MODE-FILTER absorb.
+
+    Baseline IDs come from catalog entries filtered by:
+    - mode == baseline.generated_from.benchmark_mode
+    - enforcement == 'policy_threshold'
+    """
+    mode = baseline["generated_from"]["benchmark_mode"]
+    return {s["id"] for s in catalog["scenarios"] if s["mode"] == mode and s["enforcement"] == "policy_threshold"}
+
+
+def test_baseline_ids_match_policy_threshold_catalog_for_mode():
+    """Codex iter-3 BLOCKER absorb: mode + enforcement filtered cross-validation."""
+    baseline = load_baseline()
+    catalog = load_catalog()
+    baseline_ids = {s["id"] for s in baseline["scenarios"]}
+    expected = expected_baseline_catalog_ids(catalog, baseline)
+    assert baseline_ids == expected, f"baseline IDs {baseline_ids} != mode/enforcement filter {expected}"
+
+
+def test_threshold_scenarios_subset_of_catalog():
+    threshold = load_threshold()
+    catalog = load_catalog()
+    threshold_ids = {s["id"] for s in threshold["scenarios"]}
+    catalog_ids = {s["id"] for s in catalog["scenarios"]}
+    assert threshold_ids.issubset(catalog_ids), f"threshold IDs {threshold_ids - catalog_ids} missing from catalog"
+
+
+def test_full_mode_smoke_threshold_is_advisory_null():
+    """Codex H4 absorb: full_mode_smoke threshold values null + override."""
+    threshold = load_threshold()
+    full_mode = next(s for s in threshold["scenarios"] if s["id"] == "full_mode_smoke")
+    assert full_mode["warn_threshold_pct"] is None
+    assert full_mode["hard_fail_threshold_pct"] is None
+    assert full_mode["enforcement_override"] == "advisory_only"
+
+
+def test_each_baseline_scenario_mode_matches_generated_from():
+    """Codex H5 absorb: baseline scenario mode parity via catalog lookup."""
+    baseline = load_baseline()
+    expected_mode = baseline["generated_from"]["benchmark_mode"]
+    catalog = load_catalog()
+    catalog_by_id = {s["id"]: s for s in catalog["scenarios"]}
+    for scenario in baseline["scenarios"]:
+        catalog_entry = catalog_by_id[scenario["id"]]
+        assert catalog_entry["mode"] == expected_mode, (
+            f"baseline scenario {scenario['id']} catalog mode={catalog_entry['mode']} != baseline mode={expected_mode}"
+        )
+
+
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+_FENCED_CODE_RE = re.compile(r"^(\s*)```")
+
+
+def _iter_prose_lines(text: str):
+    """Yield (line, prose) tuples for non-fenced lines with inline code stripped."""
+    in_fence = False
+    for line in text.splitlines():
+        if _FENCED_CODE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        prose = _INLINE_CODE_RE.sub("", line)
+        yield line, prose
+
+
+def test_no_sla_or_guarantee_wording_in_artifacts():
+    """Claim scanner across artifacts.
+
+    Codex iter-4 absorb: allow ``not_sla`` (schema field name) and
+    "not SLA" (disclaimer prose). Forbid positive guarantee/SLA claims.
+    Wording-discipline sections that quote forbidden tokens inside inline
+    code spans / fenced code blocks / lines explicitly flagged as
+    "forbidden|discipline|prohibited|yasak" are ignored.
+    """
+    forbidden = (
+        "we guarantee",
+        "production sla",
+        "contractual sla",
+        "guaranteed performance",
+    )
+    allowed_markers = ("not_sla", "not sla", "no sla")
+    discipline_markers = ("forbidden", "discipline", "prohibited", "yasak")
+    for path in (CATALOG_PATH, BASELINE_PATH, THRESHOLD_PATH, README_PATH):
+        for raw_line, prose in _iter_prose_lines(path.read_text()):
+            lowered_prose = prose.lower()
+            lowered_raw = raw_line.lower()
+            if any(marker in lowered_raw for marker in discipline_markers):
+                continue
+            for token in forbidden:
+                pos = lowered_prose.find(token)
+                if pos < 0:
+                    continue
+                window = lowered_prose[max(0, pos - 32) : pos + len(token) + 32]
+                if any(marker in window for marker in allowed_markers):
+                    continue
+                pytest.fail(f"forbidden SLA/guarantee wording in {path.name}: token={token!r}; window={window!r}")
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — Promote script (4 invariants)
+# ---------------------------------------------------------------------------
+
+
+def test_promote_script_constants_pinned():
+    """Codex H1 absorb: script exposes the empty-selection exit-code constant
+    and the canonical JSON emitter; both must match the documented contract.
+    """
+    import promote_baseline
+
+    assert promote_baseline.EXIT_EMPTY_SELECTION == 2
+    rendered = promote_baseline._canonical_json({"b": 1, "a": 2})
+    # sort_keys=True → keys alphabetized; trailing newline contract
+    assert rendered.startswith('{\n  "a": 2,\n  "b": 1\n}')
+    assert rendered.endswith("\n")
+
+
+def test_select_scenarios_fast_mode_includes_policy_threshold_only():
+    from promote_baseline import select_scenarios_for_baseline
+
+    catalog = load_catalog()
+    selected = select_scenarios_for_baseline(catalog, "fast")
+    ids = {s["id"] for s in selected}
+    assert ids == {"governed_review", "governed_bugfix"}
+
+
+def test_select_scenarios_full_mode_yields_empty_because_advisory_only():
+    """Codex iter-3 absorb: full mode yields 0 policy_threshold entries."""
+    from promote_baseline import select_scenarios_for_baseline
+
+    catalog = load_catalog()
+    selected = select_scenarios_for_baseline(catalog, "full")
+    assert selected == []
+
+
+def test_promote_script_deterministic_output_with_fixed_generated_at(tmp_path):
+    """Codex H7 absorb: --generated-at fixed → byte-equal output."""
+    from promote_baseline import build_baseline
+
+    scorecard = {
+        "schema_version": "v1",
+        "generated_at": "2026-04-18T10:00:00Z",
+        "git_sha": "abc1234",
+        "pr_number": None,
+        "benchmarks": [
+            {
+                "scenario": "governed_review",
+                "status": "pass",
+                "workflow_completed": True,
+                "duration_ms": 200,
+                "cost_consumed_usd": 0.01,
+                "cost_source": "mock_shim",
+                "review_score": None,
+            },
+            {
+                "scenario": "governed_bugfix",
+                "status": "pass",
+                "workflow_completed": True,
+                "duration_ms": 120,
+                "cost_consumed_usd": 0.01,
+                "cost_source": "mock_shim",
+                "review_score": None,
+            },
+        ],
+    }
+    catalog = load_catalog()
+    baseline_a = build_baseline(
+        catalog,
+        scorecard,
+        benchmark_mode="fast",
+        source_git_sha="fd8241c",
+        source_git_ref="refs/heads/main",
+        python_version="3.13",
+        runner_os="ubuntu-latest",
+        generated_at="2026-06-01T20:00:00Z",
+    )
+    baseline_b = build_baseline(
+        catalog,
+        scorecard,
+        benchmark_mode="fast",
+        source_git_sha="fd8241c",
+        source_git_ref="refs/heads/main",
+        python_version="3.13",
+        runner_os="ubuntu-latest",
+        generated_at="2026-06-01T20:00:00Z",
+    )
+    assert baseline_a == baseline_b
+
+
+def test_promote_script_cli_exits_2_on_empty_selection_without_allow_empty(tmp_path):
+    """Codex iter-4 implementation note: full mode without --allow-empty exits 2."""
+    scorecard = {
+        "schema_version": "v1",
+        "generated_at": "2026-04-18T10:00:00Z",
+        "git_sha": "abc1234",
+        "pr_number": None,
+        "benchmarks": [],
+    }
+    scorecard_path = tmp_path / "scorecard.json"
+    scorecard_path.write_text(json.dumps(scorecard))
+    out_path = tmp_path / "baseline.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--scorecard",
+            str(scorecard_path),
+            "--scenario-catalog",
+            str(CATALOG_PATH),
+            "--out",
+            str(out_path),
+            "--source-git-sha",
+            "fd8241c",
+            "--source-git-ref",
+            "refs/heads/main",
+            "--benchmark-mode",
+            "full",
+            "--python-version",
+            "3.13",
+            "--runner-os",
+            "ubuntu-latest",
+            "--generated-at",
+            "2026-06-01T20:00:00Z",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 2, (
+        f"expected exit 2 for empty selection without --allow-empty; got {result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 8 — Zero-touch governance (2 invariants)
+# ---------------------------------------------------------------------------
+
+
+def test_existing_scorecard_schema_present_and_untouched():
+    """Codex H10 absorb: tests/test_scorecard_schema.py ZERO TOUCH."""
+    path = REPO_ROOT / "tests" / "test_scorecard_schema.py"
+    assert path.exists()
+
+
+def test_existing_scorecard_schema_file_present():
+    schema_path = SCHEMAS_DIR / "scorecard.schema.v1.json"
+    assert schema_path.exists(), "existing scorecard schema must remain present"
+
+
+# ---------------------------------------------------------------------------
+# Section 9 — README discipline (3 invariants)
+# ---------------------------------------------------------------------------
+
+
+def test_readme_has_numbered_sections():
+    text = README_PATH.read_text()
+    for n in range(1, 11):
+        assert re.search(rf"^## {n}\.", text, re.MULTILINE), f"missing section {n}"
+
+
+def test_readme_mentions_guard_flags_and_disclaimer():
+    text = README_PATH.read_text()
+    assert "Not SLA" in text
+    assert "candidate baseline" in text.lower()
+    assert "support_widening" in text
+    assert "production_platform_claim" in text
+    assert "live_adapter_execution" in text
+
+
+def test_readme_documents_mode_enforcement_filter():
+    text = README_PATH.read_text().lower()
+    assert "policy_threshold" in text
+    assert "advisory_only" in text
+    assert "mode" in text and "filter" in text


### PR DESCRIPTION
## Summary

V5 Epic 7: Schema-backed performance baseline + regression threshold policy for the existing PR-B7 benchmark suite. **Policy definition only** — `enforcement_mode: advisory`; CI red gating is future E-7x slice. **ZERO TOUCH** scorecard schema test, scorecard schema file, benchmark suite, collector, and workflows.

## Cross-AI Plan-Time Consensus

**Codex thread \`019e8410\` (4 iters):** REVISE → REVISE → REVISE → **AGREE + ready_for_impl:true + must_close_findings:[]**

| Iter | Verdict | BLOCKER | Notes |
|---|---|---|---|
| 1 | REVISE | 5 (advisory enforcement, duration_ms not p95, 20/30 defaults, 3 schemas, baseline own schema) | — |
| 2 | REVISE | 1 (catalog is workflow_id source) | — |
| 3 | REVISE | 1 (mode + enforcement filter) | — |
| 4 | **AGREE** | — | 4 impl notes |

## Artifacts

- 3 Draft 2020-12 schemas (catalog, baseline, threshold)
- 3 canonical artifacts (mode-filtered baseline; advisory threshold)
- \`scripts/promote_baseline.py\` deterministic catalog-join promoter
- \`docs/performance/README.md\` 10-section operator runbook
- 45 invariants in \`tests/test_performance_baseline.py\`

## Defaults

- \`enforcement_mode: advisory\` (E-7a; future E-7x promotes)
- \`warn_threshold_pct: 20.0\` / \`hard_fail_threshold_pct: 30.0\` (conservative; matches existing repo)
- \`full_mode_smoke\` → \`enforcement_override: advisory_only\`, threshold values null

## Discipline (ZERO TOUCH)

- \`tests/test_scorecard_schema.py\`
- \`ao_kernel/defaults/schemas/scorecard.schema.v1.json\`
- \`ao_kernel/_internal/scorecard/*\`
- \`tests/benchmarks/*\`
- \`.github/workflows/*\`
- 3 guard flags \`const false\`
- No \`production SLA\` / \`guaranteed performance\` wording

## Test Plan

- [x] 45 new invariants pass
- [x] ruff clean
- [x] 3 schemas valid Draft 2020-12
- [x] promote_baseline.py deterministic byte-equal output
- [x] Empty selection → exit 2 without \`--allow-empty\`
- [x] Cross-AI peer review: Anthropic Claude (impl) ≠ OpenAI Codex (review)
- [ ] CI green → squash auto-merge

## Out-of-scope follow-ups (8)

E-7b concurrency + E-7c memory + E-7d large-corpus + E-7e multi-provider + E-7f cost p95 (E-5-4 compose) + E-7g Grafana dashboard + E-7h statistical collector + E-7x CI promotion track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)