### PR TITLE
feat(e-p0-4): README v5 promotion roadmap badge + link (V5)

### DIFF
--- a/.claude/plans/EPIC-P0-4-README-V5-ROADMAP-BADGE.md
+++ b/.claude/plans/EPIC-P0-4-README-V5-ROADMAP-BADGE.md
@@ -1,0 +1,64 @@
+# V5 Epic P0 E-P0-4: README V5 Roadmap Badge + Link
+
+> **Risk class:** conservative low-risk (docs-only)
+> **Implementer:** Anthropic Claude / **Reviewer:** OpenAI Codex (post-impl)
+
+## 1. Scope
+
+Surface the V5.0.0 Full Production Promotion Roadmap as a transparent program
+plan link in the project README. Add three lightweight Shields.io badges
+referencing the roadmap, GPP status, and guard-flag posture. **Does not**
+flip any guard flag; explicitly disclaims production-readiness.
+
+**In scope:**
+- README badge block (v5 roadmap + GPP + guard flags)
+- README roadmap-status disclaimer banner (qualified language)
+- Invariant test suite enforcing no production-ready claim creep
+
+**Out of scope (ZERO TOUCH):**
+- `.github/workflows/*`
+- `.claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md` content (link only)
+- Any guard flag flip (3 const false unchanged)
+- Production-ready badge or "GA" badge (forbidden until final operator-bound supersession PR)
+- ao-release-gate / branch protection mutation
+
+## 2. Implementation Artifacts
+
+| File | LOC | Purpose |
+|---|---|---|
+| `README.md` | +12 lines | 3 badges + roadmap-status banner disclaimer |
+| `tests/test_readme_v5_roadmap_badge.py` | ~170 | 10 invariants |
+| `.claude/plans/EPIC-P0-4-README-V5-ROADMAP-BADGE.md` | this | Plan doc |
+
+## 3. Public Claim Discipline
+
+The README banner uses **qualified language only**:
+- "transparent program plan" (NOT "production-ready")
+- "operator-bound supersession PR" (promotion authority anchor)
+- "final" (no intermediate flag flip)
+- 3 guard flags explicitly listed with `const false`
+
+**Forbidden positive-claim tokens** (scanner-enforced):
+- `production ready`, `production-ready`, `production platform`,
+  `production-platform`, `fully supported`, `ga release`,
+  `general availability`
+
+Negation prose exception: tokens may appear only after `not a `, `not an `,
+`blanket `, `"not `, `**not**`, or `no production` cues.
+
+## 4. Test Sections (10 invariants)
+
+| Section | Count | Focus |
+|---|---|---|
+| 1. Badge presence | 3 | v5 roadmap + GPP + guard flags badges |
+| 2. Link targets exist | 2 | Roadmap MD file + GPP status MD file present |
+| 3. Disclaimer banner | 2 | 3 guard flags mention + qualified language ("transparent program plan", "operator-bound supersession", "final") |
+| 4. No claim creep | 2 | No production-ready prose + no in-prose flag flip |
+| 5. Governance | 1 | E-P0-4 ZERO TOUCH `.github/workflows/` |
+
+## 5. References
+
+- V5 roadmap: `.claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md`
+- GPP status: `.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md`
+- HARD RULE Cross-AI Peer Review (2026-05-05 + 2026-05-14)
+- HARD RULE No Fake Work / Uzun Vadeli Kalıcı Çözüm

--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
 # ao-kernel
 
+[![v5 promotion roadmap](https://img.shields.io/badge/v5-promotion%20roadmap-blue)](.claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md)
+[![GPP](https://img.shields.io/badge/GPP-keep__narrow__stable__runtime-green)](.claude/plans/GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md)
+[![guard flags](https://img.shields.io/badge/guard_flags-3%20const%20false-lightgrey)](.claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md#2-tam-production-semantiği-codex-iter-1-invariant-1)
+
 Governed AI orchestration runtime — policy-driven, fail-closed, evidence-trail.
 
 ao-kernel is **not** a general-purpose agent framework or a blanket "production coding automation platform" claim. It is a **governed runtime** that enforces policies, records evidence, and provides deterministic LLM routing for production Python teams.
+
+> **Roadmap status:** A V5.0.0 Full Production Promotion Roadmap is published
+> as a transparent program plan; it does **not** flip the three guard flags
+> (`support_widening`, `production_platform_claim`, `live_adapter_execution`),
+> which remain `const false`. Promotion authority lives in the final
+> operator-bound supersession PR at the end of the roadmap, not in any
+> individual epic or slice. See
+> [`V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md`](.claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md)
+> for the evidence matrix.
 
 ## Installation
 

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,46 +1,32 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "EPIC-7X-CI-PROMOTION-TRACK",
+  "work_package": "EPIC-P0-4-README-V5-ROADMAP-BADGE",
   "implementer": { "agent": "claude", "provider": "anthropic" },
   "reviewer": { "agent": "codex", "provider": "openai", "verdict": "AGREE" },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-7x-ci-promotion-track",
+    "head_ref": "refs/heads/codex/epic-p0-4-readme-badge",
     "changed_files": [
-      ".claude/plans/EPIC-7X-CI-PROMOTION-TRACK.md",
-      "ao_kernel/_internal/scorecard/regression.py",
-      "ao_kernel/defaults/schemas/regression-comparison-result.schema.v1.json",
+      ".claude/plans/EPIC-P0-4-README-V5-ROADMAP-BADGE.md",
+      "README.md",
       "local-ai-review-evidence.v1.json",
-      "scripts/regression_gate.py",
-      "tests/test_regression_gate.py"
+      "tests/test_readme_v5_roadmap_badge.py"
     ]
   },
   "checks_considered": [
     { "name": "tests", "status": "pass" },
-    { "name": "secret_scan", "status": "pass" },
     { "name": "ruff_lint", "status": "pass" },
-    { "name": "mypy_strict", "status": "pass" },
-    { "name": "visibility_not_authority", "status": "pass" },
+    { "name": "secret_scan", "status": "pass" },
     { "name": "no_guard_flip", "status": "pass" },
-    { "name": "no_github_write_in_this_pr", "status": "pass" },
-    { "name": "cross_provider_review", "status": "pass" },
-    { "name": "compare_py_zero_touch", "status": "pass" }
+    { "name": "no_workflow_mutation", "status": "pass" },
+    { "name": "cross_provider_review", "status": "pass" }
   ],
   "findings": [
-    "V5 Epic 7x CI required-check promotion track: tooling for future advisory -> manual_block -> ci_block_candidate enforcement promotion. E-7x-1 + E-7x-2 scope (policy-aware regression comparison module + thin CLI gate); E-7x-3 workflow flip ayrı governance PR.",
-    "Codex plan-time thread 019e84b7 2-iter chain (REVISE -> AGREE). iter-1 5 BLOCKER: F1 checkout_drift (impl deferred until PR #805 merge; resolved 2026-06-01); F2 exit_semantics policy-driven (advisory/manual_block/ci_block_candidate + --strict-mode operator-local override + banner); F3 metric_direction (higher_is_worse/lower_is_worse + 8 skip reason codes); F4 schema replay/audit fields; F5 module_boundary (regression.py reuses compare.py).",
-    "iter-2 AGREE + ready_for_impl:false_until_805_merged + must_close_findings:[]. 2 impl-time pins enforced: unknown enforcement_mode ValueError fail-closed; skip_reason single canonical nullable enum.",
-    "Implementation kickoff gate cleared 2026-06-01: PR #805 (E-7a) MERGED (main commit 505885b); E-7x worktree fresh rebase; E-7a artifacts visible.",
-    "Schema regression-comparison-result.schema.v1.json: Draft 2020-12 + additionalProperties:false everywhere; const pins; guard_flags 3 const false; claim_boundary 4 const true (not_sla + not_required_check_yet + single_run_candidate_baseline + advisory_warn_default); compared_from 12 fields (4 SHA256 + benchmark_mode + enforcement_mode_resolved + cli_override_applied + generated_at); overall_status 4-enum + counts 4 integer + scenarios + observed_extra_scenarios.",
-    "Skip reason enum 8 codes: missing_baseline/missing_head/advisory_only/mode_mismatch/baseline_zero/missing_baseline_value/unit_mismatch/invalid_metric_type.",
-    "Module regression.py (~280 line): policy-aware wrapper reusing compare.py; ComparisonInputs dataclass; build_comparison_result catalog-filtered (mode + policy_threshold); direction-aware pct_change; edge case fail-closed skip; determine_exit_code policy-driven + override; ValueError unknown mode (iter-2 pin); canonical_json deterministic.",
-    "CLI scripts/regression_gate.py (~85 line thin): argparse + mutex --advisory-mode/--strict-mode; --generated-at required; --strict-mode stderr banner 'operator-local only NOT CI evidence'; imports facade only.",
-    "33 invariant test pass local: 6 schema validity + 3 negative + 5 comparison logic (warn 25% + hard 40% + improvement -25% + missing_head skip + observed_extra non-gate) + 4 exit semantics + 2 fail-closed enforcement (ValueError) + 3 catalog filter + 3 module boundary + 3 provenance + 2 CLI E2E (strict banner + exit 1 warn) + 2 governance. ruff clean.",
-    "Public claim discipline + ZERO TOUCH: PR HICBIR guard flag flip; HICBIR .github/workflows mutation; HICBIR compare.py mutation (read-only reuse + git diff invariant); HICBIR scorecard schema mutation; HICBIR E-7a artifact mutation. claim_boundary 4 const true; no production claim; no CI required-check promotion claim (deferred E-7x-3).",
-    "Risk class: conservative low-risk (schemas + module + script + tests; no runtime; no workflows; no governance escalation).",
-    "Out-of-scope follow-up slices (5): E-7x-3 workflow continue-on-error flip (governance PR; required-check) + E-7x-4 enforcement transition gate + E-7x-5 compare.py >= vs > fix + E-7x-6 PR comment poster + E-7x-7 multi-baseline trend.",
-    "Cross-AI peer review trail (HARD RULE 2026-05-05 + 2026-05-14): implementer Anthropic Claude != reviewer OpenAI Codex; thread 019e84b7 (2-iter REVISE -> AGREE + ready_for_impl:false_until_805_merged + must_close_findings:[])."
+    "V5 Epic P0 E-P0-4 README badge + roadmap link slice (low-risk docs-only). Three Shields.io badges surface roadmap as transparent program plan.",
+    "Roadmap status disclaimer banner uses qualified language: 'transparent program plan', 'operator-bound supersession PR', 'final'. Three guard flags listed const false.",
+    "10 invariants: 3 badge + 2 link target + 2 disclaimer banner + 2 no production-ready creep + 1 ZERO TOUCH workflows.",
+    "ZERO TOUCH: no .github/workflows/ mutation, no ao-release-gate mutation, no branch protection mutation, no guard flag flip, no production-ready badge."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_readme_v5_roadmap_badge.py
+++ b/tests/test_readme_v5_roadmap_badge.py
@@ -1,0 +1,153 @@
+"""V5 Epic P0 E-P0-4 invariants: README v5 roadmap badge + link discipline.
+
+The README MUST surface the v5 promotion roadmap as a transparent program
+plan link AND must NOT claim production-readiness, production-platform,
+support widening, live adapter execution, or any flag flip. The three
+guard flags must be explicitly characterized as still `const false`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+README_PATH = REPO_ROOT / "README.md"
+ROADMAP_PATH = REPO_ROOT / ".claude" / "plans" / "V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md"
+GPP_STATUS_PATH = REPO_ROOT / ".claude" / "plans" / "GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md"
+
+# Tokens that MUST NOT appear as positive claims in README prose
+PRODUCTION_CLAIM_TOKENS = (
+    "production ready",
+    "production-ready",
+    "production platform",
+    "production-platform",
+    "fully supported",
+    "ga release",
+    "general availability",
+)
+
+
+def _strip_inline_code(line: str) -> str:
+    return re.sub(r"`[^`]*`", "", line)
+
+
+def _strip_fenced_blocks(text: str) -> str:
+    lines = text.splitlines()
+    out = []
+    in_fence = False
+    for line in lines:
+        if line.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def _readme_prose() -> str:
+    return _strip_fenced_blocks(README_PATH.read_text())
+
+
+def test_readme_has_v5_promotion_roadmap_badge() -> None:
+    text = README_PATH.read_text()
+    assert "v5-promotion%20roadmap" in text, "v5 promotion roadmap badge missing"
+    assert "V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md" in text
+
+
+def test_readme_has_gpp_badge() -> None:
+    text = README_PATH.read_text()
+    assert "GPP" in text
+    assert "GENERAL-PURPOSE-PRODUCTION-PROMOTION-STATUS.md" in text
+
+
+def test_readme_has_guard_flags_badge() -> None:
+    text = README_PATH.read_text()
+    assert "guard_flags" in text
+    assert "const%20false" in text
+
+
+def test_readme_roadmap_link_target_exists() -> None:
+    assert ROADMAP_PATH.exists(), f"V5 roadmap missing at {ROADMAP_PATH}"
+
+
+def test_readme_gpp_status_link_target_exists() -> None:
+    assert GPP_STATUS_PATH.exists(), f"GPP status missing at {GPP_STATUS_PATH}"
+
+
+def test_readme_disclaimer_mentions_three_guard_flags_const_false() -> None:
+    """README banner MUST disclose the three guard flags + const false state."""
+    prose = _readme_prose().lower()
+    # Roadmap block must mention the three flags explicitly
+    assert "support_widening" in prose
+    assert "production_platform_claim" in prose
+    assert "live_adapter_execution" in prose
+    # And declare them const false
+    assert "const false" in prose or "`const false`" in prose
+
+
+def test_readme_no_production_ready_claim() -> None:
+    """No positive production-ready / production-platform claim in prose."""
+    prose = _readme_prose().lower()
+    for token in PRODUCTION_CLAIM_TOKENS:
+        # Allow only in negation prose (e.g. "not a ... production-platform claim")
+        # Substring presence is OK only if a negation cue immediately precedes it
+        idx = 0
+        while True:
+            idx = prose.find(token, idx)
+            if idx == -1:
+                break
+            window = prose[max(0, idx - 60) : idx]
+            negated = any(
+                cue in window for cue in ("not a ", "not an ", "blanket ", '"not ', "**not**", "no production")
+            )
+            assert negated, (
+                f"README contains positive production-claim token {token!r}; "
+                f"context: ...{prose[max(0, idx - 30) : idx + len(token) + 30]!r}"
+            )
+            idx += len(token)
+
+
+def test_readme_roadmap_status_banner_uses_qualified_language() -> None:
+    """The Roadmap status banner must describe promotion as transparent
+    program plan, NOT as accomplished promotion."""
+    prose = _readme_prose().lower()
+    assert "transparent program plan" in prose
+    assert "operator-bound supersession" in prose
+    assert "final" in prose
+
+
+def test_readme_does_not_flip_guard_flags_in_prose() -> None:
+    """No README sentence may claim a guard flag flipped to true."""
+    prose = _readme_prose().lower()
+    forbidden = (
+        "support_widening = true",
+        "support_widening: true",
+        "production_platform_claim = true",
+        "production_platform_claim: true",
+        "live_adapter_execution = true",
+        "live_adapter_execution: true",
+    )
+    for token in forbidden:
+        assert token not in prose, f"README must not flip guard flag in prose: {token!r}"
+
+
+def test_no_e_p0_4_workflow_mutation() -> None:
+    """E-P0-4 must not touch .github/workflows/ (low-risk docs slice)."""
+    import subprocess
+
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main...HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        import pytest
+
+        pytest.skip(f"git diff unavailable: {proc.stderr.strip()}")
+    changed = proc.stdout.split()
+    for path in changed:
+        assert not path.startswith(".github/workflows/"), f"E-P0-4 must not touch workflows: {path}"


### PR DESCRIPTION
## Summary

V5 Epic P0 E-P0-4 — README v5 promotion roadmap badge + link. Three Shields.io badges (v5 roadmap, GPP keep_narrow_stable_runtime, guard flags const false) surface the roadmap as a transparent program plan link. Roadmap status disclaimer banner uses qualified language only; does NOT flip any guard flag.

## Scope

| Item | Status |
|---|---|
| 3 Shields.io badges | Added |
| Roadmap status disclaimer banner | Added (qualified language) |
| 3 guard flags listed const false | Explicit |
| Production-ready badge / GA badge | Forbidden by invariant |
| `.github/workflows/` mutation | ZERO TOUCH (invariant) |

## Test coverage (10 invariants)

- 3 badge presence (v5 roadmap + GPP + guard flags)
- 2 link target existence (V5 roadmap MD + GPP status MD)
- 2 disclaimer banner content (3 guard flags mention + qualified language)
- 2 no production-ready claim creep (token scan + no in-prose flag flip)
- 1 ZERO TOUCH `.github/workflows/`

## Test plan

- [x] 10 invariant tests pass local
- [x] ruff clean
- [x] No guard flag flip
- [x] No \`.github/workflows/\` mutation
- [x] Negation prose exception verified (`not a production-platform claim` allowed)
- [x] Cross-provider review (post-impl Codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)