### PR TITLE
feat(e-1-4): pre-commit changelog gate hook (V5)

### DIFF
--- a/.claude/plans/EPIC-1-4-PRE-COMMIT-CHANGELOG-HOOK.md
+++ b/.claude/plans/EPIC-1-4-PRE-COMMIT-CHANGELOG-HOOK.md
@@ -1,0 +1,70 @@
+# V5 Epic 1 E-1-4: Pre-commit Changelog Hook
+
+> **Risk class:** conservative low-risk (local script only; opt-in install)
+> **Implementer:** Anthropic Claude / **Reviewer:** OpenAI Codex (post-impl)
+
+## 1. Scope
+
+Local pre-commit shell hook that enforces ADR-0005 Keep-a-Changelog
+discipline at commit time. Aligned with the existing
+`pre-commit-version-gate.sh` install pattern (CLAUDE.md §17). E-1-3
+will provide the matching CI workflow; this slice is the lightweight
+local mirror.
+
+**In scope:**
+- `.claude/scripts/pre-commit-changelog-gate.sh` (shell hook)
+- 15 invariant tests (presence/structure + decision contract +
+  coexistence with version-gate + ADR-0005/CHANGELOG presence +
+  governance)
+
+**Out of scope (ZERO TOUCH):**
+- `.github/workflows/*` (E-1-3 covers CI)
+- ADR-0005 content (referenced, not modified)
+- CHANGELOG.md content (referenced, not modified)
+- `.git/hooks/pre-commit` (operator-owned install path; documented)
+- Any guard flag flip
+
+## 2. Decision Contract
+
+| Staged | Commit message prefix | Hook decision |
+|---|---|---|
+| No code | any | PASS |
+| Code + CHANGELOG.md | any | PASS |
+| Code, no CHANGELOG | `chore:` / `docs:` / `test:` / `ci:` / `style:` / `refactor:` / `build:` / `perf:` | PASS (non-user-visible) |
+| Code, no CHANGELOG | `feat:` / `fix:` / other | BLOCK (exit 1) with actionable message |
+| `--no-verify` | any | bypass (rare; justify in message) |
+
+The hook reads `.git/COMMIT_EDITMSG` to introspect the commit prefix.
+"Code" = `ao_kernel/**/*.py` + `pyproject.toml` + `ao_kernel/defaults/**/*.json` + `scripts/**/*.py` (excluding `/tests/`).
+
+## 3. Test Sections (15 invariants)
+
+| Section | Count | Focus |
+|---|---|---|
+| 1. Presence/structure | 6 | Hook file + executable bit + bash shebang + `set -e` + CHANGELOG.md reference + Keep-a-Changelog/ADR-0005 citation |
+| 2. Allowed-prefix contract | 4 | 5 prefixes listed + `feat:` without CHANGELOG → exit 1 + `chore:` without CHANGELOG → exit 0 + `feat:` with CHANGELOG → exit 0 |
+| 3. Coexistence | 2 | Version-gate hook still present + install instruction composes both |
+| 4. ADR + governance | 3 | ADR-0005 exists + CHANGELOG.md exists + ZERO TOUCH `.github/workflows/` |
+
+Decision contract tests run the hook in a temp git repo (no global git
+side effects).
+
+## 4. Install (operator action; CLAUDE.md §17 pattern)
+
+```bash
+cat .claude/scripts/pre-commit-version-gate.sh \
+    .claude/scripts/pre-commit-changelog-gate.sh \
+    > .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+Hook is operator-installed (not auto-installed) per existing repo
+convention. The CI workflow (E-1-3) provides the non-bypassable mirror.
+
+## 5. References
+
+- ADR-0005 Keep-a-Changelog discipline
+- `.claude/scripts/pre-commit-version-gate.sh` (existing co-pattern)
+- CHANGELOG.md
+- E-1-3 future slice: CI changelog enforcement workflow
+- HARD RULE Cross-AI Peer Review + No Fake Work + Uzun Vadeli

--- a/.claude/scripts/pre-commit-changelog-gate.sh
+++ b/.claude/scripts/pre-commit-changelog-gate.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# pre-commit-changelog-gate.sh — Block code commits that forget to
+# update CHANGELOG.md per the Keep-a-Changelog discipline.
+#
+# Pattern: when staged files include any *.py / pyproject.toml /
+# ao_kernel/defaults/*.json change, the commit MUST also stage a
+# CHANGELOG.md edit OR carry an explicit `chore:` / `docs:` / `test:` /
+# `ci:` / `style:` Conventional Commit prefix that signals "no
+# user-visible change". This is the lightweight local mirror of the
+# upcoming E-1-3 CI changelog enforcement workflow.
+#
+# Install (combined with the version-gate hook):
+#   cat .claude/scripts/pre-commit-version-gate.sh \
+#       .claude/scripts/pre-commit-changelog-gate.sh \
+#       > .git/hooks/pre-commit
+#   chmod +x .git/hooks/pre-commit
+#
+# Override (rare, justify in commit message):
+#   git commit --no-verify
+#
+# E-1-4 V5 Epic 1 slice. Aligned with ADR-0005 (Keep-a-Changelog
+# discipline). Does NOT flip any guard flag.
+
+set -e
+
+# 1. What's staged?
+code_changed=$(git diff --cached --name-only \
+  | grep -E "^(ao_kernel/.*\.py|pyproject\.toml|ao_kernel/defaults/.*\.json|scripts/.*\.py)$" \
+  | grep -v '/tests/' || true)
+changelog_changed=$(git diff --cached --name-only \
+  | grep -E "^CHANGELOG\.md$" || true)
+
+# 2. No code change -> nothing to enforce
+if [ -z "$code_changed" ]; then
+  exit 0
+fi
+
+# 3. Code change with CHANGELOG.md edit -> pass
+if [ -n "$changelog_changed" ]; then
+  exit 0
+fi
+
+# 4. Code change without CHANGELOG edit -> check the commit message
+#    for a non-user-visible prefix. The message is in
+#    .git/COMMIT_EDITMSG when this hook runs.
+msg_file=".git/COMMIT_EDITMSG"
+if [ ! -f "$msg_file" ]; then
+  # Fallback: best-effort, allow if we can't introspect the message
+  exit 0
+fi
+
+first_line=$(head -n1 "$msg_file" | tr -d '\r')
+# Allowed prefixes for "no CHANGELOG required"
+allowed_re='^(chore|docs|test|ci|style|refactor|build|perf)(\(.*\))?(!)?:'
+
+if echo "$first_line" | grep -Eq "$allowed_re"; then
+  exit 0
+fi
+
+# 5. Code change + no CHANGELOG + no allowed prefix -> block
+cat <<'EOF' >&2
+ao-kernel pre-commit: CHANGELOG.md update is missing.
+
+Staged code changes detected but CHANGELOG.md is not staged. Either:
+  a) Add a CHANGELOG.md entry under ## [Unreleased] and stage it, OR
+  b) Use a non-user-visible Conventional Commit prefix in your message
+     (chore: / docs: / test: / ci: / style: / refactor: / build: / perf:)
+
+To override (rare; justify in message):
+  git commit --no-verify
+
+E-1-4 V5 Epic 1 — local mirror of the upcoming E-1-3 CI workflow.
+EOF
+exit 1

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,42 +1,33 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "CI-CODEX-PUSH-DEDUP",
+  "work_package": "EPIC-1-4-PRE-COMMIT-CHANGELOG-HOOK",
   "implementer": { "agent": "claude", "provider": "anthropic" },
   "reviewer": { "agent": "codex", "provider": "openai", "verdict": "AGREE" },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ci-codex-push-dedup",
+    "head_ref": "refs/heads/codex/epic-1-4-pre-commit-changelog",
     "changed_files": [
-      ".github/workflows/test.yml",
-      "CLAUDE.md",
-      "local-ai-review-evidence.v1.json"
+      ".claude/plans/EPIC-1-4-PRE-COMMIT-CHANGELOG-HOOK.md",
+      ".claude/scripts/pre-commit-changelog-gate.sh",
+      "local-ai-review-evidence.v1.json",
+      "tests/test_pre_commit_changelog_gate.py"
     ]
   },
   "checks_considered": [
     { "name": "tests", "status": "pass" },
+    { "name": "ruff_lint", "status": "pass" },
     { "name": "secret_scan", "status": "pass" },
-    { "name": "yaml_valid", "status": "pass" },
-    { "name": "actionlint_clean", "status": "pass" },
-    { "name": "bash_syntax_clean", "status": "pass" },
-    { "name": "required_check_names_preserved", "status": "pass" },
-    { "name": "matrix_preserved", "status": "pass" },
-    { "name": "ao_release_gate_allowlist_preserved", "status": "pass" },
-    { "name": "ao_ma10n_classic_ci_requirements_intact", "status": "pass" },
-    { "name": "no_branch_protection_mutation", "status": "pass" },
-    { "name": "no_ruleset_mutation", "status": "pass" },
     { "name": "no_guard_flip", "status": "pass" },
-    { "name": "downstream_workflow_run_unaffected", "status": "pass" },
+    { "name": "no_workflow_mutation", "status": "pass" },
     { "name": "cross_provider_review", "status": "pass" }
   ],
   "findings": [
-    "CI-perf change (PR-1 of the queue-relief program after #901 + #906): remove `codex/**` from .github/workflows/test.yml on.push.branches. Goal is to eliminate the same-SHA push-run + PR-run double-trigger on every codex/* branch update -- the concurrency key is `github.ref`, so push and PR live in separate concurrency groups and BOTH run all 9+ required checks against the same commit. In the ~45-parallel-worktree model this duplication was the dominant queue saturator. The PR run remains the canonical required-check source-of-truth; semantics do not change.",
-    "Change set (3 files; small surgical edits + one workflow line + 2 docs):\n(1) .github/workflows/test.yml: a single line removed from on.push.branches -- `- \"codex/**\"` deleted. push.branches is now `[main]` (single element, valid YAML). pull_request / pull_request_review / workflow_dispatch triggers + concurrency + matrix + every job + every required-check job name are unchanged.\n(2) CLAUDE.md §19 'CI kurali' paragraph rewritten so the documented model matches the new behavior: test.yml push trigger is main-only; pre-PR signal has two paths depending on PR base type. For base=`main` PRs, opening the PR (draft or ready) auto-triggers the workflow (canonical signal). For base=`codex/**` upper-stacked PRs, automatic trigger does NOT fire (since pull_request.branches: [main]); pre-retarget signal there requires the workflow_dispatch fallback (.claude/scripts/trigger-test-workflow.sh). A required-check honesty sentence was added: even if pre-PR branch CI ran, the same-SHA PR run will run again; the required check's source-of-truth is always the PR run.\n(3) .claude/scripts/trigger-test-workflow.sh: file header comment updated. It no longer claims 'codex/* push normally produces CI'; it now lists three honest use cases (pre-PR branch CI, base=codex/** upper-stacked PR pre-retarget signal, post-retarget recovery). The script body itself was not touched.",
-    "AO-MA-10N hard-stop ('No removal of classic CI requirements.', pinned by test_ao_ma10n_live_enforcement_cutover.py:45 + test_ao_ma10o_cc9_no_human_bootstrap_supersession.py:146 + .claude/plans/AO-MA-10N-LIVE-ENFORCEMENT-CUTOVER.md:182 + AO-MA-10O-CC9-NO-HUMAN-BOOTSTRAP-SUPERSESSION.md:137) is INTACT: no required-check is removed or renamed, branch protection / ruleset is NOT mutated, matrix python-version list still [\"3.11\",\"3.12\",\"3.13\"], AO-MA-10O CLASSIC_CI_CHECKS tuple unchanged, ao-release-gate `--required-check` allowlist (lint, typecheck, test (3.11)/(3.12)/(3.13), coverage, packaging-smoke, policy-container-smoke, release-gate-container-smoke) unchanged, enforce_job invariant test (test_ao_release_gate_enforce_job.py:478) untouched. The matrix-reduction path was deliberately abandoned earlier this session precisely because it would have collided with this hard-stop; this PR uses Codex thread 019e8a1b's plan-time AGREE alternative.",
-    "Deliberately out-of-scope: ao-release-gate-container-publish.yml still runs on codex/** push (separate concern -- container publish, not a required check, on a different workflow_run chain that the ao-autonomous-merge-executor only triggers when head_branch=main + event!=pull_request). That workflow is intact. Downstream workflow_run consumers (ao-autonomous-merge-executor.yml: only triggers on pull_request workflow_run success; deploy workflows: only on head_branch=main) are unaffected by removing codex/** push from test.yml.",
-    "Validation: YAML parses (yaml.safe_load, push.branches==[\"main\"], pull_request.branches==[\"main\"]); actionlint clean on test.yml; bash -n clean on trigger-test-workflow.sh; git diff --check clean; no invariant test pins `codex/**` in on.push.branches (taraytion sonucu: only agent='codex' string references in test_ao_ma10_high_risk_raw_review_producer.py, irrelevant). Quantitative queue-relief impact is observable post-merge via GitHub Actions run count per branch update.",
-    "Cross-AI review: Codex plan-time (thread 019e8a1b, previous session): REVISE -> AGREE on the queue-relief sequence (PR-0 uv done as #906, PR-1 now). Post-impl (thread 019e8c07): REVISE iter-1 found two documentation-side gaps -- (a) the 'open PR early -> canonical signal' sentence was scope-incorrect for upper-stacked PRs because pull_request.branches=[main] excludes base=codex/** PRs, (b) trigger-test-workflow.sh header comment still claimed codex push produces CI which is no longer true. Both absorbed in this revision: CLAUDE.md §19 now splits pre-PR signal by base type and marks workflow_dispatch fallback as mandatory for base=codex/**; script header rewritten with three honest use cases. iter-2 AGREE.",
-    "ZERO TOUCH on guard-controlled surfaces: no guard flag flip (support_widening / production_platform_claim / live_adapter_execution all remain false), no ao_kernel/ runtime change, no defaults/ change, no scripts/*.py change (only the bash header comment), no .ao/ workspace write, no branch protection mutation, no ruleset mutation, no secret material. Diff is one workflow line + two documentation surfaces."
+    "V5 Epic 1 E-1-4 pre-commit changelog gate hook (low-risk local script + tests). Aligned with ADR-0005 Keep-a-Changelog discipline + existing pre-commit-version-gate.sh install pattern (CLAUDE.md §17).",
+    "Decision contract: no code change -> PASS; code + CHANGELOG staged -> PASS; code without CHANGELOG with chore/docs/test/ci/style/refactor/build/perf prefix -> PASS (non-user-visible); code without CHANGELOG with feat/fix/other -> BLOCK with actionable message; --no-verify bypass (rare).",
+    "15 invariants: 6 presence/structure (file + exec bit + bash shebang + set -e + CHANGELOG ref + ADR-0005 citation) + 4 decision contract (5 prefixes listed + feat without CHANGELOG block + chore allowed + feat with CHANGELOG allowed) + 2 coexistence (version-gate intact + install instruction composes both) + 3 ADR/governance (ADR-0005 exists + CHANGELOG.md exists + ZERO TOUCH workflows).",
+    "Decision contract tests run the hook in temp git repos (no global git side effects). All 15 pass local.",
+    "ZERO TOUCH: no .github/workflows/ mutation (E-1-3 future slice covers CI), no ADR-0005 modification, no CHANGELOG.md content modification, no .git/hooks/pre-commit auto-install (operator-owned per CLAUDE.md §17), no guard flag flip."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_pre_commit_changelog_gate.py
+++ b/tests/test_pre_commit_changelog_gate.py
@@ -1,0 +1,215 @@
+"""V5 Epic 1 E-1-4 invariants: pre-commit changelog gate hook.
+
+Shell hook (local-only, opt-in install per CLAUDE.md §17 pattern).
+Tests verify the hook's structural correctness + decision contract
+WITHOUT actually invoking the hook against git (would require a
+sandboxed git repo). Hook semantics are exercised via direct subprocess
+calls against a temp directory.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK_PATH = REPO_ROOT / ".claude" / "scripts" / "pre-commit-changelog-gate.sh"
+VERSION_HOOK_PATH = REPO_ROOT / ".claude" / "scripts" / "pre-commit-version-gate.sh"
+CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
+
+
+# ---- 1. Presence + structure (6) ----------------------------------------
+
+
+def test_hook_file_exists() -> None:
+    assert HOOK_PATH.exists(), f"changelog hook missing at {HOOK_PATH}"
+
+
+def test_hook_is_executable() -> None:
+    mode = HOOK_PATH.stat().st_mode
+    assert mode & 0o111, f"changelog hook is not executable (mode={oct(mode)})"
+
+
+def test_hook_uses_bash_shebang() -> None:
+    first_line = HOOK_PATH.read_text().splitlines()[0]
+    assert first_line.startswith("#!"), "hook must start with shebang"
+    assert "bash" in first_line, f"hook must use bash; got: {first_line!r}"
+
+
+def test_hook_set_e_strict_mode() -> None:
+    text = HOOK_PATH.read_text()
+    assert "set -e" in text, "hook must use 'set -e' for fail-closed exit semantics"
+
+
+def test_hook_references_changelog_md() -> None:
+    text = HOOK_PATH.read_text()
+    assert "CHANGELOG.md" in text
+
+
+def test_hook_references_keep_a_changelog_discipline() -> None:
+    text = HOOK_PATH.read_text()
+    # Either the discipline name OR the ADR id must be cited
+    assert "Keep-a-Changelog" in text or "ADR-0005" in text
+
+
+# ---- 2. Allowed-prefix contract (4) -------------------------------------
+
+
+def test_hook_lists_chore_docs_test_ci_style_prefixes() -> None:
+    text = HOOK_PATH.read_text()
+    for prefix in ("chore", "docs", "test", "ci", "style"):
+        assert prefix in text, f"hook must allow {prefix}: prefix"
+
+
+def test_hook_blocks_feat_without_changelog() -> None:
+    """Run the hook in a temp git repo: staged code change with feat: prefix
+    and no CHANGELOG -> exit 1."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        subprocess.run(["git", "init", "--quiet"], cwd=tmp, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=tmp, check=True)
+        # Set up the ao_kernel structure with a tracked initial commit
+        ao_dir = tmp / "ao_kernel"
+        ao_dir.mkdir()
+        (ao_dir / "__init__.py").write_text("__version__ = '0.0.0'\n")
+        subprocess.run(["git", "add", "."], cwd=tmp, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp,
+            check=True,
+            capture_output=True,
+        )
+        # Stage a code change (not test, not pyproject) with no CHANGELOG
+        new_file = ao_dir / "feature.py"
+        new_file.write_text("def hello(): return 1\n")
+        subprocess.run(["git", "add", str(new_file)], cwd=tmp, check=True)
+        # Write commit message with feat: prefix
+        msg = tmp / ".git" / "COMMIT_EDITMSG"
+        msg.write_text("feat(ao): add hello function\n")
+        # Copy hook locally and invoke
+        local_hook = tmp / "hook.sh"
+        shutil.copy(HOOK_PATH, local_hook)
+        os.chmod(local_hook, 0o755)
+        result = subprocess.run(
+            [str(local_hook)],
+            cwd=tmp,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1, (
+            f"hook must block feat: without CHANGELOG; got returncode={result.returncode}, stderr={result.stderr!r}"
+        )
+        assert "CHANGELOG" in result.stderr
+
+
+def test_hook_allows_chore_without_changelog() -> None:
+    """chore: prefix bypasses CHANGELOG requirement."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        subprocess.run(["git", "init", "--quiet"], cwd=tmp, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=tmp, check=True)
+        ao_dir = tmp / "ao_kernel"
+        ao_dir.mkdir()
+        (ao_dir / "__init__.py").write_text("__version__ = '0.0.0'\n")
+        subprocess.run(["git", "add", "."], cwd=tmp, check=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=tmp, check=True, capture_output=True)
+        new_file = ao_dir / "internal.py"
+        new_file.write_text("CONST = 1\n")
+        subprocess.run(["git", "add", str(new_file)], cwd=tmp, check=True)
+        msg = tmp / ".git" / "COMMIT_EDITMSG"
+        msg.write_text("chore: internal cleanup\n")
+        local_hook = tmp / "hook.sh"
+        shutil.copy(HOOK_PATH, local_hook)
+        os.chmod(local_hook, 0o755)
+        result = subprocess.run([str(local_hook)], cwd=tmp, capture_output=True, text=True, check=False)
+        assert result.returncode == 0, f"hook must allow chore:; got {result.returncode}, stderr={result.stderr!r}"
+
+
+def test_hook_allows_when_changelog_staged() -> None:
+    """feat: with CHANGELOG.md staged is allowed."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        subprocess.run(["git", "init", "--quiet"], cwd=tmp, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=tmp, check=True)
+        ao_dir = tmp / "ao_kernel"
+        ao_dir.mkdir()
+        (ao_dir / "__init__.py").write_text("__version__ = '0.0.0'\n")
+        cl = tmp / "CHANGELOG.md"
+        cl.write_text("# Changelog\n\n## [Unreleased]\n")
+        subprocess.run(["git", "add", "."], cwd=tmp, check=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=tmp, check=True, capture_output=True)
+        new_file = ao_dir / "feature.py"
+        new_file.write_text("def hi(): pass\n")
+        cl.write_text("# Changelog\n\n## [Unreleased]\n- Added hi()\n")
+        subprocess.run(["git", "add", str(new_file), str(cl)], cwd=tmp, check=True)
+        msg = tmp / ".git" / "COMMIT_EDITMSG"
+        msg.write_text("feat: add hi()\n")
+        local_hook = tmp / "hook.sh"
+        shutil.copy(HOOK_PATH, local_hook)
+        os.chmod(local_hook, 0o755)
+        result = subprocess.run([str(local_hook)], cwd=tmp, capture_output=True, text=True, check=False)
+        assert result.returncode == 0, (
+            f"hook must allow feat: with CHANGELOG; got {result.returncode}, stderr={result.stderr!r}"
+        )
+
+
+# ---- 3. Coexistence with version-gate hook (2) --------------------------
+
+
+def test_version_gate_hook_still_present() -> None:
+    """E-1-4 must not delete the pre-existing pre-commit-version-gate.sh."""
+    assert VERSION_HOOK_PATH.exists()
+
+
+def test_hook_documents_install_path_alongside_version_gate() -> None:
+    """Install instruction must compose the changelog hook with the
+    version-gate hook so both fire on every commit."""
+    text = HOOK_PATH.read_text()
+    assert "pre-commit-version-gate.sh" in text
+
+
+# ---- 4. ADR-0005 + governance (3) ---------------------------------------
+
+
+def test_adr_0005_keep_a_changelog_present() -> None:
+    """ADR-0005 establishes the Keep-a-Changelog discipline."""
+    adr_path = REPO_ROOT / ".claude" / "plans" / "adr" / "ADR-0005-keep-a-changelog-per-pr-discipline.md"
+    assert adr_path.exists()
+
+
+def test_changelog_md_exists_in_repo() -> None:
+    assert CHANGELOG_PATH.exists()
+    text = CHANGELOG_PATH.read_text()
+    assert "## [Unreleased]" in text
+    assert "Keep a Changelog" in text
+
+
+def test_no_workflow_mutation() -> None:
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main...HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        pytest.skip(f"git diff unavailable: {proc.stderr.strip()}")
+    changed = proc.stdout.split()
+    for path in changed:
+        assert not path.startswith(".github/workflows/"), f"E-1-4 must not touch workflows (E-1-3 covers CI): {path}"


### PR DESCRIPTION
## Summary
V5 Epic 1 E-1-4 — local pre-commit shell hook enforcing ADR-0005 Keep-a-Changelog discipline. Operator-installed (CLAUDE.md §17 pattern). 15 invariant tests + temp-repo decision contract verification. ZERO TOUCH workflows (E-1-3 covers CI).

## Test plan
- [x] 15 invariant tests pass
- [x] Decision contract verified in temp git repos
- [x] No guard flag flip
- [x] No `.github/workflows/` mutation
- [x] Cross-provider review (post-impl Codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)