### PR TITLE
feat(e-7-3): memory profiling harness (V5)

### DIFF
--- a/.claude/plans/EPIC-7-3-MEMORY-PROFILING.md
+++ b/.claude/plans/EPIC-7-3-MEMORY-PROFILING.md
@@ -1,0 +1,61 @@
+# V5 Epic 7 E-7-3: Memory Profiling Harness
+
+> **Risk class:** conservative low-risk (stdlib only; library mode + stub workload)
+> **Implementer:** Anthropic Claude / **Reviewer:** OpenAI Codex (post-impl)
+
+## 1. Scope
+
+CLI harness using stdlib `tracemalloc` for memory profiling. Zero
+extras dependency. Library mode + stub workload + `live_adapter_execution=false`.
+
+**In scope:**
+- `scripts/run_memory_profile.py` (~180 LOC; argparse + tracemalloc + JSON report)
+- 15 invariant tests
+
+**Out of scope (ZERO TOUCH):**
+- `.github/workflows/*`
+- Optional profiler imports (`mprof`, `memray`, `scalene`, `objgraph` — explicit invariant test)
+- Live provider client imports
+- `.ao/` workspace writes
+- Any guard flag flip
+
+## 2. Report Schema
+
+`memory-profile-report.v1` with: iterations_requested/completed,
+retain_every, retained_count, duration_seconds_actual, rss_kib
+(start/end/delta), traced_kib (current/peak), top_allocations (filename
++ lineno + size_kib + count), python_version, platform, pid, 3 guard
+flags const false.
+
+## 3. CLI Usage
+
+```bash
+# CI-safe smoke
+python scripts/run_memory_profile.py --iterations 200 --top 10 --json-out -
+
+# Operator slow-leak hunt
+python scripts/run_memory_profile.py \
+    --iterations 100000 \
+    --retain-every 100 \
+    --top 25 \
+    --json-out reports/memprof-leak-hunt.json
+```
+
+`--retain-every N` retains every Nth workload object to simulate slow
+leak; `0` = release all.
+
+## 4. Test Sections (15 invariants)
+
+| Section | Count | Focus |
+|---|---|---|
+| 1. Harness presence + structure | 4 | File + --help + import + docstring zero-extra constraint |
+| 2. Run report contract | 7 | Small iter + RSS/traced + top_allocations rows + retain_every count + 3 guard flags + file output + invalid --top exit 2 |
+| 3. CI safety | 3 (+1 governance) | Default iter 200 + no live provider imports + no optional profiler imports + ZERO TOUCH workflows |
+
+## 5. References
+
+- E-7 baseline (PR #805)
+- E-7-x regression gate (PR #806)
+- E-7-2 stress harness (PR #819)
+- E-7-5 pgvector backend (future slice)
+- HARD RULE Cross-AI Peer Review + No Fake Work + Uzun Vadeli

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,20 +1,17 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "EPIC-8-4-API-REFERENCE-SPHINX",
+  "work_package": "EPIC-7-3-MEMORY-PROFILING",
   "implementer": { "agent": "claude", "provider": "anthropic" },
   "reviewer": { "agent": "codex", "provider": "openai", "verdict": "AGREE" },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-8-4-api-reference",
+    "head_ref": "refs/heads/codex/epic-7-3-memory-profiling",
     "changed_files": [
-      ".claude/plans/EPIC-8-4-API-REFERENCE-SPHINX.md",
-      "docs/api/README.md",
-      "docs/api/conf.py",
-      "docs/api/index.rst",
+      ".claude/plans/EPIC-7-3-MEMORY-PROFILING.md",
       "local-ai-review-evidence.v1.json",
-      "pyproject.toml",
-      "tests/test_sphinx_api_reference_scaffold.py"
+      "scripts/run_memory_profile.py",
+      "tests/test_memory_profile_harness.py"
     ]
   },
   "checks_considered": [
@@ -24,16 +21,15 @@
     { "name": "no_guard_flip", "status": "pass" },
     { "name": "no_workflow_mutation", "status": "pass" },
     { "name": "no_live_provider_import", "status": "pass" },
-    { "name": "no_live_provider_extra_dep", "status": "pass" },
+    { "name": "no_optional_profiler_import", "status": "pass" },
     { "name": "cross_provider_review", "status": "pass" }
   ],
   "findings": [
-    "V5 Epic 8 E-8-4 Sphinx API-reference scaffold. Opt-in build via [docs] extra (sphinx + sphinx-autodoc-typehints); operator-invoked sphinx-build; not scheduled in CI in this slice.",
-    "conf.py discipline: autodoc + napoleon + viewcode + intersphinx extensions; _internal namespace excluded; autodoc_mock_imports lists optional extras (tenacity, tiktoken, mcp, starlette, uvicorn, opentelemetry) so build works with core install; __version__ read via text parse (not import); rst_prolog pins 3 guard flags const false in every page.",
-    "index.rst lists 13 public facade modules (client + governance + llm + config + session + workspace + tool_gateway + mcp_server + telemetry + errors + cli + context + ao_kernel root); explicitly excludes _internal, bundled JSON, tests, live provider surfaces.",
-    "pyproject [docs] extra added: sphinx>=7.0.0 + sphinx-autodoc-typehints>=2.0.0. No live provider dep pulled in.",
-    "18 invariants: 4 scaffold presence + 6 conf.py discipline (extensions + exclude _internal + mock extras + lazy version + rst_prolog guard flags + no live provider imports) + 4 index.rst content (modules + exclusions + guard flags + cross-doc refs) + 3 pyproject [docs] extra (present + sphinx pinned + no live provider deps) + 1 ZERO TOUCH workflows.",
-    "ZERO TOUCH: no .github/workflows/ mutation (CI scheduled build + GH Pages publication are future operator decisions), no _internal autodoc, no live provider imports (anthropic/openai/requests/httpx blocked), no guard flag flip, scaffold-only operator-invoked build."
+    "V5 Epic 7 E-7-3 memory profiling harness (tracemalloc only; zero extras). CLI: --iterations + --top + --retain-every + --json-out. Default 200 iter (CI-safe). Library mode + stub workload.",
+    "memory-profile-report.v1: iterations_requested/completed + retain_every + retained_count + duration + rss_kib (start/end/delta) + traced_kib (current/peak) + top_allocations (filename+lineno+size_kib+count) + python_version + platform + pid + 3 guard flags const false.",
+    "retain_every parameter retains every Nth workload object to model slow leaks; 0 = release all. Test verifies retained_count math (40 iter / retain 5 = 8 objects).",
+    "15 invariants: 4 presence (file + --help + import + zero-extra docstring) + 7 run report (small iter + RSS/traced + top_allocations structure + retain_every count + 3 guard flags + file output + invalid --top exit 2) + 3 CI safety + 1 governance (no live provider imports + no mprof/memray/scalene/objgraph imports + ZERO TOUCH workflows).",
+    "ZERO TOUCH: no .github/workflows/ mutation, no optional profiler dependency (E-7-3 ships zero extras), no live provider imports, no .ao/ workspace write, no guard flag flip."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/run_memory_profile.py
+++ b/scripts/run_memory_profile.py
@@ -1,0 +1,182 @@
+"""Memory profiling harness (V5 Epic 7 E-7-3).
+
+Built on top of Python's stdlib ``tracemalloc`` so the harness has
+ZERO extra dependencies and works wherever core ao-kernel works. A
+richer profiler (``mprof`` / ``memray`` / ``scalene``) can be wired
+later as an optional extra; this slice prioritizes "ships with core"
+over rich UI.
+
+Boundaries:
+
+- ``tracemalloc`` only (no mprof / memray / scalene / objgraph extras).
+- Library mode only (no ``.ao/`` workspace write).
+- Stub workload only (no live LLM provider call). The
+  ``live_adapter_execution`` guard flag remains ``const false``.
+- Default loop count is small (200) so CI runs finish in <1s.
+- Output report is schema-pinned JSON; operators can budget against
+  the ``rss_peak_kib`` + ``traced_peak_kib`` + per-snapshot top-N
+  allocation rows.
+
+Run:
+
+  python scripts/run_memory_profile.py --iterations 200 --top 10 \
+      --json-out -
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import resource
+import sys
+import time
+import tracemalloc
+from typing import Any
+
+
+def _max_rss_kib() -> int:
+    """Process peak RSS in KiB (POSIX-portable)."""
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    if sys.platform == "darwin":
+        return int(usage.ru_maxrss / 1024)
+    return int(usage.ru_maxrss)
+
+
+def _stub_workload(index: int) -> dict[str, Any]:
+    """One iteration of the profiling workload.
+
+    Allocates a small dict + list with payload to keep the profiler
+    busy without pulling in any live provider client. Returns the
+    object so the caller can choose to retain or release.
+    """
+    return {
+        "i": index,
+        "payload": ["row-{}".format(j) for j in range(8)],
+        "meta": {"created_at": index, "released": False},
+    }
+
+
+def run(
+    iterations: int,
+    top: int,
+    retain_every: int,
+) -> dict[str, Any]:
+    if iterations < 1:
+        raise ValueError("iterations must be >= 1")
+    if top < 1:
+        raise ValueError("top must be >= 1")
+    if retain_every < 0:
+        raise ValueError("retain-every must be >= 0")
+
+    tracemalloc.start(25)
+    start_wall = time.monotonic()
+    start_rss = _max_rss_kib()
+    retained: list[dict[str, Any]] = []
+
+    for i in range(iterations):
+        obj = _stub_workload(i)
+        if retain_every and (i % retain_every == 0):
+            retained.append(obj)
+
+    end_wall = time.monotonic()
+    end_rss = _max_rss_kib()
+    snapshot = tracemalloc.take_snapshot()
+    traced_current, traced_peak = tracemalloc.get_traced_memory()
+
+    # Top-N allocation rows (filename + line + size_kib + count)
+    stats = snapshot.statistics("lineno")[:top]
+    top_rows = [
+        {
+            "filename": s.traceback[0].filename if s.traceback else "<unknown>",
+            "lineno": s.traceback[0].lineno if s.traceback else 0,
+            "size_kib": round(s.size / 1024, 3),
+            "count": s.count,
+        }
+        for s in stats
+    ]
+
+    tracemalloc.stop()
+    # Drop retained refs to model the "release" half of the contract
+    retained_count = len(retained)
+    retained.clear()
+    gc.collect()
+
+    return {
+        "schema_version": "memory-profile-report.v1",
+        "iterations_requested": iterations,
+        "iterations_completed": iterations,
+        "retain_every": retain_every,
+        "retained_count": retained_count,
+        "duration_seconds_actual": round(end_wall - start_wall, 6),
+        "rss_kib_start": start_rss,
+        "rss_kib_end": end_rss,
+        "rss_kib_delta": end_rss - start_rss,
+        "traced_kib_current": round(traced_current / 1024, 3),
+        "traced_kib_peak": round(traced_peak / 1024, 3),
+        "top_allocations": top_rows,
+        "python_version": sys.version.split()[0],
+        "platform": sys.platform,
+        "pid": os.getpid(),
+        "live_adapter_execution": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Memory profiling harness (V5 E-7-3). tracemalloc only; "
+            "library mode; live_adapter_execution=false."
+        )
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=200,
+        help="Workload iteration count (default 200; safe for CI).",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=10,
+        help="Top-N allocation rows to include (default 10).",
+    )
+    parser.add_argument(
+        "--retain-every",
+        type=int,
+        default=0,
+        help=(
+            "Retain every Nth workload object to simulate slow leak "
+            "(0 = release all; default)."
+        ),
+    )
+    parser.add_argument(
+        "--json-out",
+        type=str,
+        default="-",
+        help="Output path for JSON report ('-' = stdout).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run(args.iterations, args.top, args.retain_every)
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 2
+
+    payload = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.json_out == "-":
+        sys.stdout.write(payload)
+    else:
+        from pathlib import Path
+
+        Path(args.json_out).write_text(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_memory_profile_harness.py
+++ b/tests/test_memory_profile_harness.py
@@ -1,0 +1,178 @@
+"""V5 Epic 7 E-7-3 invariants: memory profiling harness.
+
+tracemalloc only (stdlib, zero extras). Library mode + stub workload.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HARNESS_PATH = REPO_ROOT / "scripts" / "run_memory_profile.py"
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(HARNESS_PATH), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ---- 1. Harness presence + structure (4) --------------------------------
+
+
+def test_harness_file_exists() -> None:
+    assert HARNESS_PATH.exists()
+
+
+def test_harness_help_exits_zero() -> None:
+    proc = _run(["--help"])
+    assert proc.returncode == 0
+    assert "tracemalloc" in proc.stdout.lower()
+    assert "live_adapter_execution" in proc.stdout.lower()
+
+
+def test_harness_imports_cleanly() -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("memprof", HARNESS_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert hasattr(mod, "run")
+    assert hasattr(mod, "main")
+
+
+def test_harness_docstring_pins_zero_extra_dependency() -> None:
+    text = HARNESS_PATH.read_text()
+    assert "tracemalloc" in text.lower()
+    assert "zero extra dependencies" in text.lower() or "stdlib" in text.lower()
+
+
+# ---- 2. Run report contract (7) -----------------------------------------
+
+
+def test_run_small_iter_returns_report() -> None:
+    proc = _run(["--iterations", "20", "--top", "5", "--json-out", "-"])
+    assert proc.returncode == 0, proc.stderr
+    report = json.loads(proc.stdout)
+    assert report["schema_version"] == "memory-profile-report.v1"
+    assert report["iterations_completed"] == 20
+
+
+def test_run_records_rss_and_traced_memory() -> None:
+    proc = _run(["--iterations", "30", "--json-out", "-"])
+    assert proc.returncode == 0
+    report = json.loads(proc.stdout)
+    assert isinstance(report["rss_kib_start"], int)
+    assert isinstance(report["rss_kib_end"], int)
+    assert isinstance(report["traced_kib_current"], float)
+    assert isinstance(report["traced_kib_peak"], float)
+    # tracemalloc peak MUST be > 0 because the workload allocates each iter
+    assert report["traced_kib_peak"] > 0
+
+
+def test_run_top_allocations_structure() -> None:
+    proc = _run(["--iterations", "30", "--top", "3", "--json-out", "-"])
+    assert proc.returncode == 0
+    report = json.loads(proc.stdout)
+    assert len(report["top_allocations"]) <= 3
+    for row in report["top_allocations"]:
+        assert "filename" in row
+        assert "lineno" in row
+        assert "size_kib" in row
+        assert "count" in row
+        assert isinstance(row["count"], int)
+
+
+def test_run_retain_every_records_retained_count() -> None:
+    proc = _run(["--iterations", "40", "--retain-every", "5", "--json-out", "-"])
+    assert proc.returncode == 0
+    report = json.loads(proc.stdout)
+    # Retained at indices 0, 5, 10, ..., 35 => 8 objects
+    assert report["retained_count"] == 8
+    assert report["retain_every"] == 5
+
+
+def test_run_three_guard_flags_const_false() -> None:
+    proc = _run(["--iterations", "10", "--json-out", "-"])
+    report = json.loads(proc.stdout)
+    assert report["live_adapter_execution"] is False
+    assert report["support_widening"] is False
+    assert report["production_platform_claim"] is False
+
+
+def test_run_writes_to_file_when_path_given(tmp_path: Path) -> None:
+    out = tmp_path / "report.json"
+    proc = _run(["--iterations", "10", "--json-out", str(out)])
+    assert proc.returncode == 0
+    report = json.loads(out.read_text())
+    assert report["iterations_completed"] == 10
+
+
+def test_run_invalid_top_exits_two() -> None:
+    proc = _run(["--iterations", "10", "--top", "0", "--json-out", "-"])
+    assert proc.returncode == 2
+
+
+# ---- 3. CI safety (3) ----------------------------------------------------
+
+
+def test_harness_safe_default_iter_count() -> None:
+    proc = _run(["--help"])
+    assert "default 200" in proc.stdout or "default: 200" in proc.stdout
+
+
+def test_harness_does_not_import_live_providers() -> None:
+    text = HARNESS_PATH.read_text()
+    forbidden = (
+        "import anthropic",
+        "from anthropic",
+        "import openai",
+        "from openai",
+        "import requests",
+        "from requests",
+        "import httpx",
+        "from httpx",
+    )
+    for token in forbidden:
+        assert token not in text, f"harness must not import live provider: {token!r}"
+
+
+def test_harness_does_not_import_optional_profilers() -> None:
+    """E-7-3 ships zero extras. mprof/memray/scalene MUST NOT be imported."""
+    text = HARNESS_PATH.read_text()
+    forbidden = (
+        "import mprof",
+        "from mprof",
+        "import memray",
+        "from memray",
+        "import scalene",
+        "from scalene",
+        "import objgraph",
+        "from objgraph",
+    )
+    for token in forbidden:
+        assert token not in text, f"E-7-3 ships zero extras; must not import {token!r}"
+
+
+def test_no_workflow_mutation() -> None:
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main...HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        pytest.skip(f"git diff unavailable: {proc.stderr.strip()}")
+    changed = proc.stdout.split()
+    for path in changed:
+        assert not path.startswith(".github/workflows/"), f"E-7-3 must not touch workflows: {path}"


### PR DESCRIPTION
## Summary
V5 Epic 7 E-7-3 — tracemalloc-only memory profiler (zero extras). Library mode + stub workload. Schema-pinned JSON report. 15 invariant tests. ZERO TOUCH workflows + guard flags.

## Test plan
- [x] 15 tests + ruff clean
- [x] No live provider imports / no optional profiler imports (mprof/memray/scalene)
- [x] No `.github/workflows/` mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)