### PR TITLE
fix(nist-csf): remove cross-slice ALLOWED_CHANGED_FILES allowlist test (mirror #832)

### DIFF
--- a/ao-ma-10-high-risk-reviews/NIST-CSF-allowlist-test-remove/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/NIST-CSF-allowlist-test-remove/anthropic.local-ai-review-evidence.v1.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "local-ai-review-evidence.v1",
+  "artifact_kind": "local-ai-review-evidence",
+  "review_target": "NIST-CSF-allowlist-test-remove",
+  "review_target_paths": ["tests/test_nist_csf_mapping.py"],
+  "provider": "anthropic",
+  "reviewer": "claude-opus-4.7-1m",
+  "review_method": "Adversarial post-impl review. Verified local pytest tests/test_nist_csf_mapping.py: 53 passed / 0 fail after removal. Cross-checked with PR #812 (introducing slice) + PR #832 precedent. Per-slice zero-touch invariants (test_e63e_*) still active.",
+  "verdict": "agree",
+  "ready_to_merge": true,
+  "verdict_rationale": "Same systemic anti-pattern as PR #811 → resolved in PR #832. PR #812 NIST CSF slice repeated the pattern. NIST CSF scope still protected by existing E-6-3e zero-touch tests + schema validity + drift checks (53 passing tests). Removing cross-slice allowlist eliminates blocker for ~20 open PRs. Per HARD RULE Uzun Vadeli Kalıcı Çözüm.",
+  "findings_count_by_severity": {"blocker": 0, "high": 0, "medium": 0, "low": 0},
+  "key_findings_summary": [
+    "Local pytest 53 pass / 0 fail",
+    "Per-slice zero-touch siblings preserved",
+    "3 guard flags const false intact",
+    "Mirror of PR #832 fix pattern"
+  ],
+  "consensus_state": "agree_with_openai_cross_review",
+  "guard_flags_const_false": {
+    "support_widening": false,
+    "production_platform_claim": false,
+    "live_adapter_execution": false
+  }
+}

--- a/ao-ma-10-high-risk-reviews/NIST-CSF-allowlist-test-remove/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/NIST-CSF-allowlist-test-remove/openai.local-ai-review-evidence.v1.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "local-ai-review-evidence.v1",
+  "artifact_kind": "local-ai-review-evidence",
+  "review_target": "NIST-CSF-allowlist-test-remove",
+  "review_target_paths": ["tests/test_nist_csf_mapping.py"],
+  "provider": "openai",
+  "reviewer": "codex",
+  "review_method": "Same Option 2 pattern as PR #832 (PCI-DSS allowlist test remove). Anti-pattern: cross-slice ALLOWED_CHANGED_FILES test failing on every non-NIST-CSF PR. Removal restores per-slice ownership pattern; existing test_e6_3e_*_zero_touch sibling tests preserve slice scope.",
+  "verdict": "agree",
+  "ready_to_merge": true,
+  "verdict_rationale": "Identical bug to PR #811 (PCI-DSS) → fixed in PR #832. PR #812 (NIST CSF E-6-3e) introduced same hardcoded ALLOWED_CHANGED_FILES + cross-slice diff assertion. Every non-NIST PR now fails this test. Option 2 (remove) is correct per HARD RULE Uzun Vadeli Kalıcı Çözüm; preserves per-slice zero-touch pattern siblings.",
+  "findings_count_by_severity": {"blocker": 0, "high": 0, "medium": 0, "low": 0},
+  "key_findings_summary": [],
+  "consensus_state": "agree_with_anthropic_cross_review",
+  "guard_flags_const_false": {
+    "support_widening": false,
+    "production_platform_claim": false,
+    "live_adapter_execution": false
+  }
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,66 +1,30 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-10h-multi-work-package-migration",
-  "implementer": {
-    "agent": "claude-opus-4-7-1m",
-    "provider": "anthropic"
-  },
-  "reviewer": {
-    "agent": "codex-mcp-thread-019e88c9",
-    "provider": "openai",
-    "verdict": "AGREE"
-  },
+  "work_package": "NIST-CSF-allowlist-test-remove",
+  "implementer": { "agent": "claude", "provider": "anthropic" },
+  "reviewer": { "agent": "codex", "provider": "openai", "verdict": "AGREE" },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-10h-multi-work-package",
+    "head_ref": "refs/heads/fix/nist-csf-allowlist-test-remove",
     "changed_files": [
-      ".claude/plans/AO-MA-10h-MULTI-WORK-PACKAGE-MIGRATION.md",
-      ".claude/plans/AO-MA-10h-MULTI-WORK-PACKAGE-MIGRATION.v1.json",
-      "ao-ma-10-high-risk-reviews/AO-MA-10h-multi-work-package-migration/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/AO-MA-10h-multi-work-package-migration/minimax.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/AO-MA-10h-multi-work-package-migration/openai.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/ao-ma-10-high-risk-supersession-evidence.schema.v1.json",
-      "local-ai-review-evidence.v1.json",
-      "scripts/ao_ma10_high_risk_supersession_evidence.py",
-      "tests/test_ao_ma10h_multi_work_package_schema.py",
-      "tests/test_ao_release_gate.py"
+      "tests/test_nist_csf_mapping.py",
+      "ao-ma-10-high-risk-reviews/NIST-CSF-allowlist-test-remove/openai.local-ai-review-evidence.v1.json",
+      "ao-ma-10-high-risk-reviews/NIST-CSF-allowlist-test-remove/anthropic.local-ai-review-evidence.v1.json",
+      "local-ai-review-evidence.v1.json"
     ]
   },
   "checks_considered": [
-    {
-      "name": "tests",
-      "status": "pass"
-    },
-    {
-      "name": "secret_scan",
-      "status": "pass"
-    },
-    {
-      "name": "ruff",
-      "status": "pass"
-    },
-    {
-      "name": "mypy",
-      "status": "pass"
-    },
-    {
-      "name": "design-adversarial-review",
-      "status": "pass"
-    }
+    { "name": "tests", "status": "pass" },
+    { "name": "no_workflow_mutation", "status": "pass" },
+    { "name": "no_guard_flip", "status": "pass" },
+    { "name": "cross_provider_review", "status": "pass" },
+    { "name": "secret_scan", "status": "pass" }
   ],
   "findings": [
-    "Root reviewer evidence for AO-MA-10h multi-work-package governance migration (2026-06-02). Cross-AI implementer-reviewer pair: Anthropic Claude Opus 4.7 1M (implementer) + OpenAI Codex MCP thread 019e88c9-27ec-7b53-af2d-b91b46128e0e (reviewer); distinct providers per HARD RULE Cross-AI Peer Review (2026-05-14 clarification).",
-    "Codex verdict AGREE: 'Option B doğru tasarım. work_package burada release authority veya permission boundary değil; PR'e bağlanan review/evidence kimliği. Mevcut authority zinciri ao-release-gate+github-ruleset, context binding, path allowlist, provider distinctness, unanimous AGREE, freshness ve guard flag const false kontrolleriyle kapanıyor.'",
-    "Schema widened: ao_kernel/defaults/schemas/ao-ma-10-high-risk-supersession-evidence.schema.v1.json::properties.work_package changes from const 'AO-MA-10h' to pattern '^[A-Z][A-Z0-9]*(?:-[A-Za-z0-9][A-Za-z0-9._]*)*$' with minLength 3 and maxLength 80. Aligned with .github/workflows/test.yml::reviewed_wp regex verbatim (round-trip test pinned).",
-    "Builder dynamic: scripts/ao_ma10_high_risk_supersession_evidence.py emits work_package from --review-work-package CLI arg (supplied by trusted-base workflow per-PR); removed hardcoded 'AO-MA-10h' literal. Defense-in-depth: _validate_work_package pre-check enforces same regex + length bounds.",
-    "Authority surface preserved unchanged: release_authority+github-ruleset, ai_output_release_authority=false, all three guard_flags const false (support_widening, production_platform_claim, live_adapter_execution), secrets_recorded=false, mutations_performed=false, consensus_status=AGREE const, reviewer_providers distinct pair (openai+anthropic), context_binding (head_sha, diff_digest, changed_files_count, refs, repo, high_risk_changed_paths), freshness window.",
-    "36 new invariants in tests/test_ao_ma10h_multi_work_package_schema.py pin every const, every required field, every guard flag, provider distinctness, regex parity with workflow, builder source-guard against re-hardcoding 'AO-MA-10h'. test_builder_source_no_longer_hardcodes_ao_ma_10h_work_package is a static-source guard.",
-    "Full test suite: 6191 tests passed, 79 skipped, 0 failed (python3 -m pytest tests/). Lint: ruff clean. Typecheck: mypy clean (273 source files in ao_kernel/).",
-    "ZERO TOUCH on .github/workflows/, ao_kernel/ao_release_gate.py, ruleset, branch protection, codeowners, gpp_status.v1.json. Only widened the schema field; preserved every authority boundary.",
-    "Operator follow-up after this PR merges: 21 currently-blocked PRs (#824-#899) can have CI re-triggered; the trusted-base workflow will now generate conforming high-risk supersession evidence per each PR's own work_package."
+    "Identical anti-pattern fix to PR #832 (PCI-DSS allowlist remove). PR #812 (NIST CSF E-6-3e) introduced same hardcoded ALLOWED_CHANGED_FILES cross-slice diff assertion. Every non-NIST-CSF PR fails this test → another mass pipeline blocker.",
+    "Removal: tests/test_nist_csf_mapping.py loses ALLOWED_CHANGED_FILES frozenset (lines ~30) + def test_allowlist_diff_no_other_files() function. Per-slice zero-touch siblings (test_e63e_*_zero_touch) + schema validity + drift checks preserved (53 tests still passing).",
+    "Cross-AI: implementer claude (anthropic) != reviewer codex (openai). HARD RULE Uzun Vadeli Kalıcı Çözüm: anti-pattern removal (not skip)."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_nist_csf_mapping.py
+++ b/tests/test_nist_csf_mapping.py
@@ -31,20 +31,6 @@ RUNBOOK_PATH = REPO_ROOT / "docs" / "compliance" / "nist-csf-operator-usage-runb
 RENDERER_PATH = REPO_ROOT / "scripts" / "render_nist_csf_docs.py"
 README_PATH = REPO_ROOT / "docs" / "compliance" / "README.md"
 
-ALLOWED_CHANGED_FILES = frozenset(
-    {
-        ".claude/plans/EPIC-6-E6-3E-NIST-CSF-MAPPING.md",
-        "ao_kernel/defaults/schemas/nist-csf-control-mapping.schema.v1.json",
-        "docs/compliance/README.md",
-        "docs/compliance/nist-csf-control-mapping.v1.json",
-        "docs/compliance/nist-csf-control-mapping.v1.md",
-        "docs/compliance/nist-csf-operator-usage-runbook.v1.md",
-        "local-ai-review-evidence.v1.json",
-        "scripts/render_nist_csf_docs.py",
-        "tests/test_nist_csf_mapping.py",
-    }
-)
-
 EXPECTED_FUNCTION_IDS = ("GV", "ID", "PR", "DE", "RS", "RC")
 EXPECTED_PER_FUNCTION_CATEGORIES: dict[str, frozenset[str]] = {
     "GV": frozenset({"GV.OC", "GV.RM", "GV.RR", "GV.PO", "GV.OV", "GV.SC"}),
@@ -500,12 +486,6 @@ def test_drift_committed_matches_generated() -> None:
     assert actual == expected, "Markdown drift; regenerate via render_nist_csf_docs.py"
 
 
-def test_allowlist_diff_no_other_files() -> None:
-    changed = _diff_files()
-    if changed is None:
-        pytest.skip("git diff unavailable")
-    extras = changed - ALLOWED_CHANGED_FILES
-    assert not extras, f"PR changes files outside allowlist: {extras}"
 
 
 def test_e63_catalog_zero_touch() -> None:


### PR DESCRIPTION
## Summary
- Same anti-pattern as PR #832 (PCI-DSS); now NIST CSF (#812 introduced).
- 53 local tests pass after removal.
- ~20 open PR mass blocker → unblock.
- Cross-AI: Codex AGREE + Anthropic AGREE.

## HARD RULE compliance
- Uzun Vadeli Kalıcı Çözüm: anti-pattern removal, not skip
- No Fake Work: real pytest 53 pass
- Cross-AI provider distinct
- 3 guard flags const false

🤖 Generated with [Claude Code](https://claude.com/claude-code)
