### PR TITLE
test(governance): add BLK-005 gate banning whole-diff workflow-mutation guards

### DIFF
--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,29 +1,17 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "GOV-REMOVE-WHOLE-DIFF-CROSS-SLICE-SCANS",
+  "work_package": "GOV-BLK005-PREVENT-WORKFLOW-BAN-GATE",
   "implementer": { "agent": "claude", "provider": "anthropic" },
   "reviewer": { "agent": "codex", "provider": "openai", "verdict": "AGREE" },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/remove-cross-slice-workflow-guards",
+    "head_ref": "refs/heads/codex/prevent-workflow-ban-gate",
     "changed_files": [
       "local-ai-review-evidence.v1.json",
-      "tests/test_adr_cross_ai_revalidation.py",
-      "tests/test_compliance_documentation.py",
-      "tests/test_consultation_tracing.py",
-      "tests/test_gdpr_dpia_template.py",
-      "tests/test_hipaa_mapping.py",
-      "tests/test_license_compliance.py",
-      "tests/test_memory_profile_harness.py",
-      "tests/test_nist_csf_mapping.py",
-      "tests/test_operator_runbooks.py",
-      "tests/test_pci_dss_mapping.py",
-      "tests/test_readme_v5_roadmap_badge.py",
-      "tests/test_regression_gate.py",
-      "tests/test_sphinx_api_reference_scaffold.py",
-      "tests/test_stress_session_harness.py",
-      "tests/test_vendor_escalation_matrix.py"
+      "tests/conftest.py",
+      "tests/test_conftest_quality_gate.py",
+      "tests/test_operator_runbook.py"
     ]
   },
   "checks_considered": [
@@ -32,20 +20,21 @@
     { "name": "git_diff_check", "status": "pass" },
     { "name": "secret_scan", "status": "pass" },
     { "name": "coverage_gate", "status": "pass" },
-    { "name": "zero_touch_family", "status": "pass" },
-    { "name": "delete_only", "status": "pass" },
+    { "name": "blk005_unit_matrix", "status": "pass" },
+    { "name": "no_false_positive_on_keep_tests", "status": "pass" },
     { "name": "no_guard_flip", "status": "pass" },
     { "name": "no_runtime_module_change", "status": "pass" },
     { "name": "cross_provider_review", "status": "pass" }
   ],
   "findings": [
-    "Systemic governance anti-pattern removal (delete-only). A family of v5 compliance/slice tests scanned the WHOLE PR diff (`git diff --name-only origin/main...HEAD`) and asserted file-set membership: (a) `.github/workflows/` prefix bans, (b) cross-slice 'sibling zero-touch' file sets. Because they scan the whole diff (not the authoring slice's own write-set), they block every legitimate cross-cutting PR: any workflow-maintenance PR (e.g. the parallel CI-fast PR #901) fails all 13 workflow guards, and the sibling zero-touch sets mutually freeze the compliance test files (tests/test_hipaa_mapping.py, tests/test_gdpr_dpia_template.py) so they can never be maintained by any PR.",
-    "Same anti-pattern class PCI #832 and NIST #902 already removed (cross-slice ALLOWED_CHANGED_FILES allowlists), proliferated across the v5 program. Workflow / cross-slice risk is already enforced at the correct layer: RiskClassifier marks `.github/workflows/**` high-risk (tests/test_orchestration_risk_classifier.py) and ao-release-gate gates it via the autonomous-merge eligibility prohibited-path set (tests/test_ao_ma10_autonomous_merge_eligibility.py). The pytest whole-diff scans are therefore redundant with the real policy layer and harmful to maintenance.",
-    "Removed (15 test files, 474 deletions, delete-only): (1) 13 whole-diff `.github/workflows/` prefix-ban guards (E-5-3b consultation_tracing, GDPR, E-Ops operator_runbooks, E-7-3 memory_profile, E-6-3b hipaa, E-P0-4 readme_v5, E-7-2 stress_session, E-1-6 adr, E-8-4 sphinx, E-6-6b vendor_escalation, license-compliance, E-7x regression_gate, compliance_documentation); (2) 11 compliance whole-diff cross-slice zero-touch tests (nist test_e63_catalog/b_hipaa/c_gdpr/d_pci_zero_touch; pci catalog/hipaa/gdpr; gdpr catalog/hipaa; hipaa test_e63_catalog_file_unchanged; regression_gate test_compare_py_untouched_in_pr_diff); (3) orphaned nist _diff_files helper + stale docstring prose; (4) ruff --fix unused imports (subprocess/pytest).",
-    "KEPT (per Codex keep-list, verified not removed): RI/AO-MA introducer/self-gate state-at-landing audits including forbidden_surfaces_actually_unchanged_in_diff (these are scoped to their own introducing PR, not every future PR); ADR path-filtered content invariant test_no_adr_decision_section_mutation (`git diff origin/main...HEAD -- .claude/plans/adr/` is scoped to the slice's own files, not the whole diff); hipaa test_e63_schema_unchanged (file-existence/content pin, no git diff); RiskClassifier + ao-release-gate (the correct policy layer). NIST ALLOWED_CHANGED_FILES already removed by #902, so not part of this diff.",
-    "Cross-AI review: Codex thread 019e894f (plan-time A-prime AGREE in prior thread 019e8916 which dropped). Post-impl iter-1 REVISE (3 bounded blockers: branch behind+NIST conflict with #902, git diff --check 'new blank line at EOF' x8, evidence not bound to post-rebase diff). All absorbed: reset --hard to origin/main eb279a0 + re-derived deletions on fresh base (no manual conflict; #902's allowlist removal preserved by AST skip-if-absent), EOF-normalize (`rstrip(newlines)+newline`), evidence bound to exact diff. Post-impl iter-2 AGREE ready_for_merge=true.",
-    "Validation (isolated venv, committed against base eb279a0): ruff check ao_kernel/ tests/ -> All checks passed!; git diff --check origin/main...HEAD -> clean; pytest -k 'zero_touch or untouched or unchanged or no_workflow or workflow_mutation or compare_py or allowlist' -> 73 passed, 25 skipped, 0 failed (the 5 prior failures gone); full serial suite pytest --cov --cov-branch -> exit 0, 6143 passed / 86 skipped, 85.21% >= 85% coverage gate.",
-    "ZERO TOUCH on guarded surfaces: this PR touches only tests/ (+ this evidence file). No .github/workflows/ change, no ao_kernel/ runtime module change, no scripts/ change, no defaults/ change, no .ao/ workspace write, no guard flag flip (support_widening / production_platform_claim / live_adapter_execution all remain false), no secret material. Pure delete-only test-governance hygiene."
+    "Prevention gate (a)+(b) for the whole-diff workflow-mutation anti-pattern. PR #903 removed 24 existing instances, but #816 (operator runbook) merged concurrently and reintroduced one (tests/test_operator_runbook.py::test_no_workflow_mutation) — proving the anti-pattern keeps propagating as parallel v5 slices copy it. This PR (a) removes that straggler and (b) adds a collection-time test-quality gate BLK-005 so new slices cannot reintroduce it.",
+    "BLK-005 (tests/conftest.py, AST-based, blocking): flags a test function that contains BOTH (1) a static `git diff` / wrapper `diff` argv with NO `-- <pathspec>` (whole-repo diff) AND (2) a direct-literal `.startswith(\".github/workflows/\")` assertion (or a literal tuple/list arg containing that prefix). Helpers: _call_static_argv (static list/tuple-of-str only; dynamic argv untouched), _argv_is_git_diff_without_pathspec (drops leading 'git', accepts wrapper 'diff', whole-diff iff no '--' or '--' is last token), _assert_has_direct_workflow_prefix (literal only; dynamic startswith(<var>) excluded), _blk005_scan (uses _walk_outside_nested_scopes — same nested-scope pruning as BLK-004).",
+    "Narrow boundary preserves the legitimate KEEP set (Codex plan-time + post-impl verified, thread 019e89a3): ADR path-filtered `git diff ... -- .claude/plans/adr/` (path-filtered -> not whole-diff); RI/AO-MA introducer-scoped self-gates `f.startswith(surface)` / `startswith(forbidden_prefixes)` (dynamic arg -> not matched); content-pin / file-existence tests (no git diff). Collection of the full tree (6252 tests) shows zero BLK-005 false-positives.",
+    "Unit-test matrix (tests/test_conftest_quality_gate.py, 9 tests): 3 positive (straggler pattern; wrapper _git(['diff',...]); literal tuple prefix), 5 negative (ADR path-filtered; dynamic startswith(surface); changed & introducer detection; whole-diff non-workflow assert; workflow assert with no git diff), 1 forcing function test_blk005_zero_hits_in_current_suite that locks in 0 BLK-005 hits across tests/ (self-file excluded via Path.resolve) so a future reintroduction fails first.",
+    "Cross-AI review: Codex thread 019e89a3. Plan-time AGREE (dar BLK-005 boundary, ready_for_impl). Post-impl AGREE, ready_for_merge=true, no blocking findings; Codex independently spot-checked the helper truth table (whole-diff True / path-filtered False / wrapper True / '--'-last True; literal startswith True / dynamic surface False / literal-tuple True) and the zero-hit scan.",
+    "Validation (isolated venv, base origin/main dbb874b): ruff check ao_kernel/ tests/ -> All checks passed!; git diff --check -> clean; targeted pytest (test_conftest_quality_gate.py + test_operator_runbook.py) -> 53 passed; full collection 6252 (BLK-005 collection-gate blocks no real file); full serial suite pytest --cov --cov-branch -> exit 0, 6166 passed / 86 skipped, 85.21% >= 85% coverage gate.",
+    "Documented non-blocking residual (Codex): _argv_is_git_diff_without_pathspec recognizes `[git, diff, ...]` and wrapper `[diff, ...]` but not git global-option forms (`git -C <p> diff`, `git --no-pager diff`, `git -c x=y diff`). No such guard exists in the current suite; this is an out-of-contract false-negative and a future hardening candidate, not a blocker.",
+    "ZERO TOUCH on guarded surfaces: changes are confined to tests/ (+ this evidence file). No .github/workflows/ change, no ao_kernel/ runtime module change, no scripts/ change, no defaults/ change, no .ao/ workspace write, no guard flag flip (support_widening / production_platform_claim / live_adapter_execution all remain false), no secret material."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,15 @@ Rules:
              patch.object, mocker.patch, AsyncMock, side_effect, service
              pass-through (assert service.f(mock) == VALUE), and attribute
              projection (assert result.id == VALUE). Future PRs.
+    BLK-005: Whole-diff '.github/workflows/' mutation guard. A test that runs
+             a whole-repo ``git diff`` (no ``-- <pathspec>``) AND asserts
+             ``path.startswith(".github/workflows/")`` blocks every unrelated
+             workflow-maintenance PR (the cross-slice anti-pattern PR #903
+             removed and #816 reintroduced). Workflow-change risk belongs in
+             the repo-level ao-release-gate / RiskClassifier, not a per-slice
+             pytest scan. Path-filtered diffs (``git diff ... -- <path>``) and
+             introducer-scoped self-gates (dynamic ``startswith(<var>)``) are
+             exempt by construction.
     ADV-001: Test function with 0 assert statements — warning
     ADV-002: sole assertion is 'is not None' — weak behavioral signal
 """
@@ -322,6 +331,121 @@ def _blk004_scan(
             _process(sub)
 
 
+# ── BLK-005: whole-diff '.github/workflows/' mutation guard ─────────────
+
+
+_BLK005_WORKFLOW_PREFIX = ".github/workflows/"
+
+
+def _call_static_argv(call: ast.Call) -> list[str] | None:
+    """Return the static string argv of a call whose first positional arg is a
+    list/tuple of string constants (``subprocess.run(["git", "diff", ...])`` or
+    a wrapper ``_git(["diff", ...])``). Returns ``None`` for dynamic argv — the
+    rule only acts on statically-decidable invocations.
+    """
+    if not call.args:
+        return None
+    first = call.args[0]
+    if not isinstance(first, (ast.List, ast.Tuple)):
+        return None
+    argv: list[str] = []
+    for el in first.elts:
+        if isinstance(el, ast.Constant) and isinstance(el.value, str):
+            argv.append(el.value)
+        else:
+            return None
+    return argv
+
+
+def _argv_is_git_diff_without_pathspec(argv: list[str]) -> bool:
+    """True iff ``argv`` is a ``git diff`` / ``diff`` invocation with NO pathspec
+    after a ``--`` separator (a *whole-repo* diff). Accepts wrapper forms that
+    drop the leading ``git`` token. A path-filtered diff such as
+    ``["git", "diff", "origin/main...HEAD", "--", ".claude/plans/adr/"]`` returns
+    False (the ``--`` separator is the only reliable boundary; no path heuristics).
+    """
+    if not argv:
+        return False
+    toks = argv[1:] if argv[0] == "git" else argv
+    if not toks or toks[0] != "diff":
+        return False
+    if "--" not in toks:
+        return True
+    # "--" present: whole-diff iff it is the last token (no pathspec follows).
+    return toks.index("--") == len(toks) - 1
+
+
+def _assert_has_direct_workflow_prefix(assert_node: ast.Assert) -> bool:
+    """True iff the assert subtree contains a direct *literal*
+    ``<x>.startswith(".github/workflows/")`` (or a literal tuple/list arg that
+    contains that prefix). Dynamic args (``f.startswith(surface)``,
+    ``startswith(forbidden_prefixes)``) are NOT matched — this is what keeps the
+    RI/AO-MA introducer-scoped self-gates exempt.
+    """
+    for sub in ast.walk(assert_node):
+        if not (
+            isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Attribute)
+            and sub.func.attr == "startswith"
+            and sub.args
+        ):
+            continue
+        arg0 = sub.args[0]
+        if isinstance(arg0, ast.Constant) and arg0.value == _BLK005_WORKFLOW_PREFIX:
+            return True
+        if isinstance(arg0, (ast.Tuple, ast.List)):
+            for el in arg0.elts:
+                if isinstance(el, ast.Constant) and el.value == _BLK005_WORKFLOW_PREFIX:
+                    return True
+    return False
+
+
+def _blk005_scan(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    fname: str,
+    func_name: str,
+    violations: list[_TestQualityViolation],
+) -> None:
+    """Detect BLK-005: a whole-repo ``git diff`` paired with a direct
+    ``.github/workflows/`` prefix assertion in the same test function.
+
+    This is the cross-slice workflow-mutation guard anti-pattern (PR #903 removed
+    13 instances; #816 reintroduced one in tests/test_operator_runbook.py).
+    Because it scans the WHOLE PR diff (not the authoring slice's own write-set),
+    it blocks every unrelated workflow-maintenance PR. Workflow-change risk is
+    enforced at the repo level (ao-release-gate / RiskClassifier), not a
+    per-slice pytest scan.
+
+    Narrow boundary (Codex thread 019e89a3): requires BOTH a static
+    git-diff-without-pathspec argv AND a direct-literal workflow-prefix
+    ``startswith``. Nested helper scopes are pruned (same precision boundary as
+    BLK-004).
+    """
+    has_whole_diff = False
+    for sub in _walk_outside_nested_scopes(node):
+        if isinstance(sub, ast.Call):
+            argv = _call_static_argv(sub)
+            if argv is not None and _argv_is_git_diff_without_pathspec(argv):
+                has_whole_diff = True
+                break
+    if not has_whole_diff:
+        return
+    for sub in _walk_outside_nested_scopes(node):
+        if isinstance(sub, ast.Assert) and _assert_has_direct_workflow_prefix(sub):
+            violations.append(
+                _TestQualityViolation(
+                    fname,
+                    func_name,
+                    "BLK-005",
+                    "whole-diff '.github/workflows/' mutation guard blocks unrelated "
+                    "workflow-maintenance PRs; use a path-filtered diff "
+                    "(git diff ... -- <path>) or an introducer-scoped state-at-landing "
+                    "guard. Workflow risk is enforced by ao-release-gate / RiskClassifier.",
+                )
+            )
+            return
+
+
 # ── Test Quality Gate (Scanner Entrypoint) ──────────────────────────────
 
 
@@ -398,6 +522,9 @@ def _scan_test_file(filepath: Path) -> list[_TestQualityViolation]:
         # Out of scope: patch/patch.object/mocker.patch, AsyncMock, side_effect,
         # service pass-through, attribute projection. Future PRs.
         _blk004_scan(node, fname, func_name, violations)
+
+        # BLK-005: whole-diff '.github/workflows/' mutation guard (anti-pattern)
+        _blk005_scan(node, fname, func_name, violations)
 
         # ADV-002: Weak single assertion (is not None, isinstance, len > 0)
         # Only triggers when it's the SOLE meaningful assertion in the test

--- a/tests/test_conftest_quality_gate.py
+++ b/tests/test_conftest_quality_gate.py
@@ -5,6 +5,7 @@ Validates the scanner contract:
     - BLK-002 (assert True) — blocking
     - BLK-003 (except: pass in test) — blocking
     - BLK-004 (mock-return direct-echo tautology) — blocking
+    - BLK-005 (whole-diff '.github/workflows/' mutation guard) — blocking
     - ADV-001 (no assertions) — advisory
     - ADV-002 (sole 'is not None') — advisory
     - ADV-003 (BLK-004 downgraded by behavioral signal) — advisory
@@ -479,6 +480,126 @@ def test_blk004_zero_hits_in_current_suite() -> None:
         "BLK-004 violations introduced in current tests/ tree: "
         f"{blk004_hits}. Either fix the test or extend the rule deliberately."
     )
+
+
+# ── BLK-005: whole-diff '.github/workflows/' mutation guard ─────────────
+
+
+def test_blk005_positive_straggler_pattern(tmp_path: Path) -> None:
+    # The exact anti-pattern PR #903 removed and #816 reintroduced.
+    source = (
+        "import subprocess\n"
+        "def test_no_workflow_mutation():\n"
+        "    proc = subprocess.run(['git', 'diff', '--name-only', 'origin/main...HEAD'])\n"
+        "    for path in proc.stdout.split():\n"
+        "        assert not path.startswith('.github/workflows/')\n"
+    )
+    assert "BLK-005" in _rules(_scan_source(tmp_path, source))
+
+
+def test_blk005_positive_wrapper_form(tmp_path: Path) -> None:
+    # Wrapper that drops the leading 'git' token: _git(['diff', ...]).
+    source = (
+        "def test_x():\n"
+        "    out = _git(['diff', '--name-only', 'origin/main...HEAD'])\n"
+        "    for p in out:\n"
+        "        assert not p.startswith('.github/workflows/')\n"
+    )
+    assert "BLK-005" in _rules(_scan_source(tmp_path, source))
+
+
+def test_blk005_positive_tuple_prefix(tmp_path: Path) -> None:
+    # startswith((".github/workflows/", ...)) literal-tuple form.
+    source = (
+        "import subprocess\n"
+        "def test_x():\n"
+        "    proc = subprocess.run(['git', 'diff', '--name-only', 'origin/main...HEAD'])\n"
+        "    for p in proc.stdout.split():\n"
+        "        assert not p.startswith(('.github/workflows/', 'docs/'))\n"
+    )
+    assert "BLK-005" in _rules(_scan_source(tmp_path, source))
+
+
+def test_blk005_negative_path_filtered_diff(tmp_path: Path) -> None:
+    # ADR-style path-filtered diff (-- .claude/plans/adr/): scoped → exempt.
+    source = (
+        "import subprocess\n"
+        "def test_x():\n"
+        "    proc = subprocess.run(['git', 'diff', 'origin/main...HEAD', '--', '.claude/plans/adr/'])\n"
+        "    for p in proc.stdout.split():\n"
+        "        assert not p.startswith('.github/workflows/')\n"
+    )
+    assert "BLK-005" not in _rules(_scan_source(tmp_path, source))
+
+
+def test_blk005_negative_dynamic_surface_startswith(tmp_path: Path) -> None:
+    # RI/AO-MA self-gate form: f.startswith(surface) (dynamic, not literal).
+    source = (
+        "import subprocess\n"
+        "def test_x():\n"
+        "    proc = subprocess.run(['git', 'diff', '--name-only', 'origin/main...HEAD'])\n"
+        "    surface = '.github/workflows/'\n"
+        "    for f in proc.stdout.split():\n"
+        "        assert not f.startswith(surface)\n"
+    )
+    assert "BLK-005" not in _rules(_scan_source(tmp_path, source))
+
+
+def test_blk005_negative_changed_and_introducer(tmp_path: Path) -> None:
+    # changed & introducer_signature detection, no workflow-prefix assert.
+    source = (
+        "import subprocess\n"
+        "def test_x():\n"
+        "    proc = subprocess.run(['git', 'diff', '--name-only', 'origin/main...HEAD'])\n"
+        "    changed = set(proc.stdout.split())\n"
+        "    if not (changed & {'tests/test_x.py'}):\n"
+        "        return\n"
+        "    assert 'docs/x.md' in changed\n"
+    )
+    assert "BLK-005" not in _rules(_scan_source(tmp_path, source))
+
+
+def test_blk005_negative_whole_diff_non_workflow_assert(tmp_path: Path) -> None:
+    # whole-diff but asserts on a non-workflow surface → not BLK-005.
+    source = (
+        "import subprocess\n"
+        "def test_x():\n"
+        "    proc = subprocess.run(['git', 'diff', '--name-only', 'origin/main...HEAD'])\n"
+        "    for p in proc.stdout.split():\n"
+        "        assert not p.startswith('docs/secret/')\n"
+    )
+    assert "BLK-005" not in _rules(_scan_source(tmp_path, source))
+
+
+def test_blk005_negative_workflow_assert_no_git_diff(tmp_path: Path) -> None:
+    # workflow startswith but no git diff at all → not BLK-005.
+    source = (
+        "def test_x():\n"
+        "    paths = ['ao_kernel/x.py']\n"
+        "    for p in paths:\n"
+        "        assert not p.startswith('.github/workflows/')\n"
+    )
+    assert "BLK-005" not in _rules(_scan_source(tmp_path, source))
+
+
+def test_blk005_zero_hits_in_current_suite() -> None:
+    """Lock-in: BLK-005 must have 0 hits in the current tests/ tree.
+
+    After the straggler removal (#816's test_operator_runbook.py guard), no test
+    should match the whole-diff workflow-mutation anti-pattern. A future PR that
+    reintroduces it fails here first. Self-skip uses ``Path.resolve()`` so this
+    file's string fixtures are excluded.
+    """
+    self_path = Path(__file__).resolve()
+    tests_dir = self_path.parent.parent / "tests"
+    hits: list[str] = []
+    for p in sorted(tests_dir.rglob("test_*.py")):
+        if p.resolve() == self_path:
+            continue
+        for v in _scan_test_file(p):
+            if v.rule == "BLK-005":
+                hits.append(f"{p.name}::{v.func}")
+    assert hits == [], f"BLK-005 reintroduced in tests/ tree: {hits}"
 
 
 # ── Negative: ensure self-fixtures don't leak into the rest of the suite ──

--- a/tests/test_operator_runbook.py
+++ b/tests/test_operator_runbook.py
@@ -12,10 +12,8 @@ Docs-only slice. The runbook MUST:
 from __future__ import annotations
 
 import re
-import subprocess
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RUNBOOK_PATH = REPO_ROOT / "docs" / "OPERATOR-RUNBOOK.md"
@@ -173,21 +171,3 @@ def test_runbook_lists_operator_owned_scenarios() -> None:
 def test_runbook_links_deployment_guide() -> None:
     text = RUNBOOK_PATH.read_text()
     assert "PRODUCTION-DEPLOYMENT-GUIDE.md" in text
-
-
-# ---- 4. Governance ZERO TOUCH (1) ----------------------------------------
-
-
-def test_no_workflow_mutation() -> None:
-    proc = subprocess.run(
-        ["git", "diff", "--name-only", "origin/main...HEAD"],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if proc.returncode != 0:
-        pytest.skip(f"git diff unavailable: {proc.stderr.strip()}")
-    changed = proc.stdout.split()
-    for path in changed:
-        assert not path.startswith(".github/workflows/"), f"E-8-3 must not touch workflows: {path}"


### PR DESCRIPTION
## Why

PR #903 removed **24** instances of the whole-diff cross-slice scan anti-pattern. But #816 (operator runbook) merged **concurrently** and reintroduced one (`tests/test_operator_runbook.py::test_no_workflow_mutation`) — proving the anti-pattern keeps **propagating** as parallel v5 slices copy it. Removing instances one-by-one is an endless race; this PR adds a **prevention gate**.

## What

**(a)** Removes the straggler `test_operator_runbook.py::test_no_workflow_mutation`.

**(b)** Adds **BLK-005** to the conftest collection-time test-quality gate (joins BLK-001..004): an AST rule that **blocks** any test pairing a whole-repo `git diff` (no `-- <pathspec>`) with a direct-literal `.startswith(".github/workflows/")` assertion. New slices can no longer reintroduce the workflow-maintenance-blocking pattern.

## Narrow boundary (keeps the legitimate set)

| Pattern | BLK-005? |
|---|---|
| whole-diff + literal `.startswith(".github/workflows/")` | ❌ **blocked** |
| ADR path-filtered `git diff ... -- .claude/plans/adr/` | ✅ exempt |
| RI/AO-MA introducer self-gate `f.startswith(surface)` (dynamic) | ✅ exempt |
| content-pin / file-existence (no git diff) | ✅ exempt |

9 unit tests: 3 positive (straggler, wrapper `_git(['diff',…])`, literal tuple), 5 negative (the exempt set), 1 forcing function `test_blk005_zero_hits_in_current_suite` (locks 0 hits in `tests/` → future reintroduction fails first).

## Validation (base `dbb874b`)

- `ruff check ao_kernel/ tests/` → All checks passed!
- `git diff --check` → clean
- targeted pytest (gate + operator_runbook) → 53 passed
- collection 6252 (BLK-005 collection-gate blocks **no** real file)
- full serial suite `--cov` → exit 0, **6166 passed / 86 skipped, 85.21% ≥ 85%**

## Cross-AI review

Codex thread `019e89a3`: plan-time **AGREE** (narrow boundary) → post-impl **AGREE, ready_for_merge=true**, no blocking findings (Codex spot-checked the helper truth table + zero-hit scan).

**Documented non-blocking residual:** `_argv_is_git_diff_without_pathspec` doesn't recognize git global-option forms (`git -C/--no-pager/-c diff`). No such guard exists today; future hardening candidate, not a blocker.

## Guard flags

`support_widening` / `production_platform_claim` / `live_adapter_execution` — all remain **false**. tests/-only (+ evidence), no `.github/workflows/`, no runtime module, no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
