### PR TITLE
fix(gate): allow issue-template metadata diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   workflow that delegates ADR-0005 changelog discipline to the
   canonical `ao-kernel quality check-changelog` CLI instead of
   duplicating decision logic in workflow YAML.
+- **ao-release-gate issue-template metadata allowlist**: added the
+  exact `.github/ISSUE_TEMPLATE/` prefix to the protected-base
+  release-gate diff-scope allowlist so reviewed V5 issue-form PRs can
+  merge without widening workflow, CODEOWNERS, ruleset, live-adapter,
+  support, or production-claim surfaces.
 
 ### Fixed
 

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -1,35 +1,26 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-899-project-sync-workflows",
+  "work_package": "AO-MA-ISSUE-TEMPLATE-ALLOWLIST",
   "implementer": {
-    "agent": "claude-opus-4-7-1m",
-    "provider": "anthropic"
+    "agent": "codex",
+    "provider": "openai"
   },
   "reviewer": {
-    "agent": "claude-opus-4-7-1m-adversarial-self-review",
+    "agent": "claude-code-cli",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-11e-2c-d-e-workflows",
+    "head_ref": "refs/heads/codex/ao-release-gate-issue-template-allowlist",
     "changed_files": [
-      ".claude/plans/AO-MA-11E-2c-d-e-WORKFLOWS.md",
-      ".claude/plans/AO-MA-11E-2c-d-e-WORKFLOWS.v1.json",
-      ".github/workflows/ao-ma-11e-2c-project-mirror-full-sync.yml",
-      ".github/workflows/ao-ma-11e-2d-pr-project-auto-link.yml",
-      ".github/workflows/ao-ma-11e-2e-label-cleanup-once.yml",
       "CHANGELOG.md",
-      "ao-ma-10-high-risk-reviews/AO-MA-11e-2c-d-e-workflows/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/AO-MA-11e-2c-d-e-workflows/local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/AO-MA-11e-2c-d-e-workflows/minimax.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/AO-MA-11e-2c-d-e-workflows/openai.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/ao-ma-11e-2c-d-e-workflows-evidence.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_ao_ma11e2cde_workflows_shape.py"
+      "scripts/ao_release_gate_build_payload.py",
+      "tests/test_ao_release_gate_build_payload.py"
     ]
   },
   "checks_considered": [
@@ -42,45 +33,52 @@
       "status": "pass"
     },
     {
-      "name": "pre_commit_hook_delegates_to_changelog_policy",
+      "name": "no_workflow_change",
       "status": "pass"
     },
     {
-      "name": "local_only_operator_installed_hook",
+      "name": "no_codeowners_change",
       "status": "pass"
     },
     {
-      "name": "no_github_workflow_mutation",
+      "name": "no_ruleset_change",
       "status": "pass"
     },
     {
-      "name": "no_codeowners_mutation",
+      "name": "no_branch_protection_change",
       "status": "pass"
     },
     {
-      "name": "no_ruleset_mutation",
+      "name": "no_live_adapter_execution",
       "status": "pass"
     },
     {
-      "name": "no_runtime_support_widening",
+      "name": "no_support_widening",
       "status": "pass"
     },
     {
-      "name": "guard_flags_remain_false",
+      "name": "no_production_platform_claim",
       "status": "pass"
     },
     {
-      "name": "cross_provider_review_evidence_present",
+      "name": "invariant_test_present",
+      "status": "pass"
+    },
+    {
+      "name": "changelog_entry_present",
+      "status": "pass"
+    },
+    {
+      "name": "prefix_narrower_than_dotgithub",
       "status": "pass"
     }
   ],
   "findings": [
-    "PR #909 implements the V5 Epic 1 E-1-4 local pre-commit changelog gate as an operator-installed local hook, not as release authority. The hook blocks user-visible code commits without CHANGELOG.md unless the commit prefix is explicitly non-user-visible.",
-    "The hook delegates policy intent to the existing ADR-0005 Keep-a-Changelog discipline and mirrors the future E-1-3 CI enforcement lane without mutating .github/workflows/.",
-    "The tested decision contract covers no-code pass, code+CHANGELOG pass, feat/fix-style code-without-CHANGELOG block, and non-user-visible prefixes such as chore/docs/test/ci/style/refactor/build/perf pass.",
-    "The final PR diff is intentionally limited to the E-1-4 plan document, local hook script, pre-commit hook tests, current top-level review evidence, and nested AO-MA-818 reopening review artifacts. Historical AO-MA-10h and AO-MA-CI-FIX evidence rewrites were restored to origin/main.",
-    "Guard-controlled surfaces are not widened: support_widening=false, production_platform_claim=false, live_adapter_execution=false; no CODEOWNERS, ruleset, branch-protection, live adapter, or ao_kernel runtime surface is changed.",
-    "Anthropic adversarial review confirms the local-only hook scope, CLI/ADR alignment, path-filtered no-workflow invariant, and no guard flag flip."
+    "Anthropic review accepts the allowlist addition as narrowly scoped to `.github/ISSUE_TEMPLATE/`, strictly narrower than `.github/`.",
+    "No workflow YAML, CODEOWNERS, ruleset, branch-protection, runtime adapter, support-widening, or production-platform-claim surface is touched.",
+    "The invariant test pins the new prefix and documents the PR #910 regression context.",
+    "The CHANGELOG entry accurately describes the scope and explicitly enumerates the surfaces not widened.",
+    "No secrets are recorded and no live adapter execution is requested."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -1,35 +1,26 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-899-project-sync-workflows",
+  "work_package": "AO-MA-ISSUE-TEMPLATE-ALLOWLIST",
   "implementer": {
-    "agent": "claude-opus-4-7-1m",
-    "provider": "anthropic"
+    "agent": "codex",
+    "provider": "openai"
   },
   "reviewer": {
-    "agent": "codex-mcp-thread",
+    "agent": "codex-adversarial-review",
     "provider": "openai",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-11e-2c-d-e-workflows",
+    "head_ref": "refs/heads/codex/ao-release-gate-issue-template-allowlist",
     "changed_files": [
-      ".claude/plans/AO-MA-11E-2c-d-e-WORKFLOWS.md",
-      ".claude/plans/AO-MA-11E-2c-d-e-WORKFLOWS.v1.json",
-      ".github/workflows/ao-ma-11e-2c-project-mirror-full-sync.yml",
-      ".github/workflows/ao-ma-11e-2d-pr-project-auto-link.yml",
-      ".github/workflows/ao-ma-11e-2e-label-cleanup-once.yml",
       "CHANGELOG.md",
-      "ao-ma-10-high-risk-reviews/AO-MA-11e-2c-d-e-workflows/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/AO-MA-11e-2c-d-e-workflows/local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/AO-MA-11e-2c-d-e-workflows/minimax.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/AO-MA-11e-2c-d-e-workflows/openai.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/ao-ma-11e-2c-d-e-workflows-evidence.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_ao_ma11e2cde_workflows_shape.py"
+      "scripts/ao_release_gate_build_payload.py",
+      "tests/test_ao_release_gate_build_payload.py"
     ]
   },
   "checks_considered": [
@@ -42,45 +33,32 @@
       "status": "pass"
     },
     {
-      "name": "pre_commit_hook_delegates_to_changelog_policy",
+      "name": "narrow_issue_template_prefix",
       "status": "pass"
     },
     {
-      "name": "local_only_operator_installed_hook",
+      "name": "no_workflow_change",
       "status": "pass"
     },
     {
-      "name": "no_github_workflow_mutation",
+      "name": "no_codeowners_change",
       "status": "pass"
     },
     {
-      "name": "no_codeowners_mutation",
+      "name": "no_ruleset_or_branch_protection_change",
       "status": "pass"
     },
     {
-      "name": "no_ruleset_mutation",
-      "status": "pass"
-    },
-    {
-      "name": "no_runtime_support_widening",
-      "status": "pass"
-    },
-    {
-      "name": "guard_flags_remain_false",
-      "status": "pass"
-    },
-    {
-      "name": "cross_provider_review_evidence_present",
+      "name": "release_authority_boundary",
       "status": "pass"
     }
   ],
   "findings": [
-    "PR #909 implements the V5 Epic 1 E-1-4 local pre-commit changelog gate as an operator-installed local hook, not as release authority. The hook blocks user-visible code commits without CHANGELOG.md unless the commit prefix is explicitly non-user-visible.",
-    "The hook delegates policy intent to the existing ADR-0005 Keep-a-Changelog discipline and mirrors the future E-1-3 CI enforcement lane without mutating .github/workflows/.",
-    "The tested decision contract covers no-code pass, code+CHANGELOG pass, feat/fix-style code-without-CHANGELOG block, and non-user-visible prefixes such as chore/docs/test/ci/style/refactor/build/perf pass.",
-    "The final PR diff is intentionally limited to the E-1-4 plan document, local hook script, pre-commit hook tests, current top-level review evidence, and nested AO-MA-818 reopening review artifacts. Historical AO-MA-10h and AO-MA-CI-FIX evidence rewrites were restored to origin/main.",
-    "Guard-controlled surfaces are not widened: support_widening=false, production_platform_claim=false, live_adapter_execution=false; no CODEOWNERS, ruleset, branch-protection, live adapter, or ao_kernel runtime surface is changed.",
-    "OpenAI review signal is represented as cross-provider review evidence for the E-1-4 local hook scope; AI output remains evidence only, while ao-release-gate plus GitHub ruleset remains release authority."
+    "OpenAI review accepts the `.github/ISSUE_TEMPLATE/` allowlist widening because it is exact-folder metadata, not a broad `.github/` grant.",
+    "The diff does not mutate workflows, CODEOWNERS, rulesets, branch protection, runtime adapter code, or public support tier semantics.",
+    "The regression test would fail if the protected-base builder dropped the issue-template prefix again.",
+    "The CHANGELOG entry documents the limited unblock for reviewed V5 issue-form PRs.",
+    "Release authority remains ao-release-gate plus GitHub ruleset; this review is evidence only."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,35 +1,26 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-899-project-sync-workflows",
+  "work_package": "AO-MA-ISSUE-TEMPLATE-ALLOWLIST",
   "implementer": {
-    "agent": "claude",
-    "provider": "anthropic"
+    "agent": "codex",
+    "provider": "openai"
   },
   "reviewer": {
-    "agent": "codex",
-    "provider": "openai",
+    "agent": "claude-code-cli",
+    "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-11e-2c-d-e-workflows",
+    "head_ref": "refs/heads/codex/ao-release-gate-issue-template-allowlist",
     "changed_files": [
-      ".claude/plans/AO-MA-11E-2c-d-e-WORKFLOWS.md",
-      ".claude/plans/AO-MA-11E-2c-d-e-WORKFLOWS.v1.json",
-      ".github/workflows/ao-ma-11e-2c-project-mirror-full-sync.yml",
-      ".github/workflows/ao-ma-11e-2d-pr-project-auto-link.yml",
-      ".github/workflows/ao-ma-11e-2e-label-cleanup-once.yml",
       "CHANGELOG.md",
-      "ao-ma-10-high-risk-reviews/AO-MA-11e-2c-d-e-workflows/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/AO-MA-11e-2c-d-e-workflows/local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/AO-MA-11e-2c-d-e-workflows/minimax.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/AO-MA-11e-2c-d-e-workflows/openai.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/ao-ma-11e-2c-d-e-workflows-evidence.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_ao_ma11e2cde_workflows_shape.py"
+      "scripts/ao_release_gate_build_payload.py",
+      "tests/test_ao_release_gate_build_payload.py"
     ]
   },
   "checks_considered": [
@@ -42,45 +33,28 @@
       "status": "pass"
     },
     {
-      "name": "pre_commit_hook_delegates_to_changelog_policy",
+      "name": "narrow_issue_template_prefix",
       "status": "pass"
     },
     {
-      "name": "local_only_operator_installed_hook",
+      "name": "no_workflow_codeowners_ruleset_mutation",
       "status": "pass"
     },
     {
-      "name": "no_github_workflow_mutation",
+      "name": "no_live_adapter_execution",
       "status": "pass"
     },
     {
-      "name": "no_codeowners_mutation",
-      "status": "pass"
-    },
-    {
-      "name": "no_ruleset_mutation",
-      "status": "pass"
-    },
-    {
-      "name": "no_runtime_support_widening",
-      "status": "pass"
-    },
-    {
-      "name": "guard_flags_remain_false",
-      "status": "pass"
-    },
-    {
-      "name": "cross_provider_review_evidence_present",
+      "name": "guard_flags_const_false",
       "status": "pass"
     }
   ],
   "findings": [
-    "PR #909 implements the V5 Epic 1 E-1-4 local pre-commit changelog gate as an operator-installed local hook, not as release authority. The hook blocks user-visible code commits without CHANGELOG.md unless the commit prefix is explicitly non-user-visible.",
-    "The hook delegates policy intent to the existing ADR-0005 Keep-a-Changelog discipline and mirrors the future E-1-3 CI enforcement lane without mutating .github/workflows/.",
-    "The tested decision contract covers no-code pass, code+CHANGELOG pass, feat/fix-style code-without-CHANGELOG block, and non-user-visible prefixes such as chore/docs/test/ci/style/refactor/build/perf pass.",
-    "The final PR diff is intentionally limited to the E-1-4 plan document, local hook script, pre-commit hook tests, current top-level review evidence, and nested AO-MA-818 reopening review artifacts. Historical AO-MA-10h and AO-MA-CI-FIX evidence rewrites were restored to origin/main.",
-    "Guard-controlled surfaces are not widened: support_widening=false, production_platform_claim=false, live_adapter_execution=false; no CODEOWNERS, ruleset, branch-protection, live adapter, or ao_kernel runtime surface is changed.",
-    "Root local evidence summarizes the accepted E-1-4 scope after rebase onto origin/main and binds scope_reviewed.changed_files to the current PR diff."
+    "The allowlist widening is exact and narrow: `.github/ISSUE_TEMPLATE/`, not the broader `.github/` tree.",
+    "The changed builder prefix is GitHub issue-form metadata only; workflows, CODEOWNERS, rulesets, branch protection, runtime adapter code, support widening, and production-claim surfaces remain independently guarded.",
+    "The invariant test pins the prefix and documents the PR #910 regression that triggered this unblock slice.",
+    "The CHANGELOG entry records the governance boundary and explicitly states that workflow, CODEOWNERS, ruleset, live-adapter, support, and production-claim surfaces are not widened.",
+    "AI output is review evidence only; release authority remains ao-release-gate plus GitHub ruleset."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/ao_release_gate_build_payload.py
+++ b/scripts/ao_release_gate_build_payload.py
@@ -70,6 +70,18 @@ DEFAULT_ALLOWED_PATH_PREFIXES = (
     # ao-release-gate allowlist PR + plan doc + cross-AI review).
     ".claude/scripts/",
     ".github/workflows/",
+    # V5 governance intake forms live under `.github/ISSUE_TEMPLATE/`.
+    # They are GitHub UI metadata, not runtime adapter code and not branch
+    # protection / required-check configuration. Keeping this exact folder
+    # in the base-ref allowlist lets issue-form PRs pass the diff_scope
+    # gate while the independent checks still enforce no workflow,
+    # CODEOWNERS, ruleset, live-adapter, support-widening, or production
+    # claim mutation. Regression: PR #910 (E-P0-5 minimal issue forms)
+    # was correctly reviewed but blocked with
+    # `ao_release_gate_diff_out_of_scope` because the base-ref builder did
+    # not yet recognize `.github/ISSUE_TEMPLATE/` as an allowed GitHub
+    # metadata surface.
+    ".github/ISSUE_TEMPLATE/",
     ".github/CODEOWNERS",
     "deploy/",
     "docs/",

--- a/tests/test_ao_release_gate_build_payload.py
+++ b/tests/test_ao_release_gate_build_payload.py
@@ -604,6 +604,7 @@ def test_build_payload_allowed_path_prefixes_repo_owned_not_pr_supplied(tmp_path
     # must be diff-scope eligible alongside `.claude/plans/`.
     assert ".claude/scripts/" in prefixes
     assert ".github/workflows/" in prefixes
+    assert ".github/ISSUE_TEMPLATE/" in prefixes
     # GPP-2D-3c bootstrap prerequisite: the ao-release-gate enforce
     # job reads the raw reviewer evidence file committed at the repo
     # head and generates the head-bound gate evidence file at CI
@@ -670,6 +671,27 @@ def test_build_payload_allowed_path_prefixes_includes_claude_scripts(
     mod.main(_build_argv(tmp_path, output=output))
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert ".claude/scripts/" in payload["allowed_path_prefixes"]
+
+
+def test_build_payload_allowed_path_prefixes_includes_issue_templates(
+    tmp_path: Path,
+) -> None:
+    """`.github/ISSUE_TEMPLATE/` is pinned to the base-ref allowlist so
+    GitHub issue-form metadata PRs do not trigger
+    ao_release_gate_diff_out_of_scope.
+
+    Regression for PR #910 (E-P0-5 minimal issue forms): the PR carried
+    reviewed V5 intake forms plus no workflow/CODEOWNERS/ruleset/runtime
+    mutation, but the protected-base builder denied the diff because the
+    issue-template metadata folder was not allowlisted. This prefix is
+    deliberately narrower than `.github/`: workflows, CODEOWNERS, ruleset
+    files, and branch-protection changes remain separately guarded.
+    """
+    mod = _load_module()
+    output = tmp_path / "payload.json"
+    mod.main(_build_argv(tmp_path, output=output))
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert ".github/ISSUE_TEMPLATE/" in payload["allowed_path_prefixes"]
 
 
 def test_build_payload_allowed_path_prefixes_includes_release_lifecycle_files(


### PR DESCRIPTION
## Summary

Unblocks V5 issue-form PRs such as #910 by adding the exact `.github/ISSUE_TEMPLATE/` folder to the protected-base `ao-release-gate` diff-scope allowlist.

## Scope

- Adds only the narrow `.github/ISSUE_TEMPLATE/` prefix, not broad `.github/`.
- Adds a regression invariant in `tests/test_ao_release_gate_build_payload.py`.
- Adds a CHANGELOG entry.
- Rebinds local/high-risk review evidence for this high-risk gate-builder change.

## Boundaries

- No workflow mutation.
- No CODEOWNERS, ruleset, or branch-protection mutation.
- No runtime adapter change.
- No live adapter execution.
- No support widening.
- No production platform claim.
- Release authority remains `ao-release-gate` + GitHub ruleset.

## Local validation

- `pytest -q tests/test_ao_release_gate_build_payload.py` -> 18 passed
- `ao-kernel quality check-changelog ...` -> pass
- `scripts/ao_ma10_high_risk_supersession_evidence.py` -> generated; changed_files_count=6; high_risk_changed_paths=["scripts/ao_release_gate_build_payload.py"]; consensus=AGREE; guard flags false
- `git diff --check origin/main...HEAD` -> clean

## Follow-up

After this PR lands, rebase/rerun #910 so the protected-base gate recognizes `.github/ISSUE_TEMPLATE/`.