### PR TITLE
fix(release-gate): allow CodeQL config scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **ao-release-gate CodeQL config diff-scope**: added the exact
+  `.github/codeql/codeql-config.yml` path to the protected-base
+  release-gate allowlist so reviewed CodeQL advisory baseline PRs can
+  merge without widening generic `.github/**`, `.github/codeql/**`,
+  workflow, CODEOWNERS, ruleset, support, live-adapter, or
+  production-claim surfaces.
 - **ao-release-gate Dependabot config diff-scope**: added the exact
   `.github/dependabot.yml` path to the protected-base release-gate
   allowlist so reviewed vulnerability-scanning baseline PRs can merge

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -1,19 +1,19 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-917-release-gate-dependabot-scope",
+  "work_package": "AO-MA-918-release-gate-codeql-config-scope",
   "implementer": {
-    "agent": "codex-gpt-5-release-gate-dependabot-scope",
+    "agent": "codex-gpt-5-release-gate-codeql-config-scope",
     "provider": "openai"
   },
   "reviewer": {
-    "agent": "claude-code-independent-reviewer-dependabot-scope",
+    "agent": "claude-code-independent-reviewer-codeql-config-scope",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-release-gate-dependabot-scope",
+    "head_ref": "refs/heads/codex/ao-release-gate-codeql-config-scope",
     "changed_files": [
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
@@ -37,6 +37,14 @@
       "status": "pass"
     },
     {
+      "name": "generic_github_prefix_absent",
+      "status": "pass"
+    },
+    {
+      "name": "generic_codeql_prefix_absent",
+      "status": "pass"
+    },
+    {
       "name": "workflow_governance_unchanged",
       "status": "pass"
     },
@@ -46,6 +54,10 @@
     },
     {
       "name": "ruleset_governance_unchanged",
+      "status": "pass"
+    },
+    {
+      "name": "branch_protection_unchanged",
       "status": "pass"
     },
     {
@@ -61,27 +73,16 @@
       "status": "pass"
     },
     {
-      "name": "negative_invariant_test_present",
-      "status": "pass"
-    },
-    {
-      "name": "regression_test_for_pr798",
-      "status": "pass"
-    },
-    {
       "name": "changelog_accuracy",
-      "status": "pass"
-    },
-    {
-      "name": "local_test_suite_20_passed",
       "status": "pass"
     }
   ],
   "findings": [
-    "Claude AGREE: exact path .github/dependabot.yml was added, not a prefix and not .github/.",
-    "Claude AGREE: negative invariant asserts .github/ is absent from allowed_path_prefixes, guarding against future generic GitHub metadata widening.",
-    "Claude AGREE: workflow, CODEOWNERS, ruleset, live-adapter, support-widening, and production-claim governance surfaces are untouched and remain independently gated.",
-    "Claude AGREE: source comment and changelog accurately document the PR #798 regression context and scope."
+    "Claude AGREE: exact path .github/codeql/codeql-config.yml added; no generic .github/** or .github/codeql/** widening.",
+    "Claude AGREE: test asserts exact path present and confirms .github/codeql/ plus .github/ are absent from prefixes.",
+    "Claude AGREE: changelog note accurately describes scope and explicitly lists surfaces not widened.",
+    "Claude AGREE: no workflow, CODEOWNERS, ruleset, branch-protection, runtime, live-adapter, support-widening, or production-claim surfaces touched.",
+    "Claude AGREE: pattern mirrors the existing exact-path .github/dependabot.yml precedent."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -1,19 +1,19 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-917-release-gate-dependabot-scope",
+  "work_package": "AO-MA-918-release-gate-codeql-config-scope",
   "implementer": {
-    "agent": "codex-gpt-5-release-gate-dependabot-scope",
+    "agent": "codex-gpt-5-release-gate-codeql-config-scope",
     "provider": "openai"
   },
   "reviewer": {
-    "agent": "openai-governance-review-dependabot-scope",
+    "agent": "openai-subagent-independent-reviewer-codeql-config-scope",
     "provider": "openai",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-release-gate-dependabot-scope",
+    "head_ref": "refs/heads/codex/ao-release-gate-codeql-config-scope",
     "changed_files": [
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
@@ -37,6 +37,14 @@
       "status": "pass"
     },
     {
+      "name": "generic_github_prefix_absent",
+      "status": "pass"
+    },
+    {
+      "name": "generic_codeql_prefix_absent",
+      "status": "pass"
+    },
+    {
       "name": "release_gate_diff_scope_regression",
       "status": "pass"
     },
@@ -50,10 +58,11 @@
     }
   ],
   "findings": [
-    "OpenAI implementation review: exact .github/dependabot.yml allowlist entry is narrower than a .github/ prefix and directly targets PR #798's ao_release_gate_diff_out_of_scope blocker.",
-    "The invariant test asserts both presence of .github/dependabot.yml and absence of generic .github/ prefix.",
+    "OpenAI independent review returned AGREE for the exact .github/codeql/codeql-config.yml release-gate scope fix.",
+    "The patch adds only an exact CodeQL config path, not a generic .github/codeql/ or .github/ prefix.",
+    "The invariant test asserts exact path presence and absence of both generic directory prefixes.",
     "The change does not alter workflows, CODEOWNERS, rulesets, branch protection, runtime adapter code, support-widening authority, production-platform claims, or live adapter execution.",
-    "Focused local verification passed: tests/test_ao_release_gate_build_payload.py plus the baseline allow decision smoke test."
+    "The changelog note accurately describes the reviewed CodeQL advisory baseline scope and no-widening boundary."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,31 +1,26 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-798-dependabot-trivy-scanning",
+  "work_package": "AO-MA-918-release-gate-codeql-config-scope",
   "implementer": {
-    "agent": "codex-gpt-5-e6-2-rebase-integrator",
+    "agent": "codex-gpt-5-release-gate-codeql-config-scope",
     "provider": "openai"
   },
   "reviewer": {
-    "agent": "claude-code-reviewer-pr798-e62-final",
+    "agent": "claude-code-independent-reviewer-codeql-config-scope",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-6-e6-2-vuln-scanning",
+    "head_ref": "refs/heads/codex/ao-release-gate-codeql-config-scope",
     "changed_files": [
-      ".claude/plans/EPIC-6-E6-2-VULN-SCANNING.md",
-      ".github/dependabot.yml",
-      ".github/workflows/trivy.yml",
       "CHANGELOG.md",
-      "tests/test_ao_ma11e2cde_workflows_shape.py",
-      "tests/test_epic_4_1_helm_chart_skeleton.py",
-      "tests/test_epic_4_2a_multi_tenant_boundary.py",
-      "tests/test_issue_forms_shape.py",
-      "tests/test_semantic_backends.py",
-      "tests/test_vuln_scanning_invariants.py",
-      "local-ai-review-evidence.v1.json"
+      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
+      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "scripts/ao_release_gate_build_payload.py",
+      "tests/test_ao_release_gate_build_payload.py"
     ]
   },
   "checks_considered": [
@@ -38,51 +33,55 @@
       "status": "pass"
     },
     {
-      "name": "minimum_permissions",
+      "name": "exact_path_not_prefix_widening",
       "status": "pass"
     },
     {
-      "name": "no_pull_request_target",
+      "name": "generic_github_prefix_absent",
       "status": "pass"
     },
     {
-      "name": "trivy_exact_vprefixed_semver_pin",
+      "name": "generic_codeql_prefix_absent",
       "status": "pass"
     },
     {
-      "name": "advisory_exit_code_zero",
+      "name": "workflow_governance_unchanged",
       "status": "pass"
     },
     {
-      "name": "sarif_category_distinct",
+      "name": "codeowners_governance_unchanged",
       "status": "pass"
     },
     {
-      "name": "snyk_operator_deferred",
+      "name": "ruleset_governance_unchanged",
       "status": "pass"
     },
     {
-      "name": "guard_flag_const_false",
+      "name": "branch_protection_unchanged",
       "status": "pass"
     },
     {
-      "name": "doc_workflow_version_consistency",
+      "name": "live_adapter_gate_unchanged",
+      "status": "pass"
+    },
+    {
+      "name": "support_widening_claim_unchanged",
+      "status": "pass"
+    },
+    {
+      "name": "production_platform_claim_unchanged",
       "status": "pass"
     },
     {
       "name": "changelog_discipline",
       "status": "pass"
-    },
-    {
-      "name": "legacy_slice_invariant_scope_fix",
-      "status": "pass"
     }
   ],
   "findings": [
-    "Claude re-review verdict AGREE after rebase and plan-doc version drift cleanup.",
-    "ADR-0005 changelog enforcement failure was resolved with a narrow Unreleased entry for the advisory Dependabot + Trivy filesystem scanning baseline.",
-    "CI matrix failures from stale slice-specific workflow/dot-github invariants were resolved by scoping those tests to their own slice evidence or artifact markers; no Trivy workflow guard was relaxed.",
-    "No blocking findings: advisory-only Dependabot + Trivy filesystem baseline remains scoped; Snyk, image scans, required-gate promotion, MEDIUM severity, config/secret scanning, support widening, production claim, and live adapter execution remain out of scope."
+    "Claude AGREE: exact path .github/codeql/codeql-config.yml was added, not a generic .github/codeql/ or .github/ prefix.",
+    "Claude AGREE: the invariant test asserts exact path presence and rejects both .github/codeql/ and .github/ prefix leakage.",
+    "Claude AGREE: workflow, CODEOWNERS, ruleset, branch-protection, runtime, live-adapter, support-widening, and production-claim surfaces are untouched.",
+    "Focused local verification passed: tests/test_ao_release_gate_build_payload.py plus the closed dry-run decision smoke test, compileall, git diff --check, and a no-match secret-pattern scan."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/ao_release_gate_build_payload.py
+++ b/scripts/ao_release_gate_build_payload.py
@@ -94,6 +94,13 @@ DEFAULT_ALLOWED_PATH_PREFIXES = (
     # config was not yet recognized as an allowed GitHub security metadata
     # file.
     ".github/dependabot.yml",
+    # CodeQL advisory baseline config is an exact GitHub security metadata
+    # file. It is not a workflow, CODEOWNERS rule, ruleset,
+    # branch-protection setting, runtime adapter path, support-widening
+    # claim, or production-platform claim. Keep this exact path rather
+    # than widening to `.github/codeql/` or `.github/` so unrelated GitHub
+    # governance surfaces remain independently gated.
+    ".github/codeql/codeql-config.yml",
     ".github/CODEOWNERS",
     "deploy/",
     "docs/",

--- a/tests/test_ao_release_gate_build_payload.py
+++ b/tests/test_ao_release_gate_build_payload.py
@@ -720,6 +720,30 @@ def test_build_payload_allowed_path_prefixes_includes_dependabot_config(
     assert ".github/" not in prefixes
 
 
+def test_build_payload_allowed_path_prefixes_includes_codeql_config(
+    tmp_path: Path,
+) -> None:
+    """`.github/codeql/codeql-config.yml` is pinned as an exact base-ref
+    allowlist path for the advisory CodeQL baseline config.
+
+    The allowlist intentionally does not widen to `.github/codeql/` or
+    `.github/`, so workflow, CODEOWNERS, ruleset, branch-protection,
+    runtime, support-widening, and production-claim surfaces remain
+    independently gated.
+    """
+
+    mod = _load_module()
+    output = tmp_path / "payload.json"
+    rc = mod.main(_build_argv(tmp_path, output=output))
+    assert rc == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+
+    prefixes = payload["allowed_path_prefixes"]
+    assert ".github/codeql/codeql-config.yml" in prefixes
+    assert ".github/codeql/" not in prefixes
+    assert ".github/" not in prefixes
+
+
 def test_build_payload_allowed_path_prefixes_includes_release_lifecycle_files(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes the protected-base `ao-release-gate` diff-scope false block for reviewed CodeQL advisory baseline PRs by adding only the exact GitHub metadata path:

- `.github/codeql/codeql-config.yml`

This does **not** widen to `.github/codeql/`, `.github/`, workflow, CODEOWNERS, ruleset, branch-protection, runtime, live-adapter, support-widening, or production-claim surfaces.

## Why

PR #796 currently fails `ao-release-gate` with `ao_release_gate_diff_out_of_scope` because the required check runs from protected base code. The PR includes `.github/codeql/codeql-config.yml`, but protected base does not yet know that exact config path is allowed. This PR lands the narrow base allowlist update first, matching the previous Dependabot exact-path scope fix pattern.

## Changed files

- `scripts/ao_release_gate_build_payload.py` — add exact `.github/codeql/codeql-config.yml` allowlist entry.
- `tests/test_ao_release_gate_build_payload.py` — assert exact path present and `.github/codeql/` plus `.github/` absent.
- `CHANGELOG.md` — record the no-widening scope fix.
- `local-ai-review-evidence.v1.json` and `ao-ma-10-high-risk-reviews/*` — bound review evidence for the high-risk builder script touch.

## Verification

- `python3 -m pytest -q tests/test_ao_release_gate_build_payload.py tests/test_ao_release_gate.py::test_release_gate_allows_closed_dry_run_context_without_merge_authority` → 21 passed.
- `python3 -m compileall -q scripts/ao_release_gate_build_payload.py` → pass.
- `git diff --check origin/main...HEAD` → clean.
- `scripts/local_gpp_gate.py` → `operator_may_merge`, `changed_files_count=6`, `diff_digest=sha256:651a5e19917a2cedc8d595e81d025b92f5e6a524fae4cb71f8d7bc83997e59c3`.
- `scripts/ao_ma10_high_risk_supersession_evidence.py` → `consensus_status=AGREE`, high-risk path only `scripts/ao_release_gate_build_payload.py`, providers `anthropic` + `openai`, guard flags false.

## Review evidence

- Anthropic Claude independent review: `AGREE` for exact path only, no generic `.github/**` or `.github/codeql/**` widening, no workflow/CODEOWNERS/ruleset/branch-protection/runtime/live-adapter/support-widening/production-claim mutation.
- OpenAI independent subagent review: `AGREE` for exact path only and exact-path invariant test coverage.

Release authority remains `ao-release-gate` + GitHub ruleset; AI output is evidence only.
