### PR TITLE
fix(ao-ma-11e): include V5 subissue mirror in drift check

### DIFF
--- a/.claude/plans/v5_subissues_mirror.v1.json
+++ b/.claude/plans/v5_subissues_mirror.v1.json
@@ -2,7 +2,7 @@
   "schema_version": "v5-subissues-mirror.v1",
   "parent_manifest": ".claude/plans/v5_issue_projection.v1.json",
   "parent_plan": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
-  "milestone": "v5.0.0 \u2014 Full Production Promotion",
+  "milestone": "v5.0.0 — Full Production Promotion",
   "milestone_number": 3,
   "created_at": "2026-06-02",
   "created_by": "Halildeu (operator-driven mirror via Claude session)",
@@ -14,7 +14,7 @@
     "production_platform_claim": false,
     "live_adapter_execution": false
   },
-  "rationale": "Full retroactive sub-slice mirror created 2026-06-02; 62 sub-issues across 10 parents (P0 + Epic 1-9). User explicit \"full retro mirror\" requirement (not lazy expansion). Each sub-issue carries parent ref + plan path + risk + status + DoD; Epic 9 E-9-1 alone carries all 3 guard-flip labels (atomic all-or-none flip).",
+  "rationale": "Full retroactive sub-slice mirror created 2026-06-02; 62 sub-issues across 10 parents (P0 + Epic 1-9). User explicit \"full retro mirror\" requirement (not lazy expansion). Each sub-issue carries parent ref + plan path + risk + status + mirror:authority + DoD; Epic 9 E-9-1 alone carries all 3 guard-flip labels (atomic all-or-none flip).",
   "sub_issues_by_parent": {
     "epic_p0": {
       "parent_issue_number": 773,
@@ -371,7 +371,7 @@
         {
           "slice_id": "E-8-6",
           "issue_number": 894,
-          "title": "[E-8-6] Migration guide v4.x \u2192 v5.0.0"
+          "title": "[E-8-6] Migration guide v4.x → v5.0.0"
         }
       ]
     },
@@ -400,7 +400,8 @@
       "labels": [
         "epic-p0",
         "risk:low",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "None (foundational)",
@@ -418,7 +419,8 @@
       "labels": [
         "epic-p0",
         "risk:low",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "E-P0-1",
@@ -436,7 +438,8 @@
       "labels": [
         "epic-p0",
         "risk:low",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "E-P0-1 + E-P0-2",
@@ -454,7 +457,8 @@
       "labels": [
         "epic-p0",
         "risk:low",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-P0-4-README-V5-ROADMAP-BADGE.md",
       "deps": "E-P0-1",
@@ -472,11 +476,12 @@
       "labels": [
         "epic-p0",
         "risk:low",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/v5_issue_projection.v1.json",
       "deps": "E-P0-3",
-      "description": "Issue forms (YAML): zorunlu spm_anchor + ao_authority_artifact + artifact_sha256 + plan_digest + slice_id + risk_class_source + evidence_classes; risk field manuel d\u00fc\u015f\u00fcr\u00fclemez (computed)."
+      "description": "Issue forms (YAML): zorunlu spm_anchor + ao_authority_artifact + artifact_sha256 + plan_digest + slice_id + risk_class_source + evidence_classes; risk field manuel düşürülemez (computed)."
     },
     "E-1-1": {
       "issue_number": 839,
@@ -490,7 +495,8 @@
       "labels": [
         "epic-1",
         "risk:normal",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "P0 runway",
@@ -508,11 +514,12 @@
       "labels": [
         "epic-1",
         "risk:normal",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "P0 runway",
-      "description": "GH Projects/Milestone/Issue one-way sync + anchor injection + drift checker (mirror_drift_detected \u2192 otonom DUR); V5 mirror write sync + PAT fallback."
+      "description": "GH Projects/Milestone/Issue one-way sync + anchor injection + drift checker (mirror_drift_detected → otonom DUR); V5 mirror write sync + PAT fallback."
     },
     "E-1-3": {
       "issue_number": 841,
@@ -526,7 +533,8 @@
       "labels": [
         "epic-1",
         "risk:normal",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "E-1-1",
@@ -544,11 +552,12 @@
       "labels": [
         "epic-1",
         "risk:low",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "E-1-3",
-      "description": "AO-MA-11G-2d: lokal yard\u0131mc\u0131 pre-commit hook (release authority de\u011fil)."
+      "description": "AO-MA-11G-2d: lokal yardımcı pre-commit hook (release authority değil)."
     },
     "E-1-5": {
       "issue_number": 843,
@@ -562,11 +571,12 @@
       "labels": [
         "epic-1",
         "risk:normal",
-        "status:planned"
+        "status:planned",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "E-1-1",
-      "description": "Operator claude-cli ile worker_result \u00fcret \u2192 ao-kernel native-import ingest."
+      "description": "Operator claude-cli ile worker_result üret → ao-kernel native-import ingest."
     },
     "E-1-6": {
       "issue_number": 844,
@@ -580,7 +590,8 @@
       "labels": [
         "epic-1",
         "risk:low",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "P0 runway",
@@ -598,11 +609,12 @@
       "labels": [
         "epic-1",
         "risk:high",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "operator gate",
-      "description": "Operator CODEOWNER review pending \u2014 .github/workflows/test.yml high-risk path."
+      "description": "Operator CODEOWNER review pending — .github/workflows/test.yml high-risk path."
     },
     "E-2-1": {
       "issue_number": 846,
@@ -616,7 +628,8 @@
       "labels": [
         "epic-2",
         "risk:low",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-2-LIVE-ADAPTER-EXECUTION.md",
       "deps": "PR #828 (V5 amend) + PR #827 (Epic 2 plan) + PR #826 (Epic 3 plan) all merged",
@@ -634,7 +647,8 @@
       "labels": [
         "epic-2",
         "risk:low",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-2-LIVE-ADAPTER-EXECUTION.md",
       "deps": "E-2-1",
@@ -652,7 +666,8 @@
       "labels": [
         "epic-2",
         "risk:normal",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-2-LIVE-ADAPTER-EXECUTION.md",
       "deps": "E-2-1 + E-2-2",
@@ -670,7 +685,8 @@
       "labels": [
         "epic-2",
         "risk:normal",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-2-LIVE-ADAPTER-EXECUTION.md",
       "deps": "E-2-1 + E-2-2 + E-2-3",
@@ -688,7 +704,8 @@
       "labels": [
         "epic-2",
         "risk:normal",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-2-LIVE-ADAPTER-EXECUTION.md",
       "deps": "E-2-1",
@@ -706,7 +723,8 @@
       "labels": [
         "epic-2",
         "risk:normal",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-2-LIVE-ADAPTER-EXECUTION.md",
       "deps": "E-2-1..E-2-5",
@@ -724,7 +742,8 @@
       "labels": [
         "epic-2",
         "risk:low",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-2-LIVE-ADAPTER-EXECUTION.md",
       "deps": "E-2-1..E-2-6",
@@ -742,7 +761,8 @@
       "labels": [
         "epic-3",
         "risk:low",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-3-SUPPORT-WIDENING-MATRIX.md",
       "deps": "V5 amend PR #828 + Epic 3 plan PR #826 + Epic 2 plan PR #827 all merged",
@@ -760,7 +780,8 @@
       "labels": [
         "epic-3",
         "risk:normal",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-3-SUPPORT-WIDENING-MATRIX.md",
       "deps": "E-3-1",
@@ -778,7 +799,8 @@
       "labels": [
         "epic-3",
         "risk:normal",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-3-SUPPORT-WIDENING-MATRIX.md",
       "deps": "E-3-1 + E-3-2",
@@ -796,7 +818,8 @@
       "labels": [
         "epic-3",
         "risk:low",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-3-SUPPORT-WIDENING-MATRIX.md",
       "deps": "E-3-1",
@@ -814,7 +837,8 @@
       "labels": [
         "epic-3",
         "risk:low",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-3-SUPPORT-WIDENING-MATRIX.md",
       "deps": "E-3-1",
@@ -832,7 +856,8 @@
       "labels": [
         "epic-3",
         "risk:low",
-        "status:blocked"
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-3-SUPPORT-WIDENING-MATRIX.md",
       "deps": "E-3-1..E-3-5",
@@ -850,7 +875,8 @@
       "labels": [
         "epic-4",
         "risk:low",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-4-KUBERNETES-HELM-MULTI-TENANT.md",
       "deps": "P0 mirror",
@@ -868,7 +894,8 @@
       "labels": [
         "epic-4",
         "risk:low",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-4-KUBERNETES-HELM-MULTI-TENANT.md",
       "deps": "E-4-1",
@@ -886,7 +913,8 @@
       "labels": [
         "epic-4",
         "risk:high",
-        "status:planned"
+        "status:planned",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-4-KUBERNETES-HELM-MULTI-TENANT.md",
       "deps": "E-4-2a + E-4-3 + E-4-4 + E-4-5",
@@ -904,11 +932,12 @@
       "labels": [
         "epic-4",
         "risk:normal",
-        "status:planned"
+        "status:planned",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-4-KUBERNETES-HELM-MULTI-TENANT.md",
       "deps": "E-4-1 + E-4-2a",
-      "description": "Operator DDL responsibility; ao-kernel hi\u00e7bir DDL execute etmez; env-only secret resolution (D11); secret kaynak \u00f6ncelik tablosu."
+      "description": "Operator DDL responsibility; ao-kernel hiçbir DDL execute etmez; env-only secret resolution (D11); secret kaynak öncelik tablosu."
     },
     "E-4-4": {
       "issue_number": 863,
@@ -922,7 +951,8 @@
       "labels": [
         "epic-4",
         "risk:normal",
-        "status:planned"
+        "status:planned",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-4-KUBERNETES-HELM-MULTI-TENANT.md",
       "deps": "E-4-1 + E-4-2a",
@@ -940,7 +970,8 @@
       "labels": [
         "epic-4",
         "risk:normal",
-        "status:planned"
+        "status:planned",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-4-KUBERNETES-HELM-MULTI-TENANT.md",
       "deps": "E-4-1 + E-4-2a",
@@ -958,7 +989,8 @@
       "labels": [
         "epic-4",
         "risk:low",
-        "status:planned"
+        "status:planned",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-4-KUBERNETES-HELM-MULTI-TENANT.md",
       "deps": "E-4-1..E-4-5",
@@ -976,7 +1008,8 @@
       "labels": [
         "epic-5",
         "risk:normal",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "None",
@@ -994,7 +1027,8 @@
       "labels": [
         "epic-5",
         "risk:normal",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "E-5-1",
@@ -1012,7 +1046,8 @@
       "labels": [
         "epic-5",
         "risk:normal",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-5-E5-3-DISTRIBUTED-TRACING.md",
       "deps": "E-5-1",
@@ -1030,7 +1065,8 @@
       "labels": [
         "epic-5",
         "risk:normal",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-5-E5-3B-CONSULTATION-TRACING.md",
       "deps": "E-5-3",
@@ -1048,7 +1084,8 @@
       "labels": [
         "epic-5",
         "risk:normal",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-5-E5-4-SLI-SLO-DEFINITIONS.md",
       "deps": "E-5-1",
@@ -1066,7 +1103,8 @@
       "labels": [
         "epic-5",
         "risk:normal",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-5-E5-5-ALERTMANAGER-RULE-TEMPLATES.md",
       "deps": "E-5-2",
@@ -1084,7 +1122,8 @@
       "labels": [
         "epic-6",
         "risk:high",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-6-E6-1-SBOM-GENERATION.md",
       "deps": "None",
@@ -1102,7 +1141,8 @@
       "labels": [
         "epic-6",
         "risk:high",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "None",
@@ -1120,7 +1160,8 @@
       "labels": [
         "epic-6",
         "risk:high",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-6-E6-3-SOC2-ISO-COMPLIANCE-DOCS.md",
       "deps": "None",
@@ -1138,7 +1179,8 @@
       "labels": [
         "epic-6",
         "risk:high",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-6-E6-3B-HIPAA-CONTROL-MAPPING.md",
       "deps": "E-6-3",
@@ -1156,7 +1198,8 @@
       "labels": [
         "epic-6",
         "risk:high",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-6-E6-3C-GDPR-DPIA-TEMPLATE.md",
       "deps": "E-6-3",
@@ -1174,7 +1217,8 @@
       "labels": [
         "epic-6",
         "risk:high",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-6-E6-3D-PCI-DSS-MAPPING.md",
       "deps": "E-6-3",
@@ -1192,7 +1236,8 @@
       "labels": [
         "epic-6",
         "risk:high",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "E-6-3",
@@ -1210,7 +1255,8 @@
       "labels": [
         "epic-6",
         "risk:high",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-6-E6-4-LICENSE-COMPLIANCE.md",
       "deps": "None",
@@ -1228,7 +1274,8 @@
       "labels": [
         "epic-6",
         "risk:high",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "None",
@@ -1246,7 +1293,8 @@
       "labels": [
         "epic-6",
         "risk:high",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-6-E6-6-INCIDENT-RESPONSE-PLAYBOOK.md",
       "deps": "None",
@@ -1264,7 +1312,8 @@
       "labels": [
         "epic-6",
         "risk:high",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-6-E6-6B-VENDOR-ESCALATION-MATRIX.md",
       "deps": "E-6-6",
@@ -1282,7 +1331,8 @@
       "labels": [
         "epic-7",
         "risk:normal",
-        "status:planned"
+        "status:planned",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-7-PERFORMANCE-BASELINE.md",
       "deps": "None",
@@ -1300,7 +1350,8 @@
       "labels": [
         "epic-7",
         "risk:normal",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "E-7-1",
@@ -1318,7 +1369,8 @@
       "labels": [
         "epic-7",
         "risk:normal",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-7-3-MEMORY-PROFILING.md",
       "deps": "E-7-1",
@@ -1336,7 +1388,8 @@
       "labels": [
         "epic-7",
         "risk:normal",
-        "status:planned"
+        "status:planned",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "Epic 4",
@@ -1354,7 +1407,8 @@
       "labels": [
         "epic-7",
         "risk:normal",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "None",
@@ -1372,7 +1426,8 @@
       "labels": [
         "epic-7",
         "risk:normal",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-7X-CI-PROMOTION-TRACK.md",
       "deps": "None",
@@ -1390,7 +1445,8 @@
       "labels": [
         "epic-8",
         "risk:low",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "Epic 4",
@@ -1408,7 +1464,8 @@
       "labels": [
         "epic-8",
         "risk:low",
-        "status:planned"
+        "status:planned",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "E-4-3",
@@ -1426,7 +1483,8 @@
       "labels": [
         "epic-8",
         "risk:low",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "Epic 4 + Epic 6",
@@ -1444,7 +1502,8 @@
       "labels": [
         "epic-8",
         "risk:low",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/EPIC-8-4-API-REFERENCE-SPHINX.md",
       "deps": "None",
@@ -1462,7 +1521,8 @@
       "labels": [
         "epic-8",
         "risk:low",
-        "status:in_progress"
+        "status:in_progress",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "None",
@@ -1473,14 +1533,15 @@
       "url": "https://github.com/Halildeu/ao-kernel/issues/894",
       "parent": 781,
       "slice_id": "E-8-6",
-      "title": "[E-8-6] Migration guide v4.x \u2192 v5.0.0",
+      "title": "[E-8-6] Migration guide v4.x → v5.0.0",
       "risk": "low",
       "status": "merged",
       "status_ref": "merged PR #807",
       "labels": [
         "epic-8",
         "risk:low",
-        "status:done"
+        "status:done",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "None",
@@ -1497,11 +1558,12 @@
       "status_ref": "planned (deps Epic 1-8 complete)",
       "labels": [
         "epic-9",
-        "risk:critical",
         "guard-flip:live_adapter",
-        "guard-flip:support_widening",
         "guard-flip:production_platform_claim",
-        "status:blocked"
+        "guard-flip:support_widening",
+        "risk:critical",
+        "status:blocked",
+        "mirror:authority"
       ],
       "plan_ref": ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
       "deps": "Epic 1-8 all complete (evidence packs A + B + C)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **V5 GitHub mirror drift checker sub-issue authority**: included the
+  V5 sub-issue mirror manifest in expected issue inventory, accepted
+  known optional anchor fields, normalized annotated digest values, and
+  counted only issue-backed ProjectV2 items so live mirror drift checks
+  stop misclassifying canonical sub-issues and draft project items as
+  drift.
 - **ao-release-gate CodeQL config diff-scope**: added the exact
   `.github/codeql/codeql-config.yml` path to the protected-base
   release-gate allowlist so reviewed CodeQL advisory baseline PRs can

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -1,28 +1,27 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-796-codeql-workflow",
+  "work_package": "AO-MA-11e-2-v5-mirror-drift",
   "implementer": {
-    "agent": "codex-gpt-5-codeql-workflow-rebase-integrator",
+    "agent": "codex-v5-mirror-subissues-drift",
     "provider": "openai"
   },
   "reviewer": {
-    "agent": "claude-code-independent-reviewer-pr796-codeql-final",
+    "agent": "anthropic-claude-opus-4-6-independent-reviewer",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-6-e6-5-codeql-workflow",
+    "head_ref": "refs/heads/codex/v5-mirror-subissues-drift",
     "changed_files": [
-      ".claude/plans/EPIC-6-E6-5-CODEQL-WORKFLOW.md",
-      ".github/codeql/codeql-config.yml",
-      ".github/workflows/codeql.yml",
+      ".claude/plans/v5_subissues_mirror.v1.json",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "ao_kernel/_internal/ao_ma/github_mirror_drift.py",
       "local-ai-review-evidence.v1.json",
-      "tests/test_codeql_workflow_shape.py"
+      "tests/test_ao_ma11e2a_mirror_drift_checker.py"
     ]
   },
   "checks_considered": [
@@ -35,60 +34,27 @@
       "status": "pass"
     },
     {
-      "name": "advisory_only_no_required_check_promotion",
+      "name": "guard_flag_audit",
       "status": "pass"
     },
     {
-      "name": "no_pull_request_target",
+      "name": "ruff_lint",
       "status": "pass"
     },
     {
-      "name": "no_explicit_secrets",
+      "name": "compileall",
       "status": "pass"
     },
     {
-      "name": "minimum_permissions",
-      "status": "pass"
-    },
-    {
-      "name": "no_contents_write",
-      "status": "pass"
-    },
-    {
-      "name": "no_id_token_write",
-      "status": "pass"
-    },
-    {
-      "name": "no_setup_python",
-      "status": "pass"
-    },
-    {
-      "name": "config_security_extended_only",
-      "status": "pass"
-    },
-    {
-      "name": "scoped_paths_and_ignores",
-      "status": "pass"
-    },
-    {
-      "name": "invariant_tests_cover_shape",
-      "status": "pass"
-    },
-    {
-      "name": "changelog_records_baseline",
-      "status": "pass"
-    },
-    {
-      "name": "guard_flags_const_false",
+      "name": "git_diff_check",
       "status": "pass"
     }
   ],
   "findings": [
-    "Claude AGREE: workflow is explicitly advisory-only and required-check promotion is out of scope.",
-    "Claude AGREE: pull_request_target is absent and pinned by invariant tests.",
-    "Claude AGREE: no secrets.X expressions, no contents: write, no id-token: write, no setup-python, and minimum permissions are present.",
-    "Claude AGREE: config is single source-of-truth for queries, security-extended only, with scoped paths and glob-form ignores.",
-    "Claude AGREE: changelog records the advisory baseline and no runtime/live-adapter/support-widening/production-claim/branch-protection/ruleset/CODEOWNERS mutation exists."
+    "Claude AGREE: guard flags remain false with no support widening, production claim, or live adapter execution.",
+    "Claude AGREE: subissue manifest inventory is included while compact canonical subissue bodies skip parent-anchor validation but keep label checking strict.",
+    "Claude AGREE: anchor parser accepts known optional fields and digest markdown annotations without weakening unknown-field enforcement.",
+    "Claude AGREE: ProjectV2 draft or non-issue items are excluded from issue-backed mirror item counts."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -1,28 +1,27 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-796-codeql-workflow",
+  "work_package": "AO-MA-11e-2-v5-mirror-drift",
   "implementer": {
-    "agent": "codex-gpt-5-codeql-workflow-rebase-integrator",
+    "agent": "codex-v5-mirror-subissues-drift",
     "provider": "openai"
   },
   "reviewer": {
-    "agent": "openai-subagent-independent-reviewer-pr796-codeql-final",
+    "agent": "openai-independent-reviewer",
     "provider": "openai",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-6-e6-5-codeql-workflow",
+    "head_ref": "refs/heads/codex/v5-mirror-subissues-drift",
     "changed_files": [
-      ".claude/plans/EPIC-6-E6-5-CODEQL-WORKFLOW.md",
-      ".github/codeql/codeql-config.yml",
-      ".github/workflows/codeql.yml",
+      ".claude/plans/v5_subissues_mirror.v1.json",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "ao_kernel/_internal/ao_ma/github_mirror_drift.py",
       "local-ai-review-evidence.v1.json",
-      "tests/test_codeql_workflow_shape.py"
+      "tests/test_ao_ma11e2a_mirror_drift_checker.py"
     ]
   },
   "checks_considered": [
@@ -35,60 +34,22 @@
       "status": "pass"
     },
     {
-      "name": "advisory_only_no_required_check_promotion",
+      "name": "diff_scope",
       "status": "pass"
     },
     {
-      "name": "no_pull_request_target",
+      "name": "manifest_semantic_review",
       "status": "pass"
     },
     {
-      "name": "no_explicit_secrets",
-      "status": "pass"
-    },
-    {
-      "name": "minimum_permissions",
-      "status": "pass"
-    },
-    {
-      "name": "no_contents_write",
-      "status": "pass"
-    },
-    {
-      "name": "no_id_token_write",
-      "status": "pass"
-    },
-    {
-      "name": "no_setup_python",
-      "status": "pass"
-    },
-    {
-      "name": "config_security_extended_only",
-      "status": "pass"
-    },
-    {
-      "name": "scoped_paths_and_ignores",
-      "status": "pass"
-    },
-    {
-      "name": "invariant_tests_cover_shape",
-      "status": "pass"
-    },
-    {
-      "name": "changelog_records_baseline",
-      "status": "pass"
-    },
-    {
-      "name": "guard_flags_const_false",
+      "name": "git_diff_check",
       "status": "pass"
     }
   ],
   "findings": [
-    "OpenAI independent review returned AGREE for the inspected CodeQL advisory baseline slice.",
-    "The workflow is advisory/static-analysis only and does not use pull_request_target, explicit secrets, contents: write, id-token: write, or setup-python.",
-    "The CodeQL config declares security-extended only, keeps default queries enabled, and scopes paths/ignores to ao_kernel, scripts, tests/defaults/pycache/pyc boundaries.",
-    "Invariant tests cover workflow/config shape, no extra write permissions, no explicit secrets, and PR merge-result checkout semantics.",
-    "The changelog records the advisory baseline without overclaiming, and the only review note about plan-doc test-count drift was corrected before final evidence."
+    "OpenAI AGREE: optional V5 subissues manifest is included in issue inventory without requiring parent anchors for canonical subissues.",
+    "OpenAI AGREE: known optional anchor fields and backticked digest annotations are accepted while unknown anchor fields remain strict.",
+    "OpenAI AGREE: non-issue ProjectV2 items are excluded from project item counts, matching issue-backed mirror semantics."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/ao_kernel/_internal/ao_ma/github_mirror_drift.py
+++ b/ao_kernel/_internal/ao_ma/github_mirror_drift.py
@@ -66,6 +66,14 @@ _ANCHOR_REQUIRED_FIELDS = (
     "artifact_sha256",
     "plan_digest",
 )
+_ANCHOR_KNOWN_OPTIONAL_FIELDS = (
+    "risk_class_source",
+    "evidence_classes",
+    "consensus_state",
+)
+_ANCHOR_KNOWN_FIELDS = frozenset(
+    (*_ANCHOR_REQUIRED_FIELDS, *_ANCHOR_KNOWN_OPTIONAL_FIELDS)
+)
 
 _SHA_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 _PLACEHOLDER_PATTERN = re.compile(r"^\{[^}]+\}$")
@@ -180,6 +188,27 @@ _ANCHOR_LINE_PATTERN = re.compile(
 _BACKTICK_STRIP = re.compile(r"^`(.+)`$")
 
 
+def _normalize_anchor_value(value: str) -> str:
+    """Normalize a markdown anchor value.
+
+    GitHub mirror bodies may include an inline explanation after a backticked
+    value, for example:
+        `sha256:<digest>` (manifest `.claude/plans/...`)
+
+    The digest validator should evaluate the bound value, not the explanatory
+    prose that follows it.
+    """
+    value = value.strip()
+    if value.startswith("`"):
+        closing = value.find("`", 1)
+        if closing > 1:
+            return value[1:closing]
+    bt = _BACKTICK_STRIP.match(value)
+    if bt:
+        return bt.group(1)
+    return value
+
+
 def parse_issue_anchor(body: str) -> AnchorParseResult:
     """Strict-parse anchor fields from an issue body markdown list.
 
@@ -213,10 +242,8 @@ def parse_issue_anchor(body: str) -> AnchorParseResult:
             continue
         field_name = m.group("field").lower()
         value = m.group("value").strip()
-        bt = _BACKTICK_STRIP.match(value)
-        if bt:
-            value = bt.group(1)
-        if field_name not in _ANCHOR_REQUIRED_FIELDS:
+        value = _normalize_anchor_value(value)
+        if field_name not in _ANCHOR_KNOWN_FIELDS:
             unknown.append(field_name)
             continue
         if field_name in fields:
@@ -259,6 +286,93 @@ def _load_manifest(path: Path) -> dict[str, Any]:
     return data
 
 
+def _resolve_manifest_ref(projection_manifest_path: Path, manifest_ref: str) -> Path | None:
+    """Resolve a manifest-relative path from the projection manifest.
+
+    Historical V5 manifests store refs as repo-root relative paths such as
+    `.claude/plans/v5_subissues_mirror.v1.json`. The core module only receives
+    the projection manifest path, so resolve conservatively by walking ancestors
+    and returning the first existing candidate.
+    """
+    ref_path = Path(manifest_ref)
+    if ref_path.is_absolute():
+        return ref_path if ref_path.is_file() else None
+    for ancestor in (projection_manifest_path.parent, *projection_manifest_path.parents):
+        candidate = ancestor / ref_path
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_optional_subissues_manifest(
+    projection_manifest_path: Path,
+    runtime_state: dict[str, Any],
+) -> dict[str, Any] | None:
+    ref = runtime_state.get("sub_issues_mirror_ref", {})
+    manifest_ref = ref.get("mirror_manifest_path")
+    if not isinstance(manifest_ref, str) or not manifest_ref.strip():
+        return None
+    subissues_path = _resolve_manifest_ref(projection_manifest_path, manifest_ref)
+    if subissues_path is None:
+        return None
+    return _load_manifest(subissues_path)
+
+
+def _expected_issue_inventory(
+    projection_manifest_path: Path,
+    manifest: dict[str, Any],
+    runtime_state: dict[str, Any],
+) -> dict[int, dict[str, Any]]:
+    """Build expected issue metadata from parent + optional sub-issue manifests.
+
+    `v5_issue_projection.v1.json` originally carried only the first-wave parent
+    issues. `v5_subissues_mirror.v1.json` later became repo authority for the
+    retroactive sub-slice issue mirror. The drift checker must include both, or
+    it will incorrectly classify canonical sub-issues as `extra_issue`.
+    """
+    expected_first_wave_by_id = {
+        issue["id"]: issue for issue in manifest.get("first_wave_issues", [])
+    }
+    inventory: dict[int, dict[str, Any]] = {}
+
+    for anchor_id, issue_number in runtime_state.get("issues_created", {}).items():
+        if not isinstance(issue_number, int):
+            continue
+        expected_meta = expected_first_wave_by_id.get(anchor_id, {})
+        inventory[issue_number] = {
+            "id": anchor_id,
+            "labels": list(expected_meta.get("labels", [])),
+            "anchor_required": True,
+        }
+
+    subissues_manifest = _load_optional_subissues_manifest(
+        projection_manifest_path, runtime_state
+    )
+    if subissues_manifest is None:
+        return inventory
+
+    subissues = subissues_manifest.get("sub_issues", {})
+    if not isinstance(subissues, dict):
+        return inventory
+    for slice_id, meta in subissues.items():
+        if not isinstance(meta, dict):
+            continue
+        issue_number = meta.get("issue_number")
+        if not isinstance(issue_number, int):
+            continue
+        inventory[issue_number] = {
+            "id": slice_id,
+            "labels": list(meta.get("labels", [])),
+            # Retroactive sub-slice mirror issues were created from a compact
+            # body template, not the parent V5 Anchor block. Keep label/inventory
+            # checking strict without manufacturing anchor drift for canonical
+            # sub-issues.
+            "anchor_required": False,
+        }
+
+    return inventory
+
+
 def _safe_call(gh_api_caller: Callable[[str, str], Any], method: str, api_path: str) -> tuple[Any, Optional[str]]:
     """Call gh_api_caller and capture API errors.
 
@@ -295,9 +409,13 @@ def check_github_mirror_drift(
     checked_at = now_iso or _utcnow_isoformat()
     manifest_sha = _file_sha256(projection_manifest_path)
     manifest = _load_manifest(projection_manifest_path)
+    runtime_state = manifest.get("runtime_created_state", {})
+    expected_issue_inventory = _expected_issue_inventory(
+        projection_manifest_path, manifest, runtime_state
+    )
 
     expected_counts = {
-        "issues": len(manifest.get("first_wave_issues", [])),
+        "issues": len(expected_issue_inventory),
         "labels": len(manifest.get("labels", [])),
         "project_items": (manifest.get("runtime_created_state", {}).get("project_board", {}).get("items_count", 0)),
     }
@@ -317,8 +435,6 @@ def check_github_mirror_drift(
     if not network_allowed:
         report.exit_decision = ExitDecision.NETWORK_NOT_ALLOWED
         return report
-
-    runtime_state = manifest.get("runtime_created_state", {})
 
     # 1. Milestone presence + metadata
     expected_ms = runtime_state.get("milestone", {})
@@ -370,9 +486,7 @@ def check_github_mirror_drift(
                 )
 
     # 2. Issue inventory + 3. labels + 4. anchors
-    expected_issues = runtime_state.get("issues_created", {})
-    expected_issue_numbers = set(expected_issues.values())
-    expected_first_wave_by_id = {i["id"]: i for i in manifest.get("first_wave_issues", [])}
+    expected_issue_numbers = set(expected_issue_inventory)
 
     if expected_ms_number is not None:
         issues_resp, err = _safe_call(
@@ -416,15 +530,9 @@ def check_github_mirror_drift(
             num = iss["number"]
             if num not in expected_issue_numbers:
                 continue
-            # Find anchor id key (reverse map)
-            anchor_id = None
-            for aid, n in expected_issues.items():
-                if n == num:
-                    anchor_id = aid
-                    break
-            if anchor_id is None or anchor_id not in expected_first_wave_by_id:
+            expected_meta = expected_issue_inventory.get(num)
+            if expected_meta is None:
                 continue
-            expected_meta = expected_first_wave_by_id[anchor_id]
             expected_labels = set(expected_meta.get("labels", []))
             actual_labels = {lab["name"] for lab in iss.get("labels", [])}
             if expected_labels != actual_labels:
@@ -438,6 +546,9 @@ def check_github_mirror_drift(
                         actual=sorted(actual_labels),
                     )
                 )
+
+            if not expected_meta.get("anchor_required", True):
+                continue
 
             # Anchor parse
             anchor = parse_issue_anchor(iss.get("body", "") or "")
@@ -516,7 +627,14 @@ def check_github_mirror_drift(
                 )
             )
         else:
-            actual_item_count = len(items_resp.get("items", []))
+            # ProjectV2 can contain non-issue items such as drafts. The V5
+            # mirror manifest's `items_count` tracks issue-backed mirror items,
+            # so ignore non-issue project entries here.
+            actual_item_count = sum(
+                1
+                for item in items_resp.get("items", [])
+                if (item.get("content") or {}).get("number") is not None
+            )
             if actual_item_count != expected_item_count:
                 report.drift.append(
                     DriftFinding(

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,28 +1,27 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-796-codeql-workflow",
+  "work_package": "AO-MA-11e-2-v5-mirror-drift",
   "implementer": {
-    "agent": "codex-gpt-5-codeql-workflow-rebase-integrator",
+    "agent": "codex-v5-mirror-subissues-drift",
     "provider": "openai"
   },
   "reviewer": {
-    "agent": "claude-code-independent-reviewer-pr796-codeql-final",
+    "agent": "anthropic-claude-opus-4-6-independent-reviewer",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-6-e6-5-codeql-workflow",
+    "head_ref": "refs/heads/codex/v5-mirror-subissues-drift",
     "changed_files": [
-      ".claude/plans/EPIC-6-E6-5-CODEQL-WORKFLOW.md",
-      ".github/codeql/codeql-config.yml",
-      ".github/workflows/codeql.yml",
+      ".claude/plans/v5_subissues_mirror.v1.json",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "ao_kernel/_internal/ao_ma/github_mirror_drift.py",
       "local-ai-review-evidence.v1.json",
-      "tests/test_codeql_workflow_shape.py"
+      "tests/test_ao_ma11e2a_mirror_drift_checker.py"
     ]
   },
   "checks_considered": [
@@ -35,60 +34,36 @@
       "status": "pass"
     },
     {
-      "name": "advisory_only_no_required_check_promotion",
+      "name": "guard_flag_audit",
       "status": "pass"
     },
     {
-      "name": "no_pull_request_target",
+      "name": "network_import_ban",
       "status": "pass"
     },
     {
-      "name": "no_explicit_secrets",
+      "name": "ruff_lint",
       "status": "pass"
     },
     {
-      "name": "minimum_permissions",
+      "name": "compileall",
       "status": "pass"
     },
     {
-      "name": "no_contents_write",
+      "name": "git_diff_check",
       "status": "pass"
     },
     {
-      "name": "no_id_token_write",
-      "status": "pass"
-    },
-    {
-      "name": "no_setup_python",
-      "status": "pass"
-    },
-    {
-      "name": "config_security_extended_only",
-      "status": "pass"
-    },
-    {
-      "name": "scoped_paths_and_ignores",
-      "status": "pass"
-    },
-    {
-      "name": "invariant_tests_cover_shape",
-      "status": "pass"
-    },
-    {
-      "name": "changelog_records_baseline",
-      "status": "pass"
-    },
-    {
-      "name": "guard_flags_const_false",
+      "name": "live_github_mirror_drift_smoke",
       "status": "pass"
     }
   ],
   "findings": [
-    "Claude AGREE: CodeQL workflow is advisory-only and does not promote branch-protection required checks in this slice.",
-    "Claude AGREE: workflow excludes pull_request_target, explicit secrets.X references, contents: write, id-token: write, and setup-python.",
-    "Claude AGREE: CodeQL config is the single query source-of-truth, uses security-extended only, scopes paths to ao_kernel and scripts, and ignores tests/defaults/pycache/pyc noise.",
-    "Claude AGREE: 24 invariant tests pin workflow/config shape, including PR merge-result checkout semantics and no extra write permissions.",
-    "OpenAI reviewer AGREE: no runtime, live-adapter, support-widening, production-claim, branch-protection, ruleset, or CODEOWNERS mutation; doc drift on invariant count was corrected before final evidence."
+    "Claude AGREE: guard flags remain false with no support widening, production platform claim, or live adapter execution.",
+    "Claude AGREE: subissue manifest inventory is included while compact canonical subissue bodies skip parent-anchor validation but keep label checking strict.",
+    "Claude AGREE: anchor parser accepts known optional fields and digest markdown annotations without weakening unknown-field enforcement.",
+    "Claude AGREE: ProjectV2 draft or non-issue items are excluded from issue-backed mirror item counts.",
+    "Claude AGREE: targeted tests, lint, compile, diff-check, and live GitHub mirror drift smoke passed."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_ao_ma11e2a_mirror_drift_checker.py
+++ b/tests/test_ao_ma11e2a_mirror_drift_checker.py
@@ -68,6 +68,36 @@ def _make_manifest(tmp_path: Path) -> Path:
     return path
 
 
+def _attach_subissues_manifest(
+    projection_manifest: Path,
+    *,
+    issue_number: int = 900,
+    labels: list[str] | None = None,
+) -> Path:
+    """Attach a minimal v5_subissues_mirror manifest to a projection fixture."""
+    subissues = {
+        "schema_version": "v5-subissues-mirror.v1",
+        "sub_issues": {
+            "E-1-1": {
+                "issue_number": issue_number,
+                "slice_id": "E-1-1",
+                "labels": labels or ["epic-1", "risk:normal", "status:done"],
+            }
+        },
+    }
+    subissues_path = projection_manifest.parent / "v5_subissues_mirror.v1.json"
+    subissues_path.write_text(json.dumps(subissues, indent=2), encoding="utf-8")
+
+    manifest = json.loads(projection_manifest.read_text(encoding="utf-8"))
+    manifest["runtime_created_state"]["sub_issues_mirror_ref"] = {
+        "mirror_manifest_path": "v5_subissues_mirror.v1.json",
+        "created_count": 1,
+    }
+    manifest["runtime_created_state"]["project_board"]["items_count"] = 3
+    projection_manifest.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return projection_manifest
+
+
 def _valid_anchor_body(*, spm_anchor: str, slice_id: str) -> str:
     return (
         "## V5 Anchor\n"
@@ -227,6 +257,63 @@ def test_extra_issue(tmp_path):
     assert any(d.category == "extra_issue" and d.object_id == "999" for d in report.drift)
 
 
+def test_subissue_manifest_issue_is_not_extra_and_does_not_require_parent_anchor(tmp_path):
+    manifest = _attach_subissues_manifest(_make_manifest(tmp_path))
+    responses = _make_synced_responses()
+    responses["/repos/Halildeu/ao-kernel/issues?milestone=3&state=all&per_page=100"].append(
+        {
+            "number": 900,
+            # Retro sub-slice mirror issues use a compact body, not the parent
+            # `## V5 Anchor` block. The drift checker should still verify
+            # inventory + labels without manufacturing anchor drift.
+            "body": "**Parent epic:** #774\n\n**Slice ID:** E-1-1\n",
+            "labels": [
+                {"name": "epic-1"},
+                {"name": "risk:normal"},
+                {"name": "status:done"},
+            ],
+        }
+    )
+    responses["graphql:project_items:PVT_xxx"] = {
+        "items": [
+            {"id": "i1", "content": {"number": 774}},
+            {"id": "i2", "content": {"number": 775}},
+            {"id": "i3", "content": {"number": 900}},
+        ]
+    }
+    caller = _make_caller(responses)
+    report = check_github_mirror_drift(
+        projection_manifest_path=manifest,
+        gh_api_caller=caller,
+        network_allowed=True,
+        now_iso=_now(),
+    )
+    assert report.exit_decision == ExitDecision.SYNCED
+    assert report.drift == []
+    assert report.expected_counts["issues"] == 3
+
+
+def test_subissue_manifest_still_rejects_unexpected_extra_issue(tmp_path):
+    manifest = _attach_subissues_manifest(_make_manifest(tmp_path))
+    responses = _make_synced_responses()
+    responses["/repos/Halildeu/ao-kernel/issues?milestone=3&state=all&per_page=100"].append(
+        {
+            "number": 901,
+            "body": "**Slice ID:** E-unknown\n",
+            "labels": [{"name": "epic-1"}],
+        }
+    )
+    caller = _make_caller(responses)
+    report = check_github_mirror_drift(
+        projection_manifest_path=manifest,
+        gh_api_caller=caller,
+        network_allowed=True,
+        now_iso=_now(),
+    )
+    assert any(d.category == "missing_issue" and d.object_id == "900" for d in report.drift)
+    assert any(d.category == "extra_issue" and d.object_id == "901" for d in report.drift)
+
+
 def test_label_mismatch(tmp_path):
     manifest = _make_manifest(tmp_path)
     responses = _make_synced_responses()
@@ -297,6 +384,31 @@ def test_anchor_unknown_field(tmp_path):
         now_iso=_now(),
     )
     assert any(d.category == "anchor_schema_mismatch" and d.object_id == "774" for d in report.drift)
+
+
+def test_anchor_known_template_fields_and_digest_annotation_are_accepted(tmp_path):
+    manifest = _make_manifest(tmp_path)
+    responses = _make_synced_responses()
+    responses["/repos/Halildeu/ao-kernel/issues?milestone=3&state=all&per_page=100"][0]["body"] = (
+        "## V5 Anchor\n"
+        "- **spm_anchor:** `AO-MA-SPM-V5-EPIC-1`\n"
+        "- **slice_id:** `V5-EPIC-1`\n"
+        "- **ao_authority_artifact:** `.claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md`\n"
+        f"- **artifact_sha256:** `{_VALID_ARTIFACT_SHA}`\n"
+        f"- **plan_digest:** `{_VALID_PLAN_DIGEST}` (manifest `.claude/plans/v5_issue_projection.v1.json`)\n"
+        "- **risk_class_source:** `computed_normal` (computed; NOT manually downgraded)\n"
+        "- **evidence_classes:** [plan_doc, projection_manifest]\n"
+        "- **consensus_state:** `agreed`\n"
+    )
+    caller = _make_caller(responses)
+    report = check_github_mirror_drift(
+        projection_manifest_path=manifest,
+        gh_api_caller=caller,
+        network_allowed=True,
+        now_iso=_now(),
+    )
+    assert not any(d.category == "anchor_schema_mismatch" for d in report.drift)
+    assert not any(d.category == "anchor_sha_format_invalid" for d in report.drift)
 
 
 def test_anchor_sha_format_invalid(tmp_path):
@@ -370,6 +482,27 @@ def test_project_item_count_mismatch(tmp_path):
         now_iso=_now(),
     )
     assert any(d.category == "project_item_count_mismatch" for d in report.drift)
+
+
+def test_project_item_count_ignores_non_issue_project_items(tmp_path):
+    manifest = _make_manifest(tmp_path)
+    responses = _make_synced_responses()
+    responses["graphql:project_items:PVT_xxx"] = {
+        "items": [
+            {"id": "i1", "content": {"number": 774}},
+            {"id": "i2", "content": {"number": 775}},
+            {"id": "draft1", "content": None},
+        ]
+    }
+    caller = _make_caller(responses)
+    report = check_github_mirror_drift(
+        projection_manifest_path=manifest,
+        gh_api_caller=caller,
+        network_allowed=True,
+        now_iso=_now(),
+    )
+    assert report.exit_decision == ExitDecision.SYNCED
+    assert report.drift == []
 
 
 # ---- API error ----


### PR DESCRIPTION
## Scope

Fixes the V5 GitHub mirror drift checker so the repo-owned mirror authority includes both:

- parent first-wave issue projection from `.claude/plans/v5_issue_projection.v1.json`
- optional retro sub-issue mirror authority from `.claude/plans/v5_subissues_mirror.v1.json`

## Changes

- Load optional `runtime_created_state.sub_issues_mirror_ref.mirror_manifest_path` and merge canonical sub-issues into expected issue inventory.
- Keep sub-issues strict for inventory + label matching while not requiring the parent `## V5 Anchor` block on compact retro sub-slice bodies.
- Accept known anchor optional fields: `risk_class_source`, `evidence_classes`, `consensus_state`.
- Normalize backticked SHA anchor values before trailing markdown explanations.
- Count only issue-backed ProjectV2 items, ignoring draft/non-issue items.
- Add `mirror:authority` to canonical V5 sub-issue mirror labels so manifest and live labels match.

## Validation

- `pytest -q tests/test_ao_ma11e2a_mirror_drift_checker.py tests/test_ao_ma11e2a_schema_invariant.py tests/test_ao_ma11e2b_manifest_migration.py tests/test_ao_ma11e2b_mirror_sync.py` -> 73 passed
- `ruff check ao_kernel/_internal/ao_ma/github_mirror_drift.py tests/test_ao_ma11e2a_mirror_drift_checker.py` -> pass
- `python3 -m compileall -q ao_kernel/_internal/ao_ma/github_mirror_drift.py` -> pass
- `git diff --check` -> clean
- Live drift smoke: `scripts/ao_ma11e2_v5_mirror_drift.py --allow-network` -> `exit_decision=synced`, `drift_count=0`
- `scripts/local_gpp_gate.py` -> `decision=operator_may_merge`
- `scripts/ao_ma10_high_risk_supersession_evidence.py` -> `consensus_status=AGREE`, providers `anthropic` + `openai`

## Guardrails

- No support widening.
- No production platform claim.
- No live adapter execution.
- Release authority remains repo-owned `ao-release-gate` + GitHub ruleset; AI review output is evidence only.
