### PR TITLE
feat(e-4-5): NetworkPolicy + PodSecurityStandards baseline (V5 Epic 4)

### DIFF
--- a/.claude/plans/E-4-5-NETWORKPOLICY-PSS.md
+++ b/.claude/plans/E-4-5-NETWORKPOLICY-PSS.md
@@ -1,0 +1,16 @@
+# E-4-5 — NetworkPolicy + PodSecurityStandards namespace-label baseline
+
+> V5 Epic 4. Slice #864. Guard-flag-independent. Builds on E-4-1 chart.
+
+## Delivered
+- `templates/networkpolicy.yaml` — opt-in default-deny NetworkPolicy
+  (Ingress+Egress); egress DNS-only baseline + operator-allowed CIDRs.
+- `values.yaml` `networkPolicy` + `podSecurityStandards` blocks (off/restricted).
+- `values.schema.json` — closed blocks; PSS enforceProfile enum.
+- `tests/test_epic_4_5_networkpolicy_pss.py` — 11 invariants.
+
+## Boundaries
+- Default egress DNS-only; operator MUST widen for LLM provider endpoints.
+- Chart does NOT manage the namespace; operator applies PSS enforce label
+  out-of-band. Existing container securityContext already meets 'restricted'.
+- No guard flag; no `.github/workflows/` mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **E-4-5 NetworkPolicy + PodSecurityStandards baseline** (V5 Epic 4,
+  #864): added an opt-in default-deny NetworkPolicy and PSS restricted
+  namespace-label guidance for the ao-kernel Helm chart. DNS egress is scoped
+  to the configured kube-dns namespace, operator egress widening is explicit
+  in values, and no live cluster command, workflow mutation, guard-flag flip,
+  or production readiness claim is introduced.
 - **E-4-4 observability surface** (V5 Epic 4, #863): opt-in Prometheus
   Operator ServiceMonitor CRD + optional hardened OTEL collector sidecar in
   the ao-kernel Helm chart (both disabled by default). Chart does not install

--- a/deploy/helm/ao-kernel/templates/networkpolicy.yaml
+++ b/deploy/helm/ao-kernel/templates/networkpolicy.yaml
@@ -34,9 +34,15 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
   egress:
-    # DNS resolution (kube-dns) — required for any outbound connection.
+    # DNS resolution — scoped to the kube-dns namespace ONLY (Codex E-4-5
+    # review absorb): an empty all-namespaces selector would open UDP/TCP 53
+    # to EVERY namespace's pods, not just the cluster DNS. We scope to the
+    # well-known `kube-system` namespace via its immutable metadata label.
+    # Operators whose DNS lives elsewhere override dnsNamespace.
     - to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.egress.dnsNamespace | quote }}
       ports:
         - port: 53
           protocol: UDP

--- a/deploy/helm/ao-kernel/templates/networkpolicy.yaml
+++ b/deploy/helm/ao-kernel/templates/networkpolicy.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.networkPolicy.enabled }}
+# NetworkPolicy (V5 Epic 4 E-4-5) — default-deny baseline.
+#
+# OPT-IN: rendered only when networkPolicy.enabled=true. Default-deny ingress
+# + scoped egress (DNS + operator-allowed CIDRs). The operator MUST review and
+# widen egress for the LLM provider endpoints their deployment actually uses.
+# The chart ships a least-privilege baseline; it does not assume internet-wide
+# egress.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "ao-kernel.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ao-kernel.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "ao-kernel.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
+    # Allow ingress from same-namespace pods (e.g. a scraping Prometheus).
+    - from:
+        - podSelector: {}
+      ports:
+        - port: http
+          protocol: TCP
+    {{- end }}
+    {{- with .Values.networkPolicy.ingress.extraFrom }}
+    - from:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+  egress:
+    # DNS resolution (kube-dns) — required for any outbound connection.
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- with .Values.networkPolicy.egress.allowCidrs }}
+    # Operator-allowed egress CIDRs (e.g. LLM provider ranges). Operator MUST
+    # scope these to the providers actually used; default is empty (no egress
+    # beyond DNS until the operator widens).
+    - to:
+        {{- range . }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/ao-kernel/values.schema.json
+++ b/deploy/helm/ao-kernel/values.schema.json
@@ -389,6 +389,59 @@
           "type": "string"
         }
       }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allowSameNamespace": {
+              "type": "boolean"
+            },
+            "extraFrom": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "egress": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "dnsNamespace": {
+              "type": "string"
+            },
+            "allowCidrs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "podSecurityStandards": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enforceProfile": {
+          "type": "string",
+          "enum": [
+            "privileged",
+            "baseline",
+            "restricted"
+          ]
+        }
+      }
     }
   },
   "$defs": {

--- a/deploy/helm/ao-kernel/values.yaml
+++ b/deploy/helm/ao-kernel/values.yaml
@@ -143,6 +143,10 @@ networkPolicy:
     allowSameNamespace: true
     extraFrom: []
   egress:
+    # DNS namespace the egress rule scopes port-53 to (well-known label
+    # kubernetes.io/metadata.name). Default kube-system; operators whose DNS
+    # lives elsewhere override. NOT a bare allow-all (Codex E-4-5 review).
+    dnsNamespace: "kube-system"
     # Operator-allowed egress CIDRs (LLM providers etc). Empty = DNS-only.
     allowCidrs: []
 podSecurityStandards:

--- a/deploy/helm/ao-kernel/values.yaml
+++ b/deploy/helm/ao-kernel/values.yaml
@@ -130,6 +130,27 @@ monitoring:
     # OTLP endpoint the sidecar forwards to (operator-owned backend).
     otlpEndpoint: ""
 
+# NetworkPolicy + PodSecurityStandards (V5 Epic 4 E-4-5) — OPT-IN baseline.
+#
+# networkPolicy: default-deny ingress + scoped egress (DNS + operator CIDRs).
+# Operator MUST widen egress for the LLM provider endpoints actually used.
+# podSecurityStandards: the chart's containerSecurityContext already meets the
+# 'restricted' PSS profile; the operator applies the namespace ENFORCE label
+# out-of-band (chart does not manage the namespace). See README / NOTES.
+networkPolicy:
+  enabled: false
+  ingress:
+    allowSameNamespace: true
+    extraFrom: []
+  egress:
+    # Operator-allowed egress CIDRs (LLM providers etc). Empty = DNS-only.
+    allowCidrs: []
+podSecurityStandards:
+  # The chart's pod/container securityContext satisfies 'restricted'. The
+  # operator labels the namespace: pod-security.kubernetes.io/enforce=restricted
+  # (chart does NOT manage the namespace; see docs/MULTI-TENANT-DEPLOYMENT.md).
+  enforceProfile: "restricted"
+
 # ServiceAccount (namespace-scoped; ClusterRole forbidden).
 serviceAccount:
   create: true

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-E-4-4-observability-surface",
+  "work_package": "AO-MA-E-4-5-networkpolicy-pss",
   "implementer": {
     "agent": "claude",
     "provider": "anthropic"
@@ -13,17 +13,16 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-4-4-observability-surface",
+    "head_ref": "refs/heads/codex/epic-4-5-networkpolicy-pss",
     "changed_files": [
-      ".claude/plans/E-4-4-OBSERVABILITY-SURFACE.md",
+      ".claude/plans/E-4-5-NETWORKPOLICY-PSS.md",
       "CHANGELOG.md",
-      "deploy/helm/ao-kernel/templates/deployment.yaml",
-      "deploy/helm/ao-kernel/templates/servicemonitor.yaml",
+      "deploy/helm/ao-kernel/templates/networkpolicy.yaml",
       "deploy/helm/ao-kernel/values.schema.json",
       "deploy/helm/ao-kernel/values.yaml",
       "local-ai-review-evidence.v1.json",
       "tests/test_epic_4_1_helm_chart_skeleton.py",
-      "tests/test_epic_4_4_observability_surface.py"
+      "tests/test_epic_4_5_networkpolicy_pss.py"
     ]
   },
   "checks_considered": [
@@ -36,15 +35,23 @@
       "status": "pass"
     },
     {
-      "name": "servicemonitor_gated",
+      "name": "networkpolicy_default_deny",
       "status": "pass"
     },
     {
-      "name": "otel_sidecar_hardened",
+      "name": "dns_scoped_to_kube_dns",
       "status": "pass"
     },
     {
-      "name": "no_slack_receiver",
+      "name": "pss_restricted",
+      "status": "pass"
+    },
+    {
+      "name": "no_psp_manifest",
+      "status": "pass"
+    },
+    {
+      "name": "no_deprecated_k8s_api",
       "status": "pass"
     },
     {
@@ -60,25 +67,20 @@
       "status": "pass"
     },
     {
+      "name": "changelog_entry",
+      "status": "pass"
+    },
+    {
       "name": "cross_provider_review",
-      "status": "pass"
-    },
-    {
-      "name": "otel_image_pinned",
-      "status": "pass"
-    },
-    {
-      "name": "otel_claim_narrowed_skeleton",
       "status": "pass"
     }
   ],
   "findings": [
-    "E-4-4 (#863) observability surface: ServiceMonitor CRD (gated, Prometheus Operator) + optional hardened OTEL sidecar. Both disabled default. Chart does not install Prometheus Operator; Teams primary alert routing (no Slack receiver).",
-    "13 invariants pass. OTLP endpoint plain env (no secret); sidecar securityContext hardened (no privilege escalation, readonly rootfs, drop ALL).",
-    "Low-risk lane: deploy/helm/ + tests/ + plan + CHANGELOG. NO .github/workflows/, governance, runtime mutation.",
-    "3 guard flags const false; no production claim.",
-    "E-4-1 strict-closure allowlist: monitoring.serviceMonitor.additionalLabels free-form k8s label map added to documented allowlist (test_epic_4_1 _VALUES_SCHEMA_FREEFORM_PATHS).",
-    "Codex E-4-4 review absorb (thread 019e91c6): OTEL sidecar claim narrowed to SKELETON (operator supplies collector config + main-container OTLP wiring; chart provides slot+hardened-securityContext+pinned-image+endpoint-env only). Image pinned 0.96.0 (no :latest). Restored postgresql schema block dropped by rebase. 2 new invariants (image-pinned, claim-narrowed)."
+    "E-4-5 NetworkPolicy + PodSecurityStandards baseline adds an opt-in default-deny NetworkPolicy and PSS restricted namespace-label guidance for the Helm chart.",
+    "NetworkPolicy is disabled by default; DNS egress is scoped to the configured kube-dns namespace and operator egress widening is explicit through values.",
+    "The chart does not create PodSecurityPolicy resources and does not use deprecated Kubernetes API versions.",
+    "The change is limited to deploy/helm chart files, tests, plan evidence, changelog, and local review evidence; no workflows, runtime adapter code, support tier, or production claim are changed.",
+    "Guard flags remain false and this is render-only/operator-installable beta infrastructure, not live cluster validation."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_epic_4_1_helm_chart_skeleton.py
+++ b/tests/test_epic_4_1_helm_chart_skeleton.py
@@ -226,6 +226,9 @@ _VALUES_SCHEMA_FREEFORM_PATHS = frozenset(
         # E-4-4: ServiceMonitor additionalLabels is a free-form k8s label map
         # (operator labels the ServiceMonitor so a per-tenant Prometheus selects it).
         "$.properties.monitoring.properties.serviceMonitor.properties.additionalLabels",
+        # E-4-5: extraFrom items are free-form k8s NetworkPolicyPeer objects
+        # (podSelector/namespaceSelector/ipBlock); operator supplies the shape.
+        "$.properties.networkPolicy.properties.ingress.properties.extraFrom.items",
     }
 )
 

--- a/tests/test_epic_4_5_networkpolicy_pss.py
+++ b/tests/test_epic_4_5_networkpolicy_pss.py
@@ -1,0 +1,153 @@
+"""V5 Epic 4 E-4-5 invariants: NetworkPolicy + PodSecurityStandards baseline.
+
+Opt-in default-deny NetworkPolicy (DNS-only egress until the operator widens)
++ a PodSecurityStandards 'restricted' affirmation. The chart's existing
+container securityContext already satisfies 'restricted'; the operator applies
+the namespace enforce label out-of-band (chart does not manage the namespace).
+
+Machine-enforced invariants:
+  - networkpolicy.yaml gated on networkPolicy.enabled (default false)
+  - policyTypes include Ingress + Egress; egress allows DNS
+  - egress CIDRs default empty (DNS-only baseline; operator widens)
+  - values + schema carry networkPolicy + podSecurityStandards (closed)
+  - PSS enforceProfile default 'restricted'
+  - existing container securityContext already meets 'restricted'
+  - no guard-flag key; no .github/workflows/ mutation
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CHART_DIR = _REPO_ROOT / "deploy" / "helm" / "ao-kernel"
+_VALUES = _CHART_DIR / "values.yaml"
+_SCHEMA = _CHART_DIR / "values.schema.json"
+_NETPOL = _CHART_DIR / "templates" / "networkpolicy.yaml"
+
+
+def _load_values() -> dict:
+    if yaml is None:
+        pytest.skip("PyYAML not installed")
+    return yaml.safe_load(_VALUES.read_text(encoding="utf-8"))
+
+
+# ---- 1. NetworkPolicy template (4) --------------------------------------
+
+
+def test_networkpolicy_template_exists() -> None:
+    assert _NETPOL.is_file(), "networkpolicy.yaml missing (E-4-5)"
+
+
+def test_networkpolicy_gated_on_enabled() -> None:
+    text = _NETPOL.read_text(encoding="utf-8")
+    assert "if .Values.networkPolicy.enabled" in text
+
+
+def test_networkpolicy_default_deny_both_directions() -> None:
+    text = _NETPOL.read_text(encoding="utf-8")
+    assert "policyTypes:" in text
+    assert "- Ingress" in text and "- Egress" in text
+
+
+def test_networkpolicy_egress_allows_dns() -> None:
+    text = _NETPOL.read_text(encoding="utf-8")
+    assert "port: 53" in text, "egress must allow DNS (required for any outbound)"
+
+
+# ---- 2. values + schema (3) ---------------------------------------------
+
+
+def test_values_have_networkpolicy_and_pss() -> None:
+    vals = _load_values()
+    assert "networkPolicy" in vals
+    assert "podSecurityStandards" in vals
+
+
+def test_networkpolicy_disabled_and_egress_empty_default() -> None:
+    vals = _load_values()
+    assert vals["networkPolicy"]["enabled"] is False
+    assert vals["networkPolicy"]["egress"]["allowCidrs"] == [], (
+        "default egress CIDRs must be empty (DNS-only baseline; operator widens)"
+    )
+
+
+def test_pss_enforce_profile_restricted_default() -> None:
+    vals = _load_values()
+    assert vals["podSecurityStandards"]["enforceProfile"] == "restricted"
+
+
+# ---- 3. schema closes blocks (1) ----------------------------------------
+
+
+def test_schema_closes_networkpolicy_and_pss() -> None:
+    schema = json.loads(_SCHEMA.read_text(encoding="utf-8"))
+    assert schema["properties"]["networkPolicy"].get("additionalProperties") is False
+    pss = schema["properties"]["podSecurityStandards"]
+    assert pss.get("additionalProperties") is False
+    assert "restricted" in pss["properties"]["enforceProfile"]["enum"]
+
+
+# ---- 4. existing securityContext already meets 'restricted' (1) ---------
+
+
+def test_container_securitycontext_meets_restricted() -> None:
+    vals = _load_values()
+    csc = vals["containerSecurityContext"]
+    assert csc["allowPrivilegeEscalation"] is False
+    assert csc["readOnlyRootFilesystem"] is True
+    assert csc["capabilities"]["drop"] == ["ALL"]
+    psc = vals["podSecurityContext"]
+    assert psc["runAsNonRoot"] is True
+
+
+# ---- 5. governance (2) --------------------------------------------------
+
+
+def test_no_guard_flag_key_in_new_blocks() -> None:
+    vals = _load_values()
+    blob = json.dumps({"n": vals.get("networkPolicy"), "p": vals.get("podSecurityStandards")})
+    for flag in ("support_widening", "production_platform_claim", "live_adapter_execution"):
+        assert flag not in blob, f"guard-flag key present: {flag}"
+
+
+def test_no_workflow_mutation_in_diff() -> None:
+    added = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--diff-filter=A",
+            "--name-only",
+            "origin/main...HEAD",
+            "--",
+            "tests/test_epic_4_5_networkpolicy_pss.py",
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if added.returncode != 0:
+        pytest.skip(f"git diff unavailable: {added.stderr.strip()}")
+    if not added.stdout.strip():
+        pytest.skip("E-4-5 test not ADDED by this PR (introducer pattern); invariant N/A")
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main...HEAD", "--", ".github/workflows/"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        pytest.skip(f"git diff unavailable: {proc.stderr.strip()}")
+    touched = [p for p in proc.stdout.split() if p]
+    assert not touched, f"E-4-5 must not touch .github/workflows/. Touched: {touched}"

--- a/tests/test_epic_4_5_networkpolicy_pss.py
+++ b/tests/test_epic_4_5_networkpolicy_pss.py
@@ -64,6 +64,20 @@ def test_networkpolicy_egress_allows_dns() -> None:
     assert "port: 53" in text, "egress must allow DNS (required for any outbound)"
 
 
+def test_networkpolicy_dns_scoped_to_kube_dns_namespace() -> None:
+    """Codex E-4-5 review absorb: DNS egress must be SCOPED to the kube-dns
+    namespace (well-known metadata label), NOT a bare namespaceSelector:{} that
+    opens port 53 to every namespace. The scope is operator-configurable via
+    networkPolicy.egress.dnsNamespace (default kube-system)."""
+    text = _NETPOL.read_text(encoding="utf-8")
+    assert "kubernetes.io/metadata.name" in text, "DNS egress must scope by namespace metadata label"
+    assert "namespaceSelector: {}" not in text, "DNS egress must NOT open port 53 to all namespaces"
+    vals = _load_values()
+    assert vals["networkPolicy"]["egress"]["dnsNamespace"] == "kube-system", (
+        "default DNS namespace must be kube-system"
+    )
+
+
 # ---- 2. values + schema (3) ---------------------------------------------
 
 


### PR DESCRIPTION
## E-4-5 (#864) — NetworkPolicy + PSS baseline

Opt-in **default-deny NetworkPolicy** (Ingress+Egress; DNS-only egress baseline, operator widens for LLM provider CIDRs) + **PodSecurityStandards 'restricted'** affirmation.

- `templates/networkpolicy.yaml` — gated, default-deny, DNS egress + operator CIDRs
- `values.yaml` + closed `values.schema.json` networkPolicy + podSecurityStandards blocks
- 11 invariants; existing securityContext already meets restricted

**Boundaries:** chart does NOT manage namespace (operator applies PSS label out-of-band); egress DNS-only until operator widens; no guard flag; ZERO TOUCH `.github/workflows/`.

Cross-AI: Anthropic impl / OpenAI (Codex) review. Low-risk lane.