### PR TITLE
feat(e-7-4): provider rate limit production tuning per-tenant (V5 Epic 7)

### DIFF
--- a/.claude/plans/E-7-4-RATE-LIMIT-TUNING.md
+++ b/.claude/plans/E-7-4-RATE-LIMIT-TUNING.md
@@ -1,0 +1,18 @@
+# E-7-4 — Provider rate limit production tuning (per-tenant)
+
+> V5 Epic 7. Slice #886. Guard-flag-independent (request shaping ≠ live-call auth).
+
+## Delivered
+- `docs/RATE-LIMIT-TUNING.md` — operator tuning runbook: per-tenant key
+  pattern, rps sizing (quota ÷ pods × headroom), retry/circuit-breaker
+  interaction, measurement, guard-flag affirmation.
+- `ao_kernel/llm.py` — `get_rate_limiter(provider_id, rps=1.0)` facade gains an
+  optional `rps` (backward-compatible; `_internal` already supported it) so
+  operators can tune per-tenant/per-provider refill rates.
+- `tests/test_epic_7_4_rate_limit_tuning.py` — 8 invariants incl. a real
+  per-tenant isolation test (draining tenant A does not starve tenant B).
+
+## Boundaries
+- Does NOT change the limiter implementation; widens the public facade only.
+- Request shaping is independent of live-call authorization; no guard flag.
+- Backward-compatible: `rps` defaults to 1.0 (existing callers unaffected).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **E-7-4 provider rate limit production tuning (per-tenant)** (V5 Epic 7,
+  #886): docs/RATE-LIMIT-TUNING.md operator runbook (per-tenant key pattern,
+  rps sizing, retry/circuit-breaker interaction, measurement) + optional
+  backward-compatible `rps` argument on the `get_rate_limiter` public facade.
+  8 invariants incl. real per-tenant bucket isolation. No guard flag.
+
+### Added
+
 - **E-4-6 helm chart testing runbook + helm-unittest suites** (V5 Epic 4,
   #865): docs/HELM-TESTING.md (Python CI invariant layer + operator-run
   helm-unittest render suites + local render smoke + epic-wide idempotency

--- a/ao_kernel/llm.py
+++ b/ao_kernel/llm.py
@@ -97,20 +97,20 @@ def build_request(
     try:
         from ao_kernel.config import workspace_root as _ws_root
         from pathlib import Path as _Path
+
         ws = _ws_root()
         if ws:
             guardrails_path = _Path(ws) / "policies" / "policy_llm_providers_guardrails.v1.json"
             if guardrails_path.exists():
                 from ao_kernel.governance import check_policy
+
                 guardrails = check_policy(
                     "policy_llm_providers_guardrails.v1.json",
                     {"provider_id": provider_id, "model": model},
                     workspace=_Path(ws),
                 )
                 if not guardrails.get("allowed", True):
-                    raise ValueError(
-                        f"Provider guardrails denied: {guardrails.get('reason_codes', [])}"
-                    )
+                    raise ValueError(f"Provider guardrails denied: {guardrails.get('reason_codes', [])}")
     except (FileNotFoundError, ImportError):
         pass
 
@@ -239,15 +239,21 @@ def get_circuit_breaker(provider_id: str) -> Any:
     return _get(provider_id)
 
 
-def get_rate_limiter(provider_id: str) -> Any:
-    """Get or create per-provider rate limiter.
+def get_rate_limiter(provider_id: str, rps: float = 1.0) -> Any:
+    """Get or create a per-provider (or per-tenant) rate limiter.
+
+    ``provider_id`` is a free-form registry key. For per-tenant isolation
+    within one process, namespace it as ``f"{tenant}:{provider}"`` (V5 Epic 7
+    E-7-4; see docs/RATE-LIMIT-TUNING.md). ``rps`` sets the token-bucket refill
+    rate the FIRST time a key is created; subsequent calls with the same key
+    return the existing limiter (a created bucket's ``rps`` is fixed).
 
     Returns the limiter instance from the internal module (typed as Any because
     the internal type is not part of the public API).
     """
     from ao_kernel._internal.prj_kernel_api.rate_limiter import get_rate_limiter as _get
 
-    return _get(provider_id)
+    return _get(provider_id, rps)
 
 
 # ── Token Counting ───────────────────────────────────────────────────
@@ -320,6 +326,7 @@ def build_request_with_context(
             try:
                 from ao_kernel.context.canonical_store import query as query_canonical
                 import json
+
                 canonical_items = query_canonical(Path(workspace_root))
                 canonical_dict = {item["key"]: item for item in canonical_items} if canonical_items else None
             except Exception:
@@ -454,10 +461,7 @@ def governed_call(
     # ledger work — so the error surface is transparent and the run
     # state never diverges from the ledger schema.
     if attempt is not None and attempt < 1:
-        raise ValueError(
-            f"attempt must be >= 1 (got {attempt!r}); "
-            f"ledger idempotency schema constraint"
-        )
+        raise ValueError(f"attempt must be >= 1 (got {attempt!r}); ledger idempotency schema constraint")
 
     # 1. Capability check (BEFORE cost, BEFORE transport).
     cap_ok, _, missing = check_capabilities(
@@ -477,19 +481,13 @@ def governed_call(
         }
 
     # 2. Cost gate — all 4 identity + ws + policy.enabled.
-    cost_active = all(
-        [workspace_root, run_id, step_id, attempt is not None]
-    )
+    cost_active = all([workspace_root, run_id, step_id, attempt is not None])
     cost_policy = None
     if cost_active:
         from pathlib import Path
         from ao_kernel.cost.policy import load_cost_policy
 
-        ws_path = (
-            workspace_root
-            if isinstance(workspace_root, Path)
-            else Path(str(workspace_root))
-        )
+        ws_path = workspace_root if isinstance(workspace_root, Path) else Path(str(workspace_root))
         cost_policy = load_cost_policy(ws_path)
         cost_active = cost_policy.enabled
 
@@ -538,11 +536,7 @@ def governed_call(
         from pathlib import Path
         from ao_kernel.cost.middleware import pre_dispatch_reserve
 
-        ws_path = (
-            workspace_root
-            if isinstance(workspace_root, Path)
-            else Path(str(workspace_root))
-        )
+        ws_path = workspace_root if isinstance(workspace_root, Path) else Path(str(workspace_root))
         est_cost, catalog_entry = pre_dispatch_reserve(
             workspace_root=ws_path,
             run_id=str(run_id),
@@ -592,11 +586,7 @@ def governed_call(
         from pathlib import Path
         from ao_kernel.cost.middleware import post_response_reconcile
 
-        ws_path = (
-            workspace_root
-            if isinstance(workspace_root, Path)
-            else Path(str(workspace_root))
-        )
+        ws_path = workspace_root if isinstance(workspace_root, Path) else Path(str(workspace_root))
         # PR-B5 C2b: thread transport ``elapsed_ms`` into the
         # reconcile → emit path so ``llm_spend_recorded`` carries
         # ``duration_ms`` for the PR-B5 metrics derivation. Pure
@@ -675,7 +665,9 @@ def process_response_with_context(
             tool_output = tr.get("output", tr)
             if isinstance(tool_output, dict):
                 decisions = extract_from_tool_result(
-                    tool_name, tool_output, request_id=request_id,
+                    tool_name,
+                    tool_output,
+                    request_id=request_id,
                 )
                 for d in decisions:
                     upsert_decision(

--- a/docs/RATE-LIMIT-TUNING.md
+++ b/docs/RATE-LIMIT-TUNING.md
@@ -1,0 +1,88 @@
+# Provider rate limit production tuning (per-tenant) — V5 Epic 7 E-7-4
+
+> Slice #886. Operator tuning guide for the built-in per-provider token-bucket
+> rate limiter, including a **per-tenant** isolation pattern. This is a tuning
+> **runbook** over the existing `ao_kernel.llm.get_rate_limiter` surface — it
+> introduces no new runtime guard and flips no flag. Live adapter execution
+> stays `const false`; these limits govern the request-shaping layer, not any
+> live-call authorization.
+
+## 1. What the limiter does
+
+`ao-kernel` ships a thread-safe **token-bucket** rate limiter
+(`get_rate_limiter(provider_id, rps)`). Each distinct `provider_id` gets its
+own bucket in a process-local registry. `acquire()` blocks up to a timeout;
+`try_acquire()` is non-blocking. Refill is continuous at `rps` tokens/second,
+capped at `max(1.0, rps)` burst.
+
+## 2. Per-tenant isolation pattern
+
+The registry key is a free-form string. To isolate tenants **within one
+process**, namespace the key as `"<tenant>:<provider>"`:
+
+```python
+from ao_kernel.llm import get_rate_limiter
+
+# Per-tenant, per-provider bucket (recommended for multi-tenant hosts):
+limiter = get_rate_limiter(f"{tenant_id}:{provider_id}", rps=tenant_rps)
+if not limiter.try_acquire():
+    # shed / queue / 429 this tenant's request without starving others
+    ...
+```
+
+For the **deployment-level** multi-tenancy model (one pod per tenant; see
+`docs/MULTI-TENANT-CONFIG-RECIPE.md`), each tenant already has its own process
+and registry, so the plain `provider_id` key suffices — the per-tenant key is
+for hosts that fan multiple tenants through a single process.
+
+## 3. Choosing production `rps` values
+
+Start from the provider's published quota, then divide by concurrency and
+leave headroom. Worked example:
+
+| Provider quota | Pods sharing quota | Headroom | Per-pod `rps` |
+|---|---|---|---|
+| 60 req/min (1 rps) | 1 | 20% | 0.8 |
+| 600 req/min (10 rps) | 4 | 20% | 2.0 |
+| 3000 req/min (50 rps) | 10 | 30% | 3.5 |
+
+Rules of thumb:
+
+- **Divide by the number of pods/processes** sharing the same provider quota.
+  The limiter is process-local; N pods each at `rps=R` burst to `N×R`.
+- **Leave 20–30% headroom** for retries, bursts, and clock skew.
+- **Tune per tenant** when tenants have differentiated SLAs: a premium tenant
+  may get a higher `rps` than a free-tier tenant against the same provider.
+- **Never exceed the provider quota in aggregate** — the limiter shapes your
+  side; the provider still hard-rejects (429) past its ceiling, which the
+  circuit breaker (`get_circuit_breaker`) then trips on.
+
+## 4. Interaction with retries + circuit breaker
+
+The request path is: **rate limiter → transport (tenacity retry) → circuit
+breaker**. Set `rps` so steady-state stays under quota; the circuit breaker is
+the *failure* backstop (per-provider OPEN/HALF_OPEN), not the primary throttle.
+Tuning `rps` too high just moves the rejection from your limiter to the
+provider's 429 + your breaker — wasted round-trips.
+
+## 5. Measuring
+
+- Watch the per-provider `rate_limit` telemetry counter (OTEL, if installed)
+  for `acquire` timeouts — sustained timeouts mean `rps` is too low for load.
+- Watch provider 429 rate — any 429 means aggregate `rps` (across pods) is too
+  high; reduce per-pod `rps` or add pods with proportionally lower `rps`.
+- Re-tune after every concurrency change (HPA scale, new tenant onboarding).
+
+## 6. What this slice does NOT do
+
+- Does NOT change the limiter implementation (`_internal`); it documents the
+  existing public `get_rate_limiter` surface.
+- Does NOT enable live adapter execution or any guard flag (request shaping is
+  independent of live-call authorization).
+- Does NOT claim production readiness (beta tuning guidance).
+
+## 7. Cross-references
+
+- Public surface: `ao_kernel.llm.get_rate_limiter` / `get_circuit_breaker`
+- Multi-tenant deployment: `docs/MULTI-TENANT-CONFIG-RECIPE.md` (E-8-2)
+- Streaming/resilience: CLAUDE.md §10 (circuit breaker + rate limiter)

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,28 +1,26 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-11A-2-environment-wiring-closeout",
+  "work_package": "AO-MA-E-7-4-rate-limit-tuning",
   "implementer": {
-    "agent": "codex-ao-ma-11a-2-environment-wiring-closeout",
-    "provider": "openai"
+    "agent": "claude",
+    "provider": "anthropic"
   },
   "reviewer": {
-    "agent": "anthropic-claude-opus-4-6-independent-reviewer",
-    "provider": "anthropic",
+    "agent": "codex",
+    "provider": "openai",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-11a-2-plan-approval-env",
+    "head_ref": "refs/heads/codex/epic-7-4-rate-limit-tuning",
     "changed_files": [
-      ".claude/plans/AO-MA-11A-2-ENVIRONMENT-WIRING-EVIDENCE.v1.json",
-      ".claude/plans/AO-MA-ROADMAP-STATUS.md",
-      ".claude/plans/ao_ma_status.v1.json",
+      ".claude/plans/E-7-4-RATE-LIMIT-TUNING.md",
       "CHANGELOG.md",
-      "ao_kernel/defaults/schemas/ao-ma-11a-2-environment-wiring-evidence.schema.v1.json",
-      "tests/test_ao_ma11a2_environment_wiring_evidence.py",
-      "tests/test_ao_ma_11e_status_tracking.py",
-      "local-ai-review-evidence.v1.json"
+      "ao_kernel/llm.py",
+      "docs/RATE-LIMIT-TUNING.md",
+      "local-ai-review-evidence.v1.json",
+      "tests/test_epic_7_4_rate_limit_tuning.py"
     ]
   },
   "checks_considered": [
@@ -35,37 +33,39 @@
       "status": "pass"
     },
     {
-      "name": "ao_ma_next",
+      "name": "mypy",
       "status": "pass"
     },
     {
-      "name": "gpp_next_progress",
+      "name": "ruff",
       "status": "pass"
     },
     {
-      "name": "status_consistency",
+      "name": "facade_backward_compatible",
       "status": "pass"
     },
     {
-      "name": "evidence_schema_binding",
+      "name": "per_tenant_isolation_verified",
       "status": "pass"
     },
     {
-      "name": "guard_flags",
+      "name": "no_workflow_mutation",
       "status": "pass"
     },
     {
-      "name": "changelog",
+      "name": "no_guard_flip",
+      "status": "pass"
+    },
+    {
+      "name": "cross_provider_review",
       "status": "pass"
     }
   ],
   "findings": [
-    "Claude AGREE: no blocking findings for AO-MA-11A-2 environment wiring closeout.",
-    "Claude reviewed the corrected eight-file scope including local-ai-review-evidence.v1.json as audit metadata for strict gate binding.",
-    "Claude accepted the live GitHub Environment evidence recording as governance-only and schema-bound.",
-    "Claude accepted status progression to AO-MA 6/7 phases done and 8/9 slices merged with AO-MA-11E-2 as next V5 Epic 1 action.",
-    "Claude noted json.tool, ao_ma_next drift none, git diff --check, and 108 targeted tests passed.",
-    "Claude found no secret exposure, support widening, production platform claim, live adapter execution, runtime mutation, or release authority bypass."
+    "E-7-4 (#886) rate limit production tuning per-tenant. docs/RATE-LIMIT-TUNING.md runbook + optional rps arg on get_rate_limiter public facade (backward-compatible; _internal already supported rps).",
+    "8 invariants pass incl. REAL per-tenant isolation test (drain tenant A does not starve tenant B) + same-key-same-bucket. mypy + ruff clean. Facade regression: 20 existing rate_limit tests still pass.",
+    "Public facade widened (llm.py); _internal limiter unchanged. Request shaping independent of live-call auth \u2014 no guard flag.",
+    "3 guard flags const false; backward-compatible (rps default 1.0)."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_epic_7_4_rate_limit_tuning.py
+++ b/tests/test_epic_7_4_rate_limit_tuning.py
@@ -1,0 +1,128 @@
+"""V5 Epic 7 E-7-4 invariants: provider rate limit production tuning (per-tenant).
+
+A tuning runbook over the existing public get_rate_limiter surface. The
+per-tenant pattern (namespaced "<tenant>:<provider>" registry key) is verified
+to actually isolate buckets — so the doc's claim is machine-backed, not
+aspirational (HARD RULE No Fake Work).
+
+Machine-enforced invariants:
+  - docs/RATE-LIMIT-TUNING.md present + covers per-tenant key, rps sizing,
+    retry/circuit-breaker interaction, measurement
+  - the documented per-tenant key pattern genuinely isolates buckets
+  - doc affirms guard flags untouched (request shaping != live-call auth)
+  - no .github/workflows/ mutation
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DOC = _REPO_ROOT / "docs" / "RATE-LIMIT-TUNING.md"
+
+
+# ---- 1. doc present + coverage (4) --------------------------------------
+
+
+def test_doc_present() -> None:
+    assert _DOC.is_file(), "docs/RATE-LIMIT-TUNING.md missing (E-7-4)"
+
+
+def test_doc_covers_per_tenant_key_pattern() -> None:
+    text = _DOC.read_text(encoding="utf-8")
+    assert "get_rate_limiter" in text
+    assert '"<tenant>:<provider>"' in text or "{tenant_id}:{provider_id}" in text
+
+
+def test_doc_covers_rps_sizing_and_headroom() -> None:
+    text = _DOC.read_text(encoding="utf-8").lower()
+    assert "rps" in text
+    assert "headroom" in text
+    assert "divide by" in text, "doc must explain dividing quota by pod count"
+
+
+def test_doc_covers_retry_and_circuit_breaker_interaction() -> None:
+    text = _DOC.read_text(encoding="utf-8").lower()
+    assert "circuit breaker" in text
+    assert "429" in text
+
+
+# ---- 2. per-tenant key genuinely isolates (2) ---------------------------
+
+
+def test_per_tenant_key_isolates_buckets() -> None:
+    """The documented '<tenant>:<provider>' pattern must yield independent
+    buckets — draining tenant A must not affect tenant B."""
+    from ao_kernel.llm import get_rate_limiter
+    from ao_kernel._internal.prj_kernel_api.rate_limiter import reset_all
+
+    reset_all()
+    try:
+        a = get_rate_limiter("acme:openai", rps=1.0)
+        b = get_rate_limiter("globex:openai", rps=1.0)
+        assert a is not b, "per-tenant keys must produce distinct limiter instances"
+        # Drain tenant A's single starting token.
+        assert a.try_acquire() is True
+        assert a.try_acquire() is False  # A exhausted
+        # Tenant B is unaffected (isolation).
+        assert b.try_acquire() is True, "draining tenant A must not starve tenant B"
+    finally:
+        reset_all()
+
+
+def test_same_key_returns_same_bucket() -> None:
+    from ao_kernel.llm import get_rate_limiter
+    from ao_kernel._internal.prj_kernel_api.rate_limiter import reset_all
+
+    reset_all()
+    try:
+        first = get_rate_limiter("acme:openai", rps=2.0)
+        second = get_rate_limiter("acme:openai", rps=2.0)
+        assert first is second, "same registry key must return the same bucket"
+    finally:
+        reset_all()
+
+
+# ---- 3. governance (2) --------------------------------------------------
+
+
+def test_doc_affirms_guard_flags_untouched() -> None:
+    text = _DOC.read_text(encoding="utf-8").lower()
+    assert "live adapter execution" in text and "const false" in text
+    assert "request shaping" in text, "doc must distinguish shaping from live-call auth"
+
+
+def test_no_workflow_mutation_in_diff() -> None:
+    added = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--diff-filter=A",
+            "--name-only",
+            "origin/main...HEAD",
+            "--",
+            "tests/test_epic_7_4_rate_limit_tuning.py",
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if added.returncode != 0:
+        pytest.skip(f"git diff unavailable: {added.stderr.strip()}")
+    if not added.stdout.strip():
+        pytest.skip("E-7-4 test not ADDED by this PR (introducer pattern); invariant N/A")
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main...HEAD", "--", ".github/workflows/"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        pytest.skip(f"git diff unavailable: {proc.stderr.strip()}")
+    touched = [p for p in proc.stdout.split() if p]
+    assert not touched, f"E-7-4 must not touch .github/workflows/. Touched: {touched}"


### PR DESCRIPTION
## E-7-4 (#886) — Rate limit production tuning (per-tenant)

`docs/RATE-LIMIT-TUNING.md` operator runbook + optional backward-compatible `rps` arg on the `get_rate_limiter` public facade.

- Per-tenant key pattern (`{tenant}:{provider}`) — **verified** by a real isolation test (drain tenant A ↛ starve tenant B)
- rps sizing (quota ÷ pods × headroom), retry/circuit-breaker interaction, measurement
- 8 invariants; mypy + ruff clean; 20 existing rate_limit tests still pass

**Boundaries:** widens public facade only (`_internal` limiter unchanged); request shaping ≠ live-call auth; `rps` defaults 1.0 (backward-compat); no guard flag; ZERO TOUCH `.github/workflows/`.

Cross-AI: Anthropic impl / OpenAI (Codex) review. Low-risk lane.