### PR TITLE
fix(ao-ma-11e-2): record live GitHub mirror drift evidence

### DIFF
--- a/.claude/plans/AO-MA-11E-2-LIVE-MIRROR-DRIFT-EVIDENCE.v1.json
+++ b/.claude/plans/AO-MA-11E-2-LIVE-MIRROR-DRIFT-EVIDENCE.v1.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "ao-ma-github-mirror-drift-report.v1",
+  "projection_manifest": ".claude/plans/v5_issue_projection.v1.json",
+  "manifest_sha256": "sha256:b081c9b828d3593bb49bde8802ddc7177eaa6aa15c4e319f69ffb2f1d072b102",
+  "checked_at": "2026-06-04T08:25:15Z",
+  "network_allowed": true,
+  "token_env": "GH_TOKEN",
+  "token_present": true,
+  "github_owner": "Halildeu",
+  "github_repo": "ao-kernel",
+  "expected_counts": {
+    "issues": 75,
+    "labels": 23,
+    "project_items": 71
+  },
+  "drift": [],
+  "exit_decision": "synced"
+}

--- a/.claude/plans/AO-MA-ROADMAP-STATUS.md
+++ b/.claude/plans/AO-MA-ROADMAP-STATUS.md
@@ -19,18 +19,20 @@ python3 scripts/ao_ma_next.py --format json
 - **Fazlar:** 6/7 done (86%). Tamamlanan:
   **AO-MA-11A**,
   **AO-MA-11I**, **AO-MA-11H**, **AO-MA-11F**, **AO-MA-4.6**,
-  **AO-MA-11G**. Aktif follow-up fazı: **AO-MA-11E** (in_progress).
+  **AO-MA-11G**. Aktif follow-up fazı: **AO-MA-11E** (in_progress);
+  `AO-MA-11E-2` live GitHub mirror drift evidence toplandı ve PR ref
+  bağlanmayı bekleyen `in_review` durumunda.
 - **Dilimler (slices):** 8/9 merged (89%).
 - **Current phase / slice:** `AO-MA-11E` / `AO-MA-11E-2`.
-  V5 Epic 1'de sıradaki iş GitHub Projects/Milestone/Issue one-way sync +
-  anchor injection + live drift checker.
+  V5 GitHub Milestone #3 / Issues / ProjectV2 mirror, projection manifest'e
+  karşı `drift=[]` ve `exit_decision=synced` kanıtıyla bağlı.
 
 ## Faz Tablosu
 
 | Faz | Başlık | Statü | Dilimler |
 |---|---|---|---|
 | **AO-MA-11A** | Plan Consensus + Tek Operatör Onay Kapısı | 🟢 done | 11A-1 ✅ merged, 11A-2 ✅ merged |
-| **AO-MA-11E** | GitHub-Native Operator Tracking Mirror | 🟡 in_progress | 11E-1 ✅ merged, 11E-2 ⬜ not_started |
+| **AO-MA-11E** | GitHub-Native Operator Tracking Mirror | 🟡 in_progress | 11E-1 ✅ merged, 11E-2 🟡 in_review |
 | **AO-MA-11I** | Autonomous Run Governor | 🟢 done | 11I-1 ✅ merged (#762) |
 | **AO-MA-11H** | Notification & Escalation | 🟢 done | 11H-1 ✅ merged (#763) |
 | **AO-MA-11F** | Test/Öneri/Güncelleme Evidence Registers | 🟢 done | 11F-1 ✅ merged (#765) |
@@ -44,7 +46,7 @@ python3 scripts/ao_ma_next.py --format json
 | AO-MA-11A-1 | ✅ merged | critical | agreed | approved | #758 | plan_consensus validator + 2 schema |
 | AO-MA-11A-2 | ✅ merged | high | agreed | approved | #792 | GitHub Environment `ao-ma-plan-approval` required-reviewer wiring; environment id `16221961707`; `prevent_self_review=true`; `can_admins_bypass=false` |
 | AO-MA-11E-1 | ✅ merged | critical | agreed | not_requested | #760 | derived tracking SSOT + schema + ao_ma_next + roadmap + drift core |
-| AO-MA-11E-2 | ⬜ not_started | high | not_started | not_requested | — | GitHub Projects/Milestone/Issue one-way sync + live drift |
+| AO-MA-11E-2 | 🟡 in_review | high | agreed | not_requested | pending | Live GitHub mirror drift evidence: Milestone #3 / Issues / ProjectV2 synced; PR ref binding pending |
 | AO-MA-11I-1 | ✅ merged | critical | agreed | not_requested | #762 | PAUSE kill-switch + budget cap + safe-stop |
 | AO-MA-11H-1 | ✅ merged | high | agreed | not_requested | #763 | Mavis chat + GitHub-native notification, `blocked_notification_failed` safe-stop |
 | AO-MA-11F-1 | ✅ merged | normal | agreed | not_requested | #765 | test/suggestion/update evidence registers + slice closeout + evidence bundle |
@@ -57,8 +59,9 @@ python3 scripts/ao_ma_next.py --format json
 
 ## Sıradaki
 
-1. **AO-MA-11E-2** — GitHub Projects/Milestone/Issue one-way sync +
-   anchor injection + live drift checker. High-risk follow-up; demand-driven.
+1. **AO-MA-11E-2 closeout** — carrying PR number is bound into
+   `ao_ma_status.v1.json`, then `ao-release-gate` proves the high-risk
+   evidence/update path before AO-MA-11E can be marked done.
 2. **AO-MA-11G-2 follow-up set** — CI/pre-commit changelog enforcement,
    AO-MA-4.6 dogfooding, retro ADR cross-AI revalidation, and
    CHANGELOG/pyproject allowlist widening. These are follow-up hardening

--- a/.claude/plans/ao_ma_status.v1.json
+++ b/.claude/plans/ao_ma_status.v1.json
@@ -23,7 +23,7 @@
     "authority": false,
     "direction": "ao-kernel-to-github",
     "manual_edit_override_allowed": false,
-    "sync_state": "not_wired"
+    "sync_state": "synced"
   },
   "human_status_file": ".claude/plans/AO-MA-ROADMAP-STATUS.md",
   "live_adapter_execution_allowed": false,
@@ -31,13 +31,14 @@
     "commit_sha": "38d2a48fd5150fd37cc82fcc0727823c344c8339",
     "path": ".claude/plans/AO-MA-SPM-MASTER-PLAN.md",
     "section_refs": [
-      "## 5. Roadmap \u2014 7 Faz",
-      "## 6. Bootstrap / Self-Hosting Mekanizmas\u0131"
+      "## 5. Roadmap — 7 Faz",
+      "## 6. Bootstrap / Self-Hosting Mekanizması"
     ],
     "sha256": "sha256:a769f3183d0b753bef5ba79a37d302fc664a63db119baa46b1fc72084acd2fb9"
   },
   "next_allowed_actions": [
-    "AO-MA-11A-2 GitHub Environment ao-ma-plan-approval required-reviewer wiring is live and evidence-bound (environment id 16221961707; prevent_self_review=true; can_admins_bypass=false). Next V5 Epic 1 action: AO-MA-11E-2 GitHub Projects/Milestone/Issue one-way sync + anchor injection + live drift checker. AO-MA-11G-2 hardening follow-up remains demand-driven (CI/pre-commit changelog enforcement + 4.6 dogfooding + retro ADR cross-AI revalidation + allowlist widening for CHANGELOG/pyproject)."
+    "AO-MA-11E-2 live GitHub mirror drift evidence is collected and in review: V5 GitHub Milestone #3 / Issues / ProjectV2 mirror is synced against .claude/plans/v5_issue_projection.v1.json with drift=[] and exit_decision=synced. After the carrying PR number is bound and ao-release-gate passes, close AO-MA-11E as done; then continue AO-MA-11G-2 hardening follow-up only when demand-driven.",
+    "AO-MA-11G-2 hardening follow-up remains demand-driven (CI/pre-commit changelog enforcement + AO-MA-4.6 dogfooding + retro ADR cross-AI revalidation + allowlist widening for CHANGELOG/pyproject)."
   ],
   "phases": [
     {
@@ -53,7 +54,7 @@
     },
     {
       "closed_at": null,
-      "milestone_ref": null,
+      "milestone_ref": 3,
       "phase_id": "AO-MA-11E",
       "slice_ids": [
         "AO-MA-11E-1",
@@ -297,27 +298,48 @@
     },
     {
       "anchor": {
-        "ao_authority_artifact": null,
-        "artifact_sha256": null,
-        "last_sync_run_id": null,
-        "mirror_projection_sha256": null,
+        "ao_authority_artifact": ".claude/plans/AO-MA-11E-2-LIVE-MIRROR-DRIFT-EVIDENCE.v1.json",
+        "artifact_sha256": "sha256:b8b043671ddc3623bf6cefbbcefdc0e00332e2672b6d438b6e7a26faf52a2e1e",
+        "plan_digest": "sha256:b081c9b828d3593bb49bde8802ddc7177eaa6aa15c4e319f69ffb2f1d072b102",
         "phase_id": "AO-MA-11E",
-        "plan_digest": null,
-        "slice_id": "AO-MA-11E-2"
+        "slice_id": "AO-MA-11E-2",
+        "last_sync_run_id": "manual-read-only-drift-20260604T082515Z",
+        "mirror_projection_sha256": "sha256:b081c9b828d3593bb49bde8802ddc7177eaa6aa15c4e319f69ffb2f1d072b102"
       },
       "approval_ref": {
         "state": "not_requested"
       },
       "consensus_ref": {
-        "state": "not_started"
+        "state": "agreed",
+        "consultation_refs": [
+          {
+            "provider_id": "anthropic",
+            "ref": "claude:ao-ma-11e-2-live-mirror-closeout-pending"
+          },
+          {
+            "provider_id": "openai",
+            "ref": "codex:ao-ma-11e-2-live-mirror-closeout-pending"
+          },
+          {
+            "provider_id": "minimax",
+            "ref": "mavis:ao-ma-11e-2-live-mirror-closeout-pending"
+          }
+        ]
       },
-      "evidence_refs": [],
-      "issue_ref": null,
+      "evidence_refs": [
+        {
+          "kind": "github_mirror_live_drift_report",
+          "path": ".claude/plans/AO-MA-11E-2-LIVE-MIRROR-DRIFT-EVIDENCE.v1.json",
+          "sha256": "sha256:b8b043671ddc3623bf6cefbbcefdc0e00332e2672b6d438b6e7a26faf52a2e1e",
+          "required_for_closeout": true
+        }
+      ],
+      "issue_ref": 774,
       "phase_id": "AO-MA-11E",
       "pr_refs": [],
       "risk_class": "high",
       "slice_id": "AO-MA-11E-2",
-      "status": "not_started",
+      "status": "in_review",
       "title": "GitHub Projects/Milestone/Issue one-way sync + anchor injection + live drift"
     },
     {
@@ -528,5 +550,5 @@
   ],
   "status_role": "machine_readable_derived_tracking_index",
   "support_widening_allowed": false,
-  "updated_at": "2026-05-30T04:00:00Z"
+  "updated_at": "2026-06-04T08:25:15Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **AO-MA-11E-2 live GitHub mirror drift evidence**: recorded a
+  schema-bound read-only live drift report proving the V5 GitHub Milestone
+  #3 / Issues / ProjectV2 mirror is synced against
+  `.claude/plans/v5_issue_projection.v1.json` (`drift=[]`,
+  `exit_decision=synced`, 75 issues, 23 labels, 71 project items). The AO-MA
+  tracking mirror is moved to `in_review` until the carrying PR number is
+  bound and `ao-release-gate` proves the high-risk evidence/update path.
 - **AO-MA-11A-2 environment wiring status drift**: recorded the live
   GitHub Environment `ao-ma-plan-approval` configuration as a schema-bound
   evidence artifact, pinning required reviewer `Halildeu`,

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,26 +1,27 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-E-7-4-rate-limit-tuning",
+  "work_package": "AO-MA-11E-2-live-mirror-drift-closeout",
   "implementer": {
-    "agent": "claude",
-    "provider": "anthropic"
+    "agent": "codex-ao-ma-11e-2-live-mirror-closeout",
+    "provider": "openai"
   },
   "reviewer": {
-    "agent": "codex",
-    "provider": "openai",
+    "agent": "anthropic-claude-independent-reviewer-ao-ma-11e-2",
+    "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-7-4-rate-limit-tuning",
+    "head_ref": "refs/heads/codex/ao-ma-11e-2-live-sync",
     "changed_files": [
-      ".claude/plans/E-7-4-RATE-LIMIT-TUNING.md",
+      ".claude/plans/AO-MA-11E-2-LIVE-MIRROR-DRIFT-EVIDENCE.v1.json",
+      ".claude/plans/AO-MA-ROADMAP-STATUS.md",
+      ".claude/plans/ao_ma_status.v1.json",
       "CHANGELOG.md",
-      "ao_kernel/llm.py",
-      "docs/RATE-LIMIT-TUNING.md",
       "local-ai-review-evidence.v1.json",
-      "tests/test_epic_7_4_rate_limit_tuning.py"
+      "tests/test_ao_ma11e2a_schema_invariant.py",
+      "tests/test_ao_ma_11e_status_tracking.py"
     ]
   },
   "checks_considered": [
@@ -33,39 +34,32 @@
       "status": "pass"
     },
     {
-      "name": "mypy",
+      "name": "ao_ma_next",
       "status": "pass"
     },
     {
-      "name": "ruff",
+      "name": "json_schema",
       "status": "pass"
     },
     {
-      "name": "facade_backward_compatible",
+      "name": "guard_flags",
       "status": "pass"
     },
     {
-      "name": "per_tenant_isolation_verified",
+      "name": "live_drift_report",
       "status": "pass"
     },
     {
-      "name": "no_workflow_mutation",
-      "status": "pass"
-    },
-    {
-      "name": "no_guard_flip",
-      "status": "pass"
-    },
-    {
-      "name": "cross_provider_review",
+      "name": "changelog",
       "status": "pass"
     }
   ],
   "findings": [
-    "E-7-4 (#886) rate limit production tuning per-tenant. docs/RATE-LIMIT-TUNING.md runbook + optional rps arg on get_rate_limiter public facade (backward-compatible; _internal already supported rps).",
-    "8 invariants pass incl. REAL per-tenant isolation test (drain tenant A does not starve tenant B) + same-key-same-bucket. mypy + ruff clean. Facade regression: 20 existing rate_limit tests still pass.",
-    "Public facade widened (llm.py); _internal limiter unchanged. Request shaping independent of live-call auth \u2014 no guard flag.",
-    "3 guard flags const false; backward-compatible (rps default 1.0)."
+    "Claude AGREE: no blocking findings for AO-MA-11E-2 live GitHub mirror drift evidence closeout.",
+    "Claude reviewed the full tracking/evidence scope and found no runtime mutation, support widening, production readiness claim, live adapter execution, or release authority bypass.",
+    "Claude accepted the schema-bound live drift report: drift=[], exit_decision=synced, manifest SHA pinned, and token value not recorded.",
+    "Claude accepted status transition to in_review with PR ref binding pending before final merged closeout.",
+    "Claude accepted exact SHA cross-reference between evidence_refs and anchor artifact binding."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_ao_ma11e2a_schema_invariant.py
+++ b/tests/test_ao_ma11e2a_schema_invariant.py
@@ -23,6 +23,7 @@ from ao_kernel._internal.ao_ma.github_mirror_drift import (
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SCHEMA_PATH = _REPO_ROOT / "ao_kernel" / "defaults" / "schemas" / "ao-ma-github-mirror-drift-report.schema.v1.json"
+_LIVE_EVIDENCE_PATH = _REPO_ROOT / ".claude" / "plans" / "AO-MA-11E-2-LIVE-MIRROR-DRIFT-EVIDENCE.v1.json"
 
 
 def _load_schema() -> dict:
@@ -187,6 +188,27 @@ def test_schema_enforces_sha256_pattern() -> None:
     }
     errors = list(validator.iter_errors(bad))
     assert errors, "schema MUST reject invalid SHA pattern"
+
+
+def test_committed_live_mirror_evidence_validates_and_is_synced() -> None:
+    schema = _load_schema()
+    validator = jsonschema.Draft202012Validator(schema)
+    evidence = json.loads(_LIVE_EVIDENCE_PATH.read_text(encoding="utf-8"))
+
+    errors = list(validator.iter_errors(evidence))
+    assert errors == [], f"live mirror evidence schema errors: {[e.message for e in errors]}"
+    assert evidence["projection_manifest"] == ".claude/plans/v5_issue_projection.v1.json"
+    assert evidence["manifest_sha256"] == (
+        "sha256:b081c9b828d3593bb49bde8802ddc7177eaa6aa15c4e319f69ffb2f1d072b102"
+    )
+    assert evidence["expected_counts"] == {"issues": 75, "labels": 23, "project_items": 71}
+    assert evidence["exit_decision"] == "synced"
+    assert evidence["drift"] == []
+    assert evidence["token_env"] == "GH_TOKEN"
+    serialized = json.dumps(evidence)
+    assert "gho_" not in serialized
+    assert "ghp_" not in serialized
+    assert "github_pat_" not in serialized
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ao_ma_11e_status_tracking.py
+++ b/tests/test_ao_ma_11e_status_tracking.py
@@ -500,6 +500,33 @@ def test_ao_ma_11a_2_status_is_bound_to_environment_wiring_evidence() -> None:
     )
 
 
+def test_ao_ma_11e_2_status_is_bound_to_live_mirror_drift_evidence() -> None:
+    payload = _load_status()
+    target = next(s for s in payload["slices"] if s["slice_id"] == "AO-MA-11E-2")
+
+    assert target["status"] == "in_review"
+    assert target["risk_class"] == "high"
+    assert target["issue_ref"] == 774
+    assert target["pr_refs"] == []
+    assert target["consensus_ref"]["state"] == "agreed"
+    assert target["approval_ref"]["state"] == "not_requested"
+
+    evidence = target["evidence_refs"]
+    assert evidence == [
+        {
+            "kind": "github_mirror_live_drift_report",
+            "path": ".claude/plans/AO-MA-11E-2-LIVE-MIRROR-DRIFT-EVIDENCE.v1.json",
+            "required_for_closeout": True,
+            "sha256": "sha256:b8b043671ddc3623bf6cefbbcefdc0e00332e2672b6d438b6e7a26faf52a2e1e",
+        }
+    ]
+    assert target["anchor"]["ao_authority_artifact"] == evidence[0]["path"]
+    assert target["anchor"]["artifact_sha256"] == evidence[0]["sha256"]
+    assert target["anchor"]["mirror_projection_sha256"] == (
+        "sha256:b081c9b828d3593bb49bde8802ddc7177eaa6aa15c4e319f69ffb2f1d072b102"
+    )
+
+
 def test_main_text_exit_zero_on_clean(capsys: pytest.CaptureFixture[str]) -> None:
     rc = ao_ma_next.main(["--status", str(_STATUS)])
     out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- record schema-bound AO-MA-11E-2 live GitHub mirror drift evidence
- bind ao_ma_status / roadmap / changelog to the synced V5 GitHub mirror state
- add tests for evidence schema conformance and status anchor binding

## Current state
This initial commit intentionally leaves AO-MA-11E-2 as `in_review` because the real PR number must be known before final closeout can be truthfully recorded in `pr_refs`. After this PR number is available, I will amend the same branch to bind the PR ref and mark AO-MA-11E-2/AO-MA-11E done.

## Evidence
- live drift report: `.claude/plans/AO-MA-11E-2-LIVE-MIRROR-DRIFT-EVIDENCE.v1.json`
- exit_decision: `synced`
- drift: `[]`
- expected counts: 75 issues, 23 labels, 71 project items
- local gate: `operator_may_merge`
- Claude independent review: AGREE

## Validation
- `python3 scripts/ao_ma_next.py --format json` -> drift `[]`
- `python3 -m pytest -q tests/test_local_gpp_gate.py tests/test_ao_ma_11e_status_tracking.py tests/test_ao_ma11e2a_schema_invariant.py tests/test_ao_ma11e2a_mirror_drift_checker.py` -> 158 passed
- `python3 scripts/local_gpp_gate.py ...` -> `operator_may_merge`

## Guard flags
No support widening, no production platform claim, no live adapter execution. Release authority remains ao-release-gate + GitHub ruleset.