### PR TITLE
docs(e-4-3): dedup DB env in operator runbook (Codex review follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **E-4-3 follow-up: dedup DB env in operator runbook** (Codex review absorb):
+  docs/OPERATOR-SECRET-MANAGEMENT.md showed the DB env twice (postgresql block
+  + env.secretRefs/env.plain), which would duplicate/conflict with the
+  auto-rendered DB env. The postgresql block is now documented as the single
+  way; env.secretRefs/env.plain remain for non-DB secrets (e.g. LLM keys).
+
 ### Added
 
 - **E-7-4 provider rate limit production tuning (per-tenant)** (V5 Epic 7,

--- a/docs/OPERATOR-SECRET-MANAGEMENT.md
+++ b/docs/OPERATOR-SECRET-MANAGEMENT.md
@@ -63,6 +63,13 @@ way — it only needs the resulting `Secret` name + keys.
 
 In your operator-owned `values.yaml` overlay (NOT committed with real values):
 
+The `postgresql` block is the **single** way to wire the database — when
+`enabled: true`, the chart automatically renders the `AO_KERNEL_DB_HOST`,
+`AO_KERNEL_DB_PORT`, `AO_KERNEL_DB_NAME`, `AO_KERNEL_DB_SSLMODE` (plain env) and
+`AO_KERNEL_DB_USERNAME` / `AO_KERNEL_DB_PASSWORD` (`secretKeyRef`) variables.
+**Do NOT also add these to `env.secretRefs` / `env.plain`** — that would
+duplicate (and conflict with) the auto-rendered DB env (Codex E-4-3 review).
+
 ```yaml
 postgresql:
   enabled: true
@@ -75,29 +82,13 @@ postgresql:
   secretName: "ao-kernel-db"
   usernameKey: "username"
   passwordKey: "password"
-
-env:
-  secretRefs:
-    - name: AO_KERNEL_DB_USERNAME
-      secretName: ao-kernel-db
-      secretKey: username
-    - name: AO_KERNEL_DB_PASSWORD
-      secretName: ao-kernel-db
-      secretKey: password
-  plain:
-    - name: AO_KERNEL_DB_HOST
-      value: "ao-kernel-db.example.internal"
-    - name: AO_KERNEL_DB_PORT
-      value: "5432"
-    - name: AO_KERNEL_DB_NAME
-      value: "ao_kernel"
-    - name: AO_KERNEL_DB_SSLMODE
-      value: "require"
 ```
 
 The chart renders `AO_KERNEL_DB_USERNAME` / `AO_KERNEL_DB_PASSWORD` via
 `secretKeyRef` (see `templates/deployment.yaml`); connection coordinates are
-plain env (non-secret).
+plain env (non-secret). The `env.secretRefs` / `env.plain` lists remain for
+**other** secrets (e.g. LLM provider API keys) — not for the DB, which the
+`postgresql` block owns.
 
 ## 5. Rotation
 

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,27 +1,23 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-11E-2-live-mirror-drift-closeout",
+  "work_package": "AO-MA-E-4-3-followup-dedup-env",
   "implementer": {
-    "agent": "codex-ao-ma-11e-2-live-mirror-closeout",
-    "provider": "openai"
+    "agent": "claude",
+    "provider": "anthropic"
   },
   "reviewer": {
-    "agent": "anthropic-claude-independent-reviewer-ao-ma-11e-2",
-    "provider": "anthropic",
+    "agent": "codex",
+    "provider": "openai",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-11e-2-live-sync",
+    "head_ref": "refs/heads/codex/epic-4-3-followup-dedup-env",
     "changed_files": [
-      ".claude/plans/AO-MA-11E-2-LIVE-MIRROR-DRIFT-EVIDENCE.v1.json",
-      ".claude/plans/AO-MA-ROADMAP-STATUS.md",
-      ".claude/plans/ao_ma_status.v1.json",
       "CHANGELOG.md",
-      "local-ai-review-evidence.v1.json",
-      "tests/test_ao_ma11e2a_schema_invariant.py",
-      "tests/test_ao_ma_11e_status_tracking.py"
+      "docs/OPERATOR-SECRET-MANAGEMENT.md",
+      "local-ai-review-evidence.v1.json"
     ]
   },
   "checks_considered": [
@@ -34,32 +30,26 @@
       "status": "pass"
     },
     {
-      "name": "ao_ma_next",
+      "name": "db_env_single_source",
       "status": "pass"
     },
     {
-      "name": "json_schema",
+      "name": "no_workflow_mutation",
       "status": "pass"
     },
     {
-      "name": "guard_flags",
+      "name": "no_guard_flip",
       "status": "pass"
     },
     {
-      "name": "live_drift_report",
-      "status": "pass"
-    },
-    {
-      "name": "changelog",
+      "name": "cross_provider_review",
       "status": "pass"
     }
   ],
   "findings": [
-    "Claude AGREE: no blocking findings for AO-MA-11E-2 live GitHub mirror drift evidence closeout.",
-    "Claude reviewed the full tracking/evidence scope and found no runtime mutation, support widening, production readiness claim, live adapter execution, or release authority bypass.",
-    "Claude accepted the schema-bound live drift report: drift=[], exit_decision=synced, manifest SHA pinned, and token value not recorded.",
-    "Claude accepted status transition to in_review with PR ref binding pending before final merged closeout.",
-    "Claude accepted exact SHA cross-reference between evidence_refs and anchor artifact binding."
+    "E-4-3 follow-up (Codex thread 019e91c6 absorb): docs/OPERATOR-SECRET-MANAGEMENT.md duplicate DB env removed. postgresql block is the single way (auto-renders AO_KERNEL_DB_* incl. secretKeyRef); env.secretRefs/env.plain DB duplicate removed \u2014 those lists remain for non-DB secrets (LLM keys).",
+    "E-4-3 invariant suite still passes (secretKeyRef + file-based password provisioning intact). Doc-only change.",
+    "Low-risk lane: docs/ + CHANGELOG only. No chart/runtime/.github mutation. 3 guard flags const false."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,


### PR DESCRIPTION
## E-4-3 follow-up — dedup DB env (Codex review absorb)

Codex review (thread 019e91c6) on merged #924: `docs/OPERATOR-SECRET-MANAGEMENT.md` showed the DB env **twice** (postgresql block + env.secretRefs/env.plain) — duplicating/conflicting with the auto-rendered DB env.

Fix: postgresql block is the **single** documented way (it auto-renders all AO_KERNEL_DB_* incl. secretKeyRef); the env.secretRefs/env.plain DB duplicate is removed (those lists remain for non-DB secrets like LLM keys).

Doc-only · E-4-3 invariant suite still passes · no guard flag · ZERO TOUCH workflows.

Cross-AI: Anthropic impl / OpenAI (Codex) review. Low-risk lane.