### PR TITLE
fix(ci): avoid skipped required checks on PR edits

### DIFF
--- a/.claude/plans/WP-5.1-GOVERNANCE-INVENTORY.md
+++ b/.claude/plans/WP-5.1-GOVERNANCE-INVENTORY.md
@@ -40,7 +40,9 @@ Canlı gözlem:
 - `extras-install` non-blocking (`continue-on-error: true`).
 - `push` için `main` ve `codex/**` branch'lerinde tetikleniyor.
 - `pull_request` için `opened`, `reopened`, `synchronize`,
-  `ready_for_review`, `edited` (retarget) olaylarında tetikleniyor.
+  `ready_for_review`, `edited` olaylarında tetikleniyor. `edited` event'i
+  full required-check yüzeyini çalıştırır; title/body edit'leri event-gate skip
+  üretmez, retarget da aynı PR context içinde yeniden değerlendirilir.
 - `workflow_dispatch` fallback mevcut.
 
 ### 2.2 Repo içi operasyon guard'ları

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,14 +26,13 @@ on:
 
 concurrency:
   # CI-FAST: supersede stale in-progress runs per branch/PR to stop the
-  # cancelled-run pileup. Two carve-outs preserve required-check semantics
-  # (#764): never cancel `main` (its post-merge run uploads the scorecard-main
-  # baseline), and never cancel any `pull_request: edited` event — a
-  # non-retarget edit (title/body) is skipped by `event-gate`, so cancelling
-  # would shadow-cancel an in-progress real required-check run for the same
-  # ref. Retarget edits are excluded too; conservatively cheap.
+  # cancelled-run pileup. The only carve-out preserves `main`, whose post-merge
+  # run uploads the scorecard-main baseline. `pull_request: edited` intentionally
+  # runs the full required-check surface (not an event-gate skip): title/body
+  # edits and retargets must never create skipped required-check contexts that
+  # can block autonomous merge.
   group: test-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !(github.event_name == 'pull_request' && github.event.action == 'edited') }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   event-gate:
@@ -63,16 +62,9 @@ jobs:
               ;;
             pull_request)
               case "$EVENT_ACTION" in
-                opened|reopened|synchronize|ready_for_review)
+                opened|reopened|synchronize|ready_for_review|edited)
                   should_run=true
                   trigger_reason="pull_request:$EVENT_ACTION"
-                  ;;
-                edited)
-                  # Retarget (`base` changed) must rerun the full PR gate.
-                  if jq -e '.changes.base.ref.from' "$GITHUB_EVENT_PATH" >/dev/null 2>&1; then
-                    should_run=true
-                    trigger_reason="pull_request:retargeted"
-                  fi
                   ;;
               esac
               ;;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **Required Test workflow PR edit trigger hardening**: made
+  `pull_request: edited` run the full `.github/workflows/test.yml`
+  required-check surface instead of an event-gate skip, so PR title/body edits
+  and retargets cannot create skipped branch-protection required-check contexts
+  that block autonomous merge.
 - **E-8-2 multi-tenant production config recipe** (V5 Epic 8, #890):
   docs/MULTI-TENANT-CONFIG-RECIPE.md — namespace-per-tenant isolation recipe
   delegating to Epic 4 chart surfaces (E-4-2a boundary, E-4-3 PG/secret, E-4-4

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -1,71 +1,52 @@
 {
-  "schema_version": "local-ai-review-evidence.v1",
-  "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-roadmap-status-human-mirror-sync",
-  "implementer": {
-    "agent": "codex-ao-ma-roadmap-status-sync",
-    "provider": "openai"
-  },
-  "reviewer": {
-    "agent": "anthropic-claude-independent-reviewer",
-    "provider": "anthropic",
-    "verdict": "AGREE"
-  },
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-roadmap-status-sync",
-    "changed_files": [
-      ".claude/plans/AO-MA-ROADMAP-STATUS.md",
-      "CHANGELOG.md",
-      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "local-ai-review-evidence.v1.json"
-    ]
-  },
   "checks_considered": [
     {
       "name": "tests",
       "status": "pass"
     },
     {
-      "name": "diff_scope",
-      "status": "pass"
-    },
-    {
-      "name": "ao_ma_next",
-      "status": "pass"
-    },
-    {
-      "name": "gpp_next_progress",
-      "status": "pass"
-    },
-    {
       "name": "secret_scan",
-      "status": "pass"
-    },
-    {
-      "name": "guard_flags",
-      "status": "pass"
-    },
-    {
-      "name": "no_runtime_or_workflow_change",
-      "status": "pass"
-    },
-    {
-      "name": "changelog",
       "status": "pass"
     }
   ],
   "findings": [
-    "Claude AGREE: no blocking findings.",
-    "Claude validated factual alignment with ao_ma_status progress estimates and ao_ma_next output.",
-    "Claude validated only AO-MA-ROADMAP-STATUS.md and CHANGELOG.md intended content changes.",
-    "Claude validated slice descriptions and the remaining action list accurately reflect JSON next_allowed_actions.",
-    "Claude validated changelog adequacy.",
-    "Claude validated no secret exposure, no forbidden action, and no support widening, production platform claim, live adapter execution, runtime, workflow, ruleset, CODEOWNERS, or gpp_status change."
+    "event-gate case pattern correctly expanded to `opened|reopened|synchronize|ready_for_review|edited` — edited no longer skipped",
+    "Old retarget-only jq guard (`.changes.base.ref.from`) and `pull_request:retargeted` trigger_reason correctly removed — eliminates the skip path that could produce stale skipped required-check contexts",
+    "Concurrency cancel-in-progress simplified to `github.ref != 'refs/heads/main'` — the edited-event carve-out is no longer needed since edited now runs full gate",
+    "New test `test_required_check_workflow_trigger_shape.py` pins 5 invariants: trigger type list shape, case pattern string, absence of retarget-only patterns, review event types, and workflow_dispatch fallback presence",
+    ".github/REPO-GOVERNANCE.md not in changed_files — governance doc untouched",
+    "No guard flag flip, no secret, no live adapter execution, no support widening, no production platform claim",
+    "CHANGELOG.md entry accurately describes the fix scope",
+    "WP-5.1-GOVERNANCE-INVENTORY.md doc update reflects the new edited-event semantics without overclaim",
+    "No workflow_dispatch branch gains release authority — dispatch fallback is manual-only rerun"
   ],
-  "secrets_recorded": false,
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
   "live_adapter_execution": false,
+  "production_platform_claim": false,
+  "repo": "Halildeu/ao-kernel",
+  "reviewer": {
+    "agent": "claude-code",
+    "provider": "anthropic",
+    "verdict": "AGREE"
+  },
+  "schema_version": "local-ai-review-evidence.v1",
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "changed_files": [
+      ".claude/plans/WP-5.1-GOVERNANCE-INVENTORY.md",
+      ".github/workflows/test.yml",
+      "CHANGELOG.md",
+      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
+      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "tests/test_required_check_workflow_trigger_shape.py"
+    ],
+    "head_ref": "refs/heads/codex/ci-required-check-edited-trigger-fix"
+  },
+  "secrets_recorded": false,
   "support_widening": false,
-  "production_platform_claim": false
+  "work_package": "AO-MA-CI-REQUIRED-CHECK-EDITED-FULL-RUN"
 }

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -1,42 +1,7 @@
 {
-  "schema_version": "local-ai-review-evidence.v1",
-  "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-roadmap-status-human-mirror-sync",
-  "implementer": {
-    "agent": "codex-ao-ma-roadmap-status-sync",
-    "provider": "openai"
-  },
-  "reviewer": {
-    "agent": "openai-bohr-independent-reviewer",
-    "provider": "openai",
-    "verdict": "AGREE"
-  },
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/ao-ma-roadmap-status-sync",
-    "changed_files": [
-      ".claude/plans/AO-MA-ROADMAP-STATUS.md",
-      "CHANGELOG.md",
-      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "local-ai-review-evidence.v1.json"
-    ]
-  },
   "checks_considered": [
     {
       "name": "tests",
-      "status": "pass"
-    },
-    {
-      "name": "diff_scope",
-      "status": "pass"
-    },
-    {
-      "name": "ao_ma_next",
-      "status": "pass"
-    },
-    {
-      "name": "gpp_next_progress",
       "status": "pass"
     },
     {
@@ -44,28 +9,47 @@
       "status": "pass"
     },
     {
-      "name": "guard_flags",
+      "name": "workflow_shape",
       "status": "pass"
     },
     {
-      "name": "no_runtime_or_workflow_change",
-      "status": "pass"
-    },
-    {
-      "name": "changelog",
+      "name": "ao_release_gate_pr_context",
       "status": "pass"
     }
   ],
   "findings": [
-    "OpenAI AGREE: no blocking findings.",
-    "OpenAI validated the diff is limited to the AO-MA human roadmap mirror, changelog, and review evidence metadata.",
-    "OpenAI validated the markdown mirror matches ao_ma_next and ao_ma_status: 5/7 phases done, 7/9 slices merged, current AO-MA-11G/AO-MA-11G-1, drift none.",
-    "OpenAI validated guard flags remain false and no runtime, workflow, ruleset, CODEOWNERS, or gpp_status changes are introduced.",
-    "OpenAI validated changelog adequacy.",
-    "OpenAI validated JSON formatting, git diff --check, and absence of new secret material."
+    "Noether re-review AGREE: pull_request edited remains subscribed and runs the full required-check surface, including ao-release-gate in PR context.",
+    "Noether verified stale governance inventory wording was corrected and no governance file remains in origin/main...HEAD diff.",
+    "Noether verified invariant tests cover edited full-run behavior and no retarget-only branch.",
+    "Reviewed changed files count=4"
   ],
-  "secrets_recorded": false,
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
   "live_adapter_execution": false,
+  "production_platform_claim": false,
+  "repo": "Halildeu/ao-kernel",
+  "reviewer": {
+    "agent": "codex-noether-subagent",
+    "provider": "openai",
+    "verdict": "AGREE"
+  },
+  "schema_version": "local-ai-review-evidence.v1",
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "changed_files": [
+      ".claude/plans/WP-5.1-GOVERNANCE-INVENTORY.md",
+      ".github/workflows/test.yml",
+      "CHANGELOG.md",
+      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
+      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "tests/test_required_check_workflow_trigger_shape.py"
+    ],
+    "head_ref": "refs/heads/codex/ci-required-check-edited-trigger-fix"
+  },
+  "secrets_recorded": false,
   "support_widening": false,
-  "production_platform_claim": false
+  "work_package": "AO-MA-CI-REQUIRED-CHECK-EDITED-FULL-RUN"
 }

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,27 +1,4 @@
 {
-  "schema_version": "local-ai-review-evidence.v1",
-  "repo": "Halildeu/ao-kernel",
-  "work_package": "AO-MA-E-8-2-multitenant-config-recipe",
-  "implementer": {
-    "agent": "claude",
-    "provider": "anthropic"
-  },
-  "reviewer": {
-    "agent": "codex",
-    "provider": "openai",
-    "verdict": "AGREE"
-  },
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-8-2-multitenant-config-recipe",
-    "changed_files": [
-      ".claude/plans/E-8-2-MULTITENANT-CONFIG-RECIPE.md",
-      "CHANGELOG.md",
-      "docs/MULTI-TENANT-CONFIG-RECIPE.md",
-      "local-ai-review-evidence.v1.json",
-      "tests/test_epic_8_2_multitenant_config_recipe.py"
-    ]
-  },
   "checks_considered": [
     {
       "name": "tests",
@@ -30,45 +7,46 @@
     {
       "name": "secret_scan",
       "status": "pass"
-    },
-    {
-      "name": "delegates_to_epic4",
-      "status": "pass"
-    },
-    {
-      "name": "secretkeyref_no_inline",
-      "status": "pass"
-    },
-    {
-      "name": "isolation_checklist",
-      "status": "pass"
-    },
-    {
-      "name": "no_workflow_mutation",
-      "status": "pass"
-    },
-    {
-      "name": "no_guard_flip",
-      "status": "pass"
-    },
-    {
-      "name": "changelog_entry",
-      "status": "pass"
-    },
-    {
-      "name": "cross_provider_review",
-      "status": "pass"
     }
   ],
   "findings": [
-    "E-8-2 (#890) multi-tenant production config recipe. Namespace-per-tenant isolation delegating to Epic 4 (E-4-2a/E-4-3/E-4-4/E-4-5). Per-tenant values overlay + ResourceQuota + isolation checklist.",
-    "8 invariants pass. Delegating doc \u2014 no new chart feature. secretKeyRef-only overlay (no inline password). Referenced delegate docs verified present.",
-    "Low-risk lane: docs/ + tests/ + plan + CHANGELOG. NO .github/workflows/, governance, runtime mutation.",
-    "3 guard flags const false; namespace-level isolation (not in-process); no production claim.",
-    "Codex E-8-2 review absorb (thread 019e91c6): added chart-version prerequisite note \u2014 the per-tenant overlay uses E-4-3/E-4-4/E-4-5 value keys (postgresql/monitoring/networkPolicy/podSecurityStandards) that exist only when those slices have landed; operator drops keys whose slice has not merged + verifies with helm lint (closed schema rejects unknown keys)."
+    "event-gate case pattern correctly expanded to `opened|reopened|synchronize|ready_for_review|edited` — edited no longer skipped",
+    "Old retarget-only jq guard (`.changes.base.ref.from`) and `pull_request:retargeted` trigger_reason correctly removed — eliminates the skip path that could produce stale skipped required-check contexts",
+    "Concurrency cancel-in-progress simplified to `github.ref != 'refs/heads/main'` — the edited-event carve-out is no longer needed since edited now runs full gate",
+    "New test `test_required_check_workflow_trigger_shape.py` pins 5 invariants: trigger type list shape, case pattern string, absence of retarget-only patterns, review event types, and workflow_dispatch fallback presence",
+    ".github/REPO-GOVERNANCE.md not in changed_files — governance doc untouched",
+    "No guard flag flip, no secret, no live adapter execution, no support widening, no production platform claim",
+    "CHANGELOG.md entry accurately describes the fix scope",
+    "WP-5.1-GOVERNANCE-INVENTORY.md doc update reflects the new edited-event semantics without overclaim",
+    "No workflow_dispatch branch gains release authority — dispatch fallback is manual-only rerun"
   ],
-  "secrets_recorded": false,
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
   "live_adapter_execution": false,
+  "production_platform_claim": false,
+  "repo": "Halildeu/ao-kernel",
+  "reviewer": {
+    "agent": "claude-code",
+    "provider": "anthropic",
+    "verdict": "AGREE"
+  },
+  "schema_version": "local-ai-review-evidence.v1",
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "changed_files": [
+      ".claude/plans/WP-5.1-GOVERNANCE-INVENTORY.md",
+      ".github/workflows/test.yml",
+      "CHANGELOG.md",
+      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
+      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "tests/test_required_check_workflow_trigger_shape.py"
+    ],
+    "head_ref": "refs/heads/codex/ci-required-check-edited-trigger-fix"
+  },
+  "secrets_recorded": false,
   "support_widening": false,
-  "production_platform_claim": false
+  "work_package": "AO-MA-CI-REQUIRED-CHECK-EDITED-FULL-RUN"
 }

--- a/tests/test_required_check_workflow_trigger_shape.py
+++ b/tests/test_required_check_workflow_trigger_shape.py
@@ -1,0 +1,81 @@
+"""Required-check workflow trigger invariants.
+
+The canonical ``Test`` workflow owns several branch-protection required check
+names. PR metadata edits must run the full required-check surface rather than
+being skipped by the event gate, because stale skipped runs can block autonomous
+merge even when the latest full run is green.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEST_WORKFLOW = ROOT / ".github" / "workflows" / "test.yml"
+TRIGGER_SCRIPT = ROOT / ".claude" / "scripts" / "trigger-test-workflow.sh"
+
+
+def _trigger_types(text: str, trigger_name: str) -> list[str]:
+    """Return the YAML list under ``on.<trigger_name>.types``.
+
+    This intentionally stays as a small text parser so the invariant is not
+    affected by YAML 1.1's ``on`` boolean corner case in older PyYAML builds.
+    """
+
+    lines = text.splitlines()
+    trigger_line = f"  {trigger_name}:"
+    for index, line in enumerate(lines):
+        if line == trigger_line:
+            break
+    else:
+        raise AssertionError(f"missing trigger {trigger_name!r}")
+
+    in_types = False
+    values: list[str] = []
+    for line in lines[index + 1 :]:
+        if line.startswith("  ") and not line.startswith("    "):
+            break
+        if line == "    types:":
+            in_types = True
+            continue
+        if in_types:
+            if line.startswith("      - "):
+                values.append(line.removeprefix("      - ").strip())
+                continue
+            if line.startswith("    ") and line.strip():
+                break
+    return values
+
+
+def test_required_test_workflow_runs_full_gate_for_pr_edited() -> None:
+    text = TEST_WORKFLOW.read_text(encoding="utf-8")
+    pull_request_types = _trigger_types(text, "pull_request")
+
+    assert pull_request_types == [
+        "opened",
+        "reopened",
+        "synchronize",
+        "ready_for_review",
+        "edited",
+    ]
+    assert "opened|reopened|synchronize|ready_for_review|edited" in text
+    assert "pull_request:retargeted" not in text
+    assert ".changes.base.ref.from" not in text
+
+
+def test_review_events_still_rerun_required_gate_after_review_changes() -> None:
+    text = TEST_WORKFLOW.read_text(encoding="utf-8")
+    review_types = _trigger_types(text, "pull_request_review")
+
+    assert review_types == ["submitted", "edited", "dismissed"]
+
+
+def test_required_test_workflow_keeps_manual_dispatch_fallback() -> None:
+    workflow_text = TEST_WORKFLOW.read_text(encoding="utf-8")
+    script_text = TRIGGER_SCRIPT.read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow_text
+    assert "Manual rerun reason (e.g. stacked retarget)" in workflow_text
+
+    assert "gh workflow run test.yml" in script_text
+    assert "manual-retarget-check" in script_text


### PR DESCRIPTION
## Summary

- keep `pull_request: edited` subscribed for the Test workflow so PR retarget/title-body edits refresh the same PR-context required-check surface
- remove the old event-gate skip behavior for `edited`; edited events now run the full required checks instead of producing skipped required-check contexts
- add workflow-shape invariants proving `edited` is in the trigger and full-run allowlist, with no retarget-only fallback branch
- update the stale WP-5.1 governance inventory note and changelog entry to match the current behavior
- add current high-risk review evidence for the workflow/governance-touching PR scope (`openai` + `anthropic` raw reviewer evidence plus root local review evidence)

## Why

PR body/title edits and stacked-retarget edits can leave skipped required-check contexts if the workflow subscribes to edited but event-gates the rest of the required-check surface. That blocks autonomous low-risk merge despite a later successful run.

The robust fix is not to remove `edited`; it is to keep `edited` in the PR-context trigger and let the full required-check surface run, including `ao-release-gate`.

## Validation

- `python3 -m pytest tests/test_required_check_workflow_trigger_shape.py tests/test_ao_release_gate_enforce_job.py tests/test_changelog_enforcement_workflow_shape.py tests/test_issue_forms_shape.py -q` -> 64 passed, 3 skipped
- `python3 -m pytest tests/test_ao_ma10j_high_risk_supersession_evidence_builder.py tests/test_ao_ma10_high_risk_raw_review_producer.py tests/test_local_gpp_gate.py -q` -> 75 passed
- `python3 -m pytest tests/test_ao_release_gate_build_payload.py -q` -> 20 passed
- `python3 -m ruff check tests/test_required_check_workflow_trigger_shape.py` -> pass
- `git diff --check` -> clean
- `scripts/ao_ma10_high_risk_supersession_evidence.py ...` -> generated, `changed_files_count=7`, `high_risk_changed_paths=[WP-5.1 inventory, .github/workflows/test.yml]`
- `scripts/local_gpp_gate.py ...` -> `decision=operator_may_merge`, 8/8 checks pass, `changed_files_count=7`
- `ao-kernel quality check-changelog ...` -> decision=pass
- Noether subagent review -> AGREE after `.github/REPO-GOVERNANCE.md` was restored out of PR scope and `edited` remained PR-context/full-run

## Guardrails

- no branch protection mutation
- no admin bypass
- no support widening / production platform claim / live adapter execution
- `.github/REPO-GOVERNANCE.md` intentionally restored out of this PR scope
