### PR TITLE
feat(e-2-2): per-call audit schema + fail-closed writer (infrastructure-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **E-2-2 per-call audit evidence schema + writer** (V5 Epic 2, #847): added
+  `per_call_audit.schema.v1.json` (one row per would-be LLM call: tokens, cost,
+  latency, provider-lifecycle `status` and a separate `cost_breach_state`) plus
+  the fail-closed writer `ao_kernel/_internal/evidence/per_call_audit.py`. The
+  writer validates before any write (a missing/float `actual_cost_usd` is
+  rejected), skips persistence in library mode, and in workspace mode appends
+  atomically (O_APPEND + fsync) to `evidence/per_call_audit.jsonl` — a
+  `hard_breached` row is cross-referenced to `evidence/cost_hard_breach.jsonl`.
+  `allOf`: `soft_breached`⇒`cost_breach_handling` required (object); `hard_breached`⇒
+  `status==error` + `cost_breach_handling==null`. Foreign-keys to the E-2-1
+  envelope via `envelope_digest`. Infrastructure-only: `live_adapter_execution`
+  const false; no network call; the writer does not raise `CostCeilingExceeded`
+  (that is E-2-3). No guard flip.
 - **E-2-1 live adapter envelope schema** (V5 Epic 2, #846): added the
   `live_adapter_envelope.schema.v1.json` governance envelope for a single
   (would-be) LLM provider call — request/response/cost/circuit-breaker shape

--- a/ao_kernel/_internal/evidence/per_call_audit.py
+++ b/ao_kernel/_internal/evidence/per_call_audit.py
@@ -62,7 +62,7 @@ def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
     verification stays authoritative)."""
     path.parent.mkdir(parents=True, exist_ok=True)
     line = (json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
     try:
         os.write(fd, line)  # single write => atomic line append under O_APPEND
         try:

--- a/ao_kernel/_internal/evidence/per_call_audit.py
+++ b/ao_kernel/_internal/evidence/per_call_audit.py
@@ -51,19 +51,26 @@ def _validate(row: dict[str, Any]) -> None:
 
 
 def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
-    """Append one row as canonical JSON, fsync best-effort (mirrors the
-    evidence writer's append contract: O_APPEND via 'a' + fsync)."""
+    """Append one row as a single canonical-JSON line, atomically.
+
+    A row is pre-encoded to one ``bytes`` value (line + trailing newline) and
+    written with a single ``os.write`` to a fd opened ``O_WRONLY|O_CREAT|
+    O_APPEND``. POSIX guarantees an ``O_APPEND`` write smaller than ``PIPE_BUF``
+    (>=4 KiB; audit rows are far smaller) is atomic, so concurrent writers never
+    interleave a partial line. ``fsync`` is best-effort (unsupported on some
+    network FS / bind mounts; the row is already in the page cache and integrity
+    verification stays authoritative)."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
-        handle.flush()
+    line = (json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    try:
+        os.write(fd, line)  # single write => atomic line append under O_APPEND
         try:
-            os.fsync(handle.fileno())
+            os.fsync(fd)
         except OSError:
-            # fsync may be unsupported (network FS, bind mount). The row has
-            # landed in the page cache; integrity verification stays the
-            # authoritative check (mirrors evidence/writer.py).
             pass
+    finally:
+        os.close(fd)
 
 
 def record_call(row: dict[str, Any], *, workspace_root: Path | None = None) -> dict[str, Any]:

--- a/ao_kernel/_internal/evidence/per_call_audit.py
+++ b/ao_kernel/_internal/evidence/per_call_audit.py
@@ -1,0 +1,95 @@
+"""Per-call audit evidence writer (V5 Epic 2 E-2-2).
+
+One JSONL row per (would-be) LLM call. The writer is a pure serializer:
+
+  - It validates every row against ``per_call_audit.schema.v1.json`` and FAILS
+    CLOSED (raises) on an invalid row — a missing/float cost, a flipped guard
+    flag, or a ``soft_breached`` row without ``cost_breach_handling`` is never
+    written (CLAUDE.md değişmez #1, fail-closed evidence path).
+  - In **library mode** (``workspace_root is None``) it skips persistence and
+    returns a receipt — the single-process contract, no on-disk evidence.
+  - In **workspace mode** it appends atomically (fsync) to
+    ``evidence/per_call_audit.jsonl``; a ``hard_breached`` row is ALSO appended
+    to ``evidence/cost_hard_breach.jsonl`` so the failure path is
+    cross-referenced.
+
+The writer does NOT decide cost-ceiling breaches and does NOT raise
+``CostCeilingExceeded`` — that is the E-2-3 cost-ceiling module, which calls
+this writer (try-finally) to record the fail-closed audit row before raising.
+This keeps E-2-2 free of a forward dependency on E-2-3.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+_SCHEMA_NAME = "per_call_audit.schema.v1.json"
+_AUDIT_JSONL = "per_call_audit.jsonl"
+_HARD_BREACH_JSONL = "cost_hard_breach.jsonl"
+
+
+class PerCallAuditValidationError(ValueError):
+    """Raised when an audit row does not satisfy the schema (fail-closed)."""
+
+
+def _validator() -> Draft202012Validator:
+    return Draft202012Validator(load_default("schemas", _SCHEMA_NAME))
+
+
+def _validate(row: dict[str, Any]) -> None:
+    errors = sorted(_validator().iter_errors(row), key=lambda e: list(e.absolute_path))
+    if errors:
+        joined = "; ".join(f"{'/'.join(str(p) for p in e.absolute_path) or '<root>'}: {e.message}" for e in errors)
+        raise PerCallAuditValidationError(f"per_call_audit row failed schema validation: {joined}")
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    """Append one row as canonical JSON, fsync best-effort (mirrors the
+    evidence writer's append contract: O_APPEND via 'a' + fsync)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+        handle.flush()
+        try:
+            os.fsync(handle.fileno())
+        except OSError:
+            # fsync may be unsupported (network FS, bind mount). The row has
+            # landed in the page cache; integrity verification stays the
+            # authoritative check (mirrors evidence/writer.py).
+            pass
+
+
+def record_call(row: dict[str, Any], *, workspace_root: Path | None = None) -> dict[str, Any]:
+    """Validate and (in workspace mode) persist one per-call audit row.
+
+    Returns a receipt: ``{"persisted": bool, "mode": "library"|"workspace",
+    "paths": [...]}``. Raises ``PerCallAuditValidationError`` on a schema-invalid
+    row BEFORE any write (fail-closed) — so a malformed row never lands on disk.
+    """
+    _validate(row)  # fail-closed: invalid row raises before any write
+
+    if workspace_root is None:
+        return {"persisted": False, "mode": "library", "paths": []}
+
+    evidence_dir = Path(workspace_root) / "evidence"
+    written: list[str] = []
+
+    audit_path = evidence_dir / _AUDIT_JSONL
+    _append_jsonl(audit_path, row)
+    written.append(str(audit_path))
+
+    # A hard breach is also cross-referenced in a dedicated failure artifact so
+    # the unconditional-abort path is auditable on its own (E-2-2 spec / F10).
+    if row.get("cost_breach_state") == "hard_breached":
+        breach_path = evidence_dir / _HARD_BREACH_JSONL
+        _append_jsonl(breach_path, row)
+        written.append(str(breach_path))
+
+    return {"persisted": True, "mode": "workspace", "paths": written}

--- a/ao_kernel/defaults/schemas/per_call_audit.schema.v1.json
+++ b/ao_kernel/defaults/schemas/per_call_audit.schema.v1.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/per_call_audit.schema.v1.json",
+  "title": "Per-Call Audit Evidence (V5 Epic 2 E-2-2)",
+  "description": "One audit record per (would-be) LLM call: provider/model/tokens/cost/latency/status plus an explicit cost-breach state. Foreign-keys to a live_adapter_envelope via envelope_digest. Infrastructure-only: live_adapter_execution const false; the audit fails closed when the cost field is missing.",
+  "type": "object",
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "envelope_digest",
+    "provider_id",
+    "model",
+    "request_id",
+    "intent",
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "actual_cost_usd",
+    "latency_ms",
+    "status",
+    "cost_breach_state",
+    "live_adapter_execution",
+    "recorded_at"
+  ],
+  "properties": {
+    "schema_version": { "const": "per-call-audit.v1" },
+    "artifact_kind": { "const": "per_call_audit" },
+    "envelope_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "Foreign-key to the live_adapter_envelope this call was recorded under (E-2-1 envelope_digest)."
+    },
+    "provider_id": { "type": "string", "minLength": 1 },
+    "model": { "type": "string", "minLength": 1 },
+    "request_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "intent": { "type": "string", "minLength": 1 },
+    "input_tokens": { "type": "integer", "minimum": 0 },
+    "output_tokens": { "type": "integer", "minimum": 0 },
+    "total_tokens": { "type": "integer", "minimum": 0 },
+    "actual_cost_usd": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]{8}$",
+      "description": "Decimal string, 8 dp. Required — a missing/float cost fails the schema (fail-closed, CLAUDE.md değişmez #1)."
+    },
+    "latency_ms": { "type": "integer", "minimum": 0 },
+    "status": {
+      "type": "string",
+      "enum": ["ok", "error", "stub_emitted", "dry_run_emitted"],
+      "description": "Provider call lifecycle status (NOT a breach state — see cost_breach_state)."
+    },
+    "cost_breach_state": {
+      "type": "string",
+      "enum": ["ok", "soft_breached", "hard_breached", "not_applicable"],
+      "description": "Whether this call's cost recording crossed soft/hard ceiling thresholds. Distinct from status."
+    },
+    "cost_breach_handling": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": ["decision", "soft_threshold_usd", "cumulative_cost_usd", "decided_at"],
+      "description": "Caller decision audit; required only when cost_breach_state == soft_breached (E-2-3 soft-breach contract).",
+      "properties": {
+        "decision": { "type": "string", "enum": ["continued", "stopped", "deferred"] },
+        "soft_threshold_usd": { "type": "string", "pattern": "^[0-9]+\\.[0-9]{8}$" },
+        "cumulative_cost_usd": { "type": "string", "pattern": "^[0-9]+\\.[0-9]{8}$" },
+        "decided_at": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^[0-9]{4}-((0[13578]|1[02])-(0[1-9]|[12][0-9]|3[01])|(0[469]|11)-(0[1-9]|[12][0-9]|30)|02-(0[1-9]|1[0-9]|2[0-9]))T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]+)?(Z|[+-]([01][0-9]|2[0-3]):[0-5][0-9])$"
+        }
+      }
+    },
+    "live_adapter_execution": {
+      "const": false,
+      "description": "Guard flag pin (ADR-0002 recompute-not-trust). An audit row never represents a live execution."
+    },
+    "support_widening": { "const": false },
+    "production_platform_claim": { "const": false },
+    "recorded_at": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-((0[13578]|1[02])-(0[1-9]|[12][0-9]|3[01])|(0[469]|11)-(0[1-9]|[12][0-9]|30)|02-(0[1-9]|1[0-9]|2[0-9]))T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]+)?(Z|[+-]([01][0-9]|2[0-3]):[0-5][0-9])$"
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "cost_breach_state": { "const": "soft_breached" } } },
+      "then": { "required": ["cost_breach_handling"] }
+    },
+    {
+      "if": { "properties": { "cost_breach_state": { "const": "hard_breached" } } },
+      "then": { "properties": { "status": { "const": "error" } } }
+    }
+  ]
+}

--- a/ao_kernel/defaults/schemas/per_call_audit.schema.v1.json
+++ b/ao_kernel/defaults/schemas/per_call_audit.schema.v1.json
@@ -59,21 +59,25 @@
       "description": "Whether this call's cost recording crossed soft/hard ceiling thresholds. Distinct from status."
     },
     "cost_breach_handling": {
-      "type": "object",
-      "additionalProperties": false,
-      "unevaluatedProperties": false,
-      "required": ["decision", "soft_threshold_usd", "cumulative_cost_usd", "decided_at"],
-      "description": "Caller decision audit; required only when cost_breach_state == soft_breached (E-2-3 soft-breach contract).",
-      "properties": {
-        "decision": { "type": "string", "enum": ["continued", "stopped", "deferred"] },
-        "soft_threshold_usd": { "type": "string", "pattern": "^[0-9]+\\.[0-9]{8}$" },
-        "cumulative_cost_usd": { "type": "string", "pattern": "^[0-9]+\\.[0-9]{8}$" },
-        "decided_at": {
-          "type": "string",
-          "format": "date-time",
-          "pattern": "^[0-9]{4}-((0[13578]|1[02])-(0[1-9]|[12][0-9]|3[01])|(0[469]|11)-(0[1-9]|[12][0-9]|30)|02-(0[1-9]|1[0-9]|2[0-9]))T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]+)?(Z|[+-]([01][0-9]|2[0-3]):[0-5][0-9])$"
-        }
-      }
+      "description": "Caller decision audit. Object only when cost_breach_state == soft_breached (E-2-3 soft-breach contract); null for hard_breached; null/absent otherwise.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "unevaluatedProperties": false,
+          "required": ["decision", "decided_by", "decided_at"],
+          "properties": {
+            "decision": { "type": "string", "enum": ["continued", "stopped", "deferred"] },
+            "decided_by": { "type": "string", "enum": ["operator", "policy_default", "caller_module"] },
+            "decided_at": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^[0-9]{4}-((0[13578]|1[02])-(0[1-9]|[12][0-9]|3[01])|(0[469]|11)-(0[1-9]|[12][0-9]|30)|02-(0[1-9]|1[0-9]|2[0-9]))T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]+)?(Z|[+-]([01][0-9]|2[0-3]):[0-5][0-9])$"
+            }
+          }
+        },
+        { "type": "null" }
+      ]
     },
     "live_adapter_execution": {
       "const": false,
@@ -89,12 +93,36 @@
   },
   "allOf": [
     {
-      "if": { "properties": { "cost_breach_state": { "const": "soft_breached" } } },
-      "then": { "required": ["cost_breach_handling"] }
+      "comment": "soft_breached => cost_breach_handling required AND must be the object form",
+      "if": {
+        "required": ["cost_breach_state"],
+        "properties": { "cost_breach_state": { "const": "soft_breached" } }
+      },
+      "then": {
+        "required": ["cost_breach_handling"],
+        "properties": { "cost_breach_handling": { "type": "object" } }
+      }
     },
     {
-      "if": { "properties": { "cost_breach_state": { "const": "hard_breached" } } },
-      "then": { "properties": { "status": { "const": "error" } } }
+      "comment": "any non-soft state => cost_breach_handling, if present, must be null (populated only when soft)",
+      "if": {
+        "required": ["cost_breach_state"],
+        "properties": { "cost_breach_state": { "not": { "const": "soft_breached" } } }
+      },
+      "then": {
+        "properties": { "cost_breach_handling": { "type": "null" } }
+      }
+    },
+    {
+      "comment": "hard_breached => status error AND cost_breach_handling present (null per the non-soft branch); unconditional abort row",
+      "if": {
+        "required": ["cost_breach_state"],
+        "properties": { "cost_breach_state": { "const": "hard_breached" } }
+      },
+      "then": {
+        "required": ["cost_breach_handling"],
+        "properties": { "status": { "const": "error" } }
+      }
     }
   ]
 }

--- a/docs/PER-CALL-AUDIT.md
+++ b/docs/PER-CALL-AUDIT.md
@@ -1,0 +1,71 @@
+# Per-Call Audit Evidence (V5 Epic 2 E-2-2)
+
+> Slice #847. One JSONL audit row per (would-be) LLM call. **Infrastructure
+> only**: `live_adapter_execution` is `const false`; the writer never makes a
+> network call and never flips a guard flag. Builds on the E-2-1 envelope
+> (foreign-keys via `envelope_digest`).
+
+## Schema
+
+`ao_kernel/defaults/schemas/per_call_audit.schema.v1.json` (Draft 2020-12,
+strict closure on every object). One row records: provider/model/request,
+token usage, `actual_cost_usd` (decimal-string, 8 dp, **required**), latency,
+a provider-lifecycle `status`, and a **separate** `cost_breach_state`.
+
+`status` vs `cost_breach_state` are deliberately distinct:
+
+| Field | Domain | Meaning |
+|---|---|---|
+| `status` | `ok` / `error` / `stub_emitted` / `dry_run_emitted` | provider call lifecycle |
+| `cost_breach_state` | `ok` / `soft_breached` / `hard_breached` / `not_applicable` | whether cost recording crossed a ceiling threshold |
+
+Conditional invariants (`allOf`):
+
+- `cost_breach_state == "soft_breached"` ⇒ `cost_breach_handling` required
+  (the caller-decision audit: continued/stopped/deferred + thresholds).
+- `cost_breach_state == "hard_breached"` ⇒ `status == "error"` (a hard breach
+  is an unconditional abort).
+
+Fail-closed: a missing or float `actual_cost_usd` fails schema validation, so
+the row is rejected (CLAUDE.md değişmez #1). Timestamps use the same
+calendar-coupling RFC3339 regex as E-2-1 (leap-year validity is a recompute-time
+concern, see `docs/LIVE-ADAPTER-ENVELOPE.md`).
+
+## Writer
+
+`ao_kernel/_internal/evidence/per_call_audit.py` — `record_call(row, *,
+workspace_root=None)` is a **pure serializer**:
+
+- Validates the row and **raises `PerCallAuditValidationError` before any
+  write** — a malformed row never lands on disk (fail-closed).
+- **Library mode** (`workspace_root=None`): skips persistence, returns
+  `{"persisted": False, "mode": "library", "paths": []}` (single-process
+  contract).
+- **Workspace mode**: appends atomically (O_APPEND + fsync) to
+  `evidence/per_call_audit.jsonl`. A `hard_breached` row is ALSO appended to
+  `evidence/cost_hard_breach.jsonl` so the abort path is cross-referenced.
+
+The writer does **not** decide breaches and does **not** raise
+`CostCeilingExceeded` — that is the E-2-3 cost-ceiling module, which calls this
+writer (try-finally) to record the fail-closed row before raising. This keeps
+E-2-2 free of a forward dependency on E-2-3.
+
+## What this slice does NOT do
+
+- Does NOT make a real provider call (records would-be calls under stub/dry_run).
+- Does NOT enforce a cost ceiling (that is E-2-3, which drives `cost_breach_state`).
+- Does NOT flip any guard flag.
+
+## Verification
+
+`tests/test_per_call_audit.py` — schema health, guard pins, strict closure
+(parametrized), required-field enforcement (parametrized), const/enum pins,
+decimal/sha/timestamp fail-closed, `allOf` conditionals, and writer contract
+(fail-closed-before-write, library skip, cumulative append, hard-breach
+cross-reference).
+
+## Cross-references
+
+- Envelope (E-2-1): `docs/LIVE-ADAPTER-ENVELOPE.md`
+- Cost ceiling (next, E-2-3): drives `cost_breach_state` + raises `CostCeilingExceeded`
+- Epic 2 plan: `.claude/plans/EPIC-2-LIVE-ADAPTER-EXECUTION.md` (E-2-2)

--- a/docs/PER-CALL-AUDIT.md
+++ b/docs/PER-CALL-AUDIT.md
@@ -19,12 +19,16 @@ a provider-lifecycle `status`, and a **separate** `cost_breach_state`.
 | `status` | `ok` / `error` / `stub_emitted` / `dry_run_emitted` | provider call lifecycle |
 | `cost_breach_state` | `ok` / `soft_breached` / `hard_breached` / `not_applicable` | whether cost recording crossed a ceiling threshold |
 
-Conditional invariants (`allOf`):
+Conditional invariants (`allOf`), aligned to the E-2-3 breach contract:
 
-- `cost_breach_state == "soft_breached"` ⇒ `cost_breach_handling` required
-  (the caller-decision audit: continued/stopped/deferred + thresholds).
-- `cost_breach_state == "hard_breached"` ⇒ `status == "error"` (a hard breach
-  is an unconditional abort).
+- `cost_breach_state == "soft_breached"` ⇒ `cost_breach_handling` required and
+  must be the **object** form `{decision, decided_by, decided_at}`
+  (`decided_by` ∈ {operator, policy_default, caller_module}).
+- `cost_breach_state == "hard_breached"` ⇒ `status == "error"` **and**
+  `cost_breach_handling == null` (an unconditional abort row — no caller
+  decision; written to both JSONL files).
+- `ok` / `not_applicable` ⇒ `cost_breach_handling` is null or absent (a
+  populated object is rejected — it is populated only on a soft breach).
 
 Fail-closed: a missing or float `actual_cost_usd` fails schema validation, so
 the row is rejected (CLAUDE.md değişmez #1). Timestamps use the same
@@ -41,9 +45,13 @@ workspace_root=None)` is a **pure serializer**:
 - **Library mode** (`workspace_root=None`): skips persistence, returns
   `{"persisted": False, "mode": "library", "paths": []}` (single-process
   contract).
-- **Workspace mode**: appends atomically (O_APPEND + fsync) to
-  `evidence/per_call_audit.jsonl`. A `hard_breached` row is ALSO appended to
-  `evidence/cost_hard_breach.jsonl` so the abort path is cross-referenced.
+- **Workspace mode**: appends each row as a single pre-encoded `os.write` to a
+  fd opened `O_WRONLY|O_CREAT|O_APPEND` (POSIX guarantees an `O_APPEND` write
+  below `PIPE_BUF` is atomic, so concurrent writers never interleave a partial
+  line) + best-effort `fsync`, to `evidence/per_call_audit.jsonl`. A
+  `hard_breached` row is ALSO appended to `evidence/cost_hard_breach.jsonl` so
+  the abort path is cross-referenced. A concurrent-append test asserts N writers
+  produce N parseable lines.
 
 The writer does **not** decide breaches and does **not** raise
 `CostCeilingExceeded` — that is the E-2-3 cost-ceiling module, which calls this

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "E-2-1-LIVE-ADAPTER-ENVELOPE-SCHEMA",
+  "work_package": "E-2-2-PER-CALL-AUDIT",
   "implementer": {
     "agent": "claude",
     "provider": "anthropic"
@@ -13,13 +13,13 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/feat/epic-2-1-live-adapter-envelope-schema",
+    "head_ref": "refs/heads/feat/epic-2-2-per-call-audit",
     "changed_files": [
-      ".claude/plans/EPIC-2-LIVE-ADAPTER-EXECUTION.md",
       "CHANGELOG.md",
-      "ao_kernel/defaults/schemas/live_adapter_envelope.schema.v1.json",
-      "docs/LIVE-ADAPTER-ENVELOPE.md",
-      "tests/test_live_adapter_envelope.py",
+      "ao_kernel/_internal/evidence/per_call_audit.py",
+      "ao_kernel/defaults/schemas/per_call_audit.schema.v1.json",
+      "docs/PER-CALL-AUDIT.md",
+      "tests/test_per_call_audit.py",
       "local-ai-review-evidence.v1.json"
     ]
   },
@@ -30,14 +30,16 @@
     { "name": "mypy", "status": "pass" },
     { "name": "schema_valid_draft_2020_12", "status": "pass" },
     { "name": "guard_flags_const_false", "status": "pass" },
-    { "name": "strict_closure_every_object", "status": "pass" },
+    { "name": "e23_forward_compat", "status": "pass" },
+    { "name": "writer_fail_closed", "status": "pass" },
+    { "name": "concurrent_append_line_atomic", "status": "pass" },
     { "name": "no_workflow_mutation", "status": "pass" },
     { "name": "cross_provider_review", "status": "pass" }
   ],
   "findings": [
-    "E-2-1 live adapter envelope schema (infrastructure-only). 4-iter Codex (OpenAI) cross-AI review on thread 019e92a5; all REVISE findings absorbed: (1) envelope_digest spec drift fixed (added required bare-sha256 content-address, plan §2 aligned to §702); (2) date-time fail-closed via explicit RFC3339 pattern (jsonschema does not enforce format by default); (3) closure test parametrized over every object path; (4) range-aware then calendar month/day-coupling regex (Feb<=29, 30-day months<=30); (5) leap-year validity reasoned-deferred to E-2-4 recompute-time with explicit boundary test + precise doc (no overclaim), justified by CLAUDE.md core-dependency minimalism.",
-    "Guard flags pinned const false at both schema (live_adapter_execution const false; optional support_widening/production_platform_claim const false) and evidence level. mode enum is exactly {stub, dry_run}; 'live' forbidden. No real network call represented; no guard flag flipped. Flip authority remains Epic 9 PR-Xfinal.",
-    "36 machine-enforced invariants; ruff + mypy + pytest green. Codex final verdict AGREE (iter-4). Follow-up recorded for E-2-4: dry-run harness must datetime-parse timestamps so schema-accepted-but-calendar-invalid values (e.g. non-leap 2026-02-29) fail-closed at runtime — E-2-4 acceptance blocker, not E-2-1."
+    "E-2-2 per-call audit schema + fail-closed writer (infrastructure-only). 2-iter Codex (OpenAI) cross-AI review on thread 019e92bf; all 4 REVISE findings absorbed: (1) hard-breach contract — cost_breach_handling is oneOf[object,null], allOf enforces hard=>status error + handling null (was object-only, would have broken E-2-3's hard write); (2) soft handling shape aligned to E-2-3 contract {decision, decided_by(enum), decided_at}; (3) atomic append via os.open(O_WRONLY|O_CREAT|O_APPEND) + single os.write + fsync; (4) test gaps closed — hard-null valid, hard-object invalid, soft decided_by enum, schema-invalid-no-linecount-change, concurrent 20-writer line-atomic.",
+    "Writer is a pure serializer: validate-before-write (schema-invalid row raises before any disk write), library-mode skips persistence, workspace-mode atomic JSONL append; hard_breached cross-referenced to cost_hard_breach.jsonl. Does NOT raise CostCeilingExceeded (that is E-2-3) — no forward dependency. Foreign-keys to E-2-1 envelope via envelope_digest.",
+    "40 machine-enforced invariants; ruff + mypy + pytest green. Guard flags const false at schema + evidence level; no network call; no guard flip. Codex final verdict AGREE (iter-2); E-2-3 forward-compat confirmed by reviewer payload validation."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_per_call_audit.py
+++ b/tests/test_per_call_audit.py
@@ -294,6 +294,7 @@ def test_writer_workspace_mode_appends_jsonl(tmp_path: Path) -> None:
     assert receipt["persisted"] is True and receipt["mode"] == "workspace"
     audit = tmp_path / "evidence" / "per_call_audit.jsonl"
     assert audit.is_file()
+    assert audit.stat().st_mode & 0o777 == 0o600
     rows = [json.loads(line) for line in audit.read_text(encoding="utf-8").splitlines()]
     assert len(rows) == 1 and rows[0]["envelope_digest"] == "a" * 64
 
@@ -312,6 +313,7 @@ def test_writer_hard_breach_cross_referenced(tmp_path: Path) -> None:
     assert (tmp_path / "evidence" / "per_call_audit.jsonl").is_file()
     breach = tmp_path / "evidence" / "cost_hard_breach.jsonl"
     assert breach.is_file(), "hard_breached row must also land in cost_hard_breach.jsonl"
+    assert breach.stat().st_mode & 0o777 == 0o600
     assert str(breach) in receipt["paths"]
 
 

--- a/tests/test_per_call_audit.py
+++ b/tests/test_per_call_audit.py
@@ -1,0 +1,295 @@
+"""V5 Epic 2 E-2-2 invariants: per-call audit schema + writer.
+
+Schema invariants mirror E-2-1's fail-closed discipline (strict closure at every
+object, guard-flag pins, decimal cost, calendar-coupling RFC3339, parametrized
+negatives). Writer invariants prove the fail-closed contract:
+  - schema-invalid row raises BEFORE any write
+  - library mode (workspace_root=None) skips persistence
+  - workspace mode appends valid JSONL; hard_breached is cross-referenced
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from ao_kernel._internal.evidence.per_call_audit import (
+    PerCallAuditValidationError,
+    record_call,
+)
+from ao_kernel.config import load_default
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCHEMA_NAME = "per_call_audit.schema.v1.json"
+_SCHEMA_PATH = _REPO_ROOT / "ao_kernel" / "defaults" / "schemas" / _SCHEMA_NAME
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", _SCHEMA_NAME)
+
+
+def _is_valid(payload: dict[str, Any]) -> bool:
+    return not list(Draft202012Validator(_schema()).iter_errors(payload))
+
+
+def _valid_row() -> dict[str, Any]:
+    return {
+        "schema_version": "per-call-audit.v1",
+        "artifact_kind": "per_call_audit",
+        "envelope_digest": "a" * 64,
+        "provider_id": "openai",
+        "model": "gpt-4o-mini",
+        "request_id": "0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9",
+        "intent": "FAST_TEXT",
+        "input_tokens": 12,
+        "output_tokens": 8,
+        "total_tokens": 20,
+        "actual_cost_usd": "0.00000660",
+        "latency_ms": 0,
+        "status": "dry_run_emitted",
+        "cost_breach_state": "not_applicable",
+        "live_adapter_execution": False,
+        "recorded_at": "2026-06-04T10:00:00Z",
+    }
+
+
+def _soft_breach_row() -> dict[str, Any]:
+    row = _valid_row()
+    row["status"] = "ok"
+    row["cost_breach_state"] = "soft_breached"
+    row["cost_breach_handling"] = {
+        "decision": "continued",
+        "soft_threshold_usd": "0.50000000",
+        "cumulative_cost_usd": "0.51000000",
+        "decided_at": "2026-06-04T10:00:01Z",
+    }
+    return row
+
+
+# ---- 1. schema health (2) ----------------------------------------------
+
+
+def test_schema_present_and_valid_draft_2020_12() -> None:
+    assert _SCHEMA_PATH.is_file(), f"{_SCHEMA_NAME} missing (E-2-2)"
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+
+def test_valid_rows_validate() -> None:
+    assert _is_valid(_valid_row())
+    assert _is_valid(_soft_breach_row())
+
+
+# ---- 2. guard-flag pins (2) --------------------------------------------
+
+
+def test_live_adapter_execution_pinned_false() -> None:
+    row = _valid_row()
+    row["live_adapter_execution"] = True
+    assert not _is_valid(row), "live_adapter_execution=true must be rejected"
+
+
+def test_optional_guard_flags_false_if_present() -> None:
+    for flag in ("support_widening", "production_platform_claim"):
+        bad = _valid_row()
+        bad[flag] = True
+        assert not _is_valid(bad), f"{flag}=true must be rejected"
+        ok = _valid_row()
+        ok[flag] = False
+        assert _is_valid(ok), f"{flag}=false must be accepted"
+
+
+# ---- 3. strict closure + required (2) ----------------------------------
+
+
+@pytest.mark.parametrize("path", [(), ("cost_breach_handling",)])
+def test_additional_properties_rejected_at_every_object(path: tuple[str, ...]) -> None:
+    payload = _soft_breach_row()  # has cost_breach_handling populated
+    target: Any = payload
+    for key in path:
+        target = target[key]
+    target["unexpected_field"] = "x"
+    assert not _is_valid(payload), f"additionalProperties at {path or 'root'} must be rejected"
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "schema_version",
+        "artifact_kind",
+        "envelope_digest",
+        "provider_id",
+        "model",
+        "request_id",
+        "intent",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "actual_cost_usd",
+        "latency_ms",
+        "status",
+        "cost_breach_state",
+        "live_adapter_execution",
+        "recorded_at",
+    ],
+)
+def test_each_required_field_enforced(field: str) -> None:
+    row = _valid_row()
+    del row[field]
+    assert not _is_valid(row), f"removing required '{field}' must fail"
+
+
+# ---- 4. const + enum pins (3) ------------------------------------------
+
+
+def test_const_pins_reject_wrong_values() -> None:
+    for field, bad in (("schema_version", "per-call-audit.v2"), ("artifact_kind", "other")):
+        row = _valid_row()
+        row[field] = bad
+        assert not _is_valid(row), f"{field} const must reject '{bad}'"
+
+
+def test_status_enum_complete() -> None:
+    statuses = set(_schema()["properties"]["status"]["enum"])
+    assert statuses == {"ok", "error", "stub_emitted", "dry_run_emitted"}
+
+
+def test_cost_breach_state_enum_complete() -> None:
+    states = set(_schema()["properties"]["cost_breach_state"]["enum"])
+    assert states == {"ok", "soft_breached", "hard_breached", "not_applicable"}
+
+
+# ---- 5. cost + digest + timestamp fail-closed (3) ----------------------
+
+
+def test_cost_must_be_decimal_8dp_not_float() -> None:
+    row = _valid_row()
+    row["actual_cost_usd"] = 0.0000066
+    assert not _is_valid(row), "float cost must be rejected"
+    row2 = _valid_row()
+    row2["actual_cost_usd"] = "0.01"
+    assert not _is_valid(row2), "2dp cost must be rejected; 8dp required"
+
+
+def test_envelope_digest_bare_sha256() -> None:
+    row = _valid_row()
+    row["envelope_digest"] = "sha256:" + ("a" * 64)
+    assert not _is_valid(row), "envelope_digest must be bare 64-hex"
+
+
+def test_recorded_at_calendar_coupling() -> None:
+    for bad in ("not-a-date", "2026-99-99T00:00:00Z", "2026-02-31T00:00:00Z", "2026-04-31T00:00:00Z"):
+        row = _valid_row()
+        row["recorded_at"] = bad
+        assert not _is_valid(row), f"recorded_at must reject {bad!r}"
+    # Feb-29 accepted by regex (leap validity is recompute-time, see E-2-1 boundary)
+    ok = _valid_row()
+    ok["recorded_at"] = "2026-02-29T00:00:00Z"
+    assert _is_valid(ok)
+
+
+# ---- 6. conditional invariants (allOf) (2) -----------------------------
+
+
+def test_soft_breach_requires_handling() -> None:
+    row = _valid_row()
+    row["cost_breach_state"] = "soft_breached"
+    # no cost_breach_handling
+    assert not _is_valid(row), "soft_breached without cost_breach_handling must be rejected"
+    assert _is_valid(_soft_breach_row()), "soft_breached with handling must validate"
+
+
+def test_hard_breach_requires_error_status() -> None:
+    row = _valid_row()
+    row["cost_breach_state"] = "hard_breached"
+    row["status"] = "ok"  # mismatched
+    assert not _is_valid(row), "hard_breached must require status=error"
+    row["status"] = "error"
+    assert _is_valid(row), "hard_breached + status=error must validate"
+
+
+# ---- 7. writer: fail-closed + library/workspace modes (5) --------------
+
+
+def test_writer_rejects_invalid_row_before_write(tmp_path: Path) -> None:
+    bad = _valid_row()
+    del bad["actual_cost_usd"]  # fail-closed: missing cost
+    with pytest.raises(PerCallAuditValidationError):
+        record_call(bad, workspace_root=tmp_path)
+    # nothing was written
+    assert not (tmp_path / "evidence" / "per_call_audit.jsonl").exists()
+
+
+def test_writer_library_mode_skips_persistence() -> None:
+    receipt = record_call(_valid_row(), workspace_root=None)
+    assert receipt == {"persisted": False, "mode": "library", "paths": []}
+
+
+def test_writer_workspace_mode_appends_jsonl(tmp_path: Path) -> None:
+    receipt = record_call(_valid_row(), workspace_root=tmp_path)
+    assert receipt["persisted"] is True and receipt["mode"] == "workspace"
+    audit = tmp_path / "evidence" / "per_call_audit.jsonl"
+    assert audit.is_file()
+    rows = [json.loads(line) for line in audit.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1 and rows[0]["envelope_digest"] == "a" * 64
+
+
+def test_writer_appends_are_cumulative(tmp_path: Path) -> None:
+    record_call(_valid_row(), workspace_root=tmp_path)
+    record_call(_valid_row(), workspace_root=tmp_path)
+    audit = tmp_path / "evidence" / "per_call_audit.jsonl"
+    rows = audit.read_text(encoding="utf-8").splitlines()
+    assert len(rows) == 2, "append must be cumulative (O_APPEND), not overwrite"
+
+
+def test_writer_hard_breach_cross_referenced(tmp_path: Path) -> None:
+    row = _valid_row()
+    row["cost_breach_state"] = "hard_breached"
+    row["status"] = "error"
+    receipt = record_call(row, workspace_root=tmp_path)
+    assert (tmp_path / "evidence" / "per_call_audit.jsonl").is_file()
+    breach = tmp_path / "evidence" / "cost_hard_breach.jsonl"
+    assert breach.is_file(), "hard_breached row must also land in cost_hard_breach.jsonl"
+    assert str(breach) in receipt["paths"]
+
+
+# ---- 8. governance: no workflow mutation (1) ---------------------------
+
+
+def test_no_workflow_mutation_in_diff() -> None:
+    added = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--diff-filter=A",
+            "--name-only",
+            "origin/main...HEAD",
+            "--",
+            "tests/test_per_call_audit.py",
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if added.returncode != 0:
+        pytest.skip(f"git diff unavailable: {added.stderr.strip()}")
+    if not added.stdout.strip():
+        pytest.skip("E-2-2 test not ADDED by this PR (introducer pattern); invariant N/A")
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main...HEAD", "--", ".github/workflows/"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        pytest.skip(f"git diff unavailable: {proc.stderr.strip()}")
+    touched = [p for p in proc.stdout.split() if p]
+    assert not touched, f"E-2-2 must not touch .github/workflows/. Touched: {touched}"

--- a/tests/test_per_call_audit.py
+++ b/tests/test_per_call_audit.py
@@ -59,16 +59,33 @@ def _valid_row() -> dict[str, Any]:
 
 
 def _soft_breach_row() -> dict[str, Any]:
+    """E-2-3 soft-breach contract: cost_breach_handling = {decision, decided_by,
+    decided_at} (no threshold fields)."""
     row = _valid_row()
     row["status"] = "ok"
     row["cost_breach_state"] = "soft_breached"
     row["cost_breach_handling"] = {
         "decision": "continued",
-        "soft_threshold_usd": "0.50000000",
-        "cumulative_cost_usd": "0.51000000",
+        "decided_by": "policy_default",
         "decided_at": "2026-06-04T10:00:01Z",
     }
     return row
+
+
+def _hard_breach_row() -> dict[str, Any]:
+    """E-2-3 hard-breach contract: status=error, cost_breach_handling=null."""
+    row = _valid_row()
+    row["status"] = "error"
+    row["cost_breach_state"] = "hard_breached"
+    row["cost_breach_handling"] = None
+    return row
+
+
+def _concurrent_append_worker(workspace: str, idx: int) -> None:
+    """Module-level worker so it is picklable across start methods (fork/spawn)."""
+    row = _valid_row()
+    row["request_id"] = f"{idx:08d}-4e5f-6071-8293-a4b5c6d7e8f9"
+    record_call(row, workspace_root=Path(workspace))
 
 
 # ---- 1. schema health (2) ----------------------------------------------
@@ -84,6 +101,7 @@ def test_schema_present_and_valid_draft_2020_12() -> None:
 def test_valid_rows_validate() -> None:
     assert _is_valid(_valid_row())
     assert _is_valid(_soft_breach_row())
+    assert _is_valid(_hard_breach_row())
 
 
 # ---- 2. guard-flag pins (2) --------------------------------------------
@@ -197,21 +215,61 @@ def test_recorded_at_calendar_coupling() -> None:
 # ---- 6. conditional invariants (allOf) (2) -----------------------------
 
 
-def test_soft_breach_requires_handling() -> None:
+def test_soft_breach_requires_object_handling() -> None:
     row = _valid_row()
     row["cost_breach_state"] = "soft_breached"
-    # no cost_breach_handling
     assert not _is_valid(row), "soft_breached without cost_breach_handling must be rejected"
-    assert _is_valid(_soft_breach_row()), "soft_breached with handling must validate"
+    row["cost_breach_handling"] = None  # null is not allowed for soft
+    assert not _is_valid(row), "soft_breached with null handling must be rejected"
+    assert _is_valid(_soft_breach_row()), "soft_breached with object handling must validate"
 
 
-def test_hard_breach_requires_error_status() -> None:
-    row = _valid_row()
-    row["cost_breach_state"] = "hard_breached"
-    row["status"] = "ok"  # mismatched
-    assert not _is_valid(row), "hard_breached must require status=error"
-    row["status"] = "error"
-    assert _is_valid(row), "hard_breached + status=error must validate"
+def test_soft_breach_handling_shape_matches_e23_contract() -> None:
+    # E-2-3 contract: required {decision, decided_by, decided_at}; decided_by enum
+    base = _soft_breach_row()
+    assert _is_valid(base)
+    for field in ("decision", "decided_by", "decided_at"):
+        bad = _soft_breach_row()
+        del bad["cost_breach_handling"][field]
+        assert not _is_valid(bad), f"soft handling must require {field}"
+    unknown = _soft_breach_row()
+    unknown["cost_breach_handling"]["decided_by"] = "intruder"
+    assert not _is_valid(unknown), "decided_by must be enum {operator, policy_default, caller_module}"
+    extra = _soft_breach_row()
+    extra["cost_breach_handling"]["soft_threshold_usd"] = "0.10000000"
+    assert not _is_valid(extra), "soft handling is strict-closed; unknown field rejected"
+
+
+def test_hard_breach_requires_error_status_and_null_handling() -> None:
+    # status must be error
+    bad_status = _hard_breach_row()
+    bad_status["status"] = "ok"
+    assert not _is_valid(bad_status), "hard_breached must require status=error"
+    # cost_breach_handling must be null, not an object
+    bad_obj = _hard_breach_row()
+    bad_obj["cost_breach_handling"] = {
+        "decision": "stopped",
+        "decided_by": "operator",
+        "decided_at": "2026-06-04T10:00:01Z",
+    }
+    assert not _is_valid(bad_obj), "hard_breached must carry null cost_breach_handling, not an object"
+    # the canonical hard row validates
+    assert _is_valid(_hard_breach_row())
+
+
+def test_non_soft_states_forbid_object_handling() -> None:
+    for state in ("ok", "not_applicable"):
+        row = _valid_row()
+        row["cost_breach_state"] = state
+        row["cost_breach_handling"] = {
+            "decision": "continued",
+            "decided_by": "policy_default",
+            "decided_at": "2026-06-04T10:00:01Z",
+        }
+        assert not _is_valid(row), f"{state} must not carry a populated cost_breach_handling object"
+        # null/absent is fine
+        row["cost_breach_handling"] = None
+        assert _is_valid(row), f"{state} with null handling must validate"
 
 
 # ---- 7. writer: fail-closed + library/workspace modes (5) --------------
@@ -249,14 +307,48 @@ def test_writer_appends_are_cumulative(tmp_path: Path) -> None:
 
 
 def test_writer_hard_breach_cross_referenced(tmp_path: Path) -> None:
-    row = _valid_row()
-    row["cost_breach_state"] = "hard_breached"
-    row["status"] = "error"
-    receipt = record_call(row, workspace_root=tmp_path)
+    # Uses the E-2-3 hard-breach contract (status=error, handling=null).
+    receipt = record_call(_hard_breach_row(), workspace_root=tmp_path)
     assert (tmp_path / "evidence" / "per_call_audit.jsonl").is_file()
     breach = tmp_path / "evidence" / "cost_hard_breach.jsonl"
     assert breach.is_file(), "hard_breached row must also land in cost_hard_breach.jsonl"
     assert str(breach) in receipt["paths"]
+
+
+def test_writer_invalid_row_does_not_change_existing_linecount(tmp_path: Path) -> None:
+    record_call(_valid_row(), workspace_root=tmp_path)
+    audit = tmp_path / "evidence" / "per_call_audit.jsonl"
+    before = len(audit.read_text(encoding="utf-8").splitlines())
+    bad = _valid_row()
+    bad["actual_cost_usd"] = "0.01"  # wrong precision => schema-invalid
+    with pytest.raises(PerCallAuditValidationError):
+        record_call(bad, workspace_root=tmp_path)
+    after = len(audit.read_text(encoding="utf-8").splitlines())
+    assert after == before, "a rejected row must not change the existing JSONL line count"
+
+
+def test_writer_concurrent_appends_are_line_atomic(tmp_path: Path) -> None:
+    """N concurrent processes appending must yield N lines, each parseable —
+    O_APPEND + single os.write keeps lines from interleaving (Codex E-2-2 absorb)."""
+    import multiprocessing
+
+    n = 20
+    try:
+        ctx = multiprocessing.get_context("fork")
+    except ValueError:  # platform without fork
+        pytest.skip("fork start method unavailable on this platform")
+    procs = [ctx.Process(target=_concurrent_append_worker, args=(str(tmp_path), i)) for i in range(n)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join()
+        assert p.exitcode == 0
+
+    audit = tmp_path / "evidence" / "per_call_audit.jsonl"
+    lines = audit.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == n, f"expected {n} lines, got {len(lines)}"
+    for line in lines:
+        json.loads(line)  # each line must be parseable (no interleaving)
 
 
 # ---- 8. governance: no workflow mutation (1) ---------------------------


### PR DESCRIPTION
## V5 Epic 2 E-2-2 — Per-Call Audit Evidence (#847)

**Infrastructure-only.** One JSONL audit row per (would-be) LLM call + a fail-closed writer. **No guard flag flip; no network call.** `live_adapter_execution` const false.

### What
- `per_call_audit.schema.v1.json` — strict-closure schema; `status` (provider lifecycle) vs `cost_breach_state` (ceiling) disambiguated; `actual_cost_usd` decimal-8dp required (fail-closed); calendar-coupling RFC3339; foreign-keys E-2-1 envelope via `envelope_digest`
- `allOf`: `soft_breached`⇒`cost_breach_handling` object {decision, decided_by, decided_at}; `hard_breached`⇒`status==error` + handling null; non-soft⇒no populated object
- `ao_kernel/_internal/evidence/per_call_audit.py` — pure-serializer writer: validate-before-write, library-mode skip, workspace atomic JSONL append (os.open O_APPEND + single os.write + fsync), hard-breach cross-ref. Does NOT raise `CostCeilingExceeded` (E-2-3).
- 40 invariants incl. concurrent 20-writer line-atomicity

### Cross-AI review
Implementer **claude (anthropic)** → Reviewer **codex (openai)**, thread `019e92bf`, **verdict AGREE (iter-2)**. 4 REVISE absorbed: E-2-3 hard/soft contract alignment, atomic append, test gaps. E-2-3 forward-compat confirmed.

### Guard flags (const false — unchanged)
`live_adapter_execution=false` · `support_widening=false` · `production_platform_claim=false`

Closes #847

Implementer: claude (anthropic)
Reviewer: codex (openai, thread 019e92bf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)