### PR TITLE
feat(e-2-4): add live adapter dry-run harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **E-2-4 live adapter dry-run harness** (V5 Epic 2, #849): added
+  `scripts/run_live_adapter_dryrun.py` plus
+  `ao_kernel._internal.live_adapter_dryrun` to emit schema-valid E-2-1
+  envelopes and E-2-2 per-call audit rows with deterministic stub output and
+  no provider network call. The harness installs a runtime kill-switch covering
+  raw sockets, subprocess and shell exec families, stdlib HTTP, optional HTTP
+  clients (`httpx`, `urllib3`, `requests`, `aiohttp` when installed), and
+  native escape hatches (`ctypes.CDLL`, `cffi.FFI`). It integrates E-2-3 cost
+  ceiling recording for simulated dry-run cost and exits `2` on hard breach.
+  Documentation: `docs/LIVE-ADAPTER-DRY-RUN.md`. Guard flags remain false; no
+  workflow mutation, secret readback, support widening, production claim, or
+  live adapter execution.
 - **E-2-3 cost ceiling enforcement module** (V5 Epic 2, #848): added
   `ao_kernel._internal.cost_ceiling.CostCeiling` plus the public
   `ao_kernel.cost` facade export for Decimal-only soft/hard USD ceiling

--- a/ao_kernel/_internal/cost_ceiling.py
+++ b/ao_kernel/_internal/cost_ceiling.py
@@ -64,7 +64,7 @@ def _as_decimal(value: Decimal, *, field: str) -> Decimal:
 
 
 def _format_decimal(value: Decimal) -> str:
-    return str(value.quantize(_EIGHT_DP, rounding=ROUND_HALF_UP))
+    return format(value.quantize(_EIGHT_DP, rounding=ROUND_HALF_UP), "f")
 
 
 def _safe_session_id(session_id: str) -> str:

--- a/ao_kernel/_internal/live_adapter_dryrun.py
+++ b/ao_kernel/_internal/live_adapter_dryrun.py
@@ -1,0 +1,567 @@
+"""Dry-run live-adapter evidence harness (V5 Epic 2 E-2-4).
+
+This module builds real E-2-1/E-2-2 evidence shapes while emitting only a
+deterministic stub response. It is infrastructure-only:
+
+- no provider network call is made,
+- no secret material is read or serialized,
+- ``live_adapter_execution`` / ``support_widening`` /
+  ``production_platform_claim`` remain false.
+
+The runtime kill-switch is intentionally broad. It patches common network,
+subprocess, shell, and native-library escape hatches while dry-run evidence is
+being built. Optional third-party libraries are patched only when installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime as dt
+import hashlib
+import http.client
+import importlib
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Callable, Literal, Mapping
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel._internal.evidence.per_call_audit import record_call as record_per_call_audit
+from ao_kernel.config import load_default
+from ao_kernel.cost import CostCeiling, CostCeilingExceeded
+
+_ENVELOPE_SCHEMA = "live_adapter_envelope.schema.v1.json"
+_AUDIT_SCHEMA = "per_call_audit.schema.v1.json"
+_POLICY_NAME = "policy_cost_ceiling.v1.json"
+_EIGHT_DP = Decimal("0.00000001")
+_ZERO = Decimal("0.00000000")
+_STUB_TEXT = "AO-KERNEL LIVE ADAPTER DRY-RUN STUB RESPONSE"
+_SECRET_BOUNDARY = "no_secret_material_emitted_no_token_no_credential"
+
+
+class DryRunKillSwitchError(RuntimeError):
+    """Raised when dry-run code attempts a forbidden side effect."""
+
+
+class DryRunSchemaError(ValueError):
+    """Raised when generated dry-run evidence fails schema validation."""
+
+
+@dataclass(frozen=True)
+class DryRunResult:
+    """Result returned by :func:`run_live_adapter_dryrun`."""
+
+    envelope: dict[str, Any]
+    audit_row: dict[str, Any]
+    envelope_path: Path
+    audit_receipt: dict[str, Any]
+    cost_breach_state: str
+    workspace_root: Path | None
+
+
+RestoreCallback = Callable[[], None]
+_KILLSWITCH_LOCK = threading.RLock()
+_KILLSWITCH_ACTIVE_COUNT = 0
+_KILLSWITCH_RESTORE: list[RestoreCallback] = []
+
+
+def _deny(target: str) -> Callable[..., Any]:
+    def _raise(*_args: Any, **_kwargs: Any) -> Any:
+        raise DryRunKillSwitchError(f"network call attempted by dry-run kill-switch: {target}")
+
+    return _raise
+
+
+class DryRunKillSwitches:
+    """Context manager that blocks network/subprocess bypass paths."""
+
+    def __init__(self) -> None:
+        self._entered = False
+
+    def __enter__(self) -> "DryRunKillSwitches":
+        global _KILLSWITCH_ACTIVE_COUNT
+        with _KILLSWITCH_LOCK:
+            if _KILLSWITCH_ACTIVE_COUNT == 0:
+                _KILLSWITCH_RESTORE.clear()
+                try:
+                    self._install()
+                except BaseException:
+                    self._restore_all()
+                    raise
+            _KILLSWITCH_ACTIVE_COUNT += 1
+            self._entered = True
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        global _KILLSWITCH_ACTIVE_COUNT
+        del exc_type, exc, tb
+        with _KILLSWITCH_LOCK:
+            if not self._entered:
+                return
+            self._entered = False
+            _KILLSWITCH_ACTIVE_COUNT -= 1
+            if _KILLSWITCH_ACTIVE_COUNT == 0:
+                self._restore_all()
+
+    @staticmethod
+    def _restore_all() -> None:
+        while _KILLSWITCH_RESTORE:
+            restore = _KILLSWITCH_RESTORE.pop()
+            restore()
+
+    def _patch_attr(self, obj: Any, name: str, value: Any) -> None:
+        sentinel = object()
+        original = getattr(obj, name, sentinel)
+        setattr(obj, name, value)
+
+        def _restore() -> None:
+            if original is sentinel:
+                with contextlib.suppress(AttributeError):
+                    delattr(obj, name)
+            else:
+                setattr(obj, name, original)
+
+        _KILLSWITCH_RESTORE.append(_restore)
+
+    def _patch_optional(self, module_name: str, patcher: Callable[[Any], None]) -> None:
+        with contextlib.suppress(ImportError):
+            patcher(importlib.import_module(module_name))
+
+    def _install(self) -> None:
+        self._patch_socket()
+        self._patch_subprocess()
+        self._patch_os_exec()
+        self._patch_http_stdlib()
+        self._patch_optional_http_clients()
+        self._patch_native_libs()
+
+    def _patch_socket(self) -> None:
+        # Patch the class method first so pre-captured ``socket.socket`` aliases
+        # are still blocked; then replace the module-level constructor too.
+        self._patch_attr(socket.socket, "connect", _deny("socket.socket.connect"))
+        self._patch_attr(socket, "socket", _deny("socket.socket"))
+        self._patch_attr(socket, "create_connection", _deny("socket.create_connection"))
+
+    def _patch_subprocess(self) -> None:
+        self._patch_attr(subprocess.Popen, "__init__", _deny("subprocess.Popen"))
+        for name in ("run", "call", "check_output", "check_call"):
+            self._patch_attr(subprocess, name, _deny(f"subprocess.{name}"))
+
+    def _patch_os_exec(self) -> None:
+        for name in (
+            "system",
+            "popen",
+            "spawnl",
+            "spawnle",
+            "spawnlp",
+            "spawnlpe",
+            "spawnv",
+            "spawnve",
+            "spawnvp",
+            "spawnvpe",
+            "execl",
+            "execle",
+            "execlp",
+            "execlpe",
+            "execv",
+            "execve",
+            "execvp",
+            "execvpe",
+        ):
+            if hasattr(os, name):
+                self._patch_attr(os, name, _deny(f"os.{name}"))
+
+    def _patch_http_stdlib(self) -> None:
+        self._patch_attr(urllib.request, "urlopen", _deny("urllib.request.urlopen"))
+        self._patch_attr(http.client.HTTPConnection, "request", _deny("http.client.HTTPConnection.request"))
+        self._patch_attr(http.client.HTTPSConnection, "request", _deny("http.client.HTTPSConnection.request"))
+
+    def _patch_optional_http_clients(self) -> None:
+        def _httpx(httpx: Any) -> None:
+            self._patch_attr(httpx.Client, "send", _deny("httpx.Client.send"))
+            self._patch_attr(httpx.AsyncClient, "send", _deny("httpx.AsyncClient.send"))
+            self._patch_attr(httpx, "stream", _deny("httpx.stream"))
+
+        def _urllib3(urllib3: Any) -> None:
+            pool = urllib3.connectionpool.HTTPConnectionPool
+            self._patch_attr(pool, "_make_request", _deny("urllib3.HTTPConnectionPool._make_request"))
+
+        def _requests(requests: Any) -> None:
+            self._patch_attr(requests.api, "request", _deny("requests.api.request"))
+
+        def _aiohttp(aiohttp: Any) -> None:
+            self._patch_attr(aiohttp.ClientSession, "_request", _deny("aiohttp.ClientSession._request"))
+
+        self._patch_optional("httpx", _httpx)
+        self._patch_optional("urllib3", _urllib3)
+        self._patch_optional("requests", _requests)
+        self._patch_optional("aiohttp", _aiohttp)
+
+    def _patch_native_libs(self) -> None:
+        def _ctypes(ctypes: Any) -> None:
+            self._patch_attr(ctypes, "CDLL", _deny("ctypes.CDLL"))
+
+        def _cffi(cffi: Any) -> None:
+            self._patch_attr(cffi, "FFI", _deny("cffi.FFI"))
+
+        self._patch_optional("ctypes", _ctypes)
+        self._patch_optional("cffi", _cffi)
+
+
+def install_dry_run_killswitches() -> DryRunKillSwitches:
+    """Return a context manager that blocks dry-run side effects."""
+
+    return DryRunKillSwitches()
+
+
+def _iso_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _canonical_bytes(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sha256_text(payload: str) -> str:
+    return _sha256_bytes(payload.encode("utf-8"))
+
+
+def _format_decimal(value: Decimal) -> str:
+    return format(value.quantize(_EIGHT_DP, rounding=ROUND_HALF_UP), "f")
+
+
+def _parse_decimal(value: str, *, field: str) -> Decimal:
+    try:
+        parsed = Decimal(value)
+    except InvalidOperation as exc:
+        raise ValueError(f"{field} must be a decimal string") from exc
+    if not parsed.is_finite() or parsed < _ZERO:
+        raise ValueError(f"{field} must be a finite non-negative decimal string")
+    return parsed.quantize(_EIGHT_DP, rounding=ROUND_HALF_UP)
+
+
+def _schema_validator(schema_name: str) -> Draft202012Validator:
+    return Draft202012Validator(load_default("schemas", schema_name))
+
+
+def _validate_payload(payload: dict[str, Any], *, schema_name: str) -> None:
+    errors = sorted(_schema_validator(schema_name).iter_errors(payload), key=lambda err: list(err.absolute_path))
+    if errors:
+        joined = "; ".join(f"{'/'.join(str(p) for p in err.absolute_path) or '<root>'}: {err.message}" for err in errors)
+        raise DryRunSchemaError(f"{schema_name} validation failed: {joined}")
+
+
+def _pricing_source_digest() -> str:
+    policy = load_default("policies", _POLICY_NAME)
+    return "sha256:" + _sha256_bytes(_canonical_bytes(policy))
+
+
+def _compute_envelope_digest(envelope: Mapping[str, Any]) -> str:
+    unsigned = dict(envelope)
+    unsigned.pop("envelope_digest", None)
+    return _sha256_bytes(_canonical_bytes(unsigned))
+
+
+def build_dry_run_envelope(
+    *,
+    provider_id: str,
+    model: str,
+    intent: str,
+    request_id: str | None = None,
+    prompt: str = "",
+    max_tokens: int = 256,
+    temperature: float = 0.0,
+    cost_usd: Decimal = _ZERO,
+) -> dict[str, Any]:
+    """Build and validate one E-2-1 dry-run envelope."""
+
+    request_uuid = request_id or str(uuid.uuid4())
+    now = _iso_now()
+    cost = _format_decimal(cost_usd)
+    input_tokens = 0
+    output_tokens = 0
+    envelope: dict[str, Any] = {
+        "schema_version": "live-adapter-envelope.v1",
+        "artifact_kind": "live_adapter_envelope",
+        "envelope_digest": "0" * 64,
+        "mode": "dry_run",
+        "live_adapter_execution": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+        "request": {
+            "provider_id": provider_id,
+            "model": model,
+            "request_id": request_uuid,
+            "intent": intent,
+            "messages_digest": _sha256_text(prompt),
+            "params": {"temperature": temperature, "max_tokens": max_tokens},
+        },
+        "response": {
+            "text_digest": _sha256_text(_STUB_TEXT),
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "total_tokens": input_tokens + output_tokens,
+            },
+            "latency_ms": 0.0,
+            "status": "dry_run_emitted",
+        },
+        "cost": {
+            "currency": "USD",
+            "input_cost_per_1k_usd": "0.00000000",
+            "output_cost_per_1k_usd": "0.00000000",
+            "actual_cost_usd": cost,
+            "pricing_source_digest": _pricing_source_digest(),
+        },
+        "circuit_breaker": {"state": "CLOSED", "failure_count": 0, "last_failure_at": None},
+        "secret_boundary": _SECRET_BOUNDARY,
+        "timestamps": {"created_at": now, "finalized_at": now},
+    }
+    envelope["envelope_digest"] = _compute_envelope_digest(envelope)
+    _validate_payload(envelope, schema_name=_ENVELOPE_SCHEMA)
+    return envelope
+
+
+def build_per_call_audit_row(envelope: Mapping[str, Any], *, cost_breach_state: str) -> dict[str, Any]:
+    """Build and validate the E-2-2 audit row bound to ``envelope``."""
+
+    response = envelope["response"]
+    request = envelope["request"]
+    cost = envelope["cost"]
+    row: dict[str, Any] = {
+        "schema_version": "per-call-audit.v1",
+        "artifact_kind": "per_call_audit",
+        "envelope_digest": envelope["envelope_digest"],
+        "provider_id": request["provider_id"],
+        "model": request["model"],
+        "request_id": request["request_id"],
+        "intent": request["intent"],
+        "input_tokens": response["usage"]["input_tokens"],
+        "output_tokens": response["usage"]["output_tokens"],
+        "total_tokens": response["usage"]["total_tokens"],
+        "actual_cost_usd": cost["actual_cost_usd"],
+        "latency_ms": int(response["latency_ms"]),
+        "status": response["status"],
+        "cost_breach_state": cost_breach_state,
+        "live_adapter_execution": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+        "recorded_at": envelope["timestamps"]["finalized_at"],
+    }
+    if cost_breach_state == "soft_breached":
+        row["cost_breach_handling"] = {
+            "decision": "deferred",
+            "decided_by": "policy_default",
+            "decided_at": envelope["timestamps"]["finalized_at"],
+        }
+    elif cost_breach_state == "hard_breached":
+        row["status"] = "error"
+        row["cost_breach_handling"] = None
+    _validate_payload(row, schema_name=_AUDIT_SCHEMA)
+    return row
+
+
+def _infer_workspace_root(output: Path, workspace_root: Path | None) -> Path | None:
+    if workspace_root is not None:
+        return workspace_root
+    parent = output.parent
+    if parent.name == "evidence":
+        return parent.parent
+    return None
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    tmp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(rendered)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+        os.replace(tmp_path, path)
+        with contextlib.suppress(OSError):
+            directory_fd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            tmp_path.unlink()
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def run_live_adapter_dryrun(
+    *,
+    provider_id: str,
+    model: str,
+    intent: str,
+    output: Path,
+    prompt: str = "",
+    workspace_root: Path | None = None,
+    dry_run_cost_usd: Decimal = _ZERO,
+    session_id: str = "e-2-4-dry-run",
+    max_tokens: int = 256,
+    temperature: float = 0.0,
+) -> DryRunResult:
+    """Run the dry-run harness and write one envelope artifact."""
+
+    output_path = Path(output)
+    resolved_workspace = _infer_workspace_root(output_path, workspace_root)
+    with install_dry_run_killswitches():
+        envelope = build_dry_run_envelope(
+            provider_id=provider_id,
+            model=model,
+            intent=intent,
+            prompt=prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            cost_usd=dry_run_cost_usd,
+        )
+        state: Literal["ok", "soft_breached", "hard_breached", "not_applicable"]
+        if dry_run_cost_usd == _ZERO:
+            state = "not_applicable"
+        else:
+            provisional_row = build_per_call_audit_row(envelope, cost_breach_state="ok")
+            state = CostCeiling.from_policy(workspace_root=resolved_workspace, session_id=session_id).record_call(
+                dry_run_cost_usd,
+                mode="dry_run",
+                status="dry_run_emitted",
+                audit_row=provisional_row,
+            )
+        audit_row = build_per_call_audit_row(envelope, cost_breach_state=state)
+        audit_receipt = record_per_call_audit(audit_row, workspace_root=resolved_workspace)
+        _write_json(output_path, envelope)
+    return DryRunResult(
+        envelope=envelope,
+        audit_row=audit_row,
+        envelope_path=output_path,
+        audit_receipt=audit_receipt,
+        cost_breach_state=state,
+        workspace_root=resolved_workspace,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Emit a no-network live-adapter dry-run envelope.")
+    parser.add_argument("--provider", required=True, dest="provider_id", help="Provider id to record in the envelope.")
+    parser.add_argument("--model", required=True, help="Model id to record in the envelope.")
+    parser.add_argument("--intent", required=True, help="Intent label to record in the envelope.")
+    parser.add_argument("--output", required=True, type=Path, help="Envelope artifact output path.")
+    parser.add_argument("--prompt", default="", help="Prompt text to digest; never serialized verbatim.")
+    parser.add_argument("--workspace-root", type=Path, default=None, help="Optional workspace root for JSONL evidence.")
+    parser.add_argument("--session-id", default="e-2-4-dry-run", help="Cost ceiling session id.")
+    parser.add_argument("--max-tokens", type=int, default=256, help="Dry-run request max_tokens metadata.")
+    parser.add_argument("--temperature", type=float, default=0.0, help="Dry-run request temperature metadata.")
+    parser.add_argument(
+        "--dry-run-cost-usd",
+        default="0.00000000",
+        help="Decimal-string simulated dry-run cost; defaults to zero.",
+    )
+    parser.add_argument("--output-format", choices=("json", "text"), default="json", help="Stdout format.")
+    return parser
+
+
+def _render_text(result: DryRunResult) -> str:
+    workspace = str(result.workspace_root) if result.workspace_root is not None else "library"
+    return "\n".join(
+        [
+            "live-adapter dry-run: ok",
+            f"envelope: {result.envelope_path}",
+            f"envelope_digest: {result.envelope['envelope_digest']}",
+            f"cost_breach_state: {result.cost_breach_state}",
+            f"workspace: {workspace}",
+            "live_adapter_execution: false",
+            "support_widening: false",
+            "production_platform_claim: false",
+        ]
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        cost = _parse_decimal(args.dry_run_cost_usd, field="dry_run_cost_usd")
+        result = run_live_adapter_dryrun(
+            provider_id=args.provider_id,
+            model=args.model,
+            intent=args.intent,
+            output=args.output,
+            prompt=args.prompt,
+            workspace_root=args.workspace_root,
+            dry_run_cost_usd=cost,
+            session_id=args.session_id,
+            max_tokens=args.max_tokens,
+            temperature=args.temperature,
+        )
+    except CostCeilingExceeded as exc:
+        print(f"cost ceiling breached: {exc}", file=sys.stderr)
+        return 2
+    except (DryRunKillSwitchError, DryRunSchemaError, ValueError, OSError) as exc:
+        print(f"live-adapter dry-run failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output_format == "json":
+        print(
+            json.dumps(
+                {
+                    "status": "ok",
+                    "envelope_path": str(result.envelope_path),
+                    "envelope_digest": result.envelope["envelope_digest"],
+                    "audit_receipt": result.audit_receipt,
+                    "cost_breach_state": result.cost_breach_state,
+                    "workspace_root": str(result.workspace_root) if result.workspace_root is not None else None,
+                    "live_adapter_execution": False,
+                    "support_widening": False,
+                    "production_platform_claim": False,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(_render_text(result))
+    return 0
+
+
+__all__ = [
+    "DryRunKillSwitchError",
+    "DryRunKillSwitches",
+    "DryRunResult",
+    "DryRunSchemaError",
+    "build_dry_run_envelope",
+    "build_per_call_audit_row",
+    "install_dry_run_killswitches",
+    "main",
+    "run_live_adapter_dryrun",
+]

--- a/docs/LIVE-ADAPTER-DRY-RUN.md
+++ b/docs/LIVE-ADAPTER-DRY-RUN.md
@@ -1,0 +1,55 @@
+# Live Adapter Dry-Run Harness
+
+The V5 E-2-4 dry-run harness emits the real governance evidence shape for a
+would-be live adapter call while forcing the response to a deterministic stub.
+It is infrastructure-only: it never opens a provider network connection, never
+reads or serializes secret material, and never flips the guard flags.
+
+## Command
+
+```bash
+python3 scripts/run_live_adapter_dryrun.py \
+  --provider openai \
+  --model gpt-4o-mini \
+  --intent FAST_TEXT \
+  --output evidence/dryrun-$(date -u +%Y%m%dT%H%M%SZ).envelope.v1.json
+```
+
+When the output path is inside an `evidence/` directory, the parent directory is
+treated as the workspace root and the harness also appends the E-2-2 audit row to
+`evidence/per_call_audit.jsonl`. If the output path is elsewhere and no
+`--workspace-root` is provided, the harness runs in library mode and validates
+the audit row without persisting it.
+
+## Evidence
+
+The envelope validates against `live_adapter_envelope.schema.v1.json`:
+
+- `mode: dry_run`
+- `response.status: dry_run_emitted`
+- `cost.actual_cost_usd: 0.00000000` by default
+- `live_adapter_execution: false`
+- `support_widening: false`
+- `production_platform_claim: false`
+- `envelope_digest` recomputed from canonical JSON excluding the digest field
+
+The audit row validates against `per_call_audit.schema.v1.json` and foreign-keys
+to the envelope through `envelope_digest`.
+
+## Kill-Switch
+
+While evidence is generated, the harness installs a runtime kill-switch that
+blocks raw sockets, subprocess families, shell exec helpers, stdlib HTTP,
+optional HTTP clients (`httpx`, `urllib3`, `requests`, `aiohttp` when installed),
+and native escape hatches (`ctypes.CDLL`, `cffi.FFI` when installed). Bypass
+coverage is pinned by `tests/test_dryrun_killswitch_bypass.py` and static native
+usage is pinned by `tests/test_dryrun_import_denylist.py`.
+
+## Cost Ceiling
+
+Default dry-run cost is zero, so cost ceiling state is `not_applicable`. For
+testing the E-2-3 integration, `--dry-run-cost-usd` can simulate a non-zero
+dry-run cost. If the configured hard ceiling is exceeded, the command exits `2`
+and records the E-2-2 hard-breach audit row through the cost ceiling module.
+
+This command is not live evidence and does not authorize live adapter execution.

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "E-2-3-COST-CEILING",
+  "work_package": "E-2-4-DRY-RUN-HARNESS",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,17 +13,16 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-2-3-cost-ceiling",
+    "head_ref": "refs/heads/codex/epic-2-4-dry-run-harness",
     "changed_files": [
-      ".claude/plans/adr/ADR-0006-cost-ceiling-enforcement.md",
-      ".claude/plans/adr/index.json",
       "CHANGELOG.md",
       "ao_kernel/_internal/cost_ceiling.py",
-      "ao_kernel/cost/__init__.py",
-      "ao_kernel/cost/errors.py",
-      "ao_kernel/defaults/policies/policy_cost_ceiling.v1.json",
-      "tests/test_adr_cross_ai_revalidation.py",
-      "tests/test_cost_ceiling.py",
+      "ao_kernel/_internal/live_adapter_dryrun.py",
+      "docs/LIVE-ADAPTER-DRY-RUN.md",
+      "scripts/run_live_adapter_dryrun.py",
+      "tests/test_dryrun_import_denylist.py",
+      "tests/test_dryrun_killswitch_bypass.py",
+      "tests/test_live_adapter_dryrun.py",
       "local-ai-review-evidence.v1.json"
     ]
   },
@@ -36,17 +35,20 @@
     { "name": "gpp_next_guard_flags", "status": "pass" },
     { "name": "diff_whitespace", "status": "pass" },
     { "name": "workflow_mutation_guard", "status": "pass" },
-    { "name": "hard_breach_fail_closed", "status": "pass" },
-    { "name": "workspace_lock_serialization", "status": "pass" },
+    { "name": "dry_run_no_network_killswitch", "status": "pass" },
+    { "name": "envelope_schema_validation", "status": "pass" },
+    { "name": "per_call_audit_binding", "status": "pass" },
+    { "name": "cost_ceiling_integration", "status": "pass" },
     { "name": "cross_provider_review", "status": "pass" }
   ],
   "findings": [
-    "Claude Anthropic cross-provider review returned AGREE for E-2-3 cost ceiling enforcement. Scope reviewed: cost ceiling primitive, public cost facade exports, policy JSON, ADR-0006, changelog, and tests.",
-    "Decimal-only arithmetic, explicit ok/soft_breached states, hard-breach CostCeilingExceeded behavior, reservation/settle semantics, and workspace JSONL locking were reviewed as correct.",
-    "Hard-breach audit integration is fail-closed: when the optional E-2-2 audit row is invalid, the primary CostCeilingExceeded exception is still raised with the audit validation error as cause.",
-    "Guard flags remain false in policy, state rows, and ADR metadata. No live adapter execution, support widening, production platform claim, workflow mutation, or secret recording is introduced.",
-    "The existing E-1-6 ADR body-mutation invariant was narrowed to existing ADR markdown files and now skips newly added ADR files; this preserves the original guard while avoiding false positives for ADR-0006 creation and ADR index updates.",
-    "Reviewer noted a non-blocking performance observation: workspace mode rereads JSONL state on each locked operation; acceptable for E-2-3 infrastructure-only scope and can be revisited if live execution is later superseded."
+    "Claude Anthropic cross-provider review returned AGREE for E-2-4 live adapter dry-run harness after an initial full review and a follow-up review of advisory hardening changes.",
+    "Scope reviewed: dry-run harness module, CLI wrapper, kill-switch bypass tests, import denylist tests, live adapter dry-run tests, docs, changelog, and the Decimal formatting fix in the E-2-3 cost ceiling module.",
+    "The harness emits schema-valid E-2-1 dry-run envelopes and E-2-2 per-call audit rows with deterministic stub output, prompt digesting, no prompt serialization, and no provider network call.",
+    "Runtime kill-switches block raw sockets, subprocess, shell, spawn and exec families, stdlib HTTP, optional httpx/urllib3/requests/aiohttp clients, and native ctypes/cffi escape hatches while dry-run evidence is built.",
+    "Follow-up hardening absorbed reviewer observations: overlapping kill-switch contexts now restore only after the last exit; os.exec family is patched; envelope writes use tmp file, fsync, os.replace, directory fsync, and final 0600 permissions.",
+    "E-2-3 cost ceiling integration is reviewed as correct for simulated dry-run cost: zero cost records not_applicable, hard breach exits 2 and records fail-closed cost evidence without writing the envelope artifact.",
+    "Guard flags remain false in envelope, audit row, CLI output, and gpp_next status. No workflow mutation, secret readback, live adapter execution, support widening, or production platform claim is introduced."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/run_live_adapter_dryrun.py
+++ b/scripts/run_live_adapter_dryrun.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""CLI wrapper for the V5 E-2-4 no-network live-adapter dry-run harness."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel._internal.live_adapter_dryrun import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dryrun_import_denylist.py
+++ b/tests/test_dryrun_import_denylist.py
@@ -1,0 +1,46 @@
+"""Static native-bypass denylist for the E-2-4 dry-run harness."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_TARGETS = [
+    _REPO_ROOT / "ao_kernel" / "_internal" / "live_adapter_dryrun.py",
+    _REPO_ROOT / "scripts" / "run_live_adapter_dryrun.py",
+]
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _call_name(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
+    return ""
+
+
+def test_dryrun_harness_does_not_call_native_network_bypass_primitives() -> None:
+    offenders: list[str] = []
+    for target in _TARGETS:
+        tree = ast.parse(target.read_text(encoding="utf-8"), filename=str(target))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = _call_name(node.func)
+            if name == "cffi.FFI":
+                offenders.append(f"{target}: cffi.FFI()")
+            if name == "ctypes.CDLL":
+                literal = node.args[0].value if node.args and isinstance(node.args[0], ast.Constant) else None
+                if isinstance(literal, str) and "curl" in literal.lower():
+                    offenders.append(f"{target}: ctypes.CDLL({literal!r})")
+    assert not offenders, "dry-run harness must not call native network bypass primitives: " + ", ".join(offenders)
+
+
+def test_dryrun_script_is_thin_wrapper_only() -> None:
+    script = (_REPO_ROOT / "scripts" / "run_live_adapter_dryrun.py").read_text(encoding="utf-8")
+    assert "subprocess" not in script
+    assert "socket" not in script
+    assert "urllib" not in script
+    assert "httpx" not in script

--- a/tests/test_dryrun_killswitch_bypass.py
+++ b/tests/test_dryrun_killswitch_bypass.py
@@ -1,0 +1,135 @@
+"""Runtime bypass tests for the E-2-4 dry-run kill-switch."""
+
+from __future__ import annotations
+
+import http.client
+import os
+import socket
+import subprocess
+import urllib.request
+from typing import Callable
+
+import pytest
+
+from ao_kernel._internal.live_adapter_dryrun import DryRunKillSwitchError, install_dry_run_killswitches
+
+
+def _assert_blocked(attempt: Callable[[], object]) -> None:
+    with install_dry_run_killswitches(), pytest.raises(DryRunKillSwitchError, match="network call attempted"):
+        attempt()
+
+
+def test_blocks_socket_constructor_and_create_connection() -> None:
+    _assert_blocked(lambda: socket.socket(socket.AF_INET, socket.SOCK_STREAM))
+    _assert_blocked(lambda: socket.create_connection(("127.0.0.1", 9), timeout=0.01))
+
+
+def test_blocks_precaptured_socket_connect_alias() -> None:
+    socket_class = socket.socket
+
+    def _attempt() -> object:
+        sock = socket_class(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.connect(("127.0.0.1", 9))
+            return None
+        finally:
+            sock.close()
+
+    _assert_blocked(_attempt)
+
+
+@pytest.mark.parametrize(
+    "attempt",
+    [
+        lambda: subprocess.Popen(["true"]),  # noqa: S603,S607 - bypass fixture
+        lambda: subprocess.run(["true"], check=False),  # noqa: S603,S607
+        lambda: subprocess.call(["true"]),  # noqa: S603,S607
+        lambda: subprocess.check_output(["true"]),  # noqa: S603,S607
+        lambda: subprocess.check_call(["true"]),  # noqa: S603,S607
+    ],
+)
+def test_blocks_subprocess_full_family(attempt: Callable[[], object]) -> None:
+    _assert_blocked(attempt)
+
+
+@pytest.mark.parametrize(
+    "attempt",
+    [
+        lambda: os.system("true"),
+        lambda: os.popen("true"),
+        lambda: os.spawnv(os.P_WAIT, "/bin/echo", ["echo", "x"]),
+    ],
+)
+def test_blocks_os_shell_exec_family(attempt: Callable[[], object]) -> None:
+    _assert_blocked(attempt)
+
+
+def test_exec_family_is_patched_without_invoking_originals() -> None:
+    names = ("execl", "execle", "execlp", "execlpe", "execv", "execve", "execvp", "execvpe")
+    originals = {name: getattr(os, name) for name in names if hasattr(os, name)}
+
+    with install_dry_run_killswitches():
+        for name, original in originals.items():
+            assert getattr(os, name) is not original
+
+    for name, original in originals.items():
+        assert getattr(os, name) is original
+
+
+def test_overlapping_killswitch_contexts_restore_after_last_exit() -> None:
+    original_socket = socket.socket
+    first = install_dry_run_killswitches()
+    second = install_dry_run_killswitches()
+
+    first.__enter__()
+    try:
+        second.__enter__()
+        try:
+            first.__exit__(None, None, None)
+            with pytest.raises(DryRunKillSwitchError, match="network call attempted"):
+                socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        finally:
+            second.__exit__(None, None, None)
+
+    finally:
+        if socket.socket is not original_socket:
+            first.__exit__(None, None, None)
+
+    assert socket.socket is original_socket
+
+
+def test_blocks_urllib_and_http_client() -> None:
+    _assert_blocked(lambda: urllib.request.urlopen("https://example.com", timeout=1))
+    _assert_blocked(lambda: http.client.HTTPConnection("example.com").request("GET", "/"))
+    _assert_blocked(lambda: http.client.HTTPSConnection("example.com").request("GET", "/"))
+
+
+def test_blocks_httpx_sync_async_and_stream_if_installed() -> None:
+    httpx = pytest.importorskip("httpx")
+    _assert_blocked(lambda: httpx.Client().send(httpx.Request("GET", "https://example.com")))
+    _assert_blocked(lambda: httpx.stream("GET", "https://example.com"))
+    _assert_blocked(lambda: httpx.AsyncClient().send(httpx.Request("GET", "https://example.com")))
+
+
+def test_blocks_urllib3_if_installed() -> None:
+    urllib3 = pytest.importorskip("urllib3")
+    pool = urllib3.PoolManager()
+    _assert_blocked(lambda: pool.request("GET", "https://example.com"))
+
+
+def test_blocks_requests_if_installed() -> None:
+    requests = pytest.importorskip("requests")
+    _assert_blocked(lambda: requests.get("https://example.com", timeout=1))
+
+
+def test_blocks_aiohttp_if_installed() -> None:
+    aiohttp = pytest.importorskip("aiohttp")
+    _assert_blocked(lambda: object.__new__(aiohttp.ClientSession)._request("GET", "https://example.com"))
+
+
+def test_blocks_native_library_escape_hatches_if_installed() -> None:
+    import ctypes
+
+    _assert_blocked(lambda: ctypes.CDLL("libcurl"))
+    cffi = pytest.importorskip("cffi")
+    _assert_blocked(lambda: cffi.FFI())

--- a/tests/test_live_adapter_dryrun.py
+++ b/tests/test_live_adapter_dryrun.py
@@ -1,0 +1,170 @@
+"""V5 Epic 2 E-2-4 dry-run harness invariants."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from ao_kernel._internal.live_adapter_dryrun import (
+    _compute_envelope_digest,
+    build_dry_run_envelope,
+    build_per_call_audit_row,
+    main,
+    run_live_adapter_dryrun,
+)
+from ao_kernel.config import load_default
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _validates(payload: dict[str, Any], schema_name: str) -> bool:
+    return not list(Draft202012Validator(load_default("schemas", schema_name)).iter_errors(payload))
+
+
+def test_build_dry_run_envelope_is_strict_schema_valid_and_digest_bound() -> None:
+    envelope = build_dry_run_envelope(provider_id="openai", model="gpt-4o-mini", intent="FAST_TEXT")
+
+    assert _validates(envelope, "live_adapter_envelope.schema.v1.json")
+    assert envelope["mode"] == "dry_run"
+    assert envelope["response"]["status"] == "dry_run_emitted"
+    assert envelope["live_adapter_execution"] is False
+    assert envelope["support_widening"] is False
+    assert envelope["production_platform_claim"] is False
+    assert envelope["cost"]["actual_cost_usd"] == "0.00000000"
+    assert envelope["envelope_digest"] == _compute_envelope_digest(envelope)
+
+
+def test_build_per_call_audit_row_binds_to_envelope_digest() -> None:
+    envelope = build_dry_run_envelope(provider_id="openai", model="gpt-4o-mini", intent="FAST_TEXT")
+    audit = build_per_call_audit_row(envelope, cost_breach_state="not_applicable")
+
+    assert _validates(audit, "per_call_audit.schema.v1.json")
+    assert audit["envelope_digest"] == envelope["envelope_digest"]
+    assert audit["status"] == "dry_run_emitted"
+    assert audit["cost_breach_state"] == "not_applicable"
+    assert audit["live_adapter_execution"] is False
+
+
+def test_run_live_adapter_dryrun_writes_envelope_and_workspace_audit(tmp_path: Path) -> None:
+    output = tmp_path / "evidence" / "dryrun.envelope.v1.json"
+    result = run_live_adapter_dryrun(
+        provider_id="openai",
+        model="gpt-4o-mini",
+        intent="FAST_TEXT",
+        output=output,
+        prompt="hello",
+    )
+
+    envelope = json.loads(output.read_text(encoding="utf-8"))
+    audit_rows = [json.loads(line) for line in (tmp_path / "evidence" / "per_call_audit.jsonl").read_text().splitlines()]
+    assert result.workspace_root == tmp_path
+    assert _validates(envelope, "live_adapter_envelope.schema.v1.json")
+    assert len(audit_rows) == 1
+    assert audit_rows[0]["envelope_digest"] == envelope["envelope_digest"]
+    assert audit_rows[0]["cost_breach_state"] == "not_applicable"
+    assert output.stat().st_mode & 0o777 == 0o600
+    assert not list(output.parent.glob(".dryrun.envelope.v1.json.*.tmp"))
+
+
+def test_run_live_adapter_dryrun_library_mode_when_output_not_under_evidence(tmp_path: Path) -> None:
+    output = tmp_path / "dryrun.envelope.v1.json"
+    result = run_live_adapter_dryrun(
+        provider_id="anthropic",
+        model="claude-3-5-sonnet",
+        intent="FAST_TEXT",
+        output=output,
+    )
+
+    assert output.is_file()
+    assert result.workspace_root is None
+    assert result.audit_receipt == {"persisted": False, "mode": "library", "paths": []}
+    assert not (tmp_path / "evidence").exists()
+
+
+def test_cli_returns_zero_and_prints_no_secret_or_live_claim(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    output = tmp_path / "evidence" / "dryrun.envelope.v1.json"
+
+    rc = main(
+        [
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-4o-mini",
+            "--intent",
+            "FAST_TEXT",
+            "--prompt",
+            "not serialized",
+            "--output",
+            str(output),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "not serialized" not in captured.out
+    assert "live_adapter_execution" in captured.out
+    assert json.loads(output.read_text(encoding="utf-8"))["live_adapter_execution"] is False
+
+
+def test_cli_returns_two_on_cost_ceiling_hard_breach(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    policies = tmp_path / "policies"
+    policies.mkdir()
+    (policies / "policy_cost_ceiling.v1.json").write_text(
+        json.dumps({"version": "v1", "currency": "USD", "soft_usd": "0.00000001", "hard_usd": "0.00000002"}),
+        encoding="utf-8",
+    )
+    output = tmp_path / "evidence" / "dryrun.envelope.v1.json"
+
+    rc = main(
+        [
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-4o-mini",
+            "--intent",
+            "FAST_TEXT",
+            "--output",
+            str(output),
+            "--workspace-root",
+            str(tmp_path),
+            "--dry-run-cost-usd",
+            "0.00000003",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "cost ceiling breached" in captured.err
+    assert not output.exists()
+    assert (tmp_path / "evidence" / "cost_hard_breach.jsonl").is_file()
+
+
+def test_script_cli_subprocess_smoke(tmp_path: Path) -> None:
+    output = tmp_path / "evidence" / "dryrun.envelope.v1.json"
+    proc = subprocess.run(
+        [
+            "python3",
+            "scripts/run_live_adapter_dryrun.py",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-4o-mini",
+            "--intent",
+            "FAST_TEXT",
+            "--output",
+            str(output),
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert output.is_file()
+    assert json.loads(output.read_text(encoding="utf-8"))["response"]["status"] == "dry_run_emitted"


### PR DESCRIPTION
## Summary

Closes #849.

Adds the V5 Epic 2 E-2-4 live adapter dry-run harness:

- `ao_kernel._internal.live_adapter_dryrun` builds schema-valid E-2-1 dry-run envelopes and E-2-2 per-call audit rows with deterministic stub output.
- `scripts/run_live_adapter_dryrun.py` exposes the no-network CLI path.
- Runtime kill-switches block raw sockets, subprocess, shell/spawn/exec families, stdlib HTTP, optional HTTP clients (`httpx`, `urllib3`, `requests`, `aiohttp`), and native escape hatches (`ctypes.CDLL`, `cffi.FFI`).
- E-2-3 cost ceiling integration records simulated dry-run cost and exits `2` on hard breach.
- Envelope writes use tmp + fsync + `os.replace` + directory fsync + `0600` permissions.
- Adds docs and tests for schema validity, audit binding, cost breach behavior, kill-switch bypass coverage, import denylist, and CLI smoke.

## Guard invariants

- `live_adapter_execution=false`
- `support_widening=false`
- `production_platform_claim=false`
- No workflow mutation
- No secret readback
- No provider network call

## Validation

- `python3 scripts/gpp_next.py` -> GPP closed, guard flags false
- `git diff --check` -> clean
- `pytest tests/test_live_adapter_dryrun.py tests/test_dryrun_killswitch_bypass.py tests/test_dryrun_import_denylist.py tests/test_live_adapter_envelope.py tests/test_per_call_audit.py tests/test_cost_ceiling.py tests/test_pr_b0_contracts.py -q` -> `144 passed, 3 skipped`
- `python3 -m mypy ao_kernel/_internal/live_adapter_dryrun.py ao_kernel/_internal/cost_ceiling.py tests/test_live_adapter_dryrun.py tests/test_dryrun_killswitch_bypass.py tests/test_dryrun_import_denylist.py` -> pass
- `python3 -m ruff check ao_kernel/_internal/live_adapter_dryrun.py ao_kernel/_internal/cost_ceiling.py scripts/run_live_adapter_dryrun.py tests/test_live_adapter_dryrun.py tests/test_dryrun_killswitch_bypass.py tests/test_dryrun_import_denylist.py` -> pass
- CLI smoke -> writes `dryrun.envelope.v1.json` + `per_call_audit.jsonl`, both `0600`
- `python3 scripts/local_gpp_gate.py ... --work-package E-2-4-DRY-RUN-HARNESS` -> `decision=operator_may_merge`, 8/8 pass, `diff_digest=sha256:62838629e414daf1be9c2fcb73d42b33e123ced2c98eb9472f819bfbb7a15782`

## Cross-AI review

Claude/Anthropic reviewed the E-2-4 scope and returned `VERDICT: AGREE`.

Reviewer advisory observations were absorbed before this PR:

- add `os.exec*` family patching,
- make kill-switch contexts overlapping/nested safe with module-level lock/ref-count,
- make envelope write atomic.

Follow-up Claude review returned `VERDICT: AGREE` with no blocking findings.
