### PR TITLE
feat(e-2-5): add secret resolution discipline

### DIFF
--- a/.claude/plans/adr/ADR-0007-secret-resolution-discipline.md
+++ b/.claude/plans/adr/ADR-0007-secret-resolution-discipline.md
@@ -1,0 +1,75 @@
+---
+id: ADR-0007
+title: Secret resolution discipline for V5 Epic 2 infrastructure
+status: accepted
+date: 2026-06-04
+deciders:
+  - Codex (OpenAI)
+  - Claude (Anthropic)
+retrospective: false
+review_status: original
+slice_ref: E-2-5
+guard_flags:
+  support_widening: false
+  production_platform_claim: false
+  live_adapter_execution: false
+register_authority: evidence_record_only
+github_write_authorized: false
+---
+
+# ADR-0007: Secret Resolution Discipline For V5 Epic 2 Infrastructure
+
+## Context
+
+V5 Epic 2 remains infrastructure-only. E-2-5 adds a secret discipline primitive
+for future live-adapter infrastructure without authorizing live adapter
+execution. The Epic 2 plan requires value-based taint tracking as the primary
+control and regex redaction only as defense-in-depth.
+
+Legacy secret resolver surfaces still exist for older code paths. This ADR
+records the stricter E-2-5 discipline as a new primitive rather than silently
+changing legacy behavior.
+
+## Decision
+
+Add `ao_kernel._internal.secrets.SecretResolutionDiscipline` and
+`SecretTaintSet`.
+
+The primitive:
+
+1. Resolves secrets from environment variables only.
+2. Adds every resolved value to an in-memory taint set immediately.
+3. Redacts serialized payloads by resolved value before JSON, JSONL, and log
+   output.
+4. Applies regex redaction as defense-in-depth for secret-shaped values that
+   were not resolved through the primitive.
+5. Fails closed when required env-only resolution is missing.
+6. Provides provider invalidation for rotation so taints can be cleared for a
+   rotated provider.
+7. Does not import or call vault providers, MCP parameter resolution, argv,
+   stdin, files, or HTTP headers.
+
+## Consequences
+
+- Future live-adapter infrastructure can prove that resolved secret values do
+  not appear in serialized envelopes, audit rows, log lines, or telemetry
+  payloads.
+- Regex-only redaction is not treated as sufficient authority; it is a backup
+  layer.
+- Existing dual-read API-key resolver behavior is preserved for legacy callers.
+  Adoption of E-2-5 is explicit.
+
+## Non-Goals
+
+- No live LLM/provider HTTP call.
+- No `live_adapter_execution`, `support_widening`, or
+  `production_platform_claim` flip.
+- No workflow or branch-protection mutation.
+- No vault/runtime secret provider migration for existing callers.
+
+## References
+
+- `.claude/plans/EPIC-2-LIVE-ADAPTER-EXECUTION.md` §2 E-2-5
+- `ao_kernel._internal.secrets.discipline`
+- `ao_kernel._internal.secrets.taint`
+- `tests/test_secret_discipline.py`

--- a/.claude/plans/adr/index.json
+++ b/.claude/plans/adr/index.json
@@ -47,6 +47,14 @@
       "superseded_by": null,
       "supersedes": [],
       "title": "Cost ceiling enforcement for V5 Epic 2 infrastructure"
+    },
+    {
+      "filename": "ADR-0007-secret-resolution-discipline.md",
+      "id": "ADR-0007",
+      "status": "accepted",
+      "superseded_by": null,
+      "supersedes": [],
+      "title": "Secret resolution discipline for V5 Epic 2 infrastructure"
     }
   ],
   "schema_version": "ao-ma-adr-index.v1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **E-2-5 secret resolution discipline module** (V5 Epic 2, #850): added
+  `ao_kernel._internal.secrets.SecretResolutionDiscipline` and
+  `SecretTaintSet` as the env-var-only, value-based taint primitive for future
+  live-adapter infrastructure. The module resolves secrets from environment
+  variables only, records every resolved value in memory, redacts JSON/JSONL/log
+  serialization by exact value before applying regex defense-in-depth, supports
+  provider invalidation for rotation, and fails closed on missing required env
+  secrets or manual serialization bypass. ADR:
+  `ADR-0007-secret-resolution-discipline.md`. Legacy dual-read resolver behavior
+  is preserved for existing callers; E-2-5 is explicit adoption infrastructure.
+  Guard flags remain false;
+  no workflow mutation, support widening, production claim, or live adapter
+  execution.
 - **E-2-4 live adapter dry-run harness** (V5 Epic 2, #849): added
   `scripts/run_live_adapter_dryrun.py` plus
   `ao_kernel._internal.live_adapter_dryrun` to emit schema-valid E-2-1

--- a/ao_kernel/_internal/secrets/__init__.py
+++ b/ao_kernel/_internal/secrets/__init__.py
@@ -1,2 +1,17 @@
 from __future__ import annotations
 
+from ao_kernel._internal.secrets.discipline import (
+    SecretResolutionDiscipline,
+    SecretResolutionError,
+    SecretSerializationError,
+    create_env_secret_discipline,
+)
+from ao_kernel._internal.secrets.taint import SecretTaintSet
+
+__all__ = [
+    "SecretResolutionDiscipline",
+    "SecretResolutionError",
+    "SecretSerializationError",
+    "SecretTaintSet",
+    "create_env_secret_discipline",
+]

--- a/ao_kernel/_internal/secrets/discipline.py
+++ b/ao_kernel/_internal/secrets/discipline.py
@@ -1,0 +1,167 @@
+"""Secret resolution discipline for V5 Epic 2 E-2-5.
+
+This module is the live-adapter infrastructure contract for secrets:
+
+- resolution is environment-variable-only,
+- every resolved value is added to a value-based taint set,
+- every exported serialization helper redacts by taint before writing,
+- regex redaction is defense-in-depth, not the primary control.
+
+Legacy provider factory/vault helpers remain available elsewhere for older
+surfaces. This module deliberately does not import or call them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import contextlib
+from collections.abc import Mapping
+from pathlib import Path
+
+from ao_kernel._internal.secrets.api_key_resolver import env_names_for
+from ao_kernel._internal.secrets.taint import Jsonish, SecretTaintSet
+
+
+class SecretResolutionError(RuntimeError):
+    """Raised when env-only secret resolution fails closed."""
+
+
+class SecretSerializationError(RuntimeError):
+    """Raised when a supposedly redacted payload still carries a taint."""
+
+
+class SecretResolutionDiscipline:
+    """Resolve secrets from env only and serialize through a taint set."""
+
+    def __init__(
+        self,
+        *,
+        environ: Mapping[str, str] | None = None,
+        taint_set: SecretTaintSet | None = None,
+    ) -> None:
+        self._environ = environ if environ is not None else os.environ
+        self.taint_set = taint_set if taint_set is not None else SecretTaintSet()
+
+    def resolve_env_secret(
+        self,
+        *,
+        provider_id: str,
+        env_var: str,
+        required: bool = True,
+    ) -> str | None:
+        """Resolve exactly one env var and add its value to the taint set."""
+
+        name = _validate_env_name(env_var)
+        raw = self._environ.get(name, "")
+        value = raw.strip() if isinstance(raw, str) else ""
+        if not value:
+            if required:
+                raise SecretResolutionError(f"required env secret {name!r} is missing")
+            return None
+        self.taint_set.add(provider_id, value)
+        return value
+
+    def resolve_provider_api_key(self, provider_id: str, *, required: bool = True) -> str | None:
+        """Resolve a provider API key from accepted env names only.
+
+        Unlike ``resolve_api_key`` this function does not consult the secrets
+        factory, vault stubs, MCP params, argv, stdin, files, or HTTP headers.
+        """
+
+        missing: list[str] = []
+        for env_var in env_names_for(provider_id):
+            try:
+                return self.resolve_env_secret(provider_id=provider_id, env_var=env_var, required=True)
+            except SecretResolutionError:
+                missing.append(env_var)
+        if required:
+            joined = ", ".join(missing)
+            raise SecretResolutionError(f"required env secret for provider {provider_id!r} is missing ({joined})")
+        return None
+
+    def invalidate(self, provider_id: str) -> None:
+        """Clear taints for one provider after secret rotation."""
+
+        self.taint_set.remove_provider(provider_id)
+
+    def redact_payload(self, payload: Jsonish) -> Jsonish:
+        """Return a deep-redacted copy of a JSON-like payload."""
+
+        return self.taint_set.scan_and_redact(payload)
+
+    def serialize_json(self, payload: Jsonish, *, indent: int | None = None) -> str:
+        """Redact and serialize a JSON-like payload."""
+
+        redacted = self.redact_payload(payload)
+        encoded = json.dumps(
+            redacted,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=None if indent else (",", ":"),
+            indent=indent,
+        )
+        self.assert_no_taint(encoded)
+        return encoded
+
+    def serialize_json_line(self, payload: Jsonish) -> str:
+        """Redact and serialize one JSONL line."""
+
+        return self.serialize_json(payload) + "\n"
+
+    def safe_log_line(self, text: str) -> str:
+        """Redact a free-text log line and fail closed if taint remains."""
+
+        redacted = self.taint_set.redact_text(text)
+        self.assert_no_taint(redacted)
+        return redacted
+
+    def write_json(self, path: Path, payload: Jsonish, *, indent: int = 2) -> None:
+        """Redact, serialize, and write one JSON artifact with private mode."""
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(self.serialize_json(payload, indent=indent) + "\n", encoding="utf-8")
+        with contextlib.suppress(OSError):
+            os.chmod(path, 0o600)
+
+    def append_jsonl(self, path: Path, payload: Jsonish) -> None:
+        """Redact, serialize, and append one JSONL artifact with private mode."""
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = self.serialize_json_line(payload).encode("utf-8")
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            os.write(fd, line)
+        finally:
+            os.close(fd)
+
+    def assert_no_taint(self, serialized: str) -> None:
+        """Fail closed if a tracked secret remains in serialized output."""
+
+        if self.taint_set.contains(serialized):
+            raise SecretSerializationError("serialized output still contains a resolved secret value")
+
+
+def _validate_env_name(env_var: str) -> str:
+    name = str(env_var).strip()
+    if not name or not name.replace("_", "").isalnum() or name[0].isdigit():
+        raise ValueError(f"invalid env secret name: {env_var!r}")
+    return name
+
+
+def create_env_secret_discipline(
+    *,
+    environ: Mapping[str, str] | None = None,
+    taint_set: SecretTaintSet | None = None,
+) -> SecretResolutionDiscipline:
+    """Factory for the env-only secret discipline."""
+
+    return SecretResolutionDiscipline(environ=environ, taint_set=taint_set)
+
+
+__all__ = [
+    "SecretResolutionDiscipline",
+    "SecretResolutionError",
+    "SecretSerializationError",
+    "create_env_secret_discipline",
+]

--- a/ao_kernel/_internal/secrets/taint.py
+++ b/ao_kernel/_internal/secrets/taint.py
@@ -1,0 +1,173 @@
+"""Value-based secret taint tracking for V5 Epic 2 E-2-5.
+
+The primary invariant is simple: once a secret value is resolved, that exact
+value must not appear in any serialized payload. Regex redaction is retained as
+defense-in-depth for secret-shaped values that were not resolved through this
+module.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import re
+import threading
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Mapping
+
+Jsonish = dict[str, Any] | list[Any] | tuple[Any, ...] | str | int | float | Decimal | bool | None
+
+_PROVIDER_SAFE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+@dataclass(frozen=True)
+class SecretPattern:
+    """A named defense-in-depth redaction pattern."""
+
+    name: str
+    pattern: re.Pattern[str]
+
+
+@dataclass(frozen=True)
+class SecretTaint:
+    """One resolved in-memory secret value."""
+
+    provider_id: str
+    value: str
+
+
+DEFAULT_SECRET_PATTERNS: tuple[SecretPattern, ...] = (
+    SecretPattern("anthropic_api_key", re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}")),
+    SecretPattern("openai_project_key", re.compile(r"sk-proj-[A-Za-z0-9_-]{20,}")),
+    SecretPattern("generic_sk_key", re.compile(r"sk-[A-Za-z0-9_-]{20,}")),
+    SecretPattern("aws_access_key", re.compile(r"AKIA[0-9A-Z]{16}")),
+    SecretPattern("slack_bot_token", re.compile(r"xoxb-[A-Za-z0-9-]{10,}")),
+    SecretPattern("gitlab_pat", re.compile(r"glpat-[A-Za-z0-9_-]{20}")),
+    SecretPattern("github_oauth", re.compile(r"gho_[A-Za-z0-9]{36}")),
+    SecretPattern("github_pat_classic", re.compile(r"ghp_[A-Za-z0-9]{36}")),
+    SecretPattern("github_fine_grained_pat", re.compile(r"github_pat_[A-Za-z0-9_]{82}")),
+    SecretPattern("github_server_token", re.compile(r"ghs_[A-Za-z0-9]{36}")),
+    SecretPattern("github_user_token", re.compile(r"ghu_[A-Za-z0-9]{36}")),
+    SecretPattern("jwt_prefix", re.compile(r"eyJ[A-Za-z0-9_-]{20,}\.")),
+    SecretPattern(
+        "teams_webhook_url",
+        re.compile(r"https://[a-z0-9.-]+\.webhook\.office\.com/webhookb2/[A-Za-z0-9@/\-]+"),
+    ),
+)
+
+
+def _provider_placeholder(provider_id: str) -> str:
+    safe = _PROVIDER_SAFE.sub("_", provider_id).strip("._-")[:64] or "unknown"
+    return f"[REDACTED:provider={safe}]"
+
+
+def _pattern_placeholder(pattern: SecretPattern) -> str:
+    return f"[REDACTED:pattern={pattern.name}]"
+
+
+class SecretTaintSet:
+    """In-memory set of resolved secret values.
+
+    Instances are intentionally process-local. The class stores raw secret
+    values so it can redact by value; callers must not serialize the instance.
+    """
+
+    def __init__(self, *, patterns: tuple[SecretPattern, ...] = DEFAULT_SECRET_PATTERNS) -> None:
+        self._patterns = patterns
+        self._taints: dict[tuple[str, str], SecretTaint] = {}
+        self._lock = threading.RLock()
+
+    def add(self, provider_id: str, value: str) -> None:
+        """Register a resolved secret value.
+
+        Empty or whitespace-only values are ignored: callers should raise their
+        own resolution error for required missing secrets.
+        """
+
+        if not isinstance(value, str):
+            raise TypeError("secret value must be a string")
+        stripped = value.strip()
+        if not stripped:
+            return
+        provider = str(provider_id).strip() or "unknown"
+        with self._lock:
+            self._taints[(provider, stripped)] = SecretTaint(provider, stripped)
+
+    def remove_provider(self, provider_id: str) -> None:
+        """Remove all taints for one provider after rotation/invalidation."""
+
+        provider = str(provider_id).strip() or "unknown"
+        with self._lock:
+            for key in [key for key in self._taints if key[0] == provider]:
+                del self._taints[key]
+
+    def clear(self) -> None:
+        """Remove every tracked value."""
+
+        with self._lock:
+            self._taints.clear()
+
+    def contains(self, value: str) -> bool:
+        """Return true iff any tracked secret appears in ``value``."""
+
+        if not isinstance(value, str):
+            return False
+        with self._lock:
+            return any(taint.value in value for taint in self._taints.values())
+
+    def scan_and_redact(self, payload: Jsonish) -> Jsonish:
+        """Return a deep-redacted copy of ``payload``.
+
+        String values are redacted by resolved taint first, then by regex
+        defense-in-depth. Numeric, boolean, and null values are returned
+        unchanged so cost and counter fields cannot be accidentally rewritten.
+        """
+
+        return self._scan(copy.deepcopy(payload))
+
+    def redact_text(self, text: str) -> str:
+        """Redact one string using value-based taint plus regex fallback."""
+
+        if not isinstance(text, str):
+            raise TypeError("text must be a string")
+        redacted = text
+        with self._lock:
+            taints = sorted(self._taints.values(), key=lambda taint: len(taint.value), reverse=True)
+        for taint in taints:
+            redacted = redacted.replace(taint.value, _provider_placeholder(taint.provider_id))
+        for pattern in self._patterns:
+            redacted = pattern.pattern.sub(_pattern_placeholder(pattern), redacted)
+        return redacted
+
+    def _scan(self, payload: Jsonish) -> Jsonish:
+        if isinstance(payload, str):
+            return self.redact_text(payload)
+        if isinstance(payload, dict):
+            return {str(key): self._scan(value) for key, value in payload.items()}
+        if isinstance(payload, list):
+            return [self._scan(value) for value in payload]
+        if isinstance(payload, tuple):
+            return tuple(self._scan(value) for value in payload)
+        return payload
+
+    def snapshot_metadata(self) -> tuple[Mapping[str, str], ...]:
+        """Return non-secret metadata about tracked values for tests/audits."""
+
+        with self._lock:
+            return tuple(
+                {
+                    "provider_id": taint.provider_id,
+                    "value_sha256": "sha256:" + hashlib.sha256(taint.value.encode()).hexdigest(),
+                }
+                for taint in self._taints.values()
+            )
+
+
+__all__ = [
+    "DEFAULT_SECRET_PATTERNS",
+    "Jsonish",
+    "SecretPattern",
+    "SecretTaint",
+    "SecretTaintSet",
+]

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "E-2-4-DRY-RUN-HARNESS",
+  "work_package": "E-2-5-SECRET-DISCIPLINE",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,16 +13,15 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-2-4-dry-run-harness",
+    "head_ref": "refs/heads/codex/epic-2-5-secret-discipline",
     "changed_files": [
+      ".claude/plans/adr/ADR-0007-secret-resolution-discipline.md",
+      ".claude/plans/adr/index.json",
       "CHANGELOG.md",
-      "ao_kernel/_internal/cost_ceiling.py",
-      "ao_kernel/_internal/live_adapter_dryrun.py",
-      "docs/LIVE-ADAPTER-DRY-RUN.md",
-      "scripts/run_live_adapter_dryrun.py",
-      "tests/test_dryrun_import_denylist.py",
-      "tests/test_dryrun_killswitch_bypass.py",
-      "tests/test_live_adapter_dryrun.py",
+      "ao_kernel/_internal/secrets/__init__.py",
+      "ao_kernel/_internal/secrets/discipline.py",
+      "ao_kernel/_internal/secrets/taint.py",
+      "tests/test_secret_discipline.py",
       "local-ai-review-evidence.v1.json"
     ]
   },
@@ -35,20 +34,21 @@
     { "name": "gpp_next_guard_flags", "status": "pass" },
     { "name": "diff_whitespace", "status": "pass" },
     { "name": "workflow_mutation_guard", "status": "pass" },
-    { "name": "dry_run_no_network_killswitch", "status": "pass" },
-    { "name": "envelope_schema_validation", "status": "pass" },
-    { "name": "per_call_audit_binding", "status": "pass" },
-    { "name": "cost_ceiling_integration", "status": "pass" },
-    { "name": "cross_provider_review", "status": "pass" }
+    { "name": "env_only_secret_resolution", "status": "pass" },
+    { "name": "value_taint_redaction", "status": "pass" },
+    { "name": "regex_defense_in_depth", "status": "pass" },
+    { "name": "legacy_resolver_compatibility", "status": "pass" },
+    { "name": "cross_provider_review", "status": "pass" },
+    { "name": "minimax_secondary_review", "status": "pass" }
   ],
   "findings": [
-    "Claude Anthropic cross-provider review returned AGREE for E-2-4 live adapter dry-run harness after an initial full review and a follow-up review of advisory hardening changes.",
-    "Scope reviewed: dry-run harness module, CLI wrapper, kill-switch bypass tests, import denylist tests, live adapter dry-run tests, docs, changelog, and the Decimal formatting fix in the E-2-3 cost ceiling module.",
-    "The harness emits schema-valid E-2-1 dry-run envelopes and E-2-2 per-call audit rows with deterministic stub output, prompt digesting, no prompt serialization, and no provider network call.",
-    "Runtime kill-switches block raw sockets, subprocess, shell, spawn and exec families, stdlib HTTP, optional httpx/urllib3/requests/aiohttp clients, and native ctypes/cffi escape hatches while dry-run evidence is built.",
-    "Follow-up hardening absorbed reviewer observations: overlapping kill-switch contexts now restore only after the last exit; os.exec family is patched; envelope writes use tmp file, fsync, os.replace, directory fsync, and final 0600 permissions.",
-    "E-2-3 cost ceiling integration is reviewed as correct for simulated dry-run cost: zero cost records not_applicable, hard breach exits 2 and records fail-closed cost evidence without writing the envelope artifact.",
-    "Guard flags remain false in envelope, audit row, CLI output, and gpp_next status. No workflow mutation, secret readback, live adapter execution, support widening, or production platform claim is introduced."
+    "Claude Anthropic cross-provider review returned AGREE for E-2-5 secret resolution discipline.",
+    "Mavis MiniMax secondary review also returned AGREE for the same scope and acceptance criteria.",
+    "The new discipline module resolves secrets from environment variables only and does not import or call provider factory, vault, MCP, argv, stdin, file, or header fallback paths.",
+    "Every resolved value is added to an in-memory value-based taint set; JSON, JSONL, and log serialization helpers redact by exact taint before regex defense-in-depth.",
+    "Missing required secrets fail closed with SecretResolutionError, optional missing secrets return None without taint, and provider invalidation clears provider-specific taints for rotation.",
+    "Legacy dual-read API-key resolver behavior is preserved for existing callers; E-2-5 adds explicit adoption infrastructure rather than changing legacy resolution semantics.",
+    "Guard flags remain false. No workflow mutation, support widening, production platform claim, live adapter execution, or secret readback is introduced."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_secret_discipline.py
+++ b/tests/test_secret_discipline.py
@@ -1,0 +1,183 @@
+"""E-2-5 secret resolution discipline tests."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ao_kernel._internal.secrets.discipline import (
+    SecretResolutionDiscipline,
+    SecretResolutionError,
+    SecretSerializationError,
+)
+from ao_kernel._internal.secrets.taint import SecretTaintSet
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _secret(prefix: str, length: int = 36) -> str:
+    return prefix + ("A" * length)
+
+
+def _teams_webhook() -> str:
+    return "https://" + "example.webhook.office.com/webhookb2/" + ("A" * 24)
+
+
+def test_value_based_taint_redacts_envelope_audit_log_and_telemetry(tmp_path: Path) -> None:
+    secret = _secret("sk-test-", 32)
+    discipline = SecretResolutionDiscipline(environ={"OPENAI_API_KEY": secret})
+    resolved = discipline.resolve_provider_api_key("openai")
+
+    assert resolved == secret
+
+    envelope: dict[str, Any] = {
+        "request": {"provider_id": "openai", "debug": f"key={secret}"},
+        "cost": {"actual_cost_usd": "0.00000000"},
+        "live_adapter_execution": False,
+    }
+    audit = {"status": "dry_run_emitted", "raw": secret, "total_tokens": 0}
+    telemetry = {"span": {"attrs": ["safe", secret], "attempt": 1}}
+    log_line = f"provider returned {secret}"
+
+    rendered = "\n".join(
+        [
+            discipline.serialize_json(envelope),
+            discipline.serialize_json(audit),
+            discipline.serialize_json(telemetry),
+            discipline.safe_log_line(log_line),
+        ]
+    )
+
+    assert secret not in rendered
+    assert "[REDACTED:provider=openai]" in rendered
+    assert "\"actual_cost_usd\":\"0.00000000\"" in rendered
+    assert "\"total_tokens\":0" in rendered
+
+    out = tmp_path / "evidence" / "secret-safe.json"
+    discipline.write_json(out, {"value": secret})
+    assert secret not in out.read_text(encoding="utf-8")
+    assert out.stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.parametrize(
+    ("value", "placeholder"),
+    [
+        (_secret("AKIA", 16), "[REDACTED:pattern=aws_access_key]"),
+        (_secret("sk-", 24), "[REDACTED:pattern=generic_sk_key]"),
+        (_secret("sk-ant-", 24), "[REDACTED:pattern=anthropic_api_key]"),
+        (_secret("sk-proj-", 24), "[REDACTED:pattern=openai_project_key]"),
+        (_secret("xoxb-", 16), "[REDACTED:pattern=slack_bot_token]"),
+        (_secret("glpat-", 20), "[REDACTED:pattern=gitlab_pat]"),
+        (_secret("gho_", 36), "[REDACTED:pattern=github_oauth]"),
+        (_secret("ghp_", 36), "[REDACTED:pattern=github_pat_classic]"),
+        (_secret("github_pat_", 82), "[REDACTED:pattern=github_fine_grained_pat]"),
+        (_secret("ghs_", 36), "[REDACTED:pattern=github_server_token]"),
+        (_secret("ghu_", 36), "[REDACTED:pattern=github_user_token]"),
+        (_secret("eyJ", 24) + ".", "[REDACTED:pattern=jwt_prefix]"),
+        (_teams_webhook(), "[REDACTED:pattern=teams_webhook_url]"),
+    ],
+)
+def test_regex_defense_in_depth_patterns(value: str, placeholder: str) -> None:
+    taint = SecretTaintSet()
+    redacted = taint.redact_text(f"before {value} after")
+
+    assert value not in redacted
+    assert placeholder in redacted
+
+
+def test_regex_non_matching_text_is_unchanged() -> None:
+    taint = SecretTaintSet()
+    value = "sk-short"
+
+    assert taint.redact_text(value) == value
+
+
+def test_env_only_resolution_does_not_consult_provider_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom() -> object:
+        raise AssertionError("factory must not be called by E-2-5 discipline")
+
+    monkeypatch.setenv("SECRETS_PROVIDER", "vault_stub")
+    monkeypatch.setattr("ao_kernel._internal.secrets.factory.create_provider_from_env", _boom)
+    discipline = SecretResolutionDiscipline(environ={})
+
+    with pytest.raises(SecretResolutionError, match="required env secret"):
+        discipline.resolve_provider_api_key("openai")
+
+
+def test_optional_env_resolution_returns_none_without_taint() -> None:
+    discipline = SecretResolutionDiscipline(environ={})
+
+    assert discipline.resolve_provider_api_key("openai", required=False) is None
+    assert discipline.taint_set.snapshot_metadata() == ()
+
+
+def test_invalidate_clears_provider_taint_after_rotation() -> None:
+    old_secret = _secret("sk-old-", 24)
+    discipline = SecretResolutionDiscipline(environ={"OPENAI_API_KEY": old_secret})
+    discipline.resolve_provider_api_key("openai")
+
+    assert old_secret not in discipline.safe_log_line(old_secret)
+    discipline.invalidate("openai")
+    assert discipline.safe_log_line(old_secret) == "[REDACTED:pattern=generic_sk_key]"
+
+
+def test_assert_no_taint_fails_closed_on_manual_bypass() -> None:
+    secret = _secret("sk-test-", 32)
+    discipline = SecretResolutionDiscipline(environ={"OPENAI_API_KEY": secret})
+    discipline.resolve_provider_api_key("openai")
+
+    with pytest.raises(SecretSerializationError):
+        discipline.assert_no_taint(f"manual bypass {secret}")
+
+
+def test_append_jsonl_redacts_before_write(tmp_path: Path) -> None:
+    secret = _secret("sk-test-", 32)
+    discipline = SecretResolutionDiscipline(environ={"OPENAI_API_KEY": secret})
+    discipline.resolve_provider_api_key("openai")
+
+    path = tmp_path / "evidence" / "audit.jsonl"
+    discipline.append_jsonl(path, {"secret": secret, "count": 1})
+
+    [row] = path.read_text(encoding="utf-8").splitlines()
+    parsed = json.loads(row)
+    assert parsed["secret"] == "[REDACTED:provider=openai]"
+    assert parsed["count"] == 1
+
+
+def test_discipline_module_does_not_import_vault_or_provider_factory() -> None:
+    tree = ast.parse((REPO_ROOT / "ao_kernel" / "_internal" / "secrets" / "discipline.py").read_text())
+    imported_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_names.add(node.module)
+
+    assert "ao_kernel._internal.secrets.factory" not in imported_names
+    assert "ao_kernel._internal.secrets.vault_stub_provider" not in imported_names
+    assert "ao_kernel._internal.secrets.hashicorp_vault_provider" not in imported_names
+
+
+def test_serialization_helpers_route_through_scan_and_redact() -> None:
+    tree = ast.parse((REPO_ROOT / "ao_kernel" / "_internal" / "secrets" / "discipline.py").read_text())
+    calls_by_function: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            calls: set[str] = set()
+            for child in ast.walk(node):
+                if isinstance(child, ast.Call):
+                    if isinstance(child.func, ast.Attribute):
+                        calls.add(child.func.attr)
+                    elif isinstance(child.func, ast.Name):
+                        calls.add(child.func.id)
+            calls_by_function[node.name] = calls
+
+    assert "redact_payload" in calls_by_function["serialize_json"]
+    assert "serialize_json" in calls_by_function["serialize_json_line"]
+    assert "redact_text" in calls_by_function["safe_log_line"]
+    assert "serialize_json" in calls_by_function["write_json"]
+    assert "serialize_json_line" in calls_by_function["append_jsonl"]


### PR DESCRIPTION
## Summary

Closes #850.

Adds the V5 Epic 2 E-2-5 secret resolution discipline primitive:

- `SecretResolutionDiscipline`: env-var-only secret resolution for explicit future live-adapter adoption.
- `SecretTaintSet`: value-based taint tracking with exact-value redaction before regex defense-in-depth.
- JSON / JSONL / log serialization helpers that redact through the taint set and fail closed if a resolved value survives.
- Required missing secret → `SecretResolutionError`; optional missing secret → `None`; provider invalidation clears provider taints for rotation.
- ADR-0007 + changelog + focused tests.

Legacy dual-read `resolve_api_key()` behavior is preserved for existing callers. This PR adds explicit adoption infrastructure; it does not change legacy resolution semantics.

## Guard boundary

- No workflow mutation.
- No support widening.
- No production platform claim.
- No live adapter execution.
- No secret readback or credential material recorded.

## Cross-AI review

- Claude / Anthropic: `AGREE`.
- Mavis / MiniMax: `AGREE` secondary review.
- Repo-owned local gate: `operator_may_merge`.

Local gate context:

```text
head_sha: 028a58e62c0a01aa2650126258007878637b34b7
diff_digest: sha256:add1005b040d5e075eef43ac796bf27559076a0a6eae8b6f17bd0d428d5b2076
changed_files_count: 8
```

## Validation

```text
python3 -m ruff check ao_kernel/_internal/secrets/taint.py ao_kernel/_internal/secrets/discipline.py tests/test_secret_discipline.py
# All checks passed!

python3 -m mypy ao_kernel/_internal/secrets/taint.py ao_kernel/_internal/secrets/discipline.py tests/test_secret_discipline.py
# Success: no issues found in 3 source files

pytest tests/test_secret_discipline.py tests/test_secrets_factory.py tests/test_secrets_deep.py tests/test_api_key_resolver.py tests/test_executor_policy_enforcer.py tests/test_policy_violation_kind_taxonomy_v312_h1.py -q
# 85 passed

python3 -m json.tool local-ai-review-evidence.v1.json >/dev/null
python3 -m json.tool .claude/plans/adr/index.json >/dev/null

git diff --check
# clean

gitleaks protect --source . --staged --no-banner --redact --verbose
# no leaks found

python3 scripts/local_gpp_gate.py --review-evidence local-ai-review-evidence.v1.json --repo-root . --review-base-ref refs/heads/main --review-head-ref refs/heads/codex/epic-2-5-secret-discipline --diff-base-ref origin/main --diff-head-ref HEAD --repo Halildeu/ao-kernel --work-package E-2-5-SECRET-DISCIPLINE --output /tmp/e25-local-gpp-gate.json
# Decision: operator_may_merge
```

Note: full `gitleaks detect` against repository history still reports pre-existing historical placeholder/test findings outside this PR. Staged-only scan for this PR is clean.
