### PR TITLE
feat(e-2-6): add advisory live adapter evidence workflow

### DIFF
--- a/.github/workflows/live-adapter-evidence-emit.yml
+++ b/.github/workflows/live-adapter-evidence-emit.yml
@@ -1,0 +1,64 @@
+name: live-adapter-evidence-emit
+
+# V5 Epic 2 E-2-6 Path A — advisory, artifact-only evidence.
+#
+# Boundaries:
+# - pull_request event only for PRs
+# - contents: read only
+# - no secrets context and no long-lived credentials
+# - no PR comment, no Teams notification, no provider HTTP call
+# - guard flags remain false; this is not live adapter execution
+
+on:
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: live-adapter-evidence-emit-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  emit-live-adapter-evidence:
+    name: live-adapter-evidence-emit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout PR head or dispatch ref
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install ao-kernel core
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+
+      - name: Emit advisory dry-run artifacts
+        run: |
+          python3 scripts/live_adapter_evidence_workflow_runner.py \
+            --output-dir live-adapter-evidence \
+            --output-format text
+
+      - name: Upload advisory evidence artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: live-adapter-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: live-adapter-evidence/
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `support_widening` / `production_platform_claim` / `live_adapter_execution`
   all `const false` at schema and re-asserted at runtime; no guard flip (a true
   value requires the separate v2 supersession schema, Epic 9).
+- **E-2-6 advisory live-adapter evidence workflow** (V5 Epic 2, #851):
+  added `.github/workflows/live-adapter-evidence-emit.yml` plus
+  `scripts/live_adapter_evidence_workflow_runner.py` as the Path A
+  pull-request-safe CI lane for E-2-4 dry-run artifacts. The workflow uses
+  `pull_request`/`workflow_dispatch`, `contents: read`, no secrets context, no
+  PR comments, no Teams notification, and uploads only envelope/audit/summary
+  artifacts. The runner fails closed if protected secret environment variables
+  are present, then delegates to the no-network dry-run harness. Guard flags
+  remain false; no provider HTTP call, support widening, production claim, or
+  live adapter execution is introduced.
 - **E-2-5 secret resolution discipline module** (V5 Epic 2, #850): added
   `ao_kernel._internal.secrets.SecretResolutionDiscipline` and
   `SecretTaintSet` as the env-var-only, value-based taint primitive for future

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,28 +1,25 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "E-3-1-SUPPORT-WIDENING-EVIDENCE",
+  "work_package": "E-2-6-ADVISORY-CI",
   "implementer": {
-    "agent": "claude",
-    "provider": "anthropic"
+    "agent": "codex",
+    "provider": "openai"
   },
   "reviewer": {
-    "agent": "codex",
-    "provider": "openai",
+    "agent": "claude",
+    "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/feat/epic-3-1-support-widening-evidence",
+    "head_ref": "refs/heads/codex/epic-2-6-advisory-ci",
     "changed_files": [
-      ".claude/plans/EPIC-3-E-3-1-EVIDENCE-SCHEMA.md",
-      ".claude/plans/EPIC-3-SUPPORT-WIDENING-MATRIX.md",
+      ".github/workflows/live-adapter-evidence-emit.yml",
       "CHANGELOG.md",
-      "ao_kernel/_internal/support_widening/__init__.py",
-      "ao_kernel/_internal/support_widening/evidence.py",
-      "ao_kernel/cli.py",
-      "ao_kernel/defaults/schemas/support-widening-evidence.schema.v1.json",
-      "tests/test_support_widening_evidence_v1.py",
+      "scripts/live_adapter_evidence_workflow_runner.py",
+      "tests/test_cost_ceiling.py",
+      "tests/test_live_adapter_evidence_workflow.py",
       "local-ai-review-evidence.v1.json"
     ]
   },
@@ -31,18 +28,31 @@
     { "name": "secret_scan", "status": "pass" },
     { "name": "ruff", "status": "pass" },
     { "name": "mypy", "status": "pass" },
-    { "name": "schema_valid_draft_2020_12", "status": "pass" },
-    { "name": "guard_flags_const_false", "status": "pass" },
-    { "name": "recursive_closure_shape_nodes", "status": "pass" },
-    { "name": "no_remote_ref_local_only", "status": "pass" },
-    { "name": "recompute_inputs_shadow_widening_guard", "status": "pass" },
-    { "name": "no_workflow_mutation", "status": "pass" },
+    { "name": "json_validity", "status": "pass" },
+    { "name": "gpp_next_guard_flags", "status": "pass" },
+    { "name": "diff_whitespace", "status": "pass" },
+    { "name": "workflow_trigger_guard", "status": "pass" },
+    { "name": "workflow_permissions_guard", "status": "pass" },
+    { "name": "workflow_secret_context_guard", "status": "pass" },
+    { "name": "artifact_only_guard", "status": "pass" },
+    { "name": "dry_run_harness_delegation", "status": "pass" },
+    { "name": "forbidden_secret_env_fail_closed", "status": "pass" },
+    { "name": "guard_flags_false_in_artifacts", "status": "pass" },
+    { "name": "codeql_stdout_secret_logging_hardened", "status": "pass" },
+    { "name": "legacy_cost_ceiling_workflow_guard_narrowed", "status": "pass" },
     { "name": "cross_provider_review", "status": "pass" }
   ],
   "findings": [
-    "E-3-1 support widening evidence schema + pure parse/recompute/verify module + read-only CLI (infrastructure-only). 2-iter Codex (OpenAI) cross-AI review on thread 019e9339; all 5 REVISE findings absorbed: (1) no-remote-ref test tightened to a local '#/' allowlist (http(s)-only let file/ftp/urn/bare-file through); (2) bare delegated-container closure asserted by exact json-pointer path set (was count-only); (3) plan §7 normative text reconciled with the implemented $defs+allOf+bare-container design; (4) branch rebased onto origin/main with both E-3-1 and E-2-5 CHANGELOG entries preserved; (5) invariant-count wording fixed (17 functions / 20 pytest cases).",
-    "Reviewer found NO behavioral bypass: cross-class key contamination rejected, shadow-widening key (even camelCase) rejected at any depth, double-pin fail-closed (schema const false + parse_v1 _RUNTIME_PINS re-assert) confirmed, recompute_v1 recompute-not-trust (evidence_dimensions == raw_dimensions canonical equality) and verify_v1 on-disk re-hash tamper-detection confirmed.",
-    "Guard flags const false at schema + evidence level (support_widening / production_platform_claim / live_adapter_execution / github_write_authorized) and re-asserted at runtime. No network call; no guard flip; a true value requires the separate v2 supersession schema (Epic 9). 20 pytest cases green; ruff + mypy clean."
+    "Claude Anthropic cross-provider review returned AGREE for E-2-6 Path A advisory CI.",
+    "Claude Anthropic re-review returned AGREE for the legacy E-2-3 workflow guard narrowing that allows only the E-2-6 advisory workflow path.",
+    "The workflow uses pull_request plus workflow_dispatch only and does not include pull_request_target.",
+    "The workflow grants only contents: read, uses persist-credentials: false, and has no PR comment, Teams webhook, secrets context, or write permission surface.",
+    "The runner fails closed when protected secret environment variable names are present and never logs secret values.",
+    "The runner's CLI stdout is intentionally static and does not print artifact paths, envelope digests, secret env names, or the full summary payload.",
+    "The runner delegates to the E-2-4 no-network dry-run harness and emits envelope, per-call audit, and workflow summary artifacts only.",
+    "Tests pin trigger, permission, secret-context, artifact-only, fail-closed env, AST import, and guard-flag boundaries.",
+    "The older E-2-3 cost-ceiling workflow mutation guard was narrowed to allow only the E-2-6 advisory workflow path while continuing to fail closed on unrelated workflow mutations.",
+    "Guard flags remain false. No support widening, production platform claim, live provider HTTP call, or live adapter execution is introduced."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/live_adapter_evidence_workflow_runner.py
+++ b/scripts/live_adapter_evidence_workflow_runner.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Emit advisory CI artifacts for the live-adapter dry-run harness.
+
+This wrapper is V5 Epic 2 E-2-6 Path A: pull_request-safe, artifact-only,
+and deliberately secret-free. It fails closed when protected credential
+environment variables are present, then delegates to the E-2-4 dry-run harness
+which already blocks network/subprocess/native escape paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime as dt
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from typing import Any, Mapping
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel._internal.live_adapter_dryrun import (  # noqa: E402
+    DryRunKillSwitchError,
+    DryRunSchemaError,
+    run_live_adapter_dryrun,
+)
+
+FORBIDDEN_SECRET_ENV_NAMES: tuple[str, ...] = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "AO_CLAUDE_CODE_CLI_AUTH",
+    "TEAMS_WEBHOOK_URL",
+    "AO_GITHUB_APP_PRIVATE_KEY",
+    "AO_RELEASE_GATE_WEBHOOK_SECRET",
+)
+
+
+class WorkflowEvidenceError(RuntimeError):
+    """Raised when the advisory evidence workflow would cross a boundary."""
+
+
+def _iso_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    tmp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(rendered)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+        os.replace(tmp_path, path)
+        with contextlib.suppress(OSError):
+            directory_fd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            tmp_path.unlink()
+    with contextlib.suppress(OSError):
+        os.chmod(path, 0o600)
+
+
+def _assert_no_forbidden_secret_env() -> None:
+    present = sorted(name for name in FORBIDDEN_SECRET_ENV_NAMES if os.environ.get(name))
+    if present:
+        raise WorkflowEvidenceError("forbidden secret environment variables are present for advisory CI")
+
+
+def _stdout_summary_payload() -> dict[str, object]:
+    return {
+        "mode": "advisory_ci_path_a",
+        "status": "ok",
+        "artifacts_written": True,
+        "live_adapter_execution": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+    }
+
+
+def emit_advisory_workflow_evidence(
+    *,
+    output_dir: Path,
+    provider_id: str = "openai",
+    model: str = "gpt-4o-mini",
+    intent: str = "FAST_TEXT",
+) -> dict[str, Any]:
+    """Run one dry-run call and write the advisory workflow summary."""
+
+    _assert_no_forbidden_secret_env()
+    root = Path(output_dir)
+    evidence_dir = root / "evidence"
+    envelope_path = evidence_dir / "live-adapter-dryrun.envelope.v1.json"
+    result = run_live_adapter_dryrun(
+        provider_id=provider_id,
+        model=model,
+        intent=intent,
+        output=envelope_path,
+        workspace_root=root,
+        prompt="advisory-ci-dry-run",
+        session_id="e-2-6-advisory-ci",
+    )
+    audit_path = evidence_dir / "per_call_audit.jsonl"
+    summary_path = root / "live-adapter-evidence-workflow-summary.v1.json"
+    summary: dict[str, Any] = {
+        "schema_version": "live-adapter-evidence-workflow-summary.v1",
+        "artifact_kind": "live_adapter_evidence_workflow_summary",
+        "mode": "advisory_ci_path_a",
+        "created_at": _iso_now(),
+        "trigger_surface": "pull_request_or_workflow_dispatch",
+        "permission_surface": "contents_read_only",
+        "notification_surface": "artifact_only_no_pr_comment_no_teams_webhook",
+        "secret_env_policy": {
+            "forbidden_env_names": list(FORBIDDEN_SECRET_ENV_NAMES),
+            "forbidden_env_present": [],
+        },
+        "provider_id": provider_id,
+        "model": model,
+        "intent": intent,
+        "envelope_digest": result.envelope["envelope_digest"],
+        "cost_breach_state": result.cost_breach_state,
+        "audit_receipt": result.audit_receipt,
+        "artifacts": {
+            "envelope": str(envelope_path),
+            "per_call_audit": str(audit_path),
+            "summary": str(summary_path),
+        },
+        "live_adapter_execution": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+    }
+    _write_json(summary_path, summary)
+    return summary
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Emit secret-free live-adapter advisory CI dry-run artifacts.")
+    parser.add_argument("--output-dir", type=Path, default=Path("live-adapter-evidence"))
+    parser.add_argument("--provider", dest="provider_id", default="openai")
+    parser.add_argument("--model", default="gpt-4o-mini")
+    parser.add_argument("--intent", default="FAST_TEXT")
+    parser.add_argument("--output-format", choices=("json", "text"), default="json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        emit_advisory_workflow_evidence(
+            output_dir=args.output_dir,
+            provider_id=args.provider_id,
+            model=args.model,
+            intent=args.intent,
+        )
+    except (DryRunKillSwitchError, DryRunSchemaError, WorkflowEvidenceError, OSError, ValueError) as exc:
+        print(f"live-adapter advisory evidence failed: {exc}", file=sys.stderr)
+        return 1
+    if args.output_format == "json":
+        print(json.dumps(_stdout_summary_payload(), indent=2, sort_keys=True))
+    else:
+        print("live-adapter advisory evidence: ok")
+        print("artifacts_written: true")
+        print("live_adapter_execution: false")
+        print("support_widening: false")
+        print("production_platform_claim: false")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cost_ceiling.py
+++ b/tests/test_cost_ceiling.py
@@ -250,7 +250,7 @@ def test_reservation_hard_breach_rejected(tmp_path: Path) -> None:
     assert rows[-1]["accepted"] is False
 
 
-def test_cost_ceiling_no_workflow_mutation_in_diff() -> None:
+def test_cost_ceiling_no_unrelated_workflow_mutation_in_diff() -> None:
     proc = subprocess.run(
         ["git", "diff", "--name-only", "origin/main...HEAD", "--", ".github/workflows/"],
         cwd=_REPO_ROOT,
@@ -261,4 +261,9 @@ def test_cost_ceiling_no_workflow_mutation_in_diff() -> None:
     if proc.returncode != 0:
         pytest.skip(f"git diff unavailable: {proc.stderr.strip()}")
     touched = [p for p in proc.stdout.split() if p]
-    assert not touched, f"E-2-3 must not touch .github/workflows/. Touched: {touched}"
+    # E-2-3 itself must not mutate workflow files. E-2-6 is the first
+    # explicitly authorized workflow slice in the same Epic-2 chain, so keep the
+    # older guard but narrow it to unrelated workflow drift.
+    allowed = {".github/workflows/live-adapter-evidence-emit.yml"}
+    unexpected = [p for p in touched if p not in allowed]
+    assert not unexpected, f"Epic 2 has unrelated workflow mutations. Touched: {unexpected}"

--- a/tests/test_live_adapter_evidence_workflow.py
+++ b/tests/test_live_adapter_evidence_workflow.py
@@ -1,0 +1,177 @@
+"""V5 Epic 2 E-2-6 advisory live-adapter evidence workflow invariants."""
+
+from __future__ import annotations
+
+import json
+import ast
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.live_adapter_evidence_workflow_runner import (
+    FORBIDDEN_SECRET_ENV_NAMES,
+    WorkflowEvidenceError,
+    emit_advisory_workflow_evidence,
+)
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "live-adapter-evidence-emit.yml"
+_RUNNER_PATH = _REPO_ROOT / "scripts" / "live_adapter_evidence_workflow_runner.py"
+
+
+def _workflow_text() -> str:
+    return _WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def _load_workflow() -> dict[Any, Any]:
+    if yaml is None:
+        pytest.skip("PyYAML not installed")
+    loaded = yaml.safe_load(_workflow_text())
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _on_block(workflow: dict[Any, Any]) -> dict[Any, Any]:
+    on_block = workflow.get("on") if "on" in workflow else workflow.get(True)
+    assert isinstance(on_block, dict)
+    return on_block
+
+
+def _clear_forbidden_secret_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in FORBIDDEN_SECRET_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_workflow_exists_at_canonical_path() -> None:
+    assert _WORKFLOW_PATH.exists()
+
+
+def test_workflow_uses_pull_request_and_dispatch_only() -> None:
+    workflow = _load_workflow()
+    on_block = _on_block(workflow)
+    assert sorted(on_block) == ["pull_request", "workflow_dispatch"]
+    assert "main" in on_block["pull_request"]["branches"]
+    assert "synchronize" in on_block["pull_request"]["types"]
+    assert "pull_request_target" not in _workflow_text()
+
+
+def test_workflow_is_read_only_artifact_only() -> None:
+    workflow = _load_workflow()
+    assert workflow["permissions"] == {"contents": "read"}
+    text = _workflow_text()
+    for forbidden in (
+        "contents: write",
+        "pull-requests: write",
+        "actions: write",
+        "id-token: write",
+        "issues: write",
+        "checks: write",
+        "secrets.",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "AO_CLAUDE_CODE_CLI_AUTH",
+        "TEAMS_WEBHOOK_URL",
+        "gh pr comment",
+        "curl ",
+    ):
+        assert forbidden not in text, f"unexpected advisory workflow surface: {forbidden}"
+    assert "actions/upload-artifact@v7" in text
+    assert "persist-credentials: false" in text
+
+
+def test_workflow_invokes_runner_and_uploads_directory() -> None:
+    text = _workflow_text()
+    assert "scripts/live_adapter_evidence_workflow_runner.py" in text
+    assert "--output-dir live-adapter-evidence" in text
+    assert "path: live-adapter-evidence/" in text
+
+
+def test_runner_emits_summary_envelope_and_audit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_forbidden_secret_env(monkeypatch)
+    output_dir = tmp_path / "artifact"
+    summary = emit_advisory_workflow_evidence(output_dir=output_dir)
+
+    summary_path = output_dir / "live-adapter-evidence-workflow-summary.v1.json"
+    envelope_path = output_dir / "evidence" / "live-adapter-dryrun.envelope.v1.json"
+    audit_path = output_dir / "evidence" / "per_call_audit.jsonl"
+    assert summary_path.is_file()
+    assert envelope_path.is_file()
+    assert audit_path.is_file()
+    persisted = json.loads(summary_path.read_text(encoding="utf-8"))
+    envelope = json.loads(envelope_path.read_text(encoding="utf-8"))
+    audit_rows = [json.loads(line) for line in audit_path.read_text(encoding="utf-8").splitlines()]
+
+    assert summary["mode"] == "advisory_ci_path_a"
+    assert persisted["envelope_digest"] == envelope["envelope_digest"]
+    assert audit_rows[0]["envelope_digest"] == envelope["envelope_digest"]
+    for payload in (persisted, envelope, audit_rows[0]):
+        assert payload["live_adapter_execution"] is False
+        assert payload["support_widening"] is False
+        assert payload["production_platform_claim"] is False
+    assert persisted["secret_env_policy"]["forbidden_env_present"] == []
+
+
+def test_runner_fails_closed_when_forbidden_secret_env_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_forbidden_secret_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "redacted-test-token")
+    with pytest.raises(WorkflowEvidenceError, match="forbidden secret environment variables"):
+        emit_advisory_workflow_evidence(output_dir=tmp_path / "artifact")
+
+
+def test_runner_cli_smoke(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_forbidden_secret_env(monkeypatch)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(_RUNNER_PATH),
+            "--output-dir",
+            str(tmp_path / "artifact"),
+            "--output-format",
+            "json",
+        ],
+        cwd=_REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["mode"] == "advisory_ci_path_a"
+    assert payload["artifacts_written"] is True
+    assert payload["live_adapter_execution"] is False
+    assert "envelope_digest" not in payload
+    assert "artifacts" not in payload
+
+
+def test_runner_source_does_not_import_http_or_secret_providers() -> None:
+    tree = ast.parse(_RUNNER_PATH.read_text(encoding="utf-8"), filename=str(_RUNNER_PATH))
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.append(node.module)
+    for forbidden in (
+        "requests",
+        "httpx",
+        "urllib",
+        "socket",
+        "subprocess",
+        "vault",
+        "SecretResolutionDiscipline",
+        "resolve_api_key",
+    ):
+        assert not any(module == forbidden or module.startswith(f"{forbidden}.") for module in imported_modules), (
+            f"runner must stay dry-run artifact-only: {forbidden}"
+        )


### PR DESCRIPTION
## Summary

Closes #851.

Adds V5 Epic 2 E-2-6 Path A advisory CI for live-adapter dry-run evidence:

- New `.github/workflows/live-adapter-evidence-emit.yml` using `pull_request` + `workflow_dispatch` only.
- Workflow permissions are `contents: read` only, with `persist-credentials: false` and artifact-only output.
- New `scripts/live_adapter_evidence_workflow_runner.py` delegates to the E-2-4 no-network dry-run harness and emits envelope/audit/summary artifacts.
- Runner fails closed when protected secret env names are present; it logs names only, never values.
- New workflow/runner tests pin trigger, permission, secret-context, artifact-only, fail-closed env, AST import, and guard-flag boundaries.

## Boundaries

- No `pull_request_target`.
- No secrets context, no Teams webhook, no PR comment/write surface.
- No provider HTTP call.
- No support widening, no production platform claim, no live adapter execution.
- Guard flags remain false.

## Validation

- `python3 -m ruff check scripts/live_adapter_evidence_workflow_runner.py tests/test_live_adapter_evidence_workflow.py` — pass
- `python3 -m mypy --explicit-package-bases scripts/live_adapter_evidence_workflow_runner.py tests/test_live_adapter_evidence_workflow.py` — pass
- `python3 -m mypy ao_kernel/` — pass
- `pytest tests/test_live_adapter_evidence_workflow.py tests/test_live_adapter_dryrun.py tests/test_dryrun_import_denylist.py -q` — 17 pass
- `python3 -m json.tool local-ai-review-evidence.v1.json` — pass
- `git diff --check` — pass
- staged `gitleaks protect --source . --staged --no-banner --redact --verbose` — no leaks
- `python3 scripts/gpp_next.py` — GPP closed, guard flags false
- `python3 scripts/local_gpp_gate.py ...` — `operator_may_merge`, diff digest `sha256:0e940dea7c1acc36d4644c5432ecd0a83b1b91ea8e02064656b9171273e98a57`

## Cross-AI review

Claude / Anthropic post-implementation review: `VERDICT: AGREE`.

Non-blocking reviewer note: `actions/checkout@v6` availability should be validated by CI; this repo already uses checkout v6 in existing workflows.
