### PR TITLE
feat(e-3-1): support widening evidence schema + validator (infrastructure-only)

### DIFF
--- a/.claude/plans/EPIC-3-E-3-1-EVIDENCE-SCHEMA.md
+++ b/.claude/plans/EPIC-3-E-3-1-EVIDENCE-SCHEMA.md
@@ -11,7 +11,7 @@
 - `ao_kernel/defaults/schemas/support-widening-evidence.schema.v1.json`
 - `ao_kernel/_internal/support_widening/evidence.py` (`parse_v1`, `recompute_v1`, `verify_v1`)
 - CLI `ao-kernel support-widening evidence validate <path> [--recompute]` (read-only)
-- `tests/test_support_widening_evidence_v1.py` (19 invariants)
+- `tests/test_support_widening_evidence_v1.py` (17 test functions / 20 collected pytest cases)
 
 ## Key design decisions
 

--- a/.claude/plans/EPIC-3-E-3-1-EVIDENCE-SCHEMA.md
+++ b/.claude/plans/EPIC-3-E-3-1-EVIDENCE-SCHEMA.md
@@ -1,0 +1,53 @@
+# E-3-1 — Support Widening Evidence Schema (decision record)
+
+> V5 Epic 3, slice #853. Infrastructure-only. Ships the versioned evidence
+> schema + pure parse/recompute/verify module + read-only CLI that make a future
+> support-widening decision *decidable* with real evidence — **without flipping
+> any guard flag**. `support_widening` is `const false` at the schema AND
+> re-asserted at runtime (ADR-0002 recompute-not-trust).
+
+## Deliverables
+
+- `ao_kernel/defaults/schemas/support-widening-evidence.schema.v1.json`
+- `ao_kernel/_internal/support_widening/evidence.py` (`parse_v1`, `recompute_v1`, `verify_v1`)
+- CLI `ao-kernel support-widening evidence validate <path> [--recompute]` (read-only)
+- `tests/test_support_widening_evidence_v1.py` (19 invariants)
+
+## Key design decisions
+
+1. **Per-class shapes live in `$defs`, referenced from the root `allOf`.** The
+   discriminated containers (`evidence_dimensions`, `recompute_inputs.raw_dimensions`)
+   are bare `{type:object}` at their base and get their closed shape from a
+   per-`surface_class` `$defs` entry via `if/then`. A base `additionalProperties:false`
+   there would reject the allOf-supplied keys (the JSON-Schema sibling-applicator
+   trap). Effective closure is proven by `test_wrong_class_shape_rejected`; every
+   *shape-defining* node (one that declares `properties`) carries
+   `additionalProperties:false` + `unevaluatedProperties:false`
+   (`test_recursive_strict_closure_at_every_shape_defining_node`, which also
+   asserts exactly the two known bare delegated containers exist).
+
+2. **No remote `$ref`.** Only local `#/$defs/...`. A remote `$ref` would let a
+   controlled endpoint alter the contract at validation time (TOCTOU);
+   `test_no_remote_ref` walks the schema and rejects any `http(s)` ref.
+
+3. **`recompute_inputs` is not a widening back-door.** The module
+   (`recompute_v1`) walks every key in `recompute_inputs` and rejects any matching
+   the forbidden-widening regex, and re-derives `evidence_dimensions` from
+   `recompute_inputs.raw_dimensions` (never trusting the stored value).
+
+4. **Guard pins are double-enforced.** Schema `const false` +
+   `_RUNTIME_PINS` re-assert in `parse_v1`. To emit `support_widening: true` a
+   producer must use a *different* v2 schema (Epic 9 supersession), making the
+   policy structurally enforceable, not process-dependent.
+
+5. **`verify_v1` re-hashes on-disk refs from disk** (never trusts a stored hash).
+
+## Out of scope (later slices)
+
+- Harness execution (E-3-2), advisory CI matrix (E-3-3), surface inventory doc
+  (E-3-4), consensus checklist (E-3-5), recompute-not-trust validator wiring
+  (E-3-6), and the v2 supersession schema (Epic 9). No guard-flag flip anywhere.
+
+## Cross-AI review
+
+Implementer claude (anthropic) → reviewer codex (openai). See PR evidence.

--- a/.claude/plans/EPIC-3-SUPPORT-WIDENING-MATRIX.md
+++ b/.claude/plans/EPIC-3-SUPPORT-WIDENING-MATRIX.md
@@ -489,7 +489,9 @@ Per CLAUDE.md test-quality gate (conftest AST-based BLK rules): assertions are c
 
 ### Recursive closure (per iter-2 absorb F2 — required at EVERY nested node)
 
-**Every** object node in the schema — root, `evidence_dimensions`, every per-class shape under `allOf`/`if/then`, every `$defs` entry, every nested object inside `recompute_inputs`, every supersession bind-field group — MUST carry:
+**Every shape-defining** object node in the schema — root, every per-class shape under `allOf`/`if/then` (in v1 these live in `$defs`), every `$defs` entry, every nested object inside `recompute_inputs`, every supersession bind-field group — MUST carry:
+
+> **Implementation reconciliation (E-3-1):** "shape-defining" = a node that declares `properties`. The discriminated containers `evidence_dimensions` and `recompute_inputs.raw_dimensions` are intentionally bare `{type: object}` at their base: a base `additionalProperties: false` there would reject the keys supplied by the root `allOf` `$ref` (the JSON-Schema sibling-applicator trap). Their closed shape is delegated to a per-`surface_class` `$defs` entry (each fully closed); effective closure is proven by `test_wrong_class_shape_rejected`, and `test_recursive_strict_closure_at_every_shape_defining_node` asserts (a) every node declaring `properties` is closed and (b) the bare nodes are EXACTLY those two delegated containers (exact-path set).
 
 - `type: object`
 - `additionalProperties: false`
@@ -524,7 +526,7 @@ register_authority      const "evidence_record_only"
 github_write_authorized const false
 simulated_only          const true
 live_call_made          const false
-evidence_dimensions     object (required, additionalProperties: false; per-class shape via allOf below)
+evidence_dimensions     object (required; bare {type:object} base — per-class closed shape via $defs `$ref` from the root allOf below; a base additionalProperties:false would reject the allOf-supplied keys)
 reviewer_providers      array minItems=0 (Epic 3 evidence is INFRASTRUCTURE; per-slice review trail recorded separately)
 recompute_inputs        object (required) — raw inputs from which any consensus/aggregation field MUST be re-derivable
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `ao_kernel/_internal/support_widening/evidence.py` (`parse_v1` with runtime
   guard-pin re-assert, `recompute_v1` recompute-not-trust, `verify_v1` on-disk
   re-hash) + read-only CLI `ao-kernel support-widening evidence validate <path>
-  [--recompute]`. 19 machine-enforced invariants. Infrastructure-only:
+  [--recompute]`. 17 test functions / 20 collected pytest cases (machine-enforced
+  invariants). Infrastructure-only:
   `support_widening` / `production_platform_claim` / `live_adapter_execution`
   all `const false` at schema and re-asserted at runtime; no guard flip (a true
   value requires the separate v2 supersession schema, Epic 9).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **E-3-1 support widening evidence schema + validator** (V5 Epic 3, #853):
+  added `support-widening-evidence.schema.v1.json` (per-`surface_class` evidence
+  shapes via `$defs`+`allOf`; recursive strict closure on every shape-defining
+  node; no remote `$ref`; `recompute_inputs` shadow-widening guard) + the pure
+  `ao_kernel/_internal/support_widening/evidence.py` (`parse_v1` with runtime
+  guard-pin re-assert, `recompute_v1` recompute-not-trust, `verify_v1` on-disk
+  re-hash) + read-only CLI `ao-kernel support-widening evidence validate <path>
+  [--recompute]`. 19 machine-enforced invariants. Infrastructure-only:
+  `support_widening` / `production_platform_claim` / `live_adapter_execution`
+  all `const false` at schema and re-asserted at runtime; no guard flip (a true
+  value requires the separate v2 supersession schema, Epic 9).
 - **E-2-5 secret resolution discipline module** (V5 Epic 2, #850): added
   `ao_kernel._internal.secrets.SecretResolutionDiscipline` and
   `SecretTaintSet` as the env-var-only, value-based taint primitive for future

--- a/ao_kernel/_internal/support_widening/__init__.py
+++ b/ao_kernel/_internal/support_widening/__init__.py
@@ -1,0 +1,2 @@
+"""Support widening infrastructure (V5 Epic 3). Infrastructure-only: every
+artifact pins support_widening=false; no slice here flips the guard flag."""

--- a/ao_kernel/_internal/support_widening/evidence.py
+++ b/ao_kernel/_internal/support_widening/evidence.py
@@ -1,0 +1,150 @@
+"""Support widening evidence v1 — pure parse / recompute / verify (V5 Epic 3 E-3-1).
+
+Infrastructure-only. The schema pins ``support_widening: false`` (and the other
+guard flags) as ``const false``; this module **re-asserts** those pins at runtime
+(ADR-0002 recompute-not-trust corollary) so a forged payload that somehow slipped a
+flipped flag past the schema is still rejected.
+
+  - ``parse_v1(payload, *, schema)`` — JSON-Schema validate + runtime pin re-assert.
+  - ``recompute_v1(payload)`` — re-derive ``evidence_dimensions`` from
+    ``recompute_inputs.raw_dimensions`` (never trust the stored value) and reject
+    any forbidden-widening key inside ``recompute_inputs`` at any depth.
+  - ``verify_v1(payload, *, on_disk_refs)`` — re-hash every on-disk ref FROM DISK
+    and confirm it matches the declared digest; combine parse + recompute into one
+    fail-closed verdict.
+
+No I/O at the parse/recompute boundary; the only disk reads are in ``verify_v1``,
+which re-hashes (never trusts a stored hash).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+# Guard-flag / authority pins re-asserted at runtime (must match the schema consts).
+_RUNTIME_PINS: dict[str, Any] = {
+    "schema_version": "support_widening_evidence.v1",
+    "artifact_kind": "support_widening_evidence",
+    "support_widening": False,
+    "production_platform_claim": False,
+    "live_adapter_execution": False,
+    "github_write_authorized": False,
+    "register_authority": "evidence_record_only",
+    "simulated_only": True,
+    "live_call_made": False,
+}
+
+# A recompute_inputs key matching this (at any depth) would be a shadow-widening
+# back-door; the module rejects it regardless of the stored value.
+_FORBIDDEN_WIDENING = re.compile(
+    r"(?i)(support[_-]?widening|widening[_-]?authorized|live[_-]?adapter[_-]?execution"
+    r"|production[_-]?platform[_-]?claim|github[_-]?write[_-]?authorized)"
+)
+
+
+class SupportWideningEvidenceError(ValueError):
+    """Raised when a support-widening evidence payload fails validation (fail-closed)."""
+
+
+def _iter_keys(obj: Any) -> "list[str]":
+    """Every dict key appearing anywhere in ``obj`` (recursive)."""
+    found: list[str] = []
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            found.append(key)
+            found.extend(_iter_keys(value))
+    elif isinstance(obj, list):
+        for item in obj:
+            found.extend(_iter_keys(item))
+    return found
+
+
+def parse_v1(payload: dict[str, Any], *, schema: dict[str, Any]) -> dict[str, Any]:
+    """Validate ``payload`` against ``schema`` and re-assert the runtime pins.
+
+    Raises ``SupportWideningEvidenceError`` on the first failure (fail-closed).
+    Returns ``payload`` unchanged on success.
+    """
+    errors = sorted(Draft202012Validator(schema).iter_errors(payload), key=lambda e: list(e.absolute_path))
+    if errors:
+        joined = "; ".join(f"{'/'.join(str(p) for p in e.absolute_path) or '<root>'}: {e.message}" for e in errors)
+        raise SupportWideningEvidenceError(f"schema validation failed: {joined}")
+    for key, expected in _RUNTIME_PINS.items():
+        if payload.get(key) != expected:
+            raise SupportWideningEvidenceError(
+                f"runtime pin re-assert failed: {key!r} must be {expected!r}, got {payload.get(key)!r}"
+            )
+    return payload
+
+
+def recompute_v1(payload: dict[str, Any]) -> dict[str, Any]:
+    """Re-derive ``evidence_dimensions`` from ``recompute_inputs.raw_dimensions``.
+
+    The stored ``evidence_dimensions`` is NEVER trusted: it must be byte-for-byte
+    (canonical-JSON) equal to what we re-derive from the raw inputs. Also rejects any
+    forbidden-widening key anywhere inside ``recompute_inputs``.
+
+    Returns the recomputed ``evidence_dimensions``; raises on mismatch / forbidden key.
+    """
+    recompute_inputs = payload.get("recompute_inputs")
+    if not isinstance(recompute_inputs, dict):
+        raise SupportWideningEvidenceError("recompute_inputs missing or not an object")
+
+    for key in _iter_keys(recompute_inputs):
+        if _FORBIDDEN_WIDENING.search(key):
+            raise SupportWideningEvidenceError(
+                f"recompute_inputs carries a forbidden widening key: {key!r} (shadow-widening guard)"
+            )
+
+    raw = recompute_inputs.get("raw_dimensions")
+    if not isinstance(raw, dict):
+        raise SupportWideningEvidenceError("recompute_inputs.raw_dimensions missing or not an object")
+
+    # v1 recompute contract: evidence_dimensions is re-derived as the canonical form
+    # of the raw inputs (identity-with-validation). v2 adds real aggregation here.
+    recomputed: dict[str, Any] = {str(k): v for k, v in raw.items()}
+    stored = payload.get("evidence_dimensions")
+    if json.dumps(recomputed, sort_keys=True) != json.dumps(stored, sort_keys=True):
+        raise SupportWideningEvidenceError(
+            "evidence_dimensions does not match recompute_inputs.raw_dimensions (recompute-not-trust)"
+        )
+    return recomputed
+
+
+def verify_v1(
+    payload: dict[str, Any],
+    *,
+    schema: dict[str, Any],
+    on_disk_refs: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Full fail-closed verification: parse + recompute + re-hash on-disk refs.
+
+    ``on_disk_refs`` maps a declared ``sha256:<hex>`` digest to a filesystem path; each
+    path is read and re-hashed FROM DISK and must match the declared digest. Returns a
+    report ``{"valid": True, "recomputed": {...}, "refs_verified": [...]}``; raises on
+    any failure.
+    """
+    parse_v1(payload, schema=schema)
+    recomputed = recompute_v1(payload)
+
+    verified: list[str] = []
+    for declared, path_str in (on_disk_refs or {}).items():
+        if not declared.startswith("sha256:"):
+            raise SupportWideningEvidenceError(f"on-disk ref digest must be sha256:-prefixed, got {declared!r}")
+        path = Path(path_str)
+        if not path.is_file():
+            raise SupportWideningEvidenceError(f"on-disk ref path missing: {path_str}")
+        actual = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual != declared:
+            raise SupportWideningEvidenceError(
+                f"on-disk ref digest mismatch for {path_str}: declared {declared}, recomputed {actual}"
+            )
+        verified.append(path_str)
+
+    return {"valid": True, "recomputed": recomputed, "refs_verified": verified}

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -616,6 +616,47 @@ def _parse_repo_export_targets(raw: str | None) -> list[str]:
     return targets
 
 
+def _cmd_support_widening_evidence_validate(args: argparse.Namespace) -> int:
+    """V5 Epic 3 E-3-1: validate a support_widening_evidence.v1 artifact.
+
+    Read-only — no mutation. Validates against the schema + re-asserts the runtime
+    guard pins; with --recompute, also re-derives evidence_dimensions from
+    recompute_inputs (recompute-not-trust). Exit 0 on valid, 1 on failure.
+    """
+    import json as _json
+    from pathlib import Path as _Path
+
+    from ao_kernel._internal.support_widening.evidence import (
+        SupportWideningEvidenceError,
+        parse_v1,
+        recompute_v1,
+    )
+    from ao_kernel.config import load_default
+
+    path = _Path(args.path)
+    if not path.is_file():
+        print(f"error: evidence file not found: {args.path}", file=sys.stderr)
+        return 1
+    try:
+        payload = _json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"error: cannot read/parse evidence JSON: {exc}", file=sys.stderr)
+        return 1
+
+    schema = load_default("schemas", "support-widening-evidence.schema.v1.json")
+    try:
+        parse_v1(payload, schema=schema)
+        if getattr(args, "recompute", False):
+            recompute_v1(payload)
+    except SupportWideningEvidenceError as exc:
+        print(f"INVALID: {exc}", file=sys.stderr)
+        return 1
+
+    suffix = " (+recompute)" if getattr(args, "recompute", False) else ""
+    print(f"VALID: {args.path}{suffix} — support_widening pinned false; surface_class={payload.get('surface_class')}")
+    return 0
+
+
 def _cmd_cost_reconcile(args: argparse.Namespace) -> int:
     """v3.4.0 CLI: scan ledger for orphan spend entries and stamp
     missing markers. Idempotent + cursor-based."""
@@ -1886,6 +1927,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Project root (default: cwd)",
     )
 
+    # V5 Epic 3 E-3-1: support-widening evidence validation (read-only)
+    sw_p = sub.add_parser(
+        "support-widening",
+        help="Support-widening evidence (infrastructure-only; read-only validation)",
+    )
+    sw_sub = sw_p.add_subparsers(dest="support_widening_command")
+    sw_ev_p = sw_sub.add_parser("evidence", help="Support-widening evidence commands")
+    sw_ev_sub = sw_ev_p.add_subparsers(dest="support_widening_evidence_command")
+    sw_validate_p = sw_ev_sub.add_parser(
+        "validate",
+        help="Validate a support_widening_evidence.v1 artifact (read-only; no mutation)",
+    )
+    sw_validate_p.add_argument("path", help="Path to the evidence JSON artifact")
+    sw_validate_p.add_argument(
+        "--recompute",
+        action="store_true",
+        help="Also re-derive evidence_dimensions from recompute_inputs (recompute-not-trust)",
+    )
+
     # v3.5 D3: scorecard subcommand
     scorecard_p = sub.add_parser(
         "scorecard",
@@ -2093,6 +2153,18 @@ def main(argv: list[str] | None = None) -> int:
             return _cmd_cost_compact_markers(args)
         print(
             "Usage: ao-kernel cost {reconcile|compact-markers}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # V5 Epic 3 E-3-1: support-widening evidence validation (read-only)
+    if cmd == "support-widening":
+        sw_cmd = getattr(args, "support_widening_command", None)
+        sw_ev_cmd = getattr(args, "support_widening_evidence_command", None)
+        if sw_cmd == "evidence" and sw_ev_cmd == "validate":
+            return _cmd_support_widening_evidence_validate(args)
+        print(
+            "Usage: ao-kernel support-widening evidence validate <path> [--recompute]",
             file=sys.stderr,
         )
         return 1

--- a/ao_kernel/defaults/schemas/support-widening-evidence.schema.v1.json
+++ b/ao_kernel/defaults/schemas/support-widening-evidence.schema.v1.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:support-widening-evidence:v1",
+  "title": "Support Widening Evidence (v1, infrastructure-only)",
+  "description": "Records, in library/simulated mode, the evidence a future support-widening decision would need per surface class. Infrastructure-only: support_widening is const false (a true value requires the separate v2 supersession schema). No remote $ref (local #/$defs only); per-class evidence shapes are strict-closed $defs; recompute_inputs may not carry any widening-flag key.",
+  "type": "object",
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "generated_at",
+    "repo",
+    "surface_class",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution",
+    "register_authority",
+    "github_write_authorized",
+    "simulated_only",
+    "live_call_made",
+    "evidence_dimensions",
+    "reviewer_providers",
+    "recompute_inputs"
+  ],
+  "properties": {
+    "schema_version": { "const": "support_widening_evidence.v1" },
+    "artifact_kind": { "const": "support_widening_evidence" },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-((0[13578]|1[02])-(0[1-9]|[12][0-9]|3[01])|(0[469]|11)-(0[1-9]|[12][0-9]|30)|02-(0[1-9]|1[0-9]|2[0-9]))T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]+)?(Z|[+-]([01][0-9]|2[0-3]):[0-5][0-9])$"
+    },
+    "repo": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+    "surface_class": {
+      "type": "string",
+      "enum": ["provider", "python_version", "os_platform", "db_backend", "deployment_topology"]
+    },
+    "support_widening": { "const": false },
+    "production_platform_claim": { "const": false },
+    "live_adapter_execution": { "const": false },
+    "register_authority": { "const": "evidence_record_only" },
+    "github_write_authorized": { "const": false },
+    "simulated_only": { "const": true },
+    "live_call_made": { "const": false },
+    "evidence_dimensions": {
+      "type": "object",
+      "comment": "Shape is delegated to a per-surface-class $defs entry via the root allOf (a base additionalProperties:false here would reject the allOf-supplied keys — the classic JSON-Schema sibling-applicator trap)."
+    },
+    "reviewer_providers": {
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "unevaluatedProperties": false,
+        "required": ["provider", "verdict"],
+        "properties": {
+          "provider": { "type": "string", "minLength": 1 },
+          "verdict": { "type": "string", "enum": ["AGREE", "REVISE", "RED"] }
+        }
+      }
+    },
+    "recompute_inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": ["raw_dimensions"],
+      "description": "Raw inputs from which evidence_dimensions is re-derivable. NOT a widening back-door: no key may match the forbidden-widening regex at any depth (module + test enforced).",
+      "properties": {
+        "raw_dimensions": {
+          "type": "object",
+          "comment": "Mirrors evidence_dimensions; per-class shape delegated to the same $defs entry via the root allOf."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "provider_dims": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": ["integration_tests", "stub_adapter_ids", "note"],
+      "properties": {
+        "integration_tests": {
+          "type": "object",
+          "additionalProperties": false,
+          "unevaluatedProperties": false,
+          "required": ["count"],
+          "properties": { "count": { "type": "integer", "minimum": 0 } }
+        },
+        "stub_adapter_ids": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "note": { "type": "string" }
+      }
+    },
+    "python_version_dims": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": ["matrix", "pytest_passed"],
+      "properties": {
+        "matrix": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["3.11", "3.12", "3.13"] },
+          "uniqueItems": true
+        },
+        "pytest_passed": { "type": "boolean" }
+      }
+    },
+    "os_platform_dims": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": ["platform", "smoke_passed"],
+      "properties": {
+        "platform": {
+          "type": "string",
+          "enum": ["linux-x86_64", "linux-arm64", "macos-x86_64", "macos-arm64", "windows-amd64"]
+        },
+        "smoke_passed": { "type": "boolean" }
+      }
+    },
+    "db_backend_dims": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": ["backend", "round_trip_passed"],
+      "properties": {
+        "backend": { "type": "string", "enum": ["sqlite_in_memory", "pgvector", "future_other"] },
+        "round_trip_passed": { "type": "boolean" }
+      }
+    },
+    "deployment_topology_dims": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": ["topology", "isolation_passed"],
+      "properties": {
+        "topology": {
+          "type": "string",
+          "enum": ["library", "single_tenant_container", "k8s_helm", "multi_tenant_saas"]
+        },
+        "isolation_passed": { "type": "boolean" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "required": ["surface_class"], "properties": { "surface_class": { "const": "provider" } } },
+      "then": {
+        "properties": {
+          "evidence_dimensions": { "$ref": "#/$defs/provider_dims" },
+          "recompute_inputs": { "properties": { "raw_dimensions": { "$ref": "#/$defs/provider_dims" } } }
+        }
+      }
+    },
+    {
+      "if": { "required": ["surface_class"], "properties": { "surface_class": { "const": "python_version" } } },
+      "then": {
+        "properties": {
+          "evidence_dimensions": { "$ref": "#/$defs/python_version_dims" },
+          "recompute_inputs": { "properties": { "raw_dimensions": { "$ref": "#/$defs/python_version_dims" } } }
+        }
+      }
+    },
+    {
+      "if": { "required": ["surface_class"], "properties": { "surface_class": { "const": "os_platform" } } },
+      "then": {
+        "properties": {
+          "evidence_dimensions": { "$ref": "#/$defs/os_platform_dims" },
+          "recompute_inputs": { "properties": { "raw_dimensions": { "$ref": "#/$defs/os_platform_dims" } } }
+        }
+      }
+    },
+    {
+      "if": { "required": ["surface_class"], "properties": { "surface_class": { "const": "db_backend" } } },
+      "then": {
+        "properties": {
+          "evidence_dimensions": { "$ref": "#/$defs/db_backend_dims" },
+          "recompute_inputs": { "properties": { "raw_dimensions": { "$ref": "#/$defs/db_backend_dims" } } }
+        }
+      }
+    },
+    {
+      "if": { "required": ["surface_class"], "properties": { "surface_class": { "const": "deployment_topology" } } },
+      "then": {
+        "properties": {
+          "evidence_dimensions": { "$ref": "#/$defs/deployment_topology_dims" },
+          "recompute_inputs": { "properties": { "raw_dimensions": { "$ref": "#/$defs/deployment_topology_dims" } } }
+        }
+      }
+    }
+  ]
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,27 +1,28 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "E-2-5-SECRET-DISCIPLINE",
+  "work_package": "E-3-1-SUPPORT-WIDENING-EVIDENCE",
   "implementer": {
-    "agent": "codex",
-    "provider": "openai"
+    "agent": "claude",
+    "provider": "anthropic"
   },
   "reviewer": {
-    "agent": "claude",
-    "provider": "anthropic",
+    "agent": "codex",
+    "provider": "openai",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-2-5-secret-discipline",
+    "head_ref": "refs/heads/feat/epic-3-1-support-widening-evidence",
     "changed_files": [
-      ".claude/plans/adr/ADR-0007-secret-resolution-discipline.md",
-      ".claude/plans/adr/index.json",
+      ".claude/plans/EPIC-3-E-3-1-EVIDENCE-SCHEMA.md",
+      ".claude/plans/EPIC-3-SUPPORT-WIDENING-MATRIX.md",
       "CHANGELOG.md",
-      "ao_kernel/_internal/secrets/__init__.py",
-      "ao_kernel/_internal/secrets/discipline.py",
-      "ao_kernel/_internal/secrets/taint.py",
-      "tests/test_secret_discipline.py",
+      "ao_kernel/_internal/support_widening/__init__.py",
+      "ao_kernel/_internal/support_widening/evidence.py",
+      "ao_kernel/cli.py",
+      "ao_kernel/defaults/schemas/support-widening-evidence.schema.v1.json",
+      "tests/test_support_widening_evidence_v1.py",
       "local-ai-review-evidence.v1.json"
     ]
   },
@@ -30,25 +31,18 @@
     { "name": "secret_scan", "status": "pass" },
     { "name": "ruff", "status": "pass" },
     { "name": "mypy", "status": "pass" },
-    { "name": "json_validity", "status": "pass" },
-    { "name": "gpp_next_guard_flags", "status": "pass" },
-    { "name": "diff_whitespace", "status": "pass" },
-    { "name": "workflow_mutation_guard", "status": "pass" },
-    { "name": "env_only_secret_resolution", "status": "pass" },
-    { "name": "value_taint_redaction", "status": "pass" },
-    { "name": "regex_defense_in_depth", "status": "pass" },
-    { "name": "legacy_resolver_compatibility", "status": "pass" },
-    { "name": "cross_provider_review", "status": "pass" },
-    { "name": "minimax_secondary_review", "status": "pass" }
+    { "name": "schema_valid_draft_2020_12", "status": "pass" },
+    { "name": "guard_flags_const_false", "status": "pass" },
+    { "name": "recursive_closure_shape_nodes", "status": "pass" },
+    { "name": "no_remote_ref_local_only", "status": "pass" },
+    { "name": "recompute_inputs_shadow_widening_guard", "status": "pass" },
+    { "name": "no_workflow_mutation", "status": "pass" },
+    { "name": "cross_provider_review", "status": "pass" }
   ],
   "findings": [
-    "Claude Anthropic cross-provider review returned AGREE for E-2-5 secret resolution discipline.",
-    "Mavis MiniMax secondary review also returned AGREE for the same scope and acceptance criteria.",
-    "The new discipline module resolves secrets from environment variables only and does not import or call provider factory, vault, MCP, argv, stdin, file, or header fallback paths.",
-    "Every resolved value is added to an in-memory value-based taint set; JSON, JSONL, and log serialization helpers redact by exact taint before regex defense-in-depth.",
-    "Missing required secrets fail closed with SecretResolutionError, optional missing secrets return None without taint, and provider invalidation clears provider-specific taints for rotation.",
-    "Legacy dual-read API-key resolver behavior is preserved for existing callers; E-2-5 adds explicit adoption infrastructure rather than changing legacy resolution semantics.",
-    "Guard flags remain false. No workflow mutation, support widening, production platform claim, live adapter execution, or secret readback is introduced."
+    "E-3-1 support widening evidence schema + pure parse/recompute/verify module + read-only CLI (infrastructure-only). 2-iter Codex (OpenAI) cross-AI review on thread 019e9339; all 5 REVISE findings absorbed: (1) no-remote-ref test tightened to a local '#/' allowlist (http(s)-only let file/ftp/urn/bare-file through); (2) bare delegated-container closure asserted by exact json-pointer path set (was count-only); (3) plan §7 normative text reconciled with the implemented $defs+allOf+bare-container design; (4) branch rebased onto origin/main with both E-3-1 and E-2-5 CHANGELOG entries preserved; (5) invariant-count wording fixed (17 functions / 20 pytest cases).",
+    "Reviewer found NO behavioral bypass: cross-class key contamination rejected, shadow-widening key (even camelCase) rejected at any depth, double-pin fail-closed (schema const false + parse_v1 _RUNTIME_PINS re-assert) confirmed, recompute_v1 recompute-not-trust (evidence_dimensions == raw_dimensions canonical equality) and verify_v1 on-disk re-hash tamper-detection confirmed.",
+    "Guard flags const false at schema + evidence level (support_widening / production_platform_claim / live_adapter_execution / github_write_authorized) and re-asserted at runtime. No network call; no guard flip; a true value requires the separate v2 supersession schema (Epic 9). 20 pytest cases green; ruff + mypy clean."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_support_widening_evidence_v1.py
+++ b/tests/test_support_widening_evidence_v1.py
@@ -1,0 +1,340 @@
+"""V5 Epic 3 E-3-1 invariants: support widening evidence v1.
+
+Schema (recursive strict closure, no remote $ref, recompute_inputs shadow-widening
+guard, per-surface-class evidence shapes, const-false guard pins) + the pure
+parse/recompute/verify module + the read-only CLI. Infrastructure-only: every
+artifact pins support_widening=false; no slice here flips the guard flag.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from ao_kernel._internal.support_widening.evidence import (
+    SupportWideningEvidenceError,
+    parse_v1,
+    recompute_v1,
+    verify_v1,
+)
+from ao_kernel.config import load_default
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCHEMA_NAME = "support-widening-evidence.schema.v1.json"
+_SCHEMA_PATH = _REPO_ROOT / "ao_kernel" / "defaults" / "schemas" / _SCHEMA_NAME
+
+_FORBIDDEN = (
+    "support_widening",
+    "widening_authorized",
+    "live_adapter_execution",
+    "production_platform_claim",
+    "github_write_authorized",
+)
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", _SCHEMA_NAME)
+
+
+def _is_valid(payload: dict[str, Any]) -> bool:
+    return not list(Draft202012Validator(_schema()).iter_errors(payload))
+
+
+def _base() -> dict[str, Any]:
+    return {
+        "schema_version": "support_widening_evidence.v1",
+        "artifact_kind": "support_widening_evidence",
+        "generated_at": "2026-06-04T10:00:00Z",
+        "repo": "Halildeu/ao-kernel",
+        "surface_class": "python_version",
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+        "register_authority": "evidence_record_only",
+        "github_write_authorized": False,
+        "simulated_only": True,
+        "live_call_made": False,
+        "evidence_dimensions": {"matrix": ["3.11", "3.12", "3.13"], "pytest_passed": True},
+        "reviewer_providers": [],
+        "recompute_inputs": {"raw_dimensions": {"matrix": ["3.11", "3.12", "3.13"], "pytest_passed": True}},
+    }
+
+
+def _provider() -> dict[str, Any]:
+    p = _base()
+    p["surface_class"] = "provider"
+    dims = {"integration_tests": {"count": 0}, "stub_adapter_ids": ["openai_stub"], "note": "v1 stub"}
+    p["evidence_dimensions"] = dims
+    p["recompute_inputs"] = {"raw_dimensions": json.loads(json.dumps(dims))}
+    return p
+
+
+# ---- 1. schema health (2) ----------------------------------------------
+
+
+def test_schema_present_valid_draft_2020_12() -> None:
+    assert _SCHEMA_PATH.is_file()
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$id"] == "urn:ao:support-widening-evidence:v1"
+
+
+def test_base_fixtures_validate() -> None:
+    assert _is_valid(_base())
+    assert _is_valid(_provider())
+
+
+# ---- 2. recursive strict closure (AST walk) (1) -------------------------
+
+
+def _object_nodes(node: Any) -> "list[dict[str, Any]]":
+    out: list[dict[str, Any]] = []
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            out.append(node)
+        for value in node.values():
+            out.extend(_object_nodes(value))
+    elif isinstance(node, list):
+        for item in node:
+            out.extend(_object_nodes(item))
+    return out
+
+
+def test_recursive_strict_closure_at_every_shape_defining_node() -> None:
+    """BLK-schema-strict-recursive: every `type:object` node that DECLARES
+    `properties` must carry additionalProperties:false AND unevaluatedProperties:false.
+
+    The only bare `type:object` nodes (no `properties`) are the discriminated
+    containers `evidence_dimensions` and `recompute_inputs.raw_dimensions`, whose
+    closed shape is delegated to a per-class `$defs` entry via the root `allOf`
+    (a base `additionalProperties:false` there would reject the allOf-supplied keys —
+    the JSON-Schema sibling-applicator trap). Their effective closure is proven by
+    `test_wrong_class_shape_rejected`. This test asserts every shape-DEFINING node is
+    closed, and that the bare nodes are exactly the two known delegated containers."""
+    schema = _schema()
+    nodes = _object_nodes(schema)
+    assert nodes, "expected multiple object nodes"
+    bare = 0
+    for node in nodes:
+        if "properties" in node:
+            assert node.get("additionalProperties") is False, f"shape node missing additionalProperties:false: {node!r}"
+            assert node.get("unevaluatedProperties") is False, (
+                f"shape node missing unevaluatedProperties:false: {node!r}"
+            )
+        else:
+            bare += 1
+    # exactly two delegated containers: evidence_dimensions + recompute_inputs.raw_dimensions
+    assert bare == 2, f"expected exactly 2 bare delegated object nodes, found {bare}"
+
+
+# ---- 3. no remote $ref (1) ----------------------------------------------
+
+
+def test_no_remote_ref() -> None:
+    """BLK-schema-no-remote-ref: no $ref may be an http(s) URL."""
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str):
+                assert not ref.startswith(("http://", "https://")), f"remote $ref forbidden: {ref}"
+            for value in node.values():
+                _walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    _walk(_schema())
+
+
+# ---- 4. recompute_inputs shadow-widening guard (1) ----------------------
+
+
+def test_recompute_inputs_schema_no_shadow_widening_key() -> None:
+    """BLK-recompute-inputs-no-shadow-widening: the recompute_inputs subschema
+    must declare no property whose name matches a widening flag."""
+    ri_schema = _schema()["properties"]["recompute_inputs"]
+
+    def _keys(node: Any) -> "list[str]":
+        ks: list[str] = []
+        if isinstance(node, dict):
+            props = node.get("properties")
+            if isinstance(props, dict):
+                ks.extend(props.keys())
+            for v in node.values():
+                ks.extend(_keys(v))
+        elif isinstance(node, list):
+            for it in node:
+                ks.extend(_keys(it))
+        return ks
+
+    for key in _keys(ri_schema):
+        low = key.lower()
+        assert not any(
+            f in low
+            for f in ("support_widening", "widening_authorized", "live_adapter", "production_platform", "github_write")
+        ), f"recompute_inputs schema declares a forbidden widening key: {key!r}"
+
+
+# ---- 5. guard-flag const pins (2) ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flag", ["support_widening", "production_platform_claim", "live_adapter_execution", "github_write_authorized"]
+)
+def test_guard_flags_pinned_false(flag: str) -> None:
+    bad = _base()
+    bad[flag] = True
+    assert not _is_valid(bad), f"{flag}=true must be rejected"
+
+
+def test_authority_and_simulation_pins() -> None:
+    for field, bad in (
+        ("register_authority", "release_authority"),
+        ("simulated_only", False),
+        ("live_call_made", True),
+    ):
+        payload = _base()
+        payload[field] = bad
+        assert not _is_valid(payload), f"{field} pin must reject {bad!r}"
+
+
+# ---- 6. per-surface-class dimensions (2) --------------------------------
+
+
+def test_each_surface_class_has_a_valid_shape() -> None:
+    shapes = {
+        "provider": {"integration_tests": {"count": 0}, "stub_adapter_ids": [], "note": "n"},
+        "python_version": {"matrix": ["3.11"], "pytest_passed": True},
+        "os_platform": {"platform": "linux-x86_64", "smoke_passed": True},
+        "db_backend": {"backend": "sqlite_in_memory", "round_trip_passed": True},
+        "deployment_topology": {"topology": "library", "isolation_passed": True},
+    }
+    for sclass, dims in shapes.items():
+        payload = _base()
+        payload["surface_class"] = sclass
+        payload["evidence_dimensions"] = dims
+        payload["recompute_inputs"] = {"raw_dimensions": json.loads(json.dumps(dims))}
+        assert _is_valid(payload), f"{sclass} valid shape must validate"
+
+
+def test_wrong_class_shape_rejected() -> None:
+    # provider class with python_version shape must fail (per-class allOf)
+    payload = _provider()
+    payload["evidence_dimensions"] = {"matrix": ["3.11"], "pytest_passed": True}
+    assert not _is_valid(payload), "mismatched per-class evidence_dimensions must be rejected"
+
+
+# ---- 7. module: parse / recompute / verify (5) --------------------------
+
+
+def test_parse_v1_accepts_valid_and_rejects_flipped_pin() -> None:
+    assert parse_v1(_base(), schema=_schema()) == _base()
+    bad = _base()
+    bad["support_widening"] = True
+    with pytest.raises(SupportWideningEvidenceError):
+        parse_v1(bad, schema=_schema())
+
+
+def test_recompute_v1_matches_when_consistent() -> None:
+    assert recompute_v1(_base()) == _base()["evidence_dimensions"]
+
+
+def test_recompute_v1_rejects_mismatch() -> None:
+    bad = _base()
+    bad["evidence_dimensions"] = {"matrix": ["3.11"], "pytest_passed": False}  # diverges from raw_dimensions
+    with pytest.raises(SupportWideningEvidenceError):
+        recompute_v1(bad)
+
+
+def test_recompute_v1_rejects_shadow_widening_key() -> None:
+    bad = _base()
+    bad["recompute_inputs"]["raw_dimensions"]["support_widening"] = True
+    with pytest.raises(SupportWideningEvidenceError):
+        recompute_v1(bad)
+
+
+def test_verify_v1_rehashes_on_disk_ref(tmp_path: Path) -> None:
+    import hashlib
+
+    ref_file = tmp_path / "artifact.txt"
+    ref_file.write_text("evidence-bytes", encoding="utf-8")
+    digest = "sha256:" + hashlib.sha256(ref_file.read_bytes()).hexdigest()
+    report = verify_v1(_base(), schema=_schema(), on_disk_refs={digest: str(ref_file)})
+    assert report["valid"] is True and str(ref_file) in report["refs_verified"]
+    # tamper: wrong declared digest must be rejected (recompute-not-trust)
+    with pytest.raises(SupportWideningEvidenceError):
+        verify_v1(_base(), schema=_schema(), on_disk_refs={"sha256:" + ("0" * 64): str(ref_file)})
+
+
+# ---- 8. CLI: read-only validate (2) -------------------------------------
+
+
+def _run_cli(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "ao_kernel.cli", *args],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_cli_validate_valid_artifact(tmp_path: Path) -> None:
+    artifact = tmp_path / "ev.json"
+    artifact.write_text(json.dumps(_base()), encoding="utf-8")
+    proc = _run_cli(["support-widening", "evidence", "validate", str(artifact), "--recompute"])
+    assert proc.returncode == 0, proc.stderr
+    assert "VALID" in proc.stdout
+
+
+def test_cli_validate_rejects_flipped_flag(tmp_path: Path) -> None:
+    bad = _base()
+    bad["support_widening"] = True
+    artifact = tmp_path / "bad.json"
+    artifact.write_text(json.dumps(bad), encoding="utf-8")
+    proc = _run_cli(["support-widening", "evidence", "validate", str(artifact)])
+    assert proc.returncode == 1
+    assert "INVALID" in proc.stderr
+
+
+# ---- 9. governance: no workflow mutation (1) ----------------------------
+
+
+def test_no_workflow_mutation_in_diff() -> None:
+    added = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--diff-filter=A",
+            "--name-only",
+            "origin/main...HEAD",
+            "--",
+            "tests/test_support_widening_evidence_v1.py",
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if added.returncode != 0:
+        pytest.skip(f"git diff unavailable: {added.stderr.strip()}")
+    if not added.stdout.strip():
+        pytest.skip("E-3-1 test not ADDED by this PR (introducer pattern); invariant N/A")
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main...HEAD", "--", ".github/workflows/"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        pytest.skip(f"git diff unavailable: {proc.stderr.strip()}")
+    touched = [p for p in proc.stdout.split() if p]
+    assert not touched, f"E-3-1 must not touch .github/workflows/. Touched: {touched}"

--- a/tests/test_support_widening_evidence_v1.py
+++ b/tests/test_support_widening_evidence_v1.py
@@ -93,16 +93,17 @@ def test_base_fixtures_validate() -> None:
 # ---- 2. recursive strict closure (AST walk) (1) -------------------------
 
 
-def _object_nodes(node: Any) -> "list[dict[str, Any]]":
-    out: list[dict[str, Any]] = []
+def _object_nodes(node: Any, path: str = "") -> "list[tuple[str, dict[str, Any]]]":
+    """Every (json-pointer path, node) where node is a `type:object` subschema."""
+    out: list[tuple[str, dict[str, Any]]] = []
     if isinstance(node, dict):
         if node.get("type") == "object":
-            out.append(node)
-        for value in node.values():
-            out.extend(_object_nodes(value))
+            out.append((path, node))
+        for key, value in node.items():
+            out.extend(_object_nodes(value, f"{path}/{key}"))
     elif isinstance(node, list):
-        for item in node:
-            out.extend(_object_nodes(item))
+        for i, item in enumerate(node):
+            out.extend(_object_nodes(item, f"{path}/{i}"))
     return out
 
 
@@ -115,35 +116,42 @@ def test_recursive_strict_closure_at_every_shape_defining_node() -> None:
     closed shape is delegated to a per-class `$defs` entry via the root `allOf`
     (a base `additionalProperties:false` there would reject the allOf-supplied keys —
     the JSON-Schema sibling-applicator trap). Their effective closure is proven by
-    `test_wrong_class_shape_rejected`. This test asserts every shape-DEFINING node is
-    closed, and that the bare nodes are exactly the two known delegated containers."""
+    `test_wrong_class_shape_rejected`. This asserts every shape-DEFINING node is
+    closed AND the bare nodes are EXACTLY the two known delegated containers (an
+    exact-path set, so a future displaced/added bare node fails the test)."""
     schema = _schema()
     nodes = _object_nodes(schema)
     assert nodes, "expected multiple object nodes"
-    bare = 0
-    for node in nodes:
+    bare_paths: set[str] = set()
+    for node_path, node in nodes:
         if "properties" in node:
-            assert node.get("additionalProperties") is False, f"shape node missing additionalProperties:false: {node!r}"
+            assert node.get("additionalProperties") is False, (
+                f"shape node {node_path} missing additionalProperties:false"
+            )
             assert node.get("unevaluatedProperties") is False, (
-                f"shape node missing unevaluatedProperties:false: {node!r}"
+                f"shape node {node_path} missing unevaluatedProperties:false"
             )
         else:
-            bare += 1
-    # exactly two delegated containers: evidence_dimensions + recompute_inputs.raw_dimensions
-    assert bare == 2, f"expected exactly 2 bare delegated object nodes, found {bare}"
+            bare_paths.add(node_path)
+    assert bare_paths == {
+        "/properties/evidence_dimensions",
+        "/properties/recompute_inputs/properties/raw_dimensions",
+    }, f"bare delegated object nodes drifted: {sorted(bare_paths)}"
 
 
 # ---- 3. no remote $ref (1) ----------------------------------------------
 
 
-def test_no_remote_ref() -> None:
-    """BLK-schema-no-remote-ref: no $ref may be an http(s) URL."""
+def test_only_local_defs_refs() -> None:
+    """BLK-schema-no-remote-ref: every $ref must be a local `#/...` fragment.
+    Rejects http(s)/file/ftp/urn and bare-file refs (a controllable non-local ref
+    is a validation-time TOCTOU surface)."""
 
     def _walk(node: Any) -> None:
         if isinstance(node, dict):
             ref = node.get("$ref")
             if isinstance(ref, str):
-                assert not ref.startswith(("http://", "https://")), f"remote $ref forbidden: {ref}"
+                assert ref.startswith("#/"), f"non-local $ref forbidden (local #/ only): {ref}"
             for value in node.values():
                 _walk(value)
         elif isinstance(node, list):


### PR DESCRIPTION
## V5 Epic 3 E-3-1 — Support Widening Evidence (#853)

**Infrastructure-only.** Versioned evidence schema + pure parse/recompute/verify module + read-only CLI that make a future support-widening decision *decidable* with real evidence — **without flipping any guard flag**.

### What
- `support-widening-evidence.schema.v1.json` — per-`surface_class` evidence shapes via `$defs`+`allOf`; recursive strict closure on every shape-defining node; **no remote $ref** (local `#/` only); `recompute_inputs` shadow-widening guard
- `ao_kernel/_internal/support_widening/evidence.py` — `parse_v1` (runtime guard-pin re-assert), `recompute_v1` (recompute-not-trust), `verify_v1` (on-disk re-hash)
- read-only CLI `ao-kernel support-widening evidence validate <path> [--recompute]`
- 17 test functions / 20 pytest cases (exact-path closure assert, local-ref allowlist, shadow-widening guard, per-class shapes, double-pin fail-closed)

### Cross-AI review
Implementer **claude (anthropic)** → Reviewer **codex (openai)**, thread `019e9339`, **verdict AGREE (iter-2)**. 5 REVISE absorbed (local-ref allowlist, exact-path closure, plan §7 reconcile, rebase+CHANGELOG, count wording). No behavioral bypass found.

### Guard flags (const false — unchanged)
`support_widening=false` · `production_platform_claim=false` · `live_adapter_execution=false` · `github_write_authorized=false` — schema const + runtime re-assert. v2 supersession = Epic 9.

Closes #853

Implementer: claude (anthropic)
Reviewer: codex (openai, thread 019e9339)

🤖 Generated with [Claude Code](https://claude.com/claude-code)