### PR TITLE
fix(e-2-6): harden advisory runner failure stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **E-2-6 advisory runner failure stderr hardening**: replaced handled failure
+  stderr with a fixed boundary message and added a subprocess regression test
+  proving stderr does not leak exception text, artifact paths, envelope
+  digests, protected secret environment variable names, or summary payloads.
+  Guard flags remain false; no workflow permission/trigger change, provider
+  HTTP call, support widening, production claim, or live adapter execution is
+  introduced.
 - **V5 E-1-7 CI shadow-skip status sync**: recorded PR #937 (`c7e5709`)
   as the permanent fix for the required-check shadow-skip issue originally
   tracked by PR #764, keeping `.github/workflows/test.yml` high-risk behavior

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "E-2-6-ADVISORY-CI",
+  "work_package": "E-2-6-STDERR-HARDENING",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,14 +13,11 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-2-6-advisory-ci",
+    "head_ref": "refs/heads/codex/epic-2-6-stderr-hardening",
     "changed_files": [
-      ".github/workflows/live-adapter-evidence-emit.yml",
-      "CHANGELOG.md",
+      "local-ai-review-evidence.v1.json",
       "scripts/live_adapter_evidence_workflow_runner.py",
-      "tests/test_cost_ceiling.py",
-      "tests/test_live_adapter_evidence_workflow.py",
-      "local-ai-review-evidence.v1.json"
+      "tests/test_live_adapter_evidence_workflow.py"
     ]
   },
   "checks_considered": [
@@ -38,20 +35,18 @@
     { "name": "dry_run_harness_delegation", "status": "pass" },
     { "name": "forbidden_secret_env_fail_closed", "status": "pass" },
     { "name": "guard_flags_false_in_artifacts", "status": "pass" },
-    { "name": "codeql_stdout_secret_logging_hardened", "status": "pass" },
+    { "name": "codeql_stdout_stderr_secret_logging_hardened", "status": "pass" },
     { "name": "legacy_cost_ceiling_workflow_guard_narrowed", "status": "pass" },
     { "name": "cross_provider_review", "status": "pass" }
   ],
   "findings": [
-    "Claude Anthropic cross-provider review returned AGREE for E-2-6 Path A advisory CI.",
-    "Claude Anthropic re-review returned AGREE for the legacy E-2-3 workflow guard narrowing that allows only the E-2-6 advisory workflow path.",
-    "The workflow uses pull_request plus workflow_dispatch only and does not include pull_request_target.",
-    "The workflow grants only contents: read, uses persist-credentials: false, and has no PR comment, Teams webhook, secrets context, or write permission surface.",
-    "The runner fails closed when protected secret environment variable names are present and never logs secret values.",
-    "The runner's CLI stdout is intentionally static and does not print artifact paths, envelope digests, secret env names, or the full summary payload.",
-    "The runner delegates to the E-2-4 no-network dry-run harness and emits envelope, per-call audit, and workflow summary artifacts only.",
-    "Tests pin trigger, permission, secret-context, artifact-only, fail-closed env, AST import, and guard-flag boundaries.",
-    "The older E-2-3 cost-ceiling workflow mutation guard was narrowed to allow only the E-2-6 advisory workflow path while continuing to fail closed on unrelated workflow mutations.",
+    "OpenAI reviewer Mill returned REVISE after PR #944 because the runner failure stderr could print dynamic exception text, including artifact paths.",
+    "Claude Anthropic cross-provider review returned AGREE for the E-2-6 stderr hardening follow-up after reviewing the runner, test, and evidence diff.",
+    "The runner now prints a fixed FAILURE_STDERR_MESSAGE on handled failure paths and does not interpolate exception text.",
+    "The fixed stderr message contains no runtime value, artifact path, envelope digest, protected secret environment variable name, exception message, or summary payload.",
+    "The new subprocess regression test triggers a file-as-output-dir failure and asserts stderr exactly equals the fixed message.",
+    "The regression test asserts stderr does not contain tmp_path, output_dir_file, envelope_digest, or any FORBIDDEN_SECRET_ENV_NAMES entry.",
+    "Success stdout hardening from E-2-6 remains unchanged and the workflow trigger, permission, secret-context, Teams, PR comment, provider HTTP, and artifact-only boundaries are not modified in this follow-up.",
     "Guard flags remain false. No support widening, production platform claim, live provider HTTP call, or live adapter execution is introduced."
   ],
   "secrets_recorded": false,

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -15,6 +15,7 @@
     "base_ref": "refs/heads/main",
     "head_ref": "refs/heads/codex/epic-2-6-stderr-hardening",
     "changed_files": [
+      "CHANGELOG.md",
       "local-ai-review-evidence.v1.json",
       "scripts/live_adapter_evidence_workflow_runner.py",
       "tests/test_live_adapter_evidence_workflow.py"
@@ -46,6 +47,7 @@
     "The fixed stderr message contains no runtime value, artifact path, envelope digest, protected secret environment variable name, exception message, or summary payload.",
     "The new subprocess regression test triggers a file-as-output-dir failure and asserts stderr exactly equals the fixed message.",
     "The regression test asserts stderr does not contain tmp_path, output_dir_file, envelope_digest, or any FORBIDDEN_SECRET_ENV_NAMES entry.",
+    "CHANGELOG.md records this follow-up as E-2-6 advisory runner failure stderr hardening under the existing no-support-widening and no-live-execution boundary.",
     "Success stdout hardening from E-2-6 remains unchanged and the workflow trigger, permission, secret-context, Teams, PR comment, provider HTTP, and artifact-only boundaries are not modified in this follow-up.",
     "Guard flags remain false. No support widening, production platform claim, live provider HTTP call, or live adapter execution is introduced."
   ],

--- a/scripts/live_adapter_evidence_workflow_runner.py
+++ b/scripts/live_adapter_evidence_workflow_runner.py
@@ -37,6 +37,7 @@ FORBIDDEN_SECRET_ENV_NAMES: tuple[str, ...] = (
     "AO_GITHUB_APP_PRIVATE_KEY",
     "AO_RELEASE_GATE_WEBHOOK_SECRET",
 )
+FAILURE_STDERR_MESSAGE = "live-adapter advisory evidence failed: advisory CI boundary check failed"
 
 
 class WorkflowEvidenceError(RuntimeError):
@@ -167,8 +168,8 @@ def main(argv: list[str] | None = None) -> int:
             model=args.model,
             intent=args.intent,
         )
-    except (DryRunKillSwitchError, DryRunSchemaError, WorkflowEvidenceError, OSError, ValueError) as exc:
-        print(f"live-adapter advisory evidence failed: {exc}", file=sys.stderr)
+    except (DryRunKillSwitchError, DryRunSchemaError, WorkflowEvidenceError, OSError, ValueError):
+        print(FAILURE_STDERR_MESSAGE, file=sys.stderr)
         return 1
     if args.output_format == "json":
         print(json.dumps(_stdout_summary_payload(), indent=2, sort_keys=True))

--- a/tests/test_live_adapter_evidence_workflow.py
+++ b/tests/test_live_adapter_evidence_workflow.py
@@ -13,6 +13,7 @@ import pytest
 
 from scripts.live_adapter_evidence_workflow_runner import (
     FORBIDDEN_SECRET_ENV_NAMES,
+    FAILURE_STDERR_MESSAGE,
     WorkflowEvidenceError,
     emit_advisory_workflow_evidence,
 )
@@ -152,6 +153,34 @@ def test_runner_cli_smoke(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     assert payload["live_adapter_execution"] is False
     assert "envelope_digest" not in payload
     assert "artifacts" not in payload
+
+
+def test_runner_cli_failure_stderr_is_static(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_forbidden_secret_env(monkeypatch)
+    output_dir_file = tmp_path / "artifact-file"
+    output_dir_file.write_text("not a directory", encoding="utf-8")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(_RUNNER_PATH),
+            "--output-dir",
+            str(output_dir_file),
+            "--output-format",
+            "text",
+        ],
+        cwd=_REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert proc.returncode == 1
+    assert proc.stderr.strip() == FAILURE_STDERR_MESSAGE
+    assert str(tmp_path) not in proc.stderr
+    assert str(output_dir_file) not in proc.stderr
+    assert "envelope_digest" not in proc.stderr
+    for forbidden_name in FORBIDDEN_SECRET_ENV_NAMES:
+        assert forbidden_name not in proc.stderr
 
 
 def test_runner_source_does_not_import_http_or_secret_providers() -> None:


### PR DESCRIPTION
## Summary
- Follow-up to PR #944 after independent reviewer found the handled failure path could print dynamic exception text/path in stderr.
- Replaces handled failure stderr with a fixed boundary message.
- Adds a subprocess regression test asserting stderr does not contain tmp paths, output path, envelope digest, or forbidden secret env names.
- Rebinds local AI review evidence to this 3-file follow-up scope.

## Boundaries
- No workflow trigger or permission changes.
- No provider HTTP.
- No live adapter execution.
- No support widening or production platform claim.
- Guard flags remain false.

## Cross-AI / gate evidence
- Claude Anthropic review: VERDICT: AGREE.
- local_gpp_gate: operator_may_merge, 8/8 checks pass, changed_files_count=3.

## Validation
- python3 -m json.tool local-ai-review-evidence.v1.json >/dev/null && git diff --check
- python3 -m ruff check tests/test_live_adapter_evidence_workflow.py scripts/live_adapter_evidence_workflow_runner.py
- python3 -m mypy --explicit-package-bases scripts/live_adapter_evidence_workflow_runner.py tests/test_live_adapter_evidence_workflow.py
- pytest tests/test_live_adapter_evidence_workflow.py::test_runner_cli_failure_stderr_is_static tests/test_live_adapter_evidence_workflow.py -q
- gitleaks protect --source . --staged --no-banner --redact --verbose
- manual output-dir-as-file failure probe: exit=1, stdout empty, fixed stderr only
- scripts/local_gpp_gate.py ... -> operator_may_merge