### PR TITLE
feat(e-3-2): add support-widening smoke harness

### DIFF
--- a/.claude/plans/EPIC-3-E-3-2-SMOKE-HARNESS.md
+++ b/.claude/plans/EPIC-3-E-3-2-SMOKE-HARNESS.md
@@ -19,11 +19,15 @@
    forbidden path to fail closed and restores all originals on exit —
    `socket.socket`, `http.client.HTTPConnection`, `urllib.urlopen`/`OpenerDirector`,
    `requests`/`httpx` send (patched only when importable), `subprocess.*`,
-   `os.system`/`os.popen`, `importlib.import_module(<forbidden>)`, and **secret-env
-   reads** via a sanitized allowlisted `os.environ` view + `os.getenv` guard
-   (direct `os.environ["API_KEY"]` / `get` / `in` / `os.getenv` raise;
-   `copy()`/`keys()`/iteration expose only the allowlist — the spec's preferred
-   "sanitized view" model).
+   `os.system`/`os.popen`, forbidden imports via `import` / `__import__` /
+   `importlib` / `exec("import …")`, and **env reads** under an **allowlist-only**
+   model: `os.environ` / `os.environb` are swapped for sanitized views where every
+   read path — direct (`os.environ["X"]` / `get` / `in`), `os.getenv` / `os.getenvb`,
+   and bulk (`copy`/`keys`/`items`/`values`/`iter`/`dict()`) — raises for any key
+   NOT in the small allowlist (`WORKSPACE_ROOT`, `CI`, `PYTHONPATH`, `PATH`, `HOME`,
+   `TMPDIR`). Allowlist-only (not a "secret-looking" regex) closes the gap for
+   credential-class keys like `AWS_ACCESS_KEY_ID` / `OPENAI_ORGANIZATION` that a
+   regex misses (Codex E-3-2 iter-2 absorb).
 3. **Runtime declaration:** `assert_no_live_capability(stub)` rejects any stub
    advertising `live_capability=True`.
 

--- a/.claude/plans/EPIC-3-E-3-2-SMOKE-HARNESS.md
+++ b/.claude/plans/EPIC-3-E-3-2-SMOKE-HARNESS.md
@@ -1,0 +1,56 @@
+# E-3-2 — Per-surface smoke harness scaffolding (decision record)
+
+> V5 Epic 3, slice #854. Infrastructure-only. Library-mode, stub-adapter-only
+> smoke harness that emits a `support_widening_evidence.v1` artifact (E-3-1) per
+> surface class — **no network, no `.ao/` mutation, no guard-flag flip**.
+
+## Deliverables
+
+- `scripts/run_support_smoke.py --surface <class> [--evidence-out <path>] [--repo …]`
+- `ao_kernel/_internal/support_widening/harnesses/killswitch.py` — dominant runtime kill-switch
+- `ao_kernel/_internal/support_widening/harnesses/runner.py` — `run_surface_smoke()` + per-surface stub registry
+- `tests/test_run_support_smoke.py` (15 cases: parametrized per-surface + kill-switch negatives)
+
+## Three-layer stub-purity discipline
+
+1. **Static (advisory):** forbidden-import set documented; dynamic import bypasses
+   a pure AST scan, so it is NOT the enforcement.
+2. **Runtime kill-switch (dominant):** `live_call_killswitch()` patches every
+   forbidden path to fail closed and restores all originals on exit —
+   `socket.socket`, `http.client.HTTPConnection`, `urllib.urlopen`/`OpenerDirector`,
+   `requests`/`httpx` send (patched only when importable), `subprocess.*`,
+   `os.system`/`os.popen`, `importlib.import_module(<forbidden>)`, and **secret-env
+   reads** via a sanitized allowlisted `os.environ` view + `os.getenv` guard
+   (direct `os.environ["API_KEY"]` / `get` / `in` / `os.getenv` raise;
+   `copy()`/`keys()`/iteration expose only the allowlist — the spec's preferred
+   "sanitized view" model).
+3. **Runtime declaration:** `assert_no_live_capability(stub)` rejects any stub
+   advertising `live_capability=True`.
+
+The emitted artifact pins `simulated_only: true` + `live_call_made: false` +
+`support_widening: false` (schema const + E-3-1 `parse_v1` runtime re-assert), so a
+forged "live call" payload is schema-invalid.
+
+## Design deviation from the plan's literal structure (documented)
+
+The plan listed "one module per surface class" + "one test file per surface
+class". The five surfaces are near-identical stub shells, so a **registry**
+(`_SURFACE_STUBS` in `runner.py`) + **parametrized tests** (one case per surface)
+is the DRY/maintainable form (CLAUDE.md long-term-durable-solution rule). Per-surface
+behaviour is still fully covered: `test_surface_smoke_emits_valid_pinned_artifact`
+runs once per surface class and validates the emitted artifact against the E-3-1
+schema, and `test_all_five_surface_classes_present` pins the registry set.
+
+## Lessons applied from earlier slices
+
+- Evidence artifact written `0o600` (CodeQL `py/overly-permissive-file`, caught on E-2-2).
+- Calendar-coupling RFC3339 `generated_at` from the E-3-1 schema is reused as-is.
+
+## Out of scope
+
+- Running the harness in CI (E-3-3, high-risk workflow → operator review).
+- Live evidence / v2 supersession (Epic 9).
+
+## Cross-AI review
+
+Implementer claude (anthropic) → reviewer codex (openai). See PR evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **E-3-2 per-surface support-widening smoke harness** (V5 Epic 3, #854): added
+  `scripts/run_support_smoke.py --surface <class>` + `ao_kernel/_internal/support_widening/harnesses/`
+  (`killswitch.py` dominant runtime kill-switch, `runner.py` per-surface stub
+  registry). Library-mode, stub-adapter-only smoke that emits an E-3-1
+  `support_widening_evidence.v1` artifact per surface class with `simulated_only:
+  true` / `live_call_made: false` / `support_widening: false`. The kill-switch
+  fails closed on socket / http / urllib / requests / httpx / subprocess / shell /
+  forbidden dynamic-import / secret-env access (sanitized allowlisted `os.environ`
+  view + `os.getenv` guard) and restores all originals on exit. Evidence written
+  `0o600`. 15 pytest cases (parametrized per-surface + kill-switch negatives). No
+  network call; no `.ao/` mutation; no guard-flag flip.
 - **E-2-7 pre-supersession checklist artifact** (V5 Epic 2, #852):
   added `EPIC-9-PR-Xfinal-PRE-SUPERSESSION-CHECKLIST.md` and
   `pre_supersession_checklist.schema.v1.json` as the infrastructure-only

--- a/ao_kernel/_internal/support_widening/harnesses/__init__.py
+++ b/ao_kernel/_internal/support_widening/harnesses/__init__.py
@@ -1,0 +1,7 @@
+"""Support-widening per-surface smoke harnesses (V5 Epic 3 E-3-2).
+
+Library-mode-only harnesses that exercise stub adapters (no network, no `.ao/`
+mutation) and emit a `support_widening_evidence.v1` artifact per surface class.
+Stub purity is enforced by a dominant runtime kill-switch (`killswitch.py`):
+network, subprocess, shell, dynamic-import and secret-env access all fail closed
+inside the harness execution context."""

--- a/ao_kernel/_internal/support_widening/harnesses/killswitch.py
+++ b/ao_kernel/_internal/support_widening/harnesses/killswitch.py
@@ -32,18 +32,15 @@ import contextlib
 import http.client
 import importlib
 import os
-import re
 import socket
 import subprocess
 import urllib.request
 from collections.abc import Iterator
 from typing import Any
 
-# Env keys the harness is allowed to read; everything secret-looking is denied.
+# Env keys the harness is allowed to read; EVERY other key is denied (allowlist-only).
 _ENV_ALLOWLIST = frozenset({"WORKSPACE_ROOT", "CI", "PYTHONPATH", "PATH", "HOME", "TMPDIR"})
 _ENV_ALLOWLIST_B = frozenset(k.encode() for k in _ENV_ALLOWLIST)
-
-_SECRET_KEY = re.compile(r"(?i)(api[_-]?key|secret|token|password|credential|bearer|auth)")
 
 # Modules a stub harness must never import at runtime (any import path).
 _FORBIDDEN_IMPORTS = (
@@ -77,11 +74,14 @@ def _is_forbidden_module(name: str) -> bool:
 
 
 def _secret_str(key: str) -> bool:
-    return key not in _ENV_ALLOWLIST and bool(_SECRET_KEY.search(key))
+    # Allowlist-only (spec preferred model): any key not explicitly allowlisted is
+    # denied. Closes the gap a "secret-looking" regex misses for credential-class
+    # keys like AWS_ACCESS_KEY_ID / OPENAI_ORGANIZATION (Codex E-3-2 absorb).
+    return key not in _ENV_ALLOWLIST
 
 
 def _secret_bytes(key: bytes) -> bool:
-    return key not in _ENV_ALLOWLIST_B and bool(_SECRET_KEY.search(key.decode("latin-1")))
+    return key not in _ENV_ALLOWLIST_B
 
 
 class _SanitizedEnviron(dict):  # type: ignore[type-arg]

--- a/ao_kernel/_internal/support_widening/harnesses/killswitch.py
+++ b/ao_kernel/_internal/support_widening/harnesses/killswitch.py
@@ -8,17 +8,21 @@ active, ANY of the following raises `SupportWideningError`:
   - opening a socket (`socket.socket`)
   - an HTTP client connect (`http.client.HTTPConnection`)
   - `urllib.request.urlopen` / `OpenerDirector.open`
-  - `requests` / `httpx` send paths (only patched when the dep is importable)
+  - `requests` (`request` / `Session.send` / `adapters.HTTPAdapter.send`) and
+    `httpx` (`Client.send` / `AsyncClient.send`) — patched only when importable
   - subprocess / shell exec (`subprocess.Popen/run/call/check_output/check_call`,
     `os.system`, `os.popen`)
-  - `importlib.import_module(<forbidden network/cloud/provider module>)`
+  - importing a forbidden network/cloud/provider module through ANY path —
+    `import`, `__import__`, `importlib.import_module`, or `exec("import …")`
+    (all route through the patched `builtins.__import__`)
   - reading a secret-looking environment variable through ANY `os.environ` /
-    `os.getenv` / `os.environb` path — the env is swapped for a sanitized,
-    allowlisted view for the duration, and every read path is patched as
-    defense-in-depth.
+    `os.getenv` / `os.environb` path — `os.environ`/`os.environb` are swapped for
+    sanitized views and EVERY read path (direct, membership, and bulk
+    copy/items/keys/values/iter) fails closed when a secret-looking key is present.
 
-The switch is a context manager that restores every patched attribute on exit
-(try/finally), so it never leaks into the wider process.
+Setup is rollback-safe (a failure mid-setup restores already-applied patches) and
+every patch is restored on exit (reverse order). The switch never leaks past the
+context.
 """
 
 from __future__ import annotations
@@ -37,24 +41,23 @@ from typing import Any
 
 # Env keys the harness is allowed to read; everything secret-looking is denied.
 _ENV_ALLOWLIST = frozenset({"WORKSPACE_ROOT", "CI", "PYTHONPATH", "PATH", "HOME", "TMPDIR"})
+_ENV_ALLOWLIST_B = frozenset(k.encode() for k in _ENV_ALLOWLIST)
 
 _SECRET_KEY = re.compile(r"(?i)(api[_-]?key|secret|token|password|credential|bearer|auth)")
 
-# Modules a stub harness must never import at runtime (dynamic-import covered too).
-_FORBIDDEN_IMPORTS = frozenset(
-    {
-        "requests",
-        "httpx",
-        "urllib3",
-        "socket",
-        "openai",
-        "anthropic",
-        "google.generativeai",
-        "aiohttp",
-        "boto3",
-        "paramiko",
-        "subprocess",
-    }
+# Modules a stub harness must never import at runtime (any import path).
+_FORBIDDEN_IMPORTS = (
+    "requests",
+    "httpx",
+    "urllib3",
+    "socket",
+    "openai",
+    "anthropic",
+    "google.generativeai",
+    "aiohttp",
+    "boto3",
+    "paramiko",
+    "subprocess",
 )
 
 
@@ -69,107 +72,216 @@ def _denied(what: str) -> "Any":
     return _raise
 
 
-class _SanitizedEnviron(dict):  # type: ignore[type-arg]
-    """An ``os.environ``-like mapping that denies secret-looking keys on every
-    read path (get/__getitem__/__contains__/copy/items/keys/values/__iter__)."""
+def _is_forbidden_module(name: str) -> bool:
+    return any(name == b or name.startswith(b + ".") for b in _FORBIDDEN_IMPORTS)
 
-    def _check(self, key: Any) -> None:
-        name = key.decode() if isinstance(key, bytes) else str(key)
-        if name not in _ENV_ALLOWLIST and _SECRET_KEY.search(name):
-            raise SupportWideningError(
-                f"environment read of secret-looking key {name!r} is forbidden in the smoke harness"
-            )
+
+def _secret_str(key: str) -> bool:
+    return key not in _ENV_ALLOWLIST and bool(_SECRET_KEY.search(key))
+
+
+def _secret_bytes(key: bytes) -> bool:
+    return key not in _ENV_ALLOWLIST_B and bool(_SECRET_KEY.search(key.decode("latin-1")))
+
+
+class _SanitizedEnviron(dict):  # type: ignore[type-arg]
+    """An ``os.environ``-like mapping that fails closed on every read path when a
+    secret-looking key is involved. Direct/membership reads check the requested
+    key; bulk reads (copy/items/keys/values/iter/len) raise if the *original*
+    environment contains any secret-looking key."""
+
+    def __init__(self, original: Any) -> None:
+        super().__init__({k: v for k, v in original.items() if k in _ENV_ALLOWLIST})
+        self._original = original
+
+    def _guard_bulk(self) -> None:
+        for k in self._original.keys():
+            if _secret_str(str(k)):
+                raise SupportWideningError(
+                    "bulk environment read is forbidden in the smoke harness (secret key present)"
+                )
 
     def __getitem__(self, key: Any) -> Any:
-        self._check(key)
-        return super().__getitem__(key)
+        if _secret_str(str(key)):
+            raise SupportWideningError(f"environment read of secret-looking key {key!r} is forbidden")
+        return self._original[key]
 
     def get(self, key: Any, default: Any = None) -> Any:
-        self._check(key)
-        return super().get(key, default)
+        if _secret_str(str(key)):
+            raise SupportWideningError(f"environment read of secret-looking key {key!r} is forbidden")
+        return self._original.get(key, default)
 
     def __contains__(self, key: Any) -> bool:
-        self._check(key)
-        return super().__contains__(key)
+        if _secret_str(str(key)):
+            raise SupportWideningError(f"environment membership test of secret-looking key {key!r} is forbidden")
+        return key in self._original
+
+    def copy(self) -> Any:
+        self._guard_bulk()
+        return dict(self._original)
+
+    def keys(self) -> Any:
+        self._guard_bulk()
+        return self._original.keys()
+
+    def values(self) -> Any:
+        self._guard_bulk()
+        return self._original.values()
+
+    def items(self) -> Any:
+        self._guard_bulk()
+        return self._original.items()
+
+    def __iter__(self) -> Any:
+        self._guard_bulk()
+        return iter(self._original)
+
+    def __len__(self) -> int:
+        self._guard_bulk()
+        return len(self._original)
 
 
-def _sanitized_pairs() -> "dict[str, str]":
-    return {k: v for k, v in os.environ.items() if k in _ENV_ALLOWLIST}
+class _SanitizedEnvironb(dict):  # type: ignore[type-arg]
+    """Bytes counterpart of `_SanitizedEnviron` for `os.environb`."""
+
+    def __init__(self, original: Any) -> None:
+        super().__init__({k: v for k, v in original.items() if k in _ENV_ALLOWLIST_B})
+        self._original = original
+
+    def _guard_bulk(self) -> None:
+        for k in self._original.keys():
+            if _secret_bytes(bytes(k)):
+                raise SupportWideningError("bulk environb read is forbidden in the smoke harness (secret key present)")
+
+    def __getitem__(self, key: Any) -> Any:
+        if _secret_bytes(bytes(key)):
+            raise SupportWideningError(f"environb read of secret-looking key {key!r} is forbidden")
+        return self._original[key]
+
+    def get(self, key: Any, default: Any = None) -> Any:
+        if _secret_bytes(bytes(key)):
+            raise SupportWideningError(f"environb read of secret-looking key {key!r} is forbidden")
+        return self._original.get(key, default)
+
+    def __contains__(self, key: Any) -> bool:
+        if _secret_bytes(bytes(key)):
+            raise SupportWideningError(f"environb membership of secret-looking key {key!r} is forbidden")
+        return key in self._original
+
+    def copy(self) -> Any:
+        self._guard_bulk()
+        return dict(self._original)
+
+    def keys(self) -> Any:
+        self._guard_bulk()
+        return self._original.keys()
+
+    def items(self) -> Any:
+        self._guard_bulk()
+        return self._original.items()
+
+    def __iter__(self) -> Any:
+        self._guard_bulk()
+        return iter(self._original)
 
 
 @contextlib.contextmanager
 def live_call_killswitch() -> Iterator[None]:
-    """Patch every network / subprocess / shell / dynamic-import / secret-env path
-    to fail closed, restoring all originals on exit."""
-    patches: list[tuple[Any, str, Any]] = []
+    """Patch every network / subprocess / shell / import / secret-env path to fail
+    closed, with rollback-safe setup and full restore on exit."""
+    applied: list[tuple[Any, str, Any]] = []
 
     def patch(target: Any, attr: str, replacement: Any) -> None:
         if hasattr(target, attr):
-            patches.append((target, attr, getattr(target, attr)))
+            applied.append((target, attr, getattr(target, attr)))
             setattr(target, attr, replacement)
 
-    # --- network ---
-    patch(socket.socket, "__init__", _denied("socket creation"))
-    patch(http.client.HTTPConnection, "__init__", _denied("http.client connect"))
-    patch(urllib.request, "urlopen", _denied("urllib urlopen"))
-    patch(urllib.request.OpenerDirector, "open", _denied("urllib opener"))
-    for mod_name, attrs in (("requests", ("request",)), ("httpx", ("Client", "AsyncClient"))):
-        try:
-            mod = importlib.import_module(mod_name)
-        except ImportError:
-            continue
-        if mod_name == "requests":
-            patch(mod, "request", _denied("requests.request"))
-            sess = getattr(mod, "Session", None)
-            if sess is not None:
-                patch(sess, "send", _denied("requests.Session.send"))
-        else:  # httpx
-            for cls_name in attrs:
-                cls = getattr(mod, cls_name, None)
+    def _restore() -> None:
+        for target, attr, original in reversed(applied):
+            with contextlib.suppress(Exception):
+                setattr(target, attr, original)
+
+    try:
+        # --- network ---
+        patch(socket.socket, "__init__", _denied("socket creation"))
+        patch(http.client.HTTPConnection, "__init__", _denied("http.client connect"))
+        patch(urllib.request, "urlopen", _denied("urllib urlopen"))
+        patch(urllib.request.OpenerDirector, "open", _denied("urllib opener"))
+        with contextlib.suppress(ImportError):
+            requests = importlib.import_module("requests")
+            patch(requests, "request", _denied("requests.request"))
+            if hasattr(requests, "Session"):
+                patch(requests.Session, "send", _denied("requests.Session.send"))
+            adapters = importlib.import_module("requests.adapters")
+            if hasattr(adapters, "HTTPAdapter"):
+                patch(adapters.HTTPAdapter, "send", _denied("requests.adapters.HTTPAdapter.send"))
+        with contextlib.suppress(ImportError):
+            httpx = importlib.import_module("httpx")
+            for cls_name in ("Client", "AsyncClient"):
+                cls = getattr(httpx, cls_name, None)
                 if cls is not None:
                     patch(cls, "send", _denied(f"httpx.{cls_name}.send"))
 
-    # --- subprocess / shell ---
-    patch(subprocess.Popen, "__init__", _denied("subprocess.Popen"))
-    patch(subprocess, "run", _denied("subprocess.run"))
-    patch(subprocess, "call", _denied("subprocess.call"))
-    patch(subprocess, "check_output", _denied("subprocess.check_output"))
-    patch(subprocess, "check_call", _denied("subprocess.check_call"))
-    patch(os, "system", _denied("os.system"))
-    patch(os, "popen", _denied("os.popen"))
+        # --- subprocess / shell ---
+        patch(subprocess.Popen, "__init__", _denied("subprocess.Popen"))
+        patch(subprocess, "run", _denied("subprocess.run"))
+        patch(subprocess, "call", _denied("subprocess.call"))
+        patch(subprocess, "check_output", _denied("subprocess.check_output"))
+        patch(subprocess, "check_call", _denied("subprocess.check_call"))
+        patch(os, "system", _denied("os.system"))
+        patch(os, "popen", _denied("os.popen"))
 
-    # --- dynamic import of forbidden modules ---
-    _orig_import = importlib.import_module
+        # --- import guard (covers import / __import__ / importlib / exec("import …")) ---
+        _orig_builtin_import = builtins.__import__
 
-    def _guarded_import(name: str, package: str | None = None) -> Any:
-        root = name.lstrip(".").split(".")[0]
-        if name in _FORBIDDEN_IMPORTS or root in _FORBIDDEN_IMPORTS:
-            raise SupportWideningError(f"dynamic import of forbidden module {name!r} is blocked in the smoke harness")
-        return _orig_import(name, package)
+        def _guarded_builtin_import(name: str, *a: Any, **k: Any) -> Any:
+            if _is_forbidden_module(name):
+                raise SupportWideningError(f"import of forbidden module {name!r} is blocked in the smoke harness")
+            return _orig_builtin_import(name, *a, **k)
 
-    patch(importlib, "import_module", _guarded_import)
+        patch(builtins, "__import__", _guarded_builtin_import)
 
-    # --- secret-env access (sanitized view + getenv patch) ---
-    _orig_environ = os.environ
-    _orig_getenv = os.getenv
-    sanitized = _SanitizedEnviron(_sanitized_pairs())
+        _orig_import_module = importlib.import_module
 
-    def _guarded_getenv(key: str, default: Any = None) -> Any:
-        if key not in _ENV_ALLOWLIST and _SECRET_KEY.search(key):
-            raise SupportWideningError(f"os.getenv of secret-looking key {key!r} is forbidden in the smoke harness")
-        return _orig_getenv(key, default)
+        def _guarded_import_module(name: str, package: str | None = None) -> Any:
+            target = name
+            if name.startswith(".") and package:
+                target = f"{package}{name}" if name.startswith(".") else name
+            if _is_forbidden_module(name.lstrip(".")) or _is_forbidden_module(target.lstrip(".")):
+                raise SupportWideningError(f"importlib of forbidden module {name!r} is blocked in the smoke harness")
+            return _orig_import_module(name, package)
 
-    os.environ = sanitized  # type: ignore[assignment]
-    patches.append((os, "getenv", _orig_getenv))
-    os.getenv = _guarded_getenv
+        patch(importlib, "import_module", _guarded_import_module)
+
+        # --- secret-env access (sanitized views, all read paths fail closed) ---
+        _orig_getenv = os.getenv
+
+        def _guarded_getenv(key: str, default: Any = None) -> Any:
+            if _secret_str(key):
+                raise SupportWideningError(f"os.getenv of secret-looking key {key!r} is forbidden")
+            return _orig_getenv(key, default)
+
+        patch(os, "getenv", _guarded_getenv)
+        patch(os, "environ", _SanitizedEnviron(os.environ))
+        if hasattr(os, "environb"):
+            patch(os, "environb", _SanitizedEnvironb(os.environb))
+        if hasattr(os, "getenvb"):
+            _orig_getenvb = os.getenvb
+
+            def _guarded_getenvb(key: bytes, default: Any = None) -> Any:
+                if _secret_bytes(key):
+                    raise SupportWideningError(f"os.getenvb of secret-looking key {key!r} is forbidden")
+                return _orig_getenvb(key, default)
+
+            patch(os, "getenvb", _guarded_getenvb)
+    except BaseException:
+        _restore()
+        raise
 
     try:
         yield
     finally:
-        os.environ = _orig_environ
-        for target, attr, original in reversed(patches):
-            with contextlib.suppress(Exception):
-                setattr(target, attr, original)
+        _restore()
 
 
 def assert_no_live_capability(stub: Any) -> None:
@@ -179,7 +291,3 @@ def assert_no_live_capability(stub: Any) -> None:
         raise SupportWideningError(
             f"stub adapter {stub!r} declares live_capability=True; smoke harness is simulated-only"
         )
-
-
-# `builtins` re-exported so callers can reference the same name in assertions.
-_ = builtins

--- a/ao_kernel/_internal/support_widening/harnesses/killswitch.py
+++ b/ao_kernel/_internal/support_widening/harnesses/killswitch.py
@@ -1,0 +1,185 @@
+"""Runtime kill-switch for the support-widening smoke harness (V5 Epic 3 E-3-2).
+
+The dominant (runtime) layer of the three-layer stub-purity discipline. A static
+AST scan is advisory (dynamic import bypasses it); this module is the enforcement
+that actually fails closed at execution time. While `live_call_killswitch()` is
+active, ANY of the following raises `SupportWideningError`:
+
+  - opening a socket (`socket.socket`)
+  - an HTTP client connect (`http.client.HTTPConnection`)
+  - `urllib.request.urlopen` / `OpenerDirector.open`
+  - `requests` / `httpx` send paths (only patched when the dep is importable)
+  - subprocess / shell exec (`subprocess.Popen/run/call/check_output/check_call`,
+    `os.system`, `os.popen`)
+  - `importlib.import_module(<forbidden network/cloud/provider module>)`
+  - reading a secret-looking environment variable through ANY `os.environ` /
+    `os.getenv` / `os.environb` path — the env is swapped for a sanitized,
+    allowlisted view for the duration, and every read path is patched as
+    defense-in-depth.
+
+The switch is a context manager that restores every patched attribute on exit
+(try/finally), so it never leaks into the wider process.
+"""
+
+from __future__ import annotations
+
+import builtins
+import contextlib
+import http.client
+import importlib
+import os
+import re
+import socket
+import subprocess
+import urllib.request
+from collections.abc import Iterator
+from typing import Any
+
+# Env keys the harness is allowed to read; everything secret-looking is denied.
+_ENV_ALLOWLIST = frozenset({"WORKSPACE_ROOT", "CI", "PYTHONPATH", "PATH", "HOME", "TMPDIR"})
+
+_SECRET_KEY = re.compile(r"(?i)(api[_-]?key|secret|token|password|credential|bearer|auth)")
+
+# Modules a stub harness must never import at runtime (dynamic-import covered too).
+_FORBIDDEN_IMPORTS = frozenset(
+    {
+        "requests",
+        "httpx",
+        "urllib3",
+        "socket",
+        "openai",
+        "anthropic",
+        "google.generativeai",
+        "aiohttp",
+        "boto3",
+        "paramiko",
+        "subprocess",
+    }
+)
+
+
+class SupportWideningError(RuntimeError):
+    """Raised when the smoke harness attempts a forbidden (non-stub) operation."""
+
+
+def _denied(what: str) -> "Any":
+    def _raise(*_a: Any, **_k: Any) -> Any:
+        raise SupportWideningError(f"{what} is forbidden inside the support-widening smoke harness")
+
+    return _raise
+
+
+class _SanitizedEnviron(dict):  # type: ignore[type-arg]
+    """An ``os.environ``-like mapping that denies secret-looking keys on every
+    read path (get/__getitem__/__contains__/copy/items/keys/values/__iter__)."""
+
+    def _check(self, key: Any) -> None:
+        name = key.decode() if isinstance(key, bytes) else str(key)
+        if name not in _ENV_ALLOWLIST and _SECRET_KEY.search(name):
+            raise SupportWideningError(
+                f"environment read of secret-looking key {name!r} is forbidden in the smoke harness"
+            )
+
+    def __getitem__(self, key: Any) -> Any:
+        self._check(key)
+        return super().__getitem__(key)
+
+    def get(self, key: Any, default: Any = None) -> Any:
+        self._check(key)
+        return super().get(key, default)
+
+    def __contains__(self, key: Any) -> bool:
+        self._check(key)
+        return super().__contains__(key)
+
+
+def _sanitized_pairs() -> "dict[str, str]":
+    return {k: v for k, v in os.environ.items() if k in _ENV_ALLOWLIST}
+
+
+@contextlib.contextmanager
+def live_call_killswitch() -> Iterator[None]:
+    """Patch every network / subprocess / shell / dynamic-import / secret-env path
+    to fail closed, restoring all originals on exit."""
+    patches: list[tuple[Any, str, Any]] = []
+
+    def patch(target: Any, attr: str, replacement: Any) -> None:
+        if hasattr(target, attr):
+            patches.append((target, attr, getattr(target, attr)))
+            setattr(target, attr, replacement)
+
+    # --- network ---
+    patch(socket.socket, "__init__", _denied("socket creation"))
+    patch(http.client.HTTPConnection, "__init__", _denied("http.client connect"))
+    patch(urllib.request, "urlopen", _denied("urllib urlopen"))
+    patch(urllib.request.OpenerDirector, "open", _denied("urllib opener"))
+    for mod_name, attrs in (("requests", ("request",)), ("httpx", ("Client", "AsyncClient"))):
+        try:
+            mod = importlib.import_module(mod_name)
+        except ImportError:
+            continue
+        if mod_name == "requests":
+            patch(mod, "request", _denied("requests.request"))
+            sess = getattr(mod, "Session", None)
+            if sess is not None:
+                patch(sess, "send", _denied("requests.Session.send"))
+        else:  # httpx
+            for cls_name in attrs:
+                cls = getattr(mod, cls_name, None)
+                if cls is not None:
+                    patch(cls, "send", _denied(f"httpx.{cls_name}.send"))
+
+    # --- subprocess / shell ---
+    patch(subprocess.Popen, "__init__", _denied("subprocess.Popen"))
+    patch(subprocess, "run", _denied("subprocess.run"))
+    patch(subprocess, "call", _denied("subprocess.call"))
+    patch(subprocess, "check_output", _denied("subprocess.check_output"))
+    patch(subprocess, "check_call", _denied("subprocess.check_call"))
+    patch(os, "system", _denied("os.system"))
+    patch(os, "popen", _denied("os.popen"))
+
+    # --- dynamic import of forbidden modules ---
+    _orig_import = importlib.import_module
+
+    def _guarded_import(name: str, package: str | None = None) -> Any:
+        root = name.lstrip(".").split(".")[0]
+        if name in _FORBIDDEN_IMPORTS or root in _FORBIDDEN_IMPORTS:
+            raise SupportWideningError(f"dynamic import of forbidden module {name!r} is blocked in the smoke harness")
+        return _orig_import(name, package)
+
+    patch(importlib, "import_module", _guarded_import)
+
+    # --- secret-env access (sanitized view + getenv patch) ---
+    _orig_environ = os.environ
+    _orig_getenv = os.getenv
+    sanitized = _SanitizedEnviron(_sanitized_pairs())
+
+    def _guarded_getenv(key: str, default: Any = None) -> Any:
+        if key not in _ENV_ALLOWLIST and _SECRET_KEY.search(key):
+            raise SupportWideningError(f"os.getenv of secret-looking key {key!r} is forbidden in the smoke harness")
+        return _orig_getenv(key, default)
+
+    os.environ = sanitized  # type: ignore[assignment]
+    patches.append((os, "getenv", _orig_getenv))
+    os.getenv = _guarded_getenv
+
+    try:
+        yield
+    finally:
+        os.environ = _orig_environ
+        for target, attr, original in reversed(patches):
+            with contextlib.suppress(Exception):
+                setattr(target, attr, original)
+
+
+def assert_no_live_capability(stub: Any) -> None:
+    """Layer-3 runtime declaration check: a stub adapter must not advertise
+    `live_capability=True`."""
+    if getattr(stub, "live_capability", False):
+        raise SupportWideningError(
+            f"stub adapter {stub!r} declares live_capability=True; smoke harness is simulated-only"
+        )
+
+
+# `builtins` re-exported so callers can reference the same name in assertions.
+_ = builtins

--- a/ao_kernel/_internal/support_widening/harnesses/runner.py
+++ b/ao_kernel/_internal/support_widening/harnesses/runner.py
@@ -20,10 +20,13 @@ surface class.
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import Callable
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
+
+__all__ = ["SURFACE_CLASSES", "run_surface_smoke"]
 
 from ao_kernel._internal.support_widening.evidence import parse_v1
 from ao_kernel.config import load_default
@@ -106,13 +109,20 @@ def run_surface_smoke(
     parse_v1(payload, schema=load_default("schemas", "support-widening-evidence.schema.v1.json"))
 
     if evidence_out is not None:
+        # "No .ao/ mutation" contract: refuse to write the artifact into a workspace
+        # `.ao/` directory (the harness is read-only w.r.t. the workspace).
+        if any(part == ".ao" for part in evidence_out.parts):
+            raise SupportWideningError(
+                f"evidence_out must not be under a workspace .ao/ directory (read-only contract): {evidence_out}"
+            )
         evidence_out.parent.mkdir(parents=True, exist_ok=True)
-        # 0o600: evidence artifact owner-only (CodeQL py/overly-permissive-file).
         text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
-        import os
-
+        # 0o600 owner-only (CodeQL py/overly-permissive-file). fchmod after open so
+        # an overwrite of a pre-existing wider-mode file is also tightened (O_TRUNC
+        # alone keeps the old mode).
         fd = os.open(evidence_out, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         try:
+            os.fchmod(fd, 0o600)
             os.write(fd, text.encode("utf-8"))
         finally:
             os.close(fd)

--- a/ao_kernel/_internal/support_widening/harnesses/runner.py
+++ b/ao_kernel/_internal/support_widening/harnesses/runner.py
@@ -1,0 +1,120 @@
+"""Per-surface smoke harness runner (V5 Epic 3 E-3-2).
+
+`run_surface_smoke(surface_class, ...)` runs a library-mode, stub-adapter-only
+smoke for one surface class under the dominant runtime kill-switch
+(`killswitch.live_call_killswitch`) and emits a `support_widening_evidence.v1`
+artifact (via the E-3-1 module) with `support_widening: false` in every emit path.
+
+Stub adapters per surface are declared in `_SURFACE_STUBS`; each carries
+`live_capability=False` (re-asserted at runtime, layer 3). The per-surface
+evidence shape mirrors the E-3-1 `$defs` exactly so `recompute_v1` (which checks
+`evidence_dimensions == recompute_inputs.raw_dimensions`) passes.
+
+A registry + parametrized tests replace the plan's "one module + one test file
+per surface class" literal: the five surfaces are near-identical stub shells, so a
+registry is the DRY/maintainable form (CLAUDE.md long-term-durable-solution rule).
+The per-surface behaviour is still fully covered — one parametrized test case per
+surface class.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from ao_kernel._internal.support_widening.evidence import parse_v1
+from ao_kernel.config import load_default
+
+from .killswitch import SupportWideningError, assert_no_live_capability, live_call_killswitch
+
+
+class _StubAdapter:
+    """A surface stub that conforms to an adapter shape but makes no live call."""
+
+    live_capability = False
+
+    def __init__(self, surface_class: str, dimensions: dict[str, Any]) -> None:
+        self.surface_class = surface_class
+        self._dimensions = dimensions
+
+    def evidence_dimensions(self) -> dict[str, Any]:
+        return deepcopy(self._dimensions)
+
+
+# Per-surface stub dimension builders (shapes mirror the E-3-1 $defs exactly).
+_SURFACE_STUBS: dict[str, Callable[[], dict[str, Any]]] = {
+    "provider": lambda: {
+        "integration_tests": {"count": 0},
+        "stub_adapter_ids": ["stub:provider"],
+        "note": "library-mode stub smoke; no live integration tests (v2 requires >=3)",
+    },
+    "python_version": lambda: {"matrix": ["3.11", "3.12", "3.13"], "pytest_passed": True},
+    "os_platform": lambda: {"platform": "linux-x86_64", "smoke_passed": True},
+    "db_backend": lambda: {"backend": "sqlite_in_memory", "round_trip_passed": True},
+    "deployment_topology": lambda: {"topology": "library", "isolation_passed": True},
+}
+
+SURFACE_CLASSES = tuple(_SURFACE_STUBS)
+
+
+def run_surface_smoke(
+    surface_class: str,
+    *,
+    repo: str = "Halildeu/ao-kernel",
+    generated_at: str,
+    evidence_out: Path | None = None,
+) -> dict[str, Any]:
+    """Run the stub smoke for one surface class and return a validated
+    `support_widening_evidence.v1` payload (also written to `evidence_out` if given).
+
+    Raises ``SupportWideningError`` for an unknown surface class or if the stub
+    declares live capability; raises ``SupportWideningEvidenceError`` (from the
+    E-3-1 module) if the emitted artifact is not schema-valid.
+    """
+    if surface_class not in _SURFACE_STUBS:
+        raise SupportWideningError(f"unknown surface_class {surface_class!r}; expected one of {sorted(_SURFACE_STUBS)}")
+
+    # Build the stub + run its dimension extraction under the kill-switch so any
+    # accidental network/subprocess/secret-env access fails closed.
+    with live_call_killswitch():
+        stub = _StubAdapter(surface_class, _SURFACE_STUBS[surface_class]())
+        assert_no_live_capability(stub)  # layer 3
+        dimensions = stub.evidence_dimensions()
+
+    payload: dict[str, Any] = {
+        "schema_version": "support_widening_evidence.v1",
+        "artifact_kind": "support_widening_evidence",
+        "generated_at": generated_at,
+        "repo": repo,
+        "surface_class": surface_class,
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+        "register_authority": "evidence_record_only",
+        "github_write_authorized": False,
+        "simulated_only": True,
+        "live_call_made": False,
+        "evidence_dimensions": dimensions,
+        "reviewer_providers": [],
+        "recompute_inputs": {"raw_dimensions": deepcopy(dimensions)},
+    }
+
+    # Fail closed if the artifact is not schema-valid (recompute-not-trust corollary).
+    parse_v1(payload, schema=load_default("schemas", "support-widening-evidence.schema.v1.json"))
+
+    if evidence_out is not None:
+        evidence_out.parent.mkdir(parents=True, exist_ok=True)
+        # 0o600: evidence artifact owner-only (CodeQL py/overly-permissive-file).
+        text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        import os
+
+        fd = os.open(evidence_out, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, text.encode("utf-8"))
+        finally:
+            os.close(fd)
+
+    return payload

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "E-2-7",
+  "work_package": "E-3-2",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,13 +13,16 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic-2-7-pre-supersession-checklist",
+    "head_ref": "refs/heads/codex/epic3-e2-smoke-harness",
     "changed_files": [
-      ".claude/plans/EPIC-9-PR-Xfinal-PRE-SUPERSESSION-CHECKLIST.md",
+      ".claude/plans/EPIC-3-E-3-2-SMOKE-HARNESS.md",
       "CHANGELOG.md",
-      "ao_kernel/defaults/schemas/pre_supersession_checklist.schema.v1.json",
+      "ao_kernel/_internal/support_widening/harnesses/__init__.py",
+      "ao_kernel/_internal/support_widening/harnesses/killswitch.py",
+      "ao_kernel/_internal/support_widening/harnesses/runner.py",
       "local-ai-review-evidence.v1.json",
-      "tests/test_pre_supersession_checklist_schema.py"
+      "scripts/run_support_smoke.py",
+      "tests/test_run_support_smoke.py"
     ]
   },
   "checks_considered": [
@@ -27,36 +30,29 @@
     { "name": "secret_scan", "status": "pass" },
     { "name": "ruff", "status": "pass" },
     { "name": "mypy", "status": "pass" },
+    { "name": "direct_cli_smoke", "status": "pass" },
     { "name": "json_validity", "status": "pass" },
-    { "name": "gpp_next_guard_flags", "status": "pass" },
     { "name": "diff_whitespace", "status": "pass" },
-    { "name": "changelog", "status": "pass" },
-    { "name": "schema_doc_alignment", "status": "pass" },
-    { "name": "draft_2020_12_schema", "status": "pass" },
-    { "name": "strict_closed_schema", "status": "pass" },
-    { "name": "local_refs_only", "status": "pass" },
-    { "name": "eighteen_condition_order", "status": "pass" },
-    { "name": "guard_flags_const_false", "status": "pass" },
-    { "name": "no_proposed_state_field", "status": "pass" },
-    { "name": "no_workflow_mutation", "status": "pass" },
-    { "name": "no_runtime_mutation", "status": "pass" },
-    { "name": "no_live_adapter_execution", "status": "pass" },
-    { "name": "no_support_widening", "status": "pass" },
-    { "name": "no_production_claim", "status": "pass" },
+    { "name": "gpp_next_guard_flags", "status": "pass" },
     { "name": "claude_review", "status": "pass" },
-    { "name": "mavis_verifier_review", "status": "pass" },
-    { "name": "cross_provider_review", "status": "pass" }
+    { "name": "cross_provider_review", "status": "pass" },
+    { "name": "no_guard_flag_flip", "status": "pass" },
+    { "name": "no_workflow_or_ruleset_mutation", "status": "pass" },
+    { "name": "no_dot_ao_mutation", "status": "pass" },
+    { "name": "runtime_kill_switch", "status": "pass" },
+    { "name": "direct_script_repo_root_resolution", "status": "pass" }
   ],
   "findings": [
-    "Claude Anthropic returned AGREE for E-2-7 after reviewing the checklist doc, schema, tests, and changelog diff.",
-    "Mavis MiniMax verifier session mvs_bf6be63b50b744ec8fa2cd185ba5a194 returned VERDICT AGREE after checking the 18 conditions, doc/schema alignment, local refs, guard flags, proposal-state absence, workflow/runtime absence, and changelog accuracy.",
-    "The schema is Draft 2020-12, uses only local refs, and closes root and checklist item objects against unknown fields.",
-    "The schema pins all 18 required conditions in order and the markdown checklist mirrors the same condition names.",
-    "The schema keeps support_widening, production_platform_claim, live_adapter_execution, and live_adapter_execution_current_state const false.",
-    "The schema intentionally omits live_adapter_execution_proposed_state and proposed_state; Epic 9 owns any future proposal-state schema.",
-    "The tests cover valid payload acceptance, condition order and cardinality, guard flag rejection, authority pins, strict closure, local refs only, proposal-state absence, markdown alignment, and plan alignment.",
-    "The change is infrastructure-only and does not mutate workflows, runtime adapter code, branch protection, release authority, support tier, production claim language, or guard flags.",
-    "A broader test probe exposed an existing test_cli migration failure on origin/main; Mavis confirmed that failure pre-existed and is not negative drift from E-2-7."
+    "Claude Anthropic returned VERDICT AGREE for E-3-2 after reviewing the current diff against origin/main.",
+    "Claude confirmed the change is infrastructure-only: no support_widening flip, no production_platform_claim, no live_adapter_execution, no workflow or ruleset mutation, and no .ao mutation path.",
+    "Claude confirmed the harness pins support_widening, production_platform_claim, and live_adapter_execution false in every emitted support_widening_evidence.v1 payload.",
+    "Claude confirmed scripts/run_support_smoke.py resolves the repository root itself, so direct CLI execution does not rely on PYTHONPATH or an editable install pointing at the right worktree.",
+    "Claude confirmed the runtime kill-switch guards socket, http client, urllib, requests/httpx when importable, subprocess, shell, dynamic import, and secret environment access paths.",
+    "The kill-switch uses an allowlist-only environment model; credential-class keys that do not match a secret-looking regex are still denied.",
+    "The runner rejects evidence_out paths under .ao and writes artifacts owner-only with fchmod after open, preserving the read-only workspace contract.",
+    "Local validation passed: direct CLI smoke wrote schema-valid evidence, pytest passed 38 tests with 1 expected skip, ruff passed, targeted mypy passed, and branch commit secret scan passed.",
+    "The E-3-2 diff only adds the smoke harness plan, internal support_widening harness package, CLI script, tests, changelog entry, and this local review evidence file.",
+    "No secrets were recorded in the review prompt, review output, evidence file, or local validation artifacts."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/run_support_smoke.py
+++ b/scripts/run_support_smoke.py
@@ -21,9 +21,13 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from ao_kernel._internal.support_widening.evidence import SupportWideningEvidenceError
-from ao_kernel._internal.support_widening.harnesses.killswitch import SupportWideningError
-from ao_kernel._internal.support_widening.harnesses.runner import SURFACE_CLASSES, run_surface_smoke
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel._internal.support_widening.evidence import SupportWideningEvidenceError  # noqa: E402
+from ao_kernel._internal.support_widening.harnesses.killswitch import SupportWideningError  # noqa: E402
+from ao_kernel._internal.support_widening.harnesses.runner import SURFACE_CLASSES, run_surface_smoke  # noqa: E402
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/run_support_smoke.py
+++ b/scripts/run_support_smoke.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Run a library-mode support-widening smoke for one surface class (V5 Epic 3 E-3-2).
+
+Stub-adapter-only; no network, no `.ao/` mutation. Emits a
+`support_widening_evidence.v1` artifact (support_widening pinned false) for the
+requested surface class. Read-only with respect to the workspace.
+
+    python scripts/run_support_smoke.py --surface python_version \
+        [--evidence-out path/to/evidence.json] [--repo owner/name]
+
+The harness runs under the dominant runtime kill-switch
+(`ao_kernel._internal.support_widening.harnesses.killswitch`): any network /
+subprocess / shell / dynamic-import / secret-env access inside it fails closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ao_kernel._internal.support_widening.evidence import SupportWideningEvidenceError
+from ao_kernel._internal.support_widening.harnesses.killswitch import SupportWideningError
+from ao_kernel._internal.support_widening.harnesses.runner import SURFACE_CLASSES, run_surface_smoke
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Support-widening per-surface smoke harness (library-mode, stub adapters)")
+    parser.add_argument("--surface", required=True, choices=SURFACE_CLASSES, help="Surface class to smoke")
+    parser.add_argument("--evidence-out", default=None, help="Optional path to write the v1 evidence artifact (0o600)")
+    parser.add_argument("--repo", default="Halildeu/ao-kernel", help="repo slug for the artifact")
+    args = parser.parse_args(argv)
+
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    out = Path(args.evidence_out) if args.evidence_out else None
+    try:
+        payload = run_surface_smoke(args.surface, repo=args.repo, generated_at=generated_at, evidence_out=out)
+    except (SupportWideningError, SupportWideningEvidenceError) as exc:
+        print(f"SMOKE FAILED ({args.surface}): {exc}", file=sys.stderr)
+        return 1
+
+    where = f" → {args.evidence_out}" if out else ""
+    print(f"SMOKE OK: surface={args.surface} simulated_only=true live_call_made=false support_widening=false{where}")
+    if out is None:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_run_support_smoke.py
+++ b/tests/test_run_support_smoke.py
@@ -110,14 +110,27 @@ def test_killswitch_blocks_subprocess_and_shell() -> None:
 # ---- 4. runtime kill-switch: dynamic import fail closed (1) ---------------
 
 
-def test_killswitch_blocks_forbidden_dynamic_import() -> None:
+def test_killswitch_blocks_forbidden_import_every_path() -> None:
     import importlib
 
     with live_call_killswitch():
+        # importlib.import_module
         with pytest.raises(SupportWideningError):
             importlib.import_module("requests")
         with pytest.raises(SupportWideningError):
             importlib.import_module("socket")
+        # submodule of a forbidden package (prefix match, not just root)
+        with pytest.raises(SupportWideningError):
+            importlib.import_module("google.generativeai")
+        # builtins.__import__ (covers `import X`)
+        with pytest.raises(SupportWideningError):
+            __import__("socket")
+        # exec("import …") routes through the patched __import__
+        with pytest.raises(SupportWideningError):
+            exec("import socket")  # noqa: S102
+        # eval of an __import__ call
+        with pytest.raises(SupportWideningError):
+            eval("__import__('socket')")  # noqa: S307
 
 
 # ---- 5. runtime kill-switch: secret-env fail closed, every read path (1) --
@@ -128,7 +141,7 @@ def test_killswitch_blocks_secret_env_every_path(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setenv("SECRET_TOKEN", "dummy")
     monkeypatch.setenv("PATH", os.environ.get("PATH", "/usr/bin"))
     with live_call_killswitch():
-        # direct read paths must raise
+        # direct + membership read paths must raise
         with pytest.raises(SupportWideningError):
             _ = os.environ["API_KEY"]
         with pytest.raises(SupportWideningError):
@@ -137,9 +150,24 @@ def test_killswitch_blocks_secret_env_every_path(monkeypatch: pytest.MonkeyPatch
             os.environ.get("API_KEY")
         with pytest.raises(SupportWideningError):
             _ = "API_KEY" in os.environ
-        # sanitized view: snapshot/iteration never EXPOSE a secret key
-        assert "API_KEY" not in dict(os.environ.copy())
-        assert all("API_KEY" != k and "SECRET_TOKEN" != k for k in os.environ.keys())
+        # bulk read paths must ALSO fail closed when a secret key is present —
+        # including `dict(os.environ)`, which routes through the keys() override.
+        for bulk in (
+            lambda: os.environ.copy(),
+            lambda: dict(os.environ),
+            lambda: list(os.environ.keys()),
+            lambda: list(os.environ.items()),
+            lambda: list(os.environ.values()),
+            lambda: [k for k in os.environ],
+        ):
+            with pytest.raises(SupportWideningError):
+                bulk()
+        # os.environb byte paths must fail closed too (where supported)
+        if hasattr(os, "environb"):
+            with pytest.raises(SupportWideningError):
+                _ = os.environb[b"API_KEY"]
+            with pytest.raises(SupportWideningError):
+                os.environb.get(b"SECRET_TOKEN")
         # an allowlisted key is still readable
         assert os.getenv("PATH") is not None
 
@@ -167,6 +195,38 @@ def test_live_capability_stub_rejected() -> None:
 
     with pytest.raises(SupportWideningError):
         assert_no_live_capability(_Live())
+
+
+# ---- 7b. evidence write hardening: overwrite mode + .ao reject (2) -------
+
+
+def test_evidence_overwrite_tightens_mode(tmp_path: Path) -> None:
+    out = tmp_path / "ev.json"
+    out.write_text("{}", encoding="utf-8")
+    out.chmod(0o644)  # pre-existing wide-mode artifact
+    run_surface_smoke("python_version", generated_at=_GEN_AT, evidence_out=out)
+    assert out.stat().st_mode & 0o777 == 0o600, "overwrite must tighten mode to 0o600 (fchmod)"
+
+
+def test_evidence_out_under_dot_ao_rejected(tmp_path: Path) -> None:
+    out = tmp_path / ".ao" / "ev.json"
+    with pytest.raises(SupportWideningError):
+        run_surface_smoke("python_version", generated_at=_GEN_AT, evidence_out=out)
+    assert not out.exists(), "no .ao/ artifact may be written (read-only workspace contract)"
+
+
+def test_malicious_stub_through_runner_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stub builder that attempts a forbidden op must fail closed because
+    run_surface_smoke executes the stub inside the kill-switch."""
+    from ao_kernel._internal.support_widening.harnesses import runner as _runner
+
+    def _evil() -> dict:
+        socket.socket()  # forbidden inside the harness
+        return {"matrix": ["3.11"], "pytest_passed": True}
+
+    monkeypatch.setitem(_runner._SURFACE_STUBS, "python_version", _evil)
+    with pytest.raises(SupportWideningError):
+        run_surface_smoke("python_version", generated_at=_GEN_AT)
 
 
 # ---- 8. CLI smoke (1) ----------------------------------------------------

--- a/tests/test_run_support_smoke.py
+++ b/tests/test_run_support_smoke.py
@@ -139,17 +139,21 @@ def test_killswitch_blocks_forbidden_import_every_path() -> None:
 def test_killswitch_blocks_secret_env_every_path(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("API_KEY", "dummy-not-real")
     monkeypatch.setenv("SECRET_TOKEN", "dummy")
+    # credential-class keys a "secret-looking" regex MISSES — allowlist-only catches them
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA_TEST")
+    monkeypatch.setenv("OPENAI_ORGANIZATION", "org_test")
     monkeypatch.setenv("PATH", os.environ.get("PATH", "/usr/bin"))
     with live_call_killswitch():
-        # direct + membership read paths must raise
-        with pytest.raises(SupportWideningError):
-            _ = os.environ["API_KEY"]
-        with pytest.raises(SupportWideningError):
-            os.getenv("SECRET_TOKEN")
-        with pytest.raises(SupportWideningError):
-            os.environ.get("API_KEY")
-        with pytest.raises(SupportWideningError):
-            _ = "API_KEY" in os.environ
+        # direct + membership read paths must raise (incl. non-regex credential keys)
+        for key in ("API_KEY", "SECRET_TOKEN", "AWS_ACCESS_KEY_ID", "OPENAI_ORGANIZATION"):
+            with pytest.raises(SupportWideningError):
+                _ = os.environ[key]
+            with pytest.raises(SupportWideningError):
+                os.getenv(key)
+            with pytest.raises(SupportWideningError):
+                os.environ.get(key)
+            with pytest.raises(SupportWideningError):
+                _ = key in os.environ
         # bulk read paths must ALSO fail closed when a secret key is present —
         # including `dict(os.environ)`, which routes through the keys() override.
         for bulk in (

--- a/tests/test_run_support_smoke.py
+++ b/tests/test_run_support_smoke.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import urllib.request
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 from jsonschema import Draft202012Validator
@@ -32,14 +33,14 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _GEN_AT = "2026-06-04T10:00:00Z"
 
 
-def _schema() -> dict:
-    return load_default("schemas", "support-widening-evidence.schema.v1.json")
+def _schema() -> dict[str, Any]:
+    return cast(dict[str, Any], load_default("schemas", "support-widening-evidence.schema.v1.json"))
 
 
 # ---- 1. per-surface harness (parametrized: one case per surface class) ---
 
 
-@pytest.mark.parametrize("surface", SURFACE_CLASSES)
+@pytest.mark.parametrize("surface", SURFACE_CLASSES)  # type: ignore[untyped-decorator]
 def test_surface_smoke_emits_valid_pinned_artifact(surface: str) -> None:
     payload = run_surface_smoke(surface, generated_at=_GEN_AT)
     # schema-valid (E-3-1) + correct discriminator
@@ -173,7 +174,7 @@ def test_killswitch_blocks_secret_env_every_path(monkeypatch: pytest.MonkeyPatch
             with pytest.raises(SupportWideningError):
                 os.environb.get(b"SECRET_TOKEN")
         # an allowlisted key is still readable
-        assert os.getenv("PATH") is not None
+        assert os.getenv("PATH") == os.environ["PATH"]
 
 
 # ---- 6. kill-switch restores process state on exit (1) -------------------
@@ -224,7 +225,7 @@ def test_malicious_stub_through_runner_fails_closed(monkeypatch: pytest.MonkeyPa
     run_surface_smoke executes the stub inside the kill-switch."""
     from ao_kernel._internal.support_widening.harnesses import runner as _runner
 
-    def _evil() -> dict:
+    def _evil() -> dict[str, Any]:
         socket.socket()  # forbidden inside the harness
         return {"matrix": ["3.11"], "pytest_passed": True}
 
@@ -238,10 +239,11 @@ def test_malicious_stub_through_runner_fails_closed(monkeypatch: pytest.MonkeyPa
 
 def test_cli_smoke_runs(tmp_path: Path) -> None:
     out = tmp_path / "cli_ev.json"
-    # Run the script with the repo root on PYTHONPATH so the subprocess resolves
-    # this checkout's ao_kernel (a script's sys.path[0] is its own dir, and an
-    # editable install may point at a different worktree).
-    env = {**os.environ, "PYTHONPATH": str(_REPO_ROOT)}
+    # Run the script directly. The script itself is responsible for resolving
+    # this checkout's repo root so an editable install cannot silently point at a
+    # different worktree.
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
     proc = subprocess.run(
         [sys.executable, "scripts/run_support_smoke.py", "--surface", "db_backend", "--evidence-out", str(out)],
         cwd=_REPO_ROOT,

--- a/tests/test_run_support_smoke.py
+++ b/tests/test_run_support_smoke.py
@@ -1,0 +1,227 @@
+"""V5 Epic 3 E-3-2 invariants: per-surface smoke harness + runtime kill-switch.
+
+Per-surface coverage is parametrized (one case per surface class). The dominant
+runtime kill-switch is the security core: every forbidden path (socket /
+subprocess / shell / urllib / dynamic-import / secret-env) must fail closed inside
+`live_call_killswitch()` and be restored on exit.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from ao_kernel._internal.support_widening.evidence import parse_v1
+from ao_kernel._internal.support_widening.harnesses.killswitch import (
+    SupportWideningError,
+    assert_no_live_capability,
+    live_call_killswitch,
+)
+from ao_kernel._internal.support_widening.harnesses.runner import SURFACE_CLASSES, run_surface_smoke
+from ao_kernel.config import load_default
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_GEN_AT = "2026-06-04T10:00:00Z"
+
+
+def _schema() -> dict:
+    return load_default("schemas", "support-widening-evidence.schema.v1.json")
+
+
+# ---- 1. per-surface harness (parametrized: one case per surface class) ---
+
+
+@pytest.mark.parametrize("surface", SURFACE_CLASSES)
+def test_surface_smoke_emits_valid_pinned_artifact(surface: str) -> None:
+    payload = run_surface_smoke(surface, generated_at=_GEN_AT)
+    # schema-valid (E-3-1) + correct discriminator
+    assert not list(Draft202012Validator(_schema()).iter_errors(payload)), f"{surface} payload not schema-valid"
+    assert payload["surface_class"] == surface
+    # guard + simulation pins literal in every emit path
+    assert payload["support_widening"] is False
+    assert payload["production_platform_claim"] is False
+    assert payload["live_adapter_execution"] is False
+    assert payload["simulated_only"] is True
+    assert payload["live_call_made"] is False
+    # recompute-not-trust: evidence_dimensions mirrors raw_dimensions
+    assert payload["evidence_dimensions"] == payload["recompute_inputs"]["raw_dimensions"]
+    # and it passes the E-3-1 module parse (runtime pin re-assert)
+    parse_v1(payload, schema=_schema())
+
+
+def test_all_five_surface_classes_present() -> None:
+    assert set(SURFACE_CLASSES) == {
+        "provider",
+        "python_version",
+        "os_platform",
+        "db_backend",
+        "deployment_topology",
+    }
+
+
+def test_unknown_surface_rejected() -> None:
+    with pytest.raises(SupportWideningError):
+        run_surface_smoke("not_a_surface", generated_at=_GEN_AT)
+
+
+def test_evidence_out_written_owner_only(tmp_path: Path) -> None:
+    out = tmp_path / "ev.json"
+    run_surface_smoke("python_version", generated_at=_GEN_AT, evidence_out=out)
+    assert out.is_file()
+    assert out.stat().st_mode & 0o777 == 0o600, "evidence artifact must be owner-only (0o600)"
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["surface_class"] == "python_version"
+
+
+# ---- 2. runtime kill-switch: network paths fail closed (1) ---------------
+
+
+def test_killswitch_blocks_network() -> None:
+    with live_call_killswitch():
+        with pytest.raises(SupportWideningError):
+            socket.socket()
+        with pytest.raises(SupportWideningError):
+            urllib.request.urlopen("http://example.invalid")  # noqa: S310
+
+
+# ---- 3. runtime kill-switch: subprocess / shell fail closed (1) ----------
+
+
+def test_killswitch_blocks_subprocess_and_shell() -> None:
+    with live_call_killswitch():
+        for call in (
+            lambda: subprocess.run(["echo", "x"]),  # noqa: S603,S607
+            lambda: subprocess.Popen(["echo", "x"]),  # noqa: S603,S607
+            lambda: os.system("echo x"),  # noqa: S605
+            lambda: os.popen("echo x"),
+        ):
+            with pytest.raises(SupportWideningError):
+                call()
+
+
+# ---- 4. runtime kill-switch: dynamic import fail closed (1) ---------------
+
+
+def test_killswitch_blocks_forbidden_dynamic_import() -> None:
+    import importlib
+
+    with live_call_killswitch():
+        with pytest.raises(SupportWideningError):
+            importlib.import_module("requests")
+        with pytest.raises(SupportWideningError):
+            importlib.import_module("socket")
+
+
+# ---- 5. runtime kill-switch: secret-env fail closed, every read path (1) --
+
+
+def test_killswitch_blocks_secret_env_every_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_KEY", "dummy-not-real")
+    monkeypatch.setenv("SECRET_TOKEN", "dummy")
+    monkeypatch.setenv("PATH", os.environ.get("PATH", "/usr/bin"))
+    with live_call_killswitch():
+        # direct read paths must raise
+        with pytest.raises(SupportWideningError):
+            _ = os.environ["API_KEY"]
+        with pytest.raises(SupportWideningError):
+            os.getenv("SECRET_TOKEN")
+        with pytest.raises(SupportWideningError):
+            os.environ.get("API_KEY")
+        with pytest.raises(SupportWideningError):
+            _ = "API_KEY" in os.environ
+        # sanitized view: snapshot/iteration never EXPOSE a secret key
+        assert "API_KEY" not in dict(os.environ.copy())
+        assert all("API_KEY" != k and "SECRET_TOKEN" != k for k in os.environ.keys())
+        # an allowlisted key is still readable
+        assert os.getenv("PATH") is not None
+
+
+# ---- 6. kill-switch restores process state on exit (1) -------------------
+
+
+def test_killswitch_restores_on_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_KEY", "dummy-not-real")
+    with live_call_killswitch():
+        with pytest.raises(SupportWideningError):
+            socket.socket()
+    # after exit: socket works again and the secret env is visible again
+    s = socket.socket()
+    s.close()
+    assert os.environ["API_KEY"] == "dummy-not-real"
+
+
+# ---- 7. layer-3 live_capability assertion (1) ---------------------------
+
+
+def test_live_capability_stub_rejected() -> None:
+    class _Live:
+        live_capability = True
+
+    with pytest.raises(SupportWideningError):
+        assert_no_live_capability(_Live())
+
+
+# ---- 8. CLI smoke (1) ----------------------------------------------------
+
+
+def test_cli_smoke_runs(tmp_path: Path) -> None:
+    out = tmp_path / "cli_ev.json"
+    # Run the script with the repo root on PYTHONPATH so the subprocess resolves
+    # this checkout's ao_kernel (a script's sys.path[0] is its own dir, and an
+    # editable install may point at a different worktree).
+    env = {**os.environ, "PYTHONPATH": str(_REPO_ROOT)}
+    proc = subprocess.run(
+        [sys.executable, "scripts/run_support_smoke.py", "--surface", "db_backend", "--evidence-out", str(out)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "SMOKE OK" in proc.stdout
+    assert out.is_file()
+
+
+# ---- 9. governance: no workflow mutation (1) ----------------------------
+
+
+def test_no_workflow_mutation_in_diff() -> None:
+    added = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--diff-filter=A",
+            "--name-only",
+            "origin/main...HEAD",
+            "--",
+            "tests/test_run_support_smoke.py",
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if added.returncode != 0:
+        pytest.skip(f"git diff unavailable: {added.stderr.strip()}")
+    if not added.stdout.strip():
+        pytest.skip("E-3-2 test not ADDED by this PR (introducer pattern); invariant N/A")
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main...HEAD", "--", ".github/workflows/"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        pytest.skip(f"git diff unavailable: {proc.stderr.strip()}")
+    touched = [p for p in proc.stdout.split() if p]
+    assert not touched, f"E-3-2 must not touch .github/workflows/. Touched: {touched}"

--- a/tests/test_run_support_smoke.py
+++ b/tests/test_run_support_smoke.py
@@ -141,7 +141,7 @@ def test_killswitch_blocks_secret_env_every_path(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setenv("API_KEY", "dummy-not-real")
     monkeypatch.setenv("SECRET_TOKEN", "dummy")
     # credential-class keys a "secret-looking" regex MISSES — allowlist-only catches them
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA_TEST")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "dummy-aws-access-key-id")
     monkeypatch.setenv("OPENAI_ORGANIZATION", "org_test")
     monkeypatch.setenv("PATH", os.environ.get("PATH", "/usr/bin"))
     with live_call_killswitch():


### PR DESCRIPTION
## Summary

Closes #854.

Adds V5 Epic 3 E-3-2 per-surface support-widening smoke harness infrastructure:

- `scripts/run_support_smoke.py` CLI for library-mode, stub-adapter-only smoke runs
- internal `ao_kernel._internal.support_widening.harnesses` package
- runtime kill-switch covering network, subprocess/shell, dynamic imports, and secret-env access
- `.ao/` evidence-out rejection + owner-only evidence writes
- E-3-2 plan record and changelog entry
- local cross-provider review evidence for the E-3-2 diff

This is infrastructure-only. It does not flip `support_widening`, does not claim production platform readiness, does not execute live adapters, and does not touch workflows/rulesets/branch protection.

## Validation

- `python3 scripts/run_support_smoke.py --surface provider --evidence-out /tmp/e32-provider-evidence.json && python3 -m json.tool /tmp/e32-provider-evidence.json >/dev/null`
- `pytest tests/test_run_support_smoke.py tests/test_support_widening_evidence_v1.py -q` -> 38 passed, 1 skipped
- `python3 -m ruff check ao_kernel/_internal/support_widening/harnesses scripts/run_support_smoke.py tests/test_run_support_smoke.py`
- `python3 -m mypy --explicit-package-bases --follow-imports=skip ao_kernel/_internal/support_widening/harnesses scripts/run_support_smoke.py tests/test_run_support_smoke.py`
- `gitleaks git . --redact --log-level error --exit-code 1 --log-opts origin/main..HEAD`
- `git diff --check origin/main...HEAD && git diff --check`
- `python3 -m json.tool local-ai-review-evidence.v1.json >/dev/null`
- `python3 scripts/local_gpp_gate.py ... --work-package E-3-2` -> `operator_may_merge`

Local gate context binding:

- head_sha: `e4cdf24b2b91313cf95b4ef4fd887e5e2ae7833d`
- diff_digest: `sha256:7f92bfabc1be15536a21446a2eb05272c1b6e015e4ec95887c0c20b5b874d988`
- changed_files_count: `8`

## Cross-AI review

Claude / Anthropic independent review returned `VERDICT: AGREE` for the E-3-2 diff.

Reviewer confirmed:

- no guard-flag flip
- no `.ao/` mutation path
- no workflow/ruleset mutation
- no live network/subprocess/shell execution in the harness
- dynamic import guard present
- allowlist-only secret-env guard present
- direct CLI execution works without relying on `PYTHONPATH`

## Guard flags

- `support_widening=false`
- `production_platform_claim=false`
- `live_adapter_execution=false`
