### PR TITLE
feat(e-3-5): add widening supersession consensus checklist

### DIFF
--- a/.claude/plans/EPIC-3-E-3-5-SUPERSESSION-CONSENSUS-PROTOCOL.md
+++ b/.claude/plans/EPIC-3-E-3-5-SUPERSESSION-CONSENSUS-PROTOCOL.md
@@ -1,0 +1,104 @@
+# Epic 3 E-3-5 Supersession Consensus Protocol
+
+## Status
+
+- Work package: `E-3-5`
+- Scope: process/checklist infrastructure for a future operator-bound Epic 9
+  supersession PR
+- Runtime impact: none
+- Release authority impact: none
+- Guard flags:
+  - `support_widening=false`
+  - `production_platform_claim=false`
+  - `live_adapter_execution=false`
+
+## Decision
+
+E-3-5 records the minimum cross-AI consensus and evidence-pack contract that a
+future support-widening supersession PR must satisfy before any flag flip can be
+considered. The checklist is deliberately insufficient by itself: it is an
+input to the later E-3-6 recompute validator and to a future operator-bound
+Epic 9 supersession PR.
+
+The checklist explicitly preserves the current narrow stable boundary. It does
+not execute a live adapter, widen support, mutate GitHub rulesets, publish a
+release, or claim production platform readiness.
+
+## Added Artifacts
+
+- `ao_kernel/defaults/schemas/widening-supersession-checklist.schema.v1.json`
+  defines the strict JSON Schema for the checklist artifact.
+- `ao_kernel/defaults/widening-supersession-checklist.v1.json` records the
+  default machine-checkable checklist and assertion list.
+- `tests/test_widening_supersession_checklist.py` validates the schema,
+  checklist, bind-field contract, and synthetic negative evidence-pack cases.
+
+## Protocol Minimums
+
+The checklist requires:
+
+1. An explicit `operator_authority.github_login` field. The legacy alias
+   `operator_github_login` is rejected by `additionalProperties:false`.
+2. An authorization phrase:
+   `AUTHORIZE_SUPPORT_WIDENING_SUPERSESSION`.
+3. Verified operator commit metadata on the future supersession PR.
+4. At least two reviewers from distinct non-implementer AI providers.
+5. Reviewer identities and providers disjoint from the operator and
+   implementer identities.
+6. `evidence_class=live` for every surface being widened.
+7. Provider widening backed by at least three live integration tests across a
+   seven-day evidence window.
+8. Rich `artifacts[]` provenance with `run_id`, `artifact_id`, `sha256`,
+   `produced_at`, and `head_sha`.
+9. No legacy flat `artifact_sha256[]` field.
+10. Provider verdicts pinned to `plan_digest`, `final_diff_digest`, and
+    `pr_head_sha`.
+11. Raw verdict hashes computed with `raw_verdict_sha256` excluded from the
+    canonical payload.
+12. Raw verdict transcript artifacts cross-bound through
+    `raw_verdict_artifact_ref` and `raw_verdict_artifact_digest`.
+13. Verdict completeness derived from raw provider verdict count, not from
+    producer-written consensus claims.
+14. A rollback decision tree with revert tag, revert flag, and revert evidence
+    artifact steps.
+
+## Negative Cases Covered
+
+The test suite covers the E-3-5 adversarial cases recorded in the Epic 3
+matrix:
+
+- stale replay
+- duplicate reviewer identity
+- filtered negative verdict
+- denominator manipulation
+- seven-day window race
+- final diff digest drift
+- PR head SHA drift
+- workflow run status/head/timestamp mismatch
+- orphan artifact
+- artifact missing from a declared run
+- reviewer hash recomputation mismatch
+- verdict binding drift
+- raw verdict SHA mismatch
+- raw verdict self-reference hash ambiguity
+- raw verdict artifact digest mismatch
+- dangling raw verdict artifact reference
+- raw verdict artifact provenance drift
+- operator/implementer/reviewer identity overlap
+- implementer/reviewer provider overlap
+
+## E-3-6 Boundary
+
+E-3-5 intentionally does not implement the production recompute validator. Its
+tests use a synthetic evaluator to pin the checklist's semantics without live
+GitHub API calls. E-3-6 will consume this checklist and implement the actual
+recompute-not-trust validator for future evidence packs.
+
+## Non-Goals
+
+- No support widening.
+- No production platform claim.
+- No live adapter execution.
+- No workflow/ruleset mutation.
+- No public SDK signature change.
+- No GitHub API mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **E-3-5 supersession consensus checklist** (V5 Epic 3, #857): added
+  `widening-supersession-checklist.schema.v1.json`,
+  `widening-supersession-checklist.v1.json`, and
+  `tests/test_widening_supersession_checklist.py` as the machine-checkable
+  cross-AI consensus protocol for a future operator-bound Epic 9 support
+  widening supersession PR. The checklist pins guard flags false, requires
+  operator authority, distinct non-implementer reviewers, live evidence class,
+  rich artifact/run/verdict bind fields, raw-verdict transcript cross-binding,
+  stale/replay/denominator/self-review negative cases, and a rollback decision
+  tree. Infrastructure only: no support widening, production platform claim,
+  live adapter execution, workflow mutation, or ruleset mutation.
 - **E-3-4 support surface inventory document** (V5 Epic 3, #856): added
   `docs/SUPPORT-SURFACE-INVENTORY.md`, a narrative companion to
   `SUPPORT-BOUNDARY.md` that restates today's narrow-stable boundary (pointer, not

--- a/ao_kernel/defaults/schemas/widening-supersession-checklist.schema.v1.json
+++ b/ao_kernel/defaults/schemas/widening-supersession-checklist.schema.v1.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:widening-supersession-checklist:v1",
+  "title": "AO widening supersession checklist v1",
+  "type": "object",
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "repo",
+    "work_package",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution",
+    "widening_flip_authority",
+    "checklist_alone_authorizes_flip",
+    "operator_authority",
+    "implementer_provider",
+    "reviewer_providers",
+    "evidence_pack_contract",
+    "assertions",
+    "rollback_decision_tree"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "widening_supersession_checklist.v1"
+    },
+    "artifact_kind": {
+      "const": "widening_supersession_checklist"
+    },
+    "repo": {
+      "const": "Halildeu/ao-kernel"
+    },
+    "work_package": {
+      "const": "E-3-5"
+    },
+    "support_widening": {
+      "const": false
+    },
+    "production_platform_claim": {
+      "const": false
+    },
+    "live_adapter_execution": {
+      "const": false
+    },
+    "widening_flip_authority": {
+      "const": "operator_bound_supersession_pr_only"
+    },
+    "checklist_alone_authorizes_flip": {
+      "const": false
+    },
+    "operator_authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "github_login",
+        "authorization_phrase",
+        "commit_verification_required",
+        "operator_must_be_disjoint_from_implementer_and_reviewers"
+      ],
+      "properties": {
+        "github_login": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9-]+$"
+        },
+        "authorization_phrase": {
+          "const": "AUTHORIZE_SUPPORT_WIDENING_SUPERSESSION"
+        },
+        "commit_verification_required": {
+          "const": true
+        },
+        "operator_must_be_disjoint_from_implementer_and_reviewers": {
+          "const": true
+        }
+      }
+    },
+    "implementer_provider": {
+      "$ref": "#/$defs/provider_identity"
+    },
+    "reviewer_providers": {
+      "type": "array",
+      "minItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/provider_identity"
+      }
+    },
+    "evidence_pack_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "required_evidence_class",
+        "minimum_provider_live_integration_tests",
+        "minimum_live_window_days",
+        "bind_fields",
+        "legacy_flat_artifact_sha256_allowed",
+        "recompute_not_trust_required"
+      ],
+      "properties": {
+        "required_evidence_class": {
+          "const": "live"
+        },
+        "minimum_provider_live_integration_tests": {
+          "const": 3
+        },
+        "minimum_live_window_days": {
+          "const": 7
+        },
+        "bind_fields": {
+          "$ref": "#/$defs/bind_fields"
+        },
+        "legacy_flat_artifact_sha256_allowed": {
+          "const": false
+        },
+        "recompute_not_trust_required": {
+          "const": true
+        }
+      }
+    },
+    "assertions": {
+      "type": "array",
+      "minItems": 20,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "unevaluatedProperties": false,
+        "required": [
+          "id",
+          "required",
+          "recompute_strategy",
+          "bind_fields"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[a-z0-9_]+$"
+          },
+          "required": {
+            "const": true
+          },
+          "recompute_strategy": {
+            "type": "string",
+            "minLength": 1
+          },
+          "bind_fields": {
+            "$ref": "#/$defs/bind_fields"
+          }
+        }
+      }
+    },
+    "rollback_decision_tree": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "required",
+        "revert_tag_required",
+        "revert_flag_required",
+        "revert_evidence_artifact_required"
+      ],
+      "properties": {
+        "required": {
+          "const": true
+        },
+        "revert_tag_required": {
+          "const": true
+        },
+        "revert_flag_required": {
+          "const": true
+        },
+        "revert_evidence_artifact_required": {
+          "const": true
+        }
+      }
+    }
+  },
+  "$defs": {
+    "provider_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "provider",
+        "github_login"
+      ],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": [
+            "openai",
+            "anthropic",
+            "google",
+            "mavis",
+            "minimax"
+          ]
+        },
+        "github_login": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9-]+$"
+        }
+      }
+    },
+    "bind_fields": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "plan_digest",
+          "final_diff_digest",
+          "pr_head_sha",
+          "workflow_run_ids",
+          "artifacts[].run_id",
+          "artifacts[].artifact_id",
+          "artifacts[].sha256",
+          "artifacts[].produced_at",
+          "artifacts[].head_sha",
+          "time_window_boundaries",
+          "reviewer_identity_hashes",
+          "verdict_completeness_proof",
+          "provider_verdicts[].plan_digest",
+          "provider_verdicts[].final_diff_digest",
+          "provider_verdicts[].pr_head_sha",
+          "provider_verdicts[].raw_verdict_sha256",
+          "provider_verdicts[].raw_verdict_artifact_digest",
+          "provider_verdicts[].raw_verdict_artifact_ref"
+        ]
+      }
+    }
+  }
+}

--- a/ao_kernel/defaults/widening-supersession-checklist.v1.json
+++ b/ao_kernel/defaults/widening-supersession-checklist.v1.json
@@ -1,0 +1,234 @@
+{
+  "schema_version": "widening_supersession_checklist.v1",
+  "artifact_kind": "widening_supersession_checklist",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "E-3-5",
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false,
+  "widening_flip_authority": "operator_bound_supersession_pr_only",
+  "checklist_alone_authorizes_flip": false,
+  "operator_authority": {
+    "github_login": "Halildeu",
+    "authorization_phrase": "AUTHORIZE_SUPPORT_WIDENING_SUPERSESSION",
+    "commit_verification_required": true,
+    "operator_must_be_disjoint_from_implementer_and_reviewers": true
+  },
+  "implementer_provider": {
+    "provider": "openai",
+    "github_login": "codex-implementer"
+  },
+  "reviewer_providers": [
+    {
+      "provider": "anthropic",
+      "github_login": "claude-reviewer"
+    },
+    {
+      "provider": "mavis",
+      "github_login": "mavis-reviewer"
+    }
+  ],
+  "evidence_pack_contract": {
+    "required_evidence_class": "live",
+    "minimum_provider_live_integration_tests": 3,
+    "minimum_live_window_days": 7,
+    "legacy_flat_artifact_sha256_allowed": false,
+    "recompute_not_trust_required": true,
+    "bind_fields": [
+      "plan_digest",
+      "final_diff_digest",
+      "pr_head_sha",
+      "workflow_run_ids",
+      "artifacts[].run_id",
+      "artifacts[].artifact_id",
+      "artifacts[].sha256",
+      "artifacts[].produced_at",
+      "artifacts[].head_sha",
+      "time_window_boundaries",
+      "reviewer_identity_hashes",
+      "verdict_completeness_proof",
+      "provider_verdicts[].plan_digest",
+      "provider_verdicts[].final_diff_digest",
+      "provider_verdicts[].pr_head_sha",
+      "provider_verdicts[].raw_verdict_sha256",
+      "provider_verdicts[].raw_verdict_artifact_digest",
+      "provider_verdicts[].raw_verdict_artifact_ref"
+    ]
+  },
+  "assertions": [
+    {
+      "id": "operator_authority_block_present",
+      "required": true,
+      "recompute_strategy": "Verify operator_authority.github_login, authorization phrase, and verified commit metadata from the future supersession PR.",
+      "bind_fields": ["plan_digest", "final_diff_digest", "pr_head_sha"]
+    },
+    {
+      "id": "checklist_alone_does_not_authorize_flip",
+      "required": true,
+      "recompute_strategy": "Require the future operator-bound supersession PR and reject any checklist-only widening claim.",
+      "bind_fields": ["plan_digest", "final_diff_digest"]
+    },
+    {
+      "id": "cross_ai_distinct_provider",
+      "required": true,
+      "recompute_strategy": "Recompute reviewer provider set from raw provider_verdicts and require at least two distinct non-implementer providers.",
+      "bind_fields": ["provider_verdicts[].plan_digest", "provider_verdicts[].final_diff_digest", "provider_verdicts[].pr_head_sha"]
+    },
+    {
+      "id": "evidence_class_live",
+      "required": true,
+      "recompute_strategy": "Validate every widened surface artifact declares evidence_class=live and is not simulated.",
+      "bind_fields": ["artifacts[].artifact_id", "artifacts[].sha256", "workflow_run_ids"]
+    },
+    {
+      "id": "minimum_provider_live_integration_tests",
+      "required": true,
+      "recompute_strategy": "Recompute provider live integration counts and require at least three live provider tests for provider widening.",
+      "bind_fields": ["artifacts[].artifact_id", "artifacts[].sha256", "time_window_boundaries"]
+    },
+    {
+      "id": "bind_fields_required",
+      "required": true,
+      "recompute_strategy": "Reject any assertion or evidence pack whose canonical bind field set is missing or empty.",
+      "bind_fields": ["plan_digest", "final_diff_digest", "pr_head_sha", "workflow_run_ids"]
+    },
+    {
+      "id": "legacy_artifact_sha_array_rejected",
+      "required": true,
+      "recompute_strategy": "Reject the legacy flat artifact_sha256 array name at schema and validator layers; only rich artifacts[] entries are valid.",
+      "bind_fields": ["artifacts[].run_id", "artifacts[].artifact_id", "artifacts[].sha256"]
+    },
+    {
+      "id": "stale_replay_rejected",
+      "required": true,
+      "recompute_strategy": "Reject evidence windows whose end timestamp is older than the configured replay horizon.",
+      "bind_fields": ["time_window_boundaries", "artifacts[].produced_at"]
+    },
+    {
+      "id": "duplicate_reviewer_identity_rejected",
+      "required": true,
+      "recompute_strategy": "Recompute reviewer identity hashes from raw provider verdicts and require pairwise distinct values.",
+      "bind_fields": ["reviewer_identity_hashes", "provider_verdicts[].raw_verdict_sha256"]
+    },
+    {
+      "id": "filtered_negative_verdict_rejected",
+      "required": true,
+      "recompute_strategy": "Reject evidence claiming negative verdicts exist unless raw provider verdicts include REVISE or RED; reject hidden negatives when the flag is false.",
+      "bind_fields": ["verdict_completeness_proof", "provider_verdicts[].raw_verdict_sha256"]
+    },
+    {
+      "id": "denominator_manipulation_rejected",
+      "required": true,
+      "recompute_strategy": "Recompute verdict denominator from provider_verdicts length and compare it to verdict_completeness_proof.",
+      "bind_fields": ["verdict_completeness_proof", "provider_verdicts[].raw_verdict_sha256"]
+    },
+    {
+      "id": "seven_day_window_race_rejected",
+      "required": true,
+      "recompute_strategy": "Require a minimum seven day evidence window and reject artifacts outside the declared window.",
+      "bind_fields": ["time_window_boundaries", "artifacts[].produced_at"]
+    },
+    {
+      "id": "final_diff_digest_drift_rejected",
+      "required": true,
+      "recompute_strategy": "Recompute the final merged diff digest and reject mismatch with top-level and per-verdict digests.",
+      "bind_fields": ["final_diff_digest", "provider_verdicts[].final_diff_digest"]
+    },
+    {
+      "id": "pr_head_sha_drift_rejected",
+      "required": true,
+      "recompute_strategy": "Compare pr_head_sha with the GitHub PR head SHA and with every workflow run and provider verdict.",
+      "bind_fields": ["pr_head_sha", "artifacts[].head_sha", "provider_verdicts[].pr_head_sha"]
+    },
+    {
+      "id": "workflow_run_status_mismatch_rejected",
+      "required": true,
+      "recompute_strategy": "Query workflow_run_ids and require completed/success status, matching head SHA, and in-window creation time.",
+      "bind_fields": ["workflow_run_ids", "pr_head_sha", "time_window_boundaries"]
+    },
+    {
+      "id": "orphan_artifact_rejected",
+      "required": true,
+      "recompute_strategy": "Reject any artifact whose run_id is not present in workflow_run_ids.",
+      "bind_fields": ["workflow_run_ids", "artifacts[].run_id"]
+    },
+    {
+      "id": "artifact_not_in_run_rejected",
+      "required": true,
+      "recompute_strategy": "Query each run artifact list and reject any artifacts[].artifact_id absent from its declared run.",
+      "bind_fields": ["workflow_run_ids", "artifacts[].run_id", "artifacts[].artifact_id"]
+    },
+    {
+      "id": "reviewer_hash_recomputation_mismatch_rejected",
+      "required": true,
+      "recompute_strategy": "Recompute SHA256(provider|github_login|thread_id) for every provider verdict and compare with reviewer_identity_hashes.",
+      "bind_fields": ["reviewer_identity_hashes", "provider_verdicts[].raw_verdict_sha256"]
+    },
+    {
+      "id": "verdict_binding_drift_rejected",
+      "required": true,
+      "recompute_strategy": "Reject any provider verdict not pinned to the top-level plan_digest, final_diff_digest, and pr_head_sha.",
+      "bind_fields": ["plan_digest", "final_diff_digest", "pr_head_sha", "provider_verdicts[].plan_digest", "provider_verdicts[].final_diff_digest", "provider_verdicts[].pr_head_sha"]
+    },
+    {
+      "id": "raw_verdict_sha_mismatch_rejected",
+      "required": true,
+      "recompute_strategy": "Canonicalize each provider verdict with raw_verdict_sha256 excluded and reject hash mismatch.",
+      "bind_fields": ["provider_verdicts[].raw_verdict_sha256"]
+    },
+    {
+      "id": "raw_verdict_canonical_self_reference_rejected",
+      "required": true,
+      "recompute_strategy": "Reject self-referential raw verdict hashes computed with raw_verdict_sha256 included in the payload.",
+      "bind_fields": ["provider_verdicts[].raw_verdict_sha256"]
+    },
+    {
+      "id": "raw_verdict_artifact_digest_mismatch_rejected",
+      "required": true,
+      "recompute_strategy": "Match raw_verdict_artifact_digest to the referenced transcript artifact SHA256.",
+      "bind_fields": ["provider_verdicts[].raw_verdict_artifact_digest", "provider_verdicts[].raw_verdict_artifact_ref", "artifacts[].artifact_id", "artifacts[].sha256"]
+    },
+    {
+      "id": "raw_verdict_artifact_ref_dangling_rejected",
+      "required": true,
+      "recompute_strategy": "Reject provider verdicts whose raw_verdict_artifact_ref does not resolve to artifacts[].artifact_id.",
+      "bind_fields": ["provider_verdicts[].raw_verdict_artifact_ref", "artifacts[].artifact_id"]
+    },
+    {
+      "id": "raw_verdict_artifact_provenance_rejected",
+      "required": true,
+      "recompute_strategy": "Reject referenced raw transcript artifacts whose run_id is not listed or whose head_sha differs from pr_head_sha.",
+      "bind_fields": ["workflow_run_ids", "pr_head_sha", "artifacts[].run_id", "artifacts[].head_sha", "provider_verdicts[].raw_verdict_artifact_ref"]
+    },
+    {
+      "id": "disjoint_identities_required",
+      "required": true,
+      "recompute_strategy": "Reject operator, implementer, or reviewer GitHub login overlap.",
+      "bind_fields": ["reviewer_identity_hashes", "provider_verdicts[].raw_verdict_sha256"]
+    },
+    {
+      "id": "disjoint_providers_required",
+      "required": true,
+      "recompute_strategy": "Reject reviewer provider duplication and implementer-provider overlap.",
+      "bind_fields": ["provider_verdicts[].raw_verdict_sha256"]
+    },
+    {
+      "id": "recompute_not_trust_consensus",
+      "required": true,
+      "recompute_strategy": "Re-derive consensus and widening_authorized from raw inputs; reject producer-authored consensus drift.",
+      "bind_fields": ["verdict_completeness_proof", "provider_verdicts[].raw_verdict_sha256", "artifacts[].sha256"]
+    },
+    {
+      "id": "rollback_decision_tree_present",
+      "required": true,
+      "recompute_strategy": "Require PR-body rollback tree with revert tag, revert flag, and revert evidence artifact steps.",
+      "bind_fields": ["plan_digest", "final_diff_digest"]
+    }
+  ],
+  "rollback_decision_tree": {
+    "required": true,
+    "revert_tag_required": true,
+    "revert_flag_required": true,
+    "revert_evidence_artifact_required": true
+  }
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "E-3-4",
+  "work_package": "E-3-5",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,13 +13,14 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic3-e4-surface-inventory",
+    "head_ref": "refs/heads/codex/epic3-e5-consensus-protocol",
     "changed_files": [
-      ".claude/plans/EPIC-3-E-3-4-SURFACE-INVENTORY.md",
+      ".claude/plans/EPIC-3-E-3-5-SUPERSESSION-CONSENSUS-PROTOCOL.md",
       "CHANGELOG.md",
-      "docs/SUPPORT-SURFACE-INVENTORY.md",
+      "ao_kernel/defaults/schemas/widening-supersession-checklist.schema.v1.json",
+      "ao_kernel/defaults/widening-supersession-checklist.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_support_surface_inventory_doc.py"
+      "tests/test_widening_supersession_checklist.py"
     ]
   },
   "checks_considered": [
@@ -32,7 +33,19 @@
       "status": "pass"
     },
     {
-      "name": "pytest_support_surface_inventory_doc",
+      "name": "pytest_widening_supersession_checklist",
+      "status": "pass"
+    },
+    {
+      "name": "json_schema_and_checklist_parse",
+      "status": "pass"
+    },
+    {
+      "name": "ruff_test_file",
+      "status": "pass"
+    },
+    {
+      "name": "mypy_test_file",
       "status": "pass"
     },
     {
@@ -44,27 +57,23 @@
       "status": "pass"
     },
     {
-      "name": "no_support_boundary_or_public_beta_mutation",
+      "name": "schema_recursive_strict_closure",
       "status": "pass"
     },
     {
-      "name": "no_workflow_or_ruleset_mutation",
+      "name": "canonical_operator_authority_field",
       "status": "pass"
     },
     {
-      "name": "expanded_forbidden_claim_language_guard",
+      "name": "legacy_artifact_sha256_rejection",
       "status": "pass"
     },
     {
-      "name": "verbatim_no_widening_disclaimer",
+      "name": "rich_artifacts_bind_fields",
       "status": "pass"
     },
     {
-      "name": "row_bound_prerequisite_mapping",
-      "status": "pass"
-    },
-    {
-      "name": "provider_minimum_live_test_threshold",
+      "name": "e3_5_negative_cases",
       "status": "pass"
     },
     {
@@ -77,16 +86,16 @@
     }
   ],
   "findings": [
-    "Claude Anthropic returned VERDICT AGREE for E-3-4 after reviewing the current committed diff against origin/main.",
-    "Claude confirmed BLK-no_guard_flip-1 is covered by the expanded 12-pattern forbidden-claim language guard, including case-sensitive word-boundary GA handling.",
-    "Claude confirmed BLK-no_guard_flip-2 is covered by the verbatim disclaimer: This inventory does not announce any widening; it names what would be required if widening were authorized.",
-    "Claude confirmed the document includes all five surface classes: provider, python_version, os_platform, db_backend, and deployment_topology.",
-    "Claude confirmed each prerequisite is bound to its own section 3 surface_class row, preventing false positives from the section 2 examples table.",
-    "Claude confirmed the provider row specifically requires live integration tests and names the >=3 live-test threshold.",
-    "Claude confirmed the document frames all widening rows as prerequisites, not promises, and defers widening authority to the Epic 9 operator-bound supersession PR.",
-    "Claude confirmed docs/SUPPORT-BOUNDARY.md, docs/PUBLIC-BETA.md, workflows, rulesets, runtime code, and .ao evidence are not mutated by this slice.",
-    "Local validation passed: pytest tests/test_support_surface_inventory_doc.py -q reported 9 passed; diff whitespace checks passed; gpp_next still reports all guard flags false.",
-    "The E-3-4 diff is docs/test infrastructure only: support surface inventory doc, E-3-4 decision record, changelog entry, invariant test, and this local review evidence file.",
+    "Claude Anthropic returned VERDICT AGREE for E-3-5 after reviewing the committed diff against origin/main.",
+    "Claude confirmed guard flags are pinned false in schema, checklist JSON, and tests: support_widening=false, production_platform_claim=false, live_adapter_execution=false.",
+    "Claude confirmed the checklist uses rich artifacts[] bind fields and rejects the legacy flat artifact_sha256 surface.",
+    "Claude confirmed operator_authority.github_login is the canonical field and that the legacy operator_github_login alias is rejected by additionalProperties:false.",
+    "Claude confirmed recursive strict closure is asserted for schema object nodes and only local refs are allowed.",
+    "Claude confirmed the synthetic evaluator covers stale replay, duplicate reviewer identity, filtered negative verdict, denominator manipulation, 7-day window race, final diff drift, PR head drift, workflow run mismatch, orphan/missing artifact, reviewer hash mismatch, verdict binding drift, raw verdict hash/canonicalization/artifact cross-binding, and disjoint identity/provider cases.",
+    "Claude confirmed every assertion has required=true, non-empty recompute_strategy, and non-empty bind_fields with no legacy artifact_sha256 entries.",
+    "Claude confirmed E-3-5/E-3-6 boundary is respected: E-3-5 is a synthetic checklist/test artifact only and E-3-6 will implement the production recompute validator.",
+    "Local validation passed: pytest tests/test_widening_supersession_checklist.py -q reported 16 passed; ruff and mypy passed for the new test file; JSON parse checks, diff whitespace checks, gitleaks, and gpp_next guard checks passed.",
+    "No workflow, ruleset, runtime adapter, public SDK signature, support boundary, live adapter execution, support widening, or production platform claim was introduced by this slice.",
     "No secrets were recorded in the review prompt, review output, evidence file, or local validation artifacts."
   ],
   "secrets_recorded": false,

--- a/tests/test_widening_supersession_checklist.py
+++ b/tests/test_widening_supersession_checklist.py
@@ -1,0 +1,525 @@
+"""V5 Epic 3 E-3-5 invariants: widening supersession consensus checklist.
+
+E-3-5 is a future-supersession protocol artifact only. It records the
+cross-provider consensus and bind-field requirements that a later operator-bound
+Epic 9 PR must satisfy before any support-widening flag flip can be considered.
+It does not authorize a flip, execute a live adapter, widen support, or claim
+production platform readiness.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_NAME = "widening-supersession-checklist.schema.v1.json"
+CHECKLIST_PATH = ROOT / "ao_kernel" / "defaults" / "widening-supersession-checklist.v1.json"
+SCHEMA_PATH = ROOT / "ao_kernel" / "defaults" / "schemas" / SCHEMA_NAME
+
+REQUIRED_BIND_FIELDS = {
+    "plan_digest",
+    "final_diff_digest",
+    "pr_head_sha",
+    "workflow_run_ids",
+    "artifacts[].run_id",
+    "artifacts[].artifact_id",
+    "artifacts[].sha256",
+    "artifacts[].produced_at",
+    "artifacts[].head_sha",
+    "time_window_boundaries",
+    "reviewer_identity_hashes",
+    "verdict_completeness_proof",
+    "provider_verdicts[].plan_digest",
+    "provider_verdicts[].final_diff_digest",
+    "provider_verdicts[].pr_head_sha",
+    "provider_verdicts[].raw_verdict_sha256",
+    "provider_verdicts[].raw_verdict_artifact_digest",
+    "provider_verdicts[].raw_verdict_artifact_ref",
+}
+
+REQUIRED_ASSERTIONS = {
+    "operator_authority_block_present",
+    "checklist_alone_does_not_authorize_flip",
+    "cross_ai_distinct_provider",
+    "evidence_class_live",
+    "minimum_provider_live_integration_tests",
+    "bind_fields_required",
+    "legacy_artifact_sha_array_rejected",
+    "stale_replay_rejected",
+    "duplicate_reviewer_identity_rejected",
+    "filtered_negative_verdict_rejected",
+    "denominator_manipulation_rejected",
+    "seven_day_window_race_rejected",
+    "final_diff_digest_drift_rejected",
+    "pr_head_sha_drift_rejected",
+    "workflow_run_status_mismatch_rejected",
+    "orphan_artifact_rejected",
+    "artifact_not_in_run_rejected",
+    "reviewer_hash_recomputation_mismatch_rejected",
+    "verdict_binding_drift_rejected",
+    "raw_verdict_sha_mismatch_rejected",
+    "raw_verdict_canonical_self_reference_rejected",
+    "raw_verdict_artifact_digest_mismatch_rejected",
+    "raw_verdict_artifact_ref_dangling_rejected",
+    "raw_verdict_artifact_provenance_rejected",
+    "disjoint_identities_required",
+    "disjoint_providers_required",
+    "recompute_not_trust_consensus",
+    "rollback_decision_tree_present",
+}
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", SCHEMA_NAME)
+
+
+def _checklist() -> dict[str, Any]:
+    parsed = json.loads(CHECKLIST_PATH.read_text(encoding="utf-8"))
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def _is_valid(payload: dict[str, Any]) -> bool:
+    return not list(Draft202012Validator(_schema()).iter_errors(payload))
+
+
+def _parse_z(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _identity_hash(verdict: dict[str, Any]) -> str:
+    return _sha256_text(f"{verdict['provider']}|{verdict['github_login']}|{verdict['thread_id']}")
+
+
+def _canonical_verdict_sha256(verdict: dict[str, Any]) -> str:
+    payload = {k: v for k, v in verdict.items() if k != "raw_verdict_sha256"}
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _stamp(day: int) -> str:
+    return f"2026-01-{day:02d}T00:00:00Z"
+
+
+def _valid_pack() -> dict[str, Any]:
+    pack: dict[str, Any] = {
+        "operator_authority": {"github_login": "Halildeu"},
+        "implementer_provider": {"provider": "openai", "github_login": "codex-implementer"},
+        "plan_digest": "a" * 64,
+        "final_diff_digest": "b" * 64,
+        "pr_head_sha": "c" * 40,
+        "workflow_run_ids": ["100", "101"],
+        "time_window_boundaries": {"start": _stamp(1), "end": _stamp(8)},
+        "artifacts": [
+            {
+                "run_id": "100",
+                "artifact_id": "anthropic-raw-verdict",
+                "sha256": "d" * 64,
+                "produced_at": _stamp(2),
+                "head_sha": "c" * 40,
+            },
+            {
+                "run_id": "101",
+                "artifact_id": "mavis-raw-verdict",
+                "sha256": "e" * 64,
+                "produced_at": _stamp(3),
+                "head_sha": "c" * 40,
+            },
+        ],
+        "provider_verdicts": [
+            {
+                "provider": "anthropic",
+                "github_login": "claude-reviewer",
+                "thread_id": "claude-thread-1",
+                "verdict": "AGREE",
+                "plan_digest": "a" * 64,
+                "final_diff_digest": "b" * 64,
+                "pr_head_sha": "c" * 40,
+                "raw_verdict_sha256": "",
+                "raw_verdict_artifact_digest": "d" * 64,
+                "raw_verdict_artifact_ref": "anthropic-raw-verdict",
+            },
+            {
+                "provider": "mavis",
+                "github_login": "mavis-reviewer",
+                "thread_id": "mavis-thread-1",
+                "verdict": "AGREE",
+                "plan_digest": "a" * 64,
+                "final_diff_digest": "b" * 64,
+                "pr_head_sha": "c" * 40,
+                "raw_verdict_sha256": "",
+                "raw_verdict_artifact_digest": "e" * 64,
+                "raw_verdict_artifact_ref": "mavis-raw-verdict",
+            },
+        ],
+        "verdict_completeness_proof": {
+            "verdicts_received_total": 2,
+            "verdicts_claimed_in_consensus": 2,
+            "negative_verdicts_present": False,
+        },
+    }
+    for verdict in pack["provider_verdicts"]:
+        verdict["raw_verdict_sha256"] = _canonical_verdict_sha256(verdict)
+    pack["reviewer_identity_hashes"] = [_identity_hash(v) for v in pack["provider_verdicts"]]
+    return pack
+
+
+def _api_runs_for(pack: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    runs: dict[str, dict[str, Any]] = {}
+    for run_id in pack["workflow_run_ids"]:
+        runs[run_id] = {
+            "status": "completed",
+            "conclusion": "success",
+            "head_sha": pack["pr_head_sha"],
+            "created_at": _stamp(2),
+        }
+    return runs
+
+
+def _api_artifacts_for(pack: dict[str, Any]) -> dict[str, set[str]]:
+    artifacts_by_run: dict[str, set[str]] = {}
+    for artifact in pack["artifacts"]:
+        artifacts_by_run.setdefault(artifact["run_id"], set()).add(artifact["artifact_id"])
+    return artifacts_by_run
+
+
+def _evaluate_pack(
+    pack: dict[str, Any],
+    *,
+    now: datetime | None = None,
+    api_runs: dict[str, dict[str, Any]] | None = None,
+    api_artifacts: dict[str, set[str]] | None = None,
+    recomputed_final_diff_digest: str | None = None,
+    github_pr_head_sha: str | None = None,
+) -> set[str]:
+    """Test-local E-3-5 negative-case evaluator.
+
+    The production recompute module lands in E-3-6. This helper pins the
+    checklist's adversarial cases without performing live GitHub API calls.
+    """
+    errors: set[str] = set()
+    now = now or datetime(2026, 2, 15, tzinfo=timezone.utc)
+    api_runs = api_runs or _api_runs_for(pack)
+    api_artifacts = api_artifacts or _api_artifacts_for(pack)
+    recomputed_final_diff_digest = recomputed_final_diff_digest or pack["final_diff_digest"]
+    github_pr_head_sha = github_pr_head_sha or pack["pr_head_sha"]
+
+    if "artifact_sha256" in pack:
+        errors.add("legacy_artifact_sha_array_rejected")
+
+    start = _parse_z(pack["time_window_boundaries"]["start"])
+    end = _parse_z(pack["time_window_boundaries"]["end"])
+    if end < now - timedelta(days=90):
+        errors.add("stale_replay_rejected")
+    if end - start < timedelta(days=7):
+        errors.add("seven_day_window_race_rejected")
+    for artifact in pack["artifacts"]:
+        produced_at = _parse_z(artifact["produced_at"])
+        if produced_at < start or produced_at > end:
+            errors.add("seven_day_window_race_rejected")
+
+    if pack["final_diff_digest"] != recomputed_final_diff_digest:
+        errors.add("final_diff_digest_drift_rejected")
+    if pack["pr_head_sha"] != github_pr_head_sha:
+        errors.add("pr_head_sha_drift_rejected")
+
+    for run_id in pack["workflow_run_ids"]:
+        run = api_runs.get(run_id, {})
+        if (
+            run.get("status") != "completed"
+            or run.get("conclusion") != "success"
+            or run.get("head_sha") != pack["pr_head_sha"]
+            or _parse_z(str(run.get("created_at", _stamp(20)))) < start
+            or _parse_z(str(run.get("created_at", _stamp(20)))) > end
+        ):
+            errors.add("workflow_run_status_mismatch_rejected")
+
+    artifact_by_id = {artifact["artifact_id"]: artifact for artifact in pack["artifacts"]}
+    for artifact in pack["artifacts"]:
+        if artifact["run_id"] not in pack["workflow_run_ids"]:
+            errors.add("orphan_artifact_rejected")
+        if artifact["artifact_id"] not in api_artifacts.get(artifact["run_id"], set()):
+            errors.add("artifact_not_in_run_rejected")
+
+    recomputed_hashes = [_identity_hash(verdict) for verdict in pack["provider_verdicts"]]
+    if len(set(pack["reviewer_identity_hashes"])) != len(pack["reviewer_identity_hashes"]):
+        errors.add("duplicate_reviewer_identity_rejected")
+    if pack["reviewer_identity_hashes"] != recomputed_hashes:
+        errors.add("reviewer_hash_recomputation_mismatch_rejected")
+
+    proof = pack["verdict_completeness_proof"]
+    agree_count = sum(1 for verdict in pack["provider_verdicts"] if verdict["verdict"] == "AGREE")
+    negative_count = sum(1 for verdict in pack["provider_verdicts"] if verdict["verdict"] in {"REVISE", "RED"})
+    if proof["verdicts_received_total"] != len(pack["provider_verdicts"]):
+        errors.add("denominator_manipulation_rejected")
+    if proof["verdicts_claimed_in_consensus"] != agree_count:
+        errors.add("denominator_manipulation_rejected")
+    if proof["negative_verdicts_present"] and negative_count == 0:
+        errors.add("filtered_negative_verdict_rejected")
+    if not proof["negative_verdicts_present"] and negative_count:
+        errors.add("filtered_negative_verdict_rejected")
+
+    operator_login = pack["operator_authority"]["github_login"]
+    implementer = pack["implementer_provider"]
+    reviewer_logins = [verdict["github_login"] for verdict in pack["provider_verdicts"]]
+    reviewer_providers = [verdict["provider"] for verdict in pack["provider_verdicts"]]
+    if operator_login == implementer["github_login"] or operator_login in reviewer_logins:
+        errors.add("disjoint_identities_required")
+    if len(set(reviewer_logins)) != len(reviewer_logins):
+        errors.add("disjoint_identities_required")
+    if implementer["provider"] in reviewer_providers or len(set(reviewer_providers)) != len(reviewer_providers):
+        errors.add("disjoint_providers_required")
+
+    for verdict in pack["provider_verdicts"]:
+        if (
+            verdict["plan_digest"] != pack["plan_digest"]
+            or verdict["final_diff_digest"] != pack["final_diff_digest"]
+            or verdict["pr_head_sha"] != pack["pr_head_sha"]
+        ):
+            errors.add("verdict_binding_drift_rejected")
+        if verdict["raw_verdict_sha256"] != _canonical_verdict_sha256(verdict):
+            errors.add("raw_verdict_sha_mismatch_rejected")
+            errors.add("raw_verdict_canonical_self_reference_rejected")
+        ref = verdict["raw_verdict_artifact_ref"]
+        artifact = artifact_by_id.get(ref)
+        if artifact is None:
+            errors.add("raw_verdict_artifact_ref_dangling_rejected")
+            continue
+        if verdict["raw_verdict_artifact_digest"] != artifact["sha256"]:
+            errors.add("raw_verdict_artifact_digest_mismatch_rejected")
+        if artifact["run_id"] not in pack["workflow_run_ids"] or artifact["head_sha"] != pack["pr_head_sha"]:
+            errors.add("raw_verdict_artifact_provenance_rejected")
+
+    return errors
+
+
+def test_schema_present_valid_draft_2020_12() -> None:
+    assert SCHEMA_PATH.is_file()
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["$id"] == "urn:ao:widening-supersession-checklist:v1"
+
+
+def test_checklist_payload_schema_validates_and_keeps_guards_closed() -> None:
+    checklist = _checklist()
+    assert _is_valid(checklist)
+    assert checklist["support_widening"] is False
+    assert checklist["production_platform_claim"] is False
+    assert checklist["live_adapter_execution"] is False
+    assert checklist["widening_flip_authority"] == "operator_bound_supersession_pr_only"
+    assert checklist["checklist_alone_authorizes_flip"] is False
+
+
+def test_recursive_strict_closure_for_shape_defining_object_nodes() -> None:
+    def object_nodes(node: Any, path: str = "") -> list[tuple[str, dict[str, Any]]]:
+        out: list[tuple[str, dict[str, Any]]] = []
+        if isinstance(node, dict):
+            if node.get("type") == "object":
+                out.append((path, node))
+            for key, value in node.items():
+                out.extend(object_nodes(value, f"{path}/{key}"))
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                out.extend(object_nodes(value, f"{path}/{index}"))
+        return out
+
+    for path, node in object_nodes(_schema()):
+        assert node.get("additionalProperties") is False, f"{path} missing additionalProperties:false"
+        assert node.get("unevaluatedProperties") is False, f"{path} missing unevaluatedProperties:false"
+
+
+def test_only_local_refs_are_used() -> None:
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str):
+                assert ref.startswith("#/"), f"non-local $ref forbidden: {ref}"
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(_schema())
+
+
+def test_assertion_list_has_required_ids_recompute_strategy_and_bind_fields() -> None:
+    checklist = _checklist()
+    assertions = checklist["assertions"]
+    ids = {assertion["id"] for assertion in assertions}
+    assert REQUIRED_ASSERTIONS <= ids
+    assert len(ids) == len(assertions)
+    for assertion in assertions:
+        assert assertion["required"] is True
+        assert assertion["recompute_strategy"].strip()
+        assert assertion["bind_fields"]
+        assert "artifact_sha256" not in assertion["bind_fields"]
+
+
+def test_bind_field_contract_uses_canonical_names_and_rejects_legacy_alias() -> None:
+    checklist = _checklist()
+    bind_fields = set(checklist["evidence_pack_contract"]["bind_fields"])
+    assert REQUIRED_BIND_FIELDS <= bind_fields
+    assert "artifact_sha256" not in bind_fields
+
+    bad_bind_field = copy.deepcopy(checklist)
+    bad_bind_field["assertions"][0]["bind_fields"] = ["artifact_sha256"]
+    assert not _is_valid(bad_bind_field)
+
+    bad_top_level = copy.deepcopy(checklist)
+    bad_top_level["artifact_sha256"] = ["f" * 64]
+    assert not _is_valid(bad_top_level)
+
+
+def test_operator_authority_uses_only_canonical_github_login_field() -> None:
+    checklist = _checklist()
+    assert checklist["operator_authority"]["github_login"] == "Halildeu"
+    assert "operator_github_login" not in checklist["operator_authority"]
+
+    alias_payload = copy.deepcopy(checklist)
+    alias_payload["operator_authority"]["operator_github_login"] = "Halildeu"
+    assert not _is_valid(alias_payload)
+
+
+def test_schema_rejects_missing_recompute_strategy_and_empty_bind_fields() -> None:
+    missing_strategy = copy.deepcopy(_checklist())
+    del missing_strategy["assertions"][0]["recompute_strategy"]
+    assert not _is_valid(missing_strategy)
+
+    empty_bind_fields = copy.deepcopy(_checklist())
+    empty_bind_fields["assertions"][0]["bind_fields"] = []
+    assert not _is_valid(empty_bind_fields)
+
+
+def test_synthetic_valid_pack_has_no_e_3_5_rejections() -> None:
+    assert _evaluate_pack(_valid_pack()) == set()
+
+
+def test_stale_replay_duplicate_reviewer_filtered_negative_and_denominator_reject() -> None:
+    stale = _valid_pack()
+    stale["time_window_boundaries"]["end"] = "2025-01-08T00:00:00Z"
+    assert "stale_replay_rejected" in _evaluate_pack(stale)
+
+    duplicate_identity = _valid_pack()
+    duplicate_identity["reviewer_identity_hashes"][1] = duplicate_identity["reviewer_identity_hashes"][0]
+    assert "duplicate_reviewer_identity_rejected" in _evaluate_pack(duplicate_identity)
+
+    filtered_negative = _valid_pack()
+    filtered_negative["verdict_completeness_proof"]["negative_verdicts_present"] = True
+    assert "filtered_negative_verdict_rejected" in _evaluate_pack(filtered_negative)
+
+    denominator = _valid_pack()
+    denominator["verdict_completeness_proof"]["verdicts_received_total"] = 3
+    assert "denominator_manipulation_rejected" in _evaluate_pack(denominator)
+
+
+def test_seven_day_window_and_artifact_timestamp_race_reject() -> None:
+    short_window = _valid_pack()
+    short_window["time_window_boundaries"]["end"] = "2026-01-03T00:00:00Z"
+    assert "seven_day_window_race_rejected" in _evaluate_pack(short_window)
+
+    outside_artifact = _valid_pack()
+    outside_artifact["artifacts"][0]["produced_at"] = "2026-01-10T00:00:00Z"
+    assert "seven_day_window_race_rejected" in _evaluate_pack(outside_artifact)
+
+
+def test_final_diff_digest_pr_head_and_workflow_status_drift_reject() -> None:
+    diff_drift = _valid_pack()
+    assert "final_diff_digest_drift_rejected" in _evaluate_pack(
+        diff_drift, recomputed_final_diff_digest="9" * 64
+    )
+
+    head_drift = _valid_pack()
+    assert "pr_head_sha_drift_rejected" in _evaluate_pack(head_drift, github_pr_head_sha="9" * 40)
+
+    run_drift = _valid_pack()
+    api_runs = _api_runs_for(run_drift)
+    api_runs["100"]["conclusion"] = "failure"
+    assert "workflow_run_status_mismatch_rejected" in _evaluate_pack(run_drift, api_runs=api_runs)
+
+
+def test_orphan_artifact_and_artifact_not_in_run_reject() -> None:
+    orphan = _valid_pack()
+    orphan["artifacts"][0]["run_id"] = "999"
+    assert "orphan_artifact_rejected" in _evaluate_pack(orphan)
+
+    missing_in_run = _valid_pack()
+    api_artifacts = _api_artifacts_for(missing_in_run)
+    api_artifacts["100"] = set()
+    assert "artifact_not_in_run_rejected" in _evaluate_pack(missing_in_run, api_artifacts=api_artifacts)
+
+
+def test_reviewer_hash_and_verdict_binding_drift_reject() -> None:
+    hash_drift = _valid_pack()
+    hash_drift["reviewer_identity_hashes"][0] = "0" * 64
+    assert "reviewer_hash_recomputation_mismatch_rejected" in _evaluate_pack(hash_drift)
+
+    binding_drift = _valid_pack()
+    binding_drift["provider_verdicts"][0]["final_diff_digest"] = "0" * 64
+    binding_drift["provider_verdicts"][0]["raw_verdict_sha256"] = _canonical_verdict_sha256(
+        binding_drift["provider_verdicts"][0]
+    )
+    assert "verdict_binding_drift_rejected" in _evaluate_pack(binding_drift)
+
+
+def test_raw_verdict_hash_self_reference_and_artifact_binding_reject() -> None:
+    sha_drift = _valid_pack()
+    sha_drift["provider_verdicts"][0]["raw_verdict_sha256"] = "0" * 64
+    errors = _evaluate_pack(sha_drift)
+    assert "raw_verdict_sha_mismatch_rejected" in errors
+    assert "raw_verdict_canonical_self_reference_rejected" in errors
+
+    digest_drift = _valid_pack()
+    digest_drift["provider_verdicts"][0]["raw_verdict_artifact_digest"] = "0" * 64
+    digest_drift["provider_verdicts"][0]["raw_verdict_sha256"] = _canonical_verdict_sha256(
+        digest_drift["provider_verdicts"][0]
+    )
+    assert "raw_verdict_artifact_digest_mismatch_rejected" in _evaluate_pack(digest_drift)
+
+    dangling_ref = _valid_pack()
+    dangling_ref["provider_verdicts"][0]["raw_verdict_artifact_ref"] = "missing-artifact"
+    dangling_ref["provider_verdicts"][0]["raw_verdict_sha256"] = _canonical_verdict_sha256(
+        dangling_ref["provider_verdicts"][0]
+    )
+    assert "raw_verdict_artifact_ref_dangling_rejected" in _evaluate_pack(dangling_ref)
+
+    provenance_drift = _valid_pack()
+    provenance_drift["artifacts"][0]["head_sha"] = "0" * 40
+    assert "raw_verdict_artifact_provenance_rejected" in _evaluate_pack(provenance_drift)
+
+
+def test_disjoint_identity_and_provider_requirements_reject_overlap() -> None:
+    identity_overlap = _valid_pack()
+    identity_overlap["provider_verdicts"][0]["github_login"] = "Halildeu"
+    identity_overlap["provider_verdicts"][0]["raw_verdict_sha256"] = _canonical_verdict_sha256(
+        identity_overlap["provider_verdicts"][0]
+    )
+    identity_overlap["reviewer_identity_hashes"] = [
+        _identity_hash(verdict) for verdict in identity_overlap["provider_verdicts"]
+    ]
+    assert "disjoint_identities_required" in _evaluate_pack(identity_overlap)
+
+    provider_overlap = _valid_pack()
+    provider_overlap["provider_verdicts"][0]["provider"] = "openai"
+    provider_overlap["provider_verdicts"][0]["raw_verdict_sha256"] = _canonical_verdict_sha256(
+        provider_overlap["provider_verdicts"][0]
+    )
+    provider_overlap["reviewer_identity_hashes"] = [
+        _identity_hash(verdict) for verdict in provider_overlap["provider_verdicts"]
+    ]
+    assert "disjoint_providers_required" in _evaluate_pack(provider_overlap)


### PR DESCRIPTION
## Summary
- Add E-3-5 supersession consensus protocol plan record.
- Add strict widening-supersession checklist schema + default checklist artifact.
- Add tests covering canonical bind fields, operator authority field naming, recursive strict closure, legacy artifact_sha256 rejection, and E-3-5 synthetic negative evidence-pack cases.

## Guard boundary
- No support widening.
- No production platform claim.
- No live adapter execution.
- No workflow/ruleset/runtime/public SDK mutation.
- E-3-5 is process/checklist infrastructure only; E-3-6 implements production recompute validation later.

## Validation
- pytest tests/test_widening_supersession_checklist.py -q -> 16 passed
- python3 -m json.tool schema + checklist + review evidence -> pass
- ruff check tests/test_widening_supersession_checklist.py -> pass
- mypy tests/test_widening_supersession_checklist.py -> pass
- git diff --check origin/main...HEAD && git diff --check -> pass
- gitleaks git . --redact --log-level error --exit-code 1 --log-opts origin/main..HEAD -> pass
- python3 scripts/gpp_next.py -> guard flags false
- Claude/Anthropic review -> VERDICT: AGREE
- local_gpp_gate -> operator_may_merge, diff_digest sha256:8d81869571979889331a4a478e1f6b0f85dfbddde9e26272456b7e1a94e30207, head_sha 38c9dd09b2a61bc6fda0911b8a555abcd7b66fae

Closes #857