### PR TITLE
feat(e-3-6): add support widening evidence validator

### DIFF
--- a/.claude/plans/EPIC-3-E-3-6-RECOMPUTE-VALIDATOR.md
+++ b/.claude/plans/EPIC-3-E-3-6-RECOMPUTE-VALIDATOR.md
@@ -1,0 +1,94 @@
+# E-3-6 — Recompute-not-trust Validator
+
+> V5 Epic 3 support-widening matrix infrastructure slice. This record adds a
+> deterministic validator for future support-widening supersession evidence. It
+> does not widen support, claim production readiness, execute live adapters,
+> mutate workflows, or mutate GitHub rulesets.
+
+## Status
+
+- **Work package:** E-3-6
+- **Issue:** #858
+- **Branch:** `codex/epic3-e3-6-validator`
+- **Risk:** low
+- **Authority:** `.claude/plans/EPIC-3-SUPPORT-WIDENING-MATRIX.md`
+- **Guard flags:** unchanged:
+  - `support_widening_allowed=false`
+  - `production_platform_claim_allowed=false`
+  - `live_adapter_execution_allowed=false`
+
+## Added Surface
+
+E-3-6 adds the v1-only validator surface for support-widening evidence:
+
+- `ao_kernel/_internal/support_widening/validator.py`
+- `scripts/validate_widening_evidence.py`
+- `ao_kernel/defaults/schemas/widening-supersession-evidence-pack.schema.v1.json`
+- `tests/test_widening_evidence_validator.py`
+
+The validator accepts:
+
+1. Existing `support_widening_evidence.v1` artifacts from E-3-1/E-3-2 and
+   reuses the E-3-1 parse/recompute guard-pin logic.
+2. New `widening_supersession_evidence_pack.v1` artifacts that model the
+   future operator-bound Epic 9 support-widening supersession evidence pack.
+
+## Non-Authority Boundary
+
+The E-3-6 validator is not release authority and cannot authorize support
+widening:
+
+- `support_widening`, `production_platform_claim`, and
+  `live_adapter_execution` remain false.
+- `widening_authorized` is `const false` in the v1 evidence-pack schema.
+- `support_widening_evidence.v2` and all other future schemas are rejected with
+  `unsupported_future_schema_in_epic_3`.
+- `validator_v2.py` and `support_widening_evidence.schema.v2.json` are
+  intentionally absent from the Epic 3 codebase.
+- GitHub/API observations are caller-supplied as read-only context; the module
+  performs no network calls or GitHub writes.
+
+## Machine Invariants
+
+`tests/test_widening_evidence_validator.py` pins:
+
+- Schema health and recursive strict closure.
+- Existing `support_widening_evidence.v1` compatibility.
+- v2/future schema rejection.
+- Guard-flag and `widening_authorized` true rejection.
+- Absence of `validator_v2.py` and schema v2.
+- Forged consensus / hidden negative verdict rejection.
+- Same-provider, implementer-reviewer, and operator-login collision rejection.
+- Legacy `artifact_sha256` alias rejection at top-level and nested locations.
+- Mutual `simulated_only=true` + `live_call_made=true` rejection.
+- Stale replay and seven-day timing-window race rejection.
+- Plan digest, final diff digest, PR head SHA, workflow-run, artifact, reviewer
+  hash, verdict binding, raw verdict SHA, raw transcript artifact digest, and
+  raw transcript artifact reference/provenance drift rejection.
+- CLI success/reject exit-code behavior.
+
+## Validation Plan
+
+Minimum local validation before merge:
+
+```bash
+python3 -m json.tool ao_kernel/defaults/schemas/widening-supersession-evidence-pack.schema.v1.json
+pytest tests/test_widening_evidence_validator.py \
+  tests/test_widening_supersession_checklist.py \
+  tests/test_support_widening_evidence_v1.py -q
+ruff check ao_kernel/_internal/support_widening/validator.py \
+  scripts/validate_widening_evidence.py \
+  tests/test_widening_evidence_validator.py
+mypy ao_kernel/_internal/support_widening/validator.py \
+  scripts/validate_widening_evidence.py \
+  tests/test_widening_evidence_validator.py
+python3 scripts/gpp_next.py
+git diff --check origin/main...HEAD
+```
+
+## Closure Notes
+
+E-3-6 is the final Epic 3 support-widening infrastructure slice. Closing this
+slice closes the validator runway for future operator-bound support-widening
+supersession PRs, but it still does not flip any guard flag or change public
+support tier.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **E-3-6 recompute-not-trust validator** (V5 Epic 3, #858): added
+  `ao_kernel/_internal/support_widening/validator.py`,
+  `scripts/validate_widening_evidence.py`, and
+  `widening-supersession-evidence-pack.schema.v1.json` as the v1-only
+  fail-closed validator runway for future operator-bound support-widening
+  supersession evidence packs. The validator accepts existing
+  `support_widening_evidence.v1` artifacts, rejects v2/future schemas with
+  `unsupported_future_schema_in_epic_3`, recomputes consensus/verdict/provider
+  identity/digest/artifact bindings from caller-supplied read-only context, and
+  pins `support_widening`, `production_platform_claim`, `live_adapter_execution`,
+  and `widening_authorized` false. No GitHub mutation, ruleset mutation, live
+  adapter execution, support widening, or production platform claim is
+  introduced.
 - **E-3-3 advisory support matrix workflow** (V5 Epic 3, #855): added
   `.github/workflows/support-matrix-smoke.yml` as an opt-in, advisory-only
   workflow that runs the E-3-2 stub smoke harness across all five support

--- a/ao_kernel/_internal/support_widening/validator.py
+++ b/ao_kernel/_internal/support_widening/validator.py
@@ -1,0 +1,461 @@
+"""E-3-6 support-widening recompute-not-trust validator.
+
+This module is intentionally v1-only and fail-closed. It validates two inputs:
+
+* ``support_widening_evidence.v1`` artifacts produced by the E-3-2 smoke
+  harness, by delegating to the E-3-1 parser/recompute verifier.
+* ``widening_supersession_evidence_pack.v1`` artifacts used by a future
+  operator-bound supersession PR. These packs do not authorize support
+  widening in Epic 3; they only make evidence recomputable.
+
+The module performs no GitHub writes, no network calls, and no live adapter
+execution. Authoritative observations that would normally come from GitHub or
+artifact downloads are supplied by the caller as context and recomputed here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel._internal.support_widening.evidence import (
+    SupportWideningEvidenceError,
+    parse_v1 as parse_support_widening_v1,
+    recompute_v1 as recompute_support_widening_v1,
+)
+from ao_kernel.config import load_default
+
+SUPPORTED_SCHEMA_VERSIONS = {
+    "support_widening_evidence.v1",
+    "widening_supersession_evidence_pack.v1",
+}
+UNSUPPORTED_FUTURE_SCHEMA_REASON = "unsupported_future_schema_in_epic_3"
+
+
+class WideningEvidenceValidationError(ValueError):
+    """Raised when E-3-6 validation rejects an evidence artifact."""
+
+    def __init__(self, reason_codes: list[str]):
+        self.reason_codes = sorted(set(reason_codes))
+        super().__init__(", ".join(self.reason_codes))
+
+
+@dataclass(frozen=True)
+class WorkflowRunObservation:
+    """Read-only workflow-run facts supplied by the caller."""
+
+    status: str
+    conclusion: str
+    head_sha: str
+    created_at: str
+
+
+@dataclass(frozen=True)
+class WideningEvidenceValidationContext:
+    """Authoritative recompute inputs for v1 supersession packs.
+
+    These values are caller-supplied so the pure validator stays deterministic
+    and side-effect free. A production caller may populate them from GitHub API
+    reads and artifact downloads; tests populate them from fixtures.
+    """
+
+    now: datetime | None = None
+    recomputed_plan_digest: str | None = None
+    recomputed_final_diff_digest: str | None = None
+    github_pr_head_sha: str | None = None
+    workflow_runs: Mapping[str, WorkflowRunObservation] = field(default_factory=dict)
+    workflow_artifacts: Mapping[str, frozenset[str]] = field(default_factory=dict)
+    artifact_paths: Mapping[str, Path] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "WideningEvidenceValidationContext":
+        runs: dict[str, WorkflowRunObservation] = {}
+        for run_id, run in _expect_mapping(payload.get("workflow_runs", {}), "workflow_runs").items():
+            run_obj = _expect_mapping(run, f"workflow_runs.{run_id}")
+            runs[str(run_id)] = WorkflowRunObservation(
+                status=str(run_obj.get("status", "")),
+                conclusion=str(run_obj.get("conclusion", "")),
+                head_sha=str(run_obj.get("head_sha", "")),
+                created_at=str(run_obj.get("created_at", "")),
+            )
+
+        artifacts: dict[str, frozenset[str]] = {}
+        for run_id, values in _expect_mapping(payload.get("workflow_artifacts", {}), "workflow_artifacts").items():
+            if not isinstance(values, list):
+                raise WideningEvidenceValidationError(["context_workflow_artifacts_invalid"])
+            artifacts[str(run_id)] = frozenset(str(value) for value in values)
+
+        artifact_paths = {
+            str(artifact_id): Path(str(path))
+            for artifact_id, path in _expect_mapping(payload.get("artifact_paths", {}), "artifact_paths").items()
+        }
+
+        now_raw = payload.get("now")
+        now = _parse_timestamp(str(now_raw)) if now_raw is not None else None
+        return cls(
+            now=now,
+            recomputed_plan_digest=_optional_str(payload.get("recomputed_plan_digest")),
+            recomputed_final_diff_digest=_optional_str(payload.get("recomputed_final_diff_digest")),
+            github_pr_head_sha=_optional_str(payload.get("github_pr_head_sha")),
+            workflow_runs=runs,
+            workflow_artifacts=artifacts,
+            artifact_paths=artifact_paths,
+        )
+
+
+def validate_widening_evidence(
+    payload: Mapping[str, Any],
+    *,
+    context: WideningEvidenceValidationContext | None = None,
+) -> dict[str, Any]:
+    """Validate ``payload`` and return a deterministic report.
+
+    Raises ``WideningEvidenceValidationError`` with one or more reason codes on
+    rejection. The returned report is intentionally small and gate-readable.
+    """
+    schema_version = payload.get("schema_version")
+    if schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+        raise WideningEvidenceValidationError([UNSUPPORTED_FUTURE_SCHEMA_REASON])
+
+    if schema_version == "support_widening_evidence.v1":
+        return _validate_support_widening_v1(payload)
+
+    return _validate_supersession_pack_v1(payload, context=context or WideningEvidenceValidationContext())
+
+
+def validation_report(
+    payload: Mapping[str, Any],
+    *,
+    context: WideningEvidenceValidationContext | None = None,
+) -> dict[str, Any]:
+    """Return a pass/fail report without raising."""
+    try:
+        report = validate_widening_evidence(payload, context=context)
+    except WideningEvidenceValidationError as exc:
+        return {
+            "valid": False,
+            "decision": "rejected",
+            "reason_codes": exc.reason_codes,
+            "schema_version": payload.get("schema_version"),
+            "support_widening": payload.get("support_widening"),
+            "production_platform_claim": payload.get("production_platform_claim"),
+            "live_adapter_execution": payload.get("live_adapter_execution"),
+        }
+    return report
+
+
+def _validate_support_widening_v1(payload: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise WideningEvidenceValidationError(["payload_not_object"])
+    try:
+        schema = load_default("schemas", "support-widening-evidence.schema.v1.json")
+        parse_support_widening_v1(dict(payload), schema=schema)
+        recomputed = recompute_support_widening_v1(dict(payload))
+    except SupportWideningEvidenceError as exc:
+        raise WideningEvidenceValidationError([_normalize_support_error(str(exc))]) from exc
+    if payload.get("simulated_only") is True and payload.get("live_call_made") is True:
+        raise WideningEvidenceValidationError(["mutually_exclusive_simulated_live_rejected"])
+    return {
+        "valid": True,
+        "decision": "validator_agree",
+        "reason_codes": [],
+        "schema_version": "support_widening_evidence.v1",
+        "artifact_kind": payload.get("artifact_kind"),
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+        "recomputed": recomputed,
+    }
+
+
+def _validate_supersession_pack_v1(
+    payload: Mapping[str, Any],
+    *,
+    context: WideningEvidenceValidationContext,
+) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise WideningEvidenceValidationError(["payload_not_object"])
+
+    errors: set[str] = set()
+    errors.update(_schema_errors(dict(payload)))
+    errors.update(_recursive_legacy_artifact_sha_rejections(payload))
+    errors.update(_guard_errors(payload))
+
+    if errors:
+        raise WideningEvidenceValidationError(sorted(errors))
+
+    pack = dict(payload)
+    errors.update(_time_window_errors(pack, context=context))
+    errors.update(_context_binding_errors(pack, context=context))
+    errors.update(_identity_errors(pack))
+    errors.update(_verdict_errors(pack))
+    errors.update(_artifact_errors(pack, context=context))
+
+    if errors:
+        raise WideningEvidenceValidationError(sorted(errors))
+
+    return {
+        "valid": True,
+        "decision": "validator_agree",
+        "reason_codes": [],
+        "schema_version": "widening_supersession_evidence_pack.v1",
+        "artifact_kind": pack.get("artifact_kind"),
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+        "consensus_status_recomputed": _recomputed_consensus_status(pack),
+        "reviewer_identity_hashes_recomputed": [_identity_hash(v) for v in pack["provider_verdicts"]],
+    }
+
+
+def _schema_errors(payload: dict[str, Any]) -> set[str]:
+    schema = load_default("schemas", "widening-supersession-evidence-pack.schema.v1.json")
+    errors = sorted(Draft202012Validator(schema).iter_errors(payload), key=lambda e: list(e.absolute_path))
+    if not errors:
+        return set()
+    reason_codes: set[str] = set()
+    for error in errors:
+        path = ".".join(str(part) for part in error.absolute_path)
+        if "operator_github_login" in error.message or path == "operator_authority":
+            reason_codes.add("operator_alias_rejected")
+        elif path in {"support_widening", "production_platform_claim", "live_adapter_execution", "widening_authorized"}:
+            reason_codes.add("guard_flag_true_rejected")
+        else:
+            reason_codes.add("schema_validation_failed")
+    return reason_codes
+
+
+def _guard_errors(payload: Mapping[str, Any]) -> set[str]:
+    errors: set[str] = set()
+    for key in ("support_widening", "production_platform_claim", "live_adapter_execution", "widening_authorized"):
+        if payload.get(key) is not False:
+            errors.add("guard_flag_true_rejected")
+    if payload.get("simulated_only") is True and payload.get("live_call_made") is True:
+        errors.add("mutually_exclusive_simulated_live_rejected")
+    return errors
+
+
+def _time_window_errors(
+    pack: Mapping[str, Any],
+    *,
+    context: WideningEvidenceValidationContext,
+) -> set[str]:
+    errors: set[str] = set()
+    start = _parse_timestamp(pack["time_window_boundaries"]["start"])
+    end = _parse_timestamp(pack["time_window_boundaries"]["end"])
+    now = context.now or datetime.now(timezone.utc)
+    if end < now - timedelta(days=90):
+        errors.add("stale_replay_rejected")
+    if end - start < timedelta(days=7):
+        errors.add("seven_day_window_race_rejected")
+    for artifact in pack["artifacts"]:
+        produced_at = _parse_timestamp(artifact["produced_at"])
+        if produced_at < start or produced_at > end:
+            errors.add("seven_day_window_race_rejected")
+    return errors
+
+
+def _context_binding_errors(
+    pack: Mapping[str, Any],
+    *,
+    context: WideningEvidenceValidationContext,
+) -> set[str]:
+    errors: set[str] = set()
+    if context.recomputed_plan_digest is None:
+        errors.add("plan_digest_context_missing")
+    elif pack["plan_digest"] != context.recomputed_plan_digest:
+        errors.add("plan_digest_drift_rejected")
+
+    if context.recomputed_final_diff_digest is None:
+        errors.add("final_diff_digest_context_missing")
+    elif pack["final_diff_digest"] != context.recomputed_final_diff_digest:
+        errors.add("final_diff_digest_drift_rejected")
+
+    if context.github_pr_head_sha is None:
+        errors.add("pr_head_sha_context_missing")
+    elif pack["pr_head_sha"] != context.github_pr_head_sha:
+        errors.add("pr_head_sha_drift_rejected")
+
+    start = _parse_timestamp(pack["time_window_boundaries"]["start"])
+    end = _parse_timestamp(pack["time_window_boundaries"]["end"])
+    for run_id in pack["workflow_run_ids"]:
+        run = context.workflow_runs.get(str(run_id))
+        if run is None:
+            errors.add("workflow_run_provenance_rejected")
+            continue
+        if (
+            run.status != "completed"
+            or run.conclusion != "success"
+            or run.head_sha != pack["pr_head_sha"]
+            or _parse_timestamp(run.created_at) < start
+            or _parse_timestamp(run.created_at) > end
+        ):
+            errors.add("workflow_run_provenance_rejected")
+    return errors
+
+
+def _identity_errors(pack: Mapping[str, Any]) -> set[str]:
+    errors: set[str] = set()
+    operator_login = pack["operator_authority"]["github_login"]
+    implementer = pack["implementer_provider"]
+    verdicts = pack["provider_verdicts"]
+    reviewer_logins = [verdict["github_login"] for verdict in verdicts]
+    reviewer_providers = [verdict["provider"] for verdict in verdicts]
+
+    if operator_login == implementer["github_login"] or operator_login in reviewer_logins:
+        errors.add("operator_login_collision_rejected")
+    if len(set(reviewer_logins)) != len(reviewer_logins):
+        errors.add("duplicate_reviewer_identity_rejected")
+    if implementer["provider"] in reviewer_providers:
+        errors.add("implementer_in_reviewer_rejected")
+    if len(set(reviewer_providers)) != len(reviewer_providers):
+        errors.add("same_provider_rejected")
+
+    recomputed_hashes = [_identity_hash(verdict) for verdict in verdicts]
+    if len(set(pack["reviewer_identity_hashes"])) != len(pack["reviewer_identity_hashes"]):
+        errors.add("duplicate_reviewer_identity_rejected")
+    if list(pack["reviewer_identity_hashes"]) != recomputed_hashes:
+        errors.add("reviewer_hash_recomputation_rejected")
+    return errors
+
+
+def _verdict_errors(pack: Mapping[str, Any]) -> set[str]:
+    errors: set[str] = set()
+    verdicts = pack["provider_verdicts"]
+    proof = pack["verdict_completeness_proof"]
+    agree_count = sum(1 for verdict in verdicts if verdict["verdict"] == "AGREE")
+    negative_count = sum(1 for verdict in verdicts if verdict["verdict"] in {"REVISE", "RED"})
+
+    if proof["verdicts_received_total"] != len(verdicts):
+        errors.add("denominator_manipulation_rejected")
+    if proof["verdicts_claimed_in_consensus"] != agree_count:
+        errors.add("denominator_manipulation_rejected")
+    if proof["negative_verdicts_present"] and negative_count == 0:
+        errors.add("filtered_negative_verdict_rejected")
+    if not proof["negative_verdicts_present"] and negative_count:
+        errors.add("filtered_negative_verdict_rejected")
+    if pack["consensus_status"] != _recomputed_consensus_status(pack):
+        errors.add("forged_consensus_rejected")
+
+    for verdict in verdicts:
+        if (
+            verdict["plan_digest"] != pack["plan_digest"]
+            or verdict["final_diff_digest"] != pack["final_diff_digest"]
+            or verdict["pr_head_sha"] != pack["pr_head_sha"]
+        ):
+            errors.add("verdict_binding_rejected")
+        if verdict["raw_verdict_sha256"] != canonical_verdict_sha256(verdict):
+            errors.add("raw_verdict_sha_rejected")
+    return errors
+
+
+def _artifact_errors(
+    pack: Mapping[str, Any],
+    *,
+    context: WideningEvidenceValidationContext,
+) -> set[str]:
+    errors: set[str] = set()
+    artifacts_by_id = {artifact["artifact_id"]: artifact for artifact in pack["artifacts"]}
+    workflow_run_ids = {str(run_id) for run_id in pack["workflow_run_ids"]}
+
+    for artifact in pack["artifacts"]:
+        run_id = str(artifact["run_id"])
+        artifact_id = artifact["artifact_id"]
+        if run_id not in workflow_run_ids:
+            errors.add("orphan_artifact_rejected")
+        if artifact_id not in context.workflow_artifacts.get(run_id, frozenset()):
+            errors.add("artifact_not_in_run_rejected")
+        path = context.artifact_paths.get(artifact_id)
+        if path is None:
+            errors.add("artifact_path_context_missing")
+        elif not path.is_file():
+            errors.add("artifact_path_missing")
+        else:
+            actual = hashlib.sha256(path.read_bytes()).hexdigest()
+            if actual != artifact["sha256"]:
+                errors.add("artifact_sha_drift_rejected")
+
+    for verdict in pack["provider_verdicts"]:
+        ref = verdict["raw_verdict_artifact_ref"]
+        artifact = artifacts_by_id.get(ref)
+        if artifact is None:
+            errors.add("raw_verdict_artifact_ref_dangling_rejected")
+            continue
+        if verdict["raw_verdict_artifact_digest"] != artifact["sha256"]:
+            errors.add("raw_verdict_artifact_cross_binding_rejected")
+        if artifact["run_id"] not in workflow_run_ids or artifact["head_sha"] != pack["pr_head_sha"]:
+            errors.add("raw_verdict_artifact_provenance_rejected")
+    return errors
+
+
+def canonical_verdict_sha256(verdict: Mapping[str, Any]) -> str:
+    """Canonical SHA256 for provider verdicts, excluding the hash field itself."""
+    payload = {str(k): v for k, v in verdict.items() if k != "raw_verdict_sha256"}
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _identity_hash(verdict: Mapping[str, Any]) -> str:
+    value = f"{verdict['provider']}|{verdict['github_login']}|{verdict['thread_id']}"
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _recomputed_consensus_status(pack: Mapping[str, Any]) -> str:
+    verdicts = pack["provider_verdicts"]
+    if verdicts and all(verdict["verdict"] == "AGREE" for verdict in verdicts):
+        return "agree"
+    return "not_agree"
+
+
+def _recursive_legacy_artifact_sha_rejections(node: Any) -> set[str]:
+    if isinstance(node, dict):
+        errors = {"legacy_artifact_sha_array_rejected"} if "artifact_sha256" in node else set()
+        for value in node.values():
+            errors.update(_recursive_legacy_artifact_sha_rejections(value))
+        return errors
+    if isinstance(node, list):
+        list_errors: set[str] = set()
+        for item in node:
+            list_errors.update(_recursive_legacy_artifact_sha_rejections(item))
+        return list_errors
+    return set()
+
+
+def _parse_timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise WideningEvidenceValidationError(["timestamp_parse_failed"]) from exc
+    if parsed.tzinfo is None:
+        raise WideningEvidenceValidationError(["timestamp_timezone_missing"])
+    return parsed.astimezone(timezone.utc)
+
+
+def _expect_mapping(value: Any, field_name: str) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise WideningEvidenceValidationError([f"{field_name}_invalid"])
+    return value
+
+
+def _optional_str(value: Any) -> str | None:
+    return None if value is None else str(value)
+
+
+def _normalize_support_error(message: str) -> str:
+    if "schema validation failed" in message:
+        return "schema_validation_failed"
+    if "runtime pin re-assert failed" in message:
+        return "guard_flag_true_rejected"
+    if "forbidden widening key" in message:
+        return "legacy_or_shadow_widening_rejected"
+    if "recompute_inputs.raw_dimensions" in message or "evidence_dimensions does not match" in message:
+        return "recompute_drift_rejected"
+    return "support_widening_v1_rejected"

--- a/ao_kernel/defaults/schemas/widening-supersession-evidence-pack.schema.v1.json
+++ b/ao_kernel/defaults/schemas/widening-supersession-evidence-pack.schema.v1.json
@@ -1,0 +1,315 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:widening-supersession-evidence-pack:v1",
+  "title": "AO widening supersession evidence pack v1",
+  "description": "E-3-6 recompute-not-trust evidence pack for future operator-bound support-widening supersession PRs. Epic 3 v1 is evidence-only: all guard flags remain false and widening_authorized is const false.",
+  "type": "object",
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "repo",
+    "work_package",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution",
+    "widening_authorized",
+    "evidence_class",
+    "simulated_only",
+    "live_call_made",
+    "operator_authority",
+    "implementer_provider",
+    "plan_digest",
+    "final_diff_digest",
+    "pr_head_sha",
+    "workflow_run_ids",
+    "time_window_boundaries",
+    "artifacts",
+    "provider_verdicts",
+    "reviewer_identity_hashes",
+    "verdict_completeness_proof",
+    "consensus_status"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "widening_supersession_evidence_pack.v1"
+    },
+    "artifact_kind": {
+      "const": "widening_supersession_evidence_pack"
+    },
+    "repo": {
+      "const": "Halildeu/ao-kernel"
+    },
+    "work_package": {
+      "type": "string",
+      "minLength": 1
+    },
+    "support_widening": {
+      "const": false
+    },
+    "production_platform_claim": {
+      "const": false
+    },
+    "live_adapter_execution": {
+      "const": false
+    },
+    "widening_authorized": {
+      "const": false
+    },
+    "evidence_class": {
+      "const": "live"
+    },
+    "simulated_only": {
+      "type": "boolean"
+    },
+    "live_call_made": {
+      "type": "boolean"
+    },
+    "operator_authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "github_login",
+        "authorization_phrase",
+        "commit_verification_required"
+      ],
+      "properties": {
+        "github_login": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9-]+$"
+        },
+        "authorization_phrase": {
+          "const": "AUTHORIZE_SUPPORT_WIDENING_SUPERSESSION"
+        },
+        "commit_verification_required": {
+          "const": true
+        }
+      }
+    },
+    "implementer_provider": {
+      "$ref": "#/$defs/provider_identity"
+    },
+    "plan_digest": {
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "final_diff_digest": {
+      "$ref": "#/$defs/sha256_hex"
+    },
+    "pr_head_sha": {
+      "$ref": "#/$defs/git_sha"
+    },
+    "workflow_run_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9]+$"
+      }
+    },
+    "time_window_boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "start",
+        "end"
+      ],
+      "properties": {
+        "start": {
+          "$ref": "#/$defs/rfc3339_z"
+        },
+        "end": {
+          "$ref": "#/$defs/rfc3339_z"
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "unevaluatedProperties": false,
+        "required": [
+          "run_id",
+          "artifact_id",
+          "sha256",
+          "produced_at",
+          "head_sha"
+        ],
+        "properties": {
+          "run_id": {
+            "type": "string",
+            "pattern": "^[0-9]+$"
+          },
+          "artifact_id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9_.-]+$"
+          },
+          "sha256": {
+            "$ref": "#/$defs/sha256_hex"
+          },
+          "produced_at": {
+            "$ref": "#/$defs/rfc3339_z"
+          },
+          "head_sha": {
+            "$ref": "#/$defs/git_sha"
+          }
+        }
+      }
+    },
+    "provider_verdicts": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "unevaluatedProperties": false,
+        "required": [
+          "provider",
+          "github_login",
+          "thread_id",
+          "verdict",
+          "plan_digest",
+          "final_diff_digest",
+          "pr_head_sha",
+          "raw_verdict_sha256",
+          "raw_verdict_artifact_digest",
+          "raw_verdict_artifact_ref"
+        ],
+        "properties": {
+          "provider": {
+            "type": "string",
+            "enum": [
+              "openai",
+              "anthropic",
+              "google",
+              "mavis",
+              "minimax"
+            ]
+          },
+          "github_login": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9-]+$"
+          },
+          "thread_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "verdict": {
+            "type": "string",
+            "enum": [
+              "AGREE",
+              "REVISE",
+              "RED"
+            ]
+          },
+          "plan_digest": {
+            "$ref": "#/$defs/sha256_hex"
+          },
+          "final_diff_digest": {
+            "$ref": "#/$defs/sha256_hex"
+          },
+          "pr_head_sha": {
+            "$ref": "#/$defs/git_sha"
+          },
+          "raw_verdict_sha256": {
+            "$ref": "#/$defs/sha256_hex"
+          },
+          "raw_verdict_artifact_digest": {
+            "$ref": "#/$defs/sha256_hex"
+          },
+          "raw_verdict_artifact_ref": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9_.-]+$"
+          }
+        }
+      }
+    },
+    "reviewer_identity_hashes": {
+      "type": "array",
+      "minItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/sha256_hex"
+      }
+    },
+    "verdict_completeness_proof": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "verdicts_received_total",
+        "verdicts_claimed_in_consensus",
+        "negative_verdicts_present"
+      ],
+      "properties": {
+        "verdicts_received_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "verdicts_claimed_in_consensus": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "negative_verdicts_present": {
+          "type": "boolean"
+        }
+      }
+    },
+    "consensus_status": {
+      "type": "string",
+      "enum": [
+        "agree",
+        "not_agree"
+      ]
+    }
+  },
+  "$defs": {
+    "provider_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "provider",
+        "github_login"
+      ],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": [
+            "openai",
+            "anthropic",
+            "google",
+            "mavis",
+            "minimax"
+          ]
+        },
+        "github_login": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9-]+$"
+        }
+      }
+    },
+    "sha256_hex": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "git_sha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "rfc3339_z": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-((0[13578]|1[02])-(0[1-9]|[12][0-9]|3[01])|(0[469]|11)-(0[1-9]|[12][0-9]|30)|02-(0[1-9]|1[0-9]|2[0-9]))T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$"
+    }
+  }
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -21,6 +21,7 @@
       "ao_kernel/defaults/schemas/widening-supersession-evidence-pack.schema.v1.json",
       "local-ai-review-evidence.v1.json",
       "scripts/validate_widening_evidence.py",
+      "tests/test_support_matrix_smoke_workflow.py",
       "tests/test_widening_evidence_validator.py"
     ]
   },
@@ -35,6 +36,10 @@
     },
     {
       "name": "pytest_epic3_support_widening_adjacent",
+      "status": "pass"
+    },
+    {
+      "name": "pytest_support_matrix_smoke_workflow_scope_fix",
       "status": "pass"
     },
     {
@@ -66,7 +71,11 @@
       "status": "pass"
     },
     {
-      "name": "claude_review",
+      "name": "claude_review_round_1",
+      "status": "pass"
+    },
+    {
+      "name": "claude_review_round_2",
       "status": "pass"
     },
     {
@@ -76,12 +85,14 @@
   ],
   "findings": [
     "Claude Anthropic returned VERDICT AGREE for E-3-6 after reviewing the v1-only fail-closed validator, schema, CLI, tests, plan record, changelog entry, and local validation summary.",
+    "Claude Anthropic returned VERDICT AGREE for the updated PR diff after the CI fix that scopes test_support_matrix_smoke_workflow.py's E-3-3 slice diff guard to only run when .github/workflows/support-matrix-smoke.yml changes.",
     "Claude confirmed guard flags remain false and widening_authorized is pinned false; no support widening, production platform claim, live adapter execution, GitHub mutation, ruleset mutation, network call, or live adapter call is introduced.",
     "Claude confirmed the Epic 3 validator accepts only support_widening_evidence.v1 and widening_supersession_evidence_pack.v1; future v2 input fails closed with unsupported_future_schema_in_epic_3 and validator_v2/schema v2 are absent.",
     "Claude confirmed the schema is recursively strict with additionalProperties:false and unevaluatedProperties:false on every object node.",
     "Claude confirmed raw verdict SHA256 is canonicalized with raw_verdict_sha256 excluded, and legacy artifact_sha256 is recursively rejected.",
     "Claude confirmed self-review prevention rejects same-provider, implementer-reviewer, and operator-login collisions.",
     "Claude confirmed context-binding drift checks cover plan digest, final diff digest, PR head SHA, workflow run provenance, artifact membership/hash drift, reviewer hash drift, verdict binding drift, raw verdict artifact digest/reference/provenance drift, stale replay, and seven-day window races.",
+    "Claude confirmed the E-3-3 workflow diff guard now skips unrelated PRs when support-matrix-smoke.yml is unchanged, but remains fail-closed against unexpected files when that workflow is changed.",
     "Local validation passed: JSON schema format, ruff, targeted mypy, full mypy ao_kernel, targeted E-3-6 pytest, adjacent Epic 3 pytest set, diff whitespace, gpp_next guard flags, and gitleaks secret scan.",
     "No secrets were recorded in the review prompt, review output, evidence file, or validation artifacts."
   ],

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "E-3-3",
+  "work_package": "E-3-6",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,14 +13,15 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic3-e3-ci-matrix",
+    "head_ref": "refs/heads/codex/epic3-e3-6-validator",
     "changed_files": [
-      ".claude/plans/EPIC-3-E-3-3-CI-MATRIX.md",
-      ".github/workflows/support-matrix-smoke.yml",
+      ".claude/plans/EPIC-3-E-3-6-RECOMPUTE-VALIDATOR.md",
       "CHANGELOG.md",
+      "ao_kernel/_internal/support_widening/validator.py",
+      "ao_kernel/defaults/schemas/widening-supersession-evidence-pack.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_cost_ceiling.py",
-      "tests/test_support_matrix_smoke_workflow.py"
+      "scripts/validate_widening_evidence.py",
+      "tests/test_widening_evidence_validator.py"
     ]
   },
   "checks_considered": [
@@ -29,23 +30,27 @@
       "status": "pass"
     },
     {
-      "name": "pytest_support_matrix_smoke_workflow",
+      "name": "pytest_widening_evidence_validator",
       "status": "pass"
     },
     {
-      "name": "pytest_support_matrix_plus_adjacent_evidence_harness",
+      "name": "pytest_epic3_support_widening_adjacent",
       "status": "pass"
     },
     {
-      "name": "pytest_cost_ceiling_workflow_guard",
+      "name": "json_schema_format",
       "status": "pass"
     },
     {
-      "name": "ruff_test_file",
+      "name": "ruff_validator_cli_tests",
       "status": "pass"
     },
     {
-      "name": "mypy_test_file",
+      "name": "mypy_targeted",
+      "status": "pass"
+    },
+    {
+      "name": "mypy_ao_kernel",
       "status": "pass"
     },
     {
@@ -61,14 +66,6 @@
       "status": "pass"
     },
     {
-      "name": "protected_workflow_diff_empty",
-      "status": "pass"
-    },
-    {
-      "name": "live_ruleset_collision_check",
-      "status": "pass"
-    },
-    {
       "name": "claude_review",
       "status": "pass"
     },
@@ -77,19 +74,16 @@
       "status": "pass"
     }
   ],
-    "findings": [
-        "Claude Anthropic returned VERDICT AGREE for E-3-3 after reviewing the workflow, invariant tests, plan record, changelog entry, and local validation summary.",
-        "Claude Anthropic returned VERDICT AGREE for the post-CI guard fix: adding .github/workflows/support-matrix-smoke.yml to tests/test_cost_ceiling.py is a narrow allowlist update for the explicitly authorized E-3-3 advisory workflow and does not weaken unrelated workflow drift detection.",
-        "Claude confirmed the trigger shape is pull_request types opened/labeled/synchronize/reopened plus workflow_dispatch only, with no push, schedule, repository_dispatch, or pull_request_target.",
-    "Claude confirmed both jobs carry the combined workflow_dispatch-or-support-matrix-smoke-label gate, and the summary job correctly adds a pull_request-only guard for PR review comments.",
-    "Claude confirmed the workflow permissions are exactly contents:read and pull-requests:write, with no id-token, checks, packages, actions, secrets, or environment surface.",
-    "Claude confirmed guard flags remain false and the workflow contains no true literal for support_widening, production_platform_claim, or live_adapter_execution.",
-    "Claude confirmed protected workflow and ruleset mutation checks are present and passed.",
-    "Claude confirmed the new workflow/job names are disjoint from existing required workflow names and that the live ruleset collision check is present.",
-    "Claude confirmed the matrix derives the five surface classes from the E-3-2 SURFACE_CLASSES registry and invokes scripts/run_support_smoke.py with --surface and --evidence-out.",
-    "Claude confirmed the E-3-3/Epic-9 boundary is explicit: this is advisory-only, continue-on-error, simulated-only evidence and not branch protection, required-check promotion, support widening, production claim, or live adapter execution.",
-    "Local validation passed: pytest tests/test_support_matrix_smoke_workflow.py reported 10 passed; pytest tests/test_support_matrix_smoke_workflow.py tests/test_run_support_smoke.py tests/test_support_widening_evidence_v1.py reported 47 passed and 2 existing adjacent skips; pytest tests/test_cost_ceiling.py::test_cost_ceiling_no_unrelated_workflow_mutation_in_diff passed after adding the explicitly authorized E-3-3 advisory workflow to the guard allowlist; ruff and mypy passed for the new test file; diff whitespace, gitleaks, protected workflow diff, live ruleset collision, and gpp_next guard checks passed.",
-    "No secrets were recorded in the review prompt, review output, evidence file, or local validation artifacts."
+  "findings": [
+    "Claude Anthropic returned VERDICT AGREE for E-3-6 after reviewing the v1-only fail-closed validator, schema, CLI, tests, plan record, changelog entry, and local validation summary.",
+    "Claude confirmed guard flags remain false and widening_authorized is pinned false; no support widening, production platform claim, live adapter execution, GitHub mutation, ruleset mutation, network call, or live adapter call is introduced.",
+    "Claude confirmed the Epic 3 validator accepts only support_widening_evidence.v1 and widening_supersession_evidence_pack.v1; future v2 input fails closed with unsupported_future_schema_in_epic_3 and validator_v2/schema v2 are absent.",
+    "Claude confirmed the schema is recursively strict with additionalProperties:false and unevaluatedProperties:false on every object node.",
+    "Claude confirmed raw verdict SHA256 is canonicalized with raw_verdict_sha256 excluded, and legacy artifact_sha256 is recursively rejected.",
+    "Claude confirmed self-review prevention rejects same-provider, implementer-reviewer, and operator-login collisions.",
+    "Claude confirmed context-binding drift checks cover plan digest, final diff digest, PR head SHA, workflow run provenance, artifact membership/hash drift, reviewer hash drift, verdict binding drift, raw verdict artifact digest/reference/provenance drift, stale replay, and seven-day window races.",
+    "Local validation passed: JSON schema format, ruff, targeted mypy, full mypy ao_kernel, targeted E-3-6 pytest, adjacent Epic 3 pytest set, diff whitespace, gpp_next guard flags, and gitleaks secret scan.",
+    "No secrets were recorded in the review prompt, review output, evidence file, or validation artifacts."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/validate_widening_evidence.py
+++ b/scripts/validate_widening_evidence.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Validate support-widening evidence with the E-3-6 recompute validator."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ao_kernel._internal.support_widening.validator import (  # noqa: E402
+    WideningEvidenceValidationContext,
+    validation_report,
+)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return parsed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="E-3-6 v1-only support-widening recompute-not-trust validator"
+    )
+    parser.add_argument("--evidence", required=True, help="Path to evidence JSON")
+    parser.add_argument(
+        "--context",
+        default=None,
+        help=(
+            "Optional context JSON with recomputed_plan_digest, "
+            "recomputed_final_diff_digest, github_pr_head_sha, workflow_runs, "
+            "workflow_artifacts, artifact_paths, and now"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    evidence_path = Path(args.evidence)
+    context_path = Path(args.context) if args.context else None
+    try:
+        evidence = _read_json(evidence_path)
+        context = (
+            WideningEvidenceValidationContext.from_dict(_read_json(context_path))
+            if context_path is not None
+            else WideningEvidenceValidationContext()
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(json.dumps({"valid": False, "decision": "usage_error", "error": str(exc)}, sort_keys=True))
+        return 2
+
+    report = validation_report(evidence, context=context)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["valid"] else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_support_matrix_smoke_workflow.py
+++ b/tests/test_support_matrix_smoke_workflow.py
@@ -289,6 +289,9 @@ def test_live_ruleset_required_contexts_do_not_reference_support_matrix_smoke() 
 
 def test_slice_diff_only_adds_expected_workflow_supporting_artifacts() -> None:
     changed = set(_git_diff_names(["."]))
+    if ".github/workflows/support-matrix-smoke.yml" not in changed:
+        pytest.skip("support-matrix-smoke workflow not changed by this PR")
+
     expected = {
         ".github/workflows/support-matrix-smoke.yml",
         ".claude/plans/EPIC-3-E-3-3-CI-MATRIX.md",

--- a/tests/test_widening_evidence_validator.py
+++ b/tests/test_widening_evidence_validator.py
@@ -1,0 +1,444 @@
+"""V5 Epic 3 E-3-6 invariants: recompute-not-trust validator."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel._internal.support_widening.validator import (
+    WorkflowRunObservation,
+    WideningEvidenceValidationContext,
+    canonical_verdict_sha256,
+    validation_report,
+)
+from ao_kernel.config import load_default
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_NAME = "widening-supersession-evidence-pack.schema.v1.json"
+VALIDATOR_PATH = ROOT / "ao_kernel" / "_internal" / "support_widening" / "validator.py"
+VALIDATOR_V2_PATH = ROOT / "ao_kernel" / "_internal" / "support_widening" / "validator_v2.py"
+SCHEMA_V2_PATH = ROOT / "ao_kernel" / "defaults" / "schemas" / "support_widening_evidence.schema.v2.json"
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", SCHEMA_NAME)
+
+
+def _sha_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _identity_hash(verdict: dict[str, Any]) -> str:
+    raw = f"{verdict['provider']}|{verdict['github_login']}|{verdict['thread_id']}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _valid_pack(tmp_path: Path) -> tuple[dict[str, Any], WideningEvidenceValidationContext]:
+    raw_a = tmp_path / "anthropic-raw-verdict.json"
+    raw_b = tmp_path / "mavis-raw-verdict.json"
+    raw_a.write_text('{"provider":"anthropic","verdict":"AGREE"}', encoding="utf-8")
+    raw_b.write_text('{"provider":"mavis","verdict":"AGREE"}', encoding="utf-8")
+    sha_a = _sha_file(raw_a)
+    sha_b = _sha_file(raw_b)
+    pack: dict[str, Any] = {
+        "schema_version": "widening_supersession_evidence_pack.v1",
+        "artifact_kind": "widening_supersession_evidence_pack",
+        "repo": "Halildeu/ao-kernel",
+        "work_package": "E-3-6",
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+        "widening_authorized": False,
+        "evidence_class": "live",
+        "simulated_only": False,
+        "live_call_made": False,
+        "operator_authority": {
+            "github_login": "Halildeu",
+            "authorization_phrase": "AUTHORIZE_SUPPORT_WIDENING_SUPERSESSION",
+            "commit_verification_required": True,
+        },
+        "implementer_provider": {"provider": "openai", "github_login": "codex-implementer"},
+        "plan_digest": "a" * 64,
+        "final_diff_digest": "b" * 64,
+        "pr_head_sha": "c" * 40,
+        "workflow_run_ids": ["100", "101"],
+        "time_window_boundaries": {"start": "2026-01-01T00:00:00Z", "end": "2026-01-08T00:00:00Z"},
+        "artifacts": [
+            {
+                "run_id": "100",
+                "artifact_id": "anthropic-raw-verdict",
+                "sha256": sha_a,
+                "produced_at": "2026-01-02T00:00:00Z",
+                "head_sha": "c" * 40,
+            },
+            {
+                "run_id": "101",
+                "artifact_id": "mavis-raw-verdict",
+                "sha256": sha_b,
+                "produced_at": "2026-01-03T00:00:00Z",
+                "head_sha": "c" * 40,
+            },
+        ],
+        "provider_verdicts": [
+            {
+                "provider": "anthropic",
+                "github_login": "claude-reviewer",
+                "thread_id": "claude-thread-1",
+                "verdict": "AGREE",
+                "plan_digest": "a" * 64,
+                "final_diff_digest": "b" * 64,
+                "pr_head_sha": "c" * 40,
+                "raw_verdict_sha256": "",
+                "raw_verdict_artifact_digest": sha_a,
+                "raw_verdict_artifact_ref": "anthropic-raw-verdict",
+            },
+            {
+                "provider": "mavis",
+                "github_login": "mavis-reviewer",
+                "thread_id": "mavis-thread-1",
+                "verdict": "AGREE",
+                "plan_digest": "a" * 64,
+                "final_diff_digest": "b" * 64,
+                "pr_head_sha": "c" * 40,
+                "raw_verdict_sha256": "",
+                "raw_verdict_artifact_digest": sha_b,
+                "raw_verdict_artifact_ref": "mavis-raw-verdict",
+            },
+        ],
+        "reviewer_identity_hashes": [],
+        "verdict_completeness_proof": {
+            "verdicts_received_total": 2,
+            "verdicts_claimed_in_consensus": 2,
+            "negative_verdicts_present": False,
+        },
+        "consensus_status": "agree",
+    }
+    for verdict in pack["provider_verdicts"]:
+        verdict["raw_verdict_sha256"] = canonical_verdict_sha256(verdict)
+    pack["reviewer_identity_hashes"] = [_identity_hash(verdict) for verdict in pack["provider_verdicts"]]
+
+    context = WideningEvidenceValidationContext(
+        now=datetime(2026, 1, 15, tzinfo=timezone.utc),
+        recomputed_plan_digest="a" * 64,
+        recomputed_final_diff_digest="b" * 64,
+        github_pr_head_sha="c" * 40,
+        workflow_runs={
+            "100": WorkflowRunObservation(
+                status="completed",
+                conclusion="success",
+                head_sha="c" * 40,
+                created_at="2026-01-02T00:00:00Z",
+            ),
+            "101": WorkflowRunObservation(
+                status="completed",
+                conclusion="success",
+                head_sha="c" * 40,
+                created_at="2026-01-03T00:00:00Z",
+            ),
+        },
+        workflow_artifacts={
+            "100": frozenset({"anthropic-raw-verdict"}),
+            "101": frozenset({"mavis-raw-verdict"}),
+        },
+        artifact_paths={"anthropic-raw-verdict": raw_a, "mavis-raw-verdict": raw_b},
+    )
+    return pack, context
+
+
+def _rejects(pack: dict[str, Any], context: WideningEvidenceValidationContext, code: str) -> bool:
+    report = validation_report(pack, context=context)
+    return report["valid"] is False and code in report["reason_codes"]
+
+
+def test_schema_present_valid_and_recursively_strict() -> None:
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$id"] == "urn:ao:widening-supersession-evidence-pack:v1"
+
+    def object_nodes(node: Any) -> list[dict[str, Any]]:
+        nodes: list[dict[str, Any]] = []
+        if isinstance(node, dict):
+            if node.get("type") == "object":
+                nodes.append(node)
+            for value in node.values():
+                nodes.extend(object_nodes(value))
+        elif isinstance(node, list):
+            for value in node:
+                nodes.extend(object_nodes(value))
+        return nodes
+
+    for node in object_nodes(schema):
+        assert node.get("additionalProperties") is False
+        assert node.get("unevaluatedProperties") is False
+
+
+def test_valid_supersession_pack_recomputes_to_agree(tmp_path: Path) -> None:
+    pack, context = _valid_pack(tmp_path)
+    assert not list(Draft202012Validator(_schema()).iter_errors(pack))
+    report = validation_report(pack, context=context)
+    assert report["valid"] is True
+    assert report["decision"] == "validator_agree"
+    assert report["consensus_status_recomputed"] == "agree"
+    assert report["support_widening"] is False
+
+
+def test_existing_support_widening_evidence_v1_is_accepted() -> None:
+    payload = {
+        "schema_version": "support_widening_evidence.v1",
+        "artifact_kind": "support_widening_evidence",
+        "generated_at": "2026-06-04T10:00:00Z",
+        "repo": "Halildeu/ao-kernel",
+        "surface_class": "python_version",
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+        "register_authority": "evidence_record_only",
+        "github_write_authorized": False,
+        "simulated_only": True,
+        "live_call_made": False,
+        "evidence_dimensions": {"matrix": ["3.11"], "pytest_passed": True},
+        "reviewer_providers": [],
+        "recompute_inputs": {"raw_dimensions": {"matrix": ["3.11"], "pytest_passed": True}},
+    }
+    assert validation_report(payload)["valid"] is True
+
+
+def test_v2_and_guard_flip_paths_fail_closed(tmp_path: Path) -> None:
+    pack, context = _valid_pack(tmp_path)
+    v2 = copy.deepcopy(pack)
+    v2["schema_version"] = "support_widening_evidence.v2"
+    assert _rejects(v2, context, "unsupported_future_schema_in_epic_3")
+
+    support_true = copy.deepcopy(pack)
+    support_true["support_widening"] = True
+    assert _rejects(support_true, context, "guard_flag_true_rejected")
+
+    latent_authorized = copy.deepcopy(pack)
+    latent_authorized["widening_authorized"] = True
+    assert _rejects(latent_authorized, context, "guard_flag_true_rejected")
+
+
+def test_validator_v2_absent_and_not_imported() -> None:
+    assert not VALIDATOR_V2_PATH.exists()
+    assert not SCHEMA_V2_PATH.exists()
+    tree = ast.parse(VALIDATOR_PATH.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            rendered = ast.unparse(node)
+            assert "validator_v2" not in rendered
+            assert "support_widening_evidence.schema.v2" not in rendered
+
+
+def test_forged_consensus_and_negative_verdict_rejected(tmp_path: Path) -> None:
+    pack, context = _valid_pack(tmp_path)
+    pack["provider_verdicts"][0]["verdict"] = "REVISE"
+    pack["provider_verdicts"][0]["raw_verdict_sha256"] = canonical_verdict_sha256(pack["provider_verdicts"][0])
+    assert _rejects(pack, context, "forged_consensus_rejected")
+    assert _rejects(pack, context, "filtered_negative_verdict_rejected")
+
+
+def test_self_review_identity_and_provider_overlap_rejected(tmp_path: Path) -> None:
+    pack, context = _valid_pack(tmp_path)
+    same_provider = copy.deepcopy(pack)
+    same_provider["provider_verdicts"][1]["provider"] = "anthropic"
+    same_provider["provider_verdicts"][1]["raw_verdict_sha256"] = canonical_verdict_sha256(
+        same_provider["provider_verdicts"][1]
+    )
+    same_provider["reviewer_identity_hashes"] = [_identity_hash(v) for v in same_provider["provider_verdicts"]]
+    assert _rejects(same_provider, context, "same_provider_rejected")
+
+    implementer_overlap = copy.deepcopy(pack)
+    implementer_overlap["provider_verdicts"][0]["provider"] = "openai"
+    implementer_overlap["provider_verdicts"][0]["raw_verdict_sha256"] = canonical_verdict_sha256(
+        implementer_overlap["provider_verdicts"][0]
+    )
+    implementer_overlap["reviewer_identity_hashes"] = [_identity_hash(v) for v in implementer_overlap["provider_verdicts"]]
+    assert _rejects(implementer_overlap, context, "implementer_in_reviewer_rejected")
+
+    operator_overlap = copy.deepcopy(pack)
+    operator_overlap["provider_verdicts"][0]["github_login"] = "Halildeu"
+    operator_overlap["provider_verdicts"][0]["raw_verdict_sha256"] = canonical_verdict_sha256(
+        operator_overlap["provider_verdicts"][0]
+    )
+    operator_overlap["reviewer_identity_hashes"] = [_identity_hash(v) for v in operator_overlap["provider_verdicts"]]
+    assert _rejects(operator_overlap, context, "operator_login_collision_rejected")
+
+
+def test_operator_alias_and_legacy_artifact_sha_rejected(tmp_path: Path) -> None:
+    pack, context = _valid_pack(tmp_path)
+    alias = copy.deepcopy(pack)
+    alias["operator_authority"]["operator_github_login"] = "Halildeu"
+    assert _rejects(alias, context, "operator_alias_rejected")
+
+    legacy = copy.deepcopy(pack)
+    legacy["artifact_sha256"] = ["a" * 64]
+    assert _rejects(legacy, context, "legacy_artifact_sha_array_rejected")
+
+    nested_legacy = copy.deepcopy(pack)
+    nested_legacy["provider_verdicts"][0]["artifact_sha256"] = "a" * 64
+    assert _rejects(nested_legacy, context, "legacy_artifact_sha_array_rejected")
+
+
+def test_mutually_exclusive_simulated_and_live_rejected(tmp_path: Path) -> None:
+    pack, context = _valid_pack(tmp_path)
+    pack["simulated_only"] = True
+    pack["live_call_made"] = True
+    assert _rejects(pack, context, "mutually_exclusive_simulated_live_rejected")
+
+
+def test_time_window_stale_replay_and_timestamp_race_rejected(tmp_path: Path) -> None:
+    pack, context = _valid_pack(tmp_path)
+    stale = copy.deepcopy(pack)
+    stale["time_window_boundaries"]["end"] = "2025-01-08T00:00:00Z"
+    assert _rejects(stale, context, "stale_replay_rejected")
+
+    short_window = copy.deepcopy(pack)
+    short_window["time_window_boundaries"]["end"] = "2026-01-03T00:00:00Z"
+    assert _rejects(short_window, context, "seven_day_window_race_rejected")
+
+    outside_artifact = copy.deepcopy(pack)
+    outside_artifact["artifacts"][0]["produced_at"] = "2026-01-10T00:00:00Z"
+    assert _rejects(outside_artifact, context, "seven_day_window_race_rejected")
+
+
+def test_plan_diff_head_and_workflow_context_drift_rejected(tmp_path: Path) -> None:
+    pack, context = _valid_pack(tmp_path)
+    assert _rejects(pack, context.__class__(**{**context.__dict__, "recomputed_plan_digest": "0" * 64}), "plan_digest_drift_rejected")
+    assert _rejects(
+        pack,
+        context.__class__(**{**context.__dict__, "recomputed_final_diff_digest": "0" * 64}),
+        "final_diff_digest_drift_rejected",
+    )
+    assert _rejects(pack, context.__class__(**{**context.__dict__, "github_pr_head_sha": "0" * 40}), "pr_head_sha_drift_rejected")
+
+    bad_runs = dict(context.workflow_runs)
+    bad_runs["100"] = bad_runs["100"].__class__(
+        status="completed",
+        conclusion="failure",
+        head_sha="c" * 40,
+        created_at="2026-01-02T00:00:00Z",
+    )
+    assert _rejects(pack, context.__class__(**{**context.__dict__, "workflow_runs": bad_runs}), "workflow_run_provenance_rejected")
+
+
+def test_artifact_provenance_and_hash_drift_rejected(tmp_path: Path) -> None:
+    pack, context = _valid_pack(tmp_path)
+    orphan = copy.deepcopy(pack)
+    orphan["artifacts"][0]["run_id"] = "999"
+    assert _rejects(orphan, context, "orphan_artifact_rejected")
+
+    missing_artifact = copy.deepcopy(pack)
+    workflow_artifacts = dict(context.workflow_artifacts)
+    workflow_artifacts["100"] = frozenset()
+    assert _rejects(
+        missing_artifact,
+        context.__class__(**{**context.__dict__, "workflow_artifacts": workflow_artifacts}),
+        "artifact_not_in_run_rejected",
+    )
+
+    sha_drift = copy.deepcopy(pack)
+    sha_drift["artifacts"][0]["sha256"] = "0" * 64
+    assert _rejects(sha_drift, context, "artifact_sha_drift_rejected")
+
+
+def test_reviewer_hash_verdict_binding_and_raw_hash_drift_rejected(tmp_path: Path) -> None:
+    pack, context = _valid_pack(tmp_path)
+    reviewer_hash = copy.deepcopy(pack)
+    reviewer_hash["reviewer_identity_hashes"][0] = "0" * 64
+    assert _rejects(reviewer_hash, context, "reviewer_hash_recomputation_rejected")
+
+    binding = copy.deepcopy(pack)
+    binding["provider_verdicts"][0]["final_diff_digest"] = "0" * 64
+    binding["provider_verdicts"][0]["raw_verdict_sha256"] = canonical_verdict_sha256(binding["provider_verdicts"][0])
+    assert _rejects(binding, context, "verdict_binding_rejected")
+
+    raw_hash = copy.deepcopy(pack)
+    raw_hash["provider_verdicts"][0]["raw_verdict_sha256"] = "0" * 64
+    assert _rejects(raw_hash, context, "raw_verdict_sha_rejected")
+
+
+def test_raw_verdict_artifact_cross_binding_and_dangling_ref_rejected(tmp_path: Path) -> None:
+    pack, context = _valid_pack(tmp_path)
+    digest_drift = copy.deepcopy(pack)
+    digest_drift["provider_verdicts"][0]["raw_verdict_artifact_digest"] = "0" * 64
+    digest_drift["provider_verdicts"][0]["raw_verdict_sha256"] = canonical_verdict_sha256(
+        digest_drift["provider_verdicts"][0]
+    )
+    assert _rejects(digest_drift, context, "raw_verdict_artifact_cross_binding_rejected")
+
+    dangling = copy.deepcopy(pack)
+    dangling["provider_verdicts"][0]["raw_verdict_artifact_ref"] = "missing"
+    dangling["provider_verdicts"][0]["raw_verdict_sha256"] = canonical_verdict_sha256(dangling["provider_verdicts"][0])
+    assert _rejects(dangling, context, "raw_verdict_artifact_ref_dangling_rejected")
+
+    provenance = copy.deepcopy(pack)
+    provenance["artifacts"][0]["head_sha"] = "0" * 40
+    assert _rejects(provenance, context, "raw_verdict_artifact_provenance_rejected")
+
+
+def test_cli_reports_valid_and_rejected(tmp_path: Path) -> None:
+    pack, context = _valid_pack(tmp_path)
+    evidence_path = tmp_path / "pack.json"
+    context_path = tmp_path / "context.json"
+    evidence_path.write_text(json.dumps(pack), encoding="utf-8")
+    context_path.write_text(
+        json.dumps(
+            {
+                "now": "2026-01-15T00:00:00Z",
+                "recomputed_plan_digest": "a" * 64,
+                "recomputed_final_diff_digest": "b" * 64,
+                "github_pr_head_sha": "c" * 40,
+                "workflow_runs": {
+                    "100": {
+                        "status": "completed",
+                        "conclusion": "success",
+                        "head_sha": "c" * 40,
+                        "created_at": "2026-01-02T00:00:00Z",
+                    },
+                    "101": {
+                        "status": "completed",
+                        "conclusion": "success",
+                        "head_sha": "c" * 40,
+                        "created_at": "2026-01-03T00:00:00Z",
+                    },
+                },
+                "workflow_artifacts": {"100": ["anthropic-raw-verdict"], "101": ["mavis-raw-verdict"]},
+                "artifact_paths": {key: str(path) for key, path in context.artifact_paths.items()},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    ok = subprocess.run(
+        [sys.executable, "scripts/validate_widening_evidence.py", "--evidence", str(evidence_path), "--context", str(context_path)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert ok.returncode == 0
+    assert json.loads(ok.stdout)["valid"] is True
+
+    rejected = copy.deepcopy(pack)
+    rejected["widening_authorized"] = True
+    evidence_path.write_text(json.dumps(rejected), encoding="utf-8")
+    bad = subprocess.run(
+        [sys.executable, "scripts/validate_widening_evidence.py", "--evidence", str(evidence_path), "--context", str(context_path)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert bad.returncode == 1
+    report = json.loads(bad.stdout)
+    assert report["valid"] is False
+    assert "guard_flag_true_rejected" in report["reason_codes"]


### PR DESCRIPTION
## Summary
- add a v1-only, fail-closed recompute-not-trust validator for support-widening evidence
- add a recursively strict `widening_supersession_evidence_pack.v1` schema and CLI validator
- cover guard flags, v2 rejection, artifact/workflow/context drift, reviewer identity, raw verdict binding, legacy alias rejection, and CLI behavior with focused tests

## Validation
- `python3 -m json.tool local-ai-review-evidence.v1.json`
- local evidence schema validation via `jsonschema.Draft202012Validator`
- `ruff check ao_kernel/_internal/support_widening/validator.py scripts/validate_widening_evidence.py tests/test_widening_evidence_validator.py`
- `mypy ao_kernel/_internal/support_widening/validator.py scripts/validate_widening_evidence.py tests/test_widening_evidence_validator.py`
- `mypy ao_kernel/`
- `pytest tests/test_widening_evidence_validator.py tests/test_widening_supersession_checklist.py tests/test_support_widening_evidence_v1.py tests/test_run_support_smoke.py tests/test_support_matrix_smoke_workflow.py -q`
- `git diff --check`
- `gitleaks git . --redact --log-level error --exit-code 1 --log-opts origin/main..HEAD`
- Claude Anthropic cross-AI review: `VERDICT: AGREE`

## Guardrails
- no `support_widening_allowed` flip
- no `production_platform_claim_allowed` flip
- no `live_adapter_execution_allowed` flip
- no GitHub writes, ruleset mutation, network calls, or live adapter execution in the validator
- unsupported future schema versions fail closed with `unsupported_future_schema_in_epic_3`

Closes #858
