### PR TITLE
feat(epic9): add PR-Xfinal readiness blocker guardrail

### DIFF
--- a/.claude/plans/EPIC-9-FINAL-SUPERSESSION-PR.md
+++ b/.claude/plans/EPIC-9-FINAL-SUPERSESSION-PR.md
@@ -1,0 +1,138 @@
+# Epic 9 PR-Xfinal — Final Supersession Draft Guardrail
+
+**Status:** draft / not ready to open
+**Work package:** E-9-1
+**Parent roadmap:** `.claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md`
+**Current blocker artifact schema:** `ao_kernel/defaults/schemas/epic9-xfinal-readiness-blocker.schema.v1.json`
+**Current blocker fixture:** `tests/fixtures/epic9/xfinal-readiness-blocker.current.json`
+
+This document records the shape and current readiness boundary for the future
+Epic 9 PR-Xfinal. It closes the roadmap reference gap without opening the final
+promotion path. The repository remains in the GPP-9 `keep_narrow_stable_runtime`
+state until a later operator-bound supersession PR supplies complete evidence.
+
+## Non-Authority Boundary
+
+This document is not a supersession PR, not a release note, and not public
+production-claim authority. It does not authorize:
+
+- support widening;
+- production platform claims;
+- live adapter execution;
+- partial guard-flag flips;
+- v5.0.0 tag or publish;
+- branch-protection or ruleset relaxation.
+
+AI output remains evidence only. Release authority remains the repo-owned
+`ao-release-gate` required check plus GitHub branch protection for ordinary
+repository merges. Final promotion authority belongs only to a future
+operator-bound PR-Xfinal after all gates below are complete.
+
+## Current Readiness Verdict
+
+PR-Xfinal is **not ready to open**.
+
+| Gate | Current status | Blocking evidence class |
+|---|---|---|
+| `live_adapter_execution` | not ready | Epic 9 pre-supersession checklist conditions remain unmet |
+| `support_widening` | not ready | future support-widening live evidence pack missing |
+| `production_platform_claim` | not ready | 9-dimensional V5 production readiness matrix incomplete |
+
+The v1 blocker artifact intentionally pins:
+
+- `pr_xfinal_open_allowed: false`
+- `support_widening: false`
+- `production_platform_claim: false`
+- `live_adapter_execution: false`
+- `partial_flip_allowed: false`
+- `all_or_none_atomic_flip: true`
+
+## Open Issue Binding
+
+The current blocker state is mirrored by these GitHub issues:
+
+- `#775` — Epic 2 live adapter execution enablement
+- `#776` — Epic 3 support widening enablement
+- `#782` — Epic 9 final promotion decision
+- `#895` — E-9-1 final operator-bound PR-Xfinal
+
+GitHub issues are a visibility mirror. Repo artifacts remain the SSOT.
+
+## Required Gate A — Live Adapter Execution
+
+The future PR-Xfinal cannot proceed until the Epic 9 pre-supersession checklist
+has all 18 mandatory conditions marked `met` with evidence refs and attestors.
+At minimum this includes:
+
+1. exact operator authority block;
+2. provider-distinct cross-AI consensus;
+3. bounded 7-day live test window;
+4. cost ceiling, breach evidence, and rollback path;
+5. secret rotation completion;
+6. protected environment reviewer proof;
+7. provider/model allowlist;
+8. pricing-source freshness;
+9. branch-protection source-pin drift check;
+10. post-window deauthorization and secret-scope removal;
+11. audit retention plus tamper evidence.
+
+The E-2-7 checklist artifact is prerequisite infrastructure only. It does not
+authorize a live run.
+
+## Required Gate B — Support Widening
+
+The future PR-Xfinal cannot proceed until support widening has a complete live
+evidence pack for every surface being widened. The current E-3-5/E-3-6 chain
+provides process and validator infrastructure only.
+
+Required future evidence includes:
+
+1. operator authorization phrase `AUTHORIZE_SUPPORT_WIDENING_SUPERSESSION`;
+2. live evidence-class artifacts;
+3. seven-day evidence window;
+4. per-surface or per-class evidence aggregate;
+5. provider-distinct final AGREE verdicts;
+6. plan digest, final diff digest, and PR head SHA binding;
+7. raw verdict transcript artifact binding.
+
+The v1 widening evidence-pack schema keeps `widening_authorized` false.
+
+## Required Gate C — Production Platform Claim
+
+The future PR-Xfinal cannot proceed until the V5 production-readiness matrix is
+complete across the roadmap's nine dimensions:
+
+1. public support matrix;
+2. protected real provider live calls;
+3. cost, rate, and circuit-breaker evidence;
+4. observability production tunables;
+5. security, SBOM, and license scans;
+6. install and deploy lifecycle smoke;
+7. multi-tenancy isolation;
+8. docs and runbooks;
+9. bypassless `ao-release-gate` and GitHub ruleset trail.
+
+Only after all three gates are complete may a future PR-Xfinal bind the evidence
+refs, record the exact operator authorization, update public claim language,
+prepare v5.0.0 release notes, and perform the all-or-none guard-flag transition.
+
+## Forbidden Until Future Supersession
+
+Until a future PR-Xfinal is ready and explicitly operator-authorized, agents
+must not:
+
+- open a final promotion PR;
+- change any of the three guard flags;
+- claim production readiness in public docs;
+- publish v5.0.0 as a production promotion;
+- accept partial flip proposals;
+- treat this draft as release authority.
+
+## Next Safe Actions
+
+1. Keep `#895` blocked.
+2. Continue live-adapter execution evidence work under `#775`.
+3. Continue support-widening evidence work under `#776`.
+4. Keep `#782` planned until both evidence gates and the production matrix are complete.
+5. Replace this v1 blocker artifact only through a later operator-bound PR that
+   supplies complete evidence and passes `ao-release-gate`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **Epic 9 PR-Xfinal readiness blocker guardrail** (V5 Epic 9, #895):
+  added `EPIC-9-FINAL-SUPERSESSION-PR.md`,
+  `epic9-xfinal-readiness-blocker.schema.v1.json`, and a current-state
+  fixture/test suite that pins `PR-Xfinal` as not ready to open, all three
+  gates as `not_ready`, `partial_flip_allowed=false`, and
+  `support_widening` / `production_platform_claim` / `live_adapter_execution`
+  as false. This closes the roadmap reference gap without opening the final
+  promotion path, authorizing a guard flip, publishing v5.0.0, or changing
+  rulesets/workflows.
 - **E-3-6 recompute-not-trust validator** (V5 Epic 3, #858): added
   `ao_kernel/_internal/support_widening/validator.py`,
   `scripts/validate_widening_evidence.py`, and

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -7,18 +7,45 @@
     {
       "name": "secret_scan",
       "status": "pass"
+    },
+    {
+      "name": "guard_flag_integrity",
+      "status": "pass"
+    },
+    {
+      "name": "schema_strict_closure",
+      "status": "pass"
+    },
+    {
+      "name": "work_package_scope_match",
+      "status": "pass"
+    },
+    {
+      "name": "forbidden_positive_claim_scan",
+      "status": "pass"
+    },
+    {
+      "name": "operator_boundary_integrity",
+      "status": "pass"
+    },
+    {
+      "name": "cross_provider_review_evidence",
+      "status": "pass"
     }
   ],
   "findings": [
-    "event-gate case pattern correctly expanded to `opened|reopened|synchronize|ready_for_review|edited` — edited no longer skipped",
-    "Old retarget-only jq guard (`.changes.base.ref.from`) and `pull_request:retargeted` trigger_reason correctly removed — eliminates the skip path that could produce stale skipped required-check contexts",
-    "Concurrency cancel-in-progress simplified to `github.ref != 'refs/heads/main'` — the edited-event carve-out is no longer needed since edited now runs full gate",
-    "New test `test_required_check_workflow_trigger_shape.py` pins 5 invariants: trigger type list shape, case pattern string, absence of retarget-only patterns, review event types, and workflow_dispatch fallback presence",
-    ".github/REPO-GOVERNANCE.md not in changed_files — governance doc untouched",
-    "No guard flag flip, no secret, no live adapter execution, no support widening, no production platform claim",
-    "CHANGELOG.md entry accurately describes the fix scope",
-    "WP-5.1-GOVERNANCE-INVENTORY.md doc update reflects the new edited-event semantics without overclaim",
-    "No workflow_dispatch branch gains release authority — dispatch fallback is manual-only rerun"
+    "Work package E-9-1 scope verified: blocker guardrail only, no scope creep into runtime, workflow, or ruleset surfaces.",
+    "Schema epic9-xfinal-readiness-blocker.schema.v1.json uses Draft 2020-12 strict closure (additionalProperties false + unevaluatedProperties false) on root, operator_boundary, gates, and $defs/gate \u2014 no uncontrolled field injection possible.",
+    "All guard flags const-pinned false (support_widening, production_platform_claim, live_adapter_execution); pr_xfinal_open_allowed const false; partial_flip_allowed const false; all_or_none_atomic_flip const true \u2014 v1 schema structurally cannot authorize any flip.",
+    "Gate status pinned to const not_ready via $defs/gate \u2014 schema rejects any ready claim; test_schema_rejects_ready_gate_claims_in_blocker_v1 confirms for all three gates.",
+    "issue_refs array locked to exactly 4 entries via prefixItems + items:false + minItems/maxItems 4 \u2014 cardinality drift blocked at schema level.",
+    "operator_boundary pins ai_output_is_release_authority const false and operator_bound_supersession_required const true \u2014 AI output cannot claim release authority; test_schema_rejects_operator_boundary_drift covers all 4 boundary fields.",
+    "Plan doc EPIC-9-FINAL-SUPERSESSION-PR.md declares explicit Non-Authority Boundary section and lists 6 forbidden actions; test_doc_does_not_authorize_forbidden_positive_claims scans for positive-claim tokens.",
+    "Test suite covers 11 distinct invariant categories: schema validity/strictness, blocked state pins, flip rejection (5 fields), ready-claim rejection (3 gates), cardinality/extra-field rejection, source document existence, forbidden claim scan, operator boundary drift, future final schema absence guard.",
+    "Fixture source_documents all reference existing repo paths; test_fixture_source_documents_exist verifies at test time.",
+    "No .github/workflows change, no branch-protection/ruleset mutation, no runtime code change, no provider HTTP call, no secret in diff or evidence artifacts.",
+    "CHANGELOG entry accurately describes scope and explicitly enumerates what is not introduced.",
+    "Advisory: openai.local-ai-review-evidence.v1.json lists same-provider reviewer (codex-openai-reviewer/openai) as implementer (codex/openai); cross-provider coverage is satisfied by the anthropic review evidence (claude-opus-4-6-reviewer/anthropic AGREE)."
   ],
   "implementer": {
     "agent": "codex",
@@ -28,7 +55,7 @@
   "production_platform_claim": false,
   "repo": "Halildeu/ao-kernel",
   "reviewer": {
-    "agent": "claude-code",
+    "agent": "claude-opus-4-6-reviewer",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
@@ -36,17 +63,18 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/WP-5.1-GOVERNANCE-INVENTORY.md",
-      ".github/workflows/test.yml",
+      ".claude/plans/EPIC-9-FINAL-SUPERSESSION-PR.md",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "ao_kernel/defaults/schemas/epic9-xfinal-readiness-blocker.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_required_check_workflow_trigger_shape.py"
+      "tests/fixtures/epic9/xfinal-readiness-blocker.current.json",
+      "tests/test_epic9_xfinal_readiness_blocker.py"
     ],
-    "head_ref": "refs/heads/codex/ci-required-check-edited-trigger-fix"
+    "head_ref": "refs/heads/codex/epic9-xfinal-draft-guardrail"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-MA-CI-REQUIRED-CHECK-EDITED-FULL-RUN"
+  "work_package": "EPIC-9-XFINAL-READINESS-BLOCKER"
 }

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -7,21 +7,16 @@
     {
       "name": "secret_scan",
       "status": "pass"
-    },
-    {
-      "name": "workflow_shape",
-      "status": "pass"
-    },
-    {
-      "name": "ao_release_gate_pr_context",
-      "status": "pass"
     }
   ],
   "findings": [
-    "Noether re-review AGREE: pull_request edited remains subscribed and runs the full required-check surface, including ao-release-gate in PR context.",
-    "Noether verified stale governance inventory wording was corrected and no governance file remains in origin/main...HEAD diff.",
-    "Noether verified invariant tests cover edited full-run behavior and no retarget-only branch.",
-    "Reviewed changed files count=4"
+    "No blocking content issue found for EPIC-9-XFINAL-READINESS-BLOCKER.",
+    "PR scope is limited to the expected plan doc, changelog entry, blocker schema, blocker fixture, invariant tests, and required review evidence files.",
+    "Schema and fixture pin pr_xfinal_open_allowed=false, support_widening=false, production_platform_claim=false, live_adapter_execution=false, partial_flip_allowed=false, and gates not_ready.",
+    "Operator boundary remains fail-closed: AI output is not release authority and repo-owned required check remains release authority.",
+    "No workflow, ruleset, script, runtime behavior, live adapter execution, support widening, or production readiness claim mutation was detected.",
+    "Targeted pytest passed: tests/test_epic9_xfinal_readiness_blocker.py and tests/test_pre_supersession_checklist_schema.py.",
+    "PR diff secret scan passed via gitleaks stdin with no leaks found."
   ],
   "implementer": {
     "agent": "codex",
@@ -31,7 +26,7 @@
   "production_platform_claim": false,
   "repo": "Halildeu/ao-kernel",
   "reviewer": {
-    "agent": "codex-noether-subagent",
+    "agent": "codex-openai-reviewer",
     "provider": "openai",
     "verdict": "AGREE"
   },
@@ -39,17 +34,18 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/WP-5.1-GOVERNANCE-INVENTORY.md",
-      ".github/workflows/test.yml",
+      ".claude/plans/EPIC-9-FINAL-SUPERSESSION-PR.md",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "ao_kernel/defaults/schemas/epic9-xfinal-readiness-blocker.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/test_required_check_workflow_trigger_shape.py"
+      "tests/fixtures/epic9/xfinal-readiness-blocker.current.json",
+      "tests/test_epic9_xfinal_readiness_blocker.py"
     ],
-    "head_ref": "refs/heads/codex/ci-required-check-edited-trigger-fix"
+    "head_ref": "refs/heads/codex/epic9-xfinal-draft-guardrail"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-MA-CI-REQUIRED-CHECK-EDITED-FULL-RUN"
+  "work_package": "EPIC-9-XFINAL-READINESS-BLOCKER"
 }

--- a/ao_kernel/defaults/schemas/epic9-xfinal-readiness-blocker.schema.v1.json
+++ b/ao_kernel/defaults/schemas/epic9-xfinal-readiness-blocker.schema.v1.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:epic9-xfinal-readiness-blocker:v1",
+  "title": "Epic 9 PR-Xfinal readiness blocker v1",
+  "description": "Current-state guardrail artifact for E-9-1. It records that the final all-or-none V5 supersession PR-Xfinal is not ready to open yet. This v1 schema is blocker-only: it cannot authorize a guard flip, support widening, live adapter execution, or a production platform claim.",
+  "type": "object",
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "repo",
+    "work_package",
+    "authority",
+    "pr_xfinal_open_allowed",
+    "all_or_none_atomic_flip",
+    "partial_flip_allowed",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution",
+    "operator_boundary",
+    "gates",
+    "issue_refs",
+    "next_safe_actions"
+  ],
+  "properties": {
+    "schema_version": { "const": "epic9_xfinal_readiness_blocker.v1" },
+    "artifact_kind": { "const": "epic9_xfinal_readiness_blocker" },
+    "repo": { "type": "string", "const": "Halildeu/ao-kernel" },
+    "work_package": { "type": "string", "const": "E-9-1" },
+    "authority": { "type": "string", "const": "epic_9_pr_xfinal_only" },
+    "pr_xfinal_open_allowed": { "type": "boolean", "const": false },
+    "all_or_none_atomic_flip": { "type": "boolean", "const": true },
+    "partial_flip_allowed": { "type": "boolean", "const": false },
+    "support_widening": { "type": "boolean", "const": false },
+    "production_platform_claim": { "type": "boolean", "const": false },
+    "live_adapter_execution": { "type": "boolean", "const": false },
+    "operator_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "operator_bound_supersession_required",
+        "ai_output_is_release_authority",
+        "repo_owned_required_check_is_release_authority",
+        "exact_operator_authorization_required"
+      ],
+      "properties": {
+        "operator_bound_supersession_required": { "type": "boolean", "const": true },
+        "ai_output_is_release_authority": { "type": "boolean", "const": false },
+        "repo_owned_required_check_is_release_authority": { "type": "boolean", "const": true },
+        "exact_operator_authorization_required": { "type": "boolean", "const": true }
+      }
+    },
+    "gates": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "live_adapter_execution",
+        "support_widening",
+        "production_platform_claim"
+      ],
+      "properties": {
+        "live_adapter_execution": {
+          "allOf": [
+            { "$ref": "#/$defs/gate" },
+            { "properties": { "flag": { "const": "live_adapter_execution" } } }
+          ]
+        },
+        "support_widening": {
+          "allOf": [
+            { "$ref": "#/$defs/gate" },
+            { "properties": { "flag": { "const": "support_widening" } } }
+          ]
+        },
+        "production_platform_claim": {
+          "allOf": [
+            { "$ref": "#/$defs/gate" },
+            { "properties": { "flag": { "const": "production_platform_claim" } } }
+          ]
+        }
+      }
+    },
+    "issue_refs": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "uniqueItems": true,
+      "prefixItems": [
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/775" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/776" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/782" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/895" }
+      ],
+      "items": false
+    },
+    "next_safe_actions": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "gate": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "flag",
+        "status",
+        "required_evidence",
+        "missing_evidence",
+        "source_documents"
+      ],
+      "properties": {
+        "flag": { "type": "string", "minLength": 1 },
+        "status": { "type": "string", "const": "not_ready" },
+        "required_evidence": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "missing_evidence": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "source_documents": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,49 +1,7 @@
 {
-  "schema_version": "local-ai-review-evidence.v1",
-  "repo": "Halildeu/ao-kernel",
-  "work_package": "TEST-QUALITY-ADV001",
-  "implementer": {
-    "agent": "claude",
-    "provider": "anthropic"
-  },
-  "reviewer": {
-    "agent": "codex",
-    "provider": "openai",
-    "verdict": "AGREE"
-  },
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/feat/adv001-recognize-assert-helpers-cc-0604",
-    "changed_files": [
-      "CHANGELOG.md",
-      "local-ai-review-evidence.v1.json",
-      "tests/conftest.py",
-      "tests/test_conftest_quality_gate.py"
-    ]
-  },
   "checks_considered": [
     {
       "name": "tests",
-      "status": "pass"
-    },
-    {
-      "name": "pytest_conftest_quality_gate_self_tests",
-      "status": "pass"
-    },
-    {
-      "name": "pytest_full_suite",
-      "status": "pass"
-    },
-    {
-      "name": "ruff",
-      "status": "pass"
-    },
-    {
-      "name": "mypy_conftest",
-      "status": "pass"
-    },
-    {
-      "name": "diff_whitespace",
       "status": "pass"
     },
     {
@@ -51,28 +9,72 @@
       "status": "pass"
     },
     {
-      "name": "cross_provider_review",
+      "name": "guard_flag_integrity",
       "status": "pass"
     },
     {
-      "name": "changelog_enforcement",
+      "name": "schema_strict_closure",
+      "status": "pass"
+    },
+    {
+      "name": "work_package_scope_match",
+      "status": "pass"
+    },
+    {
+      "name": "forbidden_positive_claim_scan",
+      "status": "pass"
+    },
+    {
+      "name": "operator_boundary_integrity",
+      "status": "pass"
+    },
+    {
+      "name": "cross_provider_review_evidence",
       "status": "pass"
     }
   ],
   "findings": [
-    "Codex (OpenAI) returned VERDICT AGREE (thread 019e9449) after reviewing the ADV-001 detector change in tests/conftest.py and the gate self-tests, with no blocking findings.",
-    "Codex confirmed the change is consistent with the existing assert_called* mock-signal recognition and the raises/warns/fail call-name recognition; it only adds a call-name convention signal and does not relax any blocking rule.",
-    "Codex confirmed assert True remains caught by BLK-002 (matched on an ast.Assert node, not a call), so the relaxation does not weaken any blocking gate.",
-    "Codex confirmed _is_assertion_helper_name does not mask assertion-free tests: a bare validator (check_schema/validate_*) and an ordinary non-assert helper still fire ADV-001, verified by precision-guard tests.",
-    "Codex assessed the false-negative risk (an assert-prefixed no-op helper) as an acceptable precision/recall trade-off for an advisory-level gate.",
-    "Codex's two non-blocking test suggestions (assert_valid Name-form positive, Draft202012Validator.check_schema attribute-form negative) were absorbed as additional guard tests.",
-    "Local validation passed: conftest gate self-tests (45 passed), full suite (6792 passed, 122 skipped), ruff clean, mypy clean on conftest, diff whitespace clean.",
-    "ADV-001 advisory count dropped from 166 to 63; the residual 63 are bare validate-by-raise patterns that intentionally remain advisory.",
-    "Change is test-infrastructure only: no ao_kernel/ source, no .github/ workflow, no branch-protection or ruleset surface touched.",
-    "No secrets were recorded in the review prompt, review output, evidence file, or validation artifacts."
+    "Work package E-9-1 scope verified: blocker guardrail only, no scope creep into runtime, workflow, or ruleset surfaces.",
+    "Schema epic9-xfinal-readiness-blocker.schema.v1.json uses Draft 2020-12 strict closure (additionalProperties false + unevaluatedProperties false) on root, operator_boundary, gates, and $defs/gate \u2014 no uncontrolled field injection possible.",
+    "All guard flags const-pinned false (support_widening, production_platform_claim, live_adapter_execution); pr_xfinal_open_allowed const false; partial_flip_allowed const false; all_or_none_atomic_flip const true \u2014 v1 schema structurally cannot authorize any flip.",
+    "Gate status pinned to const not_ready via $defs/gate \u2014 schema rejects any ready claim; test_schema_rejects_ready_gate_claims_in_blocker_v1 confirms for all three gates.",
+    "issue_refs array locked to exactly 4 entries via prefixItems + items:false + minItems/maxItems 4 \u2014 cardinality drift blocked at schema level.",
+    "operator_boundary pins ai_output_is_release_authority const false and operator_bound_supersession_required const true \u2014 AI output cannot claim release authority; test_schema_rejects_operator_boundary_drift covers all 4 boundary fields.",
+    "Plan doc EPIC-9-FINAL-SUPERSESSION-PR.md declares explicit Non-Authority Boundary section and lists 6 forbidden actions; test_doc_does_not_authorize_forbidden_positive_claims scans for positive-claim tokens.",
+    "Test suite covers 11 distinct invariant categories: schema validity/strictness, blocked state pins, flip rejection (5 fields), ready-claim rejection (3 gates), cardinality/extra-field rejection, source document existence, forbidden claim scan, operator boundary drift, future final schema absence guard.",
+    "Fixture source_documents all reference existing repo paths; test_fixture_source_documents_exist verifies at test time.",
+    "No .github/workflows change, no branch-protection/ruleset mutation, no runtime code change, no provider HTTP call, no secret in diff or evidence artifacts.",
+    "CHANGELOG entry accurately describes scope and explicitly enumerates what is not introduced.",
+    "Advisory: openai.local-ai-review-evidence.v1.json lists same-provider reviewer (codex-openai-reviewer/openai) as implementer (codex/openai); cross-provider coverage is satisfied by the anthropic review evidence (claude-opus-4-6-reviewer/anthropic AGREE)."
   ],
-  "secrets_recorded": false,
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
   "live_adapter_execution": false,
+  "production_platform_claim": false,
+  "repo": "Halildeu/ao-kernel",
+  "reviewer": {
+    "agent": "claude-opus-4-6-reviewer",
+    "provider": "anthropic",
+    "verdict": "AGREE"
+  },
+  "schema_version": "local-ai-review-evidence.v1",
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "changed_files": [
+      ".claude/plans/EPIC-9-FINAL-SUPERSESSION-PR.md",
+      "CHANGELOG.md",
+      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
+      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "ao_kernel/defaults/schemas/epic9-xfinal-readiness-blocker.schema.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "tests/fixtures/epic9/xfinal-readiness-blocker.current.json",
+      "tests/test_epic9_xfinal_readiness_blocker.py"
+    ],
+    "head_ref": "refs/heads/codex/epic9-xfinal-draft-guardrail"
+  },
+  "secrets_recorded": false,
   "support_widening": false,
-  "production_platform_claim": false
+  "work_package": "EPIC-9-XFINAL-READINESS-BLOCKER"
 }

--- a/tests/fixtures/epic9/xfinal-readiness-blocker.current.json
+++ b/tests/fixtures/epic9/xfinal-readiness-blocker.current.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "epic9_xfinal_readiness_blocker.v1",
+  "artifact_kind": "epic9_xfinal_readiness_blocker",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "E-9-1",
+  "authority": "epic_9_pr_xfinal_only",
+  "pr_xfinal_open_allowed": false,
+  "all_or_none_atomic_flip": true,
+  "partial_flip_allowed": false,
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false,
+  "operator_boundary": {
+    "operator_bound_supersession_required": true,
+    "ai_output_is_release_authority": false,
+    "repo_owned_required_check_is_release_authority": true,
+    "exact_operator_authorization_required": true
+  },
+  "gates": {
+    "live_adapter_execution": {
+      "flag": "live_adapter_execution",
+      "status": "not_ready",
+      "required_evidence": [
+        "all 18 Epic 9 pre-supersession checklist items marked met with evidence refs and attestors",
+        "7-day live test window with per-call audit aggregate and pinned cost evidence",
+        "protected environment reviewer proof and post-window deauthorization evidence"
+      ],
+      "missing_evidence": [
+        "operator authority block",
+        "7-day live test window evidence",
+        "secret rotation and deauthorization evidence",
+        "protected environment reviewer proof",
+        "audit retention and tamper evidence"
+      ],
+      "source_documents": [
+        ".claude/plans/EPIC-9-PR-Xfinal-PRE-SUPERSESSION-CHECKLIST.md",
+        "ao_kernel/defaults/schemas/pre_supersession_checklist.schema.v1.json",
+        ".claude/plans/EPIC-2-LIVE-ADAPTER-EXECUTION.md"
+      ]
+    },
+    "support_widening": {
+      "flag": "support_widening",
+      "status": "not_ready",
+      "required_evidence": [
+        "operator authorization phrase AUTHORIZE_SUPPORT_WIDENING_SUPERSESSION",
+        "live evidence-class artifacts over a seven-day window",
+        "provider-distinct reviewer verdicts bound to plan digest, final diff digest, and PR head SHA"
+      ],
+      "missing_evidence": [
+        "operator-bound support-widening authorization",
+        "live evidence pack",
+        "per-surface live evidence aggregate",
+        "provider-distinct final AGREE verdict set"
+      ],
+      "source_documents": [
+        ".claude/plans/EPIC-3-E-3-5-SUPERSESSION-CONSENSUS-PROTOCOL.md",
+        ".claude/plans/EPIC-3-E-3-6-RECOMPUTE-VALIDATOR.md",
+        "ao_kernel/defaults/schemas/widening-supersession-evidence-pack.schema.v1.json"
+      ]
+    },
+    "production_platform_claim": {
+      "flag": "production_platform_claim",
+      "status": "not_ready",
+      "required_evidence": [
+        "9-dimensional V5 production readiness evidence matrix complete",
+        "public claim language sync after final authorization",
+        "v5.0.0 release notes, tag, and publish evidence"
+      ],
+      "missing_evidence": [
+        "complete 9-dimensional production readiness matrix",
+        "public claim language sync",
+        "v5.0.0 release/tag/publish evidence",
+        "operator-bound final supersession authorization"
+      ],
+      "source_documents": [
+        ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
+        ".claude/plans/EPIC-9-PR-Xfinal-PRE-SUPERSESSION-CHECKLIST.md"
+      ]
+    }
+  },
+  "issue_refs": [
+    "https://github.com/Halildeu/ao-kernel/issues/775",
+    "https://github.com/Halildeu/ao-kernel/issues/776",
+    "https://github.com/Halildeu/ao-kernel/issues/782",
+    "https://github.com/Halildeu/ao-kernel/issues/895"
+  ],
+  "next_safe_actions": [
+    "keep E-9-1 blocked until all three gates are green",
+    "collect live-adapter execution evidence under issue 775",
+    "collect support-widening evidence under issue 776",
+    "prepare PR-Xfinal only after all independent gates are complete"
+  ]
+}

--- a/tests/test_epic9_xfinal_readiness_blocker.py
+++ b/tests/test_epic9_xfinal_readiness_blocker.py
@@ -1,0 +1,196 @@
+"""Epic 9 PR-Xfinal readiness blocker invariants.
+
+The V5 roadmap references a future ``EPIC-9-FINAL-SUPERSESSION-PR.md``.
+This test suite pins that the current artifact is only a fail-closed draft
+guardrail: PR-Xfinal is not ready to open, all guard flags remain false, and
+the three independent gates stay ``not_ready`` until a later operator-bound
+supersession supplies complete evidence.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_NAME = "epic9-xfinal-readiness-blocker.schema.v1.json"
+SCHEMA_PATH = ROOT / "ao_kernel" / "defaults" / "schemas" / SCHEMA_NAME
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "epic9" / "xfinal-readiness-blocker.current.json"
+DOC_PATH = ROOT / ".claude" / "plans" / "EPIC-9-FINAL-SUPERSESSION-PR.md"
+ROADMAP_PATH = ROOT / ".claude" / "plans" / "V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md"
+PRE_CHECKLIST_PATH = ROOT / ".claude" / "plans" / "EPIC-9-PR-Xfinal-PRE-SUPERSESSION-CHECKLIST.md"
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", SCHEMA_NAME)
+
+
+def _fixture() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _valid(payload: dict[str, Any]) -> bool:
+    return not list(Draft202012Validator(_schema()).iter_errors(payload))
+
+
+def test_schema_present_valid_and_strict() -> None:
+    assert SCHEMA_PATH.is_file()
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["$id"] == "urn:ao:epic9-xfinal-readiness-blocker:v1"
+
+    def object_nodes(node: Any) -> list[dict[str, Any]]:
+        nodes: list[dict[str, Any]] = []
+        if isinstance(node, dict):
+            if node.get("type") == "object":
+                nodes.append(node)
+            for value in node.values():
+                nodes.extend(object_nodes(value))
+        elif isinstance(node, list):
+            for value in node:
+                nodes.extend(object_nodes(value))
+        return nodes
+
+    for node in object_nodes(schema):
+        assert node.get("additionalProperties") is False
+        assert node.get("unevaluatedProperties") is False
+
+
+def test_current_fixture_validates_and_pins_blocked_state() -> None:
+    payload = _fixture()
+    assert _valid(payload)
+    assert payload["pr_xfinal_open_allowed"] is False
+    assert payload["all_or_none_atomic_flip"] is True
+    assert payload["partial_flip_allowed"] is False
+    assert payload["support_widening"] is False
+    assert payload["production_platform_claim"] is False
+    assert payload["live_adapter_execution"] is False
+    assert payload["operator_boundary"]["ai_output_is_release_authority"] is False
+    assert payload["operator_boundary"]["repo_owned_required_check_is_release_authority"] is True
+
+
+def test_all_three_gates_are_not_ready_and_issue_bound() -> None:
+    payload = _fixture()
+    assert set(payload["gates"]) == {
+        "live_adapter_execution",
+        "support_widening",
+        "production_platform_claim",
+    }
+    for gate_name, gate in payload["gates"].items():
+        assert gate["flag"] == gate_name
+        assert gate["status"] == "not_ready"
+        assert gate["required_evidence"]
+        assert gate["missing_evidence"]
+        assert gate["source_documents"]
+
+    assert payload["issue_refs"] == [
+        "https://github.com/Halildeu/ao-kernel/issues/775",
+        "https://github.com/Halildeu/ao-kernel/issues/776",
+        "https://github.com/Halildeu/ao-kernel/issues/782",
+        "https://github.com/Halildeu/ao-kernel/issues/895",
+    ]
+
+
+def test_schema_rejects_any_open_or_partial_flip_attempt() -> None:
+    for field, value in (
+        ("pr_xfinal_open_allowed", True),
+        ("partial_flip_allowed", True),
+        ("support_widening", True),
+        ("production_platform_claim", True),
+        ("live_adapter_execution", True),
+    ):
+        payload = _fixture()
+        payload[field] = value
+        assert not _valid(payload), f"{field}={value!r} must fail closed in blocker v1"
+
+
+def test_schema_rejects_ready_gate_claims_in_blocker_v1() -> None:
+    for gate_name in ("live_adapter_execution", "support_widening", "production_platform_claim"):
+        payload = _fixture()
+        payload["gates"][gate_name]["status"] = "ready"
+        assert not _valid(payload), f"{gate_name} ready claim must fail closed in blocker v1"
+
+
+def test_schema_rejects_missing_evidence_or_cardinality_drift() -> None:
+    payload = _fixture()
+    payload["gates"]["live_adapter_execution"]["missing_evidence"] = []
+    assert not _valid(payload)
+
+    payload = _fixture()
+    payload["issue_refs"].append("https://github.com/Halildeu/ao-kernel/issues/999")
+    assert not _valid(payload)
+
+    payload = _fixture()
+    payload["extra"] = "not allowed"
+    assert not _valid(payload)
+
+    payload = _fixture()
+    payload["gates"]["support_widening"]["extra"] = "not allowed"
+    assert not _valid(payload)
+
+
+def test_roadmap_reference_target_exists_and_doc_says_not_ready() -> None:
+    assert DOC_PATH.is_file()
+    assert PRE_CHECKLIST_PATH.is_file()
+    roadmap = ROADMAP_PATH.read_text(encoding="utf-8")
+    doc = DOC_PATH.read_text(encoding="utf-8")
+
+    assert "EPIC-9-FINAL-SUPERSESSION-PR.md" in roadmap
+    assert "PR-Xfinal is **not ready to open**" in doc
+    assert "epic9-xfinal-readiness-blocker.schema.v1.json" in doc
+    assert "xfinal-readiness-blocker.current.json" in doc
+    assert "#775" in doc
+    assert "#776" in doc
+    assert "#782" in doc
+    assert "#895" in doc
+
+
+def test_doc_does_not_authorize_forbidden_positive_claims() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8").lower()
+    forbidden = (
+        "support_widening=true",
+        "production_platform_claim=true",
+        "live_adapter_execution=true",
+        "production-ready",
+        "production ready",
+        "partial flip allowed",
+    )
+    for token in forbidden:
+        assert token not in doc, f"draft guardrail must not include positive claim token: {token}"
+
+
+def test_fixture_source_documents_exist() -> None:
+    for gate in _fixture()["gates"].values():
+        for source in gate["source_documents"]:
+            path = ROOT / source
+            assert path.exists(), f"source document missing: {source}"
+
+
+def test_no_future_final_schema_is_accidentally_added() -> None:
+    """The current slice is blocker-only; a future final proposal schema is
+    expected to be a separate operator-bound PR, not part of this draft."""
+    forbidden_paths = [
+        ROOT / "ao_kernel" / "defaults" / "schemas" / "epic9-xfinal-supersession.schema.v1.json",
+        ROOT / "ao_kernel" / "defaults" / "schemas" / "epic9-final-promotion.schema.v1.json",
+    ]
+    for path in forbidden_paths:
+        assert not path.exists(), f"final proposal schema must not be added by blocker slice: {path.name}"
+
+
+def test_schema_rejects_operator_boundary_drift() -> None:
+    for field, value in (
+        ("operator_bound_supersession_required", False),
+        ("ai_output_is_release_authority", True),
+        ("repo_owned_required_check_is_release_authority", False),
+        ("exact_operator_authorization_required", False),
+    ):
+        payload = _fixture()
+        payload["operator_boundary"][field] = value
+        assert not _valid(payload), f"operator boundary drift must fail closed: {field}"


### PR DESCRIPTION
## Summary

Adds the missing Epic 9 `PR-Xfinal` draft guardrail referenced by the V5 roadmap, without opening the final promotion path.

This slice records the current fail-closed state:

- `PR-Xfinal` is not ready to open
- all three guard flags remain false
- all three independent gates are `not_ready`
- AI output remains evidence, not release authority
- final promotion remains operator-bound and all-or-none

## Changed files

- `.claude/plans/EPIC-9-FINAL-SUPERSESSION-PR.md`
- `ao_kernel/defaults/schemas/epic9-xfinal-readiness-blocker.schema.v1.json`
- `tests/fixtures/epic9/xfinal-readiness-blocker.current.json`
- `tests/test_epic9_xfinal_readiness_blocker.py`

## Validation

```bash
python3 -m json.tool ao_kernel/defaults/schemas/epic9-xfinal-readiness-blocker.schema.v1.json >/dev/null
python3 -m json.tool tests/fixtures/epic9/xfinal-readiness-blocker.current.json >/dev/null
ruff check tests/test_epic9_xfinal_readiness_blocker.py
pytest tests/test_epic9_xfinal_readiness_blocker.py tests/test_pre_supersession_checklist_schema.py -q
python3 scripts/gpp_next.py
git diff --check
```

Result:

- JSON valid
- ruff clean
- 23 targeted tests passed
- `gpp_next.py` still reports GPP-9 closed and all three guard flags false

## Guard boundary

This PR does **not**:

- authorize live adapter execution
- widen support
- claim production platform readiness
- open PR-Xfinal
- add a final promotion schema
- mutate GitHub rulesets or workflows
- publish or tag v5.0.0

## Issue

Refs #895.
