### PR TITLE
test(quality-gate): ADV-001 recognizes assert-named helper calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **Test-quality gate ADV-001 false-positive reduction** (#954): the AST-based
+  gate in `tests/conftest.py` now counts calls to `assert`/`_assert`-named
+  helpers (e.g. a shared `_assert_rejected(...)` wrapper) as assertion-bearing,
+  clearing ADV-001 advisories for tests that verify through a helper rather than
+  an inline `assert`. High-precision: assertion-free tests, `assert True`
+  (BLK-002), and bare validate-by-raise calls (`check_schema`/`validate_*`)
+  still fire ADV-001; six gate self-tests pin the positive and precision-guard
+  behavior. ADV-001 advisory count dropped 166 → 63. Cross-AI review: Codex
+  (OpenAI) AGREE (thread 019e9449). Test-infrastructure only; guard flags
+  remain false and no workflow, support widening, production claim, or live
+  adapter execution is introduced.
 - **E-2-6 advisory runner failure stderr hardening**: replaced handled failure
   stderr with a fixed boundary message and added a subprocess regression test
   proving stderr does not leak exception text, artifact paths, envelope

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,28 +1,23 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "E-3-6",
+  "work_package": "TEST-QUALITY-ADV001",
   "implementer": {
-    "agent": "codex",
-    "provider": "openai"
+    "agent": "claude",
+    "provider": "anthropic"
   },
   "reviewer": {
-    "agent": "claude",
-    "provider": "anthropic",
+    "agent": "codex",
+    "provider": "openai",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/epic3-e3-6-validator",
+    "head_ref": "refs/heads/feat/adv001-recognize-assert-helpers-cc-0604",
     "changed_files": [
-      ".claude/plans/EPIC-3-E-3-6-RECOMPUTE-VALIDATOR.md",
-      "CHANGELOG.md",
-      "ao_kernel/_internal/support_widening/validator.py",
-      "ao_kernel/defaults/schemas/widening-supersession-evidence-pack.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "scripts/validate_widening_evidence.py",
-      "tests/test_support_matrix_smoke_workflow.py",
-      "tests/test_widening_evidence_validator.py"
+      "tests/conftest.py",
+      "tests/test_conftest_quality_gate.py"
     ]
   },
   "checks_considered": [
@@ -31,31 +26,19 @@
       "status": "pass"
     },
     {
-      "name": "pytest_widening_evidence_validator",
+      "name": "pytest_conftest_quality_gate_self_tests",
       "status": "pass"
     },
     {
-      "name": "pytest_epic3_support_widening_adjacent",
+      "name": "pytest_full_suite",
       "status": "pass"
     },
     {
-      "name": "pytest_support_matrix_smoke_workflow_scope_fix",
+      "name": "ruff",
       "status": "pass"
     },
     {
-      "name": "json_schema_format",
-      "status": "pass"
-    },
-    {
-      "name": "ruff_validator_cli_tests",
-      "status": "pass"
-    },
-    {
-      "name": "mypy_targeted",
-      "status": "pass"
-    },
-    {
-      "name": "mypy_ao_kernel",
+      "name": "mypy_conftest",
       "status": "pass"
     },
     {
@@ -63,19 +46,7 @@
       "status": "pass"
     },
     {
-      "name": "gpp_next_guard_flags",
-      "status": "pass"
-    },
-    {
       "name": "secret_scan",
-      "status": "pass"
-    },
-    {
-      "name": "claude_review_round_1",
-      "status": "pass"
-    },
-    {
-      "name": "claude_review_round_2",
       "status": "pass"
     },
     {
@@ -84,16 +55,15 @@
     }
   ],
   "findings": [
-    "Claude Anthropic returned VERDICT AGREE for E-3-6 after reviewing the v1-only fail-closed validator, schema, CLI, tests, plan record, changelog entry, and local validation summary.",
-    "Claude Anthropic returned VERDICT AGREE for the updated PR diff after the CI fix that scopes test_support_matrix_smoke_workflow.py's E-3-3 slice diff guard to only run when .github/workflows/support-matrix-smoke.yml changes.",
-    "Claude confirmed guard flags remain false and widening_authorized is pinned false; no support widening, production platform claim, live adapter execution, GitHub mutation, ruleset mutation, network call, or live adapter call is introduced.",
-    "Claude confirmed the Epic 3 validator accepts only support_widening_evidence.v1 and widening_supersession_evidence_pack.v1; future v2 input fails closed with unsupported_future_schema_in_epic_3 and validator_v2/schema v2 are absent.",
-    "Claude confirmed the schema is recursively strict with additionalProperties:false and unevaluatedProperties:false on every object node.",
-    "Claude confirmed raw verdict SHA256 is canonicalized with raw_verdict_sha256 excluded, and legacy artifact_sha256 is recursively rejected.",
-    "Claude confirmed self-review prevention rejects same-provider, implementer-reviewer, and operator-login collisions.",
-    "Claude confirmed context-binding drift checks cover plan digest, final diff digest, PR head SHA, workflow run provenance, artifact membership/hash drift, reviewer hash drift, verdict binding drift, raw verdict artifact digest/reference/provenance drift, stale replay, and seven-day window races.",
-    "Claude confirmed the E-3-3 workflow diff guard now skips unrelated PRs when support-matrix-smoke.yml is unchanged, but remains fail-closed against unexpected files when that workflow is changed.",
-    "Local validation passed: JSON schema format, ruff, targeted mypy, full mypy ao_kernel, targeted E-3-6 pytest, adjacent Epic 3 pytest set, diff whitespace, gpp_next guard flags, and gitleaks secret scan.",
+    "Codex (OpenAI) returned VERDICT AGREE (thread 019e9449) after reviewing the ADV-001 detector change in tests/conftest.py and the gate self-tests, with no blocking findings.",
+    "Codex confirmed the change is consistent with the existing assert_called* mock-signal recognition and the raises/warns/fail call-name recognition; it only adds a call-name convention signal and does not relax any blocking rule.",
+    "Codex confirmed assert True remains caught by BLK-002 (matched on an ast.Assert node, not a call), so the relaxation does not weaken any blocking gate.",
+    "Codex confirmed _is_assertion_helper_name does not mask assertion-free tests: a bare validator (check_schema/validate_*) and an ordinary non-assert helper still fire ADV-001, verified by precision-guard tests.",
+    "Codex assessed the false-negative risk (an assert-prefixed no-op helper) as an acceptable precision/recall trade-off for an advisory-level gate.",
+    "Codex's two non-blocking test suggestions (assert_valid Name-form positive, Draft202012Validator.check_schema attribute-form negative) were absorbed as additional guard tests.",
+    "Local validation passed: conftest gate self-tests (45 passed), full suite (6792 passed, 122 skipped), ruff clean, mypy clean on conftest, diff whitespace clean.",
+    "ADV-001 advisory count dropped from 166 to 63; the residual 63 are bare validate-by-raise patterns that intentionally remain advisory.",
+    "Change is test-infrastructure only: no ao_kernel/ source, no .github/ workflow, no branch-protection or ruleset surface touched.",
     "No secrets were recorded in the review prompt, review output, evidence file, or validation artifacts."
   ],
   "secrets_recorded": false,

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -15,6 +15,7 @@
     "base_ref": "refs/heads/main",
     "head_ref": "refs/heads/feat/adv001-recognize-assert-helpers-cc-0604",
     "changed_files": [
+      "CHANGELOG.md",
       "local-ai-review-evidence.v1.json",
       "tests/conftest.py",
       "tests/test_conftest_quality_gate.py"
@@ -51,6 +52,10 @@
     },
     {
       "name": "cross_provider_review",
+      "status": "pass"
+    },
+    {
+      "name": "changelog_enforcement",
       "status": "pass"
     }
   ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,11 @@ Rules:
              pytest scan. Path-filtered diffs (``git diff ... -- <path>``) and
              introducer-scoped self-gates (dynamic ``startswith(<var>)``) are
              exempt by construction.
-    ADV-001: Test function with 0 assert statements — warning
+    ADV-001: Test function with 0 assert statements — warning.
+             An ``assert`` statement, a ``pytest.raises``/``warns``/``fail``
+             call, or a call to an ``assert``/``_assert``-named helper (e.g.
+             a shared ``_assert_rejected(...)`` wrapper) all count as
+             assertions; bare validators that only raise do not.
     ADV-002: sole assertion is 'is not None' — weak behavioral signal
 """
 
@@ -143,6 +147,28 @@ _BLK004_BEHAVIORAL_ATTRS = frozenset(
         "method_calls",
     }
 )
+
+
+def _is_assertion_helper_name(name: str) -> bool:
+    """Return True if a called name declares assertion intent by convention.
+
+    A callee whose name starts with ``assert`` or ``_assert`` is an
+    assertion-bearing helper — e.g. a shared ``_assert_rejected(...)`` /
+    ``assert_valid(...)`` wrapper, or unittest's ``assertEqual``/``assertRaises``.
+    Counting such calls as assertions clears ADV-001 false-positives for tests
+    that verify behavior through a named helper rather than an inline ``assert``.
+    This is consistent with the existing ``assert_called*`` mock-signal
+    recognition and is high-precision:
+
+      - It does NOT mask assertion-free tests (no such call is present).
+      - It does NOT relax ``assert True`` (BLK-002 matches an ``ast.Assert``
+        node, not a call) or any other blocking rule.
+      - Bare side-effect validators that merely *raise* (``check_schema(...)``,
+        ``validate_*(...)``) are intentionally NOT matched: they do not declare
+        assertion intent by name, so ADV-001 still nudges toward an explicit
+        ``pytest.raises``/assert for them.
+    """
+    return name.startswith("assert") or name.startswith("_assert")
 
 
 def _ast_eq(a: ast.AST, b: ast.AST) -> bool:
@@ -560,7 +586,7 @@ def _scan_test_file(filepath: Path) -> list[_TestQualityViolation]:
                     call_name = child.func.attr
                 elif isinstance(child.func, ast.Name):
                     call_name = child.func.id
-                if call_name in ("raises", "warns", "fail"):
+                if call_name in ("raises", "warns", "fail") or _is_assertion_helper_name(call_name):
                     has_assert = True
                     break
 

--- a/tests/test_conftest_quality_gate.py
+++ b/tests/test_conftest_quality_gate.py
@@ -301,6 +301,59 @@ def test_adv001_no_assertions(tmp_path: Path) -> None:
     assert "ADV-001" in rules
 
 
+def test_adv001_cleared_by_underscore_assert_helper(tmp_path: Path) -> None:
+    """A call to an ``_assert``-prefixed helper counts as an assertion, so a
+    test that verifies via a shared helper is not a false-positive ADV-001."""
+    source = (
+        "def _assert_rejected(bad, msg):\n    raise AssertionError(msg)\n"
+        "def test_thing():\n    _assert_rejected({'x': 1}, 'must reject')\n"
+    )
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "ADV-001" not in rules
+
+
+def test_adv001_cleared_by_assert_prefixed_helper(tmp_path: Path) -> None:
+    """``assert``-prefixed helper names (e.g. ``assert_valid``, unittest's
+    ``assertEqual``) also count as assertion intent."""
+    source = "def test_thing():\n    self_obj.assertEqual(1, 1)\n"
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "ADV-001" not in rules
+
+
+def test_adv001_still_flags_bare_validator_call(tmp_path: Path) -> None:
+    """Precision guard: a bare side-effect validator that only *raises*
+    (``check_schema(...)``) does NOT declare assertion intent by name, so
+    ADV-001 still nudges toward an explicit assertion/pytest.raises."""
+    source = "def check_schema(s):\n    return None\ndef test_thing():\n    check_schema({'x': 1})\n"
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "ADV-001" in rules
+
+
+def test_adv001_cleared_by_assert_valid_name_form(tmp_path: Path) -> None:
+    """A bare ``assert_valid(...)`` (Name-form, assertion-intent wrapper)
+    counts as an assertion (Codex review guard)."""
+    source = "def assert_valid(x):\n    raise AssertionError('x')\ndef test_thing():\n    assert_valid({'x': 1})\n"
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "ADV-001" not in rules
+
+
+def test_adv001_still_flags_attribute_form_bare_validator(tmp_path: Path) -> None:
+    """Precision guard (Codex review): an attribute-form bare validator such as
+    ``Draft202012Validator.check_schema(...)`` does not declare assertion intent
+    by name, so ADV-001 still fires."""
+    source = "def test_thing():\n    Draft202012Validator.check_schema({'x': 1})\n"
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "ADV-001" in rules
+
+
+def test_adv001_not_masked_by_non_assert_helper(tmp_path: Path) -> None:
+    """Precision guard: an ordinary (non-assert-named) helper call must not
+    suppress ADV-001 — only assertion-intent names do."""
+    source = "def do_thing(x):\n    return x\ndef test_thing():\n    do_thing(1)\n"
+    rules = _rules(_scan_source(tmp_path, source))
+    assert "ADV-001" in rules
+
+
 def test_adv002_sole_is_not_none(tmp_path: Path) -> None:
     source = "def make_obj():\n    return 1\ndef test_thing():\n    obj = make_obj()\n    assert obj is not None\n"
     rules = _rules(_scan_source(tmp_path, source))


### PR DESCRIPTION
## Özet
Test-quality gate (`tests/conftest.py`, AST-based) **166 ADV-001** advisory üretiyordu; çoğu false-positive (`_assert_rejected(...)` helper'ı veya validate-by-raise ile doğrulayan testler). Root-cause fix: detector `assert`/`_assert`-isimli helper çağrılarını assertion-bearing sayar.

## Değişiklik (2 dosya, +80/-2)
- `tests/conftest.py`: `_is_assertion_helper_name()` + ADV-001 bloğunda kullanım + docstring
- `tests/test_conftest_quality_gate.py`: 6 self-test (2 positive helper + 4 precision-guard)

## Precision (false-negative korunur)
- Assertion-free testi maskelemez
- `assert True` (BLK-002) gevşemez
- Bare validator (`check_schema`/`validate_*`) **kasıtlı** advisory kalır (isim assertion-intent beyan etmiyor)

## Kanıt
- ADV-001: **166 → 63** (103 false-positive kaynaktan temizlendi)
- Full suite: **6792 passed, 122 skipped**
- ruff + mypy: temiz
- Cross-AI review: **Codex (OpenAI) AGREE** (thread 019e9449) — 2 önerdiği ek test guard absorbe edildi

## Guard flags
3 guard flag const false (test-infra değişikliği, flip yok).

Closes #954

Implementer: Anthropic (Claude) / Reviewer: OpenAI (Codex, thread 019e9449)