### PR TITLE
feat(epic9): add V5 security preflight bundle

### DIFF
--- a/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
+++ b/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
@@ -36,7 +36,7 @@ The V5 production readiness matrix is **not complete**.
 | protected real provider live calls | not_ready | 7-day live window and protected environment evidence missing |
 | cost/rate/circuit breaker evidence | partial | live cost/breach/rollback evidence missing |
 | observability production tunables | partial | final claim-bound observability/alerting evidence missing |
-| security/SBOM/license scans | partial | final release-bound SBOM/license/security bundle missing |
+| security/SBOM/license scans | partial | current preflight bundle exists; final release-bound SBOM/license/security bundle missing |
 | install/deploy lifecycle smoke | partial | v5.0.0 tag/publish and release-artifact smoke missing |
 | multi-tenancy isolation | not_ready | tenant isolation and per-tenant quota/cost evidence missing |
 | docs/runbooks | partial | final claim/release wording and runbook updates missing |
@@ -57,3 +57,14 @@ the only safe action is evidence collection under the existing issue refs:
 - `#776` support widening;
 - `#782` final promotion decision;
 - `#895` all-or-none PR-Xfinal.
+
+## Current Evidence Bundle Cross-Refs
+
+The `security_sbom_license_scans` dimension now has a current-state
+security/SBOM/license preflight bundle:
+
+- `.claude/plans/V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md`
+- `tests/fixtures/epic9/v5-security-sbom-license-preflight.current.json`
+
+That bundle binds CodeQL, Trivy, SBOM tooling, and license inventory evidence
+without treating them as final release-bound evidence.

--- a/.claude/plans/V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md
+++ b/.claude/plans/V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md
@@ -1,0 +1,48 @@
+# V5 Security/SBOM/License Preflight Bundle
+
+**Status:** current-state preflight evidence / not final release authority
+**Work package:** E-9-1
+**Parent matrix:** `.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md`
+**Schema:** `ao_kernel/defaults/schemas/v5-security-sbom-license-preflight-bundle.schema.v1.json`
+**Fixture:** `tests/fixtures/epic9/v5-security-sbom-license-preflight.current.json`
+
+This document records the current state of the `security_sbom_license_scans`
+dimension in the V5 production-readiness matrix. It binds existing committed
+security workflows, SBOM tooling, and license-compliance inventory into one
+machine-checkable preflight artifact.
+
+## Non-Authority Boundary
+
+This bundle does not authorize:
+
+- support widening;
+- production platform claims;
+- live adapter execution;
+- final release tagging or publishing;
+- opening PR-Xfinal;
+- treating advisory security workflows as required release checks.
+
+The current bundle pins `final_release_bound=false`, `support_widening=false`,
+`production_platform_claim=false`, and `live_adapter_execution=false`.
+
+## Current Preflight Evidence
+
+| Surface | Current evidence | Boundary |
+|---|---|---|
+| CodeQL | `.github/workflows/codeql.yml` | configured advisory workflow; not final release-bound evidence |
+| Trivy | `.github/workflows/trivy.yml` | configured advisory workflow; exit code remains advisory |
+| SBOM | `scripts/generate_sbom.py`, `tests/test_sbom_generation.py`, `tests/fixtures/sample-sbom.cdx.json` | generator and validation exist; no final v5 release SBOM artifact yet |
+| License compliance | `docs/license-compliance/license-compliance-policy.v1.json`, `docs/license-compliance/dependency-license-inventory.v1.json` | deny count is zero, but review-required entries still require operator disposition |
+
+## Residual Missing Evidence
+
+PR-Xfinal remains blocked for this dimension until a later operator-bound
+supersession provides:
+
+- final v5 release-bound SBOM artifact;
+- final release-bound license inventory generated from that release SBOM;
+- final security scan evidence bundle bound to the PR-Xfinal merge candidate;
+- operator disposition for review-required license entries.
+
+This is intentionally a preflight artifact. It makes the existing security
+surface auditable without changing the production claim gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **V5 security/SBOM/license preflight bundle** (V5 Epic 9, #895): added
+  `V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md`,
+  `v5-security-sbom-license-preflight-bundle.schema.v1.json`, and a
+  current-state fixture/test suite that binds CodeQL, Trivy, SBOM generator,
+  and license inventory evidence to the `security_sbom_license_scans`
+  production-readiness dimension. This is preflight evidence only:
+  final release-bound SBOM/license/security evidence remains missing and
+  `support_widening` / `production_platform_claim` / `live_adapter_execution`
+  remain false.
 - **V5 production readiness matrix blocker** (V5 Epic 9, #895): added
   `V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md`,
   `v5-production-readiness-matrix-blocker.schema.v1.json`, and a current-state

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -10,19 +10,13 @@
     }
   ],
   "findings": [
-    "Schema v5-production-readiness-matrix-blocker.schema.v1.json uses Draft 2020-12 with additionalProperties:false and unevaluatedProperties:false on root and $defs/dimension \u2014 strict closure verified",
-    "All guard flags const-pinned false (matrix_complete, pr_xfinal_open_allowed, support_widening, production_platform_claim, live_adapter_execution); operator_bound_supersession_required const true \u2014 no flip possible under blocker v1",
-    "Dimension status enum restricted to not_ready|partial \u2014 ready claim structurally rejected by schema; test_schema_rejects_ready_dimension_claims_in_blocker_v1 covers all 9 dimensions",
-    "9 dimensions identity-pinned via contains/minContains/maxContains allOf + minItems/maxItems 9 \u2014 cardinality and identity drift blocked at schema level",
-    "issue_refs pinned via prefixItems with items:false, minItems/maxItems 4, uniqueItems true \u2014 no injection of extra refs",
-    "Test suite covers 9 invariant categories: schema validity+strictness, fixture validation+closed-gate pins, guard-flip rejection (6 fields), ready-claim rejection (9 dimensions), cardinality/id drift+extra-field rejection, doc cross-references (3 docs), forbidden production-claim token scan, source document+evidence ref existence, issue ref binding",
-    "No secret-like material in diff \u2014 no API keys, tokens, credentials, or env var values detected",
-    "CHANGELOG entry correctly scoped as Gate C blocker infrastructure only with explicit non-authority enumeration",
-    "V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md non-authority boundary section lists six forbidden actions matching existing xfinal blocker pattern",
-    "EPIC-9-FINAL-SUPERSESSION-PR.md update adds production matrix blocker cross-reference and Gate C tracking detail without changing any guard flag or authority boundary",
-    "Scope matches E-9-1 work package \u2014 no workflow mutation, no ruleset change, no runtime code change, no support widening, no production claim, no provider HTTP call",
-    "Advisory: local-ai-review-evidence.v1.json at repo root is a duplicate of ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json \u2014 consider consolidating to single location to avoid drift",
-    "Advisory: openai.local-ai-review-evidence.v1.json lists same-provider reviewer (openai-reviewer/openai) as implementer (codex/openai); cross-provider coverage satisfied by this anthropic review"
+    "Anthropic reviewer verdict AGREE: no blocking issue in the V5 E-9-1 security/SBOM/license preflight evidence bundle.",
+    "Fail-closed guard state verified: final_release_bound=false, support_widening=false, production_platform_claim=false, and live_adapter_execution=false are schema/fixture/test pinned.",
+    "No production claim: document and changelog state preflight evidence only, and residual final release-bound evidence remains visible.",
+    "No live adapter execution or runtime/provider HTTP call is introduced.",
+    "Schema strictness verified: object nodes close additionalProperties and unevaluatedProperties.",
+    "Matrix linkage verified: security_sbom_license_scans remains partial and references the preflight bundle.",
+    "Secret exposure review found no credential, token, API key, webhook secret, or private key material in the diff."
   ],
   "implementer": {
     "agent": "codex",
@@ -40,17 +34,18 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/EPIC-9-FINAL-SUPERSESSION-PR.md",
       ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
+      ".claude/plans/V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/v5-production-readiness-matrix-blocker.schema.v1.json",
+      "ao_kernel/defaults/schemas/v5-security-sbom-license-preflight-bundle.schema.v1.json",
       "local-ai-review-evidence.v1.json",
       "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/test_v5_production_readiness_matrix_blocker.py"
+      "tests/fixtures/epic9/v5-security-sbom-license-preflight.current.json",
+      "tests/test_v5_security_sbom_license_preflight_bundle.py"
     ],
-    "head_ref": "refs/heads/codex/v5-production-readiness-matrix-blocker"
+    "head_ref": "refs/heads/codex/v5-security-sbom-license-preflight-bundle"
   },
   "secrets_recorded": false,
   "support_widening": false,

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -10,12 +10,13 @@
     }
   ],
   "findings": [
-    "No blocking issue found: the tracked final diff is limited to the intended E-9-1 V5 production readiness matrix blocker scope: EPIC-9 link/doc, schema, fixture, invariant test, changelog, root local-ai-review-evidence.v1.json, and the openai/anthropic high-risk review evidence files.",
-    "Fail-closed guard state verified: schema and fixture pin matrix_complete=false, pr_xfinal_open_allowed=false, support_widening=false, production_platform_claim=false, live_adapter_execution=false, and operator_bound_supersession_required=true; dimension status cannot become ready under blocker v1.",
-    "Evidence binding verified: root local-ai-review-evidence.v1.json and ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json plus anthropic.local-ai-review-evidence.v1.json are valid JSON, bind work_package=E-9-1, base_ref=refs/heads/main, head_ref=refs/heads/codex/v5-production-readiness-matrix-blocker, list the 9 tracked changed files, record AGREE, and keep secrets_recorded=false with guard flags false.",
-    "Scope guard verified: the tracked diff contains no .github/workflows change, ruleset or branch-protection mutation, runtime code mutation, PR-Xfinal opening action, v5.0.0 release/tag/publish action, support widening, production platform claim, or live adapter execution.",
-    "Tests pass: python3 -m pytest tests/test_v5_production_readiness_matrix_blocker.py completed 10 passed.",
-    "Secret scan pass: gitleaks detect over git diff origin/main...HEAD reported no leaks found; gitleaks detect --no-git over the untracked .codex-review review artifacts also reported no leaks found."
+    "OpenAI reviewer verdict AGREE: no blocking issue in the V5 E-9-1 security/SBOM/license preflight evidence bundle.",
+    "Diff is limited to the intended preflight doc/schema/fixture/test, matrix blocker cross-reference, matrix fixture evidence refs, changelog entry, and review evidence files.",
+    "Fail-closed guard state verified: final_release_bound=false, support_widening=false, production_platform_claim=false, live_adapter_execution=false, matrix_complete=false, and production_platform_claim=false in the matrix.",
+    "Production claim and live adapter execution are not introduced; no workflow, ruleset, runtime, release, tag, or publish mutation appears in the diff.",
+    "Matrix linkage is present: security_sbom_license_scans remains partial, links the new preflight doc/fixture, and still records final SBOM/license/security bundle residual gaps.",
+    "Tests considered: python3 -m pytest tests/test_v5_security_sbom_license_preflight_bundle.py tests/test_v5_production_readiness_matrix_blocker.py => 18 passed.",
+    "Secret scan considered: gitleaks over the working diff reported no leaks."
   ],
   "implementer": {
     "agent": "codex",
@@ -25,7 +26,7 @@
   "production_platform_claim": false,
   "repo": "Halildeu/ao-kernel",
   "reviewer": {
-    "agent": "openai-reviewer",
+    "agent": "kepler-openai-reviewer",
     "provider": "openai",
     "verdict": "AGREE"
   },
@@ -33,17 +34,18 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/EPIC-9-FINAL-SUPERSESSION-PR.md",
       ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
+      ".claude/plans/V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/v5-production-readiness-matrix-blocker.schema.v1.json",
+      "ao_kernel/defaults/schemas/v5-security-sbom-license-preflight-bundle.schema.v1.json",
       "local-ai-review-evidence.v1.json",
       "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/test_v5_production_readiness_matrix_blocker.py"
+      "tests/fixtures/epic9/v5-security-sbom-license-preflight.current.json",
+      "tests/test_v5_security_sbom_license_preflight_bundle.py"
     ],
-    "head_ref": "refs/heads/codex/v5-production-readiness-matrix-blocker"
+    "head_ref": "refs/heads/codex/v5-security-sbom-license-preflight-bundle"
   },
   "secrets_recorded": false,
   "support_widening": false,

--- a/ao_kernel/defaults/schemas/v5-security-sbom-license-preflight-bundle.schema.v1.json
+++ b/ao_kernel/defaults/schemas/v5-security-sbom-license-preflight-bundle.schema.v1.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:v5-security-sbom-license-preflight-bundle:v1",
+  "title": "V5 security, SBOM, and license preflight evidence bundle v1",
+  "description": "Current-state preflight bundle for the V5 production-readiness security/SBOM/license dimension. It records committed security workflows, SBOM tooling, and license inventory evidence while keeping final release-bound evidence and all production guard flags fail-closed.",
+  "type": "object",
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "repo",
+    "work_package",
+    "dimension",
+    "evidence_class",
+    "final_release_bound",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution",
+    "codeql",
+    "trivy",
+    "sbom",
+    "license_compliance",
+    "residual_missing_evidence",
+    "issue_refs"
+  ],
+  "properties": {
+    "schema_version": { "const": "v5_security_sbom_license_preflight_bundle.v1" },
+    "artifact_kind": { "const": "v5_security_sbom_license_preflight_bundle" },
+    "repo": { "const": "Halildeu/ao-kernel" },
+    "work_package": { "const": "E-9-1" },
+    "dimension": { "const": "security_sbom_license_scans" },
+    "evidence_class": { "const": "preflight_current_state" },
+    "final_release_bound": { "const": false },
+    "support_widening": { "const": false },
+    "production_platform_claim": { "const": false },
+    "live_adapter_execution": { "const": false },
+    "codeql": { "$ref": "#/$defs/security_workflow" },
+    "trivy": { "$ref": "#/$defs/security_workflow" },
+    "sbom": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "generator_path",
+        "generator_test_path",
+        "sample_fixture_path",
+        "cyclonedx_spec_version",
+        "release_component_name",
+        "release_bound_artifact_present"
+      ],
+      "properties": {
+        "generator_path": { "const": "scripts/generate_sbom.py" },
+        "generator_test_path": { "const": "tests/test_sbom_generation.py" },
+        "sample_fixture_path": { "const": "tests/fixtures/sample-sbom.cdx.json" },
+        "cyclonedx_spec_version": { "const": "1.5" },
+        "release_component_name": { "const": "ao-kernel" },
+        "release_bound_artifact_present": { "const": false }
+      }
+    },
+    "license_compliance": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "policy_path",
+        "inventory_path",
+        "inventory_schema_path",
+        "inventory_report_status",
+        "deny_count",
+        "review_count",
+        "operator_review_required"
+      ],
+      "properties": {
+        "policy_path": { "const": "docs/license-compliance/license-compliance-policy.v1.json" },
+        "inventory_path": { "const": "docs/license-compliance/dependency-license-inventory.v1.json" },
+        "inventory_schema_path": { "const": "ao_kernel/defaults/schemas/dependency-license-inventory.schema.v1.json" },
+        "inventory_report_status": { "enum": ["pass_no_deny_matches", "review_required"] },
+        "deny_count": { "const": 0 },
+        "review_count": { "type": "integer", "minimum": 1 },
+        "operator_review_required": { "const": true }
+      }
+    },
+    "residual_missing_evidence": {
+      "type": "array",
+      "minItems": 3,
+      "items": { "type": "string", "minLength": 1 },
+      "contains": { "const": "final v5 release-bound SBOM artifact" }
+    },
+    "issue_refs": {
+      "type": "array",
+      "prefixItems": [
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/782" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/895" }
+      ],
+      "items": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  },
+  "$defs": {
+    "security_workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "workflow_path",
+        "workflow_name",
+        "status",
+        "required_check",
+        "security_events_write_permission",
+        "final_release_bound"
+      ],
+      "properties": {
+        "workflow_path": { "type": "string", "pattern": "^\\.github/workflows/.+\\.yml$" },
+        "workflow_name": { "type": "string", "minLength": 1 },
+        "status": { "const": "configured_advisory" },
+        "required_check": { "const": false },
+        "security_events_write_permission": { "const": true },
+        "final_release_bound": { "const": false }
+      }
+    }
+  }
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -10,19 +10,13 @@
     }
   ],
   "findings": [
-    "Schema v5-production-readiness-matrix-blocker.schema.v1.json uses Draft 2020-12 with additionalProperties:false and unevaluatedProperties:false on root and $defs/dimension \u2014 strict closure verified",
-    "All guard flags const-pinned false (matrix_complete, pr_xfinal_open_allowed, support_widening, production_platform_claim, live_adapter_execution); operator_bound_supersession_required const true \u2014 no flip possible under blocker v1",
-    "Dimension status enum restricted to not_ready|partial \u2014 ready claim structurally rejected by schema; test_schema_rejects_ready_dimension_claims_in_blocker_v1 covers all 9 dimensions",
-    "9 dimensions identity-pinned via contains/minContains/maxContains allOf + minItems/maxItems 9 \u2014 cardinality and identity drift blocked at schema level",
-    "issue_refs pinned via prefixItems with items:false, minItems/maxItems 4, uniqueItems true \u2014 no injection of extra refs",
-    "Test suite covers 9 invariant categories: schema validity+strictness, fixture validation+closed-gate pins, guard-flip rejection (6 fields), ready-claim rejection (9 dimensions), cardinality/id drift+extra-field rejection, doc cross-references (3 docs), forbidden production-claim token scan, source document+evidence ref existence, issue ref binding",
-    "No secret-like material in diff \u2014 no API keys, tokens, credentials, or env var values detected",
-    "CHANGELOG entry correctly scoped as Gate C blocker infrastructure only with explicit non-authority enumeration",
-    "V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md non-authority boundary section lists six forbidden actions matching existing xfinal blocker pattern",
-    "EPIC-9-FINAL-SUPERSESSION-PR.md update adds production matrix blocker cross-reference and Gate C tracking detail without changing any guard flag or authority boundary",
-    "Scope matches E-9-1 work package \u2014 no workflow mutation, no ruleset change, no runtime code change, no support widening, no production claim, no provider HTTP call",
-    "Advisory: local-ai-review-evidence.v1.json at repo root is a duplicate of ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json \u2014 consider consolidating to single location to avoid drift",
-    "Advisory: openai.local-ai-review-evidence.v1.json lists same-provider reviewer (openai-reviewer/openai) as implementer (codex/openai); cross-provider coverage satisfied by this anthropic review"
+    "Anthropic reviewer verdict AGREE: no blocking issue in the V5 E-9-1 security/SBOM/license preflight evidence bundle.",
+    "Fail-closed guard state verified: schema and fixture pin final_release_bound=false, support_widening=false, production_platform_claim=false, and live_adapter_execution=false.",
+    "Matrix linkage verified: security_sbom_license_scans remains partial and links the new preflight bundle while final release-bound SBOM/license/security evidence remains missing.",
+    "Schema strictness verified: Draft 2020-12 schema closes object nodes with additionalProperties=false and unevaluatedProperties=false.",
+    "No workflow, ruleset, runtime, release, tag, publish, support widening, production claim, or live adapter execution mutation observed.",
+    "Tests considered: python3 -m pytest tests/test_v5_security_sbom_license_preflight_bundle.py tests/test_v5_production_readiness_matrix_blocker.py tests/test_sbom_generation.py tests/test_license_compliance.py -q => 79 passed, 1 skipped.",
+    "Secret scan considered: gitleaks over the working diff reported no leaks."
   ],
   "implementer": {
     "agent": "codex",
@@ -40,17 +34,18 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/EPIC-9-FINAL-SUPERSESSION-PR.md",
       ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
+      ".claude/plans/V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/v5-production-readiness-matrix-blocker.schema.v1.json",
+      "ao_kernel/defaults/schemas/v5-security-sbom-license-preflight-bundle.schema.v1.json",
       "local-ai-review-evidence.v1.json",
       "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/test_v5_production_readiness_matrix_blocker.py"
+      "tests/fixtures/epic9/v5-security-sbom-license-preflight.current.json",
+      "tests/test_v5_security_sbom_license_preflight_bundle.py"
     ],
-    "head_ref": "refs/heads/codex/v5-production-readiness-matrix-blocker"
+    "head_ref": "refs/heads/codex/v5-security-sbom-license-preflight-bundle"
   },
   "secrets_recorded": false,
   "support_widening": false,

--- a/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
+++ b/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
@@ -108,6 +108,8 @@
       "current_evidence_refs": [
         ".github/workflows/codeql.yml",
         ".github/workflows/trivy.yml",
+        ".claude/plans/V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md",
+        "tests/fixtures/epic9/v5-security-sbom-license-preflight.current.json",
         "docs/KNOWN-BUGS.md"
       ],
       "missing_evidence": [

--- a/tests/fixtures/epic9/v5-security-sbom-license-preflight.current.json
+++ b/tests/fixtures/epic9/v5-security-sbom-license-preflight.current.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "v5_security_sbom_license_preflight_bundle.v1",
+  "artifact_kind": "v5_security_sbom_license_preflight_bundle",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "E-9-1",
+  "dimension": "security_sbom_license_scans",
+  "evidence_class": "preflight_current_state",
+  "final_release_bound": false,
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false,
+  "codeql": {
+    "workflow_path": ".github/workflows/codeql.yml",
+    "workflow_name": "CodeQL Security Analysis",
+    "status": "configured_advisory",
+    "required_check": false,
+    "security_events_write_permission": true,
+    "final_release_bound": false
+  },
+  "trivy": {
+    "workflow_path": ".github/workflows/trivy.yml",
+    "workflow_name": "Trivy Vulnerability Scan",
+    "status": "configured_advisory",
+    "required_check": false,
+    "security_events_write_permission": true,
+    "final_release_bound": false
+  },
+  "sbom": {
+    "generator_path": "scripts/generate_sbom.py",
+    "generator_test_path": "tests/test_sbom_generation.py",
+    "sample_fixture_path": "tests/fixtures/sample-sbom.cdx.json",
+    "cyclonedx_spec_version": "1.5",
+    "release_component_name": "ao-kernel",
+    "release_bound_artifact_present": false
+  },
+  "license_compliance": {
+    "policy_path": "docs/license-compliance/license-compliance-policy.v1.json",
+    "inventory_path": "docs/license-compliance/dependency-license-inventory.v1.json",
+    "inventory_schema_path": "ao_kernel/defaults/schemas/dependency-license-inventory.schema.v1.json",
+    "inventory_report_status": "review_required",
+    "deny_count": 0,
+    "review_count": 3,
+    "operator_review_required": true
+  },
+  "residual_missing_evidence": [
+    "final v5 release-bound SBOM artifact",
+    "final v5 release-bound license inventory generated from the release SBOM",
+    "final security scan evidence bundle bound to the PR-Xfinal merge candidate",
+    "operator disposition for review-required license entries"
+  ],
+  "issue_refs": [
+    "https://github.com/Halildeu/ao-kernel/issues/782",
+    "https://github.com/Halildeu/ao-kernel/issues/895"
+  ]
+}

--- a/tests/test_v5_security_sbom_license_preflight_bundle.py
+++ b/tests/test_v5_security_sbom_license_preflight_bundle.py
@@ -1,0 +1,159 @@
+"""V5 security/SBOM/license preflight bundle invariants.
+
+The bundle is current-state evidence for one production-readiness dimension.
+It is useful evidence, not final release authority: the schema pins final
+release binding and all three production guard flags false.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_NAME = "v5-security-sbom-license-preflight-bundle.schema.v1.json"
+SCHEMA_PATH = ROOT / "ao_kernel" / "defaults" / "schemas" / SCHEMA_NAME
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "epic9" / "v5-security-sbom-license-preflight.current.json"
+MATRIX_PATH = ROOT / "tests" / "fixtures" / "epic9" / "v5-production-readiness-matrix.current.json"
+DOC_PATH = ROOT / ".claude" / "plans" / "V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md"
+MATRIX_DOC_PATH = ROOT / ".claude" / "plans" / "V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md"
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", SCHEMA_NAME)
+
+
+def _fixture() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _matrix() -> dict[str, Any]:
+    return json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+
+
+def _valid(payload: dict[str, Any]) -> bool:
+    return not list(Draft202012Validator(_schema()).iter_errors(payload))
+
+
+def test_schema_present_valid_and_strict() -> None:
+    assert SCHEMA_PATH.is_file()
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$id"] == "urn:ao:v5-security-sbom-license-preflight-bundle:v1"
+
+    def object_nodes(node: Any) -> list[dict[str, Any]]:
+        nodes: list[dict[str, Any]] = []
+        if isinstance(node, dict):
+            if node.get("type") == "object":
+                nodes.append(node)
+            for value in node.values():
+                nodes.extend(object_nodes(value))
+        elif isinstance(node, list):
+            for value in node:
+                nodes.extend(object_nodes(value))
+        return nodes
+
+    for node in object_nodes(schema):
+        assert node.get("additionalProperties") is False
+        assert node.get("unevaluatedProperties") is False
+
+
+def test_current_fixture_validates_and_pins_non_authority_state() -> None:
+    payload = _fixture()
+    assert _valid(payload)
+    assert payload["dimension"] == "security_sbom_license_scans"
+    assert payload["evidence_class"] == "preflight_current_state"
+    assert payload["final_release_bound"] is False
+    assert payload["support_widening"] is False
+    assert payload["production_platform_claim"] is False
+    assert payload["live_adapter_execution"] is False
+
+
+def test_schema_rejects_final_release_or_guard_flip_claims() -> None:
+    for field, value in (
+        ("final_release_bound", True),
+        ("support_widening", True),
+        ("production_platform_claim", True),
+        ("live_adapter_execution", True),
+    ):
+        payload = _fixture()
+        payload[field] = value
+        assert not _valid(payload), f"{field}={value!r} must fail closed"
+
+
+def test_security_workflow_refs_exist_and_are_advisory() -> None:
+    for key in ("codeql", "trivy"):
+        workflow = _fixture()[key]
+        path = ROOT / workflow["workflow_path"]
+        assert path.is_file()
+        text = path.read_text(encoding="utf-8")
+        assert workflow["status"] == "configured_advisory"
+        assert workflow["required_check"] is False
+        assert workflow["security_events_write_permission"] is True
+        assert "security-events: write" in text
+        assert "pull_request:" in text
+
+    assert "exit-code: \"0\"" in (ROOT / ".github/workflows/trivy.yml").read_text(encoding="utf-8")
+    assert "advisory" in (ROOT / ".github/workflows/codeql.yml").read_text(encoding="utf-8").lower()
+
+
+def test_sbom_and_license_refs_exist_and_match_current_inventory() -> None:
+    payload = _fixture()
+    for path_key in ("generator_path", "generator_test_path", "sample_fixture_path"):
+        assert (ROOT / payload["sbom"][path_key]).is_file()
+
+    for path_key in ("policy_path", "inventory_path", "inventory_schema_path"):
+        assert (ROOT / payload["license_compliance"][path_key]).is_file()
+
+    inventory = json.loads((ROOT / payload["license_compliance"]["inventory_path"]).read_text(encoding="utf-8"))
+    summary = inventory["summary"]
+    assert inventory["report_status"] == payload["license_compliance"]["inventory_report_status"]
+    assert summary["deny_count"] == payload["license_compliance"]["deny_count"]
+    assert summary["review_count"] == payload["license_compliance"]["review_count"]
+    assert payload["license_compliance"]["operator_review_required"] is True
+
+
+def test_residual_missing_evidence_keeps_pr_xfinal_blocked() -> None:
+    missing = _fixture()["residual_missing_evidence"]
+    assert "final v5 release-bound SBOM artifact" in missing
+    assert any("license inventory" in item for item in missing)
+    assert any("PR-Xfinal" in item for item in missing)
+    assert any("operator disposition" in item for item in missing)
+
+
+def test_matrix_references_security_preflight_bundle_but_stays_partial() -> None:
+    dimensions = {dimension["id"]: dimension for dimension in _matrix()["dimensions"]}
+    security = dimensions["security_sbom_license_scans"]
+    assert security["status"] == "partial"
+    assert "tests/fixtures/epic9/v5-security-sbom-license-preflight.current.json" in security[
+        "current_evidence_refs"
+    ]
+    assert "final v5 release-bound SBOM artifact" in security["missing_evidence"]
+    assert _matrix()["matrix_complete"] is False
+    assert _matrix()["production_platform_claim"] is False
+
+
+def test_docs_reference_bundle_without_positive_claim_tokens() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    matrix_doc = MATRIX_DOC_PATH.read_text(encoding="utf-8")
+    assert SCHEMA_NAME in doc
+    assert "v5-security-sbom-license-preflight.current.json" in doc
+    assert "security/SBOM/license preflight bundle" in matrix_doc
+
+    lowered = doc.lower()
+    forbidden = (
+        "production-ready",
+        "production ready",
+        "support_widening=true",
+        "production_platform_claim=true",
+        "live_adapter_execution=true",
+        "final_release_bound=true",
+    )
+    for token in forbidden:
+        assert token not in lowered, f"preflight doc must not include positive claim token: {token}"


### PR DESCRIPTION
## Summary

Adds a V5 E-9-1 security/SBOM/license preflight evidence bundle for the `security_sbom_license_scans` production-readiness dimension.

This is current-state preflight evidence only. It does not authorize PR-Xfinal, support widening, production platform claims, live adapter execution, release tagging, or publishing.

## Changed

- Add `.claude/plans/V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md`
- Add strict `v5-security-sbom-license-preflight-bundle.schema.v1.json`
- Add current fixture `tests/fixtures/epic9/v5-security-sbom-license-preflight.current.json`
- Add invariant test coverage for fail-closed guard flags, schema strictness, workflow refs, SBOM/license refs, residual missing evidence, and matrix linkage
- Link the bundle into the V5 production readiness matrix while keeping `security_sbom_license_scans` partial
- Update `CHANGELOG.md`
- Refresh local/high-risk AI review evidence for E-9-1

## Validation

- `python3 -m pytest tests/test_v5_security_sbom_license_preflight_bundle.py tests/test_v5_production_readiness_matrix_blocker.py tests/test_sbom_generation.py tests/test_license_compliance.py -q` -> 79 passed, 1 skipped
- `python3 scripts/gpp_next.py` -> GPP-9 closed; `support_widening_allowed=false`, `production_platform_claim_allowed=false`, `live_adapter_execution_allowed=false`
- `git diff --check` -> clean
- `gitleaks` over diff -> no leaks
- `scripts/local_gpp_gate.py` -> `operator_may_merge`, `changed_files_count=10`, `diff_digest=sha256:9c7e5fa4a1055b5821bacbd5bfcedef4a253fdfd31cb9c0f210e55c2f95ca4f5`
- `scripts/ao_ma10_high_risk_supersession_evidence.py` -> consensus `AGREE`; required providers OpenAI + Anthropic

## Cross-provider review

- Anthropic Claude reviewer: AGREE
- OpenAI Kepler reviewer: AGREE

## Guard boundary

No workflow/ruleset/runtime mutation. No release/tag/publish. No support widening. No production platform claim. No live adapter execution.

