### PR TITLE
feat(epic9): add V5 public support matrix preflight bundle

### DIFF
--- a/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
+++ b/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
@@ -32,7 +32,7 @@ The V5 production readiness matrix is **not complete**.
 
 | Dimension | Current status | Reason PR-Xfinal remains blocked |
 |---|---|---|
-| public support matrix | partial | final v5 public support tier and claim-language sync missing |
+| public support matrix | partial | current support-boundary preflight bundle exists; final v5 public support tier and claim-language sync missing |
 | protected real provider live calls | not_ready | 7-day live window and protected environment evidence missing |
 | cost/rate/circuit breaker evidence | partial | live cost/breach/rollback evidence missing |
 | observability production tunables | partial | final claim-bound observability/alerting evidence missing |
@@ -59,6 +59,16 @@ the only safe action is evidence collection under the existing issue refs:
 - `#895` all-or-none PR-Xfinal.
 
 ## Current Evidence Bundle Cross-Refs
+
+The `public_support_matrix` dimension now has a current-state public support
+matrix preflight bundle:
+
+- `.claude/plans/V5-PUBLIC-SUPPORT-MATRIX-PREFLIGHT-BUNDLE.md`
+- `tests/fixtures/epic9/v5-public-support-matrix-preflight.current.json`
+
+This public support matrix preflight bundle binds the existing public support boundary, support surface
+inventory, and residual PR-Xfinal support-widening gaps without treating them
+as final promoted public support.
 
 The `security_sbom_license_scans` dimension now has a current-state
 security/SBOM/license preflight bundle:

--- a/.claude/plans/V5-PUBLIC-SUPPORT-MATRIX-PREFLIGHT-BUNDLE.md
+++ b/.claude/plans/V5-PUBLIC-SUPPORT-MATRIX-PREFLIGHT-BUNDLE.md
@@ -1,0 +1,66 @@
+# V5 Public Support Matrix Preflight Bundle
+
+**Status:** current-state preflight / not promotion authority
+**Work package:** E-9-1
+**Dimension:** `public_support_matrix`
+**Parent blocker:** `.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md`
+**Schema:** `ao_kernel/defaults/schemas/v5-public-support-matrix-preflight-bundle.schema.v1.json`
+**Fixture:** `tests/fixtures/epic9/v5-public-support-matrix-preflight.current.json`
+
+This bundle records the existing support-boundary documents that a future
+PR-Xfinal must supersede before any public support tier is promoted. It binds
+the current narrow stable boundary, the beta/operator-managed lanes, and the
+surface inventory into one machine-checkable current-state artifact.
+
+## Non-Authority Boundary
+
+This document and fixture do not authorize:
+
+- support widening;
+- public claim language changes;
+- live adapter execution;
+- PR-Xfinal opening;
+- v5.0.0 tag or publish;
+- release notes or public support tier promotion.
+
+The fixture pins `final_release_bound=false`, `support_widening=false`,
+`production_platform_claim=false`, and `live_adapter_execution=false`.
+
+## Current Evidence
+
+The current public support boundary is recorded across:
+
+- `docs/PUBLIC-BETA.md`
+- `docs/SUPPORT-BOUNDARY.md`
+- `docs/SUPPORT-SURFACE-INVENTORY.md`
+
+The stable boundary remains the shipped baseline layer only. Beta,
+operator-managed, deferred, contract inventory, and example-only surfaces are
+visible as support-boundary context, not as promoted public support.
+
+## Surface Inventory
+
+The preflight fixture records the five support-widening surface classes that a
+future PR-Xfinal would have to evaluate:
+
+| Surface class | Current state | Future evidence requirement |
+|---|---|---|
+| `provider` | inventory or existing boundary only | provider live integration evidence |
+| `python_version` | inventory or existing boundary only | full test matrix for every promoted version |
+| `os_platform` | inventory or existing boundary only | smoke evidence for every promoted OS or architecture |
+| `db_backend` | inventory or existing boundary only | backend round-trip evidence on the test corpus |
+| `deployment_topology` | inventory or existing boundary only | deployment and isolation evidence for every promoted topology |
+
+All future widening evidence remains operator-bound and PR-Xfinal-bound.
+
+## Residual Missing Evidence
+
+PR-Xfinal remains blocked until at least these are complete:
+
+1. final v5.0.0 public support matrix with promoted support tier;
+2. operator-authorized public claim language sync;
+3. support-widening live evidence pack under issue `#776`;
+4. PR-Xfinal all-or-none authorization for support widening and production platform claim.
+
+Until those are available, the V5 production readiness matrix must keep
+`public_support_matrix` at `partial`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **V5 public support matrix preflight bundle** (V5 Epic 9, #895): added
+  `V5-PUBLIC-SUPPORT-MATRIX-PREFLIGHT-BUNDLE.md`,
+  `v5-public-support-matrix-preflight-bundle.schema.v1.json`, and a
+  current-state fixture/test suite that binds `PUBLIC-BETA.md`,
+  `SUPPORT-BOUNDARY.md`, and `SUPPORT-SURFACE-INVENTORY.md` to the
+  `public_support_matrix` production-readiness dimension. This is preflight
+  evidence only: final v5 public support tier, public claim language sync, and
+  support-widening live evidence remain missing, while `support_widening` /
+  `production_platform_claim` / `live_adapter_execution` remain false.
 - **V5 security/SBOM/license preflight bundle** (V5 Epic 9, #895): added
   `V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md`,
   `v5-security-sbom-license-preflight-bundle.schema.v1.json`, and a

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -7,16 +7,23 @@
     {
       "name": "secret_scan",
       "status": "pass"
+    },
+    {
+      "name": "guard_invariants",
+      "status": "pass"
+    },
+    {
+      "name": "scope_alignment",
+      "status": "pass"
     }
   ],
   "findings": [
-    "Anthropic reviewer verdict AGREE: no blocking issue in the V5 E-9-1 security/SBOM/license preflight evidence bundle.",
-    "Fail-closed guard state verified: final_release_bound=false, support_widening=false, production_platform_claim=false, and live_adapter_execution=false are schema/fixture/test pinned.",
-    "No production claim: document and changelog state preflight evidence only, and residual final release-bound evidence remains visible.",
-    "No live adapter execution or runtime/provider HTTP call is introduced.",
-    "Schema strictness verified: object nodes close additionalProperties and unevaluatedProperties.",
-    "Matrix linkage verified: security_sbom_license_scans remains partial and references the preflight bundle.",
-    "Secret exposure review found no credential, token, API key, webhook secret, or private key material in the diff."
+    "Anthropic reviewer verdict AGREE: no blocking issue in the V5 E-9-1 public support matrix preflight bundle.",
+    "Schema strictness and fixture validation are pinned by tests; object nodes close additionalProperties and unevaluatedProperties.",
+    "The bundle links PUBLIC-BETA, SUPPORT-BOUNDARY, and SUPPORT-SURFACE-INVENTORY without widening public support.",
+    "Matrix linkage is correct: public_support_matrix gains current evidence refs while status remains partial and PR-Xfinal remains blocked.",
+    "No production-ready claim, support-widening authorization, live adapter execution, v5.0.0 tag, publish, or release authority change is introduced.",
+    "Local validation considered: 26 passed, 1 skipped; secret scan passed; guard invariants passed."
   ],
   "implementer": {
     "agent": "codex",
@@ -26,7 +33,7 @@
   "production_platform_claim": false,
   "repo": "Halildeu/ao-kernel",
   "reviewer": {
-    "agent": "claude-opus-4-6-anthropic-reviewer",
+    "agent": "claude-sonnet-4-6-anthropic-reviewer",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
@@ -35,17 +42,17 @@
     "base_ref": "refs/heads/main",
     "changed_files": [
       ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
-      ".claude/plans/V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md",
+      ".claude/plans/V5-PUBLIC-SUPPORT-MATRIX-PREFLIGHT-BUNDLE.md",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/v5-security-sbom-license-preflight-bundle.schema.v1.json",
+      "ao_kernel/defaults/schemas/v5-public-support-matrix-preflight-bundle.schema.v1.json",
       "local-ai-review-evidence.v1.json",
       "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/fixtures/epic9/v5-security-sbom-license-preflight.current.json",
-      "tests/test_v5_security_sbom_license_preflight_bundle.py"
+      "tests/fixtures/epic9/v5-public-support-matrix-preflight.current.json",
+      "tests/test_v5_public_support_matrix_preflight_bundle.py"
     ],
-    "head_ref": "refs/heads/codex/v5-security-sbom-license-preflight-bundle"
+    "head_ref": "refs/heads/codex/v5-public-support-matrix-preflight-bundle-wt"
   },
   "secrets_recorded": false,
   "support_widening": false,

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -7,16 +7,23 @@
     {
       "name": "secret_scan",
       "status": "pass"
+    },
+    {
+      "name": "guard_invariants",
+      "status": "pass"
+    },
+    {
+      "name": "scope_alignment",
+      "status": "pass"
     }
   ],
   "findings": [
-    "OpenAI reviewer verdict AGREE: no blocking issue in the V5 E-9-1 security/SBOM/license preflight evidence bundle.",
-    "Diff is limited to the intended preflight doc/schema/fixture/test, matrix blocker cross-reference, matrix fixture evidence refs, changelog entry, and review evidence files.",
-    "Fail-closed guard state verified: final_release_bound=false, support_widening=false, production_platform_claim=false, live_adapter_execution=false, matrix_complete=false, and production_platform_claim=false in the matrix.",
-    "Production claim and live adapter execution are not introduced; no workflow, ruleset, runtime, release, tag, or publish mutation appears in the diff.",
-    "Matrix linkage is present: security_sbom_license_scans remains partial, links the new preflight doc/fixture, and still records final SBOM/license/security bundle residual gaps.",
-    "Tests considered: python3 -m pytest tests/test_v5_security_sbom_license_preflight_bundle.py tests/test_v5_production_readiness_matrix_blocker.py => 18 passed.",
-    "Secret scan considered: gitleaks over the working diff reported no leaks."
+    "OpenAI reviewer verdict AGREE: V5 E-9-1 public support matrix preflight scope is aligned.",
+    "Current public support boundary is recorded as preflight evidence only; no promoted support tier is introduced.",
+    "Guard state remains fail-closed: support_widening=false, production_platform_claim=false, live_adapter_execution=false, and final_release_bound=false.",
+    "The V5 production readiness matrix keeps public_support_matrix partial and preserves residual PR-Xfinal blockers.",
+    "Schema, fixture, tests, and changelog are limited to current-state evidence and do not mutate workflow, ruleset, runtime, release, tag, or publish surfaces.",
+    "Local validation considered: targeted pytest passed, git diff whitespace check passed, and gitleaks over the diff reported no leaks."
   ],
   "implementer": {
     "agent": "codex",
@@ -35,17 +42,17 @@
     "base_ref": "refs/heads/main",
     "changed_files": [
       ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
-      ".claude/plans/V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md",
+      ".claude/plans/V5-PUBLIC-SUPPORT-MATRIX-PREFLIGHT-BUNDLE.md",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/v5-security-sbom-license-preflight-bundle.schema.v1.json",
+      "ao_kernel/defaults/schemas/v5-public-support-matrix-preflight-bundle.schema.v1.json",
       "local-ai-review-evidence.v1.json",
       "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/fixtures/epic9/v5-security-sbom-license-preflight.current.json",
-      "tests/test_v5_security_sbom_license_preflight_bundle.py"
+      "tests/fixtures/epic9/v5-public-support-matrix-preflight.current.json",
+      "tests/test_v5_public_support_matrix_preflight_bundle.py"
     ],
-    "head_ref": "refs/heads/codex/v5-security-sbom-license-preflight-bundle"
+    "head_ref": "refs/heads/codex/v5-public-support-matrix-preflight-bundle-wt"
   },
   "secrets_recorded": false,
   "support_widening": false,

--- a/ao_kernel/defaults/schemas/v5-public-support-matrix-preflight-bundle.schema.v1.json
+++ b/ao_kernel/defaults/schemas/v5-public-support-matrix-preflight-bundle.schema.v1.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:v5-public-support-matrix-preflight-bundle:v1",
+  "title": "V5 public support matrix preflight evidence bundle v1",
+  "description": "Current-state preflight bundle for the V5 public support matrix dimension. It records the existing support boundary documents and surface inventory while keeping final support-tier promotion and all production guard flags fail-closed.",
+  "type": "object",
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "repo",
+    "work_package",
+    "dimension",
+    "evidence_class",
+    "final_release_bound",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution",
+    "current_boundary",
+    "support_documents",
+    "surface_inventory",
+    "residual_missing_evidence",
+    "issue_refs"
+  ],
+  "properties": {
+    "schema_version": { "const": "v5_public_support_matrix_preflight_bundle.v1" },
+    "artifact_kind": { "const": "v5_public_support_matrix_preflight_bundle" },
+    "repo": { "const": "Halildeu/ao-kernel" },
+    "work_package": { "const": "E-9-1" },
+    "dimension": { "const": "public_support_matrix" },
+    "evidence_class": { "const": "preflight_current_state" },
+    "final_release_bound": { "const": false },
+    "support_widening": { "const": false },
+    "production_platform_claim": { "const": false },
+    "live_adapter_execution": { "const": false },
+    "current_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "stable_boundary_authority",
+        "stable_support_layer",
+        "stable_public_doc_version",
+        "support_widening_allowed",
+        "public_claim_widened",
+        "future_v5_support_matrix_present"
+      ],
+      "properties": {
+        "stable_boundary_authority": { "const": "docs/PUBLIC-BETA.md" },
+        "stable_support_layer": { "const": "shipped_baseline_only" },
+        "stable_public_doc_version": { "const": "v4.0.0" },
+        "support_widening_allowed": { "const": false },
+        "public_claim_widened": { "const": false },
+        "future_v5_support_matrix_present": { "const": false }
+      }
+    },
+    "support_documents": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "public_beta_path",
+        "support_boundary_path",
+        "support_surface_inventory_path"
+      ],
+      "properties": {
+        "public_beta_path": { "const": "docs/PUBLIC-BETA.md" },
+        "support_boundary_path": { "const": "docs/SUPPORT-BOUNDARY.md" },
+        "support_surface_inventory_path": { "const": "docs/SUPPORT-SURFACE-INVENTORY.md" }
+      }
+    },
+    "surface_inventory": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": { "$ref": "#/$defs/surface_dimension" },
+      "allOf": [
+        { "contains": { "properties": { "surface_class": { "const": "provider" } }, "required": ["surface_class"] }, "minContains": 1, "maxContains": 1 },
+        { "contains": { "properties": { "surface_class": { "const": "python_version" } }, "required": ["surface_class"] }, "minContains": 1, "maxContains": 1 },
+        { "contains": { "properties": { "surface_class": { "const": "os_platform" } }, "required": ["surface_class"] }, "minContains": 1, "maxContains": 1 },
+        { "contains": { "properties": { "surface_class": { "const": "db_backend" } }, "required": ["surface_class"] }, "minContains": 1, "maxContains": 1 },
+        { "contains": { "properties": { "surface_class": { "const": "deployment_topology" } }, "required": ["surface_class"] }, "minContains": 1, "maxContains": 1 }
+      ]
+    },
+    "residual_missing_evidence": {
+      "type": "array",
+      "minItems": 4,
+      "items": { "type": "string", "minLength": 1 },
+      "contains": { "const": "final v5.0.0 public support matrix with promoted support tier" }
+    },
+    "issue_refs": {
+      "type": "array",
+      "prefixItems": [
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/776" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/782" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/895" }
+      ],
+      "items": false,
+      "minItems": 3,
+      "maxItems": 3
+    }
+  },
+  "$defs": {
+    "surface_dimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "surface_class",
+        "current_state",
+        "future_widening_prerequisite",
+        "live_evidence_required",
+        "operator_authorization_required"
+      ],
+      "properties": {
+        "surface_class": {
+          "enum": [
+            "provider",
+            "python_version",
+            "os_platform",
+            "db_backend",
+            "deployment_topology"
+          ]
+        },
+        "current_state": { "const": "inventory_only_or_existing_boundary" },
+        "future_widening_prerequisite": { "type": "string", "minLength": 1 },
+        "live_evidence_required": { "const": true },
+        "operator_authorization_required": { "const": true }
+      }
+    }
+  }
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -7,16 +7,23 @@
     {
       "name": "secret_scan",
       "status": "pass"
+    },
+    {
+      "name": "guard_invariants",
+      "status": "pass"
+    },
+    {
+      "name": "scope_alignment",
+      "status": "pass"
     }
   ],
   "findings": [
-    "Anthropic reviewer verdict AGREE: no blocking issue in the V5 E-9-1 security/SBOM/license preflight evidence bundle.",
-    "Fail-closed guard state verified: schema and fixture pin final_release_bound=false, support_widening=false, production_platform_claim=false, and live_adapter_execution=false.",
-    "Matrix linkage verified: security_sbom_license_scans remains partial and links the new preflight bundle while final release-bound SBOM/license/security evidence remains missing.",
-    "Schema strictness verified: Draft 2020-12 schema closes object nodes with additionalProperties=false and unevaluatedProperties=false.",
-    "No workflow, ruleset, runtime, release, tag, publish, support widening, production claim, or live adapter execution mutation observed.",
-    "Tests considered: python3 -m pytest tests/test_v5_security_sbom_license_preflight_bundle.py tests/test_v5_production_readiness_matrix_blocker.py tests/test_sbom_generation.py tests/test_license_compliance.py -q => 79 passed, 1 skipped.",
-    "Secret scan considered: gitleaks over the working diff reported no leaks."
+    "Anthropic reviewer verdict AGREE: no blocking issue in the V5 E-9-1 public support matrix preflight bundle.",
+    "Schema strictness and fixture validation are pinned by tests; object nodes close additionalProperties and unevaluatedProperties.",
+    "The bundle links PUBLIC-BETA, SUPPORT-BOUNDARY, and SUPPORT-SURFACE-INVENTORY without widening public support.",
+    "Matrix linkage is correct: public_support_matrix gains current evidence refs while status remains partial and PR-Xfinal remains blocked.",
+    "No production-ready claim, support-widening authorization, live adapter execution, v5.0.0 tag, publish, or release authority change is introduced.",
+    "Local validation considered: 26 passed, 1 skipped; secret scan passed; guard invariants passed."
   ],
   "implementer": {
     "agent": "codex",
@@ -26,7 +33,7 @@
   "production_platform_claim": false,
   "repo": "Halildeu/ao-kernel",
   "reviewer": {
-    "agent": "claude-opus-4-6-anthropic-reviewer",
+    "agent": "claude-sonnet-4-6-anthropic-reviewer",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
@@ -35,17 +42,17 @@
     "base_ref": "refs/heads/main",
     "changed_files": [
       ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
-      ".claude/plans/V5-SECURITY-SBOM-LICENSE-PREFLIGHT-BUNDLE.md",
+      ".claude/plans/V5-PUBLIC-SUPPORT-MATRIX-PREFLIGHT-BUNDLE.md",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/v5-security-sbom-license-preflight-bundle.schema.v1.json",
+      "ao_kernel/defaults/schemas/v5-public-support-matrix-preflight-bundle.schema.v1.json",
       "local-ai-review-evidence.v1.json",
       "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/fixtures/epic9/v5-security-sbom-license-preflight.current.json",
-      "tests/test_v5_security_sbom_license_preflight_bundle.py"
+      "tests/fixtures/epic9/v5-public-support-matrix-preflight.current.json",
+      "tests/test_v5_public_support_matrix_preflight_bundle.py"
     ],
-    "head_ref": "refs/heads/codex/v5-security-sbom-license-preflight-bundle"
+    "head_ref": "refs/heads/codex/v5-public-support-matrix-preflight-bundle-wt"
   },
   "secrets_recorded": false,
   "support_widening": false,

--- a/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
+++ b/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
@@ -21,7 +21,9 @@
       "current_evidence_refs": [
         "docs/SUPPORT-BOUNDARY.md",
         "docs/SUPPORT-SURFACE-INVENTORY.md",
-        "docs/PUBLIC-BETA.md"
+        "docs/PUBLIC-BETA.md",
+        ".claude/plans/V5-PUBLIC-SUPPORT-MATRIX-PREFLIGHT-BUNDLE.md",
+        "tests/fixtures/epic9/v5-public-support-matrix-preflight.current.json"
       ],
       "missing_evidence": [
         "final v5.0.0 public support matrix with promoted support tier",

--- a/tests/fixtures/epic9/v5-public-support-matrix-preflight.current.json
+++ b/tests/fixtures/epic9/v5-public-support-matrix-preflight.current.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "v5_public_support_matrix_preflight_bundle.v1",
+  "artifact_kind": "v5_public_support_matrix_preflight_bundle",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "E-9-1",
+  "dimension": "public_support_matrix",
+  "evidence_class": "preflight_current_state",
+  "final_release_bound": false,
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false,
+  "current_boundary": {
+    "stable_boundary_authority": "docs/PUBLIC-BETA.md",
+    "stable_support_layer": "shipped_baseline_only",
+    "stable_public_doc_version": "v4.0.0",
+    "support_widening_allowed": false,
+    "public_claim_widened": false,
+    "future_v5_support_matrix_present": false
+  },
+  "support_documents": {
+    "public_beta_path": "docs/PUBLIC-BETA.md",
+    "support_boundary_path": "docs/SUPPORT-BOUNDARY.md",
+    "support_surface_inventory_path": "docs/SUPPORT-SURFACE-INVENTORY.md"
+  },
+  "surface_inventory": [
+    {
+      "surface_class": "provider",
+      "current_state": "inventory_only_or_existing_boundary",
+      "future_widening_prerequisite": "provider live integration evidence and operator authorization under PR-Xfinal",
+      "live_evidence_required": true,
+      "operator_authorization_required": true
+    },
+    {
+      "surface_class": "python_version",
+      "current_state": "inventory_only_or_existing_boundary",
+      "future_widening_prerequisite": "full pytest matrix evidence for every promoted Python version under PR-Xfinal",
+      "live_evidence_required": true,
+      "operator_authorization_required": true
+    },
+    {
+      "surface_class": "os_platform",
+      "current_state": "inventory_only_or_existing_boundary",
+      "future_widening_prerequisite": "platform smoke evidence for every promoted OS or architecture under PR-Xfinal",
+      "live_evidence_required": true,
+      "operator_authorization_required": true
+    },
+    {
+      "surface_class": "db_backend",
+      "current_state": "inventory_only_or_existing_boundary",
+      "future_widening_prerequisite": "backend round-trip evidence on the test corpus under PR-Xfinal",
+      "live_evidence_required": true,
+      "operator_authorization_required": true
+    },
+    {
+      "surface_class": "deployment_topology",
+      "current_state": "inventory_only_or_existing_boundary",
+      "future_widening_prerequisite": "deployment and isolation evidence for every promoted topology under PR-Xfinal",
+      "live_evidence_required": true,
+      "operator_authorization_required": true
+    }
+  ],
+  "residual_missing_evidence": [
+    "final v5.0.0 public support matrix with promoted support tier",
+    "operator-authorized public claim language sync",
+    "support-widening live evidence pack under issue 776",
+    "PR-Xfinal all-or-none authorization for support widening and production platform claim"
+  ],
+  "issue_refs": [
+    "https://github.com/Halildeu/ao-kernel/issues/776",
+    "https://github.com/Halildeu/ao-kernel/issues/782",
+    "https://github.com/Halildeu/ao-kernel/issues/895"
+  ]
+}

--- a/tests/test_v5_public_support_matrix_preflight_bundle.py
+++ b/tests/test_v5_public_support_matrix_preflight_bundle.py
@@ -1,0 +1,194 @@
+"""V5 public support matrix preflight bundle invariants.
+
+The bundle is current-state evidence for one production-readiness dimension.
+It records the existing support boundary without widening support or promoting
+the public claim. Final authority remains PR-Xfinal.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_NAME = "v5-public-support-matrix-preflight-bundle.schema.v1.json"
+SCHEMA_PATH = ROOT / "ao_kernel" / "defaults" / "schemas" / SCHEMA_NAME
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "epic9" / "v5-public-support-matrix-preflight.current.json"
+MATRIX_PATH = ROOT / "tests" / "fixtures" / "epic9" / "v5-production-readiness-matrix.current.json"
+DOC_PATH = ROOT / ".claude" / "plans" / "V5-PUBLIC-SUPPORT-MATRIX-PREFLIGHT-BUNDLE.md"
+MATRIX_DOC_PATH = ROOT / ".claude" / "plans" / "V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md"
+
+
+EXPECTED_SURFACES = {
+    "provider",
+    "python_version",
+    "os_platform",
+    "db_backend",
+    "deployment_topology",
+}
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", SCHEMA_NAME)
+
+
+def _fixture() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _matrix() -> dict[str, Any]:
+    return json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+
+
+def _valid(payload: dict[str, Any]) -> bool:
+    return not list(Draft202012Validator(_schema()).iter_errors(payload))
+
+
+def test_schema_present_valid_and_strict() -> None:
+    assert SCHEMA_PATH.is_file()
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$id"] == "urn:ao:v5-public-support-matrix-preflight-bundle:v1"
+
+    def object_nodes(node: Any) -> list[dict[str, Any]]:
+        nodes: list[dict[str, Any]] = []
+        if isinstance(node, dict):
+            if node.get("type") == "object":
+                nodes.append(node)
+            for value in node.values():
+                nodes.extend(object_nodes(value))
+        elif isinstance(node, list):
+            for value in node:
+                nodes.extend(object_nodes(value))
+        return nodes
+
+    for node in object_nodes(schema):
+        assert node.get("additionalProperties") is False
+        assert node.get("unevaluatedProperties") is False
+
+
+def test_current_fixture_validates_and_pins_non_authority_state() -> None:
+    payload = _fixture()
+    assert _valid(payload)
+    assert payload["dimension"] == "public_support_matrix"
+    assert payload["evidence_class"] == "preflight_current_state"
+    assert payload["final_release_bound"] is False
+    assert payload["support_widening"] is False
+    assert payload["production_platform_claim"] is False
+    assert payload["live_adapter_execution"] is False
+    assert payload["current_boundary"]["stable_support_layer"] == "shipped_baseline_only"
+    assert payload["current_boundary"]["future_v5_support_matrix_present"] is False
+
+
+def test_schema_rejects_final_release_or_guard_flip_claims() -> None:
+    for field, value in (
+        ("final_release_bound", True),
+        ("support_widening", True),
+        ("production_platform_claim", True),
+        ("live_adapter_execution", True),
+    ):
+        payload = _fixture()
+        payload[field] = value
+        assert not _valid(payload), f"{field}={value!r} must fail closed"
+
+    payload = _fixture()
+    payload["current_boundary"]["support_widening_allowed"] = True
+    assert not _valid(payload)
+
+    payload = _fixture()
+    payload["current_boundary"]["public_claim_widened"] = True
+    assert not _valid(payload)
+
+    payload = _fixture()
+    payload["current_boundary"]["future_v5_support_matrix_present"] = True
+    assert not _valid(payload)
+
+
+def test_support_documents_exist_and_preserve_current_boundary_language() -> None:
+    payload = _fixture()
+    docs = payload["support_documents"]
+    public_beta = ROOT / docs["public_beta_path"]
+    support_boundary = ROOT / docs["support_boundary_path"]
+    support_inventory = ROOT / docs["support_surface_inventory_path"]
+    for path in (public_beta, support_boundary, support_inventory):
+        assert path.is_file()
+
+    public_beta_text = public_beta.read_text(encoding="utf-8")
+    support_boundary_text = support_boundary.read_text(encoding="utf-8")
+    support_inventory_text = support_inventory.read_text(encoding="utf-8")
+
+    assert "Stable Support Boundary" in public_beta_text
+    assert "Shipped (v4.0.0 stable)" in public_beta_text
+    assert "Beta" in public_beta_text
+    assert "Deferred" in public_beta_text
+    assert "does not claim ao-kernel is a general-purpose" in public_beta_text
+    assert "ST-2 stable boundary freeze" in support_boundary_text
+    assert "support_widening" in support_inventory_text
+    assert "announces no widening" in support_inventory_text
+
+
+def test_surface_inventory_matches_support_surface_inventory_document() -> None:
+    payload = _fixture()
+    surfaces = {item["surface_class"] for item in payload["surface_inventory"]}
+    assert surfaces == EXPECTED_SURFACES
+
+    inventory_text = (ROOT / payload["support_documents"]["support_surface_inventory_path"]).read_text(
+        encoding="utf-8"
+    )
+    for surface in EXPECTED_SURFACES:
+        assert f"`{surface}`" in inventory_text
+
+    for item in payload["surface_inventory"]:
+        assert item["current_state"] == "inventory_only_or_existing_boundary"
+        assert item["live_evidence_required"] is True
+        assert item["operator_authorization_required"] is True
+        assert item["future_widening_prerequisite"]
+
+
+def test_residual_missing_evidence_keeps_pr_xfinal_blocked() -> None:
+    missing = _fixture()["residual_missing_evidence"]
+    assert "final v5.0.0 public support matrix with promoted support tier" in missing
+    assert any("operator-authorized public claim" in item for item in missing)
+    assert any("issue 776" in item for item in missing)
+    assert any("PR-Xfinal" in item for item in missing)
+
+
+def test_matrix_references_public_support_preflight_bundle_but_stays_partial() -> None:
+    dimensions = {dimension["id"]: dimension for dimension in _matrix()["dimensions"]}
+    public_support = dimensions["public_support_matrix"]
+    assert public_support["status"] == "partial"
+    assert "tests/fixtures/epic9/v5-public-support-matrix-preflight.current.json" in public_support[
+        "current_evidence_refs"
+    ]
+    assert "final v5.0.0 public support matrix with promoted support tier" in public_support[
+        "missing_evidence"
+    ]
+    assert _matrix()["matrix_complete"] is False
+    assert _matrix()["support_widening"] is False
+    assert _matrix()["production_platform_claim"] is False
+
+
+def test_docs_reference_bundle_without_positive_claim_tokens() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    matrix_doc = MATRIX_DOC_PATH.read_text(encoding="utf-8")
+    assert SCHEMA_NAME in doc
+    assert "v5-public-support-matrix-preflight.current.json" in doc
+    assert "public support matrix preflight bundle" in matrix_doc
+
+    lowered = doc.lower()
+    forbidden = (
+        "production-ready",
+        "production ready",
+        "support_widening=true",
+        "production_platform_claim=true",
+        "live_adapter_execution=true",
+        "final_release_bound=true",
+    )
+    for token in forbidden:
+        assert token not in lowered, f"preflight doc must not include positive claim token: {token}"


### PR DESCRIPTION
## Summary

- Add the V5 public support matrix preflight bundle for Epic 9 / PR-Xfinal preparation.
- Add a strict Draft 2020-12 schema, current-state fixture, and invariant tests for `public_support_matrix`.
- Link the new bundle into the existing V5 production readiness matrix while keeping that dimension `partial`.
- Refresh local and AO-MA-10 high-risk review evidence for this exact diff scope.

## Authority Boundary

This PR is preflight/current-state evidence only. It does **not** authorize:

- support widening
- production platform claim
- live adapter execution
- PR-Xfinal opening
- v5.0.0 tag or publish
- workflow, ruleset, branch-protection, runtime, or release-surface mutation

Guard state remains false:

- `support_widening=false`
- `production_platform_claim=false`
- `live_adapter_execution=false`
- `final_release_bound=false`

## Validation

- `bash .claude/scripts/ops.sh preflight` -> branch fresh; dirty warning only before commit
- `python3 -m pytest tests/test_v5_public_support_matrix_preflight_bundle.py tests/test_v5_production_readiness_matrix_blocker.py tests/test_support_surface_inventory_doc.py -q` -> 26 passed, 1 skipped
- `git diff --check HEAD~1..HEAD` -> pass
- `gitleaks stdin` over `origin/main..HEAD` diff -> no leaks
- `python3 scripts/local_gpp_gate.py ...` -> `operator_may_merge`
- `python3 scripts/ao_ma10_high_risk_supersession_evidence.py ...` -> generated successfully
- `python3 scripts/gpp_next.py` -> GPP-9 closed; guard flags false; no blocked WPs

## Cross-AI Review

- OpenAI / Kepler reviewer: AGREE
- Anthropic / Claude reviewer: AGREE

AI output is evidence only. Release authority remains the repo-owned `ao-release-gate` required check plus GitHub ruleset.
