### PR TITLE
feat(epic9): add V5 observability preflight bundle

### DIFF
--- a/.claude/plans/V5-OBSERVABILITY-PRODUCTION-TUNABLES-PREFLIGHT-BUNDLE.md
+++ b/.claude/plans/V5-OBSERVABILITY-PRODUCTION-TUNABLES-PREFLIGHT-BUNDLE.md
@@ -1,0 +1,51 @@
+# V5 Observability Production Tunables Preflight Bundle
+
+**Status:** current-state preflight evidence / not final release authority
+**Work package:** E-9-1
+**Parent matrix:** `.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md`
+**Schema:** `ao_kernel/defaults/schemas/v5-observability-production-tunables-preflight-bundle.schema.v1.json`
+**Fixture:** `tests/fixtures/epic9/v5-observability-production-tunables-preflight.current.json`
+
+This document records the current state of the
+`observability_production_tunables` dimension in the V5
+production-readiness matrix. It binds the committed Grafana dashboard,
+SLI/SLO catalog, and performance policy artifacts into one
+machine-checkable preflight artifact.
+
+## Non-Authority Boundary
+
+This bundle does not authorize:
+
+- support widening;
+- production platform claims;
+- live adapter execution;
+- final release tagging or publishing;
+- opening PR-Xfinal;
+- treating advisory dashboard, SLI, or performance policy artifacts as final
+  claim-bound smoke evidence.
+
+The current bundle pins `final_release_bound=false`,
+`support_widening=false`, `production_platform_claim=false`, and
+`live_adapter_execution=false`.
+
+## Current Preflight Evidence
+
+| Surface | Current evidence | Boundary |
+|---|---|---|
+| Grafana dashboard | `docs/grafana/ao_kernel_default.v1.json`, `docs/grafana/README.md`, `tests/test_grafana_dashboard_shape.py` | 8-panel Prometheus dashboard shape is pinned; import/runtime smoke is not final claim-bound evidence |
+| SLI/SLO catalog | `docs/sli-catalog.v1.json`, `docs/SLI-SLO.md`, `tests/test_sli_slo_catalog.py` | 6 indicators exist; uptime remains out of scope and all catalog guard flags remain false |
+| Performance policy | `docs/performance/README.md`, `docs/performance/baseline.v1.json`, `docs/performance/performance-regression-threshold.v1.json`, `tests/test_performance_baseline.py` | advisory single-run candidate baseline; not a blocking final-release performance gate |
+
+## Residual Missing Evidence
+
+PR-Xfinal remains blocked for this dimension until a later operator-bound
+supersession provides:
+
+- final claim-bound observability smoke;
+- alerting or escalation evidence for the promoted tier;
+- operator-authorized observability runbook sync bound to PR-Xfinal;
+- production-like dashboard import and SLI evaluation evidence bound to the
+  final merge candidate.
+
+This is intentionally a preflight artifact. It makes the existing
+observability surface auditable without changing the production claim gate.

--- a/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
+++ b/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
@@ -35,7 +35,7 @@ The V5 production readiness matrix is **not complete**.
 | public support matrix | partial | current support-boundary preflight bundle exists; final v5 public support tier and claim-language sync missing |
 | protected real provider live calls | not_ready | 7-day live window and protected environment evidence missing |
 | cost/rate/circuit breaker evidence | partial | live cost/breach/rollback evidence missing |
-| observability production tunables | partial | final claim-bound observability/alerting evidence missing |
+| observability production tunables | partial | current observability preflight bundle exists; final claim-bound observability/alerting evidence missing |
 | security/SBOM/license scans | partial | current preflight bundle exists; final release-bound SBOM/license/security bundle missing |
 | install/deploy lifecycle smoke | partial | v5.0.0 tag/publish and release-artifact smoke missing |
 | multi-tenancy isolation | not_ready | tenant isolation and per-tenant quota/cost evidence missing |
@@ -78,3 +78,13 @@ security/SBOM/license preflight bundle:
 
 That bundle binds CodeQL, Trivy, SBOM tooling, and license inventory evidence
 without treating them as final release-bound evidence.
+
+The `observability_production_tunables` dimension now has a current-state
+observability production tunables preflight bundle:
+
+- `.claude/plans/V5-OBSERVABILITY-PRODUCTION-TUNABLES-PREFLIGHT-BUNDLE.md`
+- `tests/fixtures/epic9/v5-observability-production-tunables-preflight.current.json`
+
+That bundle binds Grafana dashboard shape, SLI/SLO catalog discipline, and
+advisory performance policy evidence without treating them as final
+claim-bound observability smoke or alert escalation evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **V5 observability production tunables preflight bundle** (V5 Epic 9,
+  #895): added `V5-OBSERVABILITY-PRODUCTION-TUNABLES-PREFLIGHT-BUNDLE.md`,
+  `v5-observability-production-tunables-preflight-bundle.schema.v1.json`, and
+  a current-state fixture/test suite that binds Grafana dashboard shape,
+  SLI/SLO catalog discipline, and advisory performance policy evidence to the
+  `observability_production_tunables` production-readiness dimension. This is
+  preflight evidence only: final claim-bound observability smoke,
+  alert/escalation evidence, and PR-Xfinal runbook sync remain missing while
+  `support_widening` / `production_platform_claim` / `live_adapter_execution`
+  remain false.
 - **V5 public support matrix preflight bundle** (V5 Epic 9, #895): added
   `V5-PUBLIC-SUPPORT-MATRIX-PREFLIGHT-BUNDLE.md`,
   `v5-public-support-matrix-preflight-bundle.schema.v1.json`, and a

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -18,12 +18,12 @@
     }
   ],
   "findings": [
-    "Anthropic reviewer verdict AGREE: no blocking issue in the V5 E-9-1 public support matrix preflight bundle.",
-    "Schema strictness and fixture validation are pinned by tests; object nodes close additionalProperties and unevaluatedProperties.",
-    "The bundle links PUBLIC-BETA, SUPPORT-BOUNDARY, and SUPPORT-SURFACE-INVENTORY without widening public support.",
-    "Matrix linkage is correct: public_support_matrix gains current evidence refs while status remains partial and PR-Xfinal remains blocked.",
-    "No production-ready claim, support-widening authorization, live adapter execution, v5.0.0 tag, publish, or release authority change is introduced.",
-    "Local validation considered: 26 passed, 1 skipped; secret scan passed; guard invariants passed."
+    "Anthropic reviewer verdict AGREE: no blocking issue in the V5 E-9-1 observability production tunables preflight bundle.",
+    "Schema strictness is adequate: root and nested object nodes close additionalProperties and unevaluatedProperties.",
+    "Fixture validates and preserves preflight_current_state semantics; residual PR-Xfinal observability evidence remains missing.",
+    "Tests cover guard flips, schema strictness, fixture validation, Grafana, SLI/SLO, performance policy, matrix linkage, and positive-claim token discipline.",
+    "The V5 matrix keeps observability_production_tunables partial and preserves matrix_complete=false.",
+    "No support widening, production platform claim, live adapter execution, v5 tag, publish, workflow, ruleset, runtime, or release authority change is introduced."
   ],
   "implementer": {
     "agent": "codex",
@@ -41,18 +41,18 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
+      ".claude/plans/V5-OBSERVABILITY-PRODUCTION-TUNABLES-PREFLIGHT-BUNDLE.md",
       ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
-      ".claude/plans/V5-PUBLIC-SUPPORT-MATRIX-PREFLIGHT-BUNDLE.md",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/v5-public-support-matrix-preflight-bundle.schema.v1.json",
+      "ao_kernel/defaults/schemas/v5-observability-production-tunables-preflight-bundle.schema.v1.json",
       "local-ai-review-evidence.v1.json",
+      "tests/fixtures/epic9/v5-observability-production-tunables-preflight.current.json",
       "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/fixtures/epic9/v5-public-support-matrix-preflight.current.json",
-      "tests/test_v5_public_support_matrix_preflight_bundle.py"
+      "tests/test_v5_observability_production_tunables_preflight_bundle.py"
     ],
-    "head_ref": "refs/heads/codex/v5-public-support-matrix-preflight-bundle-wt"
+    "head_ref": "refs/heads/codex/v5-observability-preflight-bundle"
   },
   "secrets_recorded": false,
   "support_widening": false,

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -18,16 +18,17 @@
     }
   ],
   "findings": [
-    "OpenAI reviewer verdict AGREE: V5 E-9-1 public support matrix preflight scope is aligned.",
-    "Current public support boundary is recorded as preflight evidence only; no promoted support tier is introduced.",
-    "Guard state remains fail-closed: support_widening=false, production_platform_claim=false, live_adapter_execution=false, and final_release_bound=false.",
-    "The V5 production readiness matrix keeps public_support_matrix partial and preserves residual PR-Xfinal blockers.",
-    "Schema, fixture, tests, and changelog are limited to current-state evidence and do not mutate workflow, ruleset, runtime, release, tag, or publish surfaces.",
-    "Local validation considered: targeted pytest passed, git diff whitespace check passed, and gitleaks over the diff reported no leaks."
+    "OpenAI reviewer verdict AGREE: V5 E-9-1 observability preflight scope is aligned.",
+    "The 7-file slice plus 3 review evidence files is current-state observability evidence only.",
+    "Schema is strict and pins final_release_bound=false plus support_widening=false, production_platform_claim=false, and live_adapter_execution=false.",
+    "Sub-claim guards fail closed for alert/escalation evidence, CI-blocking performance enforcement, and Grafana final-claim binding.",
+    "Matrix linkage is correct: observability_production_tunables stays partial and matrix_complete remains false.",
+    "No workflow, ruleset, runtime, release, tag, publish, or PR-Xfinal surface is changed.",
+    "Local validation considered: targeted pytest passed, JSON parse passed, git diff whitespace check passed, guard invariants passed, and secret scan over the diff passed."
   ],
   "implementer": {
     "agent": "codex",
-    "provider": "openai"
+    "kind": "human"
   },
   "live_adapter_execution": false,
   "production_platform_claim": false,
@@ -41,18 +42,18 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
+      ".claude/plans/V5-OBSERVABILITY-PRODUCTION-TUNABLES-PREFLIGHT-BUNDLE.md",
       ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
-      ".claude/plans/V5-PUBLIC-SUPPORT-MATRIX-PREFLIGHT-BUNDLE.md",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/v5-public-support-matrix-preflight-bundle.schema.v1.json",
+      "ao_kernel/defaults/schemas/v5-observability-production-tunables-preflight-bundle.schema.v1.json",
       "local-ai-review-evidence.v1.json",
+      "tests/fixtures/epic9/v5-observability-production-tunables-preflight.current.json",
       "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/fixtures/epic9/v5-public-support-matrix-preflight.current.json",
-      "tests/test_v5_public_support_matrix_preflight_bundle.py"
+      "tests/test_v5_observability_production_tunables_preflight_bundle.py"
     ],
-    "head_ref": "refs/heads/codex/v5-public-support-matrix-preflight-bundle-wt"
+    "head_ref": "refs/heads/codex/v5-observability-preflight-bundle"
   },
   "secrets_recorded": false,
   "support_widening": false,

--- a/ao_kernel/defaults/schemas/v5-observability-production-tunables-preflight-bundle.schema.v1.json
+++ b/ao_kernel/defaults/schemas/v5-observability-production-tunables-preflight-bundle.schema.v1.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:v5-observability-production-tunables-preflight-bundle:v1",
+  "title": "V5 observability production tunables preflight evidence bundle v1",
+  "description": "Current-state preflight bundle for the V5 observability production tunables dimension. It records existing Grafana, SLI/SLO, and performance policy evidence while keeping final claim-bound smoke, alert escalation evidence, and all production guard flags fail-closed.",
+  "type": "object",
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "repo",
+    "work_package",
+    "dimension",
+    "evidence_class",
+    "final_release_bound",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution",
+    "grafana_dashboard",
+    "sli_catalog",
+    "performance_policy",
+    "residual_missing_evidence",
+    "issue_refs"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "v5_observability_production_tunables_preflight_bundle.v1"
+    },
+    "artifact_kind": {
+      "const": "v5_observability_production_tunables_preflight_bundle"
+    },
+    "repo": {
+      "const": "Halildeu/ao-kernel"
+    },
+    "work_package": {
+      "const": "E-9-1"
+    },
+    "dimension": {
+      "const": "observability_production_tunables"
+    },
+    "evidence_class": {
+      "const": "preflight_current_state"
+    },
+    "final_release_bound": {
+      "const": false
+    },
+    "support_widening": {
+      "const": false
+    },
+    "production_platform_claim": {
+      "const": false
+    },
+    "live_adapter_execution": {
+      "const": false
+    },
+    "grafana_dashboard": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "dashboard_path",
+        "dashboard_readme_path",
+        "dashboard_shape_test_path",
+        "documented_panel_count",
+        "datasource_variable",
+        "advanced_overlay_required",
+        "final_claim_bound"
+      ],
+      "properties": {
+        "dashboard_path": {
+          "const": "docs/grafana/ao_kernel_default.v1.json"
+        },
+        "dashboard_readme_path": {
+          "const": "docs/grafana/README.md"
+        },
+        "dashboard_shape_test_path": {
+          "const": "tests/test_grafana_dashboard_shape.py"
+        },
+        "documented_panel_count": {
+          "const": 8
+        },
+        "datasource_variable": {
+          "const": "DS_PROMETHEUS"
+        },
+        "advanced_overlay_required": {
+          "const": false
+        },
+        "final_claim_bound": {
+          "const": false
+        }
+      }
+    },
+    "sli_catalog": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "catalog_path",
+        "catalog_schema_path",
+        "catalog_doc_path",
+        "catalog_test_path",
+        "indicator_count",
+        "hard_slo_count",
+        "advisory_sli_count",
+        "budget_objective_count",
+        "uptime_in_scope",
+        "operator_owned",
+        "contractual_sla",
+        "alerting_or_escalation_evidence_present"
+      ],
+      "properties": {
+        "catalog_path": {
+          "const": "docs/sli-catalog.v1.json"
+        },
+        "catalog_schema_path": {
+          "const": "ao_kernel/defaults/schemas/sli-catalog.schema.v1.json"
+        },
+        "catalog_doc_path": {
+          "const": "docs/SLI-SLO.md"
+        },
+        "catalog_test_path": {
+          "const": "tests/test_sli_slo_catalog.py"
+        },
+        "indicator_count": {
+          "const": 6
+        },
+        "hard_slo_count": {
+          "const": 3
+        },
+        "advisory_sli_count": {
+          "const": 2
+        },
+        "budget_objective_count": {
+          "const": 1
+        },
+        "uptime_in_scope": {
+          "const": false
+        },
+        "operator_owned": {
+          "const": true
+        },
+        "contractual_sla": {
+          "const": false
+        },
+        "alerting_or_escalation_evidence_present": {
+          "const": false
+        }
+      }
+    },
+    "performance_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "readme_path",
+        "baseline_path",
+        "threshold_path",
+        "scenario_catalog_path",
+        "performance_test_path",
+        "enforcement_mode",
+        "candidate_baseline",
+        "sample_count",
+        "final_claim_bound",
+        "ci_blocking_enforced"
+      ],
+      "properties": {
+        "readme_path": {
+          "const": "docs/performance/README.md"
+        },
+        "baseline_path": {
+          "const": "docs/performance/baseline.v1.json"
+        },
+        "threshold_path": {
+          "const": "docs/performance/performance-regression-threshold.v1.json"
+        },
+        "scenario_catalog_path": {
+          "const": "docs/performance/performance-scenario-catalog.v1.json"
+        },
+        "performance_test_path": {
+          "const": "tests/test_performance_baseline.py"
+        },
+        "enforcement_mode": {
+          "const": "advisory"
+        },
+        "candidate_baseline": {
+          "const": true
+        },
+        "sample_count": {
+          "const": 1
+        },
+        "final_claim_bound": {
+          "const": false
+        },
+        "ci_blocking_enforced": {
+          "const": false
+        }
+      }
+    },
+    "residual_missing_evidence": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "contains": {
+        "const": "final claim-bound observability smoke"
+      }
+    },
+    "issue_refs": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "https://github.com/Halildeu/ao-kernel/issues/782"
+        },
+        {
+          "const": "https://github.com/Halildeu/ao-kernel/issues/895"
+        }
+      ],
+      "items": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  }
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -18,12 +18,11 @@
     }
   ],
   "findings": [
-    "Anthropic reviewer verdict AGREE: no blocking issue in the V5 E-9-1 public support matrix preflight bundle.",
-    "Schema strictness and fixture validation are pinned by tests; object nodes close additionalProperties and unevaluatedProperties.",
-    "The bundle links PUBLIC-BETA, SUPPORT-BOUNDARY, and SUPPORT-SURFACE-INVENTORY without widening public support.",
-    "Matrix linkage is correct: public_support_matrix gains current evidence refs while status remains partial and PR-Xfinal remains blocked.",
-    "No production-ready claim, support-widening authorization, live adapter execution, v5.0.0 tag, publish, or release authority change is introduced.",
-    "Local validation considered: 26 passed, 1 skipped; secret scan passed; guard invariants passed."
+    "Anthropic reviewer verdict AGREE: V5 observability preflight bundle is aligned with the current-state evidence boundary.",
+    "OpenAI reviewer also returned AGREE and found no blocking fixes.",
+    "Schema and tests pin guard flags false, final release binding false, alert/escalation evidence absent, and CI-blocking performance enforcement absent.",
+    "Matrix status remains partial and PR-Xfinal remains blocked by final claim-bound observability smoke and alert/escalation evidence.",
+    "No forbidden workflow, ruleset, runtime, live adapter, tag, publish, support widening, or production claim surface is changed."
   ],
   "implementer": {
     "agent": "codex",
@@ -41,18 +40,18 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
+      ".claude/plans/V5-OBSERVABILITY-PRODUCTION-TUNABLES-PREFLIGHT-BUNDLE.md",
       ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
-      ".claude/plans/V5-PUBLIC-SUPPORT-MATRIX-PREFLIGHT-BUNDLE.md",
       "CHANGELOG.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/v5-public-support-matrix-preflight-bundle.schema.v1.json",
+      "ao_kernel/defaults/schemas/v5-observability-production-tunables-preflight-bundle.schema.v1.json",
       "local-ai-review-evidence.v1.json",
+      "tests/fixtures/epic9/v5-observability-production-tunables-preflight.current.json",
       "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/fixtures/epic9/v5-public-support-matrix-preflight.current.json",
-      "tests/test_v5_public_support_matrix_preflight_bundle.py"
+      "tests/test_v5_observability_production_tunables_preflight_bundle.py"
     ],
-    "head_ref": "refs/heads/codex/v5-public-support-matrix-preflight-bundle-wt"
+    "head_ref": "refs/heads/codex/v5-observability-preflight-bundle"
   },
   "secrets_recorded": false,
   "support_widening": false,

--- a/tests/fixtures/epic9/v5-observability-production-tunables-preflight.current.json
+++ b/tests/fixtures/epic9/v5-observability-production-tunables-preflight.current.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "v5_observability_production_tunables_preflight_bundle.v1",
+  "artifact_kind": "v5_observability_production_tunables_preflight_bundle",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "E-9-1",
+  "dimension": "observability_production_tunables",
+  "evidence_class": "preflight_current_state",
+  "final_release_bound": false,
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false,
+  "grafana_dashboard": {
+    "dashboard_path": "docs/grafana/ao_kernel_default.v1.json",
+    "dashboard_readme_path": "docs/grafana/README.md",
+    "dashboard_shape_test_path": "tests/test_grafana_dashboard_shape.py",
+    "documented_panel_count": 8,
+    "datasource_variable": "DS_PROMETHEUS",
+    "advanced_overlay_required": false,
+    "final_claim_bound": false
+  },
+  "sli_catalog": {
+    "catalog_path": "docs/sli-catalog.v1.json",
+    "catalog_schema_path": "ao_kernel/defaults/schemas/sli-catalog.schema.v1.json",
+    "catalog_doc_path": "docs/SLI-SLO.md",
+    "catalog_test_path": "tests/test_sli_slo_catalog.py",
+    "indicator_count": 6,
+    "hard_slo_count": 3,
+    "advisory_sli_count": 2,
+    "budget_objective_count": 1,
+    "uptime_in_scope": false,
+    "operator_owned": true,
+    "contractual_sla": false,
+    "alerting_or_escalation_evidence_present": false
+  },
+  "performance_policy": {
+    "readme_path": "docs/performance/README.md",
+    "baseline_path": "docs/performance/baseline.v1.json",
+    "threshold_path": "docs/performance/performance-regression-threshold.v1.json",
+    "scenario_catalog_path": "docs/performance/performance-scenario-catalog.v1.json",
+    "performance_test_path": "tests/test_performance_baseline.py",
+    "enforcement_mode": "advisory",
+    "candidate_baseline": true,
+    "sample_count": 1,
+    "final_claim_bound": false,
+    "ci_blocking_enforced": false
+  },
+  "residual_missing_evidence": [
+    "final claim-bound observability smoke",
+    "alerting or escalation evidence for promoted tier",
+    "operator-authorized observability runbook sync bound to PR-Xfinal",
+    "production-like dashboard import and SLI evaluation evidence bound to the final merge candidate"
+  ],
+  "issue_refs": [
+    "https://github.com/Halildeu/ao-kernel/issues/782",
+    "https://github.com/Halildeu/ao-kernel/issues/895"
+  ]
+}

--- a/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
+++ b/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
@@ -90,7 +90,9 @@
       "current_evidence_refs": [
         "docs/grafana/ao_kernel_default.v1.json",
         "docs/sli-catalog.v1.json",
-        "docs/performance/README.md"
+        "docs/performance/README.md",
+        ".claude/plans/V5-OBSERVABILITY-PRODUCTION-TUNABLES-PREFLIGHT-BUNDLE.md",
+        "tests/fixtures/epic9/v5-observability-production-tunables-preflight.current.json"
       ],
       "missing_evidence": [
         "final claim-bound observability smoke",

--- a/tests/test_v5_observability_production_tunables_preflight_bundle.py
+++ b/tests/test_v5_observability_production_tunables_preflight_bundle.py
@@ -1,0 +1,214 @@
+"""V5 observability production tunables preflight bundle invariants.
+
+The bundle is current-state evidence for one production-readiness dimension.
+It is useful evidence, not final release authority: the schema pins final
+release binding and all three production guard flags false.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_NAME = "v5-observability-production-tunables-preflight-bundle.schema.v1.json"
+SCHEMA_PATH = ROOT / "ao_kernel" / "defaults" / "schemas" / SCHEMA_NAME
+FIXTURE_PATH = (
+    ROOT
+    / "tests"
+    / "fixtures"
+    / "epic9"
+    / "v5-observability-production-tunables-preflight.current.json"
+)
+MATRIX_PATH = ROOT / "tests" / "fixtures" / "epic9" / "v5-production-readiness-matrix.current.json"
+DOC_PATH = ROOT / ".claude" / "plans" / "V5-OBSERVABILITY-PRODUCTION-TUNABLES-PREFLIGHT-BUNDLE.md"
+MATRIX_DOC_PATH = ROOT / ".claude" / "plans" / "V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md"
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", SCHEMA_NAME)
+
+
+def _fixture() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _matrix() -> dict[str, Any]:
+    return json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+
+
+def _valid(payload: dict[str, Any]) -> bool:
+    return not list(Draft202012Validator(_schema()).iter_errors(payload))
+
+
+def test_schema_present_valid_and_strict() -> None:
+    assert SCHEMA_PATH.is_file()
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$id"] == "urn:ao:v5-observability-production-tunables-preflight-bundle:v1"
+
+    def object_nodes(node: Any) -> list[dict[str, Any]]:
+        nodes: list[dict[str, Any]] = []
+        if isinstance(node, dict):
+            if node.get("type") == "object":
+                nodes.append(node)
+            for value in node.values():
+                nodes.extend(object_nodes(value))
+        elif isinstance(node, list):
+            for value in node:
+                nodes.extend(object_nodes(value))
+        return nodes
+
+    for node in object_nodes(schema):
+        assert node.get("additionalProperties") is False
+        assert node.get("unevaluatedProperties") is False
+
+
+def test_current_fixture_validates_and_pins_non_authority_state() -> None:
+    payload = _fixture()
+    assert _valid(payload)
+    assert payload["dimension"] == "observability_production_tunables"
+    assert payload["evidence_class"] == "preflight_current_state"
+    assert payload["final_release_bound"] is False
+    assert payload["support_widening"] is False
+    assert payload["production_platform_claim"] is False
+    assert payload["live_adapter_execution"] is False
+
+
+def test_schema_rejects_final_release_or_guard_flip_claims() -> None:
+    for field, value in (
+        ("final_release_bound", True),
+        ("support_widening", True),
+        ("production_platform_claim", True),
+        ("live_adapter_execution", True),
+    ):
+        payload = _fixture()
+        payload[field] = value
+        assert not _valid(payload), f"{field}={value!r} must fail closed"
+
+    payload = _fixture()
+    payload["sli_catalog"]["alerting_or_escalation_evidence_present"] = True
+    assert not _valid(payload)
+
+    payload = _fixture()
+    payload["performance_policy"]["ci_blocking_enforced"] = True
+    assert not _valid(payload)
+
+    payload = _fixture()
+    payload["grafana_dashboard"]["final_claim_bound"] = True
+    assert not _valid(payload)
+
+
+def test_observability_artifact_refs_exist_and_match_current_state() -> None:
+    payload = _fixture()
+    paths = [
+        payload["grafana_dashboard"]["dashboard_path"],
+        payload["grafana_dashboard"]["dashboard_readme_path"],
+        payload["grafana_dashboard"]["dashboard_shape_test_path"],
+        payload["sli_catalog"]["catalog_path"],
+        payload["sli_catalog"]["catalog_schema_path"],
+        payload["sli_catalog"]["catalog_doc_path"],
+        payload["sli_catalog"]["catalog_test_path"],
+        payload["performance_policy"]["readme_path"],
+        payload["performance_policy"]["baseline_path"],
+        payload["performance_policy"]["threshold_path"],
+        payload["performance_policy"]["scenario_catalog_path"],
+        payload["performance_policy"]["performance_test_path"],
+    ]
+    for path in paths:
+        assert (ROOT / path).is_file(), f"missing referenced artifact: {path}"
+
+
+def test_grafana_dashboard_shape_is_bound_without_final_claim() -> None:
+    grafana = _fixture()["grafana_dashboard"]
+    dashboard = json.loads((ROOT / grafana["dashboard_path"]).read_text(encoding="utf-8"))
+    assert len(dashboard["panels"]) == grafana["documented_panel_count"]
+    names = {item["name"] for item in dashboard["templating"]["list"]}
+    assert grafana["datasource_variable"] in names
+    assert grafana["advanced_overlay_required"] is False
+    assert grafana["final_claim_bound"] is False
+
+
+def test_sli_catalog_counts_and_guard_flags_match_fixture() -> None:
+    sli = _fixture()["sli_catalog"]
+    catalog = json.loads((ROOT / sli["catalog_path"]).read_text(encoding="utf-8"))
+    indicators = catalog["indicators"]
+    by_kind: dict[str, list[dict[str, Any]]] = {}
+    for indicator in indicators:
+        by_kind.setdefault(indicator["objective_kind"], []).append(indicator)
+
+    assert len(indicators) == sli["indicator_count"]
+    assert len([item for item in indicators if item.get("hard_slo") is True]) == sli["hard_slo_count"]
+    assert len(by_kind["advisory_sli"]) == sli["advisory_sli_count"]
+    assert len(by_kind["budget_objective"]) == sli["budget_objective_count"]
+    assert catalog["uptime_status"]["in_scope"] == sli["uptime_in_scope"]
+    assert catalog["guard_flags"] == {
+        "support_widening_allowed": False,
+        "production_platform_claim_allowed": False,
+        "live_adapter_execution_allowed": False,
+    }
+    assert all(indicator["operator_owned"] is sli["operator_owned"] for indicator in indicators)
+    assert all(indicator["is_contractual_sla"] is sli["contractual_sla"] for indicator in indicators)
+
+
+def test_performance_policy_is_advisory_candidate_baseline_only() -> None:
+    policy = _fixture()["performance_policy"]
+    baseline = json.loads((ROOT / policy["baseline_path"]).read_text(encoding="utf-8"))
+    threshold = json.loads((ROOT / policy["threshold_path"]).read_text(encoding="utf-8"))
+    assert threshold["enforcement_mode"] == policy["enforcement_mode"]
+    assert baseline["candidate_baseline"] is policy["candidate_baseline"]
+    assert baseline["sample_count"] == policy["sample_count"]
+    assert policy["final_claim_bound"] is False
+    assert policy["ci_blocking_enforced"] is False
+    assert baseline["guard_flags"] == threshold["guard_flags"] == {
+        "support_widening_allowed": False,
+        "production_platform_claim_allowed": False,
+        "live_adapter_execution_allowed": False,
+    }
+
+
+def test_residual_missing_evidence_keeps_pr_xfinal_blocked() -> None:
+    missing = _fixture()["residual_missing_evidence"]
+    assert "final claim-bound observability smoke" in missing
+    assert any("alerting or escalation evidence" in item for item in missing)
+    assert any("PR-Xfinal" in item for item in missing)
+    assert any("dashboard import" in item for item in missing)
+
+
+def test_matrix_references_observability_preflight_bundle_but_stays_partial() -> None:
+    dimensions = {dimension["id"]: dimension for dimension in _matrix()["dimensions"]}
+    observability = dimensions["observability_production_tunables"]
+    assert observability["status"] == "partial"
+    assert "tests/fixtures/epic9/v5-observability-production-tunables-preflight.current.json" in observability[
+        "current_evidence_refs"
+    ]
+    assert "final claim-bound observability smoke" in observability["missing_evidence"]
+    assert _matrix()["matrix_complete"] is False
+    assert _matrix()["production_platform_claim"] is False
+    assert _matrix()["live_adapter_execution"] is False
+
+
+def test_docs_reference_bundle_without_positive_claim_tokens() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    matrix_doc = MATRIX_DOC_PATH.read_text(encoding="utf-8")
+    assert SCHEMA_NAME in doc
+    assert "v5-observability-production-tunables-preflight.current.json" in doc
+    assert "observability production tunables preflight bundle" in matrix_doc
+
+    lowered = doc.lower()
+    forbidden = (
+        "production-ready",
+        "production ready",
+        "support_widening=true",
+        "production_platform_claim=true",
+        "live_adapter_execution=true",
+        "final_release_bound=true",
+    )
+    for token in forbidden:
+        assert token not in lowered, f"preflight doc must not include positive claim token: {token}"


### PR DESCRIPTION
## Summary
- add V5 observability production tunables preflight schema, fixture, doc, and tests
- bind Grafana dashboard, SLI/SLO catalog, and advisory performance policy to the V5 readiness matrix
- keep observability_production_tunables partial and PR-Xfinal/final claim evidence missing

## Guard boundary
- support_widening=false
- production_platform_claim=false
- live_adapter_execution=false
- final_release_bound=false
- no workflow, ruleset, runtime, tag, publish, or PR-Xfinal opening changes

## Validation
- python3 -m pytest tests/test_v5_observability_production_tunables_preflight_bundle.py tests/test_v5_production_readiness_matrix_blocker.py tests/test_grafana_dashboard_shape.py tests/test_sli_slo_catalog.py tests/test_performance_baseline.py -q -> 111 passed
- raw local-ai-review evidence schema validation -> pass
- local_gpp_gate -> operator_may_merge, changed_files_count=10
- high-risk supersession evidence generated
- gitleaks stdin over diff -> no leaks
- git diff --check -> clean

Cross-AI review: OpenAI Kepler AGREE + Anthropic Claude AGREE.