### PR TITLE
feat(epic9): add V5 cost-rate preflight bundle

### DIFF
--- a/.claude/plans/V5-COST-RATE-CIRCUIT-BREAKER-PREFLIGHT-BUNDLE.md
+++ b/.claude/plans/V5-COST-RATE-CIRCUIT-BREAKER-PREFLIGHT-BUNDLE.md
@@ -1,0 +1,57 @@
+# V5 Cost Rate Circuit Breaker Preflight Bundle
+
+**Status:** current-state preflight evidence / not final release authority
+**Work package:** E-9-1
+**Parent matrix:** `.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md`
+**Schema:** `ao_kernel/defaults/schemas/v5-cost-rate-circuit-breaker-preflight-bundle.schema.v1.json`
+**Fixture:** `tests/fixtures/epic9/v5-cost-rate-circuit-breaker-preflight.current.json`
+
+This document records the current state of the
+`cost_rate_circuit_breaker_evidence` dimension in the V5 production-readiness
+matrix. It binds the existing cost model, cost ceiling, per-call audit,
+simulated usage/cost evidence, rate limiter, circuit breaker, and budget-burn
+incident surfaces into one machine-checkable preflight artifact.
+
+## Non-Authority Boundary
+
+This bundle does not authorize:
+
+- support widening;
+- production platform claims;
+- live adapter execution;
+- final release tagging or publishing;
+- opening PR-Xfinal;
+- treating simulated cost or local dry-run evidence as live provider cost
+  evidence;
+- treating the dormant cost policy defaults as runtime activation.
+
+The current bundle pins `final_release_bound=false`,
+`support_widening=false`, `production_platform_claim=false`, and
+`live_adapter_execution=false`.
+
+## Current Preflight Evidence
+
+| Surface | Current evidence | Boundary |
+|---|---|---|
+| Cost tracking policy | `docs/COST-MODEL.md`, `ao_kernel/defaults/policies/policy_cost_tracking.v1.json`, `tests/test_cost_policy.py` | cost tracking is dormant by default; operators opt in with workspace policy |
+| Cost ceiling | `ao_kernel/_internal/cost_ceiling.py`, `ao_kernel/defaults/policies/policy_cost_ceiling.v1.json`, `tests/test_cost_ceiling.py` | soft breach returns explicit state; hard breach fails closed and writes audit/state evidence; not live provider evidence |
+| Per-call audit | `docs/PER-CALL-AUDIT.md`, `ao_kernel/defaults/schemas/per_call_audit.schema.v1.json`, `tests/test_per_call_audit.py` | one JSONL row per would-be call; actual cost is decimal string; no provider call |
+| Simulated usage/cost evidence | `scripts/real_adapter_usage_evidence.py`, `ao_kernel/defaults/schemas/real-adapter-usage-cost-evidence.schema.v1.json`, `tests/test_real_adapter_usage_cost_evidence.py` | autonomous path emits/validates simulated evidence only; live evidence class remains operator-bound |
+| Rate and circuit breaker primitives | `ao_kernel/_internal/prj_kernel_api/rate_limiter.py`, `ao_kernel/_internal/prj_kernel_api/circuit_breaker.py`, `tests/test_rate_limiter.py`, `tests/test_circuit_breaker.py` | local primitives are covered; no final promoted-tier traffic policy evidence |
+| Budget-burn incident surface | `docs/incident-response/scenarios/04-cost-burn-breach.md`, `docs/sli-catalog.v1.json` | budget projection is recording-only in v1; operator owns alarm overlay |
+| Pricing snapshot | `ao_kernel/defaults/pricing/openai_gpt_4o_mini.v1.json` | operator-pinned snapshot for bounded evidence; final fresh pricing-source snapshot remains missing |
+
+## Residual Missing Evidence
+
+PR-Xfinal remains blocked for this dimension until a later operator-bound
+supersession provides:
+
+- live cost evidence bound to the authorized 7-day provider window;
+- soft and hard breach evidence from a protected live run;
+- rollback evidence and budget follow-up issue automation from that run;
+- fresh pricing-source snapshot bound to PR-Xfinal;
+- operator-authorized budget alarm overlay and escalation evidence for the
+  promoted tier.
+
+This is intentionally a preflight artifact. It makes the existing cost/rate
+surface auditable without changing the production claim gate.

--- a/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
+++ b/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
@@ -34,7 +34,7 @@ The V5 production readiness matrix is **not complete**.
 |---|---|---|
 | public support matrix | partial | current support-boundary preflight bundle exists; final v5 public support tier and claim-language sync missing |
 | protected real provider live calls | not_ready | 7-day live window and protected environment evidence missing |
-| cost/rate/circuit breaker evidence | partial | live cost/breach/rollback evidence missing |
+| cost/rate/circuit breaker evidence | partial | current cost/rate/circuit breaker preflight bundle exists; live cost/breach/rollback evidence missing |
 | observability production tunables | partial | current observability preflight bundle exists; final claim-bound observability/alerting evidence missing |
 | security/SBOM/license scans | partial | current preflight bundle exists; final release-bound SBOM/license/security bundle missing |
 | install/deploy lifecycle smoke | partial | v5.0.0 tag/publish and release-artifact smoke missing |
@@ -78,6 +78,17 @@ security/SBOM/license preflight bundle:
 
 That bundle binds CodeQL, Trivy, SBOM tooling, and license inventory evidence
 without treating them as final release-bound evidence.
+
+The `cost_rate_circuit_breaker_evidence` dimension now has a current-state
+cost/rate/circuit breaker preflight bundle:
+
+- `.claude/plans/V5-COST-RATE-CIRCUIT-BREAKER-PREFLIGHT-BUNDLE.md`
+- `tests/fixtures/epic9/v5-cost-rate-circuit-breaker-preflight.current.json`
+
+That bundle binds dormant cost tracking defaults, cost ceiling enforcement,
+per-call audit, simulated usage/cost evidence, rate limiter, circuit breaker,
+budget-burn incident, and pricing snapshot evidence without treating them as
+live cost-window evidence or final rollback evidence.
 
 The `observability_production_tunables` dimension now has a current-state
 observability production tunables preflight bundle:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **V5 cost/rate/circuit breaker preflight bundle** (V5 Epic 9, #895): added
+  `V5-COST-RATE-CIRCUIT-BREAKER-PREFLIGHT-BUNDLE.md`,
+  `v5-cost-rate-circuit-breaker-preflight-bundle.schema.v1.json`, and a
+  current-state fixture/test suite that binds dormant cost tracking defaults,
+  cost ceiling enforcement, per-call audit, simulated usage/cost evidence,
+  rate limiter, circuit breaker, budget-burn incident, and pricing snapshot
+  evidence to the `cost_rate_circuit_breaker_evidence` production-readiness
+  dimension. This is preflight evidence only: live cost-window evidence,
+  protected breach/rollback evidence, fresh PR-Xfinal pricing evidence, and
+  promoted-tier budget alarm evidence remain missing while `support_widening` /
+  `production_platform_claim` / `live_adapter_execution` remain false.
 - **V5 bypassless governance preflight bundle** (V5 Epic 9 Gate C, #960):
   added `V5-BYPASSLESS-GOVERNANCE-PREFLIGHT-BUNDLE.md`,
   `v5-bypassless-governance-preflight-bundle.schema.v1.json`, a current-state

--- a/ao_kernel/defaults/schemas/v5-cost-rate-circuit-breaker-preflight-bundle.schema.v1.json
+++ b/ao_kernel/defaults/schemas/v5-cost-rate-circuit-breaker-preflight-bundle.schema.v1.json
@@ -1,0 +1,357 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:v5-cost-rate-circuit-breaker-preflight-bundle:v1",
+  "title": "V5 cost rate circuit breaker preflight evidence bundle v1",
+  "description": "Current-state preflight bundle for the V5 cost/rate/circuit-breaker dimension. It records existing cost policy, ceiling, audit, usage evidence, rate limiter, circuit breaker, incident, and pricing evidence while keeping final live cost evidence and all production guard flags fail-closed.",
+  "type": "object",
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "repo",
+    "work_package",
+    "dimension",
+    "evidence_class",
+    "final_release_bound",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution",
+    "cost_tracking_policy",
+    "cost_ceiling",
+    "per_call_audit",
+    "usage_cost_evidence",
+    "rate_and_circuit_breaker",
+    "incident_response",
+    "pricing_snapshot",
+    "residual_missing_evidence",
+    "issue_refs"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "v5_cost_rate_circuit_breaker_preflight_bundle.v1"
+    },
+    "artifact_kind": {
+      "const": "v5_cost_rate_circuit_breaker_preflight_bundle"
+    },
+    "repo": {
+      "const": "Halildeu/ao-kernel"
+    },
+    "work_package": {
+      "const": "E-9-1"
+    },
+    "dimension": {
+      "const": "cost_rate_circuit_breaker_evidence"
+    },
+    "evidence_class": {
+      "const": "preflight_current_state"
+    },
+    "final_release_bound": {
+      "const": false
+    },
+    "support_widening": {
+      "const": false
+    },
+    "production_platform_claim": {
+      "const": false
+    },
+    "live_adapter_execution": {
+      "const": false
+    },
+    "cost_tracking_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "doc_path",
+        "policy_path",
+        "policy_schema_path",
+        "policy_test_path",
+        "bundled_default_enabled",
+        "fail_closed_on_exhaust",
+        "fail_closed_on_missing_usage",
+        "routing_by_cost_enabled",
+        "strict_freshness"
+      ],
+      "properties": {
+        "doc_path": {
+          "const": "docs/COST-MODEL.md"
+        },
+        "policy_path": {
+          "const": "ao_kernel/defaults/policies/policy_cost_tracking.v1.json"
+        },
+        "policy_schema_path": {
+          "const": "ao_kernel/defaults/schemas/policy-cost-tracking.schema.v1.json"
+        },
+        "policy_test_path": {
+          "const": "tests/test_cost_policy.py"
+        },
+        "bundled_default_enabled": {
+          "const": false
+        },
+        "fail_closed_on_exhaust": {
+          "const": true
+        },
+        "fail_closed_on_missing_usage": {
+          "const": true
+        },
+        "routing_by_cost_enabled": {
+          "const": false
+        },
+        "strict_freshness": {
+          "const": false
+        }
+      }
+    },
+    "cost_ceiling": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "module_path",
+        "policy_path",
+        "test_path",
+        "soft_usd",
+        "hard_usd",
+        "hard_breach_raises",
+        "hard_breach_audit_write",
+        "workspace_state_jsonl",
+        "concurrency_lock_serialized",
+        "guard_flags_pinned_false"
+      ],
+      "properties": {
+        "module_path": {
+          "const": "ao_kernel/_internal/cost_ceiling.py"
+        },
+        "policy_path": {
+          "const": "ao_kernel/defaults/policies/policy_cost_ceiling.v1.json"
+        },
+        "test_path": {
+          "const": "tests/test_cost_ceiling.py"
+        },
+        "soft_usd": {
+          "const": "0.10000000"
+        },
+        "hard_usd": {
+          "const": "1.00000000"
+        },
+        "hard_breach_raises": {
+          "const": true
+        },
+        "hard_breach_audit_write": {
+          "const": true
+        },
+        "workspace_state_jsonl": {
+          "const": "evidence/cost_ceiling_state.jsonl"
+        },
+        "concurrency_lock_serialized": {
+          "const": true
+        },
+        "guard_flags_pinned_false": {
+          "const": true
+        }
+      }
+    },
+    "per_call_audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "doc_path",
+        "schema_path",
+        "writer_path",
+        "test_path",
+        "actual_cost_required_decimal_string",
+        "hard_breach_cross_reference_jsonl",
+        "provider_call_made"
+      ],
+      "properties": {
+        "doc_path": {
+          "const": "docs/PER-CALL-AUDIT.md"
+        },
+        "schema_path": {
+          "const": "ao_kernel/defaults/schemas/per_call_audit.schema.v1.json"
+        },
+        "writer_path": {
+          "const": "ao_kernel/_internal/evidence/per_call_audit.py"
+        },
+        "test_path": {
+          "const": "tests/test_per_call_audit.py"
+        },
+        "actual_cost_required_decimal_string": {
+          "const": true
+        },
+        "hard_breach_cross_reference_jsonl": {
+          "const": "evidence/cost_hard_breach.jsonl"
+        },
+        "provider_call_made": {
+          "const": false
+        }
+      }
+    },
+    "usage_cost_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "script_path",
+        "schema_path",
+        "test_path",
+        "autonomous_evidence_class",
+        "live_evidence_available",
+        "linked_spend_ledger_supported"
+      ],
+      "properties": {
+        "script_path": {
+          "const": "scripts/real_adapter_usage_evidence.py"
+        },
+        "schema_path": {
+          "const": "ao_kernel/defaults/schemas/real-adapter-usage-cost-evidence.schema.v1.json"
+        },
+        "test_path": {
+          "const": "tests/test_real_adapter_usage_cost_evidence.py"
+        },
+        "autonomous_evidence_class": {
+          "const": "simulated"
+        },
+        "live_evidence_available": {
+          "const": false
+        },
+        "linked_spend_ledger_supported": {
+          "const": true
+        }
+      }
+    },
+    "rate_and_circuit_breaker": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "rate_limiter_path",
+        "rate_limiter_test_path",
+        "circuit_breaker_path",
+        "circuit_breaker_test_path",
+        "rate_limiter_registry_reset_tested",
+        "circuit_breaker_transitions_tested",
+        "final_traffic_policy_evidence_present"
+      ],
+      "properties": {
+        "rate_limiter_path": {
+          "const": "ao_kernel/_internal/prj_kernel_api/rate_limiter.py"
+        },
+        "rate_limiter_test_path": {
+          "const": "tests/test_rate_limiter.py"
+        },
+        "circuit_breaker_path": {
+          "const": "ao_kernel/_internal/prj_kernel_api/circuit_breaker.py"
+        },
+        "circuit_breaker_test_path": {
+          "const": "tests/test_circuit_breaker.py"
+        },
+        "rate_limiter_registry_reset_tested": {
+          "const": true
+        },
+        "circuit_breaker_transitions_tested": {
+          "const": true
+        },
+        "final_traffic_policy_evidence_present": {
+          "const": false
+        }
+      }
+    },
+    "incident_response": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "cost_burn_scenario_path",
+        "sli_catalog_path",
+        "indicator_name",
+        "objective_kind",
+        "active_firing_alert_present",
+        "operator_alarm_overlay_required"
+      ],
+      "properties": {
+        "cost_burn_scenario_path": {
+          "const": "docs/incident-response/scenarios/04-cost-burn-breach.md"
+        },
+        "sli_catalog_path": {
+          "const": "docs/sli-catalog.v1.json"
+        },
+        "indicator_name": {
+          "const": "monthly_cost_burn_projection_usd"
+        },
+        "objective_kind": {
+          "const": "budget_objective"
+        },
+        "active_firing_alert_present": {
+          "const": false
+        },
+        "operator_alarm_overlay_required": {
+          "const": true
+        }
+      }
+    },
+    "pricing_snapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "snapshot_path",
+        "snapshot_sha256",
+        "source_authority",
+        "currency",
+        "precision_decimal_places",
+        "final_fresh_pricing_snapshot"
+      ],
+      "properties": {
+        "snapshot_path": {
+          "const": "ao_kernel/defaults/pricing/openai_gpt_4o_mini.v1.json"
+        },
+        "snapshot_sha256": {
+          "const": "sha256:b0c0baa62cf6f8c79b0ed2e4b751fcc00929eab1e128dbac4ab0d8705f4a4480"
+        },
+        "source_authority": {
+          "const": "operator_pinned"
+        },
+        "currency": {
+          "const": "USD"
+        },
+        "precision_decimal_places": {
+          "const": 8
+        },
+        "final_fresh_pricing_snapshot": {
+          "const": false
+        }
+      }
+    },
+    "residual_missing_evidence": {
+      "type": "array",
+      "minItems": 4,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "contains": {
+        "const": "live cost evidence bound to the authorized 7-day provider window"
+      }
+    },
+    "issue_refs": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "https://github.com/Halildeu/ao-kernel/issues/775"
+        },
+        {
+          "const": "https://github.com/Halildeu/ao-kernel/issues/782"
+        },
+        {
+          "const": "https://github.com/Halildeu/ao-kernel/issues/895"
+        }
+      ],
+      "items": false,
+      "minItems": 3,
+      "maxItems": 3
+    }
+  }
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -3,24 +3,26 @@
   "repo": "Halildeu/ao-kernel",
   "work_package": "E-9-1",
   "implementer": {
-    "agent": "claude",
-    "provider": "anthropic"
+    "agent": "codex",
+    "provider": "openai"
   },
   "reviewer": {
-    "agent": "codex",
-    "provider": "openai",
+    "agent": "claude",
+    "provider": "anthropic",
     "verdict": "AGREE"
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/feat/gate-c-dim9-bypassless-governance-preflight-cc-0605",
+    "head_ref": "refs/heads/codex/v5-cost-rate-circuit-breaker-preflight-bundle",
     "changed_files": [
-      ".claude/plans/V5-BYPASSLESS-GOVERNANCE-PREFLIGHT-BUNDLE.md",
+      ".claude/plans/V5-COST-RATE-CIRCUIT-BREAKER-PREFLIGHT-BUNDLE.md",
+      ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
       "CHANGELOG.md",
-      "ao_kernel/defaults/schemas/v5-bypassless-governance-preflight-bundle.schema.v1.json",
+      "ao_kernel/defaults/schemas/v5-cost-rate-circuit-breaker-preflight-bundle.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/fixtures/epic9/v5-bypassless-governance-preflight.current.json",
-      "tests/test_v5_bypassless_governance_preflight_bundle.py"
+      "tests/fixtures/epic9/v5-cost-rate-circuit-breaker-preflight.current.json",
+      "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
+      "tests/test_v5_cost_rate_circuit_breaker_preflight_bundle.py"
     ]
   },
   "checks_considered": [
@@ -29,7 +31,7 @@
       "status": "pass"
     },
     {
-      "name": "pytest_bypassless_governance_preflight_bundle",
+      "name": "pytest_cost_rate_circuit_breaker_preflight_bundle",
       "status": "pass"
     },
     {
@@ -41,29 +43,29 @@
       "status": "pass"
     },
     {
-      "name": "ruff",
-      "status": "pass"
-    },
-    {
-      "name": "changelog_enforcement",
-      "status": "pass"
-    },
-    {
       "name": "secret_scan",
       "status": "pass"
     },
     {
       "name": "cross_provider_review",
       "status": "pass"
+    },
+    {
+      "name": "guard_invariants",
+      "status": "pass"
+    },
+    {
+      "name": "scope_alignment",
+      "status": "pass"
     }
   ],
   "findings": [
-    "Codex (OpenAI) reviewed the V5 Gate C dimension 9 (bypassless_release_governance) preflight bundle and returned VERDICT AGREE after a 2-iteration REVISE absorb (thread 019e94b8).",
-    "Absorb: governance_controls pins exactly the 4 canonical controls via allOf contains + minContains/maxContains (dim#1 pattern); residual_missing_evidence pins exactly 2 slots with source-pin and uniqueness concept patterns; added negative tests for duplicate/omit control, duplicate/missing required check, and missing either residual concept.",
-    "Codex confirmed non-colliding (no edit to v5-production-readiness-matrix.current.json), matrix stays matrix_complete=false with dim#9 not_ready|partial, no hidden complete/flip path, and the current_state active claim is defensible from repo-local evidence.",
-    "Boundary: preflight current-state evidence only; does not open PR-Xfinal, flip guard flags, or advance the matrix dimension to complete; final ruleset source-pin and required-check uniqueness evidence remain PR-Xfinal-bound.",
-    "Rebased cleanly onto origin/main (after parallel #958/#959 preflight bundles landed); only the four new artifacts plus CHANGELOG and this evidence file change.",
-    "Local validation: 10 invariant tests passed; schema valid (Draft 2020-12, strict); fixture validates; ruff clean; changelog discipline pass.",
+    "Claude (Anthropic) reviewed the staged V5 cost/rate/circuit-breaker preflight bundle and returned VERDICT AGREE.",
+    "The reviewer confirmed the bundle is bounded to current-state preflight evidence and does not authorize support widening, production platform claim, live adapter execution, PR-Xfinal, tag, release, or live provider calls.",
+    "The reviewer confirmed schema strictness: object nodes are closed, issue refs and dimension values are pinned, residual missing evidence remains required, and guard flips are rejected.",
+    "The reviewer confirmed the evidence claims are defensible from repo-local artifacts covering dormant cost policy, cost ceiling, per-call audit, simulated usage-cost evidence, rate limiter, circuit breaker, pricing digest, SLI, and incident-response references.",
+    "Local validation before review: 110 tests passed for the cost/rate/circuit-breaker preflight bundle, production readiness matrix invariants, cost policy, cost ceiling, usage-cost evidence, rate limiter, and circuit breaker.",
+    "Staged secret scan passed with no leaks found.",
     "No secrets were recorded in the review prompt, review output, evidence file, or validation artifacts."
   ],
   "secrets_recorded": false,

--- a/tests/fixtures/epic9/v5-cost-rate-circuit-breaker-preflight.current.json
+++ b/tests/fixtures/epic9/v5-cost-rate-circuit-breaker-preflight.current.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": "v5_cost_rate_circuit_breaker_preflight_bundle.v1",
+  "artifact_kind": "v5_cost_rate_circuit_breaker_preflight_bundle",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "E-9-1",
+  "dimension": "cost_rate_circuit_breaker_evidence",
+  "evidence_class": "preflight_current_state",
+  "final_release_bound": false,
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false,
+  "cost_tracking_policy": {
+    "doc_path": "docs/COST-MODEL.md",
+    "policy_path": "ao_kernel/defaults/policies/policy_cost_tracking.v1.json",
+    "policy_schema_path": "ao_kernel/defaults/schemas/policy-cost-tracking.schema.v1.json",
+    "policy_test_path": "tests/test_cost_policy.py",
+    "bundled_default_enabled": false,
+    "fail_closed_on_exhaust": true,
+    "fail_closed_on_missing_usage": true,
+    "routing_by_cost_enabled": false,
+    "strict_freshness": false
+  },
+  "cost_ceiling": {
+    "module_path": "ao_kernel/_internal/cost_ceiling.py",
+    "policy_path": "ao_kernel/defaults/policies/policy_cost_ceiling.v1.json",
+    "test_path": "tests/test_cost_ceiling.py",
+    "soft_usd": "0.10000000",
+    "hard_usd": "1.00000000",
+    "hard_breach_raises": true,
+    "hard_breach_audit_write": true,
+    "workspace_state_jsonl": "evidence/cost_ceiling_state.jsonl",
+    "concurrency_lock_serialized": true,
+    "guard_flags_pinned_false": true
+  },
+  "per_call_audit": {
+    "doc_path": "docs/PER-CALL-AUDIT.md",
+    "schema_path": "ao_kernel/defaults/schemas/per_call_audit.schema.v1.json",
+    "writer_path": "ao_kernel/_internal/evidence/per_call_audit.py",
+    "test_path": "tests/test_per_call_audit.py",
+    "actual_cost_required_decimal_string": true,
+    "hard_breach_cross_reference_jsonl": "evidence/cost_hard_breach.jsonl",
+    "provider_call_made": false
+  },
+  "usage_cost_evidence": {
+    "script_path": "scripts/real_adapter_usage_evidence.py",
+    "schema_path": "ao_kernel/defaults/schemas/real-adapter-usage-cost-evidence.schema.v1.json",
+    "test_path": "tests/test_real_adapter_usage_cost_evidence.py",
+    "autonomous_evidence_class": "simulated",
+    "live_evidence_available": false,
+    "linked_spend_ledger_supported": true
+  },
+  "rate_and_circuit_breaker": {
+    "rate_limiter_path": "ao_kernel/_internal/prj_kernel_api/rate_limiter.py",
+    "rate_limiter_test_path": "tests/test_rate_limiter.py",
+    "circuit_breaker_path": "ao_kernel/_internal/prj_kernel_api/circuit_breaker.py",
+    "circuit_breaker_test_path": "tests/test_circuit_breaker.py",
+    "rate_limiter_registry_reset_tested": true,
+    "circuit_breaker_transitions_tested": true,
+    "final_traffic_policy_evidence_present": false
+  },
+  "incident_response": {
+    "cost_burn_scenario_path": "docs/incident-response/scenarios/04-cost-burn-breach.md",
+    "sli_catalog_path": "docs/sli-catalog.v1.json",
+    "indicator_name": "monthly_cost_burn_projection_usd",
+    "objective_kind": "budget_objective",
+    "active_firing_alert_present": false,
+    "operator_alarm_overlay_required": true
+  },
+  "pricing_snapshot": {
+    "snapshot_path": "ao_kernel/defaults/pricing/openai_gpt_4o_mini.v1.json",
+    "snapshot_sha256": "sha256:b0c0baa62cf6f8c79b0ed2e4b751fcc00929eab1e128dbac4ab0d8705f4a4480",
+    "source_authority": "operator_pinned",
+    "currency": "USD",
+    "precision_decimal_places": 8,
+    "final_fresh_pricing_snapshot": false
+  },
+  "residual_missing_evidence": [
+    "live cost evidence bound to the authorized 7-day provider window",
+    "soft and hard breach evidence from a protected live run",
+    "rollback evidence and budget follow-up issue automation from that run",
+    "fresh pricing-source snapshot bound to PR-Xfinal",
+    "operator-authorized budget alarm overlay and escalation evidence for the promoted tier"
+  ],
+  "issue_refs": [
+    "https://github.com/Halildeu/ao-kernel/issues/775",
+    "https://github.com/Halildeu/ao-kernel/issues/782",
+    "https://github.com/Halildeu/ao-kernel/issues/895"
+  ]
+}

--- a/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
+++ b/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
@@ -67,7 +67,9 @@
       "current_evidence_refs": [
         "docs/PER-CALL-AUDIT.md",
         "scripts/real_adapter_usage_evidence.py",
-        "scripts/live_adapter_evidence_workflow_runner.py"
+        "scripts/live_adapter_evidence_workflow_runner.py",
+        ".claude/plans/V5-COST-RATE-CIRCUIT-BREAKER-PREFLIGHT-BUNDLE.md",
+        "tests/fixtures/epic9/v5-cost-rate-circuit-breaker-preflight.current.json"
       ],
       "missing_evidence": [
         "live cost evidence bound to 7-day window",

--- a/tests/test_v5_cost_rate_circuit_breaker_preflight_bundle.py
+++ b/tests/test_v5_cost_rate_circuit_breaker_preflight_bundle.py
@@ -1,0 +1,245 @@
+"""V5 cost/rate/circuit-breaker preflight bundle invariants.
+
+The bundle is current-state evidence for one production-readiness dimension.
+It is useful evidence, not final release authority: the schema pins final
+release binding and all three production guard flags false.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_NAME = "v5-cost-rate-circuit-breaker-preflight-bundle.schema.v1.json"
+SCHEMA_PATH = ROOT / "ao_kernel" / "defaults" / "schemas" / SCHEMA_NAME
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "epic9" / "v5-cost-rate-circuit-breaker-preflight.current.json"
+MATRIX_PATH = ROOT / "tests" / "fixtures" / "epic9" / "v5-production-readiness-matrix.current.json"
+DOC_PATH = ROOT / ".claude" / "plans" / "V5-COST-RATE-CIRCUIT-BREAKER-PREFLIGHT-BUNDLE.md"
+MATRIX_DOC_PATH = ROOT / ".claude" / "plans" / "V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md"
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", SCHEMA_NAME)
+
+
+def _fixture() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _matrix() -> dict[str, Any]:
+    return json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+
+
+def _valid(payload: dict[str, Any]) -> bool:
+    return not list(Draft202012Validator(_schema()).iter_errors(payload))
+
+
+def test_schema_present_valid_and_strict() -> None:
+    assert SCHEMA_PATH.is_file()
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$id"] == "urn:ao:v5-cost-rate-circuit-breaker-preflight-bundle:v1"
+
+    def object_nodes(node: Any) -> list[dict[str, Any]]:
+        nodes: list[dict[str, Any]] = []
+        if isinstance(node, dict):
+            if node.get("type") == "object":
+                nodes.append(node)
+            for value in node.values():
+                nodes.extend(object_nodes(value))
+        elif isinstance(node, list):
+            for value in node:
+                nodes.extend(object_nodes(value))
+        return nodes
+
+    for node in object_nodes(schema):
+        assert node.get("additionalProperties") is False
+        assert node.get("unevaluatedProperties") is False
+
+
+def test_current_fixture_validates_and_pins_non_authority_state() -> None:
+    payload = _fixture()
+    assert _valid(payload)
+    assert payload["dimension"] == "cost_rate_circuit_breaker_evidence"
+    assert payload["evidence_class"] == "preflight_current_state"
+    assert payload["final_release_bound"] is False
+    assert payload["support_widening"] is False
+    assert payload["production_platform_claim"] is False
+    assert payload["live_adapter_execution"] is False
+
+
+def test_schema_rejects_final_release_or_guard_flip_claims() -> None:
+    for field, value in (
+        ("final_release_bound", True),
+        ("support_widening", True),
+        ("production_platform_claim", True),
+        ("live_adapter_execution", True),
+    ):
+        payload = _fixture()
+        payload[field] = value
+        assert not _valid(payload), f"{field}={value!r} must fail closed"
+
+    payload = _fixture()
+    payload["cost_tracking_policy"]["bundled_default_enabled"] = True
+    assert not _valid(payload)
+
+    payload = _fixture()
+    payload["usage_cost_evidence"]["live_evidence_available"] = True
+    assert not _valid(payload)
+
+    payload = _fixture()
+    payload["rate_and_circuit_breaker"]["final_traffic_policy_evidence_present"] = True
+    assert not _valid(payload)
+
+
+def test_referenced_artifacts_exist() -> None:
+    payload = _fixture()
+    paths = [
+        payload["cost_tracking_policy"]["doc_path"],
+        payload["cost_tracking_policy"]["policy_path"],
+        payload["cost_tracking_policy"]["policy_schema_path"],
+        payload["cost_tracking_policy"]["policy_test_path"],
+        payload["cost_ceiling"]["module_path"],
+        payload["cost_ceiling"]["policy_path"],
+        payload["cost_ceiling"]["test_path"],
+        payload["per_call_audit"]["doc_path"],
+        payload["per_call_audit"]["schema_path"],
+        payload["per_call_audit"]["writer_path"],
+        payload["per_call_audit"]["test_path"],
+        payload["usage_cost_evidence"]["script_path"],
+        payload["usage_cost_evidence"]["schema_path"],
+        payload["usage_cost_evidence"]["test_path"],
+        payload["rate_and_circuit_breaker"]["rate_limiter_path"],
+        payload["rate_and_circuit_breaker"]["rate_limiter_test_path"],
+        payload["rate_and_circuit_breaker"]["circuit_breaker_path"],
+        payload["rate_and_circuit_breaker"]["circuit_breaker_test_path"],
+        payload["incident_response"]["cost_burn_scenario_path"],
+        payload["incident_response"]["sli_catalog_path"],
+        payload["pricing_snapshot"]["snapshot_path"],
+    ]
+    for path in paths:
+        assert (ROOT / path).is_file(), f"missing referenced artifact: {path}"
+
+
+def test_cost_tracking_policy_defaults_are_dormant_but_fail_closed() -> None:
+    policy_ref = _fixture()["cost_tracking_policy"]
+    policy = json.loads((ROOT / policy_ref["policy_path"]).read_text(encoding="utf-8"))
+    assert policy["enabled"] is policy_ref["bundled_default_enabled"]
+    assert policy["fail_closed_on_exhaust"] is policy_ref["fail_closed_on_exhaust"]
+    assert policy["fail_closed_on_missing_usage"] is policy_ref["fail_closed_on_missing_usage"]
+    assert policy["strict_freshness"] is policy_ref["strict_freshness"]
+    assert policy["routing_by_cost"]["enabled"] is policy_ref["routing_by_cost_enabled"]
+
+
+def test_cost_ceiling_policy_and_tests_pin_soft_hard_breach_contract() -> None:
+    ceiling = _fixture()["cost_ceiling"]
+    policy = json.loads((ROOT / ceiling["policy_path"]).read_text(encoding="utf-8"))
+    tests = (ROOT / ceiling["test_path"]).read_text(encoding="utf-8")
+    module = (ROOT / ceiling["module_path"]).read_text(encoding="utf-8")
+
+    assert policy["soft_usd"] == ceiling["soft_usd"]
+    assert policy["hard_usd"] == ceiling["hard_usd"]
+    assert policy["live_adapter_execution"] is False
+    assert policy["support_widening"] is False
+    assert policy["production_platform_claim"] is False
+    assert "CostCeilingExceeded" in tests
+    assert "hard_breached" in tests
+    assert ceiling["workspace_state_jsonl"] in module
+    assert ceiling["hard_breach_audit_write"] is True
+    assert ceiling["concurrency_lock_serialized"] is True
+
+
+def test_per_call_audit_and_usage_cost_evidence_are_not_provider_execution() -> None:
+    payload = _fixture()
+    audit_doc = (ROOT / payload["per_call_audit"]["doc_path"]).read_text(encoding="utf-8")
+    usage_script = (ROOT / payload["usage_cost_evidence"]["script_path"]).read_text(encoding="utf-8")
+    usage_tests = (ROOT / payload["usage_cost_evidence"]["test_path"]).read_text(encoding="utf-8")
+
+    assert "Does NOT make a real provider call" in audit_doc
+    assert payload["per_call_audit"]["actual_cost_required_decimal_string"] is True
+    assert payload["per_call_audit"]["provider_call_made"] is False
+    assert "The script never emits live evidence" in usage_script
+    assert "``evidence_class`` is fixed to ``simulated``" in usage_script
+    assert payload["usage_cost_evidence"]["autonomous_evidence_class"] == "simulated"
+    assert payload["usage_cost_evidence"]["live_evidence_available"] is False
+    assert "live_adapter_execution=true" in usage_tests
+
+
+def test_rate_circuit_breaker_and_budget_burn_surfaces_are_preflight_only() -> None:
+    payload = _fixture()
+    rate_tests = (ROOT / payload["rate_and_circuit_breaker"]["rate_limiter_test_path"]).read_text(encoding="utf-8")
+    breaker_tests = (ROOT / payload["rate_and_circuit_breaker"]["circuit_breaker_test_path"]).read_text(
+        encoding="utf-8"
+    )
+    incident = (ROOT / payload["incident_response"]["cost_burn_scenario_path"]).read_text(encoding="utf-8")
+    catalog = json.loads((ROOT / payload["incident_response"]["sli_catalog_path"]).read_text(encoding="utf-8"))
+
+    assert "test_reset_all_clears" in rate_tests
+    assert "test_open_transitions_to_half_open" in breaker_tests
+    assert payload["rate_and_circuit_breaker"]["final_traffic_policy_evidence_present"] is False
+    assert payload["incident_response"]["indicator_name"] == "monthly_cost_burn_projection_usd"
+    assert "Recording-only in v1" in incident
+    indicator = next(item for item in catalog["indicators"] if item["name"] == "monthly_cost_burn_projection_usd")
+    assert indicator["objective_kind"] == payload["incident_response"]["objective_kind"]
+
+
+def test_pricing_snapshot_digest_and_boundary_match_fixture() -> None:
+    pricing = _fixture()["pricing_snapshot"]
+    path = ROOT / pricing["snapshot_path"]
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    data = json.loads(path.read_text(encoding="utf-8"))
+
+    assert f"sha256:{digest}" == pricing["snapshot_sha256"]
+    assert data["source_authority"] == pricing["source_authority"]
+    assert data["currency"] == pricing["currency"]
+    assert data["precision_decimal_places"] == pricing["precision_decimal_places"]
+    assert pricing["final_fresh_pricing_snapshot"] is False
+
+
+def test_residual_missing_evidence_keeps_pr_xfinal_blocked() -> None:
+    missing = _fixture()["residual_missing_evidence"]
+    assert "live cost evidence bound to the authorized 7-day provider window" in missing
+    assert any("protected live run" in item for item in missing)
+    assert any("rollback evidence" in item for item in missing)
+    assert any("fresh pricing-source snapshot" in item for item in missing)
+
+
+def test_matrix_references_cost_preflight_bundle_but_stays_partial() -> None:
+    dimensions = {dimension["id"]: dimension for dimension in _matrix()["dimensions"]}
+    cost = dimensions["cost_rate_circuit_breaker_evidence"]
+    assert cost["status"] == "partial"
+    assert "tests/fixtures/epic9/v5-cost-rate-circuit-breaker-preflight.current.json" in cost[
+        "current_evidence_refs"
+    ]
+    assert "live cost evidence bound to 7-day window" in cost["missing_evidence"]
+    assert _matrix()["matrix_complete"] is False
+    assert _matrix()["production_platform_claim"] is False
+    assert _matrix()["live_adapter_execution"] is False
+
+
+def test_docs_reference_bundle_without_positive_claim_tokens() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    matrix_doc = MATRIX_DOC_PATH.read_text(encoding="utf-8")
+    assert SCHEMA_NAME in doc
+    assert "v5-cost-rate-circuit-breaker-preflight.current.json" in doc
+    assert "cost/rate/circuit breaker preflight bundle" in matrix_doc
+
+    lowered = doc.lower()
+    forbidden = (
+        "production-ready",
+        "production ready",
+        "support_widening=true",
+        "production_platform_claim=true",
+        "live_adapter_execution=true",
+        "final_release_bound=true",
+    )
+    for token in forbidden:
+        assert token not in lowered, f"preflight doc must not include positive claim token: {token}"


### PR DESCRIPTION
## Scope

Adds the V5 cost/rate/circuit-breaker preflight bundle for the `cost_rate_circuit_breaker_evidence` production-readiness matrix dimension.

This is current-state/preflight evidence only. It does not:

- mark the V5 matrix complete
- open PR-Xfinal
- authorize support widening
- claim production platform readiness
- execute live adapters or live provider calls
- create a tag or release

## Changed files

- `.claude/plans/V5-COST-RATE-CIRCUIT-BREAKER-PREFLIGHT-BUNDLE.md`
- `ao_kernel/defaults/schemas/v5-cost-rate-circuit-breaker-preflight-bundle.schema.v1.json`
- `tests/fixtures/epic9/v5-cost-rate-circuit-breaker-preflight.current.json`
- `tests/test_v5_cost_rate_circuit_breaker_preflight_bundle.py`
- matrix doc/fixture cross-reference updates
- `local-ai-review-evidence.v1.json`
- `CHANGELOG.md`

## Validation

- `python3 -m pytest tests/test_v5_cost_rate_circuit_breaker_preflight_bundle.py tests/test_v5_production_readiness_matrix_blocker.py tests/test_cost_ceiling.py tests/test_cost_policy.py tests/test_real_adapter_usage_cost_evidence.py tests/test_rate_limiter.py tests/test_circuit_breaker.py -q` -> `110 passed`
- `git diff --cached --check` -> pass
- staged `gitleaks stdin --redact --no-banner` -> no leaks found
- Claude/Anthropic independent review -> `VERDICT: AGREE`
- `scripts/local_gpp_gate.py` -> `operator_may_merge`
  - head sha: `668e9e7fa037ef1c1e714394793d6ed11d8614ba`
  - diff digest: `sha256:5ccc31b2284ffb13f0703f8d8be91520e81cae35cb3de3bba35b6d097af10066`
  - changed files: `8`

## Guard state

- `support_widening=false`
- `production_platform_claim=false`
- `live_adapter_execution=false`
- `matrix_complete=false`
