### PR TITLE
feat(epic9): add V5 install-deploy lifecycle preflight bundle

### DIFF
--- a/.claude/plans/V5-INSTALL-DEPLOY-LIFECYCLE-PREFLIGHT-BUNDLE.md
+++ b/.claude/plans/V5-INSTALL-DEPLOY-LIFECYCLE-PREFLIGHT-BUNDLE.md
@@ -1,0 +1,57 @@
+# V5 Install Deploy Lifecycle Preflight Bundle
+
+**Status:** current-state preflight evidence / not final release authority
+**Work package:** E-9-1
+**Parent matrix:** `.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md`
+**Schema:** `ao_kernel/defaults/schemas/v5-install-deploy-lifecycle-preflight-bundle.schema.v1.json`
+**Fixture:** `tests/fixtures/epic9/v5-install-deploy-lifecycle-preflight.current.json`
+
+This document records the current state of the
+`install_deploy_lifecycle_smoke` dimension in the V5 production-readiness
+matrix. It binds the existing install, deployment, operator-runbook, Helm,
+publish workflow, and migration-guide evidence into one machine-checkable
+preflight artifact.
+
+## Non-Authority Boundary
+
+This bundle does not authorize:
+
+- support widening;
+- production platform claims;
+- live adapter execution;
+- final v5.0.0 release tagging or publishing;
+- opening PR-Xfinal;
+- treating local packaging smoke or docs tests as release-artifact smoke;
+- treating Helm render/runbook evidence as a production deployment claim.
+
+The current bundle pins `final_release_bound=false`,
+`support_widening=false`, `production_platform_claim=false`, and
+`live_adapter_execution=false`.
+
+## Current Preflight Evidence
+
+| Surface | Current evidence | Boundary |
+|---|---|---|
+| Standalone install smoke | `scripts/packaging_smoke.py`, `.github/workflows/test.yml`, `tests/test_ri7_scan_index_query_packaging_smoke_invariant.py` | proves wheel-installed smoke and repo-intelligence CLI packaging path; not bound to a v5.0.0 release artifact |
+| Deployment guide | `docs/PRODUCTION-DEPLOYMENT-GUIDE.md`, `tests/test_production_deployment_guide.py` | covers standalone, Docker, and Kubernetes patterns while explicitly keeping guard flags false |
+| Operator runbooks | `docs/OPERATOR-RUNBOOK.md`, `docs/operator-runbooks/README.md`, `docs/operator-runbooks/operator-action-checklist.v1.json`, `tests/test_operator_runbook.py`, `tests/test_operator_runbooks.py` | records operator-owned rollback, tag revert, pause, emergency stop, incident, and publishing actions; not executed by agents |
+| Helm lifecycle | `deploy/helm/ao-kernel/templates/deployment.yaml`, `deploy/helm/ao-kernel/tests/deployment_test.yaml`, `docs/HELM-TESTING.md` | render/test surface is present and default-safe; operator-run Helm plugin smoke is not CI release evidence |
+| Publish lifecycle | `.github/workflows/publish.yml`, `tests/test_publish_workflow.py`, `docs/operator-runbooks/01-pypi-publish.md` | publish workflow has tag guard, trusted-publishing environment, and strict dist globs; no v5.0.0 tag or publish evidence yet |
+| Migration guide | `docs/MIGRATION-V5.md`, `tests/test_migration_v5_doc.py` | planned upgrade/downgrade path and guard-flag discipline are documented; v5.0.0 remains unreleased |
+
+## Residual Missing Evidence
+
+PR-Xfinal remains blocked for this dimension until a later operator-bound
+supersession provides:
+
+- v5.0.0 tag evidence;
+- PyPI publish evidence for the v5.0.0 release artifact;
+- final standalone install smoke against that release artifact;
+- final Docker or container image smoke bound to that release artifact;
+- final Kubernetes/Helm deploy lifecycle smoke bound to the promoted artifact;
+- rollback and downgrade smoke from the promoted artifact back to the supported
+  baseline.
+
+This is intentionally a preflight artifact. It makes the existing
+install/deploy lifecycle surface auditable without changing the production
+claim gate.

--- a/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
+++ b/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
@@ -99,3 +99,14 @@ observability production tunables preflight bundle:
 That bundle binds Grafana dashboard shape, SLI/SLO catalog discipline, and
 advisory performance policy evidence without treating them as final
 claim-bound observability smoke or alert escalation evidence.
+
+The `install_deploy_lifecycle_smoke` dimension now has a current-state
+install/deploy lifecycle preflight bundle:
+
+- `.claude/plans/V5-INSTALL-DEPLOY-LIFECYCLE-PREFLIGHT-BUNDLE.md`
+- `tests/fixtures/epic9/v5-install-deploy-lifecycle-preflight.current.json`
+
+That bundle binds standalone packaging smoke, deployment guide, operator
+runbook, Helm render/runbook surface, publish workflow, and migration-guide
+evidence without treating them as v5.0.0 release-artifact smoke, final tag or
+publish evidence, or final deployment lifecycle evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **V5 install/deploy lifecycle preflight bundle** (V5 Epic 9, #895): added
+  `V5-INSTALL-DEPLOY-LIFECYCLE-PREFLIGHT-BUNDLE.md`,
+  `v5-install-deploy-lifecycle-preflight-bundle.schema.v1.json`, and a
+  current-state fixture/test suite that binds standalone packaging smoke,
+  deployment-guide coverage, operator runbooks, Helm render/runbook evidence,
+  publish workflow safeguards, and migration-guide downgrade discipline to the
+  `install_deploy_lifecycle_smoke` production-readiness dimension. This is
+  preflight evidence only: final v5.0.0 tag/publish evidence, release-artifact
+  install smoke, deployment lifecycle smoke, and rollback/downgrade smoke
+  remain missing while `support_widening` / `production_platform_claim` /
+  `live_adapter_execution` remain false.
 - **V5 cost/rate/circuit breaker preflight bundle** (V5 Epic 9, #895): added
   `V5-COST-RATE-CIRCUIT-BREAKER-PREFLIGHT-BUNDLE.md`,
   `v5-cost-rate-circuit-breaker-preflight-bundle.schema.v1.json`, and a

--- a/ao_kernel/defaults/schemas/v5-install-deploy-lifecycle-preflight-bundle.schema.v1.json
+++ b/ao_kernel/defaults/schemas/v5-install-deploy-lifecycle-preflight-bundle.schema.v1.json
@@ -1,0 +1,205 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:v5-install-deploy-lifecycle-preflight-bundle:v1",
+  "title": "V5 install deploy lifecycle preflight evidence bundle v1",
+  "description": "Current-state preflight bundle for the V5 install/deploy lifecycle dimension. It records existing packaging smoke, deployment guide, operator runbook, Helm, publish workflow, and migration-guide evidence while keeping final release-artifact evidence and all production guard flags fail-closed.",
+  "type": "object",
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "repo",
+    "work_package",
+    "dimension",
+    "evidence_class",
+    "final_release_bound",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution",
+    "standalone_install_smoke",
+    "deployment_guide",
+    "operator_runbooks",
+    "helm_lifecycle",
+    "publish_lifecycle",
+    "migration_guide",
+    "residual_missing_evidence",
+    "issue_refs"
+  ],
+  "properties": {
+    "schema_version": { "const": "v5_install_deploy_lifecycle_preflight_bundle.v1" },
+    "artifact_kind": { "const": "v5_install_deploy_lifecycle_preflight_bundle" },
+    "repo": { "const": "Halildeu/ao-kernel" },
+    "work_package": { "const": "E-9-1" },
+    "dimension": { "const": "install_deploy_lifecycle_smoke" },
+    "evidence_class": { "const": "preflight_current_state" },
+    "final_release_bound": { "const": false },
+    "support_widening": { "const": false },
+    "production_platform_claim": { "const": false },
+    "live_adapter_execution": { "const": false },
+    "standalone_install_smoke": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "script_path",
+        "ci_workflow_path",
+        "ri7_packaging_smoke_test_path",
+        "wheel_installed_smoke_present",
+        "release_artifact_bound",
+        "dist_cleanup_required"
+      ],
+      "properties": {
+        "script_path": { "const": "scripts/packaging_smoke.py" },
+        "ci_workflow_path": { "const": ".github/workflows/test.yml" },
+        "ri7_packaging_smoke_test_path": {
+          "const": "tests/test_ri7_scan_index_query_packaging_smoke_invariant.py"
+        },
+        "wheel_installed_smoke_present": { "const": true },
+        "release_artifact_bound": { "const": false },
+        "dist_cleanup_required": { "const": true }
+      }
+    },
+    "deployment_guide": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "doc_path",
+        "test_path",
+        "standalone_pattern",
+        "docker_pattern",
+        "kubernetes_pattern",
+        "operator_bound_supersession_required",
+        "guard_flags_const_false_documented"
+      ],
+      "properties": {
+        "doc_path": { "const": "docs/PRODUCTION-DEPLOYMENT-GUIDE.md" },
+        "test_path": { "const": "tests/test_production_deployment_guide.py" },
+        "standalone_pattern": { "const": true },
+        "docker_pattern": { "const": true },
+        "kubernetes_pattern": { "const": true },
+        "operator_bound_supersession_required": { "const": true },
+        "guard_flags_const_false_documented": { "const": true }
+      }
+    },
+    "operator_runbooks": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "operator_runbook_path",
+        "operator_runbook_test_path",
+        "operator_action_readme_path",
+        "operator_action_checklist_path",
+        "operator_action_checklist_schema_path",
+        "operator_action_checklist_test_path",
+        "operator_action_required",
+        "agent_executed_external_action"
+      ],
+      "properties": {
+        "operator_runbook_path": { "const": "docs/OPERATOR-RUNBOOK.md" },
+        "operator_runbook_test_path": { "const": "tests/test_operator_runbook.py" },
+        "operator_action_readme_path": { "const": "docs/operator-runbooks/README.md" },
+        "operator_action_checklist_path": {
+          "const": "docs/operator-runbooks/operator-action-checklist.v1.json"
+        },
+        "operator_action_checklist_schema_path": {
+          "const": "ao_kernel/defaults/schemas/operator-action-checklist.schema.v1.json"
+        },
+        "operator_action_checklist_test_path": { "const": "tests/test_operator_runbooks.py" },
+        "operator_action_required": { "const": true },
+        "agent_executed_external_action": { "const": false }
+      }
+    },
+    "helm_lifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "deployment_template_path",
+        "helm_unittest_suite_path",
+        "helm_testing_runbook_path",
+        "default_safe_single_replica",
+        "non_root_security_context_pinned",
+        "operator_run_plugin_smoke_only",
+        "release_artifact_bound"
+      ],
+      "properties": {
+        "deployment_template_path": { "const": "deploy/helm/ao-kernel/templates/deployment.yaml" },
+        "helm_unittest_suite_path": { "const": "deploy/helm/ao-kernel/tests/deployment_test.yaml" },
+        "helm_testing_runbook_path": { "const": "docs/HELM-TESTING.md" },
+        "default_safe_single_replica": { "const": true },
+        "non_root_security_context_pinned": { "const": true },
+        "operator_run_plugin_smoke_only": { "const": true },
+        "release_artifact_bound": { "const": false }
+      }
+    },
+    "publish_lifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "workflow_path",
+        "workflow_test_path",
+        "operator_runbook_path",
+        "trusted_publishing_environment",
+        "workflow_dispatch_ref_required",
+        "v_tag_guard_present",
+        "strict_dist_globs",
+        "v5_tag_evidence_present",
+        "v5_publish_evidence_present"
+      ],
+      "properties": {
+        "workflow_path": { "const": ".github/workflows/publish.yml" },
+        "workflow_test_path": { "const": "tests/test_publish_workflow.py" },
+        "operator_runbook_path": { "const": "docs/operator-runbooks/01-pypi-publish.md" },
+        "trusted_publishing_environment": { "const": "pypi" },
+        "workflow_dispatch_ref_required": { "const": true },
+        "v_tag_guard_present": { "const": true },
+        "strict_dist_globs": { "const": true },
+        "v5_tag_evidence_present": { "const": false },
+        "v5_publish_evidence_present": { "const": false }
+      }
+    },
+    "migration_guide": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "doc_path",
+        "test_path",
+        "target_version",
+        "downgrade_pin",
+        "guard_flags_const_false_documented",
+        "release_shipped"
+      ],
+      "properties": {
+        "doc_path": { "const": "docs/MIGRATION-V5.md" },
+        "test_path": { "const": "tests/test_migration_v5_doc.py" },
+        "target_version": { "const": "5.0.0" },
+        "downgrade_pin": { "const": "ao-kernel==4.1.0" },
+        "guard_flags_const_false_documented": { "const": true },
+        "release_shipped": { "const": false }
+      }
+    },
+    "residual_missing_evidence": {
+      "type": "array",
+      "minItems": 5,
+      "contains": { "const": "v5.0.0 tag evidence" },
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "issue_refs": {
+      "type": "array",
+      "prefixItems": [
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/775" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/776" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/782" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/895" }
+      ],
+      "minItems": 4,
+      "maxItems": 4,
+      "items": false
+    }
+  }
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -13,16 +13,16 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/v5-cost-rate-circuit-breaker-preflight-bundle",
+    "head_ref": "refs/heads/codex/v5-install-deploy-lifecycle-preflight-bundle",
     "changed_files": [
-      ".claude/plans/V5-COST-RATE-CIRCUIT-BREAKER-PREFLIGHT-BUNDLE.md",
+      ".claude/plans/V5-INSTALL-DEPLOY-LIFECYCLE-PREFLIGHT-BUNDLE.md",
       ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
       "CHANGELOG.md",
-      "ao_kernel/defaults/schemas/v5-cost-rate-circuit-breaker-preflight-bundle.schema.v1.json",
+      "ao_kernel/defaults/schemas/v5-install-deploy-lifecycle-preflight-bundle.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/fixtures/epic9/v5-cost-rate-circuit-breaker-preflight.current.json",
+      "tests/fixtures/epic9/v5-install-deploy-lifecycle-preflight.current.json",
       "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/test_v5_cost_rate_circuit_breaker_preflight_bundle.py"
+      "tests/test_v5_install_deploy_lifecycle_preflight_bundle.py"
     ]
   },
   "checks_considered": [
@@ -31,7 +31,7 @@
       "status": "pass"
     },
     {
-      "name": "pytest_cost_rate_circuit_breaker_preflight_bundle",
+      "name": "pytest_install_deploy_lifecycle_preflight_bundle",
       "status": "pass"
     },
     {
@@ -60,12 +60,13 @@
     }
   ],
   "findings": [
-    "Claude (Anthropic) reviewed the staged V5 cost/rate/circuit-breaker preflight bundle and returned VERDICT AGREE.",
-    "The reviewer confirmed the bundle is bounded to current-state preflight evidence and does not authorize support widening, production platform claim, live adapter execution, PR-Xfinal, tag, release, or live provider calls.",
-    "The reviewer confirmed schema strictness: object nodes are closed, issue refs and dimension values are pinned, residual missing evidence remains required, and guard flips are rejected.",
-    "The reviewer confirmed the evidence claims are defensible from repo-local artifacts covering dormant cost policy, cost ceiling, per-call audit, simulated usage-cost evidence, rate limiter, circuit breaker, pricing digest, SLI, and incident-response references.",
-    "Local validation before review: 110 tests passed for the cost/rate/circuit-breaker preflight bundle, production readiness matrix invariants, cost policy, cost ceiling, usage-cost evidence, rate limiter, and circuit breaker.",
-    "Staged secret scan passed with no leaks found.",
+    "Claude (Anthropic) reviewed the staged V5 install/deploy lifecycle preflight bundle and returned VERDICT AGREE.",
+    "The reviewer confirmed the bundle is bounded to current-state preflight evidence and does not authorize support widening, production platform claim, live adapter execution, PR-Xfinal, v5.0.0 tag or publish, or final release-artifact smoke.",
+    "The reviewer confirmed schema strictness: object nodes are closed, guard flags and nested release claims are const false, issue refs are pinned, residual missing evidence remains required, and release-claim flips are rejected.",
+    "The reviewer confirmed the evidence claims are defensible from repo-local artifacts covering packaging smoke, deployment guide, operator runbooks, Helm render/runbook surface, publish workflow safeguards, and migration-guide downgrade discipline.",
+    "The reviewer confirmed the matrix integration keeps install_deploy_lifecycle_smoke partial, matrix_complete false, and missing v5.0.0 tag/publish/final lifecycle smoke evidence explicit.",
+    "Local validation before review: 119 tests passed for the install/deploy lifecycle preflight bundle, production readiness matrix invariants, deployment guide, publish workflow, operator runbooks, RI-7 packaging smoke, and migration guide.",
+    "Staged diff secret scan passed with no leaks found.",
     "No secrets were recorded in the review prompt, review output, evidence file, or validation artifacts."
   ],
   "secrets_recorded": false,

--- a/tests/fixtures/epic9/v5-install-deploy-lifecycle-preflight.current.json
+++ b/tests/fixtures/epic9/v5-install-deploy-lifecycle-preflight.current.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "v5_install_deploy_lifecycle_preflight_bundle.v1",
+  "artifact_kind": "v5_install_deploy_lifecycle_preflight_bundle",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "E-9-1",
+  "dimension": "install_deploy_lifecycle_smoke",
+  "evidence_class": "preflight_current_state",
+  "final_release_bound": false,
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false,
+  "standalone_install_smoke": {
+    "script_path": "scripts/packaging_smoke.py",
+    "ci_workflow_path": ".github/workflows/test.yml",
+    "ri7_packaging_smoke_test_path": "tests/test_ri7_scan_index_query_packaging_smoke_invariant.py",
+    "wheel_installed_smoke_present": true,
+    "release_artifact_bound": false,
+    "dist_cleanup_required": true
+  },
+  "deployment_guide": {
+    "doc_path": "docs/PRODUCTION-DEPLOYMENT-GUIDE.md",
+    "test_path": "tests/test_production_deployment_guide.py",
+    "standalone_pattern": true,
+    "docker_pattern": true,
+    "kubernetes_pattern": true,
+    "operator_bound_supersession_required": true,
+    "guard_flags_const_false_documented": true
+  },
+  "operator_runbooks": {
+    "operator_runbook_path": "docs/OPERATOR-RUNBOOK.md",
+    "operator_runbook_test_path": "tests/test_operator_runbook.py",
+    "operator_action_readme_path": "docs/operator-runbooks/README.md",
+    "operator_action_checklist_path": "docs/operator-runbooks/operator-action-checklist.v1.json",
+    "operator_action_checklist_schema_path": "ao_kernel/defaults/schemas/operator-action-checklist.schema.v1.json",
+    "operator_action_checklist_test_path": "tests/test_operator_runbooks.py",
+    "operator_action_required": true,
+    "agent_executed_external_action": false
+  },
+  "helm_lifecycle": {
+    "deployment_template_path": "deploy/helm/ao-kernel/templates/deployment.yaml",
+    "helm_unittest_suite_path": "deploy/helm/ao-kernel/tests/deployment_test.yaml",
+    "helm_testing_runbook_path": "docs/HELM-TESTING.md",
+    "default_safe_single_replica": true,
+    "non_root_security_context_pinned": true,
+    "operator_run_plugin_smoke_only": true,
+    "release_artifact_bound": false
+  },
+  "publish_lifecycle": {
+    "workflow_path": ".github/workflows/publish.yml",
+    "workflow_test_path": "tests/test_publish_workflow.py",
+    "operator_runbook_path": "docs/operator-runbooks/01-pypi-publish.md",
+    "trusted_publishing_environment": "pypi",
+    "workflow_dispatch_ref_required": true,
+    "v_tag_guard_present": true,
+    "strict_dist_globs": true,
+    "v5_tag_evidence_present": false,
+    "v5_publish_evidence_present": false
+  },
+  "migration_guide": {
+    "doc_path": "docs/MIGRATION-V5.md",
+    "test_path": "tests/test_migration_v5_doc.py",
+    "target_version": "5.0.0",
+    "downgrade_pin": "ao-kernel==4.1.0",
+    "guard_flags_const_false_documented": true,
+    "release_shipped": false
+  },
+  "residual_missing_evidence": [
+    "v5.0.0 tag evidence",
+    "PyPI publish evidence for the v5.0.0 release artifact",
+    "final standalone install smoke against that release artifact",
+    "final Docker or container image smoke bound to that release artifact",
+    "final Kubernetes/Helm deploy lifecycle smoke bound to the promoted artifact",
+    "rollback and downgrade smoke from the promoted artifact back to the supported baseline"
+  ],
+  "issue_refs": [
+    "https://github.com/Halildeu/ao-kernel/issues/775",
+    "https://github.com/Halildeu/ao-kernel/issues/776",
+    "https://github.com/Halildeu/ao-kernel/issues/782",
+    "https://github.com/Halildeu/ao-kernel/issues/895"
+  ]
+}

--- a/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
+++ b/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
@@ -137,6 +137,13 @@
       ],
       "current_evidence_refs": [
         "docs/MIGRATION-V5.md",
+        ".claude/plans/V5-INSTALL-DEPLOY-LIFECYCLE-PREFLIGHT-BUNDLE.md",
+        "tests/fixtures/epic9/v5-install-deploy-lifecycle-preflight.current.json",
+        "scripts/packaging_smoke.py",
+        ".github/workflows/publish.yml",
+        "docs/PRODUCTION-DEPLOYMENT-GUIDE.md",
+        "docs/OPERATOR-RUNBOOK.md",
+        "deploy/helm/ao-kernel/tests/deployment_test.yaml",
         "tests/test_production_deployment_guide.py",
         "tests/test_migration_v5_doc.py"
       ],

--- a/tests/test_v5_install_deploy_lifecycle_preflight_bundle.py
+++ b/tests/test_v5_install_deploy_lifecycle_preflight_bundle.py
@@ -1,0 +1,320 @@
+"""V5 install/deploy lifecycle preflight bundle invariants.
+
+The V5 production readiness matrix keeps the install/deploy lifecycle
+dimension partial until a later operator-bound PR-Xfinal binds the evidence to
+the actual v5.0.0 release artifact. This bundle records the current preflight
+surface without authorizing a tag, publish, production claim, support widening,
+or live adapter execution.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_NAME = "v5-install-deploy-lifecycle-preflight-bundle.schema.v1.json"
+SCHEMA_PATH = ROOT / "ao_kernel" / "defaults" / "schemas" / SCHEMA_NAME
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "epic9" / "v5-install-deploy-lifecycle-preflight.current.json"
+MATRIX_FIXTURE_PATH = ROOT / "tests" / "fixtures" / "epic9" / "v5-production-readiness-matrix.current.json"
+MATRIX_DOC_PATH = ROOT / ".claude" / "plans" / "V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md"
+BUNDLE_DOC_PATH = ROOT / ".claude" / "plans" / "V5-INSTALL-DEPLOY-LIFECYCLE-PREFLIGHT-BUNDLE.md"
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", SCHEMA_NAME)
+
+
+def _fixture() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _matrix_fixture() -> dict[str, Any]:
+    return json.loads(MATRIX_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _is_valid(payload: dict[str, Any]) -> bool:
+    return not list(Draft202012Validator(_schema()).iter_errors(payload))
+
+
+def _object_nodes(node: Any) -> list[dict[str, Any]]:
+    nodes: list[dict[str, Any]] = []
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            nodes.append(node)
+        for value in node.values():
+            nodes.extend(_object_nodes(value))
+    elif isinstance(node, list):
+        for value in node:
+            nodes.extend(_object_nodes(value))
+    return nodes
+
+
+def _dimension(payload: dict[str, Any], dimension_id: str) -> dict[str, Any]:
+    for dimension in payload["dimensions"]:
+        if dimension["id"] == dimension_id:
+            return dimension
+    raise AssertionError(f"dimension not found: {dimension_id}")
+
+
+def test_schema_present_valid_and_strict() -> None:
+    assert SCHEMA_PATH.is_file()
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["$id"] == "urn:ao:v5-install-deploy-lifecycle-preflight-bundle:v1"
+
+    for node in _object_nodes(schema):
+        assert node.get("additionalProperties") is False
+        assert node.get("unevaluatedProperties") is False
+
+
+def test_current_fixture_validates_and_pins_non_authority_boundary() -> None:
+    payload = _fixture()
+    assert _is_valid(payload)
+    assert payload["schema_version"] == "v5_install_deploy_lifecycle_preflight_bundle.v1"
+    assert payload["artifact_kind"] == "v5_install_deploy_lifecycle_preflight_bundle"
+    assert payload["repo"] == "Halildeu/ao-kernel"
+    assert payload["work_package"] == "E-9-1"
+    assert payload["dimension"] == "install_deploy_lifecycle_smoke"
+    assert payload["evidence_class"] == "preflight_current_state"
+    assert payload["final_release_bound"] is False
+    assert payload["support_widening"] is False
+    assert payload["production_platform_claim"] is False
+    assert payload["live_adapter_execution"] is False
+
+
+def test_schema_rejects_final_release_or_guard_flag_flips() -> None:
+    for field in (
+        "final_release_bound",
+        "support_widening",
+        "production_platform_claim",
+        "live_adapter_execution",
+    ):
+        payload = _fixture()
+        payload[field] = True
+        assert not _is_valid(payload), f"{field}=true must fail closed"
+
+
+def test_schema_rejects_nested_release_artifact_claims() -> None:
+    mutations: tuple[tuple[str, str], ...] = (
+        ("standalone_install_smoke", "release_artifact_bound"),
+        ("helm_lifecycle", "release_artifact_bound"),
+        ("publish_lifecycle", "v5_tag_evidence_present"),
+        ("publish_lifecycle", "v5_publish_evidence_present"),
+        ("migration_guide", "release_shipped"),
+    )
+    for section, field in mutations:
+        payload = _fixture()
+        payload[section][field] = True
+        assert not _is_valid(payload), f"{section}.{field}=true must fail closed"
+
+
+def test_schema_rejects_path_or_extra_field_drift() -> None:
+    payload = _fixture()
+    payload["standalone_install_smoke"]["script_path"] = "scripts/other.py"
+    assert not _is_valid(payload)
+
+    payload = _fixture()
+    payload["publish_lifecycle"]["trusted_publishing_environment"] = "prod"
+    assert not _is_valid(payload)
+
+    payload = _fixture()
+    payload["unexpected"] = "not allowed"
+    assert not _is_valid(payload)
+
+    payload = _fixture()
+    payload["operator_runbooks"]["unexpected"] = "not allowed"
+    assert not _is_valid(payload)
+
+
+def test_all_referenced_artifacts_exist() -> None:
+    payload = _fixture()
+    path_sections = (
+        "standalone_install_smoke",
+        "deployment_guide",
+        "operator_runbooks",
+        "helm_lifecycle",
+        "publish_lifecycle",
+        "migration_guide",
+    )
+    for section_name in path_sections:
+        section = payload[section_name]
+        for key, value in section.items():
+            if key.endswith("_path"):
+                assert (ROOT / value).exists(), f"{section_name}.{key} missing: {value}"
+
+
+def test_standalone_install_smoke_surface_is_current_state_only() -> None:
+    payload = _fixture()
+    section = payload["standalone_install_smoke"]
+    workflow = (ROOT / section["ci_workflow_path"]).read_text(encoding="utf-8")
+    smoke_script = (ROOT / section["script_path"]).read_text(encoding="utf-8")
+    ri7_test = (ROOT / section["ri7_packaging_smoke_test_path"]).read_text(encoding="utf-8")
+
+    assert section["wheel_installed_smoke_present"] is True
+    assert section["release_artifact_bound"] is False
+    assert section["dist_cleanup_required"] is True
+    assert "packaging-smoke:" in workflow
+    assert "python scripts/packaging_smoke.py" in workflow
+    assert "_smoke_repo_intelligence_cli" in smoke_script
+    assert "ri7_scan_index_query_packaging_smoke_ready" in ri7_test
+
+
+def test_deployment_guide_and_operator_runbooks_keep_claim_discipline() -> None:
+    payload = _fixture()
+    deployment = payload["deployment_guide"]
+    guide = (ROOT / deployment["doc_path"]).read_text(encoding="utf-8")
+    guide_tests = (ROOT / deployment["test_path"]).read_text(encoding="utf-8")
+
+    assert deployment["standalone_pattern"] is True
+    assert deployment["docker_pattern"] is True
+    assert deployment["kubernetes_pattern"] is True
+    assert deployment["operator_bound_supersession_required"] is True
+    assert deployment["guard_flags_const_false_documented"] is True
+    assert "Standalone" in guide
+    assert "Docker" in guide
+    assert "Kubernetes" in guide
+    assert "operator-bound supersession" in guide
+    assert "test_guide_covers_standalone_pattern" in guide_tests
+    assert "test_guide_three_guard_flags_const_false_disclaimer" in guide_tests
+
+    runbooks = payload["operator_runbooks"]
+    runbook = (ROOT / runbooks["operator_runbook_path"]).read_text(encoding="utf-8")
+    action_readme = (ROOT / runbooks["operator_action_readme_path"]).read_text(encoding="utf-8")
+    action_tests = (ROOT / runbooks["operator_action_checklist_test_path"]).read_text(encoding="utf-8")
+
+    assert runbooks["operator_action_required"] is True
+    assert runbooks["agent_executed_external_action"] is False
+    for token in ("rollback", "tag revert", "pause", "emergency stop", "incident triage"):
+        assert token in runbook
+    assert "operator-action-checklist.v1.json" in action_readme
+    assert "agent_executed_external_action" in action_tests
+    assert "operator_action_required" in action_tests
+
+
+def test_helm_lifecycle_surface_is_operator_run_and_not_release_bound() -> None:
+    payload = _fixture()
+    section = payload["helm_lifecycle"]
+    deployment_test = (ROOT / section["helm_unittest_suite_path"]).read_text(encoding="utf-8")
+    helm_doc = (ROOT / section["helm_testing_runbook_path"]).read_text(encoding="utf-8")
+    template = (ROOT / section["deployment_template_path"]).read_text(encoding="utf-8")
+
+    assert section["default_safe_single_replica"] is True
+    assert section["non_root_security_context_pinned"] is True
+    assert section["operator_run_plugin_smoke_only"] is True
+    assert section["release_artifact_bound"] is False
+    assert "renders a single Deployment with replicas >= 1" in deployment_test
+    assert "runAsNonRoot" in deployment_test
+    assert "AO_KERNEL_DB_PASSWORD" in deployment_test
+    assert "readOnlyRootFilesystem: true" in template
+    assert "operator-run" in helm_doc
+    assert "Does NOT flip any guard flag" in helm_doc
+
+
+def test_publish_lifecycle_has_strict_dist_and_trusted_publishing_guards() -> None:
+    payload = _fixture()
+    section = payload["publish_lifecycle"]
+    workflow = (ROOT / section["workflow_path"]).read_text(encoding="utf-8")
+    workflow_tests = (ROOT / section["workflow_test_path"]).read_text(encoding="utf-8")
+    runbook = (ROOT / section["operator_runbook_path"]).read_text(encoding="utf-8")
+
+    assert section["trusted_publishing_environment"] == "pypi"
+    assert section["workflow_dispatch_ref_required"] is True
+    assert section["v_tag_guard_present"] is True
+    assert section["strict_dist_globs"] is True
+    assert section["v5_tag_evidence_present"] is False
+    assert section["v5_publish_evidence_present"] is False
+    assert "environment: pypi" in workflow
+    assert "id-token: write" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "required: true" in workflow
+    assert 'tags: ["v*"]' in workflow
+    assert "twine check dist/*.whl dist/*.tar.gz" in workflow
+    assert "python scripts/packaging_smoke.py" in workflow
+    assert "test_publish_workflow_dispatch_ref_is_required_and_v_tag_guarded" in workflow_tests
+    assert "test_publish_workflow_twine_args_are_strict_whitelist" in workflow_tests
+    assert "operator" in runbook.lower()
+
+
+def test_migration_guide_is_planned_and_keeps_downgrade_pin() -> None:
+    payload = _fixture()
+    section = payload["migration_guide"]
+    guide = (ROOT / section["doc_path"]).read_text(encoding="utf-8")
+    tests = (ROOT / section["test_path"]).read_text(encoding="utf-8")
+
+    assert section["target_version"] == "5.0.0"
+    assert section["downgrade_pin"] == "ao-kernel==4.1.0"
+    assert section["guard_flags_const_false_documented"] is True
+    assert section["release_shipped"] is False
+    assert "v5.0.0 is not yet released" in guide
+    assert "pip install ao-kernel==4.1.0" in guide
+    assert "support_widening" in guide
+    assert "production_platform_claim" in guide
+    assert "live_adapter_execution" in guide
+    assert "test_migration_v5_downgrade_path_pinned" in tests
+    assert "test_migration_v5_guard_flag_constant_false_pinned" in tests
+
+
+def test_residual_missing_evidence_pins_release_artifact_gap() -> None:
+    residual = _fixture()["residual_missing_evidence"]
+    expected = {
+        "v5.0.0 tag evidence",
+        "PyPI publish evidence for the v5.0.0 release artifact",
+        "final standalone install smoke against that release artifact",
+        "final Docker or container image smoke bound to that release artifact",
+        "final Kubernetes/Helm deploy lifecycle smoke bound to the promoted artifact",
+        "rollback and downgrade smoke from the promoted artifact back to the supported baseline",
+    }
+    assert set(residual) == expected
+
+
+def test_matrix_dimension_references_bundle_but_remains_partial() -> None:
+    matrix = _matrix_fixture()
+    dimension = _dimension(matrix, "install_deploy_lifecycle_smoke")
+    refs = set(dimension["current_evidence_refs"])
+    missing = set(dimension["missing_evidence"])
+
+    assert matrix["matrix_complete"] is False
+    assert matrix["support_widening"] is False
+    assert matrix["production_platform_claim"] is False
+    assert matrix["live_adapter_execution"] is False
+    assert dimension["status"] == "partial"
+    assert ".claude/plans/V5-INSTALL-DEPLOY-LIFECYCLE-PREFLIGHT-BUNDLE.md" in refs
+    assert "tests/fixtures/epic9/v5-install-deploy-lifecycle-preflight.current.json" in refs
+    assert "v5.0.0 tag and publish evidence" in missing
+    assert "final install and deployment lifecycle smoke bound to release artifact" in missing
+
+
+def test_docs_reference_bundle_without_positive_claim_tokens() -> None:
+    bundle_doc = BUNDLE_DOC_PATH.read_text(encoding="utf-8")
+    matrix_doc = MATRIX_DOC_PATH.read_text(encoding="utf-8")
+    lower = (bundle_doc + "\n" + matrix_doc).lower()
+
+    assert "v5-install-deploy-lifecycle-preflight-bundle.schema.v1.json" in bundle_doc
+    assert "v5-install-deploy-lifecycle-preflight.current.json" in bundle_doc
+    assert "install/deploy lifecycle preflight bundle" in matrix_doc
+    for token in (
+        "production-ready",
+        "production ready",
+        "support_widening=true",
+        "production_platform_claim=true",
+        "live_adapter_execution=true",
+        "final_release_bound=true",
+        "matrix_complete=true",
+    ):
+        assert token not in lower, f"positive claim token found: {token}"
+
+
+def test_fixture_copy_is_not_mutated_by_validation_helper() -> None:
+    payload = _fixture()
+    before = copy.deepcopy(payload)
+    assert _is_valid(payload)
+    assert payload == before


### PR DESCRIPTION
## Scope

Adds a V5 Epic 9 current-state preflight bundle for the `install_deploy_lifecycle_smoke` production-readiness matrix dimension.

Changed surface:
- `.claude/plans/V5-INSTALL-DEPLOY-LIFECYCLE-PREFLIGHT-BUNDLE.md`
- `ao_kernel/defaults/schemas/v5-install-deploy-lifecycle-preflight-bundle.schema.v1.json`
- `tests/fixtures/epic9/v5-install-deploy-lifecycle-preflight.current.json`
- `tests/test_v5_install_deploy_lifecycle_preflight_bundle.py`
- Matrix blocker doc/fixture cross-reference
- `CHANGELOG.md`
- `local-ai-review-evidence.v1.json`

## Non-authority boundary

This PR does **not** authorize:
- support widening
- production platform claim
- live adapter execution
- v5.0.0 tag or publish
- PR-Xfinal
- final release-artifact smoke

The matrix dimension remains `partial`, `matrix_complete=false`, and all guard flags remain false.

## Validation

Local:
- `python3 -m pytest tests/test_v5_install_deploy_lifecycle_preflight_bundle.py tests/test_v5_production_readiness_matrix_blocker.py tests/test_production_deployment_guide.py tests/test_publish_workflow.py tests/test_operator_runbook.py tests/test_operator_runbooks.py tests/test_ri7_scan_index_query_packaging_smoke_invariant.py tests/test_migration_v5_doc.py -q` -> 119 passed
- `git diff --cached --check` -> clean
- `git diff --cached | gitleaks detect --pipe --no-banner --redact` -> no leaks found
- Claude/Anthropic staged-diff review -> VERDICT: AGREE
- `python3 scripts/local_gpp_gate.py ...` -> `decision=operator_may_merge`

Local gate binding:
- head_sha: `c5a4fb244cec47da077fcf907e2fde8a2d7091ad`
- diff_digest: `sha256:3cbfb7ba1d382b7991fad7db36de456d65faf3ab9670420577b3fb88c04eaaa7`
- changed_files_count: 8

## Notes

This is preflight current-state evidence only. It makes install/deploy lifecycle readiness auditable, but final v5.0.0 tag/publish evidence, release-artifact install smoke, deployment lifecycle smoke, and rollback/downgrade smoke remain missing until a later operator-bound PR-Xfinal path.