### PR TITLE
feat(epic9): add V5 docs-runbooks preflight bundle

### DIFF
--- a/.claude/plans/V5-DOCS-RUNBOOKS-PREFLIGHT-BUNDLE.md
+++ b/.claude/plans/V5-DOCS-RUNBOOKS-PREFLIGHT-BUNDLE.md
@@ -1,0 +1,57 @@
+# V5 Docs and Runbooks Preflight Bundle
+
+**Status:** current-state preflight evidence / not final release authority
+**Work package:** E-9-1
+**Parent matrix:** `.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md`
+**Schema:** `ao_kernel/defaults/schemas/v5-docs-runbooks-preflight-bundle.schema.v1.json`
+**Fixture:** `tests/fixtures/epic9/v5-docs-runbooks-preflight.current.json`
+
+This document records the current state of the `docs_runbooks` dimension in
+the V5 production-readiness matrix. It binds deployment, operator, rollback,
+API-reference, migration, incident-response, and vendor-escalation evidence
+into one machine-checkable preflight artifact.
+
+## Non-Authority Boundary
+
+This bundle does not authorize:
+
+- support widening;
+- production platform claims;
+- live adapter execution;
+- final PR-Xfinal claim-language sync;
+- v5.0.0 release notes publication;
+- final v5.0.0 runbook update;
+- hosted API docs publication;
+- treating docs tests as release-artifact evidence.
+
+The current bundle pins `final_claim_language_synced=false`,
+`final_release_notes_present=false`, `v5_runbook_finalized=false`,
+`support_widening=false`, `production_platform_claim=false`, and
+`live_adapter_execution=false`.
+
+## Current Preflight Evidence
+
+| Surface | Current evidence | Boundary |
+|---|---|---|
+| Deployment guide | `docs/PRODUCTION-DEPLOYMENT-GUIDE.md`, `tests/test_production_deployment_guide.py` | covers standalone, Docker, and Kubernetes patterns while keeping guard flags false |
+| Operator runbook | `docs/OPERATOR-RUNBOOK.md`, `tests/test_operator_runbook.py` | covers rollback, tag revert, pause, emergency stop, and incident triage; operator-bound supersession remains required |
+| Operator action runbooks | `docs/operator-runbooks/README.md`, `docs/operator-runbooks/operator-action-checklist.v1.json`, `ao_kernel/defaults/schemas/operator-action-checklist.schema.v1.json`, `tests/test_operator_runbooks.py` | records operator-required actions without agent execution or committed credential material |
+| Rollback procedure | `docs/ROLLBACK-RUNBOOK.md`, `docs/ROLLBACK.md` | documents archive-tag recovery, no destructive history rewrite, operator ruleset authority, and forward fix or revert PR discipline |
+| API reference | `docs/api/README.md`, `docs/api/conf.py`, `docs/api/index.rst`, `tests/test_sphinx_api_reference_scaffold.py` | Sphinx scaffold exists and excludes private/live-provider surfaces; build and hosted docs remain operator decisions |
+| Migration guide | `docs/MIGRATION-V5.md`, `tests/test_migration_v5_doc.py` | planned v5 path and downgrade pin exist; the release is not shipped |
+| Incident response | `docs/incident-response/README.md`, severity matrix/schema, escalation policy, incident template, `tests/test_incident_response_playbook.py` | process contract only; not a contractual SLA and no live dispatch |
+| Vendor escalation | `docs/incident-response/vendor-escalation-matrix.v1.json`, `docs/incident-response/vendor-escalation-runbook.v1.md`, `tests/test_vendor_escalation_matrix.py` | operator-owned external handoff; no vendor SLA promise and no committed PII/contact material |
+
+## Residual Missing Evidence
+
+PR-Xfinal remains blocked for this dimension until a later operator-bound
+supersession provides:
+
+- final v5.0.0 release notes;
+- final PR-Xfinal claim-language sync;
+- final v5.0.0 runbook update;
+- hosted API docs publication decision;
+- operator-attested final docs review.
+
+This is intentionally a preflight artifact. It makes the existing docs and
+runbook surface auditable without changing the production claim gate.

--- a/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
+++ b/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
@@ -110,3 +110,15 @@ That bundle binds standalone packaging smoke, deployment guide, operator
 runbook, Helm render/runbook surface, publish workflow, and migration-guide
 evidence without treating them as v5.0.0 release-artifact smoke, final tag or
 publish evidence, or final deployment lifecycle evidence.
+
+The `docs_runbooks` dimension now has a current-state docs/runbooks preflight
+bundle:
+
+- `.claude/plans/V5-DOCS-RUNBOOKS-PREFLIGHT-BUNDLE.md`
+- `tests/fixtures/epic9/v5-docs-runbooks-preflight.current.json`
+
+That bundle binds deployment, operator, rollback, API-reference, migration,
+incident-response, and vendor-escalation documentation evidence without
+treating it as final PR-Xfinal claim-language sync, v5.0.0 release notes,
+final runbook update, hosted API-docs publication, support widening, live
+adapter execution, or a production platform claim.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **V5 docs/runbooks preflight bundle** (V5 Epic 9, #895): added
+  `V5-DOCS-RUNBOOKS-PREFLIGHT-BUNDLE.md`,
+  `v5-docs-runbooks-preflight-bundle.schema.v1.json`, and a current-state
+  fixture/test suite that binds deployment guide, operator runbook, operator
+  action runbooks, rollback procedure, API-reference scaffold, migration
+  guide, incident-response playbook, and vendor-escalation evidence to the
+  `docs_runbooks` production-readiness dimension. This is preflight evidence
+  only: final v5.0.0 release notes, PR-Xfinal claim-language sync, final
+  runbook update, hosted API-docs publication, and operator-attested final
+  docs review remain missing while `support_widening` /
+  `production_platform_claim` / `live_adapter_execution` remain false.
 - **V5 install/deploy lifecycle preflight bundle** (V5 Epic 9, #895): added
   `V5-INSTALL-DEPLOY-LIFECYCLE-PREFLIGHT-BUNDLE.md`,
   `v5-install-deploy-lifecycle-preflight-bundle.schema.v1.json`, and a

--- a/ao_kernel/defaults/schemas/v5-docs-runbooks-preflight-bundle.schema.v1.json
+++ b/ao_kernel/defaults/schemas/v5-docs-runbooks-preflight-bundle.schema.v1.json
@@ -1,0 +1,259 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:v5-docs-runbooks-preflight-bundle:v1",
+  "title": "V5 docs and runbooks preflight evidence bundle v1",
+  "description": "Current-state preflight bundle for the V5 docs/runbooks dimension. It records deployment, operator, rollback, API-reference, migration, incident-response, and vendor-escalation documentation evidence while keeping final claim language, release notes, v5 runbook finalization, and all production guard flags fail-closed.",
+  "type": "object",
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "repo",
+    "work_package",
+    "dimension",
+    "evidence_class",
+    "final_claim_language_synced",
+    "final_release_notes_present",
+    "v5_runbook_finalized",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution",
+    "deployment_guide",
+    "operator_runbook",
+    "operator_action_runbooks",
+    "rollback_procedure",
+    "api_reference",
+    "migration_guide",
+    "incident_response",
+    "vendor_escalation",
+    "residual_missing_evidence",
+    "issue_refs"
+  ],
+  "properties": {
+    "schema_version": { "const": "v5_docs_runbooks_preflight_bundle.v1" },
+    "artifact_kind": { "const": "v5_docs_runbooks_preflight_bundle" },
+    "repo": { "const": "Halildeu/ao-kernel" },
+    "work_package": { "const": "E-9-1" },
+    "dimension": { "const": "docs_runbooks" },
+    "evidence_class": { "const": "preflight_current_state" },
+    "final_claim_language_synced": { "const": false },
+    "final_release_notes_present": { "const": false },
+    "v5_runbook_finalized": { "const": false },
+    "support_widening": { "const": false },
+    "production_platform_claim": { "const": false },
+    "live_adapter_execution": { "const": false },
+    "deployment_guide": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "doc_path",
+        "test_path",
+        "standalone_pattern",
+        "docker_pattern",
+        "kubernetes_pattern",
+        "operator_bound_supersession_required",
+        "guard_flags_const_false_documented"
+      ],
+      "properties": {
+        "doc_path": { "const": "docs/PRODUCTION-DEPLOYMENT-GUIDE.md" },
+        "test_path": { "const": "tests/test_production_deployment_guide.py" },
+        "standalone_pattern": { "const": true },
+        "docker_pattern": { "const": true },
+        "kubernetes_pattern": { "const": true },
+        "operator_bound_supersession_required": { "const": true },
+        "guard_flags_const_false_documented": { "const": true }
+      }
+    },
+    "operator_runbook": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "doc_path",
+        "test_path",
+        "rollback",
+        "tag_revert",
+        "pause",
+        "emergency_stop",
+        "incident_triage",
+        "operator_bound_supersession_required"
+      ],
+      "properties": {
+        "doc_path": { "const": "docs/OPERATOR-RUNBOOK.md" },
+        "test_path": { "const": "tests/test_operator_runbook.py" },
+        "rollback": { "const": true },
+        "tag_revert": { "const": true },
+        "pause": { "const": true },
+        "emergency_stop": { "const": true },
+        "incident_triage": { "const": true },
+        "operator_bound_supersession_required": { "const": true }
+      }
+    },
+    "operator_action_runbooks": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "readme_path",
+        "checklist_path",
+        "schema_path",
+        "test_path",
+        "operator_action_required",
+        "agent_executed_external_action",
+        "credential_material_committed"
+      ],
+      "properties": {
+        "readme_path": { "const": "docs/operator-runbooks/README.md" },
+        "checklist_path": { "const": "docs/operator-runbooks/operator-action-checklist.v1.json" },
+        "schema_path": { "const": "ao_kernel/defaults/schemas/operator-action-checklist.schema.v1.json" },
+        "test_path": { "const": "tests/test_operator_runbooks.py" },
+        "operator_action_required": { "const": true },
+        "agent_executed_external_action": { "const": false },
+        "credential_material_committed": { "const": false }
+      }
+    },
+    "rollback_procedure": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "runbook_path",
+        "package_rollback_doc_path",
+        "archive_tag_preservation",
+        "no_destructive_history_rewrite",
+        "operator_ruleset_authority",
+        "forward_fix_or_revert_pr_required"
+      ],
+      "properties": {
+        "runbook_path": { "const": "docs/ROLLBACK-RUNBOOK.md" },
+        "package_rollback_doc_path": { "const": "docs/ROLLBACK.md" },
+        "archive_tag_preservation": { "const": true },
+        "no_destructive_history_rewrite": { "const": true },
+        "operator_ruleset_authority": { "const": true },
+        "forward_fix_or_revert_pr_required": { "const": true }
+      }
+    },
+    "api_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "readme_path",
+        "conf_path",
+        "index_path",
+        "test_path",
+        "sphinx_scaffold_present",
+        "operator_invoked_build",
+        "hosted_docs_published",
+        "live_provider_surfaces_excluded",
+        "guard_flags_const_false_documented"
+      ],
+      "properties": {
+        "readme_path": { "const": "docs/api/README.md" },
+        "conf_path": { "const": "docs/api/conf.py" },
+        "index_path": { "const": "docs/api/index.rst" },
+        "test_path": { "const": "tests/test_sphinx_api_reference_scaffold.py" },
+        "sphinx_scaffold_present": { "const": true },
+        "operator_invoked_build": { "const": true },
+        "hosted_docs_published": { "const": false },
+        "live_provider_surfaces_excluded": { "const": true },
+        "guard_flags_const_false_documented": { "const": true }
+      }
+    },
+    "migration_guide": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "doc_path",
+        "test_path",
+        "target_version",
+        "downgrade_pin",
+        "release_shipped",
+        "guard_flags_const_false_documented"
+      ],
+      "properties": {
+        "doc_path": { "const": "docs/MIGRATION-V5.md" },
+        "test_path": { "const": "tests/test_migration_v5_doc.py" },
+        "target_version": { "const": "5.0.0" },
+        "downgrade_pin": { "const": "ao-kernel==4.1.0" },
+        "release_shipped": { "const": false },
+        "guard_flags_const_false_documented": { "const": true }
+      }
+    },
+    "incident_response": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "readme_path",
+        "severity_matrix_path",
+        "severity_schema_path",
+        "escalation_policy_path",
+        "incident_template_path",
+        "test_path",
+        "operator_owned",
+        "is_contractual_sla",
+        "guard_flags_const_false_documented",
+        "no_live_dispatch"
+      ],
+      "properties": {
+        "readme_path": { "const": "docs/incident-response/README.md" },
+        "severity_matrix_path": { "const": "docs/incident-response/severity-matrix.v1.json" },
+        "severity_schema_path": { "const": "ao_kernel/defaults/schemas/severity-matrix.schema.v1.json" },
+        "escalation_policy_path": { "const": "docs/incident-response/escalation-policy.v1.yml" },
+        "incident_template_path": { "const": "docs/incident-response/incident-template.v1.md" },
+        "test_path": { "const": "tests/test_incident_response_playbook.py" },
+        "operator_owned": { "const": true },
+        "is_contractual_sla": { "const": false },
+        "guard_flags_const_false_documented": { "const": true },
+        "no_live_dispatch": { "const": true }
+      }
+    },
+    "vendor_escalation": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "matrix_path",
+        "schema_path",
+        "runbook_path",
+        "test_path",
+        "operator_owned_external_handoff",
+        "no_vendor_sla_promise",
+        "account_manager_contact_operator_provisioned",
+        "no_pii_in_repo"
+      ],
+      "properties": {
+        "matrix_path": { "const": "docs/incident-response/vendor-escalation-matrix.v1.json" },
+        "schema_path": { "const": "ao_kernel/defaults/schemas/vendor-escalation-matrix.schema.v1.json" },
+        "runbook_path": { "const": "docs/incident-response/vendor-escalation-runbook.v1.md" },
+        "test_path": { "const": "tests/test_vendor_escalation_matrix.py" },
+        "operator_owned_external_handoff": { "const": true },
+        "no_vendor_sla_promise": { "const": true },
+        "account_manager_contact_operator_provisioned": { "const": true },
+        "no_pii_in_repo": { "const": true }
+      }
+    },
+    "residual_missing_evidence": {
+      "type": "array",
+      "minItems": 5,
+      "contains": { "const": "final v5.0.0 release notes" },
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "issue_refs": {
+      "type": "array",
+      "prefixItems": [
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/775" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/776" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/782" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/895" }
+      ],
+      "minItems": 4,
+      "maxItems": 4,
+      "items": false
+    }
+  }
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -13,16 +13,16 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/v5-install-deploy-lifecycle-preflight-bundle",
+    "head_ref": "refs/heads/codex/v5-docs-runbooks-preflight-bundle",
     "changed_files": [
-      ".claude/plans/V5-INSTALL-DEPLOY-LIFECYCLE-PREFLIGHT-BUNDLE.md",
+      ".claude/plans/V5-DOCS-RUNBOOKS-PREFLIGHT-BUNDLE.md",
       ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
       "CHANGELOG.md",
-      "ao_kernel/defaults/schemas/v5-install-deploy-lifecycle-preflight-bundle.schema.v1.json",
+      "ao_kernel/defaults/schemas/v5-docs-runbooks-preflight-bundle.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/fixtures/epic9/v5-install-deploy-lifecycle-preflight.current.json",
+      "tests/fixtures/epic9/v5-docs-runbooks-preflight.current.json",
       "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/test_v5_install_deploy_lifecycle_preflight_bundle.py"
+      "tests/test_v5_docs_runbooks_preflight_bundle.py"
     ]
   },
   "checks_considered": [
@@ -31,7 +31,7 @@
       "status": "pass"
     },
     {
-      "name": "pytest_install_deploy_lifecycle_preflight_bundle",
+      "name": "pytest_docs_runbooks_preflight_bundle",
       "status": "pass"
     },
     {
@@ -60,12 +60,14 @@
     }
   ],
   "findings": [
-    "Claude (Anthropic) reviewed the staged V5 install/deploy lifecycle preflight bundle and returned VERDICT AGREE.",
-    "The reviewer confirmed the bundle is bounded to current-state preflight evidence and does not authorize support widening, production platform claim, live adapter execution, PR-Xfinal, v5.0.0 tag or publish, or final release-artifact smoke.",
-    "The reviewer confirmed schema strictness: object nodes are closed, guard flags and nested release claims are const false, issue refs are pinned, residual missing evidence remains required, and release-claim flips are rejected.",
-    "The reviewer confirmed the evidence claims are defensible from repo-local artifacts covering packaging smoke, deployment guide, operator runbooks, Helm render/runbook surface, publish workflow safeguards, and migration-guide downgrade discipline.",
-    "The reviewer confirmed the matrix integration keeps install_deploy_lifecycle_smoke partial, matrix_complete false, and missing v5.0.0 tag/publish/final lifecycle smoke evidence explicit.",
-    "Local validation before review: 119 tests passed for the install/deploy lifecycle preflight bundle, production readiness matrix invariants, deployment guide, publish workflow, operator runbooks, RI-7 packaging smoke, and migration guide.",
+    "Claude (Anthropic) reviewed the staged V5 docs/runbooks preflight bundle and returned VERDICT AGREE.",
+    "The reviewer confirmed the diff is limited to docs/runbooks preflight evidence and does not touch runtime code.",
+    "The reviewer confirmed all top-level authority and guard flags remain const false: final_claim_language_synced, final_release_notes_present, v5_runbook_finalized, support_widening, production_platform_claim, and live_adapter_execution.",
+    "The reviewer confirmed nested authority flips are rejected for agent_executed_external_action, credential_material_committed, hosted_docs_published, release_shipped, and is_contractual_sla.",
+    "The reviewer confirmed the docs_runbooks matrix dimension remains partial while matrix_complete, pr_xfinal_open_allowed, support_widening, production_platform_claim, and live_adapter_execution remain false.",
+    "The reviewer confirmed schema strictness: every object node is closed, issue refs are pinned, and residual missing evidence remains required.",
+    "The reviewer confirmed evidence refs are defensible from repo-local documentation and tests covering deployment, operator, rollback, API-reference, migration, incident-response, and vendor-escalation surfaces.",
+    "Local validation before review: 190 targeted tests passed for the docs/runbooks preflight bundle, production readiness matrix invariants, operator runbooks, migration guide, deployment guide, API-reference scaffold, incident-response playbook, and vendor-escalation matrix.",
     "Staged diff secret scan passed with no leaks found.",
     "No secrets were recorded in the review prompt, review output, evidence file, or validation artifacts."
   ],

--- a/tests/fixtures/epic9/v5-docs-runbooks-preflight.current.json
+++ b/tests/fixtures/epic9/v5-docs-runbooks-preflight.current.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "v5_docs_runbooks_preflight_bundle.v1",
+  "artifact_kind": "v5_docs_runbooks_preflight_bundle",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "E-9-1",
+  "dimension": "docs_runbooks",
+  "evidence_class": "preflight_current_state",
+  "final_claim_language_synced": false,
+  "final_release_notes_present": false,
+  "v5_runbook_finalized": false,
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false,
+  "deployment_guide": {
+    "doc_path": "docs/PRODUCTION-DEPLOYMENT-GUIDE.md",
+    "test_path": "tests/test_production_deployment_guide.py",
+    "standalone_pattern": true,
+    "docker_pattern": true,
+    "kubernetes_pattern": true,
+    "operator_bound_supersession_required": true,
+    "guard_flags_const_false_documented": true
+  },
+  "operator_runbook": {
+    "doc_path": "docs/OPERATOR-RUNBOOK.md",
+    "test_path": "tests/test_operator_runbook.py",
+    "rollback": true,
+    "tag_revert": true,
+    "pause": true,
+    "emergency_stop": true,
+    "incident_triage": true,
+    "operator_bound_supersession_required": true
+  },
+  "operator_action_runbooks": {
+    "readme_path": "docs/operator-runbooks/README.md",
+    "checklist_path": "docs/operator-runbooks/operator-action-checklist.v1.json",
+    "schema_path": "ao_kernel/defaults/schemas/operator-action-checklist.schema.v1.json",
+    "test_path": "tests/test_operator_runbooks.py",
+    "operator_action_required": true,
+    "agent_executed_external_action": false,
+    "credential_material_committed": false
+  },
+  "rollback_procedure": {
+    "runbook_path": "docs/ROLLBACK-RUNBOOK.md",
+    "package_rollback_doc_path": "docs/ROLLBACK.md",
+    "archive_tag_preservation": true,
+    "no_destructive_history_rewrite": true,
+    "operator_ruleset_authority": true,
+    "forward_fix_or_revert_pr_required": true
+  },
+  "api_reference": {
+    "readme_path": "docs/api/README.md",
+    "conf_path": "docs/api/conf.py",
+    "index_path": "docs/api/index.rst",
+    "test_path": "tests/test_sphinx_api_reference_scaffold.py",
+    "sphinx_scaffold_present": true,
+    "operator_invoked_build": true,
+    "hosted_docs_published": false,
+    "live_provider_surfaces_excluded": true,
+    "guard_flags_const_false_documented": true
+  },
+  "migration_guide": {
+    "doc_path": "docs/MIGRATION-V5.md",
+    "test_path": "tests/test_migration_v5_doc.py",
+    "target_version": "5.0.0",
+    "downgrade_pin": "ao-kernel==4.1.0",
+    "release_shipped": false,
+    "guard_flags_const_false_documented": true
+  },
+  "incident_response": {
+    "readme_path": "docs/incident-response/README.md",
+    "severity_matrix_path": "docs/incident-response/severity-matrix.v1.json",
+    "severity_schema_path": "ao_kernel/defaults/schemas/severity-matrix.schema.v1.json",
+    "escalation_policy_path": "docs/incident-response/escalation-policy.v1.yml",
+    "incident_template_path": "docs/incident-response/incident-template.v1.md",
+    "test_path": "tests/test_incident_response_playbook.py",
+    "operator_owned": true,
+    "is_contractual_sla": false,
+    "guard_flags_const_false_documented": true,
+    "no_live_dispatch": true
+  },
+  "vendor_escalation": {
+    "matrix_path": "docs/incident-response/vendor-escalation-matrix.v1.json",
+    "schema_path": "ao_kernel/defaults/schemas/vendor-escalation-matrix.schema.v1.json",
+    "runbook_path": "docs/incident-response/vendor-escalation-runbook.v1.md",
+    "test_path": "tests/test_vendor_escalation_matrix.py",
+    "operator_owned_external_handoff": true,
+    "no_vendor_sla_promise": true,
+    "account_manager_contact_operator_provisioned": true,
+    "no_pii_in_repo": true
+  },
+  "residual_missing_evidence": [
+    "final v5.0.0 release notes",
+    "final PR-Xfinal claim language sync",
+    "final v5.0.0 runbook update",
+    "hosted API docs publication decision",
+    "operator-attested final docs review"
+  ],
+  "issue_refs": [
+    "https://github.com/Halildeu/ao-kernel/issues/775",
+    "https://github.com/Halildeu/ao-kernel/issues/776",
+    "https://github.com/Halildeu/ao-kernel/issues/782",
+    "https://github.com/Halildeu/ao-kernel/issues/895"
+  ]
+}

--- a/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
+++ b/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
@@ -185,10 +185,18 @@
         "API reference and migration guide"
       ],
       "current_evidence_refs": [
+        ".claude/plans/V5-DOCS-RUNBOOKS-PREFLIGHT-BUNDLE.md",
+        "tests/fixtures/epic9/v5-docs-runbooks-preflight.current.json",
+        "docs/PRODUCTION-DEPLOYMENT-GUIDE.md",
         "docs/OPERATOR-RUNBOOK.md",
         "docs/operator-runbooks/README.md",
+        "docs/ROLLBACK-RUNBOOK.md",
         "docs/MIGRATION-V5.md",
-        "docs/api/README.md"
+        "docs/api/README.md",
+        "docs/incident-response/README.md",
+        "docs/incident-response/severity-matrix.v1.json",
+        "docs/incident-response/incident-template.v1.md",
+        "docs/incident-response/vendor-escalation-runbook.v1.md"
       ],
       "missing_evidence": [
         "final PR-Xfinal claim language sync",

--- a/tests/test_v5_docs_runbooks_preflight_bundle.py
+++ b/tests/test_v5_docs_runbooks_preflight_bundle.py
@@ -1,0 +1,352 @@
+"""V5 docs/runbooks preflight bundle invariants.
+
+The V5 production readiness matrix keeps the docs/runbooks dimension partial
+until a later operator-bound PR-Xfinal synchronizes final claim language,
+release notes, and final runbook updates. This bundle records the current
+preflight surface without authorizing support widening, production platform
+claims, live adapter execution, hosted docs publication, or final v5.0.0
+release wording.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_NAME = "v5-docs-runbooks-preflight-bundle.schema.v1.json"
+SCHEMA_PATH = ROOT / "ao_kernel" / "defaults" / "schemas" / SCHEMA_NAME
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "epic9" / "v5-docs-runbooks-preflight.current.json"
+MATRIX_FIXTURE_PATH = ROOT / "tests" / "fixtures" / "epic9" / "v5-production-readiness-matrix.current.json"
+MATRIX_DOC_PATH = ROOT / ".claude" / "plans" / "V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md"
+BUNDLE_DOC_PATH = ROOT / ".claude" / "plans" / "V5-DOCS-RUNBOOKS-PREFLIGHT-BUNDLE.md"
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", SCHEMA_NAME)
+
+
+def _fixture() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _matrix_fixture() -> dict[str, Any]:
+    return json.loads(MATRIX_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _is_valid(payload: dict[str, Any]) -> bool:
+    return not list(Draft202012Validator(_schema()).iter_errors(payload))
+
+
+def _object_nodes(node: Any) -> list[dict[str, Any]]:
+    nodes: list[dict[str, Any]] = []
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            nodes.append(node)
+        for value in node.values():
+            nodes.extend(_object_nodes(value))
+    elif isinstance(node, list):
+        for value in node:
+            nodes.extend(_object_nodes(value))
+    return nodes
+
+
+def _dimension(payload: dict[str, Any], dimension_id: str) -> dict[str, Any]:
+    for dimension in payload["dimensions"]:
+        if dimension["id"] == dimension_id:
+            return dimension
+    raise AssertionError(f"dimension not found: {dimension_id}")
+
+
+def test_schema_present_valid_and_strict() -> None:
+    assert SCHEMA_PATH.is_file()
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["$id"] == "urn:ao:v5-docs-runbooks-preflight-bundle:v1"
+
+    for node in _object_nodes(schema):
+        assert node.get("additionalProperties") is False
+        assert node.get("unevaluatedProperties") is False
+
+
+def test_current_fixture_validates_and_pins_non_authority_boundary() -> None:
+    payload = _fixture()
+    assert _is_valid(payload)
+    assert payload["schema_version"] == "v5_docs_runbooks_preflight_bundle.v1"
+    assert payload["artifact_kind"] == "v5_docs_runbooks_preflight_bundle"
+    assert payload["repo"] == "Halildeu/ao-kernel"
+    assert payload["work_package"] == "E-9-1"
+    assert payload["dimension"] == "docs_runbooks"
+    assert payload["evidence_class"] == "preflight_current_state"
+    assert payload["final_claim_language_synced"] is False
+    assert payload["final_release_notes_present"] is False
+    assert payload["v5_runbook_finalized"] is False
+    assert payload["support_widening"] is False
+    assert payload["production_platform_claim"] is False
+    assert payload["live_adapter_execution"] is False
+
+
+def test_schema_rejects_claim_release_or_guard_flag_flips() -> None:
+    for field in (
+        "final_claim_language_synced",
+        "final_release_notes_present",
+        "v5_runbook_finalized",
+        "support_widening",
+        "production_platform_claim",
+        "live_adapter_execution",
+    ):
+        payload = _fixture()
+        payload[field] = True
+        assert not _is_valid(payload), f"{field}=true must fail closed"
+
+
+def test_schema_rejects_nested_authority_or_publication_claims() -> None:
+    mutations: tuple[tuple[str, str], ...] = (
+        ("operator_action_runbooks", "agent_executed_external_action"),
+        ("operator_action_runbooks", "credential_material_committed"),
+        ("api_reference", "hosted_docs_published"),
+        ("migration_guide", "release_shipped"),
+        ("incident_response", "is_contractual_sla"),
+    )
+    for section, field in mutations:
+        payload = _fixture()
+        payload[section][field] = True
+        assert not _is_valid(payload), f"{section}.{field}=true must fail closed"
+
+
+def test_schema_rejects_path_or_extra_field_drift() -> None:
+    payload = _fixture()
+    payload["api_reference"]["readme_path"] = "docs/api/other.md"
+    assert not _is_valid(payload)
+
+    payload = _fixture()
+    payload["rollback_procedure"]["runbook_path"] = "docs/ROLLBACK.md"
+    assert not _is_valid(payload)
+
+    payload = _fixture()
+    payload["unexpected"] = "not allowed"
+    assert not _is_valid(payload)
+
+    payload = _fixture()
+    payload["incident_response"]["unexpected"] = "not allowed"
+    assert not _is_valid(payload)
+
+
+def test_all_referenced_artifacts_exist() -> None:
+    payload = _fixture()
+    path_sections = (
+        "deployment_guide",
+        "operator_runbook",
+        "operator_action_runbooks",
+        "rollback_procedure",
+        "api_reference",
+        "migration_guide",
+        "incident_response",
+        "vendor_escalation",
+    )
+    for section_name in path_sections:
+        section = payload[section_name]
+        for key, value in section.items():
+            if key.endswith("_path"):
+                assert (ROOT / value).exists(), f"{section_name}.{key} missing: {value}"
+
+
+def test_deployment_and_operator_docs_cover_required_surfaces() -> None:
+    payload = _fixture()
+    deployment = payload["deployment_guide"]
+    guide = (ROOT / deployment["doc_path"]).read_text(encoding="utf-8")
+    guide_tests = (ROOT / deployment["test_path"]).read_text(encoding="utf-8")
+
+    assert deployment["standalone_pattern"] is True
+    assert deployment["docker_pattern"] is True
+    assert deployment["kubernetes_pattern"] is True
+    assert deployment["operator_bound_supersession_required"] is True
+    assert "Standalone" in guide
+    assert "Docker" in guide
+    assert "Kubernetes" in guide
+    assert "operator-bound supersession" in guide
+    assert "test_guide_covers_standalone_pattern" in guide_tests
+    assert "test_guide_three_guard_flags_const_false_disclaimer" in guide_tests
+
+    runbook = payload["operator_runbook"]
+    text = (ROOT / runbook["doc_path"]).read_text(encoding="utf-8")
+    tests = (ROOT / runbook["test_path"]).read_text(encoding="utf-8")
+
+    for token in ("Rollback", "Tag Revert", "Pause", "Emergency Stop", "Incident Triage"):
+        assert token in text
+    for test_name in (
+        "test_runbook_covers_rollback_scenario",
+        "test_runbook_covers_tag_revert_scenario",
+        "test_runbook_covers_pause_scenario",
+        "test_runbook_covers_emergency_stop_scenario",
+        "test_runbook_covers_incident_triage_tree",
+    ):
+        assert test_name in tests
+
+
+def test_operator_action_runbooks_keep_operator_and_credential_boundary() -> None:
+    payload = _fixture()
+    section = payload["operator_action_runbooks"]
+    readme = (ROOT / section["readme_path"]).read_text(encoding="utf-8")
+    checklist = json.loads((ROOT / section["checklist_path"]).read_text(encoding="utf-8"))
+    tests = (ROOT / section["test_path"]).read_text(encoding="utf-8")
+
+    assert section["operator_action_required"] is True
+    assert section["agent_executed_external_action"] is False
+    assert section["credential_material_committed"] is False
+    assert "operator-action-checklist.v1.json" in readme
+    assert "operator-action-checklist.schema.v1.json" in readme
+    assert checklist["runbook_disclaimer"]["operator_action_required"] is True
+    assert checklist["runbook_disclaimer"]["no_credential_committed"] is True
+    assert "test_schema_rejects_agent_executed_external_action_true" in tests
+    assert "test_schema_rejects_credential_material_committed_true" in tests
+
+
+def test_rollback_procedure_records_recovery_discipline() -> None:
+    payload = _fixture()
+    section = payload["rollback_procedure"]
+    runbook = (ROOT / section["runbook_path"]).read_text(encoding="utf-8")
+    package_doc = (ROOT / section["package_rollback_doc_path"]).read_text(encoding="utf-8")
+
+    assert section["archive_tag_preservation"] is True
+    assert section["no_destructive_history_rewrite"] is True
+    assert section["operator_ruleset_authority"] is True
+    assert section["forward_fix_or_revert_pr_required"] is True
+    assert "No destructive history rewrite" in runbook
+    assert "Archive tag preservation" in runbook
+    assert "Operator authority is preserved" in runbook
+    assert "Forward fix" in runbook
+    assert "Package-level rollback" in package_doc
+    assert "Release rollback rule" in package_doc
+
+
+def test_api_reference_scaffold_is_opt_in_and_excludes_live_provider_surfaces() -> None:
+    payload = _fixture()
+    section = payload["api_reference"]
+    readme = (ROOT / section["readme_path"]).read_text(encoding="utf-8")
+    conf = (ROOT / section["conf_path"]).read_text(encoding="utf-8")
+    index = (ROOT / section["index_path"]).read_text(encoding="utf-8")
+    tests = (ROOT / section["test_path"]).read_text(encoding="utf-8")
+
+    assert section["sphinx_scaffold_present"] is True
+    assert section["operator_invoked_build"] is True
+    assert section["hosted_docs_published"] is False
+    assert section["live_provider_surfaces_excluded"] is True
+    assert "sphinx-build -b html docs/api docs/api/_build/html" in readme
+    assert "Hosted-docs URL + GitHub Pages publication is a separate operator" in readme
+    assert "Live provider client surfaces" in readme
+    assert "sphinx.ext.autodoc" in conf
+    assert "sphinx.ext.napoleon" in conf
+    assert "_internal" in index
+    assert "test_docs_extra_does_not_include_live_providers" in tests
+
+
+def test_migration_and_incident_docs_keep_release_and_sla_boundaries() -> None:
+    payload = _fixture()
+    migration = payload["migration_guide"]
+    migration_doc = (ROOT / migration["doc_path"]).read_text(encoding="utf-8")
+    migration_tests = (ROOT / migration["test_path"]).read_text(encoding="utf-8")
+
+    assert migration["target_version"] == "5.0.0"
+    assert migration["downgrade_pin"] == "ao-kernel==4.1.0"
+    assert migration["release_shipped"] is False
+    assert "v5.0.0 is not yet released" in migration_doc
+    assert "pip install ao-kernel==4.1.0" in migration_doc
+    assert "test_migration_v5_conservative_public_claim" in migration_tests
+    assert "test_migration_v5_downgrade_path_pinned" in migration_tests
+
+    incident = payload["incident_response"]
+    incident_readme = (ROOT / incident["readme_path"]).read_text(encoding="utf-8")
+    incident_tests = (ROOT / incident["test_path"]).read_text(encoding="utf-8")
+
+    assert incident["operator_owned"] is True
+    assert incident["is_contractual_sla"] is False
+    assert incident["no_live_dispatch"] is True
+    assert "Not SLA" in incident_readme
+    assert "Not a production platform claim" in incident_readme
+    assert "no live PagerDuty/Opsgenie integration" in incident_readme
+    assert "test_schema_rejects_is_contractual_sla_true" in incident_tests
+    assert "test_readme_regulatory_and_vendor_boundary_sections" in incident_tests
+
+
+def test_vendor_escalation_keeps_external_handoff_boundary() -> None:
+    payload = _fixture()
+    section = payload["vendor_escalation"]
+    matrix = json.loads((ROOT / section["matrix_path"]).read_text(encoding="utf-8"))
+    runbook = (ROOT / section["runbook_path"]).read_text(encoding="utf-8").lower()
+    tests = (ROOT / section["test_path"]).read_text(encoding="utf-8")
+
+    assert section["operator_owned_external_handoff"] is True
+    assert section["no_vendor_sla_promise"] is True
+    assert section["account_manager_contact_operator_provisioned"] is True
+    assert section["no_pii_in_repo"] is True
+    assert matrix["matrix_disclaimer"]["operator_owned_external_handoff"] is True
+    assert matrix["matrix_disclaimer"]["no_vendor_sla_promise"] is True
+    assert matrix["matrix_disclaimer"]["no_pii_in_repo"] is True
+    assert "no vendor sla promise" in runbook or "do not promise vendor sla" in runbook
+    assert "test_all_account_manager_contacts_operator_provisioned" in tests
+    assert "test_no_personal_email_committed" in tests
+
+
+def test_matrix_refs_docs_runbooks_bundle_but_keeps_dimension_partial() -> None:
+    matrix = _matrix_fixture()
+    dimension = _dimension(matrix, "docs_runbooks")
+
+    assert dimension["status"] == "partial"
+    assert ".claude/plans/V5-DOCS-RUNBOOKS-PREFLIGHT-BUNDLE.md" in dimension["current_evidence_refs"]
+    assert "tests/fixtures/epic9/v5-docs-runbooks-preflight.current.json" in dimension["current_evidence_refs"]
+    assert "docs/PRODUCTION-DEPLOYMENT-GUIDE.md" in dimension["current_evidence_refs"]
+    assert "docs/ROLLBACK-RUNBOOK.md" in dimension["current_evidence_refs"]
+    assert "docs/incident-response/README.md" in dimension["current_evidence_refs"]
+    assert "final PR-Xfinal claim language sync" in dimension["missing_evidence"]
+    assert "final release notes and v5.0.0 runbook update" in dimension["missing_evidence"]
+    assert matrix["matrix_complete"] is False
+    assert matrix["pr_xfinal_open_allowed"] is False
+    assert matrix["support_widening"] is False
+    assert matrix["production_platform_claim"] is False
+    assert matrix["live_adapter_execution"] is False
+
+
+def test_bundle_doc_has_cross_refs_without_positive_claim_tokens() -> None:
+    text = BUNDLE_DOC_PATH.read_text(encoding="utf-8")
+    matrix_doc = MATRIX_DOC_PATH.read_text(encoding="utf-8")
+
+    assert "V5 Docs and Runbooks Preflight Bundle" in text
+    assert "final_claim_language_synced=false" in text
+    assert "final_release_notes_present=false" in text
+    assert "v5_runbook_finalized=false" in text
+    assert "V5-DOCS-RUNBOOKS-PREFLIGHT-BUNDLE.md" in matrix_doc
+    assert "v5-docs-runbooks-preflight.current.json" in matrix_doc
+
+    forbidden = (
+        "production-ready",
+        "production ready",
+        "support_widening=true",
+        "production_platform_claim=true",
+        "live_adapter_execution=true",
+        "final_claim_language_synced=true",
+        "final_release_notes_present=true",
+        "v5_runbook_finalized=true",
+        "hosted_docs_published=true",
+    )
+    lowered = text.lower()
+    for token in forbidden:
+        assert token not in lowered, f"bundle doc must not include positive claim token: {token}"
+
+
+def test_residual_missing_evidence_keeps_final_docs_work_explicit() -> None:
+    missing = _fixture()["residual_missing_evidence"]
+    assert missing == [
+        "final v5.0.0 release notes",
+        "final PR-Xfinal claim language sync",
+        "final v5.0.0 runbook update",
+        "hosted API docs publication decision",
+        "operator-attested final docs review",
+    ]


### PR DESCRIPTION
## Summary

Adds a V5 Epic 9 docs/runbooks preflight bundle for the `docs_runbooks` production-readiness dimension. The bundle records current deployment guide, operator runbook, operator action runbooks, rollback procedure, API reference scaffold, migration guide, incident-response playbook, and vendor-escalation evidence.

This remains preflight evidence only: `docs_runbooks` stays `partial`; final v5.0.0 release notes, PR-Xfinal claim-language sync, final runbook update, hosted API-docs publication, and operator-attested final docs review remain missing.

## Guard boundary

- No support widening
- No production platform claim
- No live adapter execution
- No PR-Xfinal opening
- No final v5.0.0 release-note or claim-language assertion
- No runtime/workflow/ruleset changes

## Validation

- `pytest tests/test_v5_docs_runbooks_preflight_bundle.py tests/test_v5_production_readiness_matrix_blocker.py tests/test_operator_runbook.py tests/test_operator_runbooks.py tests/test_migration_v5_doc.py tests/test_production_deployment_guide.py tests/test_sphinx_api_reference_scaffold.py tests/test_incident_response_playbook.py tests/test_vendor_escalation_matrix.py -q` -> 190 passed
- `python3 -m json.tool` on new schema, new fixture, matrix fixture, and local review evidence -> pass
- `git diff --cached --check` -> pass
- `gitleaks protect --staged --redact` -> no leaks found
- Claude (Anthropic) staged-diff review -> `VERDICT: AGREE`
- `python3 scripts/local_gpp_gate.py ...` -> `decision: operator_may_merge`, head `4cd0470ad41761e765081945adca398f37a52408`, diff digest `sha256:12a122dcf9f63ba0d52c25127304b06dab5e662265e8b38e0f7d4496c74b8de4`
