### PR TITLE
feat(epic9): add V5 multi-tenancy preflight bundle

### DIFF
--- a/.claude/plans/V5-MULTI-TENANCY-ISOLATION-PREFLIGHT-BUNDLE.md
+++ b/.claude/plans/V5-MULTI-TENANCY-ISOLATION-PREFLIGHT-BUNDLE.md
@@ -1,0 +1,94 @@
+# V5 Multi-Tenancy Isolation Preflight Bundle
+
+**Status:** current-state preflight evidence only
+**Work package:** E-9-1
+**Dimension:** `multi_tenancy_isolation`
+**Schema:** `ao_kernel/defaults/schemas/v5-multi-tenancy-isolation-preflight-bundle.schema.v1.json`
+**Fixture:** `tests/fixtures/epic9/v5-multi-tenancy-isolation-preflight.current.json`
+
+This bundle records the current repo-local multi-tenancy isolation evidence for
+the future V5 PR-Xfinal readiness matrix. It binds the existing Epic 4 advisory
+tenant boundary matrix, multi-tenant deployment runbook, per-tenant config
+recipe, Helm chart boundary tests, and per-tenant rate-limit evidence into one
+machine-checkable current-state artifact.
+
+## Non-Authority Boundary
+
+This bundle does not authorize:
+
+- support widening;
+- production platform claims;
+- live adapter execution;
+- runtime-side tenant isolation claims;
+- live cross-tenant attack-test claims;
+- opening PR-Xfinal.
+
+The fixture pins `runtime_enforced=false`, `live_validated=false`,
+`tenant_isolation_ready=false`, `support_widening=false`,
+`production_platform_claim=false`, and `live_adapter_execution=false`.
+
+## What Is Currently Proven
+
+The repo has a current advisory boundary surface for multi-tenancy:
+
+1. `.claude/plans/tenant_isolation_matrix.v1.json` is in
+   `e_4_2b_final_seal` state with exactly seven filled dimensions.
+2. `docs/MULTI-TENANT-DEPLOYMENT.md` documents the operator-installed
+   Kubernetes boundary pattern and explicitly keeps `runtime_enforced=false`
+   and `live_validated=false`.
+3. `docs/MULTI-TENANT-CONFIG-RECIPE.md` records the namespace-per-tenant,
+   database-per-tenant, Secret-per-tenant, NetworkPolicy, ServiceMonitor label,
+   and ResourceQuota recipe.
+4. `deploy/helm/ao-kernel/` renders namespace-scoped RBAC, `secretKeyRef`
+   secret indirection, NetworkPolicy, ServiceMonitor, and pod resource
+   requests/limits surfaces that the operator can compose per tenant.
+5. `docs/RATE-LIMIT-TUNING.md` and `tests/test_epic_7_4_rate_limit_tuning.py`
+   prove the documented `"<tenant>:<provider>"` key pattern creates independent
+   process-local limiter buckets.
+
+These are preflight artifacts. They are useful V5 evidence, but they remain
+advisory until a later operator-bound PR supplies live tenant-isolation proof.
+
+## Why The Matrix Moves To Partial
+
+Before this bundle, the V5 matrix only pointed `multi_tenancy_isolation` at the
+roadmap and marked the dimension `not_ready`. The current repo now has enough
+evidence to record a partial current-state surface:
+
+- advisory matrix final seal exists;
+- operator runbooks and recipes exist;
+- Helm boundary and rate-limit tests exist;
+- guard flags remain false;
+- missing live/operator evidence is explicit.
+
+This moves the dimension to `partial`, not `ready`.
+
+## Residual Missing Evidence
+
+The following evidence is still required for a future PR-Xfinal path:
+
+- live cluster CNI/RBAC/NetworkPolicy validation evidence;
+- cross-tenant leak-prevention or attack-test evidence;
+- operator-applied ResourceQuota and LimitRange evidence;
+- per-tenant live cost/quota dashboard evidence;
+- operator-attested tenant isolation review bound to the final release
+  artifact.
+
+Until those are present, the V5 production readiness matrix remains incomplete.
+
+## Cross-References
+
+- Matrix blocker:
+  `.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md`
+- Current matrix fixture:
+  `tests/fixtures/epic9/v5-production-readiness-matrix.current.json`
+- Advisory matrix:
+  `.claude/plans/tenant_isolation_matrix.v1.json`
+- Final advisory seal:
+  `.claude/plans/E-4-2b-MULTI-TENANT-FINAL-SEAL.v1.json`
+- Multi-tenant deployment runbook:
+  `docs/MULTI-TENANT-DEPLOYMENT.md`
+- Multi-tenant config recipe:
+  `docs/MULTI-TENANT-CONFIG-RECIPE.md`
+- Rate-limit tuning:
+  `docs/RATE-LIMIT-TUNING.md`

--- a/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
+++ b/.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md
@@ -38,7 +38,7 @@ The V5 production readiness matrix is **not complete**.
 | observability production tunables | partial | current observability preflight bundle exists; final claim-bound observability/alerting evidence missing |
 | security/SBOM/license scans | partial | current preflight bundle exists; final release-bound SBOM/license/security bundle missing |
 | install/deploy lifecycle smoke | partial | v5.0.0 tag/publish and release-artifact smoke missing |
-| multi-tenancy isolation | not_ready | tenant isolation and per-tenant quota/cost evidence missing |
+| multi-tenancy isolation | partial | current advisory multi-tenancy preflight bundle exists; live tenant-isolation, quota, and cost evidence missing |
 | docs/runbooks | partial | final claim/release wording and runbook updates missing |
 | bypassless release governance | partial | PR-Xfinal source-pin/collision evidence missing |
 
@@ -122,3 +122,15 @@ incident-response, and vendor-escalation documentation evidence without
 treating it as final PR-Xfinal claim-language sync, v5.0.0 release notes,
 final runbook update, hosted API-docs publication, support widening, live
 adapter execution, or a production platform claim.
+
+The `multi_tenancy_isolation` dimension now has a current-state multi-tenancy
+isolation preflight bundle:
+
+- `.claude/plans/V5-MULTI-TENANCY-ISOLATION-PREFLIGHT-BUNDLE.md`
+- `tests/fixtures/epic9/v5-multi-tenancy-isolation-preflight.current.json`
+
+That bundle binds the Epic 4 advisory tenant isolation matrix, multi-tenant
+deployment runbook, namespace-per-tenant config recipe, Helm boundary evidence,
+and per-tenant rate-limit evidence without treating them as runtime-enforced
+tenant isolation, live cross-tenant validation, final quota/cost evidence,
+support widening, live adapter execution, or a production platform claim.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **V5 multi-tenancy isolation preflight bundle** (V5 Epic 9, #895): added
+  `V5-MULTI-TENANCY-ISOLATION-PREFLIGHT-BUNDLE.md`,
+  `v5-multi-tenancy-isolation-preflight-bundle.schema.v1.json`, and a
+  current-state fixture/test suite that binds the Epic 4 advisory tenant
+  isolation matrix, multi-tenant deployment runbook, namespace-per-tenant
+  config recipe, Helm boundary evidence, and per-tenant rate-limit evidence to
+  the `multi_tenancy_isolation` production-readiness dimension. This is
+  preflight evidence only: live cluster CNI/RBAC/NetworkPolicy validation,
+  cross-tenant leak-prevention evidence, operator-applied quota evidence,
+  per-tenant live cost/quota dashboard evidence, and final release-bound
+  operator attestation remain missing while `support_widening` /
+  `production_platform_claim` / `live_adapter_execution` remain false.
 - **V5 docs/runbooks preflight bundle** (V5 Epic 9, #895): added
   `V5-DOCS-RUNBOOKS-PREFLIGHT-BUNDLE.md`,
   `v5-docs-runbooks-preflight-bundle.schema.v1.json`, and a current-state

--- a/ao_kernel/defaults/schemas/v5-multi-tenancy-isolation-preflight-bundle.schema.v1.json
+++ b/ao_kernel/defaults/schemas/v5-multi-tenancy-isolation-preflight-bundle.schema.v1.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:v5-multi-tenancy-isolation-preflight-bundle:v1",
+  "title": "V5 multi-tenancy isolation preflight evidence bundle v1",
+  "description": "Current-state preflight bundle for the V5 multi_tenancy_isolation dimension. It records advisory matrix, operator runbook, config recipe, Helm boundary, and rate-limit evidence while keeping runtime enforcement, live validation, tenant isolation readiness, and all production guard flags fail-closed.",
+  "type": "object",
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "repo",
+    "work_package",
+    "dimension",
+    "evidence_class",
+    "runtime_enforced",
+    "operator_enforceable",
+    "operator_action_required",
+    "live_validated",
+    "tenant_isolation_ready",
+    "support_widening",
+    "production_platform_claim",
+    "live_adapter_execution",
+    "advisory_matrix",
+    "deployment_runbook",
+    "config_recipe",
+    "helm_boundary",
+    "rate_limit",
+    "residual_missing_evidence",
+    "issue_refs"
+  ],
+  "properties": {
+    "schema_version": { "const": "v5_multi_tenancy_isolation_preflight_bundle.v1" },
+    "artifact_kind": { "const": "v5_multi_tenancy_isolation_preflight_bundle" },
+    "repo": { "const": "Halildeu/ao-kernel" },
+    "work_package": { "const": "E-9-1" },
+    "dimension": { "const": "multi_tenancy_isolation" },
+    "evidence_class": { "const": "preflight_current_state" },
+    "runtime_enforced": { "const": false },
+    "operator_enforceable": { "const": true },
+    "operator_action_required": { "const": true },
+    "live_validated": { "const": false },
+    "tenant_isolation_ready": { "const": false },
+    "support_widening": { "const": false },
+    "production_platform_claim": { "const": false },
+    "live_adapter_execution": { "const": false },
+    "advisory_matrix": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "matrix_path",
+        "matrix_schema_path",
+        "final_seal_evidence_path",
+        "test_path",
+        "matrix_status",
+        "dimensions_count",
+        "exact_dimensions",
+        "all_entries_filled",
+        "runtime_enforced_global",
+        "live_validated_global",
+        "operator_enforceable_all",
+        "operator_action_required_all"
+      ],
+      "properties": {
+        "matrix_path": { "const": ".claude/plans/tenant_isolation_matrix.v1.json" },
+        "matrix_schema_path": { "const": "ao_kernel/defaults/schemas/tenant-isolation-matrix.schema.v1.json" },
+        "final_seal_evidence_path": { "const": ".claude/plans/E-4-2b-MULTI-TENANT-FINAL-SEAL.v1.json" },
+        "test_path": { "const": "tests/test_epic_4_2b_matrix_invariants.py" },
+        "matrix_status": { "const": "e_4_2b_final_seal" },
+        "dimensions_count": { "const": 7 },
+        "exact_dimensions": {
+          "type": "array",
+          "prefixItems": [
+            { "const": "namespace_isolation" },
+            { "const": "rbac_scope" },
+            { "const": "secret_isolation" },
+            { "const": "network_policy" },
+            { "const": "resource_quota" },
+            { "const": "audit_boundary" },
+            { "const": "cost_tracking_advisory" }
+          ],
+          "minItems": 7,
+          "maxItems": 7,
+          "items": false
+        },
+        "all_entries_filled": { "const": true },
+        "runtime_enforced_global": { "const": false },
+        "live_validated_global": { "const": false },
+        "operator_enforceable_all": { "const": true },
+        "operator_action_required_all": { "const": true }
+      }
+    },
+    "deployment_runbook": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "doc_path",
+        "advisory_boundary",
+        "runtime_enforced",
+        "live_validated",
+        "operator_enforceable",
+        "operator_action_required",
+        "covers_seven_dimensions",
+        "live_cluster_commands_embedded"
+      ],
+      "properties": {
+        "doc_path": { "const": "docs/MULTI-TENANT-DEPLOYMENT.md" },
+        "advisory_boundary": { "const": true },
+        "runtime_enforced": { "const": false },
+        "live_validated": { "const": false },
+        "operator_enforceable": { "const": true },
+        "operator_action_required": { "const": true },
+        "covers_seven_dimensions": { "const": true },
+        "live_cluster_commands_embedded": { "const": false }
+      }
+    },
+    "config_recipe": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "doc_path",
+        "test_path",
+        "namespace_per_tenant",
+        "dedicated_database_and_secret",
+        "network_policy_default_deny",
+        "servicemonitor_tenant_label",
+        "resource_quota_operator_owned",
+        "delegates_to_epic4_slices",
+        "inline_secret_material_present"
+      ],
+      "properties": {
+        "doc_path": { "const": "docs/MULTI-TENANT-CONFIG-RECIPE.md" },
+        "test_path": { "const": "tests/test_epic_8_2_multitenant_config_recipe.py" },
+        "namespace_per_tenant": { "const": true },
+        "dedicated_database_and_secret": { "const": true },
+        "network_policy_default_deny": { "const": true },
+        "servicemonitor_tenant_label": { "const": true },
+        "resource_quota_operator_owned": { "const": true },
+        "delegates_to_epic4_slices": { "const": true },
+        "inline_secret_material_present": { "const": false }
+      }
+    },
+    "helm_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "chart_root",
+        "values_path",
+        "test_path",
+        "namespace_scoped_rbac",
+        "cluster_scoped_rbac_present",
+        "secret_key_ref_only",
+        "network_policy_template_present",
+        "pod_resources_present",
+        "servicemonitor_surface_present",
+        "resourcequota_rendered_by_chart"
+      ],
+      "properties": {
+        "chart_root": { "const": "deploy/helm/ao-kernel" },
+        "values_path": { "const": "deploy/helm/ao-kernel/values.yaml" },
+        "test_path": { "const": "tests/test_epic_4_1_helm_chart_skeleton.py" },
+        "namespace_scoped_rbac": { "const": true },
+        "cluster_scoped_rbac_present": { "const": false },
+        "secret_key_ref_only": { "const": true },
+        "network_policy_template_present": { "const": true },
+        "pod_resources_present": { "const": true },
+        "servicemonitor_surface_present": { "const": true },
+        "resourcequota_rendered_by_chart": { "const": false }
+      }
+    },
+    "rate_limit": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "doc_path",
+        "test_path",
+        "per_tenant_key_pattern",
+        "bucket_isolation_tested",
+        "process_local_registry",
+        "live_adapter_execution"
+      ],
+      "properties": {
+        "doc_path": { "const": "docs/RATE-LIMIT-TUNING.md" },
+        "test_path": { "const": "tests/test_epic_7_4_rate_limit_tuning.py" },
+        "per_tenant_key_pattern": { "const": true },
+        "bucket_isolation_tested": { "const": true },
+        "process_local_registry": { "const": true },
+        "live_adapter_execution": { "const": false }
+      }
+    },
+    "residual_missing_evidence": {
+      "type": "array",
+      "prefixItems": [
+        { "const": "live cluster CNI/RBAC/NetworkPolicy validation evidence" },
+        { "const": "cross-tenant leak prevention or attack-test evidence" },
+        { "const": "operator-applied ResourceQuota and LimitRange evidence" },
+        { "const": "per-tenant live cost/quota dashboard evidence" },
+        { "const": "operator-attested tenant isolation review bound to final release artifact" }
+      ],
+      "minItems": 5,
+      "maxItems": 5,
+      "items": false
+    },
+    "issue_refs": {
+      "type": "array",
+      "prefixItems": [
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/775" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/776" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/782" },
+        { "const": "https://github.com/Halildeu/ao-kernel/issues/895" }
+      ],
+      "minItems": 4,
+      "maxItems": 4,
+      "items": false
+    }
+  }
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -13,16 +13,16 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/v5-docs-runbooks-preflight-bundle",
+    "head_ref": "refs/heads/codex/v5-multi-tenancy-isolation-preflight-bundle",
     "changed_files": [
-      ".claude/plans/V5-DOCS-RUNBOOKS-PREFLIGHT-BUNDLE.md",
+      ".claude/plans/V5-MULTI-TENANCY-ISOLATION-PREFLIGHT-BUNDLE.md",
       ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
       "CHANGELOG.md",
-      "ao_kernel/defaults/schemas/v5-docs-runbooks-preflight-bundle.schema.v1.json",
+      "ao_kernel/defaults/schemas/v5-multi-tenancy-isolation-preflight-bundle.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/fixtures/epic9/v5-docs-runbooks-preflight.current.json",
+      "tests/fixtures/epic9/v5-multi-tenancy-isolation-preflight.current.json",
       "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/test_v5_docs_runbooks_preflight_bundle.py"
+      "tests/test_v5_multi_tenancy_isolation_preflight_bundle.py"
     ]
   },
   "checks_considered": [
@@ -31,7 +31,7 @@
       "status": "pass"
     },
     {
-      "name": "pytest_docs_runbooks_preflight_bundle",
+      "name": "pytest_multi_tenancy_preflight_bundle",
       "status": "pass"
     },
     {
@@ -60,14 +60,15 @@
     }
   ],
   "findings": [
-    "Claude (Anthropic) reviewed the staged V5 docs/runbooks preflight bundle and returned VERDICT AGREE.",
-    "The reviewer confirmed the diff is limited to docs/runbooks preflight evidence and does not touch runtime code.",
-    "The reviewer confirmed all top-level authority and guard flags remain const false: final_claim_language_synced, final_release_notes_present, v5_runbook_finalized, support_widening, production_platform_claim, and live_adapter_execution.",
-    "The reviewer confirmed nested authority flips are rejected for agent_executed_external_action, credential_material_committed, hosted_docs_published, release_shipped, and is_contractual_sla.",
-    "The reviewer confirmed the docs_runbooks matrix dimension remains partial while matrix_complete, pr_xfinal_open_allowed, support_widening, production_platform_claim, and live_adapter_execution remain false.",
-    "The reviewer confirmed schema strictness: every object node is closed, issue refs are pinned, and residual missing evidence remains required.",
-    "The reviewer confirmed evidence refs are defensible from repo-local documentation and tests covering deployment, operator, rollback, API-reference, migration, incident-response, and vendor-escalation surfaces.",
-    "Local validation before review: 190 targeted tests passed for the docs/runbooks preflight bundle, production readiness matrix invariants, operator runbooks, migration guide, deployment guide, API-reference scaffold, incident-response playbook, and vendor-escalation matrix.",
+    "Claude (Anthropic) reviewed the staged V5 multi-tenancy isolation preflight bundle and returned VERDICT AGREE.",
+    "The reviewer confirmed the matrix fixture moves multi_tenancy_isolation from not_ready to partial only, while matrix_complete, pr_xfinal_open_allowed, support_widening, production_platform_claim, and live_adapter_execution remain false.",
+    "The reviewer confirmed no positive authority claims are made for runtime enforcement, live validation, tenant isolation readiness, production readiness, support widening, live adapter execution, or PR-Xfinal openability.",
+    "The reviewer confirmed the schema is strict and fail-closed with additionalProperties=false and unevaluatedProperties=false on every object, const-false guard fields, and exact arrays for dimensions, residual missing evidence, and issue refs.",
+    "The reviewer confirmed tests bind actual repo artifacts: tenant_isolation_matrix, E-4-2b final seal, MULTI-TENANT-DEPLOYMENT, MULTI-TENANT-CONFIG-RECIPE, Helm boundary files, and RATE-LIMIT-TUNING.",
+    "The reviewer confirmed residual missing evidence keeps live/operator gaps explicit: live CNI/RBAC/NetworkPolicy validation, cross-tenant leak-prevention testing, operator-applied quota proof, per-tenant live cost/quota dashboard evidence, and final release-bound operator attestation.",
+    "The reviewer confirmed scope is local only: plan docs, schema, fixture, matrix fixture, changelog, and test file; no workflow, ruleset, GitHub permission, runtime code, or guard flag mutation.",
+    "Local validation before review: JSON parse checks passed for the new schema, new fixture, and production readiness matrix fixture.",
+    "Local validation before review: 88 targeted tests passed with 10 skipped for the multi-tenancy preflight bundle, production readiness matrix blocker, Epic 4 tenant boundary/final seal, multi-tenant config recipe, rate-limit tuning, and Helm chart skeleton surfaces.",
     "Staged diff secret scan passed with no leaks found.",
     "No secrets were recorded in the review prompt, review output, evidence file, or validation artifacts."
   ],

--- a/tests/fixtures/epic9/v5-multi-tenancy-isolation-preflight.current.json
+++ b/tests/fixtures/epic9/v5-multi-tenancy-isolation-preflight.current.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": "v5_multi_tenancy_isolation_preflight_bundle.v1",
+  "artifact_kind": "v5_multi_tenancy_isolation_preflight_bundle",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "E-9-1",
+  "dimension": "multi_tenancy_isolation",
+  "evidence_class": "preflight_current_state",
+  "runtime_enforced": false,
+  "operator_enforceable": true,
+  "operator_action_required": true,
+  "live_validated": false,
+  "tenant_isolation_ready": false,
+  "support_widening": false,
+  "production_platform_claim": false,
+  "live_adapter_execution": false,
+  "advisory_matrix": {
+    "matrix_path": ".claude/plans/tenant_isolation_matrix.v1.json",
+    "matrix_schema_path": "ao_kernel/defaults/schemas/tenant-isolation-matrix.schema.v1.json",
+    "final_seal_evidence_path": ".claude/plans/E-4-2b-MULTI-TENANT-FINAL-SEAL.v1.json",
+    "test_path": "tests/test_epic_4_2b_matrix_invariants.py",
+    "matrix_status": "e_4_2b_final_seal",
+    "dimensions_count": 7,
+    "exact_dimensions": [
+      "namespace_isolation",
+      "rbac_scope",
+      "secret_isolation",
+      "network_policy",
+      "resource_quota",
+      "audit_boundary",
+      "cost_tracking_advisory"
+    ],
+    "all_entries_filled": true,
+    "runtime_enforced_global": false,
+    "live_validated_global": false,
+    "operator_enforceable_all": true,
+    "operator_action_required_all": true
+  },
+  "deployment_runbook": {
+    "doc_path": "docs/MULTI-TENANT-DEPLOYMENT.md",
+    "advisory_boundary": true,
+    "runtime_enforced": false,
+    "live_validated": false,
+    "operator_enforceable": true,
+    "operator_action_required": true,
+    "covers_seven_dimensions": true,
+    "live_cluster_commands_embedded": false
+  },
+  "config_recipe": {
+    "doc_path": "docs/MULTI-TENANT-CONFIG-RECIPE.md",
+    "test_path": "tests/test_epic_8_2_multitenant_config_recipe.py",
+    "namespace_per_tenant": true,
+    "dedicated_database_and_secret": true,
+    "network_policy_default_deny": true,
+    "servicemonitor_tenant_label": true,
+    "resource_quota_operator_owned": true,
+    "delegates_to_epic4_slices": true,
+    "inline_secret_material_present": false
+  },
+  "helm_boundary": {
+    "chart_root": "deploy/helm/ao-kernel",
+    "values_path": "deploy/helm/ao-kernel/values.yaml",
+    "test_path": "tests/test_epic_4_1_helm_chart_skeleton.py",
+    "namespace_scoped_rbac": true,
+    "cluster_scoped_rbac_present": false,
+    "secret_key_ref_only": true,
+    "network_policy_template_present": true,
+    "pod_resources_present": true,
+    "servicemonitor_surface_present": true,
+    "resourcequota_rendered_by_chart": false
+  },
+  "rate_limit": {
+    "doc_path": "docs/RATE-LIMIT-TUNING.md",
+    "test_path": "tests/test_epic_7_4_rate_limit_tuning.py",
+    "per_tenant_key_pattern": true,
+    "bucket_isolation_tested": true,
+    "process_local_registry": true,
+    "live_adapter_execution": false
+  },
+  "residual_missing_evidence": [
+    "live cluster CNI/RBAC/NetworkPolicy validation evidence",
+    "cross-tenant leak prevention or attack-test evidence",
+    "operator-applied ResourceQuota and LimitRange evidence",
+    "per-tenant live cost/quota dashboard evidence",
+    "operator-attested tenant isolation review bound to final release artifact"
+  ],
+  "issue_refs": [
+    "https://github.com/Halildeu/ao-kernel/issues/775",
+    "https://github.com/Halildeu/ao-kernel/issues/776",
+    "https://github.com/Halildeu/ao-kernel/issues/782",
+    "https://github.com/Halildeu/ao-kernel/issues/895"
+  ]
+}

--- a/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
+++ b/tests/fixtures/epic9/v5-production-readiness-matrix.current.json
@@ -157,22 +157,33 @@
     },
     {
       "id": "multi_tenancy_isolation",
-      "status": "not_ready",
+      "status": "partial",
       "required_evidence": [
         "tenant isolation test suite",
         "RBAC, secret, quota, and audit isolation evidence",
         "per-tenant cost tracking and rate limit evidence"
       ],
       "current_evidence_refs": [
-        ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md"
+        ".claude/plans/V5-MULTI-TENANCY-ISOLATION-PREFLIGHT-BUNDLE.md",
+        "tests/fixtures/epic9/v5-multi-tenancy-isolation-preflight.current.json",
+        "docs/MULTI-TENANT-DEPLOYMENT.md",
+        "docs/MULTI-TENANT-CONFIG-RECIPE.md",
+        "docs/RATE-LIMIT-TUNING.md",
+        ".claude/plans/tenant_isolation_matrix.v1.json",
+        ".claude/plans/E-4-2b-MULTI-TENANT-FINAL-SEAL.v1.json",
+        "deploy/helm/ao-kernel/values.yaml"
       ],
       "missing_evidence": [
-        "tenant isolation implementation evidence",
-        "cross-tenant leak prevention test evidence",
-        "per-tenant cost and quota evidence"
+        "live cluster CNI/RBAC/NetworkPolicy validation evidence",
+        "cross-tenant leak prevention or attack-test evidence",
+        "operator-applied ResourceQuota and LimitRange evidence",
+        "per-tenant live cost/quota dashboard evidence",
+        "operator-attested tenant isolation review bound to final release artifact"
       ],
       "source_documents": [
-        ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md"
+        ".claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md",
+        ".claude/plans/EPIC-9-FINAL-SUPERSESSION-PR.md",
+        ".claude/plans/EPIC-4-KUBERNETES-HELM-MULTI-TENANT.md"
       ]
     },
     {

--- a/tests/test_v5_multi_tenancy_isolation_preflight_bundle.py
+++ b/tests/test_v5_multi_tenancy_isolation_preflight_bundle.py
@@ -1,0 +1,324 @@
+"""V5 multi-tenancy isolation preflight bundle invariants.
+
+The V5 production readiness matrix keeps the multi-tenancy dimension partial
+until a later operator-bound PR supplies live cluster validation, cross-tenant
+leak-prevention evidence, per-tenant quota/cost proof, and final release-bound
+operator attestation. This bundle records current advisory evidence only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_NAME = "v5-multi-tenancy-isolation-preflight-bundle.schema.v1.json"
+SCHEMA_PATH = ROOT / "ao_kernel" / "defaults" / "schemas" / SCHEMA_NAME
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "epic9" / "v5-multi-tenancy-isolation-preflight.current.json"
+MATRIX_FIXTURE_PATH = ROOT / "tests" / "fixtures" / "epic9" / "v5-production-readiness-matrix.current.json"
+MATRIX_DOC_PATH = ROOT / ".claude" / "plans" / "V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md"
+BUNDLE_DOC_PATH = ROOT / ".claude" / "plans" / "V5-MULTI-TENANCY-ISOLATION-PREFLIGHT-BUNDLE.md"
+TENANT_MATRIX_PATH = ROOT / ".claude" / "plans" / "tenant_isolation_matrix.v1.json"
+
+EXPECTED_DIMENSIONS = [
+    "namespace_isolation",
+    "rbac_scope",
+    "secret_isolation",
+    "network_policy",
+    "resource_quota",
+    "audit_boundary",
+    "cost_tracking_advisory",
+]
+
+
+def _schema() -> dict[str, Any]:
+    return load_default("schemas", SCHEMA_NAME)
+
+
+def _fixture() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _matrix_fixture() -> dict[str, Any]:
+    return json.loads(MATRIX_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _tenant_matrix() -> dict[str, Any]:
+    return json.loads(TENANT_MATRIX_PATH.read_text(encoding="utf-8"))
+
+
+def _is_valid(payload: dict[str, Any]) -> bool:
+    return not list(Draft202012Validator(_schema()).iter_errors(payload))
+
+
+def _object_nodes(node: Any) -> list[dict[str, Any]]:
+    nodes: list[dict[str, Any]] = []
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            nodes.append(node)
+        for value in node.values():
+            nodes.extend(_object_nodes(value))
+    elif isinstance(node, list):
+        for value in node:
+            nodes.extend(_object_nodes(value))
+    return nodes
+
+
+def _dimension(payload: dict[str, Any], dimension_id: str) -> dict[str, Any]:
+    for dimension in payload["dimensions"]:
+        if dimension["id"] == dimension_id:
+            return dimension
+    raise AssertionError(f"dimension not found: {dimension_id}")
+
+
+def test_schema_present_valid_and_strict() -> None:
+    assert SCHEMA_PATH.is_file()
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["$id"] == "urn:ao:v5-multi-tenancy-isolation-preflight-bundle:v1"
+
+    for node in _object_nodes(schema):
+        assert node.get("additionalProperties") is False
+        assert node.get("unevaluatedProperties") is False
+
+
+def test_current_fixture_validates_and_pins_non_authority_boundary() -> None:
+    payload = _fixture()
+    assert _is_valid(payload)
+    assert payload["schema_version"] == "v5_multi_tenancy_isolation_preflight_bundle.v1"
+    assert payload["artifact_kind"] == "v5_multi_tenancy_isolation_preflight_bundle"
+    assert payload["repo"] == "Halildeu/ao-kernel"
+    assert payload["work_package"] == "E-9-1"
+    assert payload["dimension"] == "multi_tenancy_isolation"
+    assert payload["evidence_class"] == "preflight_current_state"
+    assert payload["runtime_enforced"] is False
+    assert payload["operator_enforceable"] is True
+    assert payload["operator_action_required"] is True
+    assert payload["live_validated"] is False
+    assert payload["tenant_isolation_ready"] is False
+    assert payload["support_widening"] is False
+    assert payload["production_platform_claim"] is False
+    assert payload["live_adapter_execution"] is False
+
+
+def test_schema_rejects_runtime_live_ready_or_guard_flips() -> None:
+    for field in (
+        "runtime_enforced",
+        "live_validated",
+        "tenant_isolation_ready",
+        "support_widening",
+        "production_platform_claim",
+        "live_adapter_execution",
+    ):
+        payload = _fixture()
+        payload[field] = True
+        assert not _is_valid(payload), f"{field}=true must fail closed"
+
+
+def test_schema_rejects_nested_authority_or_boundary_claim_flips() -> None:
+    mutations: tuple[tuple[str, str, bool], ...] = (
+        ("advisory_matrix", "runtime_enforced_global", True),
+        ("advisory_matrix", "live_validated_global", True),
+        ("deployment_runbook", "runtime_enforced", True),
+        ("deployment_runbook", "live_validated", True),
+        ("deployment_runbook", "live_cluster_commands_embedded", True),
+        ("config_recipe", "inline_secret_material_present", True),
+        ("helm_boundary", "cluster_scoped_rbac_present", True),
+        ("helm_boundary", "resourcequota_rendered_by_chart", True),
+        ("rate_limit", "live_adapter_execution", True),
+    )
+    for section, field, value in mutations:
+        payload = _fixture()
+        payload[section][field] = value
+        assert not _is_valid(payload), f"{section}.{field}={value!r} must fail closed"
+
+
+def test_schema_rejects_path_or_extra_field_drift() -> None:
+    payload = _fixture()
+    payload["deployment_runbook"]["doc_path"] = "docs/OTHER.md"
+    assert not _is_valid(payload)
+
+    payload = _fixture()
+    payload["rate_limit"]["doc_path"] = "docs/OTHER.md"
+    assert not _is_valid(payload)
+
+    payload = _fixture()
+    payload["unexpected"] = "not allowed"
+    assert not _is_valid(payload)
+
+    payload = _fixture()
+    payload["helm_boundary"]["unexpected"] = "not allowed"
+    assert not _is_valid(payload)
+
+
+def test_all_referenced_artifacts_exist() -> None:
+    payload = _fixture()
+    for section_name in ("advisory_matrix", "deployment_runbook", "config_recipe", "helm_boundary", "rate_limit"):
+        section = payload[section_name]
+        for key, value in section.items():
+            if key.endswith("_path") or key in {"chart_root", "values_path"}:
+                assert (ROOT / value).exists(), f"{section_name}.{key} missing: {value}"
+
+
+def test_advisory_matrix_exactly_binds_final_seal_without_live_claim() -> None:
+    payload = _fixture()
+    section = payload["advisory_matrix"]
+    matrix = _tenant_matrix()
+
+    assert section["matrix_status"] == "e_4_2b_final_seal"
+    assert section["exact_dimensions"] == EXPECTED_DIMENSIONS
+    assert matrix["matrix_status"] == "e_4_2b_final_seal"
+    assert matrix["advisory_only"] is True
+    assert matrix["runtime_enforced_global"] is False
+    assert matrix["live_validated_global"] is False
+    assert len(matrix["dimensions"]) == 7
+    assert [entry["dimension"] for entry in matrix["dimensions"]] == EXPECTED_DIMENSIONS
+
+    for entry in matrix["dimensions"]:
+        assert entry["entry_status"] == "filled"
+        assert entry["runtime_enforced"] is False
+        assert entry["operator_enforceable"] is True
+        assert entry["operator_action_required"] is True
+        assert entry["live_validated"] is False
+        assert entry["downstream_evidence_ref"]
+
+
+def test_deployment_runbook_keeps_advisory_boundary_and_no_live_cluster_commands() -> None:
+    section = _fixture()["deployment_runbook"]
+    doc = (ROOT / section["doc_path"]).read_text(encoding="utf-8")
+    lower = doc.lower()
+
+    assert section["advisory_boundary"] is True
+    assert section["runtime_enforced"] is False
+    assert section["live_validated"] is False
+    assert "advisory boundary" in lower
+    assert "runtime_enforced: false" in doc
+    assert "live_validated: false" in doc
+    assert "no live cross-tenant attack test has run" in lower
+    for command in ("helm install", "helm upgrade", "kubectl apply"):
+        assert command not in doc, f"deployment runbook must not embed live cluster command: {command}"
+
+
+def test_config_recipe_covers_namespace_per_tenant_without_inline_secrets() -> None:
+    section = _fixture()["config_recipe"]
+    doc = (ROOT / section["doc_path"]).read_text(encoding="utf-8")
+    tests = (ROOT / section["test_path"]).read_text(encoding="utf-8")
+    lower = doc.lower()
+
+    assert section["namespace_per_tenant"] is True
+    assert section["dedicated_database_and_secret"] is True
+    assert section["network_policy_default_deny"] is True
+    assert section["resource_quota_operator_owned"] is True
+    assert section["inline_secret_material_present"] is False
+    assert "deployment-level isolation" in lower
+    assert "dedicated postgresql" in lower
+    assert "networkpolicy default-deny" in lower
+    assert "resourcequota applied" in lower
+    assert "secretname" in lower
+    for slice_id in ("E-4-2a", "E-4-3", "E-4-4", "E-4-5"):
+        assert slice_id in doc
+    assert "test_recipe_overlay_uses_secretkeyref_not_inline" in tests
+
+
+def test_helm_boundary_has_namespace_scope_secret_refs_and_no_chart_quota() -> None:
+    section = _fixture()["helm_boundary"]
+    chart_root = ROOT / section["chart_root"]
+    values = (ROOT / section["values_path"]).read_text(encoding="utf-8")
+    rbac = (chart_root / "templates" / "rbac.yaml").read_text(encoding="utf-8")
+    deployment = (chart_root / "templates" / "deployment.yaml").read_text(encoding="utf-8")
+
+    assert section["namespace_scoped_rbac"] is True
+    assert section["cluster_scoped_rbac_present"] is False
+    assert section["secret_key_ref_only"] is True
+    assert section["network_policy_template_present"] is True
+    assert section["pod_resources_present"] is True
+    assert section["resourcequota_rendered_by_chart"] is False
+    assert "kind: Role" in rbac
+    assert "kind: RoleBinding" in rbac
+    assert "kind: ClusterRole" not in rbac
+    assert "kind: ClusterRoleBinding" not in rbac
+    assert "secretKeyRef" in deployment
+    assert "resources:" in values
+    assert (chart_root / "templates" / "networkpolicy.yaml").is_file()
+    assert (chart_root / "templates" / "servicemonitor.yaml").is_file()
+    assert not list(chart_root.glob("templates/*resourcequota*"))
+
+
+def test_rate_limit_preflight_records_per_tenant_bucket_isolation_only() -> None:
+    section = _fixture()["rate_limit"]
+    doc = (ROOT / section["doc_path"]).read_text(encoding="utf-8")
+    tests = (ROOT / section["test_path"]).read_text(encoding="utf-8")
+
+    assert section["per_tenant_key_pattern"] is True
+    assert section["bucket_isolation_tested"] is True
+    assert section["live_adapter_execution"] is False
+    assert '"<tenant>:<provider>"' in doc or "{tenant_id}:{provider_id}" in doc
+    assert "test_per_tenant_key_isolates_buckets" in tests
+    assert "live adapter execution" in doc.lower()
+    assert "const false" in doc.lower()
+
+
+def test_matrix_refs_multi_tenancy_bundle_but_keeps_dimension_partial() -> None:
+    matrix = _matrix_fixture()
+    dimension = _dimension(matrix, "multi_tenancy_isolation")
+
+    assert dimension["status"] == "partial"
+    assert ".claude/plans/V5-MULTI-TENANCY-ISOLATION-PREFLIGHT-BUNDLE.md" in dimension["current_evidence_refs"]
+    assert "tests/fixtures/epic9/v5-multi-tenancy-isolation-preflight.current.json" in dimension["current_evidence_refs"]
+    assert "docs/MULTI-TENANT-DEPLOYMENT.md" in dimension["current_evidence_refs"]
+    assert "docs/MULTI-TENANT-CONFIG-RECIPE.md" in dimension["current_evidence_refs"]
+    assert "docs/RATE-LIMIT-TUNING.md" in dimension["current_evidence_refs"]
+    assert ".claude/plans/tenant_isolation_matrix.v1.json" in dimension["current_evidence_refs"]
+    assert "live cluster CNI/RBAC/NetworkPolicy validation evidence" in dimension["missing_evidence"]
+    assert "cross-tenant leak prevention or attack-test evidence" in dimension["missing_evidence"]
+    assert "per-tenant live cost/quota dashboard evidence" in dimension["missing_evidence"]
+    assert matrix["matrix_complete"] is False
+    assert matrix["pr_xfinal_open_allowed"] is False
+    assert matrix["support_widening"] is False
+    assert matrix["production_platform_claim"] is False
+    assert matrix["live_adapter_execution"] is False
+
+
+def test_bundle_doc_has_cross_refs_without_positive_claim_tokens() -> None:
+    text = BUNDLE_DOC_PATH.read_text(encoding="utf-8")
+    matrix_doc = MATRIX_DOC_PATH.read_text(encoding="utf-8")
+
+    assert "V5 Multi-Tenancy Isolation Preflight Bundle" in text
+    assert "runtime_enforced=false" in text
+    assert "live_validated=false" in text
+    assert "tenant_isolation_ready=false" in text
+    assert "V5-MULTI-TENANCY-ISOLATION-PREFLIGHT-BUNDLE.md" in matrix_doc
+    assert "v5-multi-tenancy-isolation-preflight.current.json" in matrix_doc
+
+    forbidden = (
+        "production-ready",
+        "production ready",
+        "support_widening=true",
+        "production_platform_claim=true",
+        "live_adapter_execution=true",
+        "runtime_enforced=true",
+        "live_validated=true",
+        "tenant_isolation_ready=true",
+        "matrix_complete=true",
+        "pr_xfinal_open_allowed=true",
+    )
+    lowered = text.lower()
+    for token in forbidden:
+        assert token not in lowered, f"bundle doc must not include positive claim token: {token}"
+
+
+def test_residual_missing_evidence_keeps_live_tenant_work_explicit() -> None:
+    assert _fixture()["residual_missing_evidence"] == [
+        "live cluster CNI/RBAC/NetworkPolicy validation evidence",
+        "cross-tenant leak prevention or attack-test evidence",
+        "operator-applied ResourceQuota and LimitRange evidence",
+        "per-tenant live cost/quota dashboard evidence",
+        "operator-attested tenant isolation review bound to final release artifact",
+    ]


### PR DESCRIPTION
## Summary

Adds the V5 Epic 9 multi-tenancy isolation preflight bundle and wires the production-readiness matrix multi_tenancy_isolation dimension from not_ready to partial.

Scope is evidence-only:
- new strict schema: v5-multi-tenancy-isolation-preflight-bundle.schema.v1.json
- new current fixture: v5-multi-tenancy-isolation-preflight.current.json
- new invariant test: test_v5_multi_tenancy_isolation_preflight_bundle.py
- matrix blocker doc + fixture cross-ref update
- changelog + local AI review evidence update

## Non-authority boundary

This PR does not claim tenant isolation readiness, runtime enforcement, live validation, support widening, production platform readiness, PR-Xfinal openability, or live adapter execution. Residual missing evidence remains explicit: live CNI/RBAC/NetworkPolicy validation, cross-tenant leak-prevention testing, operator-applied quota proof, per-tenant live cost/quota dashboard evidence, and final release-bound operator attestation.

## Validation

- python3 -m json.tool ao_kernel/defaults/schemas/v5-multi-tenancy-isolation-preflight-bundle.schema.v1.json
- python3 -m json.tool tests/fixtures/epic9/v5-multi-tenancy-isolation-preflight.current.json
- python3 -m json.tool tests/fixtures/epic9/v5-production-readiness-matrix.current.json
- pytest tests/test_v5_multi_tenancy_isolation_preflight_bundle.py tests/test_v5_production_readiness_matrix_blocker.py tests/test_epic_4_2a_multi_tenant_boundary.py tests/test_epic_4_2b_matrix_invariants.py tests/test_epic_8_2_multitenant_config_recipe.py tests/test_epic_7_4_rate_limit_tuning.py tests/test_epic_4_1_helm_chart_skeleton.py -q -> 88 passed, 10 skipped
- git diff --cached --check
- gitleaks protect --staged --redact -> no leaks found
- Claude (Anthropic) staged-diff review -> VERDICT: AGREE
- python3 scripts/local_gpp_gate.py ... -> operator_may_merge

## Local gate context binding

- head_sha: 6b516af898738da126192532e096c06d411e6531
- diff_digest: sha256:befb69454a3900c71d1e0debc3ca50e88f19273fba2b329eb1e1c9df30e0e554
- changed_files_count: 8

## Guard flags

- support_widening=false
- production_platform_claim=false
- live_adapter_execution=false
