### PR TITLE
feat(context): doc-bridge — ingest .md context into governed store + render packet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **Context doc-bridge** (`ao_kernel.context.doc_bridge`): ingest a repo's
+  `.md`-governed context (AGENTS.md, ADRs, `current-state`, decision records)
+  into the governed canonical store, then render a short, provenance-tagged
+  markdown **context packet** for injection into any AI (Claude / Codex /
+  Mavis). Surfaces: public `ingest_docs()` / `render_context_packet()` and a CLI
+  `ao-kernel context {ingest,packet}`. A declarative, schema-validated mapping
+  (`ao_kernel/defaults/context_bridge/doc_mapping.default.v1.json`, schema
+  `context-doc-bridge-mapping.schema.v1.json`) drives extraction; bundled
+  defaults cover the common ADR / entry-doc / state-doc conventions and are fully
+  overridable. Design + acceptance criteria were set by a cross-AI plan-time gate
+  (Codex AGREE): authoritative provenance lives **inside** each canonical item's
+  `provenance.doc_bridge` namespace (no side-map), the batch is written under a
+  single CAS revision via the new `canonical_store.promote_many`, and the packet
+  is **fail-closed** — items whose source file was deleted or drifted (re-applied
+  mapping no longer reproduces the same key + `value_hash`) are excluded, secret-
+  like values are skipped (never redacted-and-stored), unverified `doc_claim`
+  facts are opt-in and labelled `UNVERIFIED`, and the packet header states it is
+  source-derived context that cannot override `support_widening` /
+  `production_platform_claim` / `live_adapter_execution`. Source repos are read
+  read-only; mapping globs are repo-root confined (symlink / `..` / oversize
+  rejected). `compile_context`, the MCP surface, and the three guard flags are
+  untouched. Cross-AI review: Codex (OpenAI).
+
 ## [4.2.1] - 2026-06-07
 
 ### Added

--- a/ao_kernel/_internal/context_doc_bridge/__init__.py
+++ b/ao_kernel/_internal/context_doc_bridge/__init__.py
@@ -1,0 +1,5 @@
+"""Internal implementation of the context doc-bridge.
+
+Public surface is ``ao_kernel.context.doc_bridge``; these modules carry the
+parsing / mapping / key / ingest / render logic that may churn across versions.
+"""

--- a/ao_kernel/_internal/context_doc_bridge/ingest.py
+++ b/ao_kernel/_internal/context_doc_bridge/ingest.py
@@ -122,12 +122,13 @@ def ingest_docs(
     max_bytes = int(spec.get("max_file_bytes", mapping.DEFAULT_MAX_BYTES))
 
     report = IngestReport()
-    items: list[dict[str, Any]] = []
-    seen: dict[str, tuple[str, str]] = {}
+    raw: list[dict[str, Any]] = []
 
     for rule in spec["rules"]:
         mid = rule["mapping_id"]
         policy = rule.get("collision_policy", "strict")
+        rtype = rule["type"]
+        category = "fact" if rtype == "fact" else "architecture"
         for src in mapping.resolve_sources(repo, rule["glob"], max_files=max_files, max_bytes=max_bytes):
             src_rel = str(src.relative_to(repo))
             text = src.read_text(encoding="utf-8", errors="replace")
@@ -136,17 +137,7 @@ def ingest_docs(
                 if parser.looks_like_secret(ex.value):
                     report.secrets_skipped.append(f"{src_rel} ({ex.key})")
                     continue
-                supersedes: str | None = None
-                prev = seen.get(ex.key)
-                if prev is not None and prev != (src_rel, mid):
-                    if policy == "supersede":
-                        supersedes = ex.key
-                    else:  # strict | update_same_source: reject cross-source collision
-                        report.collisions.append(f"{ex.key}: {prev[0]} vs {src_rel}")
-                        continue
-                seen[ex.key] = (src_rel, mid)
-                category = "fact" if rule["type"] == "fact" else "architecture"
-                items.append(
+                raw.append(
                     {
                         "key": ex.key,
                         "value": ex.value,
@@ -154,30 +145,86 @@ def ingest_docs(
                         "source": "agent",
                         "confidence": ex.confidence,
                         "session_id": "doc-bridge",
-                        "supersedes": supersedes,
+                        "supersedes": None,
                         "provenance": _build_provenance(rule, src_rel, ex, doc_hash),
+                        "_policy": policy,
+                        "_src_mid": (src_rel, mid),
+                        "_type": rtype,
                     }
                 )
-                report.by_type[rule["type"]] = report.by_type.get(rule["type"], 0) + 1
 
-    if items:
-        report.revision = _cas_write(ws, items)
-        report.ingested = len(items)
+    if raw:
+        report.revision = _resolve_and_write(ws, raw, report)
     return report
 
 
-def _cas_write(ws: Path, items: list[dict[str, Any]], retries: int = 1) -> str:
-    """Single-revision batch write with read-revision-mutate-write retry.
+def _existing_doc_bridge_keys(store: dict[str, Any]) -> dict[str, tuple[str, str]]:
+    """Map already-stored doc-bridge keys -> (src, mapping_id) for collision check."""
+    out: dict[str, tuple[str, str]] = {}
+    for section in ("decisions", "facts"):
+        for key, item in store.get(section, {}).items():
+            if not isinstance(item, dict):
+                continue
+            namespace = (item.get("provenance") or {}).get(PROVENANCE_NS)
+            if isinstance(namespace, dict):
+                out[key] = (namespace.get("src", ""), namespace.get("mapping_id", ""))
+    return out
 
-    On conflict the loop re-loads a FRESH snapshot + revision (never re-writes
-    the stale snapshot) — Codex acceptance #1.
+
+def _select_items(
+    raw: list[dict[str, Any]],
+    existing: dict[str, tuple[str, str]],
+) -> tuple[list[dict[str, Any]], list[str], dict[str, int]]:
+    """Apply collision policy against BOTH this batch and the existing store.
+
+    A key already owned by a DIFFERENT ``(src, mapping_id)`` is a collision:
+    ``strict`` / ``update_same_source`` skip it (never a silent overwrite),
+    ``supersede`` records ``supersedes``. The same ``(src, mapping_id)`` is an
+    in-place update. Pure + recomputed on every CAS attempt (post-impl #3).
+    """
+    seen: dict[str, tuple[str, str]] = {}
+    final: list[dict[str, Any]] = []
+    collisions: list[str] = []
+    by_type: dict[str, int] = {}
+    for cand in raw:
+        key = cand["key"]
+        src_mid = cand["_src_mid"]
+        owner = seen.get(key) or existing.get(key)
+        supersedes: str | None = None
+        if owner is not None and owner != src_mid:
+            if cand["_policy"] == "supersede":
+                supersedes = key
+            else:
+                collisions.append(f"{key}: {owner[0]} vs {src_mid[0]}")
+                continue
+        seen[key] = src_mid
+        item = {k: v for k, v in cand.items() if not k.startswith("_")}
+        item["supersedes"] = supersedes
+        final.append(item)
+        by_type[cand["_type"]] = by_type.get(cand["_type"], 0) + 1
+    return final, collisions, by_type
+
+
+def _resolve_and_write(ws: Path, raw: list[dict[str, Any]], report: IngestReport, retries: int = 1) -> str:
+    """Collision-resolve against the live store, then write in one CAS revision.
+
+    Read-revision-mutate-write: on conflict, re-load a FRESH snapshot, re-resolve
+    collisions against it, and re-write — never re-writes a stale snapshot
+    (Codex acceptance #1 + post-impl #3, cross-store collision).
     """
     attempt = 0
     while True:
         store = cs.load_store(ws)
         expected = cs.store_revision(store)
+        existing = _existing_doc_bridge_keys(store)
+        final, collisions, by_type = _select_items(raw, existing)
+        report.collisions = collisions
+        report.by_type = by_type
+        report.ingested = len(final)
+        if not final:
+            return expected  # all collided / nothing to write; store unchanged
         try:
-            return cs.promote_many(ws, items, expected_revision=expected, allow_overwrite=False)
+            return cs.promote_many(ws, final, expected_revision=expected, allow_overwrite=False)
         except CanonicalRevisionConflict:
             attempt += 1
             if attempt > retries:

--- a/ao_kernel/_internal/context_doc_bridge/ingest.py
+++ b/ao_kernel/_internal/context_doc_bridge/ingest.py
@@ -1,0 +1,184 @@
+"""Ingest repo ``.md`` sources into the canonical store with doc_bridge provenance.
+
+Authoritative provenance lives inside each canonical item's ``provenance``
+field under the ``doc_bridge`` namespace (no side-map — Codex acceptance #3).
+The whole batch is written under a single CAS revision via
+``canonical_store.promote_many`` (Codex acceptance #1: no partial state).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ao_kernel._internal.context_doc_bridge import keygen, mapping, parser
+from ao_kernel.context import canonical_store as cs
+from ao_kernel.errors import CanonicalRevisionConflict
+
+PROVENANCE_NS = "doc_bridge"
+PROVENANCE_SCHEMA_VERSION = "doc-bridge-provenance.v1"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass
+class Extracted:
+    """One deterministic entry extracted from a source under a rule."""
+
+    key: str
+    value: str
+    confidence: float
+    status: str
+    doc_date: str
+    value_hash: str
+
+
+@dataclass
+class IngestReport:
+    ingested: int = 0
+    revision: str = ""
+    by_type: dict[str, int] = field(default_factory=dict)
+    secrets_skipped: list[str] = field(default_factory=list)
+    collisions: list[str] = field(default_factory=list)
+
+
+def _confidence_for(rule: dict[str, Any], status: str) -> float:
+    status_map = rule.get("status_map")
+    if status_map:
+        return float(status_map.get(status.lower(), status_map.get("unknown", 0.7)))
+    return float(rule.get("confidence", 0.7))
+
+
+def extract_from_source(rule: dict[str, Any], src_rel: str, text: str) -> list[Extracted]:
+    """Deterministically extract entries from one source's text under a rule.
+
+    Pure + shared by ingest (write) and renderer (re-verify): identical inputs
+    always produce identical keys + value_hash, so the renderer can detect when
+    a source drifted away from what was ingested.
+    """
+    strategy = rule["value_strategy"]
+    template = rule["key_template"]
+    fname = Path(src_rel).name
+    stem = keygen.stem_of(fname)
+    num = keygen.num_of(fname)
+    out: list[Extracted] = []
+
+    if strategy == "first_heading":
+        value = parser.first_heading(text, stem)
+        key = keygen.render_key(template, stem=stem, num=num)
+        out.append(Extracted(key, value, _confidence_for(rule, "unknown"), "", "", parser.sha256_text(value)))
+    elif strategy == "status_line":
+        title = parser.first_heading(text, stem)
+        status, date = parser.status_and_date(text)
+        value = f"{title} [{status}{(' ' + date) if date else ''}]"
+        key = keygen.render_key(template, stem=stem, num=num)
+        out.append(Extracted(key, value, _confidence_for(rule, status), status, date, parser.sha256_text(value)))
+    elif strategy == "section_headings":
+        limit = int(rule.get("max_items", 8))
+        for index, heading in enumerate(parser.section_headings(text, limit)):
+            key = keygen.render_key(template, stem=stem, num=num, index=index)
+            out.append(Extracted(key, heading, _confidence_for(rule, "unknown"), "", "", parser.sha256_text(heading)))
+    return out
+
+
+def _build_provenance(rule: dict[str, Any], src_rel: str, ex: Extracted, doc_hash: str) -> dict[str, Any]:
+    return {
+        PROVENANCE_NS: {
+            "schema_version": PROVENANCE_SCHEMA_VERSION,
+            "src": src_rel,
+            "mapping_id": rule["mapping_id"],
+            "type": rule["type"],
+            "tier": rule["tier"],
+            "status": ex.status,
+            "doc_date": ex.doc_date,
+            "doc_hash": doc_hash,
+            "value_hash": ex.value_hash,
+            "observed_at": _now_iso(),
+        }
+    }
+
+
+def ingest_docs(
+    root: str | Path,
+    *,
+    repo_root: str | Path | None = None,
+    mapping_path: str | None = None,
+) -> IngestReport:
+    """Parse repo ``.md`` sources per the mapping and write them to the store.
+
+    ``root`` is the workspace root (where ``.ao`` lives). ``repo_root`` (where
+    the ``.md`` sources are scanned) defaults to ``root`` — a single root in the
+    common in-repo case (Codex acceptance #2). Same signature shape as
+    :func:`render_context_packet` so the two never get transposed.
+    """
+    ws = Path(root)
+    repo = Path(repo_root) if repo_root is not None else ws
+    spec = mapping.load_mapping(mapping_path)
+    max_files = int(spec.get("max_files_per_rule", mapping.DEFAULT_MAX_FILES))
+    max_bytes = int(spec.get("max_file_bytes", mapping.DEFAULT_MAX_BYTES))
+
+    report = IngestReport()
+    items: list[dict[str, Any]] = []
+    seen: dict[str, tuple[str, str]] = {}
+
+    for rule in spec["rules"]:
+        mid = rule["mapping_id"]
+        policy = rule.get("collision_policy", "strict")
+        for src in mapping.resolve_sources(repo, rule["glob"], max_files=max_files, max_bytes=max_bytes):
+            src_rel = str(src.relative_to(repo))
+            text = src.read_text(encoding="utf-8", errors="replace")
+            doc_hash = parser.sha256_file(src)
+            for ex in extract_from_source(rule, src_rel, text):
+                if parser.looks_like_secret(ex.value):
+                    report.secrets_skipped.append(f"{src_rel} ({ex.key})")
+                    continue
+                supersedes: str | None = None
+                prev = seen.get(ex.key)
+                if prev is not None and prev != (src_rel, mid):
+                    if policy == "supersede":
+                        supersedes = ex.key
+                    else:  # strict | update_same_source: reject cross-source collision
+                        report.collisions.append(f"{ex.key}: {prev[0]} vs {src_rel}")
+                        continue
+                seen[ex.key] = (src_rel, mid)
+                category = "fact" if rule["type"] == "fact" else "architecture"
+                items.append(
+                    {
+                        "key": ex.key,
+                        "value": ex.value,
+                        "category": category,
+                        "source": "agent",
+                        "confidence": ex.confidence,
+                        "session_id": "doc-bridge",
+                        "supersedes": supersedes,
+                        "provenance": _build_provenance(rule, src_rel, ex, doc_hash),
+                    }
+                )
+                report.by_type[rule["type"]] = report.by_type.get(rule["type"], 0) + 1
+
+    if items:
+        report.revision = _cas_write(ws, items)
+        report.ingested = len(items)
+    return report
+
+
+def _cas_write(ws: Path, items: list[dict[str, Any]], retries: int = 1) -> str:
+    """Single-revision batch write with read-revision-mutate-write retry.
+
+    On conflict the loop re-loads a FRESH snapshot + revision (never re-writes
+    the stale snapshot) — Codex acceptance #1.
+    """
+    attempt = 0
+    while True:
+        store = cs.load_store(ws)
+        expected = cs.store_revision(store)
+        try:
+            return cs.promote_many(ws, items, expected_revision=expected, allow_overwrite=False)
+        except CanonicalRevisionConflict:
+            attempt += 1
+            if attempt > retries:
+                raise

--- a/ao_kernel/_internal/context_doc_bridge/keygen.py
+++ b/ao_kernel/_internal/context_doc_bridge/keygen.py
@@ -1,0 +1,33 @@
+"""Deterministic key rendering for the context doc-bridge (internal)."""
+
+from __future__ import annotations
+
+import re
+
+_LEADING_NUM = re.compile(r"^(\d+)")
+_ALLOWED_PLACEHOLDERS = {"stem", "index", "num"}
+_PLACEHOLDER = re.compile(r"\{([a-z_]+)\}")
+
+
+def stem_of(filename: str) -> str:
+    return re.sub(r"\.md$", "", filename, flags=re.IGNORECASE)
+
+
+def num_of(filename: str) -> str:
+    m = _LEADING_NUM.match(filename)
+    return m.group(1) if m else stem_of(filename)
+
+
+def validate_template(template: str) -> None:
+    """Reject templates referencing unknown placeholders (fail-closed)."""
+    unknown = {n for n in _PLACEHOLDER.findall(template) if n not in _ALLOWED_PLACEHOLDERS}
+    if unknown:
+        raise ValueError(
+            f"key_template {template!r} uses unknown placeholder(s): "
+            f"{sorted(unknown)}; allowed: {sorted(_ALLOWED_PLACEHOLDERS)}"
+        )
+
+
+def render_key(template: str, *, stem: str = "", index: int = 0, num: str = "") -> str:
+    validate_template(template)
+    return template.format(stem=stem, index=index, num=num)

--- a/ao_kernel/_internal/context_doc_bridge/mapping.py
+++ b/ao_kernel/_internal/context_doc_bridge/mapping.py
@@ -41,6 +41,42 @@ def _pattern_is_safe(pattern: str) -> bool:
     return ".." not in pattern.split("/")
 
 
+def resolve_within_repo(
+    repo_root: Path,
+    rel: str,
+    *,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> Path | None:
+    """Resolve a single repo-relative path with full fail-closed confinement.
+
+    Returns the path only if it is relative (no absolute / ``~`` / ``..``), not a
+    symlink, resolves under ``repo_root``, exists as a file, and is within
+    ``max_bytes``; otherwise ``None``. Shared by ingest (glob results) and render
+    (provenance ``src`` re-verify) so the security boundary is identical on both
+    sides — a source that becomes a symlink or escapes the repo after ingest is
+    rejected at render time too.
+    """
+    if not rel or rel.startswith("/") or rel.startswith("~"):
+        return None
+    if ".." in rel.split("/"):
+        return None
+    repo_real = repo_root.resolve()
+    p = repo_root / rel
+    if p.is_symlink() or not p.is_file():
+        return None
+    try:
+        real = p.resolve()
+        real.relative_to(repo_real)
+    except (ValueError, OSError):
+        return None
+    try:
+        if real.stat().st_size > max_bytes:
+            return None
+    except OSError:
+        return None
+    return p
+
+
 def resolve_sources(
     repo_root: Path,
     pattern: str,
@@ -50,31 +86,21 @@ def resolve_sources(
 ) -> list[Path]:
     """Return repo-confined, existing, size-bounded files matching ``pattern``.
 
-    Fail-closed confinement:
-        * reject absolute / ``~`` / ``..`` patterns outright,
-        * skip symlinks (even if the target is in-repo),
-        * skip any match whose resolved real path escapes ``repo_root``,
-        * skip files over ``max_bytes``,
-        * cap at ``max_files``, deterministic sort.
+    Rejects absolute / ``~`` / ``..`` patterns outright, then applies
+    :func:`resolve_within_repo` per match (symlink / escape / oversize skipped),
+    caps at ``max_files``, deterministic sort.
     """
     if not _pattern_is_safe(pattern):
         return []
-    repo_real = repo_root.resolve()
     out: list[Path] = []
     for p in sorted(repo_root.glob(pattern)):
-        if p.is_symlink() or not p.is_file():
-            continue
         try:
-            real = p.resolve()
-            real.relative_to(repo_real)
-        except (ValueError, OSError):
+            rel = str(p.relative_to(repo_root))
+        except ValueError:
             continue
-        try:
-            if real.stat().st_size > max_bytes:
-                continue
-        except OSError:
-            continue
-        out.append(p)
-        if len(out) >= max_files:
-            break
+        resolved = resolve_within_repo(repo_root, rel, max_bytes=max_bytes)
+        if resolved is not None:
+            out.append(resolved)
+            if len(out) >= max_files:
+                break
     return out

--- a/ao_kernel/_internal/context_doc_bridge/mapping.py
+++ b/ao_kernel/_internal/context_doc_bridge/mapping.py
@@ -1,0 +1,80 @@
+"""Mapping load + schema validation + repo-confined source resolution (internal)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from ao_kernel.config import load_default
+
+_SCHEMA_NAME = "context-doc-bridge-mapping.schema.v1.json"
+_DEFAULT_MAPPING = "doc_mapping.default.v1.json"
+
+DEFAULT_MAX_FILES = 500
+DEFAULT_MAX_BYTES = 1_048_576
+
+
+def load_mapping(path: str | None = None) -> dict[str, Any]:
+    """Load the bundled default mapping (path=None) or a custom mapping file.
+
+    Always schema-validated before return (fail-closed on malformed config).
+    """
+    if path is None:
+        mapping = load_default("context_bridge", _DEFAULT_MAPPING)
+    else:
+        mapping = json.loads(Path(path).read_text(encoding="utf-8"))
+    validate_mapping(mapping)
+    return mapping
+
+
+def validate_mapping(mapping: dict[str, Any]) -> None:
+    from jsonschema import Draft202012Validator
+
+    schema = load_default("schemas", _SCHEMA_NAME)
+    Draft202012Validator(schema).validate(mapping)
+
+
+def _pattern_is_safe(pattern: str) -> bool:
+    if pattern.startswith("/") or pattern.startswith("~"):
+        return False
+    return ".." not in pattern.split("/")
+
+
+def resolve_sources(
+    repo_root: Path,
+    pattern: str,
+    *,
+    max_files: int = DEFAULT_MAX_FILES,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> list[Path]:
+    """Return repo-confined, existing, size-bounded files matching ``pattern``.
+
+    Fail-closed confinement:
+        * reject absolute / ``~`` / ``..`` patterns outright,
+        * skip symlinks (even if the target is in-repo),
+        * skip any match whose resolved real path escapes ``repo_root``,
+        * skip files over ``max_bytes``,
+        * cap at ``max_files``, deterministic sort.
+    """
+    if not _pattern_is_safe(pattern):
+        return []
+    repo_real = repo_root.resolve()
+    out: list[Path] = []
+    for p in sorted(repo_root.glob(pattern)):
+        if p.is_symlink() or not p.is_file():
+            continue
+        try:
+            real = p.resolve()
+            real.relative_to(repo_real)
+        except (ValueError, OSError):
+            continue
+        try:
+            if real.stat().st_size > max_bytes:
+                continue
+        except OSError:
+            continue
+        out.append(p)
+        if len(out) >= max_files:
+            break
+    return out

--- a/ao_kernel/_internal/context_doc_bridge/parser.py
+++ b/ao_kernel/_internal/context_doc_bridge/parser.py
@@ -1,0 +1,92 @@
+"""Source-document parsing for the context doc-bridge (internal).
+
+Pure helpers: read a ``.md`` source, extract a short value via a bounded
+strategy, hash it, and screen for secret-like tokens. No network; the only
+I/O is reading the file path the caller already resolved + confined.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+MAX_VALUE_LEN = 300
+
+# Secret-like token screens. A source value matching any of these is NOT
+# ingested (Codex acceptance #4: skip + diagnostic, never redact-and-store).
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"sk-[A-Za-z0-9]{12,}"),
+    re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),  # JWT
+    re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._\-]{12,}"),
+    re.compile(
+        r"(?i)\b(?:password|passwd|secret|api[_-]?key|access[_-]?token|"
+        r"client[_-]?secret|refresh[_-]?token)\b\s*[:=]\s*\S{6,}"
+    ),
+    re.compile(r"-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),  # AWS access key id
+)
+
+_STATUS_KEYWORDS = (
+    "Accepted",
+    "Kabul",
+    "Approved",
+    "Rejected",
+    "Reddedildi",
+    "Superseded",
+    "Deprecated",
+    "Proposed",
+    "Draft",
+)
+
+
+def sha256_text(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def looks_like_secret(text: str) -> bool:
+    """True if the text contains a secret-like token (block ingest)."""
+    return any(p.search(text) for p in _SECRET_PATTERNS)
+
+
+def _clip(text: str) -> str:
+    return " ".join(text.split())[:MAX_VALUE_LEN]
+
+
+def first_heading(text: str, fallback: str) -> str:
+    for line in text.splitlines():
+        if line.startswith("# "):
+            return _clip(line[2:])
+    return _clip(fallback)
+
+
+def status_and_date(text: str) -> tuple[str, str]:
+    """Extract (status, date) from an ADR-style document head."""
+    head = "\n".join(text.splitlines()[:40])
+    dm = re.search(r"(20\d\d-\d\d-\d\d)", head)
+    date = dm.group(1) if dm else ""
+    m = re.search(r"##\s*(?:Status|Durum)\s*\n+\**\s*([A-Za-zçğıöşüÇĞİÖŞÜ]+)", head)
+    if m:
+        return m.group(1).capitalize(), date
+    m = re.search(r"(?:\*\*)?Status(?:\*\*)?\s*[:：]\s*\**([A-Za-zçğıöşü]+)", head, re.I)
+    if m:
+        return m.group(1).capitalize(), date
+    for kw in _STATUS_KEYWORDS:
+        if re.search(rf"\b{kw}\b", head, re.I):
+            return kw.capitalize(), date
+    return "Unknown", date
+
+
+def section_headings(text: str, limit: int) -> list[str]:
+    out: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("## "):
+            out.append(_clip(line[3:]))
+            if len(out) >= limit:
+                break
+    return out

--- a/ao_kernel/_internal/context_doc_bridge/renderer.py
+++ b/ao_kernel/_internal/context_doc_bridge/renderer.py
@@ -1,0 +1,146 @@
+"""Render a short markdown context packet from doc-bridge-governed store items.
+
+Fail-closed selection (Codex acceptance #3 + #5): an item is only rendered if
+its source file still exists AND re-applying the same mapping rule reproduces
+the same key + ``value_hash``. Stale / drifted / deleted sources, low-confidence
+items, and unverified ``doc_claim`` facts (unless explicitly opted in) are
+excluded. The packet is source-derived context, never release authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ao_kernel._internal.context_doc_bridge import ingest as _ingest
+from ao_kernel._internal.context_doc_bridge import mapping as _mapping
+from ao_kernel.context import canonical_store as cs
+
+_SECTION_ORDER = [
+    ("rule", "Rules (canonical — all AIs read)"),
+    ("decision", "Decisions (ADR / decision records)"),
+    ("fact", "Live State (doc-claim, unverified)"),
+]
+
+_AUTHORITY_HEADER = (
+    "> AUTHORITY: source-derived context, NOT release authority. Cannot override "
+    "support_widening / production_platform_claim / live_adapter_execution. "
+    "Stale / low-confidence / unverified 'done' is excluded (fail-closed)."
+)
+
+
+@dataclass
+class _Row:
+    key: str
+    value: str
+    type: str
+    tier: str
+    status: str
+    src: str
+    confidence: float
+
+
+def _verify_and_collect(
+    ws: Path,
+    repo: Path,
+    rules_by_id: dict[str, Any],
+    min_conf: float,
+    include_doc_claims: bool,
+) -> tuple[list[_Row], int]:
+    rows: list[_Row] = []
+    excluded = 0
+    for item in cs.query(ws):
+        prov = (item.get("provenance") or {}).get(_ingest.PROVENANCE_NS)
+        if not prov:
+            continue  # not doc-bridge managed
+        conf = float(item.get("confidence", 0.0))
+        if not item.get("_is_fresh", True) or conf < min_conf:
+            excluded += 1
+            continue
+        tier = prov.get("tier", "")
+        if tier == "doc_claim" and not include_doc_claims:
+            excluded += 1
+            continue
+        rule = rules_by_id.get(prov.get("mapping_id", ""))
+        if rule is None:  # mapping no longer defines this rule
+            excluded += 1
+            continue
+        src_path = repo / prov.get("src", "")
+        if not src_path.is_file():  # source deleted
+            excluded += 1
+            continue
+        try:
+            text = src_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            excluded += 1
+            continue
+        reproduced = {e.key: e for e in _ingest.extract_from_source(rule, prov["src"], text)}
+        match = reproduced.get(item["key"])
+        if match is None or match.value_hash != prov.get("value_hash"):
+            excluded += 1  # source drifted away from what was ingested
+            continue
+        rows.append(
+            _Row(
+                key=item["key"],
+                value=str(item.get("value", "")),
+                type=prov.get("type", ""),
+                tier=tier,
+                status=prov.get("status", ""),
+                src=prov.get("src", ""),
+                confidence=conf,
+            )
+        )
+    return rows, excluded
+
+
+def render_context_packet(
+    workspace_root: str | Path,
+    *,
+    repo_root: str | Path | None = None,
+    mapping_path: str | None = None,
+    profile: str | None = None,
+    min_conf: float = 0.7,
+    max_items: int = 20,
+    include_doc_claims: bool = False,
+) -> str:
+    """Render the markdown context packet (see module docstring for the contract).
+
+    ``max_items`` caps each section independently (top-N by confidence) so an
+    ADR-heavy repo cannot crowd opted-in live-state facts out of the packet.
+    """
+    ws = Path(workspace_root)
+    repo = Path(repo_root) if repo_root is not None else ws
+    spec = _mapping.load_mapping(mapping_path)
+    rules_by_id = {r["mapping_id"]: r for r in spec["rules"]}
+
+    rows, excluded = _verify_and_collect(ws, repo, rules_by_id, min_conf, include_doc_claims)
+    sections: list[tuple[str, list[_Row]]] = []
+    shown = 0
+    for type_, header in _SECTION_ORDER:
+        group = sorted((r for r in rows if r.type == type_), key=lambda r: -r.confidence)[:max_items]
+        if group:
+            sections.append((header, group))
+            shown += len(group)
+    capped = len(rows) - shown
+
+    lines = [
+        f"# Context Packet — ao-kernel governed (fresh + conf>={min_conf})",
+        f"> {shown} item shown · {excluded} excluded (stale/low-conf/unverified)"
+        + (f" · {capped} over per-section cap" if capped else "")
+        + (f" · profile {profile}" if profile else ""),
+        _AUTHORITY_HEADER,
+        "",
+    ]
+    for header, group in sections:
+        lines.append(f"## {header}")
+        for r in group:
+            tag = f"<src: {r.src} | conf {r.confidence:.2f}"
+            if r.status and r.status.lower() not in ("active", "accepted", "kabul"):
+                tag += f" | {r.status}"
+            if r.tier == "doc_claim":
+                tag += " | UNVERIFIED"
+            tag += ">"
+            lines.append(f"- {r.value}  {tag}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/ao_kernel/_internal/context_doc_bridge/renderer.py
+++ b/ao_kernel/_internal/context_doc_bridge/renderer.py
@@ -1,8 +1,9 @@
 """Render a short markdown context packet from doc-bridge-governed store items.
 
-Fail-closed selection (Codex acceptance #3 + #5): an item is only rendered if
-its source file still exists AND re-applying the same mapping rule reproduces
-the same key + ``value_hash``. Stale / drifted / deleted sources, low-confidence
+Fail-closed selection: an item is only rendered if its source still resolves
+under repo-root confinement, its current ``doc_hash`` matches what was ingested
+(no byte drift), AND re-applying the same mapping rule reproduces the same key +
+``value_hash``. Stale / drifted / deleted / symlinked sources, low-confidence
 items, and unverified ``doc_claim`` facts (unless explicitly opted in) are
 excluded. The packet is source-derived context, never release authority.
 """
@@ -15,6 +16,7 @@ from typing import Any
 
 from ao_kernel._internal.context_doc_bridge import ingest as _ingest
 from ao_kernel._internal.context_doc_bridge import mapping as _mapping
+from ao_kernel._internal.context_doc_bridge import parser as _parser
 from ao_kernel.context import canonical_store as cs
 
 _SECTION_ORDER = [
@@ -47,6 +49,7 @@ def _verify_and_collect(
     rules_by_id: dict[str, Any],
     min_conf: float,
     include_doc_claims: bool,
+    max_bytes: int,
 ) -> tuple[list[_Row], int]:
     rows: list[_Row] = []
     excluded = 0
@@ -66,8 +69,16 @@ def _verify_and_collect(
         if rule is None:  # mapping no longer defines this rule
             excluded += 1
             continue
-        src_path = repo / prov.get("src", "")
-        if not src_path.is_file():  # source deleted
+        # Re-verify the source under the SAME confinement as ingest: deleted,
+        # symlinked, escaped, or oversize -> exclude (Codex post-impl #2).
+        src_path = _mapping.resolve_within_repo(repo, prov.get("src", ""), max_bytes=max_bytes)
+        if src_path is None:
+            excluded += 1
+            continue
+        # File-integrity: ANY byte drift in the source -> exclude until re-ingest
+        # (Codex post-impl #1 — heading may be stable while body/authority text
+        # changed; doc_hash equality is the strong guard).
+        if _parser.sha256_file(src_path) != prov.get("doc_hash"):
             excluded += 1
             continue
         try:
@@ -113,8 +124,9 @@ def render_context_packet(
     repo = Path(repo_root) if repo_root is not None else ws
     spec = _mapping.load_mapping(mapping_path)
     rules_by_id = {r["mapping_id"]: r for r in spec["rules"]}
+    max_bytes = int(spec.get("max_file_bytes", _mapping.DEFAULT_MAX_BYTES))
 
-    rows, excluded = _verify_and_collect(ws, repo, rules_by_id, min_conf, include_doc_claims)
+    rows, excluded = _verify_and_collect(ws, repo, rules_by_id, min_conf, include_doc_claims, max_bytes)
     sections: list[tuple[str, list[_Row]]] = []
     shown = 0
     for type_, header in _SECTION_ORDER:

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -616,6 +616,73 @@ def _parse_repo_export_targets(raw: str | None) -> list[str]:
     return targets
 
 
+def _cmd_context_ingest(args: argparse.Namespace) -> int:
+    import json as _json
+    from pathlib import Path as _Path
+
+    from ao_kernel.context.doc_bridge import ingest_docs
+
+    root = _Path(args.root or ".").resolve()
+    if not root.is_dir():
+        print(f"workspace root not found: {root}", file=sys.stderr)
+        return 1
+    repo_root = _Path(args.repo).resolve() if args.repo else None
+    try:
+        report = ingest_docs(root, repo_root=repo_root, mapping_path=args.mapping)
+    except Exception as exc:  # noqa: BLE001 — surface mapping/IO errors as CLI failure
+        print(f"context ingest failed: {exc}", file=sys.stderr)
+        return 1
+    if args.output == "json":
+        print(
+            _json.dumps(
+                {
+                    "ingested": report.ingested,
+                    "revision": report.revision,
+                    "by_type": report.by_type,
+                    "secrets_skipped": report.secrets_skipped,
+                    "collisions": report.collisions,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            f"ingested={report.ingested} by_type={report.by_type} "
+            f"secrets_skipped={len(report.secrets_skipped)} "
+            f"collisions={len(report.collisions)}"
+        )
+        for collision in report.collisions:
+            print(f"  collision (skipped): {collision}", file=sys.stderr)
+        for secret in report.secrets_skipped:
+            print(f"  secret-like (skipped): {secret}", file=sys.stderr)
+    return 0
+
+
+def _cmd_context_packet(args: argparse.Namespace) -> int:
+    from pathlib import Path as _Path
+
+    from ao_kernel.context.doc_bridge import render_context_packet
+
+    root = _Path(args.root or ".").resolve()
+    repo_root = _Path(args.repo).resolve() if args.repo else None
+    try:
+        packet = render_context_packet(
+            root,
+            repo_root=repo_root,
+            mapping_path=args.mapping,
+            profile=args.profile,
+            min_conf=args.min_conf,
+            max_items=args.max_items,
+            include_doc_claims=args.include_doc_claims,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface mapping/IO errors as CLI failure
+        print(f"context packet failed: {exc}", file=sys.stderr)
+        return 1
+    print(packet)
+    return 0
+
+
 def _cmd_support_widening_evidence_validate(args: argparse.Namespace) -> int:
     """V5 Epic 3 E-3-1: validate a support_widening_evidence.v1 artifact.
 
@@ -1301,6 +1368,28 @@ def _build_parser() -> argparse.ArgumentParser:
     migrate_p.add_argument("--backup", action="store_true", help="Backup files before mutation")
 
     sub.add_parser("doctor", help="Workspace health check")
+
+    # Context doc-bridge (.md sources -> governed store -> markdown packet)
+    ctx_p = sub.add_parser("context", help="Context doc-bridge: ingest .md sources + render packet")
+    ctx_sub = ctx_p.add_subparsers(dest="context_command")
+    ctx_ing = ctx_sub.add_parser("ingest", help="Ingest repo .md sources into the governed store")
+    ctx_ing.add_argument("--root", default=".", help="Workspace root (.ao location); default: cwd")
+    ctx_ing.add_argument("--repo", default=None, help="Repo root to scan (default: --root)")
+    ctx_ing.add_argument("--mapping", default=None, help="Custom mapping JSON path (default: bundled)")
+    ctx_ing.add_argument("--output", choices=["text", "json"], default="text")
+    ctx_pkt = ctx_sub.add_parser("packet", help="Render the markdown context packet")
+    ctx_pkt.add_argument("--root", default=".", help="Workspace root (.ao location); default: cwd")
+    ctx_pkt.add_argument("--repo", default=None, help="Repo root for source re-verify (default: --root)")
+    ctx_pkt.add_argument("--mapping", default=None, help="Custom mapping JSON path (default: bundled)")
+    ctx_pkt.add_argument("--profile", default=None, help="Context profile label (cosmetic)")
+    ctx_pkt.add_argument("--min-conf", type=float, default=0.7, dest="min_conf")
+    ctx_pkt.add_argument("--max-items", type=int, default=20, dest="max_items")
+    ctx_pkt.add_argument(
+        "--include-doc-claims",
+        action="store_true",
+        dest="include_doc_claims",
+        help="Include unverified doc-claim facts (labelled UNVERIFIED)",
+    )
 
     # Evidence subcommands (PR-A5)
     ev_p = sub.add_parser("evidence", help="Evidence timeline + replay + manifest")
@@ -2107,6 +2196,16 @@ def main(argv: list[str] | None = None) -> int:
             "Usage: ao-kernel repo {scan,index,query,export-plan,export} [--project-root PATH] [--output {text,json}]",
             file=sys.stderr,
         )
+        return 1
+
+    # Context doc-bridge subcommand
+    if cmd == "context":
+        ctx_cmd = getattr(args, "context_command", None)
+        if ctx_cmd == "ingest":
+            return _cmd_context_ingest(args)
+        if ctx_cmd == "packet":
+            return _cmd_context_packet(args)
+        print("Usage: ao-kernel context {ingest,packet} [--root PATH] [--repo PATH]", file=sys.stderr)
         return 1
 
     # Executor subcommand (PR-C6)

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -639,7 +639,9 @@ def _cmd_context_ingest(args: argparse.Namespace) -> int:
                     "ingested": report.ingested,
                     "revision": report.revision,
                     "by_type": report.by_type,
-                    "secrets_skipped": report.secrets_skipped,
+                    # Count only — never emit secret-detector-derived source refs
+                    # (py/clear-text-logging-sensitive-data; defense in depth).
+                    "secrets_skipped_count": len(report.secrets_skipped),
                     "collisions": report.collisions,
                 },
                 indent=2,
@@ -654,8 +656,10 @@ def _cmd_context_ingest(args: argparse.Namespace) -> int:
         )
         for collision in report.collisions:
             print(f"  collision (skipped): {collision}", file=sys.stderr)
-        for secret in report.secrets_skipped:
-            print(f"  secret-like (skipped): {secret}", file=sys.stderr)
+        if report.secrets_skipped:
+            # Count only — never echo secret-detector-derived source refs
+            # (py/clear-text-logging-sensitive-data; defense in depth).
+            print(f"  {len(report.secrets_skipped)} secret-like value(s) skipped", file=sys.stderr)
     return 0
 
 

--- a/ao_kernel/config.py
+++ b/ao_kernel/config.py
@@ -24,6 +24,7 @@ _VALID_RESOURCE_TYPES = frozenset(
         "extensions",
         "operations",
         "catalogs",
+        "context_bridge",
     }
 )
 # "catalogs" added in FAZ-B PR-B0 (CNS-028v2 iter-5 W2/W4 absorb):

--- a/ao_kernel/context/canonical_store.py
+++ b/ao_kernel/context/canonical_store.py
@@ -58,11 +58,11 @@ class CanonicalDecision:
     category: str = "general"  # architecture | runtime | user_pref | approved_plan | fact
     source: str = "agent"
     confidence: float = 0.8
-    promoted_from: str = ""    # session_id where decision originated
+    promoted_from: str = ""  # session_id where decision originated
     promoted_at: str = ""
-    fresh_until: str = ""      # considered current until
-    review_after: str = ""     # should be reconsidered
-    expires_at: str = ""       # hard expiration
+    fresh_until: str = ""  # considered current until
+    review_after: str = ""  # should be reconsidered
+    expires_at: str = ""  # hard expiration
     supersedes: str | None = None  # previous decision key
     provenance: dict[str, Any] = field(default_factory=dict)  # evidence linkage
     schema_version: str = "v1"
@@ -122,15 +122,11 @@ def load_store(workspace_root: Path) -> dict[str, Any]:
     try:
         raw = path.read_text(encoding="utf-8")
     except OSError as exc:
-        raise CanonicalStoreCorruptedError(
-            f"Cannot read canonical store at {path}: {exc}"
-        ) from exc
+        raise CanonicalStoreCorruptedError(f"Cannot read canonical store at {path}: {exc}") from exc
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError as exc:
-        raise CanonicalStoreCorruptedError(
-            f"Canonical store JSON at {path} is invalid: {exc}"
-        ) from exc
+        raise CanonicalStoreCorruptedError(f"Canonical store JSON at {path} is invalid: {exc}") from exc
     if not isinstance(parsed, dict):
         raise CanonicalStoreCorruptedError(
             f"Canonical store at {path} must be a JSON object, got {type(parsed).__name__}"
@@ -201,9 +197,9 @@ def save_store_cas(
     # raising here instead of falling back avoids a silent downgrade.
     if not lock_supported():
         from ao_kernel._internal.shared.lock import LockPlatformNotSupported
+
         raise LockPlatformNotSupported(
-            "save_store_cas requires POSIX fcntl locking; Windows support "
-            "is tracked in Tranche D (v3.1.0)."
+            "save_store_cas requires POSIX fcntl locking; Windows support is tracked in Tranche D (v3.1.0)."
         )
 
     with file_lock(lockfile):
@@ -212,8 +208,7 @@ def save_store_cas(
         if not allow_overwrite and expected_revision is not None:
             if current_rev != expected_revision:
                 raise CanonicalRevisionConflict(
-                    f"Revision mismatch: expected {expected_revision}, "
-                    f"store is at {current_rev}"
+                    f"Revision mismatch: expected {expected_revision}, store is at {current_rev}"
                 )
         store["updated_at"] = _now_iso()
         write_json_atomic(path, store)
@@ -233,13 +228,9 @@ def _load_store_locked(workspace_root: Path) -> dict[str, Any]:
     try:
         parsed = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        raise CanonicalStoreCorruptedError(
-            f"Canonical store JSON at {path} is invalid: {exc}"
-        ) from exc
+        raise CanonicalStoreCorruptedError(f"Canonical store JSON at {path} is invalid: {exc}") from exc
     if not isinstance(parsed, dict):
-        raise CanonicalStoreCorruptedError(
-            f"Canonical store at {path} must be a JSON object"
-        )
+        raise CanonicalStoreCorruptedError(f"Canonical store at {path} must be a JSON object")
     return parsed
 
 
@@ -260,9 +251,9 @@ def _mutate_with_cas(
 
     if not lock_supported():
         from ao_kernel._internal.shared.lock import LockPlatformNotSupported
+
         raise LockPlatformNotSupported(
-            "canonical mutators require POSIX fcntl locking; "
-            "Windows support is tracked in Tranche D (v3.1.0)."
+            "canonical mutators require POSIX fcntl locking; Windows support is tracked in Tranche D (v3.1.0)."
         )
 
     with file_lock(lockfile):
@@ -271,8 +262,7 @@ def _mutate_with_cas(
         if not allow_overwrite and expected_revision is not None:
             if current_rev != expected_revision:
                 raise CanonicalRevisionConflict(
-                    f"Revision mismatch: expected {expected_revision}, "
-                    f"store is at {current_rev}"
+                    f"Revision mismatch: expected {expected_revision}, store is at {current_rev}"
                 )
         mutator(current)
         current["updated_at"] = _now_iso()
@@ -346,6 +336,7 @@ def promote_decision(
 
     try:
         from ao_kernel.telemetry import record_canonical_promote
+
         record_canonical_promote(category=category)
     except Exception:
         pass
@@ -353,6 +344,7 @@ def promote_decision(
     if vector_store is not None:
         try:
             from ao_kernel.context.semantic_indexer import index_decision
+
             index_decision(
                 key=key,
                 value=value,
@@ -444,6 +436,67 @@ def promote_from_ephemeral(
     return promoted
 
 
+def promote_many(
+    workspace_root: Path,
+    items: list[dict[str, Any]],
+    *,
+    expected_revision: str | None = None,
+    allow_overwrite: bool = True,
+    fresh_days: int = 30,
+    review_days: int = 90,
+    expire_days: int = 365,
+) -> str:
+    """Promote multiple decisions/facts atomically under a SINGLE CAS revision.
+
+    All-or-nothing: every item lands in one write or the call raises and the
+    store is unchanged (no partial state). This is the batch path callers like
+    the context doc-bridge use to avoid per-item revision churn / partial
+    ingest (CNS doc-bridge plan, Codex acceptance #1).
+
+    Each ``items`` entry is a dict with keys:
+        key (required), value, category, source, confidence, session_id,
+        supersedes, provenance.
+
+    Returns the post-write revision token.
+
+    Raises:
+        CanonicalRevisionConflict: ``expected_revision`` no longer matches and
+            ``allow_overwrite`` is False.
+        KeyError: an item is missing the required ``key``.
+    """
+    now = _now_iso()
+    fresh = _future_iso(fresh_days)
+    review = _future_iso(review_days)
+    expire = _future_iso(expire_days)
+
+    def _apply(store: dict[str, Any]) -> None:
+        for item in items:
+            category = item.get("category", "general")
+            decision = CanonicalDecision(
+                key=item["key"],
+                value=item.get("value"),
+                category=category,
+                source=item.get("source", "agent"),
+                confidence=item.get("confidence", 0.8),
+                promoted_from=item.get("session_id", ""),
+                promoted_at=now,
+                fresh_until=fresh,
+                review_after=review,
+                expires_at=expire,
+                supersedes=item.get("supersedes"),
+                provenance=item.get("provenance") or {},
+            )
+            target = "facts" if category == "fact" else "decisions"
+            store.setdefault(target, {})[item["key"]] = asdict(decision)
+
+    return _mutate_with_cas(
+        workspace_root,
+        _apply,
+        expected_revision=expected_revision,
+        allow_overwrite=allow_overwrite,
+    )
+
+
 __all__ = [
     "CanonicalDecision",
     "load_store",
@@ -452,5 +505,6 @@ __all__ = [
     "store_revision",
     "promote_decision",
     "promote_from_ephemeral",
+    "promote_many",
     "query",
 ]

--- a/ao_kernel/context/doc_bridge.py
+++ b/ao_kernel/context/doc_bridge.py
@@ -1,0 +1,28 @@
+"""Public context doc-bridge facade.
+
+Bridges a repo's ``.md``-governed context (AGENTS.md, ADRs, current-state, ...)
+into the ao-kernel governed store, and renders a short, provenance-tagged
+markdown context packet for injection into any AI (Claude / Codex / Mavis).
+
+Design: governed JSON store (query / freshness / provenance / tier) + a rendered
+markdown packet (fresh + high-confidence only, NOT a full dump). The store stays
+the single source of truth; the packet is derived and fail-closed.
+
+    from ao_kernel.context.doc_bridge import ingest_docs, render_context_packet
+
+    report = ingest_docs("/path/to/repo")            # root = repo = workspace
+    packet = render_context_packet("/path/to/repo")  # short markdown packet
+
+Both take the workspace root first; pass ``repo_root=`` to scan a different
+tree (e.g. ingest an external repo read-only into a separate workspace).
+
+The implementation lives in ``ao_kernel._internal.context_doc_bridge`` and may
+change across versions; this facade is the stable surface.
+"""
+
+from __future__ import annotations
+
+from ao_kernel._internal.context_doc_bridge.ingest import IngestReport, ingest_docs
+from ao_kernel._internal.context_doc_bridge.renderer import render_context_packet
+
+__all__ = ["ingest_docs", "render_context_packet", "IngestReport"]

--- a/ao_kernel/defaults/context_bridge/doc_mapping.default.v1.json
+++ b/ao_kernel/defaults/context_bridge/doc_mapping.default.v1.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "context-doc-bridge-mapping.v1",
+  "max_files_per_rule": 500,
+  "max_file_bytes": 1048576,
+  "rules": [
+    {
+      "mapping_id": "default.agents",
+      "glob": "AGENTS.md",
+      "type": "rule",
+      "tier": "repo_canonical",
+      "key_template": "rule.agents-md",
+      "value_strategy": "first_heading",
+      "confidence": 0.95,
+      "collision_policy": "update_same_source"
+    },
+    {
+      "mapping_id": "default.context-priority",
+      "glob": "docs/context-priority-rules.md",
+      "type": "rule",
+      "tier": "repo_canonical",
+      "key_template": "rule.context-priority",
+      "value_strategy": "first_heading",
+      "confidence": 0.95,
+      "collision_policy": "update_same_source"
+    },
+    {
+      "mapping_id": "default.adr",
+      "glob": "docs/adr/[0-9]*.md",
+      "type": "decision",
+      "tier": "canonical_doc",
+      "key_template": "decision.adr.{stem}",
+      "value_strategy": "status_line",
+      "status_map": {
+        "accepted": 0.9, "kabul": 0.9, "approved": 0.9,
+        "proposed": 0.6, "draft": 0.55,
+        "rejected": 0.45, "reddedildi": 0.45,
+        "superseded": 0.3, "deprecated": 0.3,
+        "unknown": 0.7
+      },
+      "collision_policy": "strict"
+    },
+    {
+      "mapping_id": "default.current-state",
+      "glob": "docs/state/current-state.md",
+      "type": "fact",
+      "tier": "doc_claim",
+      "key_template": "fact.current-state.{index}",
+      "value_strategy": "section_headings",
+      "confidence": 0.55,
+      "max_items": 8,
+      "collision_policy": "update_same_source"
+    }
+  ]
+}

--- a/ao_kernel/defaults/schemas/context-doc-bridge-mapping.schema.v1.json
+++ b/ao_kernel/defaults/schemas/context-doc-bridge-mapping.schema.v1.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ao-kernel/schemas/context-doc-bridge-mapping.v1.json",
+  "title": "Context doc-bridge mapping (v1)",
+  "description": "Declarative, bounded mapping from repo .md sources to governed context entries. Repo-root confined, deterministic, no DSL.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "rules"],
+  "properties": {
+    "schema_version": {"const": "context-doc-bridge-mapping.v1"},
+    "max_files_per_rule": {"type": "integer", "minimum": 1, "maximum": 2000, "default": 500},
+    "max_file_bytes": {"type": "integer", "minimum": 1, "maximum": 10485760, "default": 1048576},
+    "rules": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 100,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["mapping_id", "glob", "type", "tier", "key_template", "value_strategy"],
+        "properties": {
+          "mapping_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{0,63}$"},
+          "glob": {"type": "string", "minLength": 1, "maxLength": 256},
+          "type": {"enum": ["rule", "decision", "fact"]},
+          "tier": {"enum": ["repo_canonical", "canonical_doc", "doc_claim"]},
+          "key_template": {"type": "string", "minLength": 1, "maxLength": 128},
+          "value_strategy": {"enum": ["first_heading", "status_line", "section_headings"]},
+          "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+          "status_map": {
+            "type": "object",
+            "additionalProperties": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+            "minProperties": 1
+          },
+          "collision_policy": {"enum": ["strict", "supersede", "update_same_source"], "default": "strict"},
+          "max_items": {"type": "integer", "minimum": 1, "maximum": 500}
+        }
+      }
+    }
+  }
+}

--- a/docs/CONTEXT-BRIDGE.md
+++ b/docs/CONTEXT-BRIDGE.md
@@ -1,0 +1,107 @@
+# Context Doc-Bridge
+
+`.md`-tabanlı bağlam yöneten bir repo'nun (AGENTS.md, ADR'lar, `current-state`,
+karar kayıtları) içeriğini **governed canonical store**'a alır ve oradan kısa,
+provenance'lı bir **markdown context packet** üretir. Packet herhangi bir AI'a
+(Claude / Codex / Mavis) enjekte edilebilir.
+
+> Tasarım = cross-AI plan-time mutabakatı (Codex AGREE): **governed JSON store**
+> (query / freshness / provenance / tier) + ondan türetilen **kısa markdown
+> packet** (yalnız fresh + high-confidence; tam dump DEĞİL). Store tek doğruluk
+> kaynağıdır; packet türetilmiştir ve fail-closed'dur.
+
+## Neden
+
+Multi-AI bir ekipte her AI kendi bağlam dosyasını okur (Claude → CLAUDE.md,
+Codex/OpenCode → AGENTS.md). Aynı "truth" birden çok dosyaya dağılınca **drift**
+oluşur. Doc-bridge structured truth'u (ADR / current-state / kararlar) tek
+governed store'da toplar; her AI **aynı** packet'i okur → drift biter, freshness
++ provenance + tier governed olur.
+
+## Kullanım
+
+### SDK
+
+```python
+from ao_kernel.context.doc_bridge import ingest_docs, render_context_packet
+
+report = ingest_docs("/path/to/repo")          # root = repo = workspace
+print(report.ingested, report.by_type)
+
+packet = render_context_packet("/path/to/repo")  # kısa markdown packet
+```
+
+İki fonksiyon da ilk argüman olarak **workspace root**'u (`.ao` konumu) alır.
+Farklı bir ağacı taramak için (örn. bir repo'yu read-only ayrı workspace'e almak)
+`repo_root=` geçin:
+
+```python
+ingest_docs("/tmp/ws", repo_root="/path/to/repo")          # repo read-only kalır
+render_context_packet("/tmp/ws", repo_root="/path/to/repo")
+```
+
+### CLI
+
+```bash
+ao-kernel context ingest                       # cwd'yi tara, .ao store'a yaz
+ao-kernel context ingest --repo /path --output json
+ao-kernel context packet                       # default packet (conf>=0.7)
+ao-kernel context packet --include-doc-claims --min-conf 0.5
+ao-kernel context packet --mapping custom-mapping.json
+```
+
+## Mapping
+
+Çıkarım declarative, schema-validated bir mapping ile sürülür. Bundled default
+(`ao_kernel/defaults/context_bridge/doc_mapping.default.v1.json`) yaygın
+conventions'ı kapsar ve tamamen override edilebilir. Şema:
+`ao_kernel/defaults/schemas/context-doc-bridge-mapping.schema.v1.json`.
+
+Her kural:
+
+| Alan | Açıklama |
+|---|---|
+| `mapping_id` | Kuralın stabil kimliği (provenance + re-verify için) |
+| `glob` | Repo-root'a göre desen (mutlak / `..` / symlink reddedilir) |
+| `type` | `rule` \| `decision` \| `fact` (packet bölümlemesi) |
+| `tier` | `repo_canonical` \| `canonical_doc` \| `doc_claim` |
+| `key_template` | `{stem}` / `{num}` / `{index}` ile deterministic key |
+| `value_strategy` | `first_heading` \| `status_line` \| `section_headings` |
+| `confidence` / `status_map` | Sabit confidence veya status→confidence eşlemesi |
+| `collision_policy` | `strict` \| `supersede` \| `update_same_source` |
+
+## Fail-closed garantiler
+
+- **Stale / drift / silinmiş kaynak**: packet render anında kaynak dosya
+  re-hash edilir ve mapping kuralı tekrar uygulanır. Dosya silinmişse veya aynı
+  key + `value_hash` üretilemiyorsa item packet'e **GİRMEZ**.
+- **Secret koruması**: secret-benzeri token içeren değer ingest **edilmez**
+  (redakte edilip saklanmaz); diagnostic'te raporlanır.
+- **`doc_claim` opt-in**: doküman-iddiası (`current-state` "done/green" gibi)
+  release truth değildir; default packet'e girmez. `--include-doc-claims` ile
+  `UNVERIFIED` etiketiyle görünür.
+- **Authority sınırı**: packet header'ı net belirtir — bu **source-derived
+  context'tir, release authority DEĞİLDİR**; `support_widening`,
+  `production_platform_claim`, `live_adapter_execution` guard flag'lerini
+  **override edemez**.
+- **Atomic**: tüm batch tek CAS revision altında yazılır (partial-write yok).
+
+## Multi-AI wiring
+
+`.md` giriş dosyaları (AGENTS.md / CLAUDE.md) **kalır** — onlar session-bootstrap
+sözleşmeleridir. Doc-bridge altta paylaşılan governed truth katmanını besler:
+
+```
+AGENTS.md + context-priority + current-state + ADR + decisions
+        │  ao-kernel context ingest (read-only)
+        ▼
+   governed store (.ao/)  ── tek SSOT (provenance + freshness + tier)
+        │  ao-kernel context packet
+   Claude · Codex · Mavis   (üçü de AYNI fresh+high-confidence packet'i okur)
+```
+
+## Sınırlar (v1)
+
+- Kaynak repo **read-only** okunur; bridge repoya yazmaz (`.ao` workspace hariç).
+- `compile_context` (LLM-call pipeline), MCP yüzeyi ve 3 guard flag **değişmez**.
+- MCP `ao_memory_read`'in packet döndürmesi v1 kapsamı dışındadır (gelecek).

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "V5-RELEASE-4.2.1",
+  "work_package": "CONTEXT-DOC-BRIDGE",
   "implementer": {
     "agent": "claude-opus-4-8",
     "provider": "anthropic"
@@ -13,42 +13,79 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/chore/release-v4.2.1-c-2026-06-07",
+    "head_ref": "refs/heads/feat/context-bridge-claude-2026-06-08",
     "changed_files": [
       "CHANGELOG.md",
-      "ao_kernel/__init__.py",
-      "deploy/helm/ao-kernel/Chart.yaml",
-      "deploy/helm/ao-kernel/values.yaml",
-      "docs/PRODUCTION-DEPLOYMENT-GUIDE.md",
-      "docs/USING-AO-KERNEL-IN-YOUR-PROJECT.md",
-      "docs/operator-runbooks/01-pypi-publish.md",
-      "docs/operator-runbooks/README.md",
-      "docs/operator-runbooks/operator-action-checklist.v1.json",
+      "ao_kernel/_internal/context_doc_bridge/__init__.py",
+      "ao_kernel/_internal/context_doc_bridge/ingest.py",
+      "ao_kernel/_internal/context_doc_bridge/keygen.py",
+      "ao_kernel/_internal/context_doc_bridge/mapping.py",
+      "ao_kernel/_internal/context_doc_bridge/parser.py",
+      "ao_kernel/_internal/context_doc_bridge/renderer.py",
+      "ao_kernel/cli.py",
+      "ao_kernel/config.py",
+      "ao_kernel/context/canonical_store.py",
+      "ao_kernel/context/doc_bridge.py",
+      "ao_kernel/defaults/context_bridge/doc_mapping.default.v1.json",
+      "ao_kernel/defaults/schemas/context-doc-bridge-mapping.schema.v1.json",
+      "docs/CONTEXT-BRIDGE.md",
       "local-ai-review-evidence.v1.json",
-      "pyproject.toml",
-      "tests/test_pr_a6_features.py",
-      "tests/test_v421_version_pin.py"
+      "tests/test_context_doc_bridge.py"
     ]
   },
   "checks_considered": [
-    {"name": "secret_scan", "status": "pass"},
-    {"name": "tests", "status": "pass"},
-    {"name": "ruff", "status": "pass"},
-    {"name": "version_single_source_of_truth", "status": "pass"},
-    {"name": "release_facing_install_surfaces_match_version", "status": "pass"},
-    {"name": "changelog_cut_and_history_preserved", "status": "pass"},
-    {"name": "guard_flags_false", "status": "pass"},
-    {"name": "release_semantic_discipline_version_only", "status": "pass"},
-    {"name": "no_workflow_ruleset_branch_protection_change", "status": "pass"}
+    {
+      "name": "tests",
+      "status": "pass"
+    },
+    {
+      "name": "ruff",
+      "status": "pass"
+    },
+    {
+      "name": "mypy",
+      "status": "pass"
+    },
+    {
+      "name": "secret_scan",
+      "status": "pass"
+    },
+    {
+      "name": "guard_flags_false",
+      "status": "pass"
+    },
+    {
+      "name": "no_support_widening",
+      "status": "pass"
+    },
+    {
+      "name": "no_promotion",
+      "status": "pass"
+    },
+    {
+      "name": "no_live_adapter_execution",
+      "status": "pass"
+    },
+    {
+      "name": "no_workflow_ruleset_branch_protection_change",
+      "status": "pass"
+    },
+    {
+      "name": "compile_context_signature_unchanged",
+      "status": "pass"
+    },
+    {
+      "name": "mcp_surface_unchanged",
+      "status": "pass"
+    }
   ],
   "findings": [
-    "v4.2.1 patch release. Bumps the single source-of-truth version (pyproject.toml + ao_kernel.__version__) 4.2.0 -> 4.2.1 and cuts CHANGELOG [Unreleased] into a new [4.2.1] - 2026-06-07 entry (the post-4.2.0 work: cross-repo dogfood evidence doc + 5 dead-extension retirements + complete PRJ-UI-COCKPIT-LITE web UI removal). [4.2.0] and [4.1.0] history preserved; section order Unreleased > 4.2.1 > 4.2.0.",
-    "Release-facing install surfaces tracked to 4.2.1 (enforced by test_release_facing_install_surfaces_match_version): consumer onboarding exact pin (USING-AO-KERNEL-IN-YOUR-PROJECT.md), Helm default image tag (values.yaml), and operator publish-dispatch ref + expected artifact (operator-action-checklist.v1.json). Also bumped: Helm Chart appVersion 4.2.0 -> 4.2.1 + chart version 0.1.0 -> 0.1.1, operator runbook 01-pypi-publish.md + README, PRODUCTION-DEPLOYMENT-GUIDE.md, and the test_pr_a6 version-bump assertions.",
-    "Version-pin test renamed test_v420_version_pin.py -> test_v421_version_pin.py with 4.2.1 assertions + updated changelog section-order/history checks.",
-    "Historical version-specific artifacts intentionally left at 4.2.0: docs/EVIDENCE-V4.2.0-CROSS-REPO-DOGFOOD.md (the 4.2.0 dogfood evidence) + its test, the CHANGELOG [4.2.0] entry, .ao consultations, plan docs, and the COMPETITOR-MATRIX 'FAZ-E ship (v4.2.0)' roadmap label.",
-    "Release semantic discipline honored: pyproject change is limited to project.version (no scripts/build-system/tool config churn). The three guard flags remain const false (gpp_status keep_narrow_stable_runtime); no support widening, no production-platform claim, no live adapter execution.",
-    "Verification: full pytest 6988 passed / 125 skipped / 0 failed; ruff clean. The release PR carries the chore-no-changelog label because the cut leaves [Unreleased] empty (ADR-0005).",
-    "No secrets, credentials, or sensitive material were found in the reviewed diff. No .github workflow/ruleset/branch-protection/app changes."
+    "Codex (OpenAI) two-gate cross-AI review on thread 019ea7e3. Plan-time: REVISE -> v2 absorbed (thin public facade + _internal impl; authoritative provenance inside canonical item provenance.doc_bridge with NO side-map; bounded schema-validated mapping; packet separate from compile_context) -> AGREE. Post-impl: REVISE -> 3 findings closed (1) render now requires doc_hash equality, (2) render re-resolves provenance src under the same repo-root confinement as ingest via shared resolve_within_repo, (3) key collision checked against the LIVE store inside the CAS loop, not just the batch -> AGREE.",
+    "Feature: ao_kernel.context.doc_bridge ingests a repo's .md-governed context (AGENTS.md, ADRs, current-state, decision records) into the governed canonical store and renders a short, provenance-tagged markdown context packet for any AI. Surfaces: ingest_docs()/render_context_packet() + CLI 'ao-kernel context {ingest,packet}'. New canonical_store.promote_many() writes the batch under a single CAS revision.",
+    "Fail-closed packet selection: a source that is deleted, drifted (doc_hash mismatch OR mapping no longer reproduces key+value_hash), symlinked, escaped or oversize is excluded; secret-like values are skipped (never redacted-and-stored); unverified doc_claim facts are opt-in and labelled UNVERIFIED; the packet header states it is source-derived context that cannot override the guard flags.",
+    "Boundary: the three guard flags stay const false; compile_context (LLM-call pipeline) and the MCP surface are untouched (machine-checked by tests); no support widening, no production-platform claim, no live adapter execution. No change to .github workflows, rulesets, branch protection, or apps.",
+    "Verification: full pytest 6976 passed / 127 skipped / 0 failed; ruff clean; mypy clean on the new modules + facade. 25 dedicated behavioral tests including the three post-impl regressions (body-only drift, post-ingest symlink, cross-ingest collision).",
+    "No secrets, credentials, or sensitive material were found in the reviewed diff (synthetic secret-detection test tokens are assembled at runtime and never appear contiguously in source)."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/tests/test_context_doc_bridge.py
+++ b/tests/test_context_doc_bridge.py
@@ -240,3 +240,63 @@ def test_parser_secret_detection() -> None:
     assert _parser.looks_like_secret("api_key = abcdef123456")
     assert _parser.looks_like_secret(_FAKE_GHP)
     assert not _parser.looks_like_secret("a normal architecture decision heading")
+
+
+def test_body_drift_same_heading_excluded(repo: Path) -> None:
+    # Codex post-impl #1: heading (value_hash) stable but body changed ->
+    # doc_hash differs -> item must be excluded by the file-integrity guard.
+    ingest_docs(repo)
+    _write(repo / "AGENTS.md", "# AGENTS - testrepo\n\nCOMPLETELY DIFFERENT BODY TEXT.\n")
+    packet = render_context_packet(repo)
+    assert "AGENTS - testrepo" not in packet
+
+
+def test_source_replaced_by_symlink_excluded(repo: Path) -> None:
+    # Codex post-impl #2: a source that becomes a symlink after ingest is
+    # rejected at render under the same confinement as ingest.
+    ingest_docs(repo)
+    target = repo.parent / "evil_agents.md"
+    target.write_text("# AGENTS - testrepo\n", encoding="utf-8")
+    (repo / "AGENTS.md").unlink()
+    (repo / "AGENTS.md").symlink_to(target)
+    packet = render_context_packet(repo)
+    assert "AGENTS - testrepo" not in packet
+
+
+def test_cross_ingest_collision_does_not_overwrite(tmp_path: Path) -> None:
+    # Codex post-impl #3: a different source claiming an existing key (strict)
+    # is a collision against the live store, not a silent overwrite.
+    (tmp_path / ".ao").mkdir()
+    mp = tmp_path / "m.json"
+    mp.write_text(
+        json.dumps(
+            {
+                "schema_version": "context-doc-bridge-mapping.v1",
+                "rules": [
+                    {
+                        "mapping_id": "x",
+                        "glob": "*/*.md",
+                        "type": "rule",
+                        "tier": "repo_canonical",
+                        "key_template": "rule.fixed",
+                        "value_strategy": "first_heading",
+                        "confidence": 0.9,
+                        "collision_policy": "strict",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write(tmp_path / "a/one.md", "# One\n")
+    first = ingest_docs(tmp_path, mapping_path=str(mp))
+    assert first.ingested == 1
+
+    (tmp_path / "a/one.md").unlink()
+    _write(tmp_path / "b/two.md", "# Two\n")
+    second = ingest_docs(tmp_path, mapping_path=str(mp))
+    assert second.ingested == 0
+    assert len(second.collisions) == 1
+
+    stored = {i["key"]: i for i in cs.query(tmp_path, include_expired=True)}
+    assert stored["rule.fixed"]["value"] == "One"

--- a/tests/test_context_doc_bridge.py
+++ b/tests/test_context_doc_bridge.py
@@ -263,6 +263,174 @@ def test_source_replaced_by_symlink_excluded(repo: Path) -> None:
     assert "AGENTS - testrepo" not in packet
 
 
+def _run_cli(argv: list[str]) -> int:
+    from ao_kernel.cli import main
+
+    return main(argv)
+
+
+def test_cli_ingest_then_packet(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert _run_cli(["context", "ingest", "--root", str(repo)]) == 0
+    assert "ingested=" in capsys.readouterr().out
+    assert _run_cli(["context", "packet", "--root", str(repo)]) == 0
+    out = capsys.readouterr().out
+    assert "Context Packet" in out
+    assert "AUTHORITY" in out
+
+
+def test_cli_ingest_json_output(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert _run_cli(["context", "ingest", "--root", str(repo), "--output", "json"]) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["ingested"] == 6
+    assert data["by_type"] == {"rule": 2, "decision": 2, "fact": 2}
+
+
+def test_cli_ingest_bad_root_returns_1(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert _run_cli(["context", "ingest", "--root", str(tmp_path / "missing")]) == 1
+    assert "not found" in capsys.readouterr().err
+
+
+def test_cli_context_no_subcommand_usage(capsys: pytest.CaptureFixture[str]) -> None:
+    assert _run_cli(["context"]) == 1
+    assert "Usage" in capsys.readouterr().err
+
+
+def test_cli_packet_include_doc_claims(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _run_cli(["context", "ingest", "--root", str(repo)])
+    capsys.readouterr()
+    rc = _run_cli(["context", "packet", "--root", str(repo), "--include-doc-claims", "--min-conf", "0.5"])
+    assert rc == 0
+    assert "UNVERIFIED" in capsys.readouterr().out
+
+
+def test_cli_ingest_reports_collisions_and_secrets(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (tmp_path / ".ao").mkdir()
+    _write(tmp_path / "a/one.md", "# One\n")
+    _write(tmp_path / "b/two.md", "# Two\n")
+    _write(tmp_path / "AGENTS.md", f"# token {_FAKE_SK}\n")
+    mp = tmp_path / "m.json"
+    mp.write_text(
+        json.dumps(
+            {
+                "schema_version": "context-doc-bridge-mapping.v1",
+                "rules": [
+                    {
+                        "mapping_id": "agents",
+                        "glob": "AGENTS.md",
+                        "type": "rule",
+                        "tier": "repo_canonical",
+                        "key_template": "rule.agents-md",
+                        "value_strategy": "first_heading",
+                        "confidence": 0.95,
+                    },
+                    {
+                        "mapping_id": "fixed",
+                        "glob": "*/*.md",
+                        "type": "rule",
+                        "tier": "repo_canonical",
+                        "key_template": "rule.fixed",
+                        "value_strategy": "first_heading",
+                        "confidence": 0.9,
+                        "collision_policy": "strict",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = _run_cli(["context", "ingest", "--root", str(tmp_path), "--mapping", str(mp)])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "collision" in err
+    assert "secret-like" in err
+
+
+def test_cli_packet_failure_returns_1(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json", encoding="utf-8")
+    rc = _run_cli(["context", "packet", "--root", str(tmp_path), "--mapping", str(bad)])
+    assert rc == 1
+    assert "failed" in capsys.readouterr().err
+
+
+def test_supersede_policy_overrides(tmp_path: Path) -> None:
+    (tmp_path / ".ao").mkdir()
+    _write(tmp_path / "a/one.md", "# One\n")
+    _write(tmp_path / "b/two.md", "# Two\n")
+    mp = tmp_path / "m.json"
+    mp.write_text(
+        json.dumps(
+            {
+                "schema_version": "context-doc-bridge-mapping.v1",
+                "rules": [
+                    {
+                        "mapping_id": "x",
+                        "glob": "*/*.md",
+                        "type": "rule",
+                        "tier": "repo_canonical",
+                        "key_template": "rule.fixed",
+                        "value_strategy": "first_heading",
+                        "confidence": 0.9,
+                        "collision_policy": "supersede",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    report = ingest_docs(tmp_path, mapping_path=str(mp))
+    # supersede: both sources are accepted (no collision skip); the later source
+    # (b/two.md) wins the shared key and records supersedes.
+    assert report.ingested == 2
+    assert report.collisions == []
+    stored = {i["key"]: i for i in cs.query(tmp_path, include_expired=True)}
+    assert stored["rule.fixed"]["value"] == "Two"
+    assert stored["rule.fixed"]["supersedes"] == "rule.fixed"
+
+
+def test_ingest_no_matching_sources(tmp_path: Path) -> None:
+    (tmp_path / ".ao").mkdir()
+    report = ingest_docs(tmp_path)
+    assert report.ingested == 0
+    assert report.by_type == {}
+
+
+def test_keygen_rejects_unknown_placeholder() -> None:
+    from ao_kernel._internal.context_doc_bridge import keygen
+
+    with pytest.raises(ValueError, match="unknown placeholder"):
+        keygen.render_key("rule.{bogus}", stem="x")
+
+
+def test_render_excludes_when_mapping_rule_removed(repo: Path, tmp_path: Path) -> None:
+    # ingest with the default mapping, then render with a mapping that no longer
+    # defines those mapping_ids -> every item's rule is gone -> all excluded.
+    ingest_docs(repo)
+    empty_map = tmp_path / "empty.json"
+    empty_map.write_text(
+        json.dumps(
+            {
+                "schema_version": "context-doc-bridge-mapping.v1",
+                "rules": [
+                    {
+                        "mapping_id": "unrelated",
+                        "glob": "NOPE.md",
+                        "type": "rule",
+                        "tier": "repo_canonical",
+                        "key_template": "rule.nope",
+                        "value_strategy": "first_heading",
+                        "confidence": 0.9,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    packet = render_context_packet(repo, mapping_path=str(empty_map))
+    assert "AGENTS - testrepo" not in packet
+    assert "Use Postgres" not in packet
+
+
 def test_cross_ingest_collision_does_not_overwrite(tmp_path: Path) -> None:
     # Codex post-impl #3: a different source claiming an existing key (strict)
     # is a collision against the live store, not a silent overwrite.
@@ -300,3 +468,115 @@ def test_cross_ingest_collision_does_not_overwrite(tmp_path: Path) -> None:
 
     stored = {i["key"]: i for i in cs.query(tmp_path, include_expired=True)}
     assert stored["rule.fixed"]["value"] == "One"
+
+
+def test_resolve_within_repo_rejections(tmp_path: Path) -> None:
+    (tmp_path / "ok.md").write_text("# ok\n", encoding="utf-8")
+    assert _mapping.resolve_within_repo(tmp_path, "") is None
+    assert _mapping.resolve_within_repo(tmp_path, "../x.md") is None
+    assert _mapping.resolve_within_repo(tmp_path, "/etc/hosts") is None
+    assert _mapping.resolve_within_repo(tmp_path, "~/x.md") is None
+    assert _mapping.resolve_within_repo(tmp_path, "missing.md") is None
+    resolved = _mapping.resolve_within_repo(tmp_path, "ok.md")
+    assert resolved is not None
+    assert resolved.name == "ok.md"
+
+
+def test_resolve_within_repo_oversize(tmp_path: Path) -> None:
+    (tmp_path / "big.md").write_text("# " + ("x" * 100), encoding="utf-8")
+    assert _mapping.resolve_within_repo(tmp_path, "big.md", max_bytes=10) is None
+
+
+def test_resolve_sources_max_files_cap(tmp_path: Path) -> None:
+    for i in range(3):
+        (tmp_path / f"d{i}.md").write_text(f"# {i}\n", encoding="utf-8")
+    assert len(_mapping.resolve_sources(tmp_path, "*.md", max_files=1)) == 1
+
+
+def test_parser_section_headings_limit() -> None:
+    text = "# title\n\n## A\n\n## B\n\n## C\n"
+    assert _parser.section_headings(text, 2) == ["A", "B"]
+
+
+def test_parser_status_durum_and_inline_date() -> None:
+    assert _parser.status_and_date("## Durum\n\n**Kabul** (2026-02-01)")[0] == "Kabul"
+    status, date = _parser.status_and_date("# x\n\nSuperseded by ADR-9 on 2026-02-03\n")
+    assert status == "Superseded"
+    assert date == "2026-02-03"
+
+
+def test_renderer_skips_non_bridge_decisions(tmp_path: Path) -> None:
+    (tmp_path / ".ao").mkdir()
+    cs.promote_decision(tmp_path, key="manual.x", value="hand-recorded value", confidence=0.95)
+    packet = render_context_packet(tmp_path)
+    assert "hand-recorded value" not in packet
+
+
+def test_cli_ingest_failure_returns_1(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (tmp_path / ".ao").mkdir()
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json", encoding="utf-8")
+    rc = _run_cli(["context", "ingest", "--root", str(tmp_path), "--mapping", str(bad)])
+    assert rc == 1
+    assert "failed" in capsys.readouterr().err
+
+
+def test_parser_first_heading_fallback() -> None:
+    assert _parser.first_heading("no heading line here", "fallback-stem") == "fallback-stem"
+
+
+def test_packet_per_section_cap(repo: Path) -> None:
+    ingest_docs(repo)
+    packet = render_context_packet(repo, max_items=1)
+    # 2 rules + 2 decisions exist but each section is capped at 1
+    assert packet.count("- AGENTS - testrepo") + packet.count("- Context Priority") == 1
+    assert "over per-section cap" in packet
+
+
+def test_packet_min_conf_excludes_everything(repo: Path) -> None:
+    ingest_docs(repo)
+    packet = render_context_packet(repo, min_conf=0.99)
+    assert "0 item shown" in packet
+    assert "## Rules" not in packet
+
+
+def test_packet_low_threshold_shows_status_but_still_drops_doc_claims(repo: Path) -> None:
+    # A Proposed ADR (conf 0.6) clears a low min_conf and renders WITH its status
+    # tag; doc_claim facts (conf 0.55) clear the conf bar too but are still
+    # dropped because doc-claims are opt-in.
+    _write(repo / "docs/adr/0003-proposed.md", "# 0003 - Proposed Thing\n\n## Status\n\n**Proposed**\n")
+    ingest_docs(repo)
+    packet = render_context_packet(repo, min_conf=0.5)
+    assert "Proposed Thing" in packet
+    assert "Proposed]" in packet or "| Proposed>" in packet
+    assert "Live Delta" not in packet
+
+
+def test_render_value_strategy_change_excludes(repo: Path, tmp_path: Path) -> None:
+    # Same file + same doc_hash, but render uses a mapping whose rule (same
+    # mapping_id) extracts a DIFFERENT value -> value_hash no longer reproduces
+    # -> excluded even though the bytes are unchanged.
+    ingest_map = tmp_path / "ingest.json"
+    base_rule = {
+        "mapping_id": "agents",
+        "glob": "AGENTS.md",
+        "type": "rule",
+        "tier": "repo_canonical",
+        "key_template": "rule.agents-md",
+        "value_strategy": "first_heading",
+        "confidence": 0.95,
+    }
+    ingest_map.write_text(
+        json.dumps({"schema_version": "context-doc-bridge-mapping.v1", "rules": [base_rule]}),
+        encoding="utf-8",
+    )
+    ingest_docs(repo, mapping_path=str(ingest_map))
+    assert "AGENTS - testrepo" in render_context_packet(repo, mapping_path=str(ingest_map))
+
+    drift_rule = dict(base_rule, value_strategy="section_headings")
+    drift_map = tmp_path / "drift.json"
+    drift_map.write_text(
+        json.dumps({"schema_version": "context-doc-bridge-mapping.v1", "rules": [drift_rule]}),
+        encoding="utf-8",
+    )
+    assert "AGENTS - testrepo" not in render_context_packet(repo, mapping_path=str(drift_map))

--- a/tests/test_context_doc_bridge.py
+++ b/tests/test_context_doc_bridge.py
@@ -343,6 +343,23 @@ def test_cli_ingest_reports_collisions_and_secrets(tmp_path: Path, capsys: pytes
     err = capsys.readouterr().err
     assert "collision" in err
     assert "secret-like" in err
+    # Regression lock (CodeQL py/clear-text-logging): the secret-bearing source
+    # path/key must NEVER be echoed — only a count.
+    assert "AGENTS.md" not in err
+    assert "rule.agents-md" not in err
+
+
+def test_cli_ingest_json_never_leaks_secret_source(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (tmp_path / ".ao").mkdir()
+    _write(tmp_path / "AGENTS.md", f"# token {_FAKE_SK}\n")
+    rc = _run_cli(["context", "ingest", "--root", str(tmp_path), "--output", "json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["secrets_skipped_count"] == 1
+    assert "secrets_skipped" not in data  # the list of source refs is never emitted
+    assert "AGENTS.md" not in out
+    assert "rule.agents-md" not in out
 
 
 def test_cli_packet_failure_returns_1(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_context_doc_bridge.py
+++ b/tests/test_context_doc_bridge.py
@@ -1,0 +1,242 @@
+"""Tests for the context doc-bridge (ingest + render + provenance + guards).
+
+Covers the Codex plan-time acceptance criteria: provenance in canonical items,
+single-revision CAS batch, fail-closed stale/drift/deleted source exclusion,
+doc_claim opt-in, secret skip-not-redact, mapping bounds (traversal/symlink/
+malformed), key collision, idempotency, and the no-touch guards on
+``compile_context`` / MCP surface / guard flags.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from ao_kernel._internal.context_doc_bridge import mapping as _mapping
+from ao_kernel._internal.context_doc_bridge import parser as _parser
+from ao_kernel.context import canonical_store as cs
+from ao_kernel.context.doc_bridge import ingest_docs, render_context_packet
+
+_GUARD_FLAGS = ("live_adapter_execution", "support_widening", "production_platform_claim")
+
+# Synthetic secret-like tokens assembled at runtime so the literal never appears
+# contiguously in source (repo .githooks/pre-commit secret scanner) while still
+# triggering looks_like_secret() at runtime. NOT real credentials.
+_FAKE_SK = "sk-" + "abcdefghijklmnop12345"
+_FAKE_GHP = "ghp_" + "0123456789abcdefghij0123456789"
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / ".ao").mkdir()
+    _write(tmp_path / "AGENTS.md", "# AGENTS - testrepo\n\nentry surface.\n")
+    _write(tmp_path / "docs/context-priority-rules.md", "# Context Priority Rules\n\nrules.\n")
+    _write(
+        tmp_path / "docs/adr/0001-use-pg.md",
+        "# 0001 - Use Postgres\n\n## Status\n\n**Accepted** (2026-01-02)\n\nctx.\n",
+    )
+    _write(
+        tmp_path / "docs/adr/0002-no-mesh.md",
+        "# 0002 - No Mesh\n\n## Status\n\n**Rejected** (2026-01-03)\n\nctx.\n",
+    )
+    _write(tmp_path / "docs/adr/README.md", "# ADR index\n")  # excluded by [0-9]* glob
+    _write(tmp_path / "docs/state/current-state.md", "# Current State\n\n## Live Delta A\n\n## Live Delta B\n")
+    return tmp_path
+
+
+def test_ingest_happy_path_writes_items_with_provenance(repo: Path) -> None:
+    report = ingest_docs(repo)
+    assert report.ingested == 6
+    assert report.by_type == {"rule": 2, "decision": 2, "fact": 2}
+    items = {i["key"]: i for i in cs.query(repo)}
+    prov = items["rule.agents-md"]["provenance"]["doc_bridge"]
+    assert prov["src"] == "AGENTS.md"
+    assert prov["type"] == "rule"
+    assert prov["doc_hash"].startswith("sha256:")
+    assert prov["value_hash"].startswith("sha256:")
+    assert prov["schema_version"] == "doc-bridge-provenance.v1"
+
+
+def test_adr_status_drives_confidence(repo: Path) -> None:
+    ingest_docs(repo)
+    items = {i["key"]: i for i in cs.query(repo, include_expired=True)}
+    assert items["decision.adr.0001-use-pg"]["confidence"] == 0.9
+    assert items["decision.adr.0002-no-mesh"]["confidence"] == 0.45
+
+
+def test_readme_excluded_by_glob(repo: Path) -> None:
+    ingest_docs(repo)
+    keys = {i["key"] for i in cs.query(repo, include_expired=True)}
+    assert not any("readme" in k.lower() for k in keys)
+
+
+def test_packet_default_excludes_doc_claims_and_low_conf(repo: Path) -> None:
+    ingest_docs(repo)
+    packet = render_context_packet(repo)
+    assert "AGENTS - testrepo" in packet
+    assert "Use Postgres" in packet
+    assert "No Mesh" not in packet
+    assert "Live Delta A" not in packet
+    assert "AUTHORITY" in packet
+
+
+def test_packet_include_doc_claims_labels_unverified(repo: Path) -> None:
+    ingest_docs(repo)
+    packet = render_context_packet(repo, include_doc_claims=True, min_conf=0.5)
+    assert "Live Delta A" in packet
+    assert "UNVERIFIED" in packet
+
+
+def test_authority_header_names_all_guard_flags(repo: Path) -> None:
+    ingest_docs(repo)
+    packet = render_context_packet(repo)
+    for flag in _GUARD_FLAGS:
+        assert flag in packet
+
+
+def test_stale_source_deleted_excluded(repo: Path) -> None:
+    ingest_docs(repo)
+    (repo / "AGENTS.md").unlink()
+    packet = render_context_packet(repo)
+    assert "AGENTS - testrepo" not in packet
+
+
+def test_source_drift_excluded(repo: Path) -> None:
+    ingest_docs(repo)
+    _write(repo / "AGENTS.md", "# AGENTS - DRIFTED\n")
+    packet = render_context_packet(repo)
+    assert "AGENTS - testrepo" not in packet
+    assert "DRIFTED" not in packet
+
+
+def test_idempotent_ingest_no_duplicate_keys(repo: Path) -> None:
+    report1 = ingest_docs(repo)
+    count1 = len(cs.query(repo, include_expired=True))
+    report2 = ingest_docs(repo)
+    count2 = len(cs.query(repo, include_expired=True))
+    assert count1 == count2
+    assert report2.ingested == report1.ingested
+
+
+def test_cas_single_revision_batch(repo: Path) -> None:
+    before = cs.store_revision(cs.load_store(repo))
+    report = ingest_docs(repo)
+    after = cs.store_revision(cs.load_store(repo))
+    assert report.revision == after
+    assert after != before
+
+
+def test_secret_like_value_skipped_not_stored(tmp_path: Path) -> None:
+    (tmp_path / ".ao").mkdir()
+    _write(tmp_path / "AGENTS.md", f"# token {_FAKE_SK}\n")
+    report = ingest_docs(tmp_path)
+    assert any("AGENTS.md" in entry for entry in report.secrets_skipped)
+    keys = {i["key"] for i in cs.query(tmp_path, include_expired=True)}
+    assert "rule.agents-md" not in keys
+
+
+def test_no_ingested_key_is_a_guard_flag(repo: Path) -> None:
+    ingest_docs(repo)
+    keys = {i["key"] for i in cs.query(repo, include_expired=True)}
+    for flag in _GUARD_FLAGS:
+        assert flag not in keys
+
+
+def test_path_traversal_pattern_rejected(tmp_path: Path) -> None:
+    assert _mapping.resolve_sources(tmp_path, "../escape/*.md") == []
+    assert _mapping.resolve_sources(tmp_path, "/etc/*.conf") == []
+    assert _mapping.resolve_sources(tmp_path, "~/secret.md") == []
+
+
+def test_symlink_escape_skipped(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside_secret.md"
+    outside.write_text("# secret outside repo\n", encoding="utf-8")
+    link = tmp_path / "AGENTS.md"
+    link.symlink_to(outside)
+    assert _mapping.resolve_sources(tmp_path, "AGENTS.md") == []
+
+
+def test_oversize_file_skipped(tmp_path: Path) -> None:
+    big = tmp_path / "BIG.md"
+    big.write_text("# big\n" + ("x" * 100), encoding="utf-8")
+    found = _mapping.resolve_sources(tmp_path, "BIG.md", max_bytes=10)
+    assert found == []
+
+
+def test_malformed_mapping_rejected(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"schema_version": "wrong", "rules": []}), encoding="utf-8")
+    with pytest.raises(Exception):  # noqa: B017 — jsonschema ValidationError surface
+        _mapping.load_mapping(str(bad))
+
+
+def test_default_mapping_is_schema_valid() -> None:
+    spec = _mapping.load_mapping(None)
+    assert spec["schema_version"] == "context-doc-bridge-mapping.v1"
+    assert len(spec["rules"]) >= 1
+
+
+def test_key_collision_strict_reported_and_skipped(tmp_path: Path) -> None:
+    (tmp_path / ".ao").mkdir()
+    _write(tmp_path / "a/one.md", "# One\n")
+    _write(tmp_path / "b/two.md", "# Two\n")
+    mp = tmp_path / "m.json"
+    mp.write_text(
+        json.dumps(
+            {
+                "schema_version": "context-doc-bridge-mapping.v1",
+                "rules": [
+                    {
+                        "mapping_id": "x",
+                        "glob": "*/*.md",
+                        "type": "rule",
+                        "tier": "repo_canonical",
+                        "key_template": "rule.fixed",
+                        "value_strategy": "first_heading",
+                        "confidence": 0.9,
+                        "collision_policy": "strict",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    report = ingest_docs(tmp_path, mapping_path=str(mp))
+    assert report.ingested == 1
+    assert len(report.collisions) == 1
+
+
+def test_compile_context_signature_unchanged() -> None:
+    from ao_kernel.context.context_compiler import compile_context
+
+    params = set(inspect.signature(compile_context).parameters)
+    assert "doc_bridge" not in params
+    assert "context_packet" not in params
+
+
+def test_mcp_server_does_not_wire_doc_bridge() -> None:
+    from ao_kernel import mcp_server
+
+    source = Path(mcp_server.__file__).read_text(encoding="utf-8")
+    assert "doc_bridge" not in source
+    assert "context_doc_bridge" not in source
+
+
+def test_parser_status_variants() -> None:
+    assert _parser.status_and_date("## Status\n\n**Accepted** (2026-01-02)")[0] == "Accepted"
+    assert _parser.status_and_date("Status: Rejected")[0] == "Rejected"
+    assert _parser.status_and_date("# no status here")[0] == "Unknown"
+
+
+def test_parser_secret_detection() -> None:
+    assert _parser.looks_like_secret("api_key = abcdef123456")
+    assert _parser.looks_like_secret(_FAKE_GHP)
+    assert not _parser.looks_like_secret("a normal architecture decision heading")


### PR DESCRIPTION
Closes #986.

## Ne
`ao_kernel.context.doc_bridge`: bir repo'nun `.md`-tabanlı bağlamını (AGENTS.md, ADR'lar, current-state, karar kayıtları) governed canonical store'a alır + kısa, provenance'lı **markdown context packet** üretir (Claude/Codex/Mavis enjekte eder). Surfaces: `ingest_docs()` / `render_context_packet()` + CLI `ao-kernel context {ingest,packet}`. Yeni `canonical_store.promote_many()` batch'i tek CAS revision'da yazar.

## Fail-closed garantiler
- Silinmiş / drifted (doc_hash mismatch) / mapping-reproduce-fail / symlinked / escaped / oversize source → packet'e GİRMEZ.
- Secret-like değer → skip (redakte-edip-saklama YOK).
- doc_claim facts → opt-in, `UNVERIFIED` etiketli.
- Packet header: source-derived context; guard flag'leri (support_widening / production_platform_claim / live_adapter_execution) override edemez.
- Bounded schema-validated mapping; repo-root confined globs (symlink/`..`/oversize reddi).

## Boundary
3 guard flag const false; `compile_context` + MCP yüzeyi DEĞİŞMEDİ (test ile machine-checked); support widening / production-platform / live adapter YOK.

## Cross-AI gate (provider-distinct)
- Implementer: Claude (anthropic). Reviewer: Codex (openai) — thread 019ea7e3.
- **Plan-time**: REVISE → v2 → AGREE. **Post-impl**: REVISE → 3 bulgu kapatıldı (doc_hash verify, render-time confinement, cross-store collision) → AGREE.
- 25 davranışsal test; full suite **6976 passed**; ruff + mypy temiz.
- Otonom merge lane: `local-ai-review-evidence.v1.json` → `local_gpp_gate` decision=**operator_may_merge** (lokal doğrulandı, tüm checks pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)