### PR TITLE
fix(security): scrub URL secrets from internal_gate health probe outputs (CodeQL #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **`internal_gate_host_health_probe` URL secret scrubbing**: a
+  `--policy-url` / `--release-gate-url` (or `--host`-derived URL) whose
+  userinfo (`https://user:password@host`), query (`?token=...`), or fragment
+  (`#...`) carried a secret was flagged (`..._credentials_forbidden` /
+  `..._not_canonical`) but the raw URL was still echoed into the evidence
+  payload (top-level `policy_url`/`release_gate_url` **and** the per-service
+  `service_results[].url`), the rendered text, the JSON output, and the
+  persisted artifact — leaking the secret in clear text (CodeQL
+  `py/clear-text-logging-sensitive-data`, HIGH; cross-AI verified Claude +
+  Codex). `_sanitize_url` now strips userinfo, query, and fragment before the
+  URL reaches any stored/emitted surface; the forbidden-userinfo and
+  not-canonical findings are still raised (computed from the raw URL). No
+  behavior change for credential-free canonical URLs.
+
 ## [4.3.0] - 2026-06-08
 
 ### Added

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "V5-RELEASE-4.3.0",
+  "work_package": "CODEQL-11-URL-USERINFO-LEAK",
   "implementer": {
     "agent": "claude-opus-4-8",
     "provider": "anthropic"
@@ -13,21 +13,12 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/chore/release-v4.3.0",
+    "head_ref": "refs/heads/fix/health-probe-url-userinfo-leak",
     "changed_files": [
       "CHANGELOG.md",
-      "ao_kernel/__init__.py",
-      "deploy/helm/ao-kernel/Chart.yaml",
-      "deploy/helm/ao-kernel/values.yaml",
-      "docs/PRODUCTION-DEPLOYMENT-GUIDE.md",
-      "docs/USING-AO-KERNEL-IN-YOUR-PROJECT.md",
-      "docs/operator-runbooks/01-pypi-publish.md",
-      "docs/operator-runbooks/README.md",
-      "docs/operator-runbooks/operator-action-checklist.v1.json",
       "local-ai-review-evidence.v1.json",
-      "pyproject.toml",
-      "tests/test_pr_a6_features.py",
-      "tests/test_v430_version_pin.py"
+      "scripts/internal_gate_host_health_probe.py",
+      "tests/test_internal_gate_host_health_probe.py"
     ]
   },
   "checks_considered": [
@@ -44,37 +35,25 @@
       "status": "pass"
     },
     {
-      "name": "version_single_source_of_truth",
-      "status": "pass"
-    },
-    {
-      "name": "release_facing_install_surfaces_match_version",
-      "status": "pass"
-    },
-    {
-      "name": "changelog_cut_and_history_preserved",
-      "status": "pass"
-    },
-    {
       "name": "guard_flags_false",
-      "status": "pass"
-    },
-    {
-      "name": "release_semantic_discipline_version_only",
       "status": "pass"
     },
     {
       "name": "no_workflow_ruleset_branch_protection_change",
       "status": "pass"
+    },
+    {
+      "name": "changelog_entry_added",
+      "status": "pass"
     }
   ],
   "findings": [
-    "Codex (OpenAI) cross-AI post-impl review on thread 019ea892. Verdict REVISE -> AGREE. The single REVISE blocker was governance-recipe, not code: a deploy/** high-risk release PR must include a current-bound root local-ai-review-evidence.v1.json so the trusted-base workflow can derive REVIEW_WORK_PACKAGE for the AO-MA-10 supersession builder (test.yml only reads the root reviewer evidence when it is part of the current PR diff; an absent root evidence makes the builder fail closed). This file is that current-bound root evidence; matches the proven #978 (v4.2.1) 13-file release diff shape.",
-    "Release content: v4.3.0 ships the context doc-bridge feature (ao_kernel.context.doc_bridge + CLI 'ao-kernel context {ingest,packet}', merged in #987) to PyPI. Minor bump (additive feature). Single-source version pin verified consistent by Codex: pyproject 4.3.0 == ao_kernel.__version__ 4.3.0 == CHANGELOG [4.3.0] == Helm appVersion 4.3.0 == values image tag 4.3.0 == docs ao-kernel==4.3.0 == operator checklist ref refs/tags/v4.3.0 + PyPI artifact /4.3.0/.",
-    "CHANGELOG cut verified: empty [Unreleased], [4.3.0] - 2026-06-08 below it, [4.2.1] and [4.2.0] history preserved, newest-first order. Version-pin test renamed v4.2.1 -> v4.3.0 (tests/test_v430_version_pin.py) and tests/test_pr_a6_features.py TestVersionBump updated to 4.3.0.",
-    "Scope is release-mechanical only: 13 files, no runtime feature code beyond the __version__ string; no change to .github workflows, rulesets, branch protection, GitHub apps, or the ao-ma-10-high-risk-reviews/{openai,anthropic} state-at-landing supersession pins.",
-    "Boundary: the three guard flags stay const false (support_widening, production_platform_claim, live_adapter_execution); gpp_status closure stays keep_narrow_stable_runtime. This is a governed control-plane release, NOT a production-platform promotion.",
-    "Verification: full pytest 7023 passed / 123 skipped / 0 failed under CI-parity venv (extras dev,llm,metrics); branch coverage 85.02% >= 85 gate; ruff clean. No secrets or credential material in the reviewed diff."
+    "Codex (OpenAI) cross-AI review on thread 019ea8bd. Verdict REVISE -> REVISE -> AGREE. This PR fixes the one REAL leak Codex flagged during the 18-alert CodeQL triage (#11), then closed a second leak vector Codex found in iter-1 (query/fragment in addition to userinfo).",
+    "Bug: scripts/internal_gate_host_health_probe.py flagged userinfo-bearing health URLs (..._credentials_forbidden) and query/fragment (..._not_canonical) but still echoed the raw URL into the evidence payload (top-level policy_url/release_gate_url AND per-service service_results[].url), the rendered text, the JSON output, and the persisted artifact — leaking the secret in clear text. CodeQL py/clear-text-logging-sensitive-data, HIGH.",
+    "Fix: new _sanitize_url() strips userinfo + query + fragment before the URL reaches any stored/emitted surface; findings are still computed from the raw URL (so credentials_forbidden + not_canonical are preserved). No behavior change for credential-free canonical URLs.",
+    "Verification: ruff clean; tests/test_internal_gate_host_health_probe.py 9 passed including the new regression (userinfo+query+fragment secret absent from payload, render text, JSON, and nested service_results[].url) + _sanitize_url unit. Codex independently confirmed via no-write probe that the secret leaks in none of these surfaces.",
+    "Boundary: low-risk change (scripts/ + tests/ + CHANGELOG only); no .github workflows, rulesets, branch protection, deploy/, or guard-flag changes. The 17 other triaged alerts were verified false-positive (cross-AI) and dismissed.",
+    "No secrets or credential material committed in the diff (the test uses a synthetic placeholder 'sup3rs3cret')."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/internal_gate_host_health_probe.py
+++ b/scripts/internal_gate_host_health_probe.py
@@ -99,6 +99,37 @@ def _url_findings(url: str, *, allow_http_localhost: bool) -> list[dict[str, str
     return findings
 
 
+def _sanitize_url(url: str) -> str:
+    """Return ``url`` stripped of every secret-bearing component.
+
+    Health URLs must be canonical and credential-free (``_url_findings``
+    flags ``..._credentials_forbidden`` for userinfo and
+    ``..._not_canonical`` for query/fragment), but the URL is still echoed
+    into the evidence payload, the per-service ``service_results[].url``,
+    the rendered text, the JSON output, and the persisted artifact. Any of
+    userinfo (``user:password@``), the query string (``?token=...``), and
+    the fragment (``#...``) can carry a secret, so all three are removed
+    before the URL reaches any stored/emitted surface — a caller-supplied
+    ``https://user:pw@host/p?token=SECRET#SECRET`` can never leak in clear
+    text. Findings are computed from the raw URL upstream, so the
+    forbidden-userinfo / not-canonical flags are preserved. A
+    credential-free canonical URL is returned unchanged; non-parseable
+    input is defensively stripped of userinfo, query, and fragment.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except ValueError:
+        return url.split("@", 1)[-1].split("?", 1)[0].split("#", 1)[0]
+    if not parsed.netloc:
+        return url
+    if not (parsed.username or parsed.password or parsed.query or parsed.fragment):
+        return url
+    host = parsed.hostname or ""
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+    return urllib.parse.urlunparse(parsed._replace(netloc=host, query="", fragment=""))
+
+
 def _is_public_https_url(url: str) -> bool:
     parsed = urllib.parse.urlparse(url)
     return parsed.scheme == "https" and parsed.hostname not in LOCAL_HTTP_HOSTS
@@ -144,7 +175,7 @@ def _probe_service(
     if findings:
         return {
             "service": service,
-            "url": url,
+            "url": _sanitize_url(url),
             "status": "blocked",
             "http_status": None,
             "health_status": None,
@@ -158,7 +189,7 @@ def _probe_service(
     except (OSError, TimeoutError, urllib.error.URLError) as exc:
         return {
             "service": service,
-            "url": url,
+            "url": _sanitize_url(url),
             "status": "blocked",
             "http_status": None,
             "health_status": None,
@@ -274,8 +305,8 @@ def build_evidence(
         "status": status,
         "operator_owned_platform_infrastructure": True,
         "end_user_self_host_required": False,
-        "policy_url": policy_url,
-        "release_gate_url": release_gate_url,
+        "policy_url": _sanitize_url(policy_url),
+        "release_gate_url": _sanitize_url(release_gate_url),
         "policy_health_evidence": policy_health_evidence,
         "release_gate_health_evidence": release_gate_health_evidence,
         "public_https_hosting_evidence": public_https_hosting_evidence,

--- a/tests/test_internal_gate_host_health_probe.py
+++ b/tests/test_internal_gate_host_health_probe.py
@@ -192,3 +192,46 @@ def test_health_probe_cli_writes_json_artifact(tmp_path: Path, capsys: Any, monk
     assert payload["status"] == "hosted_health_ready"
     assert payload["public_https_hosting_evidence"] is True
     assert "public_https_hosting_evidence: true" in captured.out
+
+
+def test_health_probe_strips_url_secrets_from_all_outputs() -> None:
+    """A caller-supplied URL whose userinfo, query, OR fragment carries a
+    secret must never leak it as clear text into the evidence payload (incl.
+    per-service service_results[].url), the rendered text, the JSON output, or
+    the persisted artifact (CodeQL py/clear-text-logging #11, cross-AI verified
+    Claude + Codex). Secrets are flagged AND scrubbed, not just flagged."""
+
+    mod = _module()
+    secret = "sup3rs3cret"
+
+    def transport(_url: str, _timeout_seconds: float) -> tuple[int, bytes]:
+        return 200, _json_response("GPP-2af")
+
+    payload = mod.build_evidence(
+        policy_url=f"https://user:{secret}@gate.example.test/policy/healthz?token={secret}#{secret}",
+        release_gate_url=f"https://user:{secret}@gate.example.test/release-gate/healthz?token={secret}",
+        transport=transport,
+    )
+
+    # Userinfo + query + fragment scrubbed from the stored URLs (host/path kept).
+    assert payload["policy_url"] == "https://gate.example.test/policy/healthz"
+    assert payload["release_gate_url"] == "https://gate.example.test/release-gate/healthz"
+    # The leaks are still flagged, not silently accepted.
+    codes = {f["code"] for f in payload["findings"]}
+    assert "internal_gate_host_health_url_credentials_forbidden" in codes
+    assert "internal_gate_host_health_url_not_canonical" in codes
+    # The secret must not survive in ANY emitted surface, including the
+    # per-service result URLs nested under service_results.
+    assert secret not in json.dumps(payload)
+    assert secret not in mod._render_text(payload)
+    for result in payload["service_results"].values():
+        assert secret not in result["url"]
+
+
+def test_sanitize_url_strips_userinfo_query_fragment_but_noops_canonical() -> None:
+    mod = _module()
+    clean = "https://gate.example.test:8443/policy/healthz"
+    assert mod._sanitize_url(clean) == clean
+    assert mod._sanitize_url("https://user:pw@gate.example.test:8443/x") == "https://gate.example.test:8443/x"
+    assert mod._sanitize_url("https://gate.example.test/x?token=secret") == "https://gate.example.test/x"
+    assert mod._sanitize_url("https://gate.example.test/x#secret") == "https://gate.example.test/x"


### PR DESCRIPTION
Closes #990. Resolves CodeQL HIGH alert #11 (`py/clear-text-logging-sensitive-data`).

## Problem
`scripts/internal_gate_host_health_probe.py` flagged health URLs carrying secrets — userinfo (`https://user:password@host`, `..._credentials_forbidden`), query (`?token=...`) or fragment (`#...`, `..._not_canonical`) — but still echoed the **raw** URL into the evidence payload (top-level `policy_url`/`release_gate_url` **and** the per-service `service_results[].url`), the rendered text, the JSON output, and the persisted artifact → secret leaked in clear text.

## Fix
New `_sanitize_url()` strips userinfo + query + fragment before the URL reaches any stored/emitted surface. Findings are still computed from the **raw** URL, so `credentials_forbidden` + `not_canonical` are preserved. No behavior change for credential-free canonical URLs. Regression test asserts the secret never appears in payload, render text, JSON, or nested `service_results[].url`.

## Triage context
Part of the 18-alert CodeQL HIGH triage. The other 17 (`clear-text-logging`/`clear-text-storage` in attestation/decision/cost/smoke tooling) were cross-AI verified false-positive (sanitized governance artifacts / repo variables / hashes; secret never reaches the sink under the D43 stdin-pipe + no-secret-evidence discipline) and dismissed. **This is the 1 real leak Codex caught** — exactly the value of provider-distinct cross-AI peer review.

## Verification (No-Fake-Work)
- Cross-AI two-gate (provider-distinct): implementer **anthropic**/claude-opus-4-8, reviewer **openai**/codex **AGREE** (thread 019ea8bd, REVISE→REVISE→AGREE; Codex independently confirmed via no-write probe).
- Local: `ruff` clean; `pytest tests/test_internal_gate_host_health_probe.py` → 9 passed.
- Low-risk scope (scripts/ + tests/ + CHANGELOG); no `.github/**`, rulesets, branch protection, `deploy/**`, or guard-flag changes.

Implementer: anthropic (claude-opus-4-8)
Reviewer:    openai (codex, thread 019ea8bd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)