### PR TITLE
release: prepare ao-kernel 4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- **v4.3.1 release metadata prep**: aligned package version, CLI version
+  reporting, Helm tags, install/deploy docs, PyPI publish runbook/checklist,
+  and release version-pin tests for the v4.3.1 patch release. This is release
+  metadata only; no V5 promotion, support widening, production platform claim,
+  or live adapter execution.
+
+## [4.3.1] - 2026-06-17
+
 ### Fixed
 
 - **`internal_gate_host_health_probe` URL secret scrubbing**: a

--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ ao-kernel is **not** a general-purpose agent framework or a blanket "production 
 
 ```bash
 pip install ao-kernel                # Core (only jsonschema dependency)
-pip install ao-kernel==4.0.0         # Exact stable pin
+pip install ao-kernel==4.3.1         # Exact stable pin
 pip install ao-kernel[llm]           # LLM modules (tenacity + tiktoken)
 pip install ao-kernel[mcp]           # MCP server support
 pip install ao-kernel[otel]          # OpenTelemetry instrumentation
 pip install ao-kernel[llm,mcp,otel]  # Everything
 ```
 
-`v4.0.0` is live on PyPI. Post-publish verification confirmed both
-`pip install ao-kernel` and `pip install ao-kernel==4.0.0` resolve to
-`ao-kernel 4.0.0` in fresh virtual environments.
+`v4.3.1` is the current stable patch line prepared for PyPI. Post-publish
+verification must confirm both `pip install ao-kernel` and
+`pip install ao-kernel==4.3.1` resolve to `ao-kernel 4.3.1` in fresh virtual
+environments.
 
 **For production-grade live LLM calls**, install the `[llm]` extra. Without it the runtime still dispatches requests, but two guarantees weaken: **retry / backoff** (`tenacity`) degrades to a single-attempt call so transient 429 / 5xx responses fail the request instead of being retried, and **exact token counting** (`tiktoken`) falls back to a heuristic estimator (~4 chars/token) so budget accounting is approximate. The core install is fully sufficient for policy evaluation, evidence replay, workflow inspection, and MCP server hosting.
 

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -9,21 +9,43 @@
       "status": "pass"
     },
     {
-      "name": "guard_invariants",
+      "name": "version_pin_consistency",
       "status": "pass"
     },
     {
-      "name": "scope_alignment",
+      "name": "guard_flags",
+      "status": "pass"
+    },
+    {
+      "name": "v5_overclaim",
+      "status": "pass"
+    },
+    {
+      "name": "operator_boundary",
+      "status": "pass"
+    },
+    {
+      "name": "changelog_discipline",
+      "status": "pass"
+    },
+    {
+      "name": "helm_metadata",
+      "status": "pass"
+    },
+    {
+      "name": "pypi_publish_dispatch_boundary",
       "status": "pass"
     }
   ],
   "findings": [
-    "Anthropic reviewer verdict AGREE: no blocking issue in the V5 E-9-1 observability production tunables preflight bundle.",
-    "Schema strictness is adequate: root and nested object nodes close additionalProperties and unevaluatedProperties.",
-    "Fixture validates and preserves preflight_current_state semantics; residual PR-Xfinal observability evidence remains missing.",
-    "Tests cover guard flips, schema strictness, fixture validation, Grafana, SLI/SLO, performance policy, matrix linkage, and positive-claim token discipline.",
-    "The V5 matrix keeps observability_production_tunables partial and preserves matrix_complete=false.",
-    "No support widening, production platform claim, live adapter execution, v5 tag, publish, workflow, ruleset, runtime, or release authority change is introduced."
+    "Anthropic Claude CLI review verdict AGREE for REL-4-3-1: all version pins are internally consistent for 4.3.1 across package metadata, CLI version reporting, Helm metadata, install/deploy docs, operator runbooks, checklist, and tests.",
+    "Guard flags remain closed: no support widening, no production platform claim, no live adapter execution, and no V5 promotion language is introduced.",
+    "No credential material, API keys, tokens, or secrets were detected in the reviewed diff.",
+    "Operator publish boundary is maintained: the runbook directs operator dispatch of publish.yml, and the PR does not push a tag or dispatch publishing.",
+    "CHANGELOG order is acceptable with [Unreleased] above [4.3.1] above [4.3.0]; the release entry documents the URL secret-scrubbing fix and preserves prior history.",
+    "Helm chart semver remains unchanged while appVersion and image tag are bumped to 4.3.1, matching manual pin discipline.",
+    "The v4.3.1 version-pin test file verifies pyproject, __version__, changelog order, guard flags, install docs, Helm tag, and operator publish checklist against the release version.",
+    "Rollback guidance uses the next corrective patch pattern v4.3.2 and avoids destructive package deletion."
   ],
   "implementer": {
     "agent": "codex",
@@ -33,7 +55,7 @@
   "production_platform_claim": false,
   "repo": "Halildeu/ao-kernel",
   "reviewer": {
-    "agent": "claude-sonnet-4-6-anthropic-reviewer",
+    "agent": "anthropic-release-reviewer",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
@@ -41,20 +63,26 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/V5-OBSERVABILITY-PRODUCTION-TUNABLES-PREFLIGHT-BUNDLE.md",
-      ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
       "CHANGELOG.md",
+      "README.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/v5-observability-production-tunables-preflight-bundle.schema.v1.json",
+      "ao_kernel/__init__.py",
+      "deploy/helm/ao-kernel/Chart.yaml",
+      "deploy/helm/ao-kernel/values.yaml",
+      "docs/PRODUCTION-DEPLOYMENT-GUIDE.md",
+      "docs/USING-AO-KERNEL-IN-YOUR-PROJECT.md",
+      "docs/operator-runbooks/01-pypi-publish.md",
+      "docs/operator-runbooks/README.md",
+      "docs/operator-runbooks/operator-action-checklist.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/fixtures/epic9/v5-observability-production-tunables-preflight.current.json",
-      "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/test_v5_observability_production_tunables_preflight_bundle.py"
+      "pyproject.toml",
+      "tests/test_pr_a6_features.py",
+      "tests/test_v431_version_pin.py"
     ],
-    "head_ref": "refs/heads/codex/v5-observability-preflight-bundle"
+    "head_ref": "refs/heads/codex/release-4.3.1"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "E-9-1"
+  "work_package": "REL-4-3-1"
 }

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -9,32 +9,39 @@
       "status": "pass"
     },
     {
-      "name": "guard_invariants",
+      "name": "version_pin_consistency",
       "status": "pass"
     },
     {
-      "name": "scope_alignment",
+      "name": "guard_flags",
+      "status": "pass"
+    },
+    {
+      "name": "operator_boundary",
+      "status": "pass"
+    },
+    {
+      "name": "packaging_smoke",
       "status": "pass"
     }
   ],
   "findings": [
-    "OpenAI reviewer verdict AGREE: V5 E-9-1 observability preflight scope is aligned.",
-    "The 7-file slice plus 3 review evidence files is current-state observability evidence only.",
-    "Schema is strict and pins final_release_bound=false plus support_widening=false, production_platform_claim=false, and live_adapter_execution=false.",
-    "Sub-claim guards fail closed for alert/escalation evidence, CI-blocking performance enforcement, and Grafana final-claim binding.",
-    "Matrix linkage is correct: observability_production_tunables stays partial and matrix_complete remains false.",
-    "No workflow, ruleset, runtime, release, tag, publish, or PR-Xfinal surface is changed.",
-    "Local validation considered: targeted pytest passed, JSON parse passed, git diff whitespace check passed, guard invariants passed, and secret scan over the diff passed."
+    "OpenAI Codex review verdict AGREE for REL-4-3-1: pyproject.toml and ao_kernel.__version__ both report 4.3.1, and release-facing docs/tests pin the same version.",
+    "The release prep is a narrow patch metadata update carrying the already-merged URL secret-scrubbing fix; it does not add runtime behavior beyond version/reporting/install/deploy pins.",
+    "README and operator runbooks correctly say the package is prepared for PyPI and keep publish as an operator-controlled workflow dispatch after tag/ref verification.",
+    "Helm changes are limited to appVersion and image tag 4.3.1; chart semver and guard boundaries remain unchanged.",
+    "No V5 promotion, support widening, production platform claim, live adapter execution, workflow dispatch, release tag push, or credential commit is introduced.",
+    "Local and GitHub verification passed for changelog enforcement, targeted release tests, runbook tests, packaging smoke, twine check, CodeQL, Trivy, lint, typecheck, Python test matrix, coverage, benchmark-fast, and scorecard."
   ],
   "implementer": {
     "agent": "codex",
-    "kind": "human"
+    "provider": "openai"
   },
   "live_adapter_execution": false,
   "production_platform_claim": false,
   "repo": "Halildeu/ao-kernel",
   "reviewer": {
-    "agent": "kepler-openai-reviewer",
+    "agent": "codex-release-reviewer",
     "provider": "openai",
     "verdict": "AGREE"
   },
@@ -42,20 +49,26 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/V5-OBSERVABILITY-PRODUCTION-TUNABLES-PREFLIGHT-BUNDLE.md",
-      ".claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md",
       "CHANGELOG.md",
+      "README.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/v5-observability-production-tunables-preflight-bundle.schema.v1.json",
+      "ao_kernel/__init__.py",
+      "deploy/helm/ao-kernel/Chart.yaml",
+      "deploy/helm/ao-kernel/values.yaml",
+      "docs/PRODUCTION-DEPLOYMENT-GUIDE.md",
+      "docs/USING-AO-KERNEL-IN-YOUR-PROJECT.md",
+      "docs/operator-runbooks/01-pypi-publish.md",
+      "docs/operator-runbooks/README.md",
+      "docs/operator-runbooks/operator-action-checklist.v1.json",
       "local-ai-review-evidence.v1.json",
-      "tests/fixtures/epic9/v5-observability-production-tunables-preflight.current.json",
-      "tests/fixtures/epic9/v5-production-readiness-matrix.current.json",
-      "tests/test_v5_observability_production_tunables_preflight_bundle.py"
+      "pyproject.toml",
+      "tests/test_pr_a6_features.py",
+      "tests/test_v431_version_pin.py"
     ],
-    "head_ref": "refs/heads/codex/v5-observability-preflight-bundle"
+    "head_ref": "refs/heads/codex/release-4.3.1"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "E-9-1"
+  "work_package": "REL-4-3-1"
 }

--- a/ao_kernel/__init__.py
+++ b/ao_kernel/__init__.py
@@ -1,6 +1,6 @@
 """ao-kernel — Governed AI orchestration runtime."""
 
-__version__ = "4.3.0"
+__version__ = "4.3.1"
 
 from ao_kernel.client import AoKernelClient
 from ao_kernel.config import load_default, load_with_override, workspace_root

--- a/deploy/helm/ao-kernel/Chart.yaml
+++ b/deploy/helm/ao-kernel/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 version: 0.1.2
 # appVersion bound to ao_kernel.__version__ at slice author time.
 # This is a manual pin per Epic 4 plan (NO auto-bump); operator confirms match on upgrade.
-appVersion: "4.3.0"
+appVersion: "4.3.1"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/Halildeu/ao-kernel
 sources:

--- a/deploy/helm/ao-kernel/values.yaml
+++ b/deploy/helm/ao-kernel/values.yaml
@@ -16,7 +16,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/halildeu/ao-kernel
   # Operator should pin a digest in production; tag default is for skeleton testing.
-  tag: "4.3.0"
+  tag: "4.3.1"
   pullPolicy: IfNotPresent
 
 # Optional image pull secrets (operator-managed Kubernetes Secrets).

--- a/docs/PRODUCTION-DEPLOYMENT-GUIDE.md
+++ b/docs/PRODUCTION-DEPLOYMENT-GUIDE.md
@@ -92,7 +92,7 @@ USER aoekernel
 WORKDIR /home/aoekernel
 
 # Pin to a specific ao-kernel release
-RUN pip install --no-cache-dir 'ao-kernel==4.3.0' 'ao-kernel[mcp,llm,otel]'
+RUN pip install --no-cache-dir 'ao-kernel==4.3.1' 'ao-kernel[mcp,llm,otel]'
 
 # Workspace + evidence volume mount points
 VOLUME /home/aoekernel/.ao
@@ -106,7 +106,7 @@ CMD ["ao-kernel", "mcp", "serve"]
 ```yaml
 services:
   ao-kernel:
-    image: your-registry/ao-kernel:4.3.0
+    image: your-registry/ao-kernel:4.3.1
     user: aoekernel
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}

--- a/docs/USING-AO-KERNEL-IN-YOUR-PROJECT.md
+++ b/docs/USING-AO-KERNEL-IN-YOUR-PROJECT.md
@@ -45,7 +45,7 @@ ao-kernel is a **control-plane**, not a provider-API client. The intended model:
 
 ```bash
 pip install ao-kernel                 # Core (only jsonschema dependency)
-pip install ao-kernel==4.3.0          # Exact pin
+pip install ao-kernel==4.3.1          # Exact pin
 pip install ao-kernel[mcp]            # + MCP server over stdio (governance tools for AI agents)
 pip install ao-kernel[mcp-http]       # + MCP server over HTTP (adds starlette + uvicorn)
 pip install ao-kernel[llm]            # + LLM modules (tenacity + tiktoken)

--- a/docs/operator-runbooks/01-pypi-publish.md
+++ b/docs/operator-runbooks/01-pypi-publish.md
@@ -1,4 +1,4 @@
-# Runbook 01 — PyPI v4.3.0 Publish (P0-1)
+# Runbook 01 — PyPI v4.3.1 Publish (P0-1)
 
 > **Agent-prepared only.** This runbook directs the operator to dispatch
 > the existing `.github/workflows/publish.yml` workflow. The agent does
@@ -6,8 +6,8 @@
 
 ## Prerequisites
 
-- v4.3.0 tag pushed to `origin` (verify: `git tag --list v4.3.0`)
-- Tag SHA matches main release commit (`git rev-parse v4.3.0` ↔
+- v4.3.1 tag pushed to `origin` (verify: `git tag --list v4.3.1`)
+- Tag SHA matches main release commit (`git rev-parse v4.3.1` ↔
   `git rev-parse origin/main`)
 - PyPI maintainer permissions for `ao-kernel`
 - GHCR maintainer permissions for the matching container
@@ -17,7 +17,7 @@
 1. Confirm the tag is reachable:
    ```bash
    git fetch --tags origin
-   git rev-parse refs/tags/v4.3.0
+   git rev-parse refs/tags/v4.3.1
    ```
 2. Confirm the workflow file is on the head commit:
    ```bash
@@ -27,20 +27,20 @@
    ```bash
    gh workflow run publish.yml \
        --repo Halildeu/ao-kernel \
-       --ref refs/tags/v4.3.0 \
-       --field ref=refs/tags/v4.3.0
+      --ref refs/tags/v4.3.1 \
+      --field ref=refs/tags/v4.3.1
    ```
 4. Watch the run:
    ```bash
    gh run watch --repo Halildeu/ao-kernel
    ```
-5. Confirm `https://pypi.org/project/ao-kernel/4.3.0/` resolves.
+5. Confirm `https://pypi.org/project/ao-kernel/4.3.1/` resolves.
 6. Confirm the GHCR container tag exists and matches.
 
 ## Verification
 
-- PyPI page: `https://pypi.org/project/ao-kernel/4.3.0/`
-- GHCR container: matching v4.3.0 digest
+- PyPI page: `https://pypi.org/project/ao-kernel/4.3.1/`
+- GHCR container: matching v4.3.1 digest
 - Workflow run conclusion is `success`
 - No test version published to the production index
 
@@ -48,18 +48,18 @@
 
 PyPI releases are NOT deletable. The correct rollback path is:
 
-- `pip` users: `pip install ao-kernel==<previous>` to pin away from 4.3.0
+- `pip` users: `pip install ao-kernel==<previous>` to pin away from 4.3.1
 - Maintainer: **yank** the broken release if necessary (this is reversible)
-  and publish a corrective patch release (next patch, e.g. `v4.3.1`)
-- Do NOT attempt to delete 4.3.0 from PyPI; deletion is not supported and
+  and publish a corrective patch release (next patch, e.g. `v4.3.2`)
+- Do NOT attempt to delete 4.3.1 from PyPI; deletion is not supported and
   yank-then-corrective-patch is the safer path
 
 ## Stop and contact owner if
 
 - The tag SHA does not match `origin/main` head at the time of release
-- `pypi.org` already has a `4.3.0` entry from an earlier accidental publish
+- `pypi.org` already has a `4.3.1` entry from an earlier accidental publish
 - The workflow run shows unexpected `inputs` (a `ref` value other than
-  `refs/tags/v4.3.0`)
+  `refs/tags/v4.3.1`)
 - The GHCR push step fails (digest mismatch)
 - The `inputs.ref` v-tag guard rejects the input
 

--- a/docs/operator-runbooks/README.md
+++ b/docs/operator-runbooks/README.md
@@ -19,7 +19,7 @@
 | File | Role |
 |---|---|
 | [`operator-action-checklist.v1.json`](operator-action-checklist.v1.json) | Schema-backed checklist (4 actions, pending state) |
-| [`01-pypi-publish.md`](01-pypi-publish.md) | P0-1: PyPI v4.3.0 publish dispatch |
+| [`01-pypi-publish.md`](01-pypi-publish.md) | P0-1: PyPI v4.3.1 publish dispatch |
 | [`02-plan-approval-environment.md`](02-plan-approval-environment.md) | AO-MA-11A-2: `ao-ma-plan-approval` environment configure |
 | [`03-mirror-pat-secret.md`](03-mirror-pat-secret.md) | AO-MA-11E-2b: `REPO_GH_PAT_PROJECTS_RW` secret seed |
 | [`04-mirror-sync-environment.md`](04-mirror-sync-environment.md) | AO-MA-11E-2b: `ao-ma-mirror-sync` environment configure |
@@ -29,7 +29,7 @@
 
 | # | Action | Workflow | Environment | Secret | ETA |
 |---|---|---|---|---|---|
-| 1 | PyPI v4.3.0 publish | `publish.yml` | `pypi` | — | 5 min |
+| 1 | PyPI v4.3.1 publish | `publish.yml` | `pypi` | — | 5 min |
 | 2 | Plan-approval env configure | `ao-ma-11a-plan-approval.yml` | `ao-ma-plan-approval` | — | 4 min |
 | 3 | Mirror PAT secret seed | `ao-ma-11e-2b-mirror-sync.yml` | — (secret-only) | `REPO_GH_PAT_PROJECTS_RW` | 6 min |
 | 4 | Mirror-sync env configure | `ao-ma-11e-2b-mirror-sync.yml` | `ao-ma-mirror-sync` | — | 4 min |
@@ -69,7 +69,7 @@
 - The runbooks NEVER instruct the operator to take an irreversible action
   without an explicit verification step.
 
-## 3. Action 1 — PyPI v4.3.0 Publish (P0-1)
+## 3. Action 1 — PyPI v4.3.1 Publish (P0-1)
 
 See [`01-pypi-publish.md`](01-pypi-publish.md).
 

--- a/docs/operator-runbooks/operator-action-checklist.v1.json
+++ b/docs/operator-runbooks/operator-action-checklist.v1.json
@@ -21,18 +21,18 @@
   "actions": [
     {
       "id": "p0-1-pypi-publish",
-      "title": "PyPI v4.3.0 publish dispatch (P0-1)",
+      "title": "PyPI v4.3.1 publish dispatch (P0-1)",
       "runbook_path": "docs/operator-runbooks/01-pypi-publish.md",
       "workflow_path": ".github/workflows/publish.yml",
       "environment_name": "pypi",
       "secret_names": [],
-      "dispatch_inputs": { "ref": "refs/tags/v4.3.0" },
+      "dispatch_inputs": { "ref": "refs/tags/v4.3.1" },
       "expected_artifacts": [
-        "https://pypi.org/project/ao-kernel/4.3.0/"
+        "https://pypi.org/project/ao-kernel/4.3.1/"
       ],
       "operator_must_verify": [
         "tag SHA matches main release commit",
-        "GHCR + PyPI parity for ao-kernel 4.3.0",
+        "GHCR + PyPI parity for ao-kernel 4.3.1",
         "no test release published to production index"
       ],
       "forbidden_claims": [
@@ -46,7 +46,7 @@
       "agent_prep_status": "done",
       "operator_action_status": "pending",
       "status_evidence_refs": [],
-      "blocker_for": ["v4.3.0 GA"],
+      "blocker_for": ["v4.3.1 GA"],
       "estimated_minutes": 5,
       "dependencies": []
     },

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,62 +1,78 @@
 {
-  "schema_version": "local-ai-review-evidence.v1",
-  "repo": "Halildeu/ao-kernel",
-  "work_package": "CODEQL-11-URL-USERINFO-LEAK",
-  "implementer": {
-    "agent": "claude-opus-4-8",
-    "provider": "anthropic"
-  },
-  "reviewer": {
-    "agent": "codex",
-    "provider": "openai",
-    "verdict": "AGREE"
-  },
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/fix/health-probe-url-userinfo-leak",
-    "changed_files": [
-      "CHANGELOG.md",
-      "local-ai-review-evidence.v1.json",
-      "scripts/internal_gate_host_health_probe.py",
-      "tests/test_internal_gate_host_health_probe.py"
-    ]
-  },
   "checks_considered": [
-    {
-      "name": "secret_scan",
-      "status": "pass"
-    },
     {
       "name": "tests",
       "status": "pass"
     },
     {
-      "name": "ruff",
+      "name": "secret_scan",
       "status": "pass"
     },
     {
-      "name": "guard_flags_false",
+      "name": "version_pin_consistency",
       "status": "pass"
     },
     {
-      "name": "no_workflow_ruleset_branch_protection_change",
+      "name": "guard_flags",
       "status": "pass"
     },
     {
-      "name": "changelog_entry_added",
+      "name": "operator_boundary",
+      "status": "pass"
+    },
+    {
+      "name": "changelog_discipline",
+      "status": "pass"
+    },
+    {
+      "name": "packaging_smoke",
       "status": "pass"
     }
   ],
   "findings": [
-    "Codex (OpenAI) cross-AI review on thread 019ea8bd. Verdict REVISE -> REVISE -> AGREE. This PR fixes the one REAL leak Codex flagged during the 18-alert CodeQL triage (#11), then closed a second leak vector Codex found in iter-1 (query/fragment in addition to userinfo).",
-    "Bug: scripts/internal_gate_host_health_probe.py flagged userinfo-bearing health URLs (..._credentials_forbidden) and query/fragment (..._not_canonical) but still echoed the raw URL into the evidence payload (top-level policy_url/release_gate_url AND per-service service_results[].url), the rendered text, the JSON output, and the persisted artifact — leaking the secret in clear text. CodeQL py/clear-text-logging-sensitive-data, HIGH.",
-    "Fix: new _sanitize_url() strips userinfo + query + fragment before the URL reaches any stored/emitted surface; findings are still computed from the raw URL (so credentials_forbidden + not_canonical are preserved). No behavior change for credential-free canonical URLs.",
-    "Verification: ruff clean; tests/test_internal_gate_host_health_probe.py 9 passed including the new regression (userinfo+query+fragment secret absent from payload, render text, JSON, and nested service_results[].url) + _sanitize_url unit. Codex independently confirmed via no-write probe that the secret leaks in none of these surfaces.",
-    "Boundary: low-risk change (scripts/ + tests/ + CHANGELOG only); no .github workflows, rulesets, branch protection, deploy/, or guard-flag changes. The 17 other triaged alerts were verified false-positive (cross-AI) and dismissed.",
-    "No secrets or credential material committed in the diff (the test uses a synthetic placeholder 'sup3rs3cret')."
+    "Anthropic CLI review verdict AGREE for REL-4-3-1: version pins are internally consistent across pyproject.toml, ao_kernel.__version__, Helm appVersion/image tag, install docs, deployment docs, operator runbook/checklist, and release version-pin tests.",
+    "The change is release metadata only for ao-kernel 4.3.1; it does not promote V5, widen support, claim production-platform readiness, or execute live adapters.",
+    "Operator publish boundary is preserved: runbooks require operator dispatch for publish.yml against refs/tags/v4.3.1, and the agent did not push a release tag or dispatch the publish workflow.",
+    "No credential material, API keys, tokens, or secrets were found in the reviewed diff; checklist fields keep credential_material_committed=false and agent_executed_external_action=false.",
+    "Changelog discipline is acceptable: [Unreleased] remains above [4.3.1], [4.3.0] history is preserved, and the v4.3.1 release entry documents the URL secret-scrubbing fix.",
+    "Local verification and PR checks passed for changelog, CodeQL, Trivy, lint, typecheck, Python 3.11/3.12/3.13 tests, coverage, benchmark-fast, packaging-smoke, scorecard, twine check, and targeted release/runbook tests."
   ],
-  "secrets_recorded": false,
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
   "live_adapter_execution": false,
+  "production_platform_claim": false,
+  "repo": "Halildeu/ao-kernel",
+  "reviewer": {
+    "agent": "anthropic-release-reviewer",
+    "provider": "anthropic",
+    "verdict": "AGREE"
+  },
+  "schema_version": "local-ai-review-evidence.v1",
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "changed_files": [
+      "CHANGELOG.md",
+      "README.md",
+      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
+      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "ao_kernel/__init__.py",
+      "deploy/helm/ao-kernel/Chart.yaml",
+      "deploy/helm/ao-kernel/values.yaml",
+      "docs/PRODUCTION-DEPLOYMENT-GUIDE.md",
+      "docs/USING-AO-KERNEL-IN-YOUR-PROJECT.md",
+      "docs/operator-runbooks/01-pypi-publish.md",
+      "docs/operator-runbooks/README.md",
+      "docs/operator-runbooks/operator-action-checklist.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "pyproject.toml",
+      "tests/test_pr_a6_features.py",
+      "tests/test_v431_version_pin.py"
+    ],
+    "head_ref": "refs/heads/codex/release-4.3.1"
+  },
+  "secrets_recorded": false,
   "support_widening": false,
-  "production_platform_claim": false
+  "work_package": "REL-4-3-1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ao-kernel"
-version = "4.3.0"
+version = "4.3.1"
 description = "Governed AI orchestration runtime — policy-driven, fail-closed, evidence-trail"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_pr_a6_features.py
+++ b/tests/test_pr_a6_features.py
@@ -93,10 +93,10 @@ class TestLlmFallback:
 
 
 class TestVersionBump:
-    def test_version_is_4_3_0(self) -> None:
+    def test_version_is_4_3_1(self) -> None:
         import ao_kernel
 
-        assert ao_kernel.__version__ == "4.3.0"
+        assert ao_kernel.__version__ == "4.3.1"
 
     def test_pyproject_version_matches(self) -> None:
         import tomllib
@@ -106,7 +106,7 @@ class TestVersionBump:
             pyproject = Path(__file__).parent.parent / "pyproject.toml"
         with open(pyproject, "rb") as f:
             data = tomllib.load(f)
-        assert data["project"]["version"] == "4.3.0"
+        assert data["project"]["version"] == "4.3.1"
 
 
 class TestMetaExtras:

--- a/tests/test_v431_version_pin.py
+++ b/tests/test_v431_version_pin.py
@@ -1,15 +1,11 @@
-"""v4.3.0 release version + dependency pin tests.
+"""v4.3.1 release version + dependency pin tests.
 
 Single source-of-truth pin: pyproject.toml::project.version,
-ao_kernel.__version__, and the Keep-a-Changelog [4.3.0] entry MUST all
-agree. PyYAML runtime dependency MUST stay declared. This minor release
-ships the post-4.2.1 governed control-plane feature onto PyPI: the
-context doc-bridge (`ao_kernel.context.doc_bridge` + `ao-kernel context
-{ingest,packet}`) that ingests a repo's `.md`-governed context into the
-governed canonical store and renders a fail-closed, provenance-tagged
-markdown context packet for any AI. It is a governed control-plane
-release, NOT a production-platform promotion: the three guard flags
-remain const false.
+ao_kernel.__version__, and the Keep-a-Changelog [4.3.1] entry MUST all
+agree. PyYAML runtime dependency MUST stay declared. This patch release
+ships the post-4.3.0 internal-gate host health probe URL secret-scrubbing
+fix onto PyPI. It is a narrow stable runtime bugfix, NOT a
+production-platform promotion: the three guard flags remain const false.
 
 Semantic discipline (carried from the v4.2.x lane): a release PR may only
 change project.version + project.dependencies + (optional)
@@ -34,15 +30,15 @@ def _load_pyproject() -> dict:
         return tomllib.load(handle)
 
 
-def test_pyproject_version_is_4_3_0() -> None:
+def test_pyproject_version_is_4_3_1() -> None:
     data = _load_pyproject()
-    assert data["project"]["version"] == "4.3.0"
+    assert data["project"]["version"] == "4.3.1"
 
 
-def test_ao_kernel_dunder_version_is_4_3_0() -> None:
+def test_ao_kernel_dunder_version_is_4_3_1() -> None:
     import ao_kernel
 
-    assert ao_kernel.__version__ == "4.3.0"
+    assert ao_kernel.__version__ == "4.3.1"
 
 
 def test_version_consistency_pyproject_matches_dunder() -> None:
@@ -68,33 +64,33 @@ def test_pyyaml_runtime_dependency_declared() -> None:
     )
 
 
-def test_changelog_has_4_3_0_entry() -> None:
-    """Keep-a-Changelog [4.3.0] - YYYY-MM-DD entry MUST exist; release
+def test_changelog_has_4_3_1_entry() -> None:
+    """Keep-a-Changelog [4.3.1] - YYYY-MM-DD entry MUST exist; release
     discipline (ADR-0005) enforced at release time."""
 
     text = _CHANGELOG.read_text(encoding="utf-8")
-    assert "## [4.3.0]" in text, "CHANGELOG.md missing [4.3.0] release entry"
+    assert "## [4.3.1]" in text, "CHANGELOG.md missing [4.3.1] release entry"
 
 
-def test_changelog_preserves_prior_4_2_1_entry() -> None:
-    """The prior [4.2.1] entry MUST remain (history is append-only)."""
+def test_changelog_preserves_prior_4_3_0_entry() -> None:
+    """The prior [4.3.0] entry MUST remain (history is append-only)."""
 
     text = _CHANGELOG.read_text(encoding="utf-8")
-    assert "## [4.2.1]" in text, "CHANGELOG.md must preserve the [4.2.1] history entry"
+    assert "## [4.3.0]" in text, "CHANGELOG.md must preserve the [4.3.0] history entry"
 
 
-def test_changelog_section_order_unreleased_then_4_3_0_then_4_2_1() -> None:
-    """Heading order MUST be [Unreleased] above [4.3.0] above [4.2.1] so
+def test_changelog_section_order_unreleased_then_4_3_1_then_4_3_0() -> None:
+    """Heading order MUST be [Unreleased] above [4.3.1] above [4.3.0] so
     future PRs keep dogfooding the per-PR Keep-a-Changelog discipline and
     release history stays newest-first."""
 
     text = _CHANGELOG.read_text(encoding="utf-8")
     unreleased_idx = text.find("## [Unreleased]")
+    v431_idx = text.find("## [4.3.1]")
     v430_idx = text.find("## [4.3.0]")
-    v421_idx = text.find("## [4.2.1]")
     assert unreleased_idx >= 0
-    assert v430_idx > unreleased_idx, "[Unreleased] heading MUST appear above [4.3.0]"
-    assert v421_idx > v430_idx, "[4.3.0] heading MUST appear above [4.2.1]"
+    assert v431_idx > unreleased_idx, "[Unreleased] heading MUST appear above [4.3.1]"
+    assert v430_idx > v431_idx, "[4.3.1] heading MUST appear above [4.3.0]"
 
 
 def test_release_keeps_guard_flags_false() -> None:


### PR DESCRIPTION
## Summary
- bump ao-kernel package/version surfaces to 4.3.1
- move the internal_gate_host_health_probe URL secret-scrubbing fix into a 4.3.1 changelog entry
- update install, Helm, production deployment, and PyPI publish runbook/checklist pins to 4.3.1

## Verification
- python3 -m pytest tests/test_v431_version_pin.py tests/test_pr_a6_features.py tests/test_internal_gate_host_health_probe.py tests/test_epic_4_1_helm_chart_skeleton.py -q
- python3 scripts/packaging_smoke.py
- python3 -m twine check dist/*.whl dist/*.tar.gz
- python3 -m pytest tests/test_operator_runbooks.py tests/test_using_ao_kernel_in_your_project_doc.py -q
- git diff --check

## Release boundary
- Patch release only: security/secret-scrubbing fix after 4.3.0
- No V5 promotion
- No support_widening, production_platform_claim, or live_adapter_execution flag change
- PyPI publish dispatch remains operator-runbook controlled