### PR TITLE
Add product release manifest SSOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **Product release manifest SSOT**: added a bundled
+  `ao_kernel/defaults/release/product-release-manifest.v1.json` that makes the
+  user/operator-facing product version explicit for `ao-kernel` 4.3.1 while
+  keeping Helm chart, schema/policy contract, and V5 roadmap lifecycle versions
+  separate by design. Tests now bind the manifest to package/import/CLI version,
+  install docs, Helm `appVersion`/image tag, and operator publish ref. Publish
+  remains operator-pending; no guard flag flip, support widening, production
+  platform claim, or live adapter execution.
 - **v4.3.1 release metadata prep**: aligned package version, CLI version
   reporting, Helm tags, install/deploy docs, PyPI publish runbook/checklist,
   and release version-pin tests for the v4.3.1 patch release. This is release

--- a/ao_kernel/defaults/release/__init__.py
+++ b/ao_kernel/defaults/release/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled release metadata for operator and consumer version alignment."""

--- a/ao_kernel/defaults/release/product-release-manifest.v1.json
+++ b/ao_kernel/defaults/release/product-release-manifest.v1.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "product-release-manifest.v1",
+  "artifact_kind": "product_release_manifest",
+  "product": "ao-kernel",
+  "product_version": "4.3.1",
+  "release_line": "v4",
+  "published_package": {
+    "name": "ao-kernel",
+    "version": "4.3.1",
+    "pypi_project_url": "https://pypi.org/project/ao-kernel/4.3.1/",
+    "publish_status": "operator_publish_pending",
+    "operator_publish_ref": "refs/tags/v4.3.1"
+  },
+  "components": {
+    "python_package": "4.3.1",
+    "cli": "4.3.1",
+    "helm_app_version": "4.3.1",
+    "docs_install_pin": "4.3.1",
+    "operator_publish_ref": "refs/tags/v4.3.1"
+  },
+  "not_equalized_by_design": {
+    "helm_chart_version": "chart package lifecycle; keep deploy/helm/ao-kernel/Chart.yaml::version independent from appVersion",
+    "json_schema_versions": "contract lifecycle; do not rewrite *.schema.v1.json just to match product_version",
+    "policy_versions": "contract lifecycle; do not rewrite policy_*.v1.json just to match product_version",
+    "v5": "roadmap/promotion line; not a published package version until a future operator-bound promotion release"
+  },
+  "guard_flags": {
+    "support_widening": false,
+    "production_platform_claim": false,
+    "live_adapter_execution": false
+  },
+  "release_authority": {
+    "source_ready_authority": "ao-release-gate+github-ruleset",
+    "publish_authority": "operator-runbook",
+    "ai_output_release_authority": false
+  }
+}

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,4 +1,27 @@
 {
+  "schema_version": "local-ai-review-evidence.v1",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "GPP-9",
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
+  "reviewer": {
+    "agent": "claude-code",
+    "provider": "anthropic",
+    "verdict": "AGREE"
+  },
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "head_ref": "refs/heads/codex/release-manifest-ssot",
+    "changed_files": [
+      "CHANGELOG.md",
+      "ao_kernel/defaults/release/__init__.py",
+      "ao_kernel/defaults/release/product-release-manifest.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "tests/test_release_manifest_ssot.py"
+    ]
+  },
   "checks_considered": [
     {
       "name": "tests",
@@ -9,70 +32,22 @@
       "status": "pass"
     },
     {
-      "name": "version_pin_consistency",
-      "status": "pass"
-    },
-    {
       "name": "guard_flags",
       "status": "pass"
     },
     {
-      "name": "operator_boundary",
-      "status": "pass"
-    },
-    {
-      "name": "changelog_discipline",
-      "status": "pass"
-    },
-    {
-      "name": "packaging_smoke",
+      "name": "release_boundary",
       "status": "pass"
     }
   ],
   "findings": [
-    "Anthropic CLI review verdict AGREE for REL-4-3-1: version pins are internally consistent across pyproject.toml, ao_kernel.__version__, Helm appVersion/image tag, install docs, deployment docs, operator runbook/checklist, and release version-pin tests.",
-    "The change is release metadata only for ao-kernel 4.3.1; it does not promote V5, widen support, claim production-platform readiness, or execute live adapters.",
-    "Operator publish boundary is preserved: runbooks require operator dispatch for publish.yml against refs/tags/v4.3.1, and the agent did not push a release tag or dispatch the publish workflow.",
-    "No credential material, API keys, tokens, or secrets were found in the reviewed diff; checklist fields keep credential_material_committed=false and agent_executed_external_action=false.",
-    "Changelog discipline is acceptable: [Unreleased] remains above [4.3.1], [4.3.0] history is preserved, and the v4.3.1 release entry documents the URL secret-scrubbing fix.",
-    "Local verification and PR checks passed for changelog, CodeQL, Trivy, lint, typecheck, Python 3.11/3.12/3.13 tests, coverage, benchmark-fast, packaging-smoke, scorecard, twine check, and targeted release/runbook tests."
+    "Claude review: product release manifest boundary and operator-pending publish status are correct.",
+    "Claude review: tests bind the manifest to package, import/CLI version, Helm appVersion/tag, install docs, and operator publish ref.",
+    "Claude review: no secrets, live adapter execution, support widening, or production platform claim were introduced.",
+    "Claude review: initial tautological v5 assertion was removed before final evidence."
   ],
-  "implementer": {
-    "agent": "codex",
-    "provider": "openai"
-  },
-  "live_adapter_execution": false,
-  "production_platform_claim": false,
-  "repo": "Halildeu/ao-kernel",
-  "reviewer": {
-    "agent": "anthropic-release-reviewer",
-    "provider": "anthropic",
-    "verdict": "AGREE"
-  },
-  "schema_version": "local-ai-review-evidence.v1",
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "changed_files": [
-      "CHANGELOG.md",
-      "README.md",
-      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/__init__.py",
-      "deploy/helm/ao-kernel/Chart.yaml",
-      "deploy/helm/ao-kernel/values.yaml",
-      "docs/PRODUCTION-DEPLOYMENT-GUIDE.md",
-      "docs/USING-AO-KERNEL-IN-YOUR-PROJECT.md",
-      "docs/operator-runbooks/01-pypi-publish.md",
-      "docs/operator-runbooks/README.md",
-      "docs/operator-runbooks/operator-action-checklist.v1.json",
-      "local-ai-review-evidence.v1.json",
-      "pyproject.toml",
-      "tests/test_pr_a6_features.py",
-      "tests/test_v431_version_pin.py"
-    ],
-    "head_ref": "refs/heads/codex/release-4.3.1"
-  },
   "secrets_recorded": false,
+  "live_adapter_execution": false,
   "support_widening": false,
-  "work_package": "REL-4-3-1"
+  "production_platform_claim": false
 }

--- a/tests/test_release_manifest_ssot.py
+++ b/tests/test_release_manifest_ssot.py
@@ -1,0 +1,131 @@
+"""Product release manifest SSOT tests.
+
+The bundled manifest is the consumer/operator-facing version alignment surface:
+it pins the published product version and the install/deploy surfaces that must
+move with it. Contract versions such as schema/policy v1 and roadmap lines such
+as V5 remain independent lifecycle markers by design.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import json
+import tomllib
+from pathlib import Path
+
+import yaml
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MANIFEST = _REPO_ROOT / "ao_kernel" / "defaults" / "release" / "product-release-manifest.v1.json"
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+
+def _load_manifest() -> dict:
+    return json.loads(_MANIFEST.read_text(encoding="utf-8"))
+
+
+def _load_pyproject() -> dict:
+    with _PYPROJECT.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def _load_chart() -> dict:
+    return yaml.safe_load((_REPO_ROOT / "deploy" / "helm" / "ao-kernel" / "Chart.yaml").read_text(encoding="utf-8"))
+
+
+def _load_values() -> dict:
+    return yaml.safe_load((_REPO_ROOT / "deploy" / "helm" / "ao-kernel" / "values.yaml").read_text(encoding="utf-8"))
+
+
+def _load_operator_checklist() -> dict:
+    return json.loads(
+        (_REPO_ROOT / "docs" / "operator-runbooks" / "operator-action-checklist.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+def test_release_manifest_shape_and_authority_boundary() -> None:
+    manifest = _load_manifest()
+
+    assert manifest["schema_version"] == "product-release-manifest.v1"
+    assert manifest["artifact_kind"] == "product_release_manifest"
+    assert manifest["product"] == "ao-kernel"
+    assert manifest["release_line"] == "v4"
+    assert manifest["published_package"]["publish_status"] == "operator_publish_pending"
+    assert manifest["release_authority"] == {
+        "source_ready_authority": "ao-release-gate+github-ruleset",
+        "publish_authority": "operator-runbook",
+        "ai_output_release_authority": False,
+    }
+
+
+def test_release_manifest_is_packaged_as_importlib_resource() -> None:
+    data = (
+        importlib.resources.files("ao_kernel.defaults.release")
+        .joinpath("product-release-manifest.v1.json")
+        .read_text(encoding="utf-8")
+    )
+
+    assert json.loads(data) == _load_manifest()
+
+
+def test_product_version_matches_python_package_and_cli_surfaces() -> None:
+    import ao_kernel
+
+    manifest = _load_manifest()
+    pyproject = _load_pyproject()
+    product_version = manifest["product_version"]
+
+    assert product_version == "4.3.1"
+    assert pyproject["project"]["name"] == manifest["published_package"]["name"]
+    assert pyproject["project"]["version"] == product_version
+    assert ao_kernel.__version__ == product_version
+    assert manifest["published_package"]["version"] == product_version
+    assert manifest["components"]["python_package"] == product_version
+    assert manifest["components"]["cli"] == product_version
+
+
+def test_product_version_matches_install_docs_helm_app_and_operator_publish_ref() -> None:
+    manifest = _load_manifest()
+    version = manifest["product_version"]
+    tag_ref = f"refs/tags/v{version}"
+
+    onboarding = (_REPO_ROOT / "docs" / "USING-AO-KERNEL-IN-YOUR-PROJECT.md").read_text(encoding="utf-8")
+    assert f"ao-kernel=={version}" in onboarding
+    assert manifest["components"]["docs_install_pin"] == version
+
+    chart = _load_chart()
+    values = _load_values()
+    assert chart["appVersion"] == version
+    assert values["image"]["tag"] == version
+    assert manifest["components"]["helm_app_version"] == version
+
+    checklist = _load_operator_checklist()
+    publish_action = next(action for action in checklist["actions"] if action["id"] == "p0-1-pypi-publish")
+    assert publish_action["dispatch_inputs"]["ref"] == tag_ref
+    assert any(f"/{version}/" in artifact for artifact in publish_action["expected_artifacts"])
+    assert manifest["published_package"]["operator_publish_ref"] == tag_ref
+    assert manifest["components"]["operator_publish_ref"] == tag_ref
+    assert manifest["published_package"]["pypi_project_url"].endswith(f"/{version}/")
+
+
+def test_non_product_versions_are_declared_not_equalized_by_design() -> None:
+    manifest = _load_manifest()
+    chart = _load_chart()
+    not_equalized = manifest["not_equalized_by_design"]
+
+    assert chart["version"] != manifest["product_version"]
+    assert "helm_chart_version" in not_equalized
+    assert "json_schema_versions" in not_equalized
+    assert "policy_versions" in not_equalized
+    assert "v5" in not_equalized
+
+
+def test_manifest_keeps_release_guard_flags_false() -> None:
+    assert _load_manifest()["guard_flags"] == {
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+    }


### PR DESCRIPTION
## Summary
- add bundled product release manifest for ao-kernel 4.3.1
- keep Helm chart/schema/policy/V5 lifecycle versions explicitly not equalized by design
- add tests that bind product version to package, CLI/import version, install docs, Helm appVersion/tag, and operator publish ref
- refresh root local AI review evidence for this PR after Claude final review

## Local evidence
- python3 -m pytest tests/test_release_manifest_ssot.py tests/test_v431_version_pin.py -q
- python3 -m ruff check tests/test_release_manifest_ssot.py
- git diff --check
- python3 -m build --wheel --outdir /tmp/ao-kernel-release-manifest-wheel; manifest present in wheel
- python3 scripts/packaging_smoke.py
- ao-kernel quality check-changelog: decision=pass
- scripts/local_gpp_gate.py: decision=operator_may_merge; changed_files_count=5; head_sha=b2235b706ef26bf74d62e540f51905add6791613
- Claude Code (Anthropic) final review: Verdict=AGREE; Secret risk=no; Guard flags unchanged=yes

## Release boundary
- publish_status remains operator_publish_pending
- no PyPI publish, tag dispatch, live adapter execution, support widening, or production-platform claim