### PR TITLE
[codex] Redact secret-like files from repo intelligence scans

### DIFF
--- a/.claude/plans/RI-7.5-OPERATOR-VERIFIED-RUNTIME-SEMANTICS.v1.json
+++ b/.claude/plans/RI-7.5-OPERATOR-VERIFIED-RUNTIME-SEMANTICS.v1.json
@@ -31,7 +31,7 @@
       "evidence_class": "operator_script_verified",
       "script_ref": "scripts/ri7_operator_verified_runtime_semantics.py::_verify_no_root_authority_file_write",
       "result_summary": "repo_intelligence private modules confine writes to .ao/context (manifest) and RI-5b exporter (token-gated create-only)",
-      "sha256": "007a8cbb3d82248f459fae4e88b2475715e999c01a67c0994e5fd77939cd86b0"
+      "sha256": "f5dfec19d0f1179340a4a4fa59a5799f565358bc76c1c7149edb7f12d9bbdb46"
     },
     {
       "id": "no_mcp_repo_intelligence_tool_exposed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **Repo-intelligence secret-aware scanning**: `repo scan` now excludes
+  secret-like paths and high-confidence token/private-key content from generated
+  context artifacts, recording only metadata under `secret_redaction` in
+  `repo_map.json`. Agent packs report the redacted-file count, while secret
+  values remain absent from repo maps and handoff packs. No vector writes, root
+  export, live GitHub/ProjectV2 mutation, support widening, production platform
+  claim, or live adapter execution.
 - **Product release manifest SSOT**: added a bundled
   `ao_kernel/defaults/release/product-release-manifest.v1.json` that makes the
   user/operator-facing product version explicit for `ao-kernel` 4.3.1 while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Repo-intelligence secret-aware scanning**: `repo scan` now excludes
   secret-like paths and high-confidence token/private-key content from generated
   context artifacts, recording only metadata under `secret_redaction` in
-  `repo_map.json`. Agent packs report the redacted-file count, while secret
-  values remain absent from repo maps and handoff packs. No vector writes, root
-  export, live GitHub/ProjectV2 mutation, support widening, production platform
-  claim, or live adapter execution.
+  `repo_map.json`. Agent packs report the redacted-file count, while the CLI
+  stdout summary stays artifact-pointer-only and secret values remain absent
+  from repo maps and handoff packs. No vector writes, root export, live
+  GitHub/ProjectV2 mutation, support widening, production platform claim, or
+  live adapter execution.
 - **Product release manifest SSOT**: added a bundled
   `ao_kernel/defaults/release/product-release-manifest.v1.json` that makes the
   user/operator-facing product version explicit for `ao-kernel` 4.3.1 while

--- a/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json
@@ -7,45 +7,25 @@
     {
       "name": "secret_scan",
       "status": "pass"
-    },
-    {
-      "name": "version_pin_consistency",
-      "status": "pass"
-    },
-    {
-      "name": "guard_flags",
-      "status": "pass"
-    },
-    {
-      "name": "v5_overclaim",
-      "status": "pass"
-    },
-    {
-      "name": "operator_boundary",
-      "status": "pass"
-    },
-    {
-      "name": "changelog_discipline",
-      "status": "pass"
-    },
-    {
-      "name": "helm_metadata",
-      "status": "pass"
-    },
-    {
-      "name": "pypi_publish_dispatch_boundary",
-      "status": "pass"
     }
   ],
   "findings": [
-    "Anthropic Claude CLI review verdict AGREE for REL-4-3-1: all version pins are internally consistent for 4.3.1 across package metadata, CLI version reporting, Helm metadata, install/deploy docs, operator runbooks, checklist, and tests.",
-    "Guard flags remain closed: no support widening, no production platform claim, no live adapter execution, and no V5 promotion language is introduced.",
-    "No credential material, API keys, tokens, or secrets were detected in the reviewed diff.",
-    "Operator publish boundary is maintained: the runbook directs operator dispatch of publish.yml, and the PR does not push a tag or dispatch publishing.",
-    "CHANGELOG order is acceptable with [Unreleased] above [4.3.1] above [4.3.0]; the release entry documents the URL secret-scrubbing fix and preserves prior history.",
-    "Helm chart semver remains unchanged while appVersion and image tag are bumped to 4.3.1, matching manual pin discipline.",
-    "The v4.3.1 version-pin test file verifies pyproject, __version__, changelog order, guard flags, install docs, Helm tag, and operator publish checklist against the release version.",
-    "Rollback guidance uses the next corrective patch pattern v4.3.2 and avoids destructive package deletion."
+    "Work package RI-SECRET-AWARE-SCANNER matches diff scope: new secret_scan.py module, scanner.py integration, schema extension, CLI summary hardening, and tests",
+    "New secret_scan.py records only metadata (pattern_ids, scan_status, reason) \u2014 never matched values, line content, or snippets",
+    "Schema repo-map.schema.v1.json adds secret_redaction with const guards: metadata_only=true, secrets_recorded=false, action=excluded_from_context",
+    "CLI stdout summary changed to artifact-pointer-only (details_path instead of inline summary counts), preventing accidental secret leakage through CLI output",
+    "Content patterns cover private keys (RSA/EC/OPENSSH/DSA/PGP), OpenAI API keys, GitHub PATs (classic+fine-grained), AWS access key IDs \u2014 reasonable high-confidence set",
+    "Path patterns cover .env, *.pem, *.key, *.p12, *.pfx, SSH key files, secrets.*, credentials.* \u2014 standard secret-like paths",
+    "Two-phase scan: path-match first (no read needed), then content-match with 5MB cap and graceful OSError handling",
+    "Tests verify secret values do not appear in serialized repo_map or CLI stdout output",
+    "RI-7.5 plan artifact change is SHA256 update for no_root_authority_file_write invariant plus trailing newline fix \u2014 consistent with new write surface in scanner",
+    "No vector writes introduced \u2014 scan path remains read-only",
+    "No root export, no MCP tool exposure, no live GitHub/ProjectV2 mutation",
+    "No support_widening, production_platform_claim, or live_adapter_execution flip",
+    "Guard flags in plan artifact remain false",
+    "No __init__.py or public facade export added for secret_scan \u2014 stays in _internal",
+    "Chunker test updated: .env now excluded at scanner level (secret_redaction) rather than chunker level (chunk_secret_like_skipped) \u2014 correct layering shift",
+    "context_pack_builder.py adds secret_redacted_files row to summary table \u2014 metadata only, no values"
   ],
   "implementer": {
     "agent": "codex",
@@ -55,7 +35,7 @@
   "production_platform_claim": false,
   "repo": "Halildeu/ao-kernel",
   "reviewer": {
-    "agent": "anthropic-release-reviewer",
+    "agent": "anthropic-claude-reviewer",
     "provider": "anthropic",
     "verdict": "AGREE"
   },
@@ -63,26 +43,23 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
+      ".claude/plans/RI-7.5-OPERATOR-VERIFIED-RUNTIME-SEMANTICS.v1.json",
       "CHANGELOG.md",
-      "README.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/__init__.py",
-      "deploy/helm/ao-kernel/Chart.yaml",
-      "deploy/helm/ao-kernel/values.yaml",
-      "docs/PRODUCTION-DEPLOYMENT-GUIDE.md",
-      "docs/USING-AO-KERNEL-IN-YOUR-PROJECT.md",
-      "docs/operator-runbooks/01-pypi-publish.md",
-      "docs/operator-runbooks/README.md",
-      "docs/operator-runbooks/operator-action-checklist.v1.json",
+      "ao_kernel/_internal/repo_intelligence/context_pack_builder.py",
+      "ao_kernel/_internal/repo_intelligence/scanner.py",
+      "ao_kernel/_internal/repo_intelligence/secret_scan.py",
+      "ao_kernel/cli.py",
+      "ao_kernel/defaults/schemas/repo-map.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "pyproject.toml",
-      "tests/test_pr_a6_features.py",
-      "tests/test_v431_version_pin.py"
+      "tests/test_cli_repo_scan.py",
+      "tests/test_repo_intelligence_chunker.py",
+      "tests/test_repo_intelligence_scanner.py"
     ],
-    "head_ref": "refs/heads/codex/release-4.3.1"
+    "head_ref": "refs/heads/codex/ri-secret-aware-scanner"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "REL-4-3-1"
+  "work_package": "RI-SECRET-AWARE-SCANNER"
 }

--- a/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json
@@ -9,7 +9,7 @@
       "status": "pass"
     },
     {
-      "name": "version_pin_consistency",
+      "name": "codeql",
       "status": "pass"
     },
     {
@@ -17,21 +17,17 @@
       "status": "pass"
     },
     {
-      "name": "operator_boundary",
-      "status": "pass"
-    },
-    {
-      "name": "packaging_smoke",
+      "name": "release_boundary",
       "status": "pass"
     }
   ],
   "findings": [
-    "OpenAI Codex review verdict AGREE for REL-4-3-1: pyproject.toml and ao_kernel.__version__ both report 4.3.1, and release-facing docs/tests pin the same version.",
-    "The release prep is a narrow patch metadata update carrying the already-merged URL secret-scrubbing fix; it does not add runtime behavior beyond version/reporting/install/deploy pins.",
-    "README and operator runbooks correctly say the package is prepared for PyPI and keep publish as an operator-controlled workflow dispatch after tag/ref verification.",
-    "Helm changes are limited to appVersion and image tag 4.3.1; chart semver and guard boundaries remain unchanged.",
-    "No V5 promotion, support widening, production platform claim, live adapter execution, workflow dispatch, release tag push, or credential commit is introduced.",
-    "Local and GitHub verification passed for changelog enforcement, targeted release tests, runbook tests, packaging smoke, twine check, CodeQL, Trivy, lint, typecheck, Python test matrix, coverage, benchmark-fast, and scorecard."
+    "OpenAI Codex review verdict AGREE: repo-intelligence secret-aware scanner excludes secret-like paths and high-confidence token/private-key content from generated context artifacts.",
+    "OpenAI Codex review: CLI stdout is artifact-pointer-only for scan details; redaction counts and records remain in .ao/context/repo_map.json metadata.",
+    "OpenAI Codex review: local gates passed for ruff, focused pytest, changelog discipline, and whitespace; GitHub CI passed CodeQL, tests, coverage, packaging, Trivy, lint, and typecheck before release-gate metadata binding.",
+    "OpenAI Codex review: no vector write, root export, live GitHub/ProjectV2 mutation, support widening, production platform claim, or live adapter execution is introduced.",
+    "OpenAI Codex review: reviewed 10 changed file(s).",
+    "OpenAI Codex review: high-risk path classifier flagged 1 path(s); release authority remains ao-release-gate plus GitHub ruleset."
   ],
   "implementer": {
     "agent": "codex",
@@ -41,7 +37,7 @@
   "production_platform_claim": false,
   "repo": "Halildeu/ao-kernel",
   "reviewer": {
-    "agent": "codex-release-reviewer",
+    "agent": "codex-reviewer",
     "provider": "openai",
     "verdict": "AGREE"
   },
@@ -49,26 +45,23 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
+      ".claude/plans/RI-7.5-OPERATOR-VERIFIED-RUNTIME-SEMANTICS.v1.json",
       "CHANGELOG.md",
-      "README.md",
       "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
       "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
-      "ao_kernel/__init__.py",
-      "deploy/helm/ao-kernel/Chart.yaml",
-      "deploy/helm/ao-kernel/values.yaml",
-      "docs/PRODUCTION-DEPLOYMENT-GUIDE.md",
-      "docs/USING-AO-KERNEL-IN-YOUR-PROJECT.md",
-      "docs/operator-runbooks/01-pypi-publish.md",
-      "docs/operator-runbooks/README.md",
-      "docs/operator-runbooks/operator-action-checklist.v1.json",
+      "ao_kernel/_internal/repo_intelligence/context_pack_builder.py",
+      "ao_kernel/_internal/repo_intelligence/scanner.py",
+      "ao_kernel/_internal/repo_intelligence/secret_scan.py",
+      "ao_kernel/cli.py",
+      "ao_kernel/defaults/schemas/repo-map.schema.v1.json",
       "local-ai-review-evidence.v1.json",
-      "pyproject.toml",
-      "tests/test_pr_a6_features.py",
-      "tests/test_v431_version_pin.py"
+      "tests/test_cli_repo_scan.py",
+      "tests/test_repo_intelligence_chunker.py",
+      "tests/test_repo_intelligence_scanner.py"
     ],
-    "head_ref": "refs/heads/codex/release-4.3.1"
+    "head_ref": "refs/heads/codex/ri-secret-aware-scanner"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "REL-4-3-1"
+  "work_package": "RI-SECRET-AWARE-SCANNER"
 }

--- a/ao_kernel/_internal/repo_intelligence/context_pack_builder.py
+++ b/ao_kernel/_internal/repo_intelligence/context_pack_builder.py
@@ -107,6 +107,7 @@ def _append_summary(
         ("Included files", _int(repo_summary.get("included_files"))),
         ("Included directories", _int(repo_summary.get("included_directories"))),
         ("Ignored paths", _int(repo_summary.get("ignored_paths"))),
+        ("Secret-redacted files", _int(repo_summary.get("secret_redacted_files"))),
         ("Repo diagnostics", _int(repo_summary.get("diagnostics"))),
         ("Python packages", _int(repo_summary.get("python_packages"))),
         ("Python modules", _int(repo_summary.get("python_modules"))),

--- a/ao_kernel/_internal/repo_intelligence/scanner.py
+++ b/ao_kernel/_internal/repo_intelligence/scanner.py
@@ -11,6 +11,11 @@ from typing import Any
 import ao_kernel
 from ao_kernel._internal.repo_intelligence.ignore_rules import should_ignore_path
 from ao_kernel._internal.repo_intelligence.language_detector import detect_language
+from ao_kernel._internal.repo_intelligence.secret_scan import (
+    SECRET_SCAN_MAX_BYTES,
+    active_secret_pattern_ids,
+    decide_secret_redaction,
+)
 from ao_kernel._internal.shared.utils import now_iso8601
 
 JsonDict = dict[str, Any]
@@ -25,6 +30,7 @@ def scan_repo(project_root: str | Path) -> JsonDict:
     included_files: list[JsonDict] = []
     ignored_paths: list[JsonDict] = []
     diagnostics: list[JsonDict] = []
+    secret_redactions: list[JsonDict] = []
     directories: set[str] = set()
 
     stack = [root]
@@ -68,6 +74,42 @@ def scan_repo(project_root: str | Path) -> JsonDict:
             try:
                 if entry.is_file():
                     stat = entry.stat()
+                    secret_decision = decide_secret_redaction(
+                        rel_path,
+                        content=None,
+                        size_bytes=stat.st_size,
+                    )
+                    if not secret_decision.redacted:
+                        content = _read_secret_scan_bytes(
+                            entry,
+                            rel_path=rel_path,
+                            size_bytes=stat.st_size,
+                            diagnostics=diagnostics,
+                        )
+                        secret_decision = decide_secret_redaction(
+                            rel_path,
+                            content=content,
+                            size_bytes=stat.st_size,
+                        )
+                    if secret_decision.redacted:
+                        ignored_paths.append(
+                            {
+                                "path": rel_path,
+                                "kind": "file",
+                                "reason": secret_decision.reason or "secret_redaction:file",
+                            }
+                        )
+                        secret_redactions.append(
+                            {
+                                "path": rel_path,
+                                "kind": "file",
+                                "action": "excluded_from_context",
+                                "reason": secret_decision.reason or "secret_redaction:file",
+                                "pattern_ids": list(secret_decision.pattern_ids),
+                                "scan_status": secret_decision.scan_status,
+                            }
+                        )
+                        continue
                     included_files.append(
                         {
                             "path": rel_path,
@@ -83,6 +125,7 @@ def scan_repo(project_root: str | Path) -> JsonDict:
 
     included_files.sort(key=lambda item: str(item["path"]))
     ignored_paths.sort(key=lambda item: str(item["path"]))
+    secret_redactions.sort(key=lambda item: str(item["path"]))
     diagnostics.sort(key=lambda item: str(item["path"]))
     parsed_pyproject = _load_pyproject(root, included_files, diagnostics)
     diagnostics.sort(key=lambda item: str(item["path"]))
@@ -103,6 +146,7 @@ def scan_repo(project_root: str | Path) -> JsonDict:
             "included_files": len(included_files),
             "included_directories": len(directories),
             "ignored_paths": len(ignored_paths),
+            "secret_redacted_files": len(secret_redactions),
             "diagnostics": len(diagnostics),
             "languages": dict(sorted(language_counts.items())),
             "python_packages": sum(1 for item in python_candidates if item["kind"] == "package"),
@@ -123,6 +167,17 @@ def scan_repo(project_root: str | Path) -> JsonDict:
             ],
             "paths": ignored_paths,
         },
+        "secret_redaction": {
+            "mode": "exclude_file",
+            "max_scan_bytes": SECRET_SCAN_MAX_BYTES,
+            "patterns": list(active_secret_pattern_ids()),
+            "summary": {
+                "redacted_files": len(secret_redactions),
+                "metadata_only": True,
+                "secrets_recorded": False,
+            },
+            "records": secret_redactions,
+        },
         "languages": dict(sorted(language_counts.items())),
         "python": {
             "candidates": python_candidates,
@@ -140,6 +195,22 @@ def _repo_relative_posix(path: Path, root: Path) -> str:
 
 def _diagnostic(path: str, code: str, message: str) -> JsonDict:
     return {"path": path, "code": code, "message": message}
+
+
+def _read_secret_scan_bytes(
+    path: Path,
+    *,
+    rel_path: str,
+    size_bytes: int,
+    diagnostics: list[JsonDict],
+) -> bytes | None:
+    if size_bytes > SECRET_SCAN_MAX_BYTES:
+        return None
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        diagnostics.append(_diagnostic(rel_path, "secret_scan_unreadable", str(exc)))
+        return None
 
 
 def _load_pyproject(root: Path, included_files: list[JsonDict], diagnostics: list[JsonDict]) -> JsonDict:

--- a/ao_kernel/_internal/repo_intelligence/secret_scan.py
+++ b/ao_kernel/_internal/repo_intelligence/secret_scan.py
@@ -1,0 +1,119 @@
+"""Secret-aware exclusion helpers for repo-intelligence scans."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+from pathlib import PurePosixPath
+
+SECRET_SCAN_MAX_BYTES = 5_000_000
+
+SECRET_LIKE_PATH_PATTERNS: tuple[str, ...] = (
+    ".env",
+    ".env.*",
+    "*.pem",
+    "*.key",
+    "*.p12",
+    "*.pfx",
+    "id_rsa",
+    "id_dsa",
+    "id_ed25519",
+    "secrets.*",
+    "credentials.*",
+)
+
+
+@dataclass(frozen=True)
+class SecretPattern:
+    pattern_id: str
+    expression: re.Pattern[bytes]
+
+
+CONTENT_PATTERNS: tuple[SecretPattern, ...] = (
+    SecretPattern("private_key_block", re.compile(rb"-----BEGIN (?:RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----")),
+    SecretPattern("pgp_private_key_block", re.compile(rb"-----BEGIN PGP PRIVATE KEY BLOCK-----")),
+    SecretPattern("openai_api_key_like", re.compile(rb"sk-[A-Za-z0-9_-]{20,}")),
+    SecretPattern("github_classic_pat_like", re.compile(rb"ghp_[A-Za-z0-9_]{20,}")),
+    SecretPattern("github_fine_grained_pat_like", re.compile(rb"github_pat_[A-Za-z0-9_]{20,}")),
+    SecretPattern("aws_access_key_id_like", re.compile(rb"AKIA[0-9A-Z]{16}")),
+)
+
+
+@dataclass(frozen=True)
+class SecretScanDecision:
+    redacted: bool
+    reason: str | None = None
+    pattern_ids: tuple[str, ...] = ()
+    scan_status: str = "not_applicable"
+
+
+def decide_secret_redaction(
+    repo_relative_path: str,
+    *,
+    content: bytes | None,
+    size_bytes: int,
+) -> SecretScanDecision:
+    """Return whether a file must be excluded from RI context artifacts.
+
+    The decision is metadata-only. It returns pattern identifiers, never
+    matched values, line content, or snippets.
+    """
+    path_match = _match_secret_like_path(repo_relative_path)
+    if path_match is not None:
+        return SecretScanDecision(
+            redacted=True,
+            reason=f"secret_redaction:path:{path_match}:file",
+            pattern_ids=(f"path:{path_match}",),
+            scan_status="path_match",
+        )
+    if content is None:
+        return SecretScanDecision(
+            redacted=False,
+            scan_status="content_not_read",
+        )
+    if size_bytes > SECRET_SCAN_MAX_BYTES:
+        return SecretScanDecision(
+            redacted=False,
+            scan_status="content_too_large",
+        )
+    pattern_ids = tuple(pattern.pattern_id for pattern in CONTENT_PATTERNS if pattern.expression.search(content))
+    if pattern_ids:
+        return SecretScanDecision(
+            redacted=True,
+            reason="secret_redaction:content:file",
+            pattern_ids=pattern_ids,
+            scan_status="content_match",
+        )
+    return SecretScanDecision(redacted=False, scan_status="clean")
+
+
+def active_secret_pattern_ids() -> tuple[str, ...]:
+    path_ids = tuple(f"path:{pattern}" for pattern in SECRET_LIKE_PATH_PATTERNS)
+    content_ids = tuple(pattern.pattern_id for pattern in CONTENT_PATTERNS)
+    return (*path_ids, *content_ids)
+
+
+def _match_secret_like_path(repo_relative_path: str) -> str | None:
+    normalized = repo_relative_path.strip("/")
+    if not normalized:
+        return None
+    path = PurePosixPath(normalized)
+    parts = tuple(part for part in path.parts if part)
+    name = path.name
+    for pattern in SECRET_LIKE_PATH_PATTERNS:
+        if "/" in pattern:
+            if fnmatchcase(normalized, pattern):
+                return pattern
+            continue
+        if any(part == pattern for part in parts) or fnmatchcase(name, pattern):
+            return pattern
+    return None
+
+
+__all__ = [
+    "SECRET_SCAN_MAX_BYTES",
+    "SecretScanDecision",
+    "active_secret_pattern_ids",
+    "decide_secret_redaction",
+]

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -119,12 +119,13 @@ def _cmd_repo_scan(args: argparse.Namespace) -> int:
         repo_chunks=repo_chunks,
         agent_pack=agent_pack,
     )
+    cli_summary = _repo_scan_cli_summary(repo_map.get("summary"))
     summary = {
         "status": "ok",
         "command": "repo scan",
         "project_root": ".",
         "project_root_name": project_root.name,
-        "summary": repo_map["summary"],
+        "summary": cli_summary,
         "artifacts": write_result["artifacts"],
     }
     if args.output == "json":
@@ -132,11 +133,39 @@ def _cmd_repo_scan(args: argparse.Namespace) -> int:
     else:
         print("repo scan complete")
         print("project_root: .")
-        print(f"included_files: {repo_map['summary']['included_files']}")
+        print(f"included_files: {cli_summary['included_files']}")
         print("artifacts:")
         for artifact in write_result["artifacts"]:
             print(f"- {artifact['path']}")
     return 0
+
+
+def _repo_scan_cli_summary(repo_summary: Any) -> dict[str, Any]:
+    if not isinstance(repo_summary, dict):
+        repo_summary = {}
+    raw_languages = repo_summary.get("languages")
+    languages: dict[str, int] = {}
+    if isinstance(raw_languages, dict):
+        languages = {str(name): _nonnegative_int(count) for name, count in raw_languages.items()}
+    return {
+        "included_files": _nonnegative_int(repo_summary.get("included_files")),
+        "included_directories": _nonnegative_int(repo_summary.get("included_directories")),
+        "ignored_paths": _nonnegative_int(repo_summary.get("ignored_paths")),
+        "secret_redacted_files": _nonnegative_int(repo_summary.get("secret_redacted_files")),
+        "diagnostics": _nonnegative_int(repo_summary.get("diagnostics")),
+        "languages": languages,
+        "python_packages": _nonnegative_int(repo_summary.get("python_packages")),
+        "python_modules": _nonnegative_int(repo_summary.get("python_modules")),
+        "python_entrypoints": _nonnegative_int(repo_summary.get("python_entrypoints")),
+    }
+
+
+def _nonnegative_int(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(parsed, 0)
 
 
 def _cmd_repo_index(args: argparse.Namespace) -> int:

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -111,7 +111,7 @@ def _cmd_repo_scan(args: argparse.Namespace) -> int:
         symbol_index=symbol_index,
         repo_chunks=repo_chunks,
     )
-    write_result = write_repo_scan_artifacts(
+    write_repo_scan_artifacts(
         context_dir=context_dir,
         repo_map=repo_map,
         import_graph=import_graph,
@@ -120,13 +120,14 @@ def _cmd_repo_scan(args: argparse.Namespace) -> int:
         agent_pack=agent_pack,
     )
     cli_summary = _repo_scan_cli_summary(repo_map.get("summary"))
+    cli_artifacts = _repo_scan_cli_artifacts()
     summary = {
         "status": "ok",
         "command": "repo scan",
         "project_root": ".",
         "project_root_name": project_root.name,
         "summary": cli_summary,
-        "artifacts": write_result["artifacts"],
+        "artifacts": cli_artifacts,
     }
     if args.output == "json":
         print(_json.dumps(summary, indent=2, sort_keys=True))
@@ -135,9 +136,24 @@ def _cmd_repo_scan(args: argparse.Namespace) -> int:
         print("project_root: .")
         print(f"included_files: {cli_summary['included_files']}")
         print("artifacts:")
-        for artifact in write_result["artifacts"]:
+        for artifact in cli_artifacts:
             print(f"- {artifact['path']}")
     return 0
+
+
+def _repo_scan_cli_artifacts() -> list[dict[str, str]]:
+    return [
+        {"path": ".ao/context/repo_map.json", "schema_ref": "repo-map.schema.v1.json"},
+        {"path": ".ao/context/import_graph.json", "schema_ref": "python-import-graph.schema.v1.json"},
+        {"path": ".ao/context/symbol_index.json", "schema_ref": "python-symbol-index.schema.v1.json"},
+        {"path": ".ao/context/repo_chunks.json", "schema_ref": "repo-chunks.schema.v1.json"},
+        {
+            "path": ".ao/context/agent_pack.md",
+            "format_ref": "agent-pack-markdown.v1",
+            "media_type": "text/markdown",
+        },
+        {"path": ".ao/context/repo_index_manifest.json", "schema_ref": "repo-index-manifest.schema.v1.json"},
+    ]
 
 
 def _repo_scan_cli_summary(repo_summary: Any) -> dict[str, Any]:

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -119,30 +119,25 @@ def _cmd_repo_scan(args: argparse.Namespace) -> int:
         repo_chunks=repo_chunks,
         agent_pack=agent_pack,
     )
-    cli_summary = _repo_scan_cli_summary(repo_map.get("summary"))
     cli_artifacts = _repo_scan_cli_artifacts()
     summary = {
         "status": "ok",
         "command": "repo scan",
         "project_root": ".",
         "project_root_name": project_root.name,
-        "summary": cli_summary,
+        "summary": {"details_path": ".ao/context/repo_map.json"},
         "artifacts": cli_artifacts,
     }
     if args.output == "json":
-        _write_stdout_line(_json.dumps(summary, indent=2, sort_keys=True))
+        print(_json.dumps(summary, indent=2, sort_keys=True))
     else:
         print("repo scan complete")
         print("project_root: .")
-        _write_stdout_line(f"included_files: {cli_summary['included_files']}")
+        print("details: .ao/context/repo_map.json")
         print("artifacts:")
         for artifact in cli_artifacts:
             print(f"- {artifact['path']}")
     return 0
-
-
-def _write_stdout_line(text: str) -> None:
-    sys.stdout.write(f"{text}\n")
 
 
 def _repo_scan_cli_artifacts() -> list[dict[str, str]]:
@@ -158,34 +153,6 @@ def _repo_scan_cli_artifacts() -> list[dict[str, str]]:
         },
         {"path": ".ao/context/repo_index_manifest.json", "schema_ref": "repo-index-manifest.schema.v1.json"},
     ]
-
-
-def _repo_scan_cli_summary(repo_summary: Any) -> dict[str, Any]:
-    if not isinstance(repo_summary, dict):
-        repo_summary = {}
-    raw_languages = repo_summary.get("languages")
-    languages: dict[str, int] = {}
-    if isinstance(raw_languages, dict):
-        languages = {str(name): _nonnegative_int(count) for name, count in raw_languages.items()}
-    return {
-        "included_files": _nonnegative_int(repo_summary.get("included_files")),
-        "included_directories": _nonnegative_int(repo_summary.get("included_directories")),
-        "ignored_paths": _nonnegative_int(repo_summary.get("ignored_paths")),
-        "secret_redacted_files": _nonnegative_int(repo_summary.get("secret_redacted_files")),
-        "diagnostics": _nonnegative_int(repo_summary.get("diagnostics")),
-        "languages": languages,
-        "python_packages": _nonnegative_int(repo_summary.get("python_packages")),
-        "python_modules": _nonnegative_int(repo_summary.get("python_modules")),
-        "python_entrypoints": _nonnegative_int(repo_summary.get("python_entrypoints")),
-    }
-
-
-def _nonnegative_int(value: Any) -> int:
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        return 0
-    return max(parsed, 0)
 
 
 def _cmd_repo_index(args: argparse.Namespace) -> int:

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -130,15 +130,19 @@ def _cmd_repo_scan(args: argparse.Namespace) -> int:
         "artifacts": cli_artifacts,
     }
     if args.output == "json":
-        print(_json.dumps(summary, indent=2, sort_keys=True))
+        _write_stdout_line(_json.dumps(summary, indent=2, sort_keys=True))
     else:
         print("repo scan complete")
         print("project_root: .")
-        print(f"included_files: {cli_summary['included_files']}")
+        _write_stdout_line(f"included_files: {cli_summary['included_files']}")
         print("artifacts:")
         for artifact in cli_artifacts:
             print(f"- {artifact['path']}")
     return 0
+
+
+def _write_stdout_line(text: str) -> None:
+    sys.stdout.write(f"{text}\n")
 
 
 def _repo_scan_cli_artifacts() -> list[dict[str, str]]:

--- a/ao_kernel/defaults/schemas/repo-map.schema.v1.json
+++ b/ao_kernel/defaults/schemas/repo-map.schema.v1.json
@@ -12,6 +12,7 @@
     "summary",
     "files",
     "ignored",
+    "secret_redaction",
     "languages",
     "python",
     "diagnostics"
@@ -54,6 +55,7 @@
         "included_files",
         "included_directories",
         "ignored_paths",
+        "secret_redacted_files",
         "diagnostics",
         "languages",
         "python_packages",
@@ -70,6 +72,10 @@
           "minimum": 0
         },
         "ignored_paths": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "secret_redacted_files": {
           "type": "integer",
           "minimum": 0
         },
@@ -122,6 +128,50 @@
     },
     "languages": {
       "$ref": "#/$defs/language_counts"
+    },
+    "secret_redaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "max_scan_bytes", "patterns", "summary", "records"],
+      "properties": {
+        "mode": {
+          "const": "exclude_file"
+        },
+        "max_scan_bytes": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "patterns": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["redacted_files", "metadata_only", "secrets_recorded"],
+          "properties": {
+            "redacted_files": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "metadata_only": {
+              "const": true
+            },
+            "secrets_recorded": {
+              "const": false
+            }
+          }
+        },
+        "records": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/secret_redaction_record"
+          }
+        }
+      }
     },
     "python": {
       "type": "object",
@@ -210,6 +260,37 @@
         "reason": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "secret_redaction_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "kind", "action", "reason", "pattern_ids", "scan_status"],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/relative_path"
+        },
+        "kind": {
+          "const": "file"
+        },
+        "action": {
+          "const": "excluded_from_context"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pattern_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "scan_status": {
+          "enum": ["path_match", "content_match"]
         }
       }
     },

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,27 +1,4 @@
 {
-  "schema_version": "local-ai-review-evidence.v1",
-  "repo": "Halildeu/ao-kernel",
-  "work_package": "GPP-9",
-  "implementer": {
-    "agent": "codex",
-    "provider": "openai"
-  },
-  "reviewer": {
-    "agent": "claude-code",
-    "provider": "anthropic",
-    "verdict": "AGREE"
-  },
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/release-manifest-ssot",
-    "changed_files": [
-      "CHANGELOG.md",
-      "ao_kernel/defaults/release/__init__.py",
-      "ao_kernel/defaults/release/product-release-manifest.v1.json",
-      "local-ai-review-evidence.v1.json",
-      "tests/test_release_manifest_ssot.py"
-    ]
-  },
   "checks_considered": [
     {
       "name": "tests",
@@ -30,24 +7,59 @@
     {
       "name": "secret_scan",
       "status": "pass"
-    },
-    {
-      "name": "guard_flags",
-      "status": "pass"
-    },
-    {
-      "name": "release_boundary",
-      "status": "pass"
     }
   ],
   "findings": [
-    "Claude review: product release manifest boundary and operator-pending publish status are correct.",
-    "Claude review: tests bind the manifest to package, import/CLI version, Helm appVersion/tag, install docs, and operator publish ref.",
-    "Claude review: no secrets, live adapter execution, support widening, or production platform claim were introduced.",
-    "Claude review: initial tautological v5 assertion was removed before final evidence."
+    "Work package RI-SECRET-AWARE-SCANNER matches diff scope: new secret_scan.py module, scanner.py integration, schema extension, CLI summary hardening, and tests",
+    "New secret_scan.py records only metadata (pattern_ids, scan_status, reason) \u2014 never matched values, line content, or snippets",
+    "Schema repo-map.schema.v1.json adds secret_redaction with const guards: metadata_only=true, secrets_recorded=false, action=excluded_from_context",
+    "CLI stdout summary changed to artifact-pointer-only (details_path instead of inline summary counts), preventing accidental secret leakage through CLI output",
+    "Content patterns cover private keys (RSA/EC/OPENSSH/DSA/PGP), OpenAI API keys, GitHub PATs (classic+fine-grained), AWS access key IDs \u2014 reasonable high-confidence set",
+    "Path patterns cover .env, *.pem, *.key, *.p12, *.pfx, SSH key files, secrets.*, credentials.* \u2014 standard secret-like paths",
+    "Two-phase scan: path-match first (no read needed), then content-match with 5MB cap and graceful OSError handling",
+    "Tests verify secret values do not appear in serialized repo_map or CLI stdout output",
+    "RI-7.5 plan artifact change is SHA256 update for no_root_authority_file_write invariant plus trailing newline fix \u2014 consistent with new write surface in scanner",
+    "No vector writes introduced \u2014 scan path remains read-only",
+    "No root export, no MCP tool exposure, no live GitHub/ProjectV2 mutation",
+    "No support_widening, production_platform_claim, or live_adapter_execution flip",
+    "Guard flags in plan artifact remain false",
+    "No __init__.py or public facade export added for secret_scan \u2014 stays in _internal",
+    "Chunker test updated: .env now excluded at scanner level (secret_redaction) rather than chunker level (chunk_secret_like_skipped) \u2014 correct layering shift",
+    "context_pack_builder.py adds secret_redacted_files row to summary table \u2014 metadata only, no values"
   ],
-  "secrets_recorded": false,
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
   "live_adapter_execution": false,
+  "production_platform_claim": false,
+  "repo": "Halildeu/ao-kernel",
+  "reviewer": {
+    "agent": "anthropic-claude-reviewer",
+    "provider": "anthropic",
+    "verdict": "AGREE"
+  },
+  "schema_version": "local-ai-review-evidence.v1",
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "changed_files": [
+      ".claude/plans/RI-7.5-OPERATOR-VERIFIED-RUNTIME-SEMANTICS.v1.json",
+      "CHANGELOG.md",
+      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
+      "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json",
+      "ao_kernel/_internal/repo_intelligence/context_pack_builder.py",
+      "ao_kernel/_internal/repo_intelligence/scanner.py",
+      "ao_kernel/_internal/repo_intelligence/secret_scan.py",
+      "ao_kernel/cli.py",
+      "ao_kernel/defaults/schemas/repo-map.schema.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "tests/test_cli_repo_scan.py",
+      "tests/test_repo_intelligence_chunker.py",
+      "tests/test_repo_intelligence_scanner.py"
+    ],
+    "head_ref": "refs/heads/codex/ri-secret-aware-scanner"
+  },
+  "secrets_recorded": false,
   "support_widening": false,
-  "production_platform_claim": false
+  "work_package": "RI-SECRET-AWARE-SCANNER"
 }

--- a/tests/test_cli_repo_scan.py
+++ b/tests/test_cli_repo_scan.py
@@ -30,6 +30,7 @@ def test_repo_scan_json_output_writes_only_context_artifacts(tmp_path: Path, cap
     assert captured.err == ""
     assert payload["status"] == "ok"
     assert payload["summary"]["included_files"] == 3
+    assert payload["summary"]["secret_redacted_files"] == 0
     assert [item["path"] for item in payload["artifacts"]] == [
         ".ao/context/repo_map.json",
         ".ao/context/import_graph.json",
@@ -74,3 +75,23 @@ def test_repo_scan_missing_ao_fails_with_init_hint(tmp_path: Path, capsys) -> No
     assert captured.out == ""
     assert "ao-kernel init" in captured.err
     assert not (project / ".ao").exists()
+
+
+def test_repo_scan_json_output_reports_secret_redaction_without_values(tmp_path: Path, capsys) -> None:
+    project = _make_cli_project(tmp_path)
+    token = "sk-" + ("b" * 24)
+    (project / "pkg" / "leaky.py").write_text(f"TOKEN = {token!r}\n", encoding="utf-8")
+
+    rc = main(["repo", "scan", "--project-root", str(project), "--output", "json"])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    repo_map = json.loads((project / ".ao" / "context" / "repo_map.json").read_text(encoding="utf-8"))
+
+    assert rc == 0
+    assert captured.err == ""
+    assert payload["summary"]["secret_redacted_files"] == 1
+    assert repo_map["secret_redaction"]["summary"]["redacted_files"] == 1
+    assert repo_map["secret_redaction"]["records"][0]["path"] == "pkg/leaky.py"
+    assert repo_map["secret_redaction"]["records"][0]["pattern_ids"] == ["openai_api_key_like"]
+    assert token not in captured.out
+    assert token not in json.dumps(repo_map, sort_keys=True)

--- a/tests/test_cli_repo_scan.py
+++ b/tests/test_cli_repo_scan.py
@@ -29,8 +29,7 @@ def test_repo_scan_json_output_writes_only_context_artifacts(tmp_path: Path, cap
     assert rc == 0
     assert captured.err == ""
     assert payload["status"] == "ok"
-    assert payload["summary"]["included_files"] == 3
-    assert payload["summary"]["secret_redacted_files"] == 0
+    assert payload["summary"] == {"details_path": ".ao/context/repo_map.json"}
     assert [item["path"] for item in payload["artifacts"]] == [
         ".ao/context/repo_map.json",
         ".ao/context/import_graph.json",
@@ -60,6 +59,7 @@ def test_repo_scan_default_output_is_text(tmp_path: Path, capsys) -> None:
     assert rc == 0
     assert captured.err == ""
     assert "repo scan complete" in captured.out
+    assert "details: .ao/context/repo_map.json" in captured.out
     assert ".ao/context/repo_map.json" in captured.out
 
 
@@ -89,7 +89,7 @@ def test_repo_scan_json_output_reports_secret_redaction_without_values(tmp_path:
 
     assert rc == 0
     assert captured.err == ""
-    assert payload["summary"]["secret_redacted_files"] == 1
+    assert payload["summary"] == {"details_path": ".ao/context/repo_map.json"}
     assert repo_map["secret_redaction"]["summary"]["redacted_files"] == 1
     assert repo_map["secret_redaction"]["records"][0]["path"] == "pkg/leaky.py"
     assert repo_map["secret_redaction"]["records"][0]["pattern_ids"] == ["openai_api_key_like"]

--- a/tests/test_repo_intelligence_chunker.py
+++ b/tests/test_repo_intelligence_chunker.py
@@ -84,10 +84,15 @@ def test_build_repo_chunks_is_deterministic_except_generator_timestamp(tmp_path:
 def test_build_repo_chunks_records_skip_diagnostics_without_embedding_secret_like_files(tmp_path: Path) -> None:
     project = _make_chunk_project(tmp_path)
 
+    repo_map = scan_repo(project)
     chunks = _build_chunks(project)
 
+    redacted_paths = {item["path"] for item in repo_map["secret_redaction"]["records"]}
+    assert ".env" in redacted_paths
+    assert all(item["path"] != ".env" for item in repo_map["files"])
+
     diagnostics = {(item["path"], item["code"]) for item in chunks["diagnostics"]}
-    assert (".env", "chunk_secret_like_skipped") in diagnostics
+    assert (".env", "chunk_secret_like_skipped") not in diagnostics
     assert ("image.png", "chunk_secret_like_skipped") in diagnostics
     assert all(item["source_path"] != ".env" for item in chunks["chunks"])
     assert all(item["source_path"] != "image.png" for item in chunks["chunks"])

--- a/tests/test_repo_intelligence_scanner.py
+++ b/tests/test_repo_intelligence_scanner.py
@@ -51,6 +51,12 @@ def test_scan_repo_builds_schema_valid_deterministic_map(tmp_path: Path) -> None
     assert _stable_repo_map(first) == _stable_repo_map(second)
     assert first["project"]["name"] == "sample-project"
     assert first["summary"]["included_files"] >= 5
+    assert first["summary"]["secret_redacted_files"] == 0
+    assert first["secret_redaction"]["summary"] == {
+        "redacted_files": 0,
+        "metadata_only": True,
+        "secrets_recorded": False,
+    }
     assert first["languages"]["python"] == 4
     assert first["languages"]["markdown"] == 1
 
@@ -96,3 +102,39 @@ def test_scan_repo_does_not_follow_symlinks(tmp_path: Path) -> None:
 
     assert "linked.py" not in file_paths
     assert "symlink_skipped" in diagnostic_codes
+
+
+def test_scan_repo_excludes_secret_like_files_without_recording_values(tmp_path: Path) -> None:
+    project = _make_sample_repo(tmp_path)
+    token = "sk-" + ("a" * 24)
+    private_key_marker = "-----BEGIN " + "PRIVATE KEY-----"
+    (project / ".env").write_text("TOKEN=example\n", encoding="utf-8")
+    (project / "pkg" / "token.py").write_text(f"TOKEN = {token!r}\n", encoding="utf-8")
+    (project / "pkg" / "key.txt").write_text(f"{private_key_marker}\nredacted\n", encoding="utf-8")
+
+    repo_map = scan_repo(project)
+
+    validate_repo_map(repo_map)
+    paths = {item["path"] for item in repo_map["files"]}
+    ignored = {item["path"]: item["reason"] for item in repo_map["ignored"]["paths"]}
+    redaction = repo_map["secret_redaction"]
+
+    assert ".env" not in paths
+    assert "pkg/token.py" not in paths
+    assert "pkg/key.txt" not in paths
+    assert ignored[".env"].startswith("secret_redaction:path:.env")
+    assert ignored["pkg/token.py"] == "secret_redaction:content:file"
+    assert ignored["pkg/key.txt"] == "secret_redaction:content:file"
+    assert repo_map["summary"]["secret_redacted_files"] == 3
+    assert redaction["summary"] == {
+        "redacted_files": 3,
+        "metadata_only": True,
+        "secrets_recorded": False,
+    }
+    records = {item["path"]: item for item in redaction["records"]}
+    assert records[".env"]["pattern_ids"] == ["path:.env"]
+    assert records["pkg/token.py"]["pattern_ids"] == ["openai_api_key_like"]
+    assert records["pkg/key.txt"]["pattern_ids"] == ["private_key_block"]
+    serialized = str(repo_map)
+    assert token not in serialized
+    assert private_key_marker not in serialized


### PR DESCRIPTION
## Summary

Adds a secret-aware redaction layer to repo-intelligence scans so sensitive files and high-confidence secret-like content are excluded from generated context artifacts.

## What changed

- Added internal secret scan helpers for path and content based redaction decisions.
- Updated `repo scan` to exclude redacted files from `repo_map.files` and record metadata-only redaction records.
- Extended the repo-map schema with `secret_redaction` and `summary.secret_redacted_files`.
- Updated agent context pack summaries to report secret-redacted file counts.
- Added scanner, chunker, and CLI coverage to assert that secret values are not recorded in scan output.

## Why

Repo-intelligence artifacts are intended for handoff, indexing, and query workflows. Secret-like files should not be included in those artifacts even when the user runs the scan against a real repository containing `.env`, private keys, or token-like content.

## Validation

- `python3 -m pytest tests/test_repo_intelligence_scanner.py tests/test_cli_repo_scan.py tests/test_repo_intelligence_artifacts.py tests/test_repo_intelligence_chunker.py tests/test_repo_intelligence_context_pack_builder.py tests/test_cli_repo_index.py tests/test_cli_repo_query.py tests/test_cli_repo_export_plan.py tests/test_repo_intelligence_vector_plan.py tests/test_repo_intelligence_vector_retriever.py tests/test_repo_intelligence_export_plan.py -q`
- Result: `74 passed, 64 warnings`
- CLI dogfood with a temporary repo confirmed:
  - `.env` is excluded from `repo_map.files`
  - fake token-like content is metadata-only redacted
  - fake token value is absent from `repo_map.json`
  - fake token value is absent from `agent_pack.md`
- `git diff --check`

## Notes

This PR does not enable vector writes, root export, or live GitHub/ProjectV2 mutation. Those remain separately gated surfaces.