### PR TITLE
fix(ao-ma-10): bootstrap high-risk runtime provider quorum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **AO-MA-10 high-risk runtime provider bootstrap**: trusted-base high-risk supersession runtime, evidence builder, raw-review producer, schemas, fixtures, and fail-closed tests now support the dynamic OpenAI/Anthropic/MiniMax reviewer quorum while excluding the implementation provider from reviewer authority. This prepares the follow-up provider-separation PR without changing the workflow reviewer request policy, widening support, claiming production readiness, or executing live adapters.
 - **AO-MA-10 high-risk reviewer provider bootstrap**: `local-ai-review-evidence.v1` now recognizes `minimax` as an allowed AI provider so trusted-base `ao-release-gate` validation can consume real MiniMax reviewer evidence in follow-up high-risk provider-separation PRs. This is a schema compatibility bootstrap only; it does not widen support, claim production readiness, or execute live adapters.
 - **AO-MA-11E-2c Project mirror full sync**: heal-mode ProjectV2 mutations now
   require the operator-managed `REPO_GH_PAT_PROJECTS_RW` secret. When that

--- a/ao_kernel/ao_release_gate.py
+++ b/ao_kernel/ao_release_gate.py
@@ -31,6 +31,8 @@ LOCAL_GATE_EVIDENCE_SCHEMA_NAME = "local-gpp-gate-evidence.schema.v1.json"
 REVIEW_EVIDENCE_ACCEPTANCE_SCHEMA_NAME = "ao-release-gate-review-evidence-input.schema.v1.json"
 AO_MA10_EVIDENCE_BUNDLE_SCHEMA_NAME = "ao-ma-10-evidence-bundle.schema.v1.json"
 AO_MA10_HIGH_RISK_SUPERSESSION_SCHEMA_NAME = "ao-ma-10-high-risk-supersession-evidence.schema.v1.json"
+HIGH_RISK_SUPERSESSION_REVIEW_PROVIDER_POOL = ("openai", "anthropic", "minimax")
+HIGH_RISK_SUPERSESSION_DEFAULT_REVIEWERS = ("openai", "anthropic")
 
 HIGH_RISK_PATH_PATTERNS = (
     ".github/**",
@@ -48,6 +50,27 @@ HIGH_RISK_PATH_PATTERNS = (
 AO_MA10_LOW_RISK_AUTONOMOUS_SMOKE_PREFIX = "docs/evidence/ao-ma-10l-autonomous-smoke/"
 AO_MA10_DEDICATED_MERGE_ACTOR = "gladyatore-lab"
 AO_MA10_OPERATOR_PRODUCER_ACTOR = "halildeu"
+
+
+def expected_high_risk_supersession_reviewers(implementer_provider: str) -> tuple[str, str]:
+    """Return the required reviewer-provider quorum for a high-risk implementer.
+
+    The quorum is dynamic by design: when the implementer is one of the AI
+    providers in the review pool, that provider is excluded and the other two
+    providers must review. Human or out-of-pool implementers keep the historical
+    OpenAI + Anthropic quorum.
+    """
+
+    if implementer_provider in HIGH_RISK_SUPERSESSION_REVIEW_PROVIDER_POOL:
+        providers = tuple(
+            provider
+            for provider in HIGH_RISK_SUPERSESSION_REVIEW_PROVIDER_POOL
+            if provider != implementer_provider
+        )
+        if len(providers) != 2:
+            raise ValueError("high-risk review provider pool must yield exactly two reviewers")
+        return providers
+    return HIGH_RISK_SUPERSESSION_DEFAULT_REVIEWERS
 
 
 def diff_digest(changed_paths: list[str]) -> str:
@@ -1027,9 +1050,10 @@ def _evaluate_high_risk_supersession_checks(
 
     This evidence can satisfy the path-sensitive high-risk gate only when
     it is schema-valid, context-bound to the current PR, records unanimous
-    OpenAI + Anthropic AGREE verdicts, and keeps release-authority and
-    guard-flag boundaries closed. AI output remains evidence; the release
-    authority remains this deterministic gate plus GitHub enforcement.
+    the expected cross-provider AGREE verdicts after excluding the implementer
+    provider, and keeps release-authority and guard-flag boundaries closed. AI
+    output remains evidence; the release authority remains this deterministic
+    gate plus GitHub enforcement.
     """
 
     if high_risk_supersession_evidence is None:
@@ -1245,9 +1269,31 @@ def _evaluate_high_risk_supersession_checks(
     provider_verdicts = _as_list(high_risk_supersession_evidence.get("provider_verdicts"))
     provider_ids = [item.get("provider_id") for item in provider_verdicts if isinstance(item, dict)]
     provider_ids_are_distinct = len(set(provider_ids)) == len(provider_ids)
-    required_provider_ids = {"openai", "anthropic"}
-    required_providers_are_present = required_provider_ids.issubset(set(provider_ids))
-    if not provider_ids_are_distinct or not required_providers_are_present:
+    implementer_provider = high_risk_supersession_evidence.get("implementer_provider")
+    expected_provider_ids = (
+        expected_high_risk_supersession_reviewers(implementer_provider)
+        if isinstance(implementer_provider, str)
+        else ()
+    )
+    reviewer_providers = high_risk_supersession_evidence.get("reviewer_providers")
+    required_reviewer_providers = high_risk_supersession_evidence.get("required_reviewer_providers")
+    provider_ids_match_expected = set(provider_ids) == set(expected_provider_ids)
+    reviewer_providers_match_expected = (
+        isinstance(reviewer_providers, list)
+        and set(item for item in reviewer_providers if isinstance(item, str)) == set(expected_provider_ids)
+    )
+    required_providers_match_expected = (
+        isinstance(required_reviewer_providers, list)
+        and set(item for item in required_reviewer_providers if isinstance(item, str)) == set(expected_provider_ids)
+    )
+    implementer_provider_excluded = implementer_provider not in set(provider_ids)
+    if (
+        not provider_ids_are_distinct
+        or not provider_ids_match_expected
+        or not reviewer_providers_match_expected
+        or not required_providers_match_expected
+        or not implementer_provider_excluded
+    ):
         return (
             [
                 evidence_present,
@@ -1256,12 +1302,16 @@ def _evaluate_high_risk_supersession_checks(
                 _blocked(
                     "high_risk_supersession_consensus",
                     finding_code="ao_release_gate_high_risk_supersession_same_provider_self_review",
-                    detail="High-risk supersession evidence contains duplicate providers or omits OpenAI/Anthropic.",
+                    detail=(
+                        "High-risk supersession evidence contains duplicate providers, "
+                        "includes the implementer provider as a reviewer, or does not "
+                        "match the expected reviewer quorum for the implementer provider."
+                    ),
                 ),
                 _blocked(
                     "high_risk_supersession_context_bound",
                     finding_code="ao_release_gate_high_risk_supersession_context_unverifiable",
-                    detail="High-risk supersession context binding cannot be trusted; provider identity is not distinct.",
+                    detail="High-risk supersession context binding cannot be trusted; provider identity is not independent.",
                 ),
                 authority_check,
             ],
@@ -1270,7 +1320,7 @@ def _evaluate_high_risk_supersession_checks(
 
     consensus_check = _pass(
         "high_risk_supersession_consensus",
-        detail="High-risk supersession evidence records unanimous AGREE from OpenAI and Anthropic providers.",
+        detail="High-risk supersession evidence records unanimous AGREE from the expected independent reviewer providers.",
     )
     raw_binding = high_risk_supersession_evidence.get("context_binding")
     binding = raw_binding if isinstance(raw_binding, dict) else None

--- a/ao_kernel/defaults/schemas/ao-ma-10-high-risk-supersession-evidence.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ao-ma-10-high-risk-supersession-evidence.schema.v1.json
@@ -16,6 +16,7 @@
     "ai_output_release_authority",
     "guard_flags",
     "context_binding",
+    "implementer_provider",
     "reviewer_providers",
     "required_reviewer_providers",
     "provider_verdicts",
@@ -88,41 +89,32 @@
     "context_binding": {
       "$ref": "#/$defs/context_binding"
     },
+    "implementer_provider": {
+      "$ref": "#/$defs/implementer_provider_id",
+      "description": "Provider that authored the implementation under review. Human implementers use the sentinel 'human'. Release-gate recomputes required_reviewer_providers from this field and rejects any reviewer provider overlap."
+    },
     "reviewer_providers": {
       "type": "array",
       "minItems": 2,
+      "maxItems": 2,
       "uniqueItems": true,
       "items": {
         "$ref": "#/$defs/provider_id"
-      },
-      "contains": {
-        "const": "openai"
-      },
-      "allOf": [
-        {
-          "contains": {
-            "const": "anthropic"
-          }
-        }
-      ]
+      }
     },
     "required_reviewer_providers": {
       "type": "array",
-      "prefixItems": [
-        {
-          "const": "openai"
-        },
-        {
-          "const": "anthropic"
-        }
-      ],
-      "items": false,
       "minItems": 2,
-      "maxItems": 2
+      "maxItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/provider_id"
+      }
     },
     "provider_verdicts": {
       "type": "array",
       "minItems": 2,
+      "maxItems": 2,
       "items": {
         "$ref": "#/$defs/provider_verdict"
       }
@@ -174,6 +166,17 @@
         "openai",
         "anthropic",
         "minimax"
+      ]
+    },
+    "implementer_provider_id": {
+      "type": "string",
+      "enum": [
+        "openai",
+        "anthropic",
+        "minimax",
+        "google",
+        "xai",
+        "human"
       ]
     },
     "context_binding": {

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -10,10 +10,16 @@
     }
   ],
   "findings": [
-    "Claude AGREE: minimal schema compatibility bootstrap for MiniMax provider evidence.",
-    "All three local-ai-review provider enum sites updated consistently.",
-    "CHANGELOG scope is explicit: no support widening, no production platform claim, no live adapter execution.",
-    "No runtime behavior or release authority change."
+    "Claude adversarial review returned AGREE for PR #999 trusted-base high-risk runtime provider bootstrap.",
+    "Runtime recomputes the required high-risk reviewer quorum from implementer_provider; schema-provided required_reviewer_providers is not trusted as release authority.",
+    "OpenAI, Anthropic, and MiniMax implementers are excluded from reviewer authority by the new runtime quorum; same-provider overlap is denied fail-closed after this bootstrap lands.",
+    "Out-of-pool implementers such as google, xai, or human preserve the historical OpenAI plus Anthropic reviewer quorum.",
+    "Schema broadening to dynamic reviewer pairs is paired with ao-release-gate runtime set-equality enforcement, so provider quorum cannot fail open through schema shape alone.",
+    "Evidence builder rejects raw reviews when providers disagree on implementer_provider or any reviewer provider overlaps the implementer provider.",
+    "Raw-review producer selects required reviewer commands dynamically and excludes the implementer provider before invoking provider commands.",
+    "Context binding remains head, ref, diff, and high-risk-path bound at release-gate runtime; per-provider verdict bindings must match aggregate binding.",
+    "Bootstrap boundary is explicit: this PR uses the pre-separation trusted-base OpenAI plus Anthropic high-risk authority path; follow-up PR #997 enforces Anthropic plus MiniMax for OpenAI implementers.",
+    "No support widening, production platform claim, live adapter execution, or release-authority transfer to AI output is introduced."
   ],
   "implementer": {
     "agent": "codex",
@@ -32,12 +38,21 @@
     "base_ref": "refs/heads/main",
     "changed_files": [
       "CHANGELOG.md",
-      "ao_kernel/defaults/schemas/local-ai-review-evidence.schema.v1.json",
-      "local-ai-review-evidence.v1.json"
+      "ao_kernel/ao_release_gate.py",
+      "ao_kernel/defaults/schemas/ao-ma-10-high-risk-supersession-evidence.schema.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "scripts/ao_ma10_high_risk_raw_review_producer.py",
+      "scripts/ao_ma10_high_risk_supersession_evidence.py",
+      "tests/fixtures/ao_ma_10h/high_risk_supersession.valid.json",
+      "tests/test_ao_ma10_high_risk_raw_review_producer.py",
+      "tests/test_ao_ma10h_high_risk_supersession_contract.py",
+      "tests/test_ao_ma10h_multi_work_package_schema.py",
+      "tests/test_ao_ma10j_high_risk_supersession_evidence_builder.py",
+      "tests/test_ao_release_gate.py"
     ],
-    "head_ref": "refs/heads/codex/issue-985-minimax-provider-bootstrap"
+    "head_ref": "refs/heads/codex/issue-985-high-risk-provider-runtime-bootstrap"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-MA-985-MINIMAX-PROVIDER-BOOTSTRAP"
+  "work_package": "AO-MA-985-HIGH-RISK-RUNTIME-BOOTSTRAP"
 }

--- a/scripts/ao_ma10_high_risk_raw_review_producer.py
+++ b/scripts/ao_ma10_high_risk_raw_review_producer.py
@@ -40,11 +40,14 @@ from ao_kernel.ao_release_gate import _high_risk_paths  # noqa: E402
 from ao_kernel.config import load_default  # noqa: E402
 
 RAW_REVIEW_SCHEMA = "local-ai-review-evidence.schema.v1.json"
-REQUIRED_PROVIDERS = ("openai", "anthropic")
+PROVIDER_REVIEW_POOL = ("openai", "anthropic", "minimax")
+DEFAULT_REVIEWER_PROVIDERS = ("openai", "anthropic")
+REQUIRED_PROVIDERS = DEFAULT_REVIEWER_PROVIDERS
 DEFAULT_OUTPUT_DIR = Path("ao-ma-10-high-risk-reviews")
 PROVIDER_COMMAND_ENVS = {
     "openai": "AO_MA10_OPENAI_REVIEW_CMD",
     "anthropic": "AO_MA10_ANTHROPIC_REVIEW_CMD",
+    "minimax": "AO_MA10_MINIMAX_REVIEW_CMD",
 }
 SECRET_PATTERNS = (
     re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"),
@@ -58,6 +61,15 @@ SECRET_PATTERNS = (
 class ProviderCommand:
     provider: str
     command: tuple[str, ...]
+
+
+def required_reviewer_providers(implementer_provider: str) -> tuple[str, str]:
+    if implementer_provider in PROVIDER_REVIEW_POOL:
+        providers = tuple(provider for provider in PROVIDER_REVIEW_POOL if provider != implementer_provider)
+        if len(providers) != 2:
+            raise ValueError("provider review pool must yield exactly two reviewers")
+        return providers
+    return DEFAULT_REVIEWER_PROVIDERS
 
 
 def _run_git(repo_root: Path, args: list[str]) -> str:
@@ -181,14 +193,18 @@ def _normalize_reviewer_payload(
     return raw
 
 
-def _parse_provider_specs(values: list[str]) -> dict[str, ProviderCommand]:
+def _parse_provider_specs(
+    values: list[str],
+    *,
+    required_providers: tuple[str, ...] = DEFAULT_REVIEWER_PROVIDERS,
+) -> dict[str, ProviderCommand]:
     commands: dict[str, ProviderCommand] = {}
     for value in values:
         if "=" not in value:
             raise ValueError("--provider must have form provider=command")
         provider, raw_command = value.split("=", 1)
         provider = provider.strip()
-        if provider not in REQUIRED_PROVIDERS:
+        if provider not in PROVIDER_REVIEW_POOL:
             raise ValueError(f"unsupported provider {provider!r}")
         command = tuple(shlex.split(raw_command))
         if not command:
@@ -205,7 +221,7 @@ def _parse_provider_specs(values: list[str]) -> dict[str, ProviderCommand]:
                 command=tuple(shlex.split(raw_command)),
             )
 
-    missing = sorted(set(REQUIRED_PROVIDERS) - set(commands))
+    missing = sorted(set(required_providers) - set(commands))
     if missing:
         raise ValueError(f"missing required provider command(s): {', '.join(missing)}")
     return commands
@@ -289,6 +305,10 @@ def produce_raw_reviews(
     high_risk_paths = _high_risk_paths(changed_files)
     if not high_risk_paths:
         raise ValueError("no high-risk changed paths found; raw review producer is not needed")
+    implementer_provider = implementer.get("provider")
+    if not isinstance(implementer_provider, str) or not implementer_provider:
+        raise ValueError("implementer provider is required")
+    required_providers = required_reviewer_providers(implementer_provider)
     diff = _diff_text(repo_root, base_ref, head_ref, max_diff_bytes)
     _assert_no_secret_like_text(diff, label="git diff")
     request = _review_request(
@@ -302,7 +322,7 @@ def produce_raw_reviews(
     )
 
     rendered: dict[str, dict[str, Any]] = {}
-    for provider in REQUIRED_PROVIDERS:
+    for provider in required_providers:
         output = _run_provider_command(provider_commands[provider], request, timeout_seconds)
         rendered[provider] = _normalize_reviewer_payload(
             provider=provider,
@@ -332,9 +352,17 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--head-ref", required=True)
     parser.add_argument("--repo-root", type=Path, default=Path("."))
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
-    parser.add_argument("--provider", action="append", default=[], help="provider=command; required for openai and anthropic unless env commands are set")
+    parser.add_argument(
+        "--provider",
+        action="append",
+        default=[],
+        help=(
+            "provider=command; required providers are selected from "
+            "openai/anthropic/minimax after excluding --implementer-provider"
+        ),
+    )
     parser.add_argument("--implementer-agent", default="autonomous-implementer")
-    parser.add_argument("--implementer-provider", choices=["anthropic", "openai", "google", "xai"], default="openai")
+    parser.add_argument("--implementer-provider", choices=["anthropic", "openai", "google", "xai", "minimax"], default="openai")
     parser.add_argument("--max-diff-bytes", type=int, default=200_000)
     parser.add_argument("--timeout-seconds", type=int, default=600)
     return parser
@@ -343,7 +371,8 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    provider_commands = _parse_provider_specs(args.provider)
+    required_providers = required_reviewer_providers(args.implementer_provider)
+    provider_commands = _parse_provider_specs(args.provider, required_providers=required_providers)
     paths = produce_raw_reviews(
         repository=args.repository,
         work_package=args.work_package,
@@ -356,7 +385,7 @@ def main(argv: list[str] | None = None) -> int:
         max_diff_bytes=args.max_diff_bytes,
         timeout_seconds=args.timeout_seconds,
     )
-    for provider in REQUIRED_PROVIDERS:
+    for provider in required_providers:
         print(f"{provider}: {paths[provider]}")
     return 0
 

--- a/scripts/ao_ma10_high_risk_supersession_evidence.py
+++ b/scripts/ao_ma10_high_risk_supersession_evidence.py
@@ -58,7 +58,8 @@ from ao_kernel.config import load_default
 RAW_REVIEW_SCHEMA = "local-ai-review-evidence.schema.v1.json"
 HIGH_RISK_SUPERSESSION_SCHEMA = "ao-ma-10-high-risk-supersession-evidence.schema.v1.json"
 RELEASE_AUTHORITY = "ao-release-gate+github-ruleset"
-REQUIRED_PROVIDER_IDS = ("openai", "anthropic")
+PROVIDER_REVIEW_POOL = ("openai", "anthropic", "minimax")
+DEFAULT_REVIEWER_PROVIDER_IDS = ("openai", "anthropic")
 
 # Canonical work_package regex shared with the trusted-base workflow's
 # reviewed_wp step (.github/workflows/test.yml line ~634) and the schema's
@@ -100,10 +101,26 @@ def _validate_work_package(value: str) -> None:
 # stem also pins the expected reviewer provider (anti audit-provenance drift).
 HIGH_RISK_REVIEW_REPO_RELATIVE_PATHS: dict[str, str] = {
     "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json": "anthropic",
+    "ao-ma-10-high-risk-reviews/minimax.local-ai-review-evidence.v1.json": "minimax",
     "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json": "openai",
 }
 
 VALID_BINDING_MODES = ("added", "modified", "unchanged")
+
+
+def _implementer_provider_id(implementer: dict[str, Any]) -> str:
+    if implementer.get("kind") == "human":
+        return "human"
+    provider = implementer.get("provider")
+    if not isinstance(provider, str) or not provider:
+        raise ValueError("raw review implementer provider missing")
+    return provider
+
+
+def required_reviewer_provider_ids(implementer_provider: str) -> tuple[str, str]:
+    if implementer_provider in PROVIDER_REVIEW_POOL:
+        return tuple(provider for provider in PROVIDER_REVIEW_POOL if provider != implementer_provider)  # type: ignore[return-value]
+    return DEFAULT_REVIEWER_PROVIDER_IDS
 
 
 def _run_git(repo_root: Path, args: list[str]) -> str:
@@ -220,6 +237,8 @@ def _provider_verdict_from_raw_review(
     raw_review: dict[str, Any],
     raw_path: Path,
     *,
+    implementer_provider: str,
+    required_provider_ids: tuple[str, str],
     repository: str,
     review_work_package: str,
     review_base_ref: str,
@@ -275,7 +294,9 @@ def _provider_verdict_from_raw_review(
         raise ValueError("raw review contains a forbidden finding")
 
     provider_id = reviewer.get("provider")
-    if provider_id not in REQUIRED_PROVIDER_IDS:
+    if provider_id == implementer_provider:
+        raise ValueError("raw review reviewer provider must differ from implementer provider")
+    if provider_id not in required_provider_ids:
         raise ValueError("raw review provider is not required for high-risk supersession")
 
     # Path-to-provider binding (audit provenance): the openai.* file must
@@ -377,10 +398,21 @@ def build_high_risk_supersession_evidence(
     raw_reviews = [(path, _load_json(path)) for path in raw_review_paths]
     if len(raw_reviews) < 2:
         raise ValueError("at least two raw high-risk review evidence files are required")
+    implementer_providers = {
+        _implementer_provider_id(raw_review["implementer"])
+        for _path, raw_review in raw_reviews
+        if isinstance(raw_review.get("implementer"), dict)
+    }
+    if len(implementer_providers) != 1:
+        raise ValueError("raw reviews must agree on exactly one implementer provider")
+    implementer_provider = next(iter(implementer_providers))
+    required_provider_ids = required_reviewer_provider_ids(implementer_provider)
     provider_verdicts = [
         _provider_verdict_from_raw_review(
             raw_review,
             raw_path,
+            implementer_provider=implementer_provider,
+            required_provider_ids=required_provider_ids,
             repository=repository,
             review_work_package=review_work_package,
             review_base_ref=review_base_ref,
@@ -395,8 +427,11 @@ def build_high_risk_supersession_evidence(
         for raw_path, raw_review in raw_reviews
     ]
     provider_ids = [verdict["provider_id"] for verdict in provider_verdicts]
-    if sorted(provider_ids) != sorted(REQUIRED_PROVIDER_IDS):
-        raise ValueError("high-risk supersession requires exactly OpenAI and Anthropic reviewer providers")
+    if sorted(provider_ids) != sorted(required_provider_ids):
+        raise ValueError(
+            "high-risk supersession requires exactly the expected reviewer "
+            "providers after excluding the implementer provider"
+        )
 
     evidence = {
         "schema_version": "ao-ma-10-high-risk-supersession-evidence.v1",
@@ -425,8 +460,9 @@ def build_high_risk_supersession_evidence(
             "live_adapter_execution": False,
         },
         "context_binding": context_binding,
+        "implementer_provider": implementer_provider,
         "reviewer_providers": sorted(provider_ids),
-        "required_reviewer_providers": list(REQUIRED_PROVIDER_IDS),
+        "required_reviewer_providers": list(required_provider_ids),
         "provider_verdicts": provider_verdicts,
         "consensus_status": "AGREE",
         "max_revise_rounds": 3,

--- a/tests/fixtures/ao_ma_10h/high_risk_supersession.valid.json
+++ b/tests/fixtures/ao_ma_10h/high_risk_supersession.valid.json
@@ -24,6 +24,7 @@
     "production_platform_claim": false,
     "support_widening": false
   },
+  "implementer_provider": "google",
   "max_revise_rounds": 3,
   "mutations_performed": false,
   "planning_only": true,

--- a/tests/test_ao_ma10_high_risk_raw_review_producer.py
+++ b/tests/test_ao_ma10_high_risk_raw_review_producer.py
@@ -101,18 +101,18 @@ def _provider_commands(
             provider=provider_id,
             command=(sys.executable, str(fake), provider_id),
         )
-        for provider_id in producer.REQUIRED_PROVIDERS
+        for provider_id in producer.PROVIDER_REVIEW_POOL
     }
 
 
-def test_producer_writes_schema_valid_openai_and_anthropic_raw_reviews(tmp_path: Path) -> None:
+def test_producer_writes_schema_valid_default_openai_and_anthropic_raw_reviews(tmp_path: Path) -> None:
     repo = _repo_with_high_risk_change(tmp_path)
     output_dir = tmp_path / "reviews"
 
     paths = producer.produce_raw_reviews(
         repository="Halildeu/ao-kernel",
         work_package="AO-MA-10K",
-        implementer={"agent": "codex", "provider": "openai"},
+        implementer={"agent": "codex", "provider": "google"},
         base_ref="main",
         head_ref="feature",
         repo_root=repo,
@@ -134,6 +134,27 @@ def test_producer_writes_schema_valid_openai_and_anthropic_raw_reviews(tmp_path:
         assert payload["support_widening"] is False
         assert payload["production_platform_claim"] is False
         assert payload["live_adapter_execution"] is False
+
+
+def test_producer_excludes_implementer_provider_from_required_reviewers(tmp_path: Path) -> None:
+    repo = _repo_with_high_risk_change(tmp_path)
+    output_dir = tmp_path / "reviews"
+
+    paths = producer.produce_raw_reviews(
+        repository="Halildeu/ao-kernel",
+        work_package="AO-MA-10K",
+        implementer={"agent": "codex", "provider": "openai"},
+        base_ref="main",
+        head_ref="feature",
+        repo_root=repo,
+        output_dir=output_dir,
+        provider_commands=_provider_commands(tmp_path),
+        max_diff_bytes=200_000,
+        timeout_seconds=30,
+    )
+
+    assert set(paths) == {"anthropic", "minimax"}
+    assert "openai" not in paths
 
 
 def test_producer_requires_both_provider_commands() -> None:
@@ -230,6 +251,8 @@ def test_cli_outputs_paths_without_secret_values(tmp_path: Path) -> None:
             f"openai={sys.executable} {fake} openai",
             "--provider",
             f"anthropic={sys.executable} {fake} anthropic",
+            "--implementer-provider",
+            "google",
         ],
         cwd=Path(__file__).resolve().parents[1],
         capture_output=True,

--- a/tests/test_ao_ma10h_high_risk_supersession_contract.py
+++ b/tests/test_ao_ma10h_high_risk_supersession_contract.py
@@ -83,16 +83,18 @@ def test_ao_ma10h_valid_fixture_validates() -> None:
     assert _errors(_fixture()) == []
 
 
-def test_ao_ma10h_rejects_same_or_missing_required_provider() -> None:
+def test_ao_ma10h_rejects_duplicate_provider_but_allows_dynamic_provider_pairs() -> None:
     duplicate = _fixture()
     duplicate["reviewer_providers"] = ["openai", "openai"]
     duplicate["provider_verdicts"][1]["provider_id"] = "openai"
     assert _errors(duplicate)
 
-    missing = _fixture()
-    missing["reviewer_providers"] = ["openai", "minimax"]
-    missing["provider_verdicts"][1]["provider_id"] = "minimax"
-    assert _errors(missing)
+    dynamic_pair = _fixture()
+    dynamic_pair["implementer_provider"] = "anthropic"
+    dynamic_pair["reviewer_providers"] = ["openai", "minimax"]
+    dynamic_pair["required_reviewer_providers"] = ["openai", "minimax"]
+    dynamic_pair["provider_verdicts"][1]["provider_id"] = "minimax"
+    assert _errors(dynamic_pair) == []
 
 
 def test_ao_ma10h_rejects_non_agree_or_stale_evidence() -> None:

--- a/tests/test_ao_ma10h_multi_work_package_schema.py
+++ b/tests/test_ao_ma10h_multi_work_package_schema.py
@@ -201,26 +201,35 @@ def test_migration_does_not_relax_authority_or_guard_const_pins() -> None:
         assert guard_flags[flag]["const"] is False, f"{flag} must stay const false"
 
 
-def test_migration_preserves_provider_distinctness_and_pair_requirement() -> None:
-    """OpenAI + Anthropic both required, distinct, no fallback widening."""
+def test_migration_preserves_provider_distinctness_and_dynamic_pair_shape() -> None:
+    """Two distinct reviewers are required; release-gate enforces the dynamic pair."""
 
     schema = _schema()
+    assert "implementer_provider" in schema["required"]
+    implementer_provider = schema["properties"]["implementer_provider"]
+    assert implementer_provider["$ref"] == "#/$defs/implementer_provider_id"
+    assert schema["$defs"]["implementer_provider_id"]["enum"] == [
+        "openai",
+        "anthropic",
+        "minimax",
+        "google",
+        "xai",
+        "human",
+    ]
+
     reviewer_providers = schema["properties"]["reviewer_providers"]
     assert reviewer_providers["minItems"] == 2
+    assert reviewer_providers["maxItems"] == 2
     assert reviewer_providers["uniqueItems"] is True
-    # The two required-contains clauses (one direct, one in allOf) must
-    # both still pin openai + anthropic.
-    assert reviewer_providers["contains"] == {"const": "openai"}
-    assert any(clause.get("contains") == {"const": "anthropic"} for clause in reviewer_providers["allOf"])
+    assert reviewer_providers["items"] == {"$ref": "#/$defs/provider_id"}
+    assert "contains" not in reviewer_providers
+    assert "allOf" not in reviewer_providers
 
     required_providers = schema["properties"]["required_reviewer_providers"]
-    assert required_providers["prefixItems"] == [
-        {"const": "openai"},
-        {"const": "anthropic"},
-    ]
-    assert required_providers["items"] is False
     assert required_providers["minItems"] == 2
     assert required_providers["maxItems"] == 2
+    assert required_providers["uniqueItems"] is True
+    assert required_providers["items"] == {"$ref": "#/$defs/provider_id"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ao_ma10j_high_risk_supersession_evidence_builder.py
+++ b/tests/test_ao_ma10j_high_risk_supersession_evidence_builder.py
@@ -48,6 +48,7 @@ def _raw_review(
     provider: str,
     agent: str,
     changed_files: list[str],
+    implementer_provider: str = "google",
     verdict: str = "AGREE",
     head_ref: str = "refs/heads/feature",
     work_package: str = "AO-MA-10j",
@@ -57,7 +58,7 @@ def _raw_review(
         "schema_version": "local-ai-review-evidence.v1",
         "repo": "Halildeu/ao-kernel",
         "work_package": work_package,
-        "implementer": {"agent": "implementer-agent", "provider": "google"},
+        "implementer": {"agent": "implementer-agent", "provider": implementer_provider},
         "reviewer": {"agent": agent, "provider": provider, "verdict": verdict},
         "scope_reviewed": {
             "base_ref": base_ref,
@@ -259,6 +260,7 @@ def test_build_high_risk_supersession_evidence_from_raw_runtime_reviews(
     schema = load_default("schemas", "ao-ma-10-high-risk-supersession-evidence.schema.v1.json")
     assert list(Draft202012Validator(schema).iter_errors(evidence)) == []
     assert evidence["schema_version"] == "ao-ma-10-high-risk-supersession-evidence.v1"
+    assert evidence["implementer_provider"] == "google"
     assert evidence["reviewer_providers"] == ["anthropic", "openai"]
     assert evidence["context_binding"]["head_sha"] == _git(repo, "rev-parse", "feature")
     assert evidence["context_binding"]["changed_files_count"] == len(changed_files)
@@ -283,8 +285,121 @@ def test_build_high_risk_supersession_rejects_missing_required_provider(
     # fails first (before provider-set check). Match either reason.
     with pytest.raises(
         ValueError,
-        match="(does not match path-bound expected provider|exactly OpenAI and Anthropic)",
+        match="(does not match path-bound expected provider|expected reviewer providers)",
     ):
+        build_high_risk_supersession_evidence(
+            repository="Halildeu/ao-kernel",
+            review_work_package="AO-MA-10j",
+            review_base_ref="refs/heads/main",
+            review_head_ref="refs/heads/feature",
+            diff_base_ref="main",
+            diff_head_ref="feature",
+            repo_root=repo,
+            raw_review_paths=review_paths,
+            max_age_seconds=3600,
+            round_index=1,
+            generated_at="2026-05-28T00:00:00Z",
+        )
+
+
+def test_build_high_risk_supersession_rejects_reviewer_provider_overlap_with_implementer(
+    high_risk_repo: tuple[Path, list[Path], list[str]],
+) -> None:
+    repo, review_paths, _changed_files = high_risk_repo
+    for path in review_paths:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw["implementer"]["provider"] = "openai"
+        path.write_text(json.dumps(raw, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _git(repo, "add", "ao-ma-10-high-risk-reviews/")
+    _git(repo, "commit", "--amend", "--no-edit")
+
+    with pytest.raises(ValueError, match="reviewer provider must differ from implementer provider"):
+        build_high_risk_supersession_evidence(
+            repository="Halildeu/ao-kernel",
+            review_work_package="AO-MA-10j",
+            review_base_ref="refs/heads/main",
+            review_head_ref="refs/heads/feature",
+            diff_base_ref="main",
+            diff_head_ref="feature",
+            repo_root=repo,
+            raw_review_paths=review_paths,
+            max_age_seconds=3600,
+            round_index=1,
+            generated_at="2026-05-28T00:00:00Z",
+        )
+
+
+def test_build_high_risk_supersession_accepts_quorum_after_excluding_implementer_provider(
+    high_risk_repo: tuple[Path, list[Path], list[str]],
+) -> None:
+    repo, review_paths, changed_files = high_risk_repo
+    changed_files = sorted(
+        [
+            *changed_files,
+            "ao-ma-10-high-risk-reviews/minimax.local-ai-review-evidence.v1.json",
+        ]
+    )
+    anthropic_path = next(path for path in review_paths if path.name.startswith("anthropic."))
+    anthropic = _raw_review(
+        provider="anthropic",
+        agent="claude-reviewer",
+        changed_files=changed_files,
+        implementer_provider="openai",
+    )
+    anthropic_path.write_text(json.dumps(anthropic, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    minimax_path = repo / "ao-ma-10-high-risk-reviews/minimax.local-ai-review-evidence.v1.json"
+    minimax_path.write_text(
+        json.dumps(
+            _raw_review(
+                provider="minimax",
+                agent="minimax-reviewer",
+                changed_files=changed_files,
+                implementer_provider="openai",
+            ),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "ao-ma-10-high-risk-reviews/")
+    _git(repo, "commit", "--amend", "--no-edit")
+
+    evidence = build_high_risk_supersession_evidence(
+        repository="Halildeu/ao-kernel",
+        review_work_package="AO-MA-10j",
+        review_base_ref="refs/heads/main",
+        review_head_ref="refs/heads/feature",
+        diff_base_ref="main",
+        diff_head_ref="feature",
+        repo_root=repo,
+        raw_review_paths=[anthropic_path, minimax_path],
+        max_age_seconds=3600,
+        round_index=1,
+        generated_at="2026-05-28T00:00:00Z",
+    )
+
+    assert evidence["implementer_provider"] == "openai"
+    assert evidence["reviewer_providers"] == ["anthropic", "minimax"]
+    assert evidence["required_reviewer_providers"] == ["anthropic", "minimax"]
+    assert {item["provider_id"] for item in evidence["provider_verdicts"]} == {"anthropic", "minimax"}
+
+
+def test_build_high_risk_supersession_rejects_implementer_provider_disagreement(
+    high_risk_repo: tuple[Path, list[Path], list[str]],
+) -> None:
+    repo, review_paths, _changed_files = high_risk_repo
+    first = json.loads(review_paths[0].read_text(encoding="utf-8"))
+    first["implementer"]["provider"] = "openai"
+    review_paths[0].write_text(json.dumps(first, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    second = json.loads(review_paths[1].read_text(encoding="utf-8"))
+    second["implementer"]["provider"] = "anthropic"
+    review_paths[1].write_text(json.dumps(second, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _git(repo, "add", "ao-ma-10-high-risk-reviews/")
+    _git(repo, "commit", "--amend", "--no-edit")
+
+    with pytest.raises(ValueError, match="must agree on exactly one implementer provider"):
         build_high_risk_supersession_evidence(
             repository="Halildeu/ao-kernel",
             review_work_package="AO-MA-10j",
@@ -488,7 +603,7 @@ def test_schema_pins_binding_mode_enum_on_provider_verdict() -> None:
 def test_high_risk_review_repo_relative_paths_pin_provider() -> None:
     """The path-to-provider audit binding map must include both required
     providers exactly once and point to the matching filename."""
-    assert sorted(HIGH_RISK_REVIEW_REPO_RELATIVE_PATHS.values()) == ["anthropic", "openai"]
+    assert sorted(HIGH_RISK_REVIEW_REPO_RELATIVE_PATHS.values()) == ["anthropic", "minimax", "openai"]
     for path, provider in HIGH_RISK_REVIEW_REPO_RELATIVE_PATHS.items():
         assert provider in path  # filename contains the provider name
 

--- a/tests/test_ao_release_gate.py
+++ b/tests/test_ao_release_gate.py
@@ -18,6 +18,7 @@ from ao_kernel.ao_release_gate import (
     RELEASE_GATE_CHECK_NAME,
     build_ao_release_gate_decision,
     diff_digest,
+    expected_high_risk_supersession_reviewers,
     render_ao_release_gate_decision_text,
     write_ao_release_gate_decision,
 )
@@ -174,6 +175,7 @@ def _high_risk_supersession_evidence(
     provider_verdict: str = "AGREE",
     binding_mode: str = "added",
     work_package: str = "AO-MA-10h",
+    implementer_provider: str = "google",
 ) -> dict[str, object]:
     """Build accepting high-risk supersession evidence.
 
@@ -204,13 +206,19 @@ def _high_risk_supersession_evidence(
         "high_risk_changed_paths": high_risk_paths,
     }
     provider_verdicts = []
-    for provider, agent in zip(provider_ids, ("codex-reviewer", "claude-reviewer"), strict=False):
+    expected_reviewers = list(expected_high_risk_supersession_reviewers(implementer_provider))
+    agent_by_provider = {
+        "openai": "codex-reviewer",
+        "anthropic": "claude-reviewer",
+        "minimax": "minimax-reviewer",
+    }
+    for provider in provider_ids:
         provider_verdicts.append(
             {
                 "schema_version": "ao-ma-10-provider-consensus.v1",
                 "artifact_kind": "ao_ma_10_provider_consensus",
                 "provider_id": provider,
-                "agent_id": agent,
+                "agent_id": agent_by_provider.get(provider, f"{provider}-reviewer"),
                 "role": "reviewer",
                 "risk_classification": "high",
                 "verdict": provider_verdict,
@@ -241,8 +249,9 @@ def _high_risk_supersession_evidence(
             "live_adapter_execution": False,
         },
         "context_binding": context,
-        "reviewer_providers": ["openai", "anthropic"],
-        "required_reviewer_providers": ["openai", "anthropic"],
+        "implementer_provider": implementer_provider,
+        "reviewer_providers": expected_reviewers,
+        "required_reviewer_providers": expected_reviewers,
         "provider_verdicts": provider_verdicts,
         "consensus_status": consensus_status,
         "max_revise_rounds": 3,
@@ -563,6 +572,39 @@ def test_release_gate_denies_high_risk_supersession_same_provider_self_review() 
     assert decision["decision"] == DENY_POLICY_VIOLATION_DECISION
     assert "ao_release_gate_high_risk_supersession_same_provider_self_review" in decision["findings"]
     assert "ao_release_gate_high_risk_human_review_missing" in decision["findings"]
+
+
+def test_release_gate_denies_high_risk_supersession_implementer_provider_overlap() -> None:
+    evidence = _high_risk_supersession_evidence(
+        provider_ids=("openai", "anthropic"),
+        implementer_provider="openai",
+    )
+    decision = build_ao_release_gate_decision(
+        _high_risk_without_review_payload(),
+        _gpp_status(),
+        review_evidence=_review_evidence(),
+        high_risk_supersession_evidence=evidence,
+    )
+
+    assert decision["decision"] == DENY_POLICY_VIOLATION_DECISION
+    assert "ao_release_gate_high_risk_supersession_same_provider_self_review" in decision["findings"]
+
+
+def test_release_gate_allows_high_risk_supersession_with_implementer_excluded_quorum() -> None:
+    evidence = _high_risk_supersession_evidence(
+        provider_ids=("anthropic", "minimax"),
+        implementer_provider="openai",
+    )
+    decision = build_ao_release_gate_decision(
+        _high_risk_without_review_payload(),
+        _gpp_status(),
+        review_evidence=_review_evidence(),
+        high_risk_supersession_evidence=evidence,
+    )
+
+    assert decision["decision"] == ALLOW_AUTONOMOUS_MERGE_DECISION
+    assert _find_check(decision, "high_risk_supersession_consensus")["status"] == "pass"
+    assert _find_check(decision, "path_sensitive_human_review")["status"] == "pass"
 
 
 def test_release_gate_denies_high_risk_supersession_context_mismatch_as_untrusted() -> None:


### PR DESCRIPTION
## Summary

- Bootstrap trusted-base high-risk supersession runtime support for the dynamic OpenAI/Anthropic/MiniMax reviewer quorum.
- Add MiniMax raw-review path allowlist, implementer-provider exclusion, schema field, fixture updates, and fail-closed tests.
- Deliberately excludes `.github/workflows/test.yml` request-policy changes and MiniMax raw review evidence; those remain in follow-up PR #997 after this trusted-base support lands.

## Guardrails

- support_widening=false
- production_platform_claim=false
- live_adapter_execution=false
- AI output remains evidence only; release authority remains repo-owned ao-release-gate + GitHub enforcement.

## Validation

- Targeted local tests previously passed on the same runtime changes: `193 passed` for high-risk producer/builder/release-gate/local-gate subset.
- Cross-AI plan consult with Claude: AGREE on splitting this trusted-base runtime bootstrap before #997 workflow policy.
