### PR TITLE
test(v5): add governed-control-plane gap audit guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **V5 governed-control-plane gap audit**: added a machine-readable gap audit
+  artifact, strict JSON Schema, and invariant tests that pin all guard flags to
+  `false`, keep v5 tag/publish disallowed, bind release authority to
+  `ao-release-gate` plus GitHub branch protection, reject fake MiniMax review
+  evidence, and fail PR diffs that flip `.claude/plans/gpp_status.v1.json`
+  guard flags to `true`. This is docs/test/schema hardening only; it does not
+  tag or publish a release, widen support, claim production-platform readiness,
+  or execute live adapters.
 - **v4.x governed-control-plane release checklist**: added an operator-bound
   release checklist for the next safe v4.x governed-control-plane release,
   plus a V5 no-go section and invariant tests that keep v5.0.0 tag/publish,

--- a/ao_kernel/defaults/schemas/v5-governed-control-plane-gap-audit.schema.v1.json
+++ b/ao_kernel/defaults/schemas/v5-governed-control-plane-gap-audit.schema.v1.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:v5-governed-control-plane-gap-audit:v1",
+  "title": "V5 governed control-plane gap audit v1",
+  "description": "Machine-readable audit artifact for the current V5 no-go boundary. It pins guard flags false, records the repo-owned release authority, rejects fake MiniMax evidence, and describes the remaining operator-bound blockers before any future V5 tag or publish can be reconsidered.",
+  "type": "object",
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "repo",
+    "work_package",
+    "authority",
+    "guard_flags",
+    "release_boundary",
+    "gap_items",
+    "forbidden_change_audit",
+    "next_safe_actions"
+  ],
+  "properties": {
+    "schema_version": { "const": "v5-governed-control-plane-gap-audit.v1" },
+    "artifact_kind": { "const": "v5_governed_control_plane_gap_audit" },
+    "repo": { "const": "Halildeu/ao-kernel" },
+    "work_package": { "const": "V5-GAP-FORBIDDEN-CHANGE-AUDIT" },
+    "authority": { "const": "docs/V5-GOVERNED-CONTROL-PLANE-READINESS-GAP.md" },
+    "guard_flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "support_widening_allowed",
+        "production_platform_claim_allowed",
+        "live_adapter_execution_allowed"
+      ],
+      "properties": {
+        "support_widening_allowed": { "type": "boolean", "const": false },
+        "production_platform_claim_allowed": { "type": "boolean", "const": false },
+        "live_adapter_execution_allowed": { "type": "boolean", "const": false }
+      }
+    },
+    "release_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "v5_tag_publish_allowed",
+        "release_target",
+        "release_authority",
+        "ai_output_release_authority",
+        "fake_minimax_evidence_allowed",
+        "operator_bound_supersession_required"
+      ],
+      "properties": {
+        "v5_tag_publish_allowed": { "type": "boolean", "const": false },
+        "release_target": { "const": "v4.x-governed-control-plane" },
+        "release_authority": {
+          "const": "ao-release-gate-plus-github-branch-protection"
+        },
+        "ai_output_release_authority": { "type": "boolean", "const": false },
+        "fake_minimax_evidence_allowed": { "type": "boolean", "const": false },
+        "operator_bound_supersession_required": { "type": "boolean", "const": true }
+      }
+    },
+    "gap_items": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/gap_item" },
+      "allOf": [
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "id": { "const": "minimax-provider-evidence-for-997" }
+            },
+            "required": ["id"]
+          },
+          "minContains": 1,
+          "maxContains": 1
+        },
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "id": { "const": "repo-intelligence-promotion-decision" }
+            },
+            "required": ["id"]
+          },
+          "minContains": 1,
+          "maxContains": 1
+        },
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "id": { "const": "v5-major-release-supersession" }
+            },
+            "required": ["id"]
+          },
+          "minContains": 1,
+          "maxContains": 1
+        },
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "id": { "const": "v4-governed-control-plane-release-checklist" }
+            },
+            "required": ["id"]
+          },
+          "minContains": 1,
+          "maxContains": 1
+        }
+      ]
+    },
+    "forbidden_change_audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "source_path",
+        "git_diff_base",
+        "git_diff_guard_flags",
+        "false_to_true_flip_allowed",
+        "machine_enforced_by"
+      ],
+      "properties": {
+        "source_path": { "const": ".claude/plans/gpp_status.v1.json" },
+        "git_diff_base": { "const": "origin/main...HEAD" },
+        "git_diff_guard_flags": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "uniqueItems": true,
+          "prefixItems": [
+            { "const": "support_widening_allowed" },
+            { "const": "production_platform_claim_allowed" },
+            { "const": "live_adapter_execution_allowed" }
+          ],
+          "items": false
+        },
+        "false_to_true_flip_allowed": { "type": "boolean", "const": false },
+        "machine_enforced_by": {
+          "const": "tests/test_v5_governed_control_plane_gap_audit.py"
+        }
+      }
+    },
+    "next_safe_actions": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "$defs": {
+    "gap_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "unevaluatedProperties": false,
+      "required": [
+        "id",
+        "title",
+        "status",
+        "owner_boundary",
+        "evidence_required",
+        "current_evidence",
+        "blocking_for_v5_tag_publish"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "minimax-provider-evidence-for-997",
+            "repo-intelligence-promotion-decision",
+            "v5-major-release-supersession",
+            "v4-governed-control-plane-release-checklist"
+          ]
+        },
+        "title": { "type": "string", "minLength": 1 },
+        "status": {
+          "type": "string",
+          "enum": ["open", "blocked_external", "operator_bound", "done"]
+        },
+        "owner_boundary": {
+          "type": "string",
+          "enum": ["agent", "operator", "operator_environment", "repo_owned_gate"]
+        },
+        "evidence_required": { "type": "string", "minLength": 1 },
+        "current_evidence": { "type": "string", "minLength": 1 },
+        "blocking_for_v5_tag_publish": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json
+++ b/docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "v5-governed-control-plane-gap-audit.v1",
+  "artifact_kind": "v5_governed_control_plane_gap_audit",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "V5-GAP-FORBIDDEN-CHANGE-AUDIT",
+  "authority": "docs/V5-GOVERNED-CONTROL-PLANE-READINESS-GAP.md",
+  "guard_flags": {
+    "support_widening_allowed": false,
+    "production_platform_claim_allowed": false,
+    "live_adapter_execution_allowed": false
+  },
+  "release_boundary": {
+    "v5_tag_publish_allowed": false,
+    "release_target": "v4.x-governed-control-plane",
+    "release_authority": "ao-release-gate-plus-github-branch-protection",
+    "ai_output_release_authority": false,
+    "fake_minimax_evidence_allowed": false,
+    "operator_bound_supersession_required": true
+  },
+  "gap_items": [
+    {
+      "id": "minimax-provider-evidence-for-997",
+      "title": "Real MiniMax provider review evidence for high-risk provider separation",
+      "status": "blocked_external",
+      "owner_boundary": "operator_environment",
+      "evidence_required": "A real MiniMax AGREE review for the exact #997 PR scope, produced by working MiniMax tooling and accepted by ao-release-gate.",
+      "current_evidence": "#997 remains fail-closed because MiniMax evidence is BLOCK or unavailable; fake MiniMax AGREE evidence is forbidden.",
+      "blocking_for_v5_tag_publish": true
+    },
+    {
+      "id": "repo-intelligence-promotion-decision",
+      "title": "Operator-bound repo-intelligence promotion or non-promotion decision",
+      "status": "operator_bound",
+      "owner_boundary": "operator",
+      "evidence_required": "An explicit operator decision consuming the committed RI-7 evidence manifest and preserving or changing support boundaries through a separate authority path.",
+      "current_evidence": "The manifest-backed readiness report is ready_for_operator_decision, but it is evidence only and does not authorize autonomous support widening.",
+      "blocking_for_v5_tag_publish": true
+    },
+    {
+      "id": "v5-major-release-supersession",
+      "title": "Explicit major-release supersession before any v5 tag or publish",
+      "status": "operator_bound",
+      "owner_boundary": "operator",
+      "evidence_required": "A separate operator-bound supersession PR that explicitly reopens the major-release path and passes ao-release-gate without guard-flag drift.",
+      "current_evidence": "The active safe target is v4.x governed-control-plane; v5.0.0 tag or publish is not open in the autonomous lane.",
+      "blocking_for_v5_tag_publish": true
+    },
+    {
+      "id": "v4-governed-control-plane-release-checklist",
+      "title": "Governed-control-plane v4.x release checklist",
+      "status": "done",
+      "owner_boundary": "agent",
+      "evidence_required": "A conservative v4.x checklist that preserves guard flags false and does not tag or publish a release.",
+      "current_evidence": "PR #1002 added docs/V4-GOVERNED-CONTROL-PLANE-RELEASE-CHECKLIST.md and no-go tests.",
+      "blocking_for_v5_tag_publish": false
+    }
+  ],
+  "forbidden_change_audit": {
+    "source_path": ".claude/plans/gpp_status.v1.json",
+    "git_diff_base": "origin/main...HEAD",
+    "git_diff_guard_flags": [
+      "support_widening_allowed",
+      "production_platform_claim_allowed",
+      "live_adapter_execution_allowed"
+    ],
+    "false_to_true_flip_allowed": false,
+    "machine_enforced_by": "tests/test_v5_governed_control_plane_gap_audit.py"
+  },
+  "next_safe_actions": [
+    "Keep #997 fail-closed until real MiniMax AGREE evidence exists.",
+    "Use the v4.x governed-control-plane release checklist for any near-term release preparation.",
+    "Treat RI-7 readiness as input to a later operator-bound promotion or non-promotion decision.",
+    "Do not tag or publish v5.0.0 without an explicit operator-bound supersession PR."
+  ]
+}

--- a/docs/V5-GOVERNED-CONTROL-PLANE-READINESS-GAP.md
+++ b/docs/V5-GOVERNED-CONTROL-PLANE-READINESS-GAP.md
@@ -7,6 +7,7 @@
 - `.claude/plans/V5-FULL-PRODUCTION-PROMOTION-ROADMAP.md`
 - `.claude/plans/V5-PRODUCTION-READINESS-MATRIX-BLOCKER.md`
 - `.claude/plans/EPIC-9-PR-XFINAL-SUPERSESSION-CLOSEOUT.md`
+- `docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json`
 - `scripts/repo_intelligence_tier_promotion_readiness.py --output json`
 - `scripts/repo_intelligence_tier_promotion_readiness.py --output json --evidence-manifest .claude/plans/RI-7-EVIDENCE-MANIFEST.v1.json`
 
@@ -45,6 +46,27 @@ The safe release framing is therefore:
 - **Only possible later:** a major release explicitly renamed as a governed
   control-plane GA, with changelog/PyPI/docs stating that all three guard flags
   remain false and that no production-platform promotion happened.
+
+## Machine-Enforced Gap Audit
+
+`docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json` is the machine-readable
+companion artifact for this note. It is validated by
+`tests/test_v5_governed_control_plane_gap_audit.py` against
+`ao_kernel/defaults/schemas/v5-governed-control-plane-gap-audit.schema.v1.json`.
+
+The audit artifact pins:
+
+- all three guard flags to `false`;
+- `v5_tag_publish_allowed=false`;
+- release authority to `ao-release-gate` plus GitHub branch protection;
+- AI review output as evidence only, not release authority;
+- fake MiniMax `AGREE` evidence as forbidden;
+- the remaining V5 blockers as MiniMax/environment and operator-bound items.
+
+The same test file also audits the PR diff for
+`.claude/plans/gpp_status.v1.json` using `origin/main...HEAD` and fails if any
+guard flag is changed to `true` in the PR, staged diff, or local working diff.
+This is a guardrail for autonomous slices only; it does not authorize a release.
 
 ## Current Readiness Tool Output
 
@@ -139,7 +161,7 @@ The correct completion path for `#985` is:
 | Order | Work | Owner boundary | Exit condition |
 |---:|---|---|---|
 | 1 | MiniMax provider/tooling unblock for `#997` | Operator/environment + agent verification | Real MiniMax `AGREE` evidence replaces `BLOCK`; `ao-release-gate` passes. |
-| 2 | Governed-control-plane v4.x release checklist | Agent planning only | `docs/V4-GOVERNED-CONTROL-PLANE-RELEASE-CHECKLIST.md` records packaging, docs, changelog, version, and publish preflight without tag/publish or guard flips. |
+| 2 | Governed-control-plane v4.x release checklist | Agent planning only | Done by PR #1002: `docs/V4-GOVERNED-CONTROL-PLANE-RELEASE-CHECKLIST.md` records packaging, docs, changelog, version, and publish preflight without tag/publish or guard flips. |
 | 3 | Repo-intelligence promotion decision PR | Operator-bound | Consumes the manifest-backed readiness report and explicitly chooses promotion or non-promotion. No autonomous guard flip. |
 | 4 | Separate major-release supersession, if ever desired | Operator-bound | Explicitly renames the release target as governed control-plane GA; no general-purpose production-platform claim unless separately authorized. |
 

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "V4-RELEASE-CHECKLIST-V5-NO-GO",
+  "work_package": "V5-GAP-FORBIDDEN-CHANGE-AUDIT",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,13 +13,14 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/v4-release-checklist-v5-no-go",
+    "head_ref": "refs/heads/codex/v5-gap-forbidden-change-audit",
     "changed_files": [
       "CHANGELOG.md",
-      "docs/V4-GOVERNED-CONTROL-PLANE-RELEASE-CHECKLIST.md",
+      "ao_kernel/defaults/schemas/v5-governed-control-plane-gap-audit.schema.v1.json",
+      "docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json",
       "docs/V5-GOVERNED-CONTROL-PLANE-READINESS-GAP.md",
       "local-ai-review-evidence.v1.json",
-      "tests/test_v4_release_checklist_v5_no_go.py"
+      "tests/test_v5_governed_control_plane_gap_audit.py"
     ]
   },
   "checks_considered": [
@@ -45,13 +46,14 @@
     }
   ],
   "findings": [
-    "Claude reviewed the v4 governed-control-plane release checklist and v5 no-go guard diff.",
-    "Claude returned AGREE with no blocking issue for the docs/tests/changelog-only scope.",
-    "The review confirmed the change keeps guard flags false and does not tag or publish v5.0.0.",
-    "The review confirmed #997 remains fail-closed until real MiniMax AGREE evidence exists.",
-    "The review confirmed release authority remains ao-release-gate plus GitHub branch protection, not AI output.",
-    "The tests check is backed by pytest over the v4 release checklist no-go, V5 readiness gap, publish workflow, and migration docs tests.",
-    "The secret_scan check is backed by the repository pre-commit hook.",
+    "Claude reviewed the V5 governed-control-plane gap audit plan and returned AGREE with mandatory hardening.",
+    "The implementation applies Claude hardening H1: git diff audit uses origin/main...HEAD and also checks staged and working-tree diffs.",
+    "The implementation applies Claude hardening H2: the schema closes all object layers with additionalProperties false.",
+    "The implementation applies Claude hardening H3: critical guard and release-boundary booleans are schema-pinned with const false.",
+    "The schema and artifact keep support_widening_allowed, production_platform_claim_allowed, and live_adapter_execution_allowed false.",
+    "The artifact keeps v5 tag/publish disallowed and release authority bound to ao-release-gate plus GitHub branch protection.",
+    "The artifact records fake MiniMax AGREE evidence as forbidden and keeps #997 blocked until real MiniMax evidence exists.",
+    "No runtime, workflow, webhook, tag, publish, support-widening, production-claim, or live-adapter surface is changed.",
     "No blocking findings."
   ],
   "secrets_recorded": false,

--- a/tests/test_v5_governed_control_plane_gap_audit.py
+++ b/tests/test_v5_governed_control_plane_gap_audit.py
@@ -1,0 +1,186 @@
+"""Machine-enforced invariants for the V5 governed control-plane gap audit."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCHEMA_PATH = (
+    _REPO_ROOT
+    / "ao_kernel"
+    / "defaults"
+    / "schemas"
+    / "v5-governed-control-plane-gap-audit.schema.v1.json"
+)
+_ARTIFACT_PATH = _REPO_ROOT / "docs" / "V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json"
+_GPP_STATUS_PATH = ".claude/plans/gpp_status.v1.json"
+_GUARD_TRUE_PATTERN = re.compile(
+    r'^\+\s*"(support_widening_allowed|production_platform_claim_allowed|'
+    r'live_adapter_execution_allowed)"\s*:\s*true\b',
+    re.MULTILINE,
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    assert path.exists(), f"missing artifact: {path}"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _schema() -> dict[str, Any]:
+    return _load_json(_SCHEMA_PATH)
+
+
+def _artifact() -> dict[str, Any]:
+    return _load_json(_ARTIFACT_PATH)
+
+
+def _validator() -> Draft202012Validator:
+    schema = _schema()
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def _git_diff(*args: str) -> str:
+    proc = subprocess.run(
+        ["git", "diff", "--unified=0", *args, "--", _GPP_STATUS_PATH],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout
+
+
+def test_gap_audit_schema_and_artifact_validate() -> None:
+    """The committed audit artifact must validate against its strict schema."""
+    errors = list(_validator().iter_errors(_artifact()))
+    assert errors == []
+
+
+def test_gap_audit_keeps_release_boundary_closed() -> None:
+    """The audit artifact must not authorize V5 tag/publish or AI release authority."""
+    artifact = _artifact()
+
+    assert artifact["guard_flags"] == {
+        "support_widening_allowed": False,
+        "production_platform_claim_allowed": False,
+        "live_adapter_execution_allowed": False,
+    }
+    assert artifact["release_boundary"] == {
+        "v5_tag_publish_allowed": False,
+        "release_target": "v4.x-governed-control-plane",
+        "release_authority": "ao-release-gate-plus-github-branch-protection",
+        "ai_output_release_authority": False,
+        "fake_minimax_evidence_allowed": False,
+        "operator_bound_supersession_required": True,
+    }
+
+
+def test_gap_audit_records_remaining_v5_tag_blockers() -> None:
+    """V5 publish remains blocked by real MiniMax and operator-bound decisions."""
+    items = {item["id"]: item for item in _artifact()["gap_items"]}
+
+    assert items["minimax-provider-evidence-for-997"]["status"] == "blocked_external"
+    assert (
+        items["minimax-provider-evidence-for-997"]["owner_boundary"]
+        == "operator_environment"
+    )
+    assert "fake MiniMax AGREE evidence is forbidden" in (
+        items["minimax-provider-evidence-for-997"]["current_evidence"]
+    )
+    assert items["repo-intelligence-promotion-decision"]["status"] == "operator_bound"
+    assert items["v5-major-release-supersession"]["status"] == "operator_bound"
+    assert items["v4-governed-control-plane-release-checklist"]["status"] == "done"
+
+    blockers = [
+        item["id"]
+        for item in items.values()
+        if item["blocking_for_v5_tag_publish"] is True
+    ]
+    assert blockers == [
+        "minimax-provider-evidence-for-997",
+        "repo-intelligence-promotion-decision",
+        "v5-major-release-supersession",
+    ]
+
+
+def test_gap_audit_schema_rejects_guard_or_release_authority_drift() -> None:
+    """Schema validation must fail if critical false-pinned fields turn true."""
+    validator = _validator()
+    artifact = _artifact()
+
+    mutated = copy.deepcopy(artifact)
+    mutated["guard_flags"]["support_widening_allowed"] = True
+    assert list(validator.iter_errors(mutated))
+
+    mutated = copy.deepcopy(artifact)
+    mutated["release_boundary"]["v5_tag_publish_allowed"] = True
+    assert list(validator.iter_errors(mutated))
+
+    mutated = copy.deepcopy(artifact)
+    mutated["release_boundary"]["fake_minimax_evidence_allowed"] = True
+    assert list(validator.iter_errors(mutated))
+
+    mutated = copy.deepcopy(artifact)
+    mutated["release_boundary"]["ai_output_release_authority"] = True
+    assert list(validator.iter_errors(mutated))
+
+
+def test_gap_audit_schema_rejects_injected_extra_fields() -> None:
+    """Every object layer is closed to extra evidence-injection fields."""
+    validator = _validator()
+    artifact = _artifact()
+
+    mutated = copy.deepcopy(artifact)
+    mutated["unexpected"] = "bypass"
+    assert list(validator.iter_errors(mutated))
+
+    mutated = copy.deepcopy(artifact)
+    mutated["guard_flags"]["unexpected"] = "bypass"
+    assert list(validator.iter_errors(mutated))
+
+    mutated = copy.deepcopy(artifact)
+    mutated["release_boundary"]["unexpected"] = "bypass"
+    assert list(validator.iter_errors(mutated))
+
+    mutated = copy.deepcopy(artifact)
+    mutated["gap_items"][0]["unexpected"] = "bypass"
+    assert list(validator.iter_errors(mutated))
+
+    mutated = copy.deepcopy(artifact)
+    mutated["forbidden_change_audit"]["unexpected"] = "bypass"
+    assert list(validator.iter_errors(mutated))
+
+
+def test_gpp_status_pr_diff_does_not_flip_guard_flags_true() -> None:
+    """Any PR diff that flips GPP guard flags false->true is forbidden."""
+    artifact = _artifact()
+    assert artifact["forbidden_change_audit"] == {
+        "source_path": _GPP_STATUS_PATH,
+        "git_diff_base": "origin/main...HEAD",
+        "git_diff_guard_flags": [
+            "support_widening_allowed",
+            "production_platform_claim_allowed",
+            "live_adapter_execution_allowed",
+        ],
+        "false_to_true_flip_allowed": False,
+        "machine_enforced_by": "tests/test_v5_governed_control_plane_gap_audit.py",
+    }
+
+    combined_diff = "\n".join(
+        [
+            _git_diff("origin/main...HEAD"),
+            _git_diff("--cached"),
+            _git_diff(),
+        ]
+    )
+    assert not _GUARD_TRUE_PATTERN.search(combined_diff), combined_diff


### PR DESCRIPTION
## Summary

Adds a machine-readable V5 governed-control-plane gap audit artifact plus strict schema and invariants.

## Scope

- docs/test/schema/evidence only
- no runtime, workflow, webhook, tag, publish, support-widening, production-platform claim, or live-adapter changes
- preserves release authority as repo-owned ao-release-gate plus GitHub branch protection

## What changed

- Added `docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json`
- Added `ao_kernel/defaults/schemas/v5-governed-control-plane-gap-audit.schema.v1.json`
- Added `tests/test_v5_governed_control_plane_gap_audit.py`
- Linked the audit artifact from the V5 readiness gap note
- Updated `local-ai-review-evidence.v1.json` for this PR scope

## Claude consultation

Claude returned AGREE at plan-time with three mandatory hardening requirements:

1. diff audit uses `origin/main...HEAD` fail-closed semantics
2. nested schema objects close extra fields with `additionalProperties: false`
3. critical booleans are schema-pinned with `const: false`

All three were implemented. Claude final review returned AGREE with no blocking finding.

## Validation

- `python3 -m json.tool docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json >/dev/null`
- `python3 -m json.tool local-ai-review-evidence.v1.json >/dev/null`
- `pytest -q tests/test_v5_governed_control_plane_gap_audit.py tests/test_v5_governed_control_plane_readiness_gap.py tests/test_v4_release_checklist_v5_no_go.py tests/test_publish_workflow.py tests/test_migration_v5_doc` -> 40 passed
- `git diff --check`
- `bash .githooks/pre-commit`
- `python3 scripts/gpp_next.py` -> GPP-9 closed, guard flags false
- `scripts/local_gpp_gate.py` -> `operator_may_merge`

## Guard boundary

This PR does not authorize v5.0.0 tag/publish. #997 remains fail-closed until real MiniMax AGREE evidence exists. AI output remains evidence only, not release authority.