### PR TITLE
docs(runbook): record MiniMax/Mavis runtime workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **MiniMax/Mavis high-risk review runbook**: added an operator runbook for
+  the local MiniMax/Mavis daemon workaround and credential-readiness gate used
+  while diagnosing PR #997 high-risk review evidence. The runbook records the
+  portable worktree/port setup, safe cleanup marker, stop conditions, and raw
+  review producer boundary; it does not provide credentials, fabricate review
+  evidence, close PR #997, widen support, claim production-platform readiness,
+  execute live adapters, or change guard flags.
 - **V5 governed-control-plane gap audit**: added a machine-readable gap audit
   artifact, strict JSON Schema, and invariant tests that pin all guard flags to
   `false`, keep v5 tag/publish disallowed, bind release authority to

--- a/docs/operator-runbooks/05-minimax-mavis-runtime.md
+++ b/docs/operator-runbooks/05-minimax-mavis-runtime.md
@@ -1,0 +1,185 @@
+# Runbook 05 - MiniMax/Mavis Runtime Workaround for High-Risk Review Evidence
+
+> **Agent-prepared only.** This runbook records the local runtime workaround
+> discovered while diagnosing the MiniMax/Mavis reviewer lane for PR #997.
+> It does not provide credentials, does not fabricate review evidence, does
+> not close PR #997, does not widen support, does not authorize live adapter
+> execution, and does not make a production platform claim.
+
+## Purpose
+
+PR #997 is intentionally fail-closed until MiniMax/Mavis produces real
+high-risk review evidence with an `AGREE` verdict. The required artifact is:
+
+```text
+ao-ma-10-high-risk-reviews/minimax.local-ai-review-evidence.v1.json
+```
+
+The repository-owned `ao-release-gate` required check remains release
+authority. AI reviewer output is evidence only. A MiniMax `REVISE` or `BLOCK`
+verdict must keep the PR blocked.
+
+## Observed Failure Modes
+
+The default MiniMax/Mavis CLI path was not enough in the local Codex sandbox:
+
+- Default daemon startup attempted to write under the user Mavis home and
+  failed with filesystem permission errors.
+- Running the daemon with system Node found incompatible native modules.
+- A long local data directory caused the broker socket path to exceed the
+  Unix socket length limit.
+- The workaround was observed with the MiniMax Code app bundled Electron
+  runtime reporting Node `v22.20.0` and module ABI `139`. If the app runtime
+  changes, re-check the config response shape before relying on this runbook.
+- CLI `status` style commands were not reliable against the manually started
+  daemon, while the `/mavis/api/config` endpoint was reliable.
+- Runtime startup is separate from credential readiness. The latest observed
+  configuration reported an invalid API-key status, so provider review could
+  not run.
+
+## Prerequisites
+
+1. Work from a clean feature worktree, not the primary checkout.
+2. Never commit `.m/`, `.mavis/`, config files, logs, tokens, or provider
+   credential material.
+3. Do not paste credential material into prompts, PR comments, logs, shell
+   history, or repository files.
+4. Do not proceed to evidence generation unless the config endpoint reports
+   credential readiness.
+
+## Start the Local Daemon
+
+Use the Electron runtime bundled with the MiniMax Code app. The short `.m`
+data directory avoids the socket path limit, and the local npm cache avoids
+writing to the user npm cache.
+
+```bash
+export WORKTREE_ROOT="/path/to/your/feature-worktree"
+export MINIMAX_MAVIS_PORT="${MINIMAX_MAVIS_PORT:-55321}"
+
+cd "$WORKTREE_ROOT"
+
+mkdir -p .m/npm-cache
+: > .m/.runbook-05-minimax-mavis-runtime
+
+PATH='/Applications/MiniMax Code.app/Contents/Resources/resources/opencode:'"$PATH" \
+ELECTRON_RUN_AS_NODE=1 \
+NODE_PATH='/Applications/MiniMax Code.app/Contents/Resources/app.asar.unpacked/node_modules:/Applications/MiniMax Code.app/Contents/Resources/resources/daemon/node_modules' \
+npm_config_cache="$PWD/.m/npm-cache" \
+NPM_CONFIG_CACHE="$PWD/.m/npm-cache" \
+'/Applications/MiniMax Code.app/Contents/MacOS/MiniMax Code' \
+'/Applications/MiniMax Code.app/Contents/Resources/resources/daemon/daemon.js' \
+  --port "$MINIMAX_MAVIS_PORT" \
+  --data-dir "$PWD/.m"
+```
+
+Run this in a foreground terminal while producing evidence. Stop it with
+`Ctrl-C` after the evidence attempt. If the selected port is already in use,
+choose another local port and use the same `MINIMAX_MAVIS_PORT` value in the
+verification command below.
+
+## Verify Runtime and Credential Readiness
+
+Use the local config endpoint, not the CLI `status` command:
+
+```bash
+/usr/bin/curl -sS --max-time 2 "http://127.0.0.1:${MINIMAX_MAVIS_PORT:-55321}/mavis/api/config" \
+  | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("apiKeyStatus",{}).get("valid"))'
+```
+
+Expected value before any provider review attempt:
+
+```text
+true
+```
+
+If the value is anything else, stop. The runtime may be up, but the provider
+credential gate is not satisfied.
+
+## Credential Gate
+
+Credential setup is operator-owned. The agent must not produce or guess a
+provider key.
+
+- Prefer MiniMax/Mavis UI or the operator-approved local secret mechanism for
+  key configuration.
+- Do not pass provider keys as shell arguments.
+- Do not echo provider keys.
+- Do not print the config file.
+- Do not commit generated runtime state.
+- Do not claim MiniMax review success unless the provider actually returns
+  valid review JSON and the repository tests accept it.
+
+## Evidence Production Boundary
+
+The high-risk evidence producer expects a command in
+`AO_MA10_MINIMAX_REVIEW_CMD`. The source of truth is
+`scripts/ao_ma10_high_risk_raw_review_producer.py`, where the MiniMax provider
+maps to that environment variable. Tests for this producer live in
+`tests/test_ao_ma10_high_risk_raw_review_producer.py`.
+
+The command must:
+
+1. Read review input JSON from stdin.
+2. Return JSON on stdout.
+3. Include the required reviewer fields: `agent`, `verdict`,
+   `checks_considered`, and `findings`.
+4. Return a real MiniMax/Mavis verdict.
+
+The repository checks must accept the generated artifact, including provider
+separation, context binding, secret scan, and schema validation. Manual edits
+that convert a non-AGREE result into `AGREE` are forbidden.
+
+Example invocation shape, with the provider command supplied by the operator:
+
+```bash
+export AO_MA10_MINIMAX_REVIEW_CMD="/path/to/minimax-review-wrapper"
+
+python3 scripts/ao_ma10_high_risk_raw_review_producer.py \
+  --work-package "AO-MA-10 high-risk provider separation" \
+  --base-ref origin/main \
+  --head-ref HEAD \
+  --implementer-provider openai
+```
+
+## Stop Conditions
+
+Stop and keep PR #997 blocked if any of these occur:
+
+- The config endpoint does not report credential readiness.
+- The selected local port is already in use and no alternate port has been
+  selected consistently.
+- Provider request returns an authentication, timeout, or transport error.
+- Provider response is not valid JSON.
+- Provider response records `REVISE`, `BLOCK`, or any non-AGREE verdict.
+- Any token, key, credential, or config value is printed.
+- Any evidence file is manually altered to change the provider verdict.
+
+## Cleanup
+
+After the local evidence attempt, stop the foreground daemon and remove local
+runtime state from the worktree:
+
+```bash
+test -f .m/.runbook-05-minimax-mavis-runtime || {
+  echo "cleanup marker missing; refusing to delete .m"
+  exit 1
+}
+
+find .m -type f -delete
+find .m -type l -delete
+find .m -depth -type d -empty -delete
+```
+
+Confirm the worktree does not include generated state:
+
+```bash
+git status --short
+```
+
+## References
+
+- PR #997 diagnosis comment: `https://github.com/Halildeu/ao-kernel/pull/997#issuecomment-4794769811`
+- V5 gap document: `docs/V5-GOVERNED-CONTROL-PLANE-READINESS-GAP.md`
+- V5 gap audit: `docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json`
+- High-risk review artifacts: `ao-ma-10-high-risk-reviews/`

--- a/docs/operator-runbooks/README.md
+++ b/docs/operator-runbooks/README.md
@@ -23,6 +23,7 @@
 | [`02-plan-approval-environment.md`](02-plan-approval-environment.md) | AO-MA-11A-2: `ao-ma-plan-approval` environment configure |
 | [`03-mirror-pat-secret.md`](03-mirror-pat-secret.md) | AO-MA-11E-2b: `REPO_GH_PAT_PROJECTS_RW` secret seed |
 | [`04-mirror-sync-environment.md`](04-mirror-sync-environment.md) | AO-MA-11E-2b: `ao-ma-mirror-sync` environment configure |
+| [`05-minimax-mavis-runtime.md`](05-minimax-mavis-runtime.md) | MiniMax/Mavis local runtime workaround + credential gate for high-risk review evidence |
 | [`../../ao_kernel/defaults/schemas/operator-action-checklist.schema.v1.json`](../../ao_kernel/defaults/schemas/operator-action-checklist.schema.v1.json) | JSON Schema (Draft 2020-12) |
 
 ## 1. Checklist Overview

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,28 +1,4 @@
 {
-  "schema_version": "local-ai-review-evidence.v1",
-  "repo": "Halildeu/ao-kernel",
-  "work_package": "V5-GAP-FORBIDDEN-CHANGE-AUDIT",
-  "implementer": {
-    "agent": "codex",
-    "provider": "openai"
-  },
-  "reviewer": {
-    "agent": "claude-cli",
-    "provider": "anthropic",
-    "verdict": "AGREE"
-  },
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/v5-gap-forbidden-change-audit",
-    "changed_files": [
-      "CHANGELOG.md",
-      "ao_kernel/defaults/schemas/v5-governed-control-plane-gap-audit.schema.v1.json",
-      "docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json",
-      "docs/V5-GOVERNED-CONTROL-PLANE-READINESS-GAP.md",
-      "local-ai-review-evidence.v1.json",
-      "tests/test_v5_governed_control_plane_gap_audit.py"
-    ]
-  },
   "checks_considered": [
     {
       "name": "tests",
@@ -31,33 +7,37 @@
     {
       "name": "secret_scan",
       "status": "pass"
-    },
-    {
-      "name": "diff_check",
-      "status": "pass"
-    },
-    {
-      "name": "gpp_status",
-      "status": "pass"
-    },
-    {
-      "name": "claude_review",
-      "status": "pass"
     }
   ],
   "findings": [
-    "Claude reviewed the V5 governed-control-plane gap audit plan and returned AGREE with mandatory hardening.",
-    "The implementation applies Claude hardening H1: git diff audit uses origin/main...HEAD and also checks staged and working-tree diffs.",
-    "The implementation applies Claude hardening H2: the schema closes all object layers with additionalProperties false.",
-    "The implementation applies Claude hardening H3: critical guard and release-boundary booleans are schema-pinned with const false.",
-    "The schema and artifact keep support_widening_allowed, production_platform_claim_allowed, and live_adapter_execution_allowed false.",
-    "The artifact keeps v5 tag/publish disallowed and release authority bound to ao-release-gate plus GitHub branch protection.",
-    "The artifact records fake MiniMax AGREE evidence as forbidden and keeps #997 blocked until real MiniMax evidence exists.",
-    "No runtime, workflow, webhook, tag, publish, support-widening, production-claim, or live-adapter surface is changed.",
-    "No blocking findings."
+    "runbook scope is documentation only and preserves release authority boundary",
+    "credential material is not included and MiniMax success remains credential-gated",
+    "cleanup and stop conditions are safe after prior REVISE findings were absorbed"
   ],
-  "secrets_recorded": false,
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
   "live_adapter_execution": false,
+  "production_platform_claim": false,
+  "repo": "Halildeu/ao-kernel",
+  "reviewer": {
+    "agent": "claude",
+    "provider": "anthropic",
+    "verdict": "AGREE"
+  },
+  "schema_version": "local-ai-review-evidence.v1",
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "changed_files": [
+      "CHANGELOG.md",
+      "docs/operator-runbooks/05-minimax-mavis-runtime.md",
+      "docs/operator-runbooks/README.md",
+      "local-ai-review-evidence.v1.json"
+    ],
+    "head_ref": "refs/heads/codex/minimax-mavis-runtime-runbook"
+  },
+  "secrets_recorded": false,
   "support_widening": false,
-  "production_platform_claim": false
+  "work_package": "AO-MA-10-MINIMAX-MAVIS-RUNBOOK"
 }


### PR DESCRIPTION
## Summary
- add operator runbook 05 for the MiniMax/Mavis local runtime workaround discovered while diagnosing PR #997
- document the credential gate, stop conditions, safe cleanup marker, and evidence-production boundary
- index the new runbook from docs/operator-runbooks/README.md
- add CHANGELOG entry and root local-ai-review-evidence.v1.json for ao-release-gate binding

## Scope boundary
- docs/evidence only; no runtime, workflow, schema, ruleset, or GPP status mutation
- no credential material and no provider key placeholders
- does not close PR #997; MiniMax/Mavis real AGREE evidence remains credential-gated
- no support widening, no production platform claim, no live adapter execution

## Cross-AI consultation
- Claude initial verdict: REVISE (6 findings)
- Absorbed: portable WORKTREE_ROOT, configurable port, cleanup marker guard, removed broken reference, runtime ABI note, producer/test source references
- Claude re-review: AGREE
- Claude final diff review with local-ai-review-evidence: AGREE

## Verification
- git diff --check origin/main...HEAD
- pytest -q tests/test_operator_runbooks.py tests/test_operator_runbook.py (49 passed)
- python3 -m json.tool local-ai-review-evidence.v1.json
- scripts/local_gpp_gate.py -> operator_may_merge; 8/8 checks true
- secret-prefix scan on new runbook
- python3 scripts/gpp_next.py guard summary: GPP-9 closed; support_widening=false, production_platform_claim=false, live_adapter_execution=false

Blocked-by for #997 remains: MiniMax/Mavis real credential provisioning
