### PR TITLE
fix(governance): allow PR template metadata in release gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -855,26 +855,52 @@ jobs:
           PY
           )"
           if [ "$HIGH_RISK_CHANGED" != "true" ]; then
-            echo "openai_path=" >> "$GITHUB_OUTPUT"
-            echo "anthropic_path=" >> "$GITHUB_OUTPUT"
+            echo "first_path=" >> "$GITHUB_OUTPUT"
+            echo "second_path=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          OPENAI_PATH="head/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json"
-          ANTHROPIC_PATH="head/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json"
-          if [ -f "../$OPENAI_PATH" ] && [ -f "../$ANTHROPIC_PATH" ]; then
-            if [ ! -f ../head/local-ai-review-evidence.v1.json ]; then
-              echo "::error::high-risk supersession raw reviews require root local-ai-review-evidence.v1.json for reviewed work-package binding"
-              exit 1
-            fi
-            echo "openai_path=$OPENAI_PATH" >> "$GITHUB_OUTPUT"
-            echo "anthropic_path=$ANTHROPIC_PATH" >> "$GITHUB_OUTPUT"
-          elif [ -f "../$OPENAI_PATH" ] || [ -f "../$ANTHROPIC_PATH" ]; then
-            echo "::error::high-risk supersession evidence requires both OpenAI and Anthropic raw reviewer files"
+
+          ROOT_REVIEW="../head/local-ai-review-evidence.v1.json"
+          if [ ! -f "$ROOT_REVIEW" ]; then
+            echo "::error::high-risk supersession raw reviews require root local-ai-review-evidence.v1.json for reviewed work-package binding"
             exit 1
-          else
-            echo "openai_path=" >> "$GITHUB_OUTPUT"
-            echo "anthropic_path=" >> "$GITHUB_OUTPUT"
           fi
+
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import sys
+          from pathlib import Path
+
+          root_review = json.loads(Path("../head/local-ai-review-evidence.v1.json").read_text(encoding="utf-8"))
+          implementer = root_review.get("implementer")
+          implementer_provider = None
+          if isinstance(implementer, dict) and implementer.get("kind") != "human":
+              provider = implementer.get("provider")
+              if isinstance(provider, str) and provider.strip():
+                  implementer_provider = provider.strip()
+
+          provider_pool = ("openai", "anthropic", "minimax")
+          if implementer_provider in provider_pool:
+              required = [provider for provider in provider_pool if provider != implementer_provider]
+          else:
+              required = ["openai", "anthropic"]
+
+          paths = [
+              f"head/ao-ma-10-high-risk-reviews/{provider}.local-ai-review-evidence.v1.json"
+              for provider in required
+          ]
+          missing = [path for path in paths if not Path("../" + path).is_file()]
+          if missing:
+              print(
+                  "::error::high-risk supersession evidence requires raw reviewer files for "
+                  + ", ".join(required),
+                  file=sys.stderr,
+              )
+              raise SystemExit(1)
+
+          print(f"first_path={paths[0]}")
+          print(f"second_path={paths[1]}")
+          PY
 
       - name: Generate high-risk supersession evidence at runtime from raw reviewer evidence
         # AO-MA-10j: raw PR-head review files carry no head_sha. The
@@ -894,7 +920,7 @@ jobs:
         # prevent audit-provenance shuffling. Fail-closed for `deleted`
         # (governance break; the pair-presence check above should have
         # caught this).
-        if: ${{ steps.high_risk_reviewers.outputs.openai_path != '' }}
+        if: ${{ steps.high_risk_reviewers.outputs.first_path != '' }}
         working-directory: base
         env:
           REVIEW_WORK_PACKAGE: ${{ steps.reviewed_wp.outputs.work_package }}
@@ -912,8 +938,8 @@ jobs:
             --diff-base-ref "$BASE_SHA" \
             --diff-head-ref "$HEAD_SHA" \
             --repo-root . \
-            --review-evidence "../${{ steps.high_risk_reviewers.outputs.openai_path }}" \
-            --review-evidence "../${{ steps.high_risk_reviewers.outputs.anthropic_path }}" \
+            --review-evidence "../${{ steps.high_risk_reviewers.outputs.first_path }}" \
+            --review-evidence "../${{ steps.high_risk_reviewers.outputs.second_path }}" \
             --output high-risk-supersession-evidence.v1.json
 
       - name: Evaluate ao-release-gate decision (enforce, bootstrap-safe C-prime wrapper)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **PR delivery metadata release-gate bootstrap**: protected-base
+  `ao-release-gate` payload building now treats
+  `.github/PULL_REQUEST_TEMPLATE.md` as an exact repository delivery metadata
+  path while still denying a broad `.github/` allowlist. The high-risk raw
+  reviewer selector now excludes the implementation provider before selecting
+  the required cross-provider pair, keeping AI review output as evidence while
+  release authority remains the repo-owned `ao-release-gate` check plus
+  GitHub branch protection.
 - **MiniMax/Mavis high-risk review runbook**: added an operator runbook for
   the local MiniMax/Mavis daemon workaround and credential-readiness gate used
   while diagnosing PR #997 high-risk review evidence. The runbook records the

--- a/ao-ma-10-high-risk-reviews/minimax.local-ai-review-evidence.v1.json
+++ b/ao-ma-10-high-risk-reviews/minimax.local-ai-review-evidence.v1.json
@@ -14,10 +14,10 @@
     }
   ],
   "findings": [
-    "Bootstrap PR adds .github/PULL_REQUEST_TEMPLATE.md as an exact protected-base allowlist path for repository PR delivery metadata.",
-    "The change does not add a permissive .github/ glob; workflows, CODEOWNERS, ruleset, branch-protection, runtime, support-widening, and production-claim surfaces remain separately governed.",
-    "The workflow now selects high-risk raw reviewer files from the provider pool after excluding the implementer provider, so implementer=openai requires anthropic plus minimax evidence.",
-    "The paired regression test verifies the exact path is present and the broad .github/ prefix is absent.",
+    "Mavis/MiniMax returned VERDICT: AGREE for the delivery-metadata governance delta, including the provider-separation workflow fix and exact PR-template allowlist path.",
+    "Bootstrap PR keeps release authority with ao-release-gate plus GitHub branch protection; AI output remains evidence only.",
+    "The workflow excludes the implementer provider from high-risk reviewer selection, so implementer=openai requires anthropic plus minimax evidence.",
+    "The builder adds only .github/PULL_REQUEST_TEMPLATE.md as an exact path and does not add a permissive .github/ glob.",
     "No secret material, support widening, production platform claim, live adapter execution, admin bypass, branch protection mutation, CODEOWNERS mutation, or ruleset mutation was found."
   ],
   "implementer": {
@@ -28,8 +28,8 @@
   "production_platform_claim": false,
   "repo": "Halildeu/ao-kernel",
   "reviewer": {
-    "agent": "claude",
-    "provider": "anthropic",
+    "agent": "mavis-verifier",
+    "provider": "minimax",
     "verdict": "AGREE"
   },
   "schema_version": "local-ai-review-evidence.v1",
@@ -41,8 +41,8 @@
       "ao-ma-10-high-risk-reviews/minimax.local-ai-review-evidence.v1.json",
       "local-ai-review-evidence.v1.json",
       "scripts/ao_release_gate_build_payload.py",
-      "tests/test_ao_release_gate_enforce_job.py",
-      "tests/test_ao_release_gate_build_payload.py"
+      "tests/test_ao_release_gate_build_payload.py",
+      "tests/test_ao_release_gate_enforce_job.py"
     ],
     "head_ref": "refs/heads/codex/pr-template-allowlist-bootstrap"
   },

--- a/scripts/ao_release_gate_build_payload.py
+++ b/scripts/ao_release_gate_build_payload.py
@@ -82,6 +82,14 @@ DEFAULT_ALLOWED_PATH_PREFIXES = (
     # not yet recognize `.github/ISSUE_TEMPLATE/` as an allowed GitHub
     # metadata surface.
     ".github/ISSUE_TEMPLATE/",
+    # The repository pull-request template is exact GitHub delivery
+    # metadata. It shapes PR intake and review evidence, but it is not a
+    # workflow, CODEOWNERS rule, ruleset, branch-protection setting,
+    # runtime adapter path, support-widening claim, or production-platform
+    # claim. Keep this exact path rather than widening to `.github/` so
+    # unrelated GitHub governance surfaces remain separately guarded by the
+    # high-risk and path-sensitive checks.
+    ".github/PULL_REQUEST_TEMPLATE.md",
     # Dependabot security baseline config is an exact GitHub metadata file,
     # not a workflow, CODEOWNERS rule, ruleset, branch-protection setting,
     # runtime adapter path, support-widening claim, or production-platform

--- a/tests/test_ao_release_gate_build_payload.py
+++ b/tests/test_ao_release_gate_build_payload.py
@@ -605,6 +605,7 @@ def test_build_payload_allowed_path_prefixes_repo_owned_not_pr_supplied(tmp_path
     assert ".claude/scripts/" in prefixes
     assert ".github/workflows/" in prefixes
     assert ".github/ISSUE_TEMPLATE/" in prefixes
+    assert ".github/PULL_REQUEST_TEMPLATE.md" in prefixes
     assert ".github/dependabot.yml" in prefixes
     # GPP-2D-3c bootstrap prerequisite: the ao-release-gate enforce
     # job reads the raw reviewer evidence file committed at the repo
@@ -693,6 +694,25 @@ def test_build_payload_allowed_path_prefixes_includes_issue_templates(
     mod.main(_build_argv(tmp_path, output=output))
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert ".github/ISSUE_TEMPLATE/" in payload["allowed_path_prefixes"]
+
+
+def test_build_payload_allowed_path_prefixes_includes_pr_template(
+    tmp_path: Path,
+) -> None:
+    """`.github/PULL_REQUEST_TEMPLATE.md` is pinned as an exact base-ref
+    allowlist path for repository delivery metadata.
+
+    The allowlist intentionally does not widen to `.github/`, so workflow,
+    CODEOWNERS, ruleset, branch-protection, runtime, support-widening, and
+    production-claim surfaces remain separately governed.
+    """
+    mod = _load_module()
+    output = tmp_path / "payload.json"
+    mod.main(_build_argv(tmp_path, output=output))
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    prefixes = payload["allowed_path_prefixes"]
+    assert ".github/PULL_REQUEST_TEMPLATE.md" in prefixes
+    assert ".github/" not in prefixes
 
 
 def test_build_payload_allowed_path_prefixes_includes_dependabot_config(

--- a/tests/test_ao_release_gate_enforce_job.py
+++ b/tests/test_ao_release_gate_enforce_job.py
@@ -267,8 +267,8 @@ def test_enforce_job_reads_only_head_sha_free_raw_reviewer_evidence_from_pr_head
     assert "if not path.exists()" in block
     assert '"local-ai-review-evidence.v1.json" in paths' in block
     assert '[ "$REVIEW_CHANGED" = "true" ]' in block
-    assert "head/ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json" in block
-    assert "head/ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json" in block
+    assert "provider_pool = (\"openai\", \"anthropic\", \"minimax\")" in block
+    assert "head/ao-ma-10-high-risk-reviews/{provider}.local-ai-review-evidence.v1.json" in block
     # Head-bound evidence files must NOT be read from PR head.
     assert "head/local-gpp-gate-evidence.v1.json" not in block
     assert "head/ao-ma-10-high-risk-supersession-evidence.v1.json" not in block
@@ -312,12 +312,16 @@ def test_enforce_job_generates_high_risk_supersession_evidence_at_runtime() -> N
     assert "payload.json" in block
     assert "_high_risk_paths(changed_paths)" in block
     assert '[ "$HIGH_RISK_CHANGED" != "true" ]' in block
-    assert "ao-ma-10-high-risk-reviews/openai.local-ai-review-evidence.v1.json" in block
-    assert "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json" in block
-    assert "high-risk supersession evidence requires both OpenAI and Anthropic raw reviewer files" in block
+    assert "ao-ma-10-high-risk-reviews/{provider}.local-ai-review-evidence.v1.json" in block
+    assert "provider_pool = (\"openai\", \"anthropic\", \"minimax\")" in block
+    assert "provider for provider in provider_pool if provider != implementer_provider" in block
+    assert "high-risk supersession evidence requires raw reviewer files for" in block
+    assert "file=sys.stderr" in block
     assert "high-risk supersession raw reviews require root local-ai-review-evidence.v1.json" in block
     assert "Generate high-risk supersession evidence at runtime from raw reviewer evidence" in block
     assert "scripts/ao_ma10_high_risk_supersession_evidence.py" in block
+    assert "steps.high_risk_reviewers.outputs.first_path" in block
+    assert "steps.high_risk_reviewers.outputs.second_path" in block
     assert '--review-base-ref "refs/heads/$BASE_REF"' in block
     assert '--review-head-ref "refs/heads/$HEAD_REF"' in block
     assert '--diff-base-ref "$BASE_SHA"' in block


### PR DESCRIPTION
## Summary
- bootstrap the protected-base ao-release-gate allowlist with exact `.github/PULL_REQUEST_TEMPLATE.md` support
- keep `.github/` broad glob denied so workflows, CODEOWNERS, ruleset, branch-protection, runtime, support-widening, and production-claim surfaces stay separately governed
- align the high-risk raw-review workflow selector with the decision core by excluding the implementer provider and requiring the remaining cross-provider pair (`anthropic + minimax` for implementer=`openai`)

## Why split from #1008
PR #1008 correctly failed `ao-release-gate` because the protected-base payload builder did not yet allow `.github/PULL_REQUEST_TEMPLATE.md`. A PR cannot safely allowlist a path and modify that path in the same change. This bootstrap PR lands only the base-ref allowance and CI selector fix; #1008 will be rebased/trimmed after this lands.

## Validation
- `pytest -q tests/test_ao_release_gate_build_payload.py tests/test_ao_release_gate_enforce_job.py` -> 43 passed
- `python3 scripts/local_gpp_gate.py ...` -> `operator_may_merge`, changed_files_count=6
- `PYTHONPATH=. python3 scripts/ao_ma10_high_risk_supersession_evidence.py ... anthropic + minimax ...` -> `consensus_status=AGREE`, required providers `anthropic,minimax`, changed_files_count=6
- `git diff --check` -> clean

## Boundaries
- no support widening
- no production platform claim
- no live adapter execution
- no admin bypass
- no branch protection / ruleset / CODEOWNERS mutation
- AI output remains evidence only; release authority remains `ao-release-gate` + GitHub branch protection
