### PR TITLE
feat(pr-metadata): productize delivery metadata validation

### DIFF
--- a/.claude/plans/GPP-2B-AO-RELEASE-GATE-REQUIRED-CHECK-MAPPING.md
+++ b/.claude/plans/GPP-2B-AO-RELEASE-GATE-REQUIRED-CHECK-MAPPING.md
@@ -53,12 +53,13 @@ stays `blocked`.
   `ao_kernel/ao_release_gate_service.py` + `ao_release_gate_runtime.py`.
 - A repo-owned GitHub App release gate. Consumes a PR-shaped GitHub payload
   plus the GPP status JSON. Emits an `ao-release-gate` GitHub check-run.
-- Thirty-three checks (GPP-2D-2b added `review_evidence` and
+- Thirty-four checks (GPP-2D-2b added `review_evidence` and
   `review_evidence_context_bound` to the original eighteen; GPP-2D-6b added
   `path_sensitive_human_review`; AO-MA-10b added six
   `ao_ma10_*` checks for future low-risk autonomous merge evidence; AO-MA-10i
   added six `high_risk_supersession_*` checks for context-bound high-risk
-  supersession evidence);
+  supersession evidence; the PR delivery metadata productization slice added
+  the diagnostic-only `pr_delivery_metadata_diagnostic` check);
   `decision = allow_autonomous_merge` only when all pass, otherwise one of
   `deny_policy_violation`, `deny_missing_evidence`, `deny_stale_branch`,
   `deny_untrusted_context`, `error_fail_closed`.
@@ -72,7 +73,7 @@ stays `blocked`.
 
 ### 3.1 Check correspondence
 
-| Local gate check (8) | ao-release-gate check(s) (33) | Category |
+| Local gate check (8) | ao-release-gate check(s) (34) | Category |
 |---|---|---|
 | `startup_preflight_passed` | `payload_shape`, `repository` | A — evaluation context is structurally valid |
 | `gpp_status_checked` | `gpp_status`, `gpp_closed_boundaries` | A — GPP-2 blocked + support/production/live-adapter guards false |
@@ -81,7 +82,7 @@ stays `blocked`.
 | `secret_scan_passed` | `secret_boundary` | A — no secret material |
 | `forbidden_actions_absent` | `admin_bypass_boundary`, `bot_boundary`, `agent_authority_boundary`, `live_adapter_boundary` | A — no forbidden action / authority |
 | `reviewer_agree`, `cross_provider_verified` | `review_evidence` | A — cross-AI reviewer AGREE + cross-provider verdict consumed by ao-release-gate via the local-gpp-gate-evidence acceptance profile (GPP-2D-2b) |
-| *(none)* | `pull_request`, `issue_link`, `base_ref`, `branch_freshness`, `fork_boundary`, `event_boundary`, `gpp_issue_consistency`, `review_evidence_context_bound`, `high_risk_supersession_evidence`, `high_risk_supersession_schema`, `high_risk_supersession_freshness`, `high_risk_supersession_consensus`, `high_risk_supersession_context_bound`, `high_risk_supersession_authority_boundary`, `path_sensitive_human_review`, `ao_ma10_autonomous_request`, `ao_ma10_evidence_bundle`, `ao_ma10_evidence_bundle_schema`, `ao_ma10_consensus`, `ao_ma10_context_bound`, `ao_ma10_authority_boundary` | B — GitHub PR-context and AO-MA-10 autonomous-lane checks, ao-release-gate-only |
+| *(none)* | `pull_request`, `issue_link`, `base_ref`, `branch_freshness`, `fork_boundary`, `event_boundary`, `gpp_issue_consistency`, `review_evidence_context_bound`, `high_risk_supersession_evidence`, `high_risk_supersession_schema`, `high_risk_supersession_freshness`, `high_risk_supersession_consensus`, `high_risk_supersession_context_bound`, `high_risk_supersession_authority_boundary`, `path_sensitive_human_review`, `ao_ma10_autonomous_request`, `ao_ma10_evidence_bundle`, `ao_ma10_evidence_bundle_schema`, `ao_ma10_consensus`, `ao_ma10_context_bound`, `ao_ma10_authority_boundary`, `pr_delivery_metadata_diagnostic` | B — GitHub PR-context, AO-MA-10 autonomous-lane, and PR delivery metadata diagnostic checks, ao-release-gate-only |
 
 - **Category A** — both gates verify the same governance condition from
   different vantage points (local repo state vs. GitHub PR payload). These are
@@ -97,9 +98,11 @@ stays `blocked`.
   count, plus `path_sensitive_human_review`, which uses GitHub review metadata
   to require current-head non-author approval only when high-risk paths
   changed, plus AO-MA-10 evidence-bundle checks that bind future low-risk
-  autonomous merge consensus to the PR context). The local gate has no PR
-  payload and cannot perform these; they are inherently ao-release-gate-only
-  and require no reconciliation.
+  autonomous merge consensus to the PR context, plus
+  `pr_delivery_metadata_diagnostic`, which carries a sanitized PR-body metadata
+  diagnostic without making PR-author text release authority). The local gate
+  has no PR payload and cannot perform these; they are inherently
+  ao-release-gate-only and require no reconciliation.
 - **Category C** — historical: the cross-AI peer review verdict was previously
   unmappable (local-only) and tracked in §4 as the substantive gap. GPP-2D-2b
   closes that gap by wiring the ao-release-gate decision core to consume the

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,17 +5,46 @@
 ## Delivery metadata
 
 <!--
-Machine-readable reviewer input. Keep this block current; a follow-up gate will
-parse it against `pr-delivery-metadata.schema.v1.json`.
+Machine-readable reviewer input. This single JSON block is validated by
+`ao-kernel pr-metadata validate --body-file ...` against
+`pr-delivery-metadata.schema.v1.json`.
+
+PR-authored metadata is evidence/diagnostic input only. Release authority
+remains the repo-owned `ao-release-gate` required check plus GitHub branch
+protection; the gate derives risk from trusted API/diff context, not from this
+PR body declaration.
 -->
 
-```yaml
-Issue: <#123 or N/A>
-Tracked by: <#123 or N/A>
-Work package: <AO-MA/GPP/Epic id or N/A>
-Risk class: <low|normal|high|governance|critical-fix>
-Release authority impact: <none|ao-release-gate-input-only|ao-release-gate-logic|github-ruleset|support-tier-or-claim>
-Critical-Fix: no
+```json pr-delivery-metadata
+{
+  "boundary_declaration": {
+    "boundary_cross": false,
+    "credential_read": false,
+    "credential_write": false,
+    "none_of_the_above": true,
+    "state_mutation_production": false,
+    "state_mutation_test": false,
+    "user_approval_evidence": "N/A",
+    "user_communication": false
+  },
+  "critical_fix": false,
+  "cross_ai_review": {
+    "implementer_provider": "openai",
+    "review_artifacts": [
+      "N/A"
+    ],
+    "reviewer_providers": [
+      "anthropic"
+    ],
+    "same_provider_exception": "N/A",
+    "verdict": "N/A"
+  },
+  "issue": "N/A",
+  "release_authority_impact": "none",
+  "risk_class": "normal",
+  "tracked_by": "N/A",
+  "work_package": "AO-MA-or-GPP-id"
+}
 ```
 
 ## Scope
@@ -25,12 +54,12 @@ Critical-Fix: no
 - Why now:
 - Files / surfaces changed:
 
-## Boundary declaration
+## Boundary declaration (human mirror)
 
 <!--
-At least one item must be selected. If `none of the above` is selected, every
-other item must remain unselected. Credential material must never be copied into
-the PR body, comments, logs, or evidence artifacts.
+Keep this section aligned with the JSON block above. The validator reads the
+JSON block; this mirror is for reviewer scanning only. Credential material must
+never be copied into the PR body, comments, logs, or evidence artifacts.
 -->
 
 This PR includes:
@@ -45,21 +74,14 @@ This PR includes:
 
 User/operator approval evidence: `<link or N/A>`
 
-## Cross-AI review evidence
+## Cross-AI review evidence (human mirror)
 
 <!--
-AI review is evidence only. Release authority remains `ao-release-gate` plus
-GitHub branch protection. For high-risk/governance-sensitive PRs, reviewers must
-be provider-separated from the implementer and the repo-owned gate must pass.
+Keep this section aligned with the JSON block above. AI review is evidence only.
+Release authority remains `ao-release-gate` plus GitHub branch protection. For
+high-risk/governance-sensitive PRs, reviewers must be provider-separated from the
+implementer and the repo-owned gate must pass.
 -->
-
-```yaml
-Implementer provider: <openai|anthropic|minimax|human|other>
-Reviewer provider(s): <openai|anthropic|minimax|human|other|N/A>
-Review artifact(s): <PR comment URL, evidence path, or N/A>
-Verdict: <AGREE|REVISE|BLOCK|N/A>
-Same-provider exception: N/A
-```
 
 ## Validation
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -532,6 +532,7 @@ jobs:
         run: |
           gh pr view "$PR_NUMBER" --repo "$REPO_FULL" --json files > pr-files.json
           gh pr view "$PR_NUMBER" --repo "$REPO_FULL" --json reviews,author > pr-reviews.json
+          gh pr view "$PR_NUMBER" --repo "$REPO_FULL" --json body --jq '.body // ""' > pr-body.md
           gh api "repos/$REPO_FULL/commits/$HEAD_SHA/check-runs?per_page=100" > check-runs.json
 
       - name: Compute branch_up_to_date from base
@@ -583,6 +584,11 @@ jobs:
       - name: Build API-derived release-gate payload
         working-directory: base
         run: |
+          PR_BODY_ARGS=()
+          if python scripts/ao_release_gate_build_payload.py --help | grep -q -- "--pr-body-file"; then
+            PR_BODY_ARGS=(--pr-body-file pr-body.md)
+          fi
+
           python scripts/ao_release_gate_build_payload.py \
             --repository "$REPO_FULL" \
             --pr-number "$PR_NUMBER" \
@@ -594,6 +600,7 @@ jobs:
             --gpp-status .claude/plans/gpp_status.v1.json \
             --pr-files-json pr-files.json \
             --check-runs-json check-runs.json \
+            "${PR_BODY_ARGS[@]}" \
             --required-check lint \
             --required-check typecheck \
             --required-check "test (3.11)" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **PR delivery metadata productization**: added the packaged
+  `ao-kernel pr-metadata` CLI (`schema`, `template`, and `validate`) so any
+  installed `ao-kernel` runtime can generate and validate the canonical PR
+  delivery metadata block without copying repo-local docs. The pull request
+  template now uses a single fenced JSON block, and `ao-release-gate` carries a
+  sanitized `untrusted_pr_delivery_metadata` diagnostic summary from the PR
+  body. PR-author metadata remains diagnostic only: it never changes release
+  authority, weakens trusted diff/API/GPP checks, mutates branch protection,
+  widens support, claims production-platform readiness, or executes live
+  adapters.
 - **PR delivery metadata release-gate bootstrap**: protected-base
   `ao-release-gate` payload building now treats
   `.github/PULL_REQUEST_TEMPLATE.md` as an exact repository delivery metadata

--- a/ao_kernel/_internal/live_adapter_dryrun.py
+++ b/ao_kernel/_internal/live_adapter_dryrun.py
@@ -143,7 +143,16 @@ class DryRunKillSwitches:
         with contextlib.suppress(ImportError):
             patcher(importlib.import_module(module_name))
 
+    def _preload_optional(self, module_name: str) -> None:
+        with contextlib.suppress(ImportError):
+            importlib.import_module(module_name)
+
+    def _preload_optional_http_clients(self) -> None:
+        for module_name in ("httpx", "urllib3", "requests", "aiohttp"):
+            self._preload_optional(module_name)
+
     def _install(self) -> None:
+        self._preload_optional_http_clients()
         self._patch_socket()
         self._patch_subprocess()
         self._patch_os_exec()

--- a/ao_kernel/ao_release_gate.py
+++ b/ao_kernel/ao_release_gate.py
@@ -342,6 +342,12 @@ class AoReleaseGateContext(TypedDict):
     live_adapter_execution_requested: bool | None
     low_risk_autonomous_merge_requested: bool | None
     low_risk_autonomous_merge_request_valid: bool | None
+    pr_delivery_metadata_present: bool | None
+    pr_delivery_metadata_valid: bool | None
+    pr_delivery_metadata_finding_code: str | None
+    pr_delivery_metadata_risk_class: str | None
+    pr_delivery_metadata_release_authority_impact: str | None
+    pr_delivery_metadata_work_package: str | None
     reviewed_slice: str | None
     gpp_current_wp_id: str | None
     gpp_current_wp_issue: str | None
@@ -513,6 +519,31 @@ def _autonomous_merge_request_context(
     if len(set(values)) > 1:
         return None, False
     return values[0], True
+
+
+def _pr_delivery_metadata_context(root: dict[str, Any], service: dict[str, Any]) -> dict[str, Any]:
+    """Return sanitized untrusted PR delivery metadata diagnostics."""
+
+    raw = _as_dict(root.get("untrusted_pr_delivery_metadata")) or _as_dict(
+        service.get("untrusted_pr_delivery_metadata")
+    )
+    if not raw:
+        return {
+            "present": None,
+            "valid": None,
+            "finding_code": None,
+            "risk_class": None,
+            "release_authority_impact": None,
+            "work_package": None,
+        }
+    return {
+        "present": _bool(raw.get("present")),
+        "valid": _bool(raw.get("valid")),
+        "finding_code": _string(raw.get("finding_code")),
+        "risk_class": _string(raw.get("risk_class")),
+        "release_authority_impact": _string(raw.get("release_authority_impact")),
+        "work_package": _string(raw.get("work_package")),
+    }
 
 
 def _service_context(payload: dict[str, Any]) -> dict[str, Any]:
@@ -728,6 +759,52 @@ def _check(
     return _blocked(name, finding_code=finding_code, detail=blocked_detail)
 
 
+def _pr_delivery_metadata_diagnostic_check(context: AoReleaseGateContext) -> AoReleaseGateCheck:
+    """Return a diagnostic-only PR delivery metadata check.
+
+    The PR body is PR-author controlled, so this check never emits a finding
+    code and never influences release-gate allow/deny. It makes the portable
+    product validator visible in the release-gate artifact without granting PR
+    body text release authority.
+    """
+
+    if context["pr_delivery_metadata_valid"] is True:
+        risk_class = context["pr_delivery_metadata_risk_class"] or "<missing>"
+        impact = context["pr_delivery_metadata_release_authority_impact"] or "<missing>"
+        return _pass(
+            "pr_delivery_metadata_diagnostic",
+            detail=(
+                "Untrusted PR delivery metadata is present and schema-valid "
+                f"(risk_class={risk_class}, release_authority_impact={impact}). "
+                "This is diagnostic only; trusted diff/API context remains release authority input."
+            ),
+        )
+    if context["pr_delivery_metadata_present"] is False:
+        return _pass(
+            "pr_delivery_metadata_diagnostic",
+            detail=(
+                "Untrusted PR delivery metadata is absent. This is diagnostic only in this release-gate "
+                "version and does not affect allow/deny."
+            ),
+        )
+    if context["pr_delivery_metadata_present"] is True:
+        code = context["pr_delivery_metadata_finding_code"] or "pr_delivery_metadata_invalid"
+        return _pass(
+            "pr_delivery_metadata_diagnostic",
+            detail=(
+                f"Untrusted PR delivery metadata is present but invalid ({code}). "
+                "This is diagnostic only in this release-gate version and does not affect allow/deny."
+            ),
+        )
+    return _pass(
+        "pr_delivery_metadata_diagnostic",
+        detail=(
+            "PR delivery metadata diagnostics were not supplied by the trusted-base payload builder. "
+            "This is diagnostic only and does not affect allow/deny."
+        ),
+    )
+
+
 def extract_ao_release_gate_context(payload: object, gpp_status: object) -> AoReleaseGateContext:
     """Extract normalized release-gate context from dry-run inputs."""
 
@@ -745,6 +822,7 @@ def extract_ao_release_gate_context(payload: object, gpp_status: object) -> AoRe
         service.get("pr_author"),
         _as_dict(pull_request.get("author")).get("login"),
     )
+    pr_delivery_metadata = _pr_delivery_metadata_context(root, service)
     changed_paths = _strings(root.get("changed_paths")) or _strings(service.get("changed_paths"))
     allowed_path_prefixes = _strings(root.get("allowed_path_prefixes")) or _strings(
         service.get("allowed_path_prefixes")
@@ -793,6 +871,14 @@ def extract_ao_release_gate_context(payload: object, gpp_status: object) -> AoRe
         ),
         "low_risk_autonomous_merge_requested": autonomous_requested,
         "low_risk_autonomous_merge_request_valid": autonomous_request_valid,
+        "pr_delivery_metadata_present": _bool(pr_delivery_metadata.get("present")),
+        "pr_delivery_metadata_valid": _bool(pr_delivery_metadata.get("valid")),
+        "pr_delivery_metadata_finding_code": _string(pr_delivery_metadata.get("finding_code")),
+        "pr_delivery_metadata_risk_class": _string(pr_delivery_metadata.get("risk_class")),
+        "pr_delivery_metadata_release_authority_impact": _string(
+            pr_delivery_metadata.get("release_authority_impact")
+        ),
+        "pr_delivery_metadata_work_package": _string(pr_delivery_metadata.get("work_package")),
         "reviewed_slice": _first_string(root.get("reviewed_slice"), service.get("reviewed_slice")),
         "gpp_current_wp_id": _first_string(current_wp.get("id")),
         "gpp_current_wp_issue": _first_string(current_wp.get("issue")),
@@ -2086,6 +2172,7 @@ def build_ao_release_gate_decision(
             pass_detail="Changed paths are inside the explicit work-package allowlist.",
             blocked_detail="Changed paths or allowlist are missing, or a changed path is out of scope.",
         ),
+        _pr_delivery_metadata_diagnostic_check(context),
         *high_risk_supersession_checks,
         _check(
             "path_sensitive_human_review",

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -744,6 +744,59 @@ def _cmd_support_widening_evidence_validate(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_pr_metadata_schema(args: argparse.Namespace) -> int:
+    """Print the bundled PR delivery metadata schema."""
+
+    import json as _json
+
+    from ao_kernel.pr_metadata import load_pr_delivery_metadata_schema
+
+    print(_json.dumps(load_pr_delivery_metadata_schema(), indent=2, sort_keys=True))
+    return 0
+
+
+def _cmd_pr_metadata_template(args: argparse.Namespace) -> int:
+    """Print the canonical portable PR delivery metadata JSON block."""
+
+    from ao_kernel.pr_metadata import pr_delivery_metadata_template_json
+
+    print("```json pr-delivery-metadata")
+    print(pr_delivery_metadata_template_json())
+    print("```")
+    return 0
+
+
+def _cmd_pr_metadata_validate(args: argparse.Namespace) -> int:
+    """Validate a PR body markdown file against the bundled metadata schema."""
+
+    import json as _json
+    from pathlib import Path as _Path
+
+    from ao_kernel.pr_metadata import validate_pr_delivery_metadata_markdown
+
+    if args.body_file == "-":
+        body = sys.stdin.read()
+    else:
+        body_path = _Path(args.body_file)
+        if not body_path.is_file():
+            print(f"PR body file not found: {body_path}", file=sys.stderr)
+            return 2
+        body = body_path.read_text(encoding="utf-8")
+    result = validate_pr_delivery_metadata_markdown(body)
+    payload = result.to_dict()
+    if args.output == "json":
+        print(_json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        status = "VALID" if result.valid else "INVALID"
+        print(f"{status}: {result.finding_code}")
+        print(result.message)
+        if result.risk_class:
+            print(f"risk_class: {result.risk_class}")
+        if result.release_authority_impact:
+            print(f"release_authority_impact: {result.release_authority_impact}")
+    return 0 if result.valid else 1
+
+
 def _cmd_cost_reconcile(args: argparse.Namespace) -> int:
     """v3.4.0 CLI: scan ledger for orphan spend entries and stamp
     missing markers. Idempotent + cursor-based."""
@@ -1409,6 +1462,25 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         dest="include_doc_claims",
         help="Include unverified doc-claim facts (labelled UNVERIFIED)",
+    )
+
+    pr_meta_p = sub.add_parser(
+        "pr-metadata",
+        help="PR delivery metadata schema, template, and validation commands",
+    )
+    pr_meta_sub = pr_meta_p.add_subparsers(dest="pr_metadata_command")
+    pr_meta_sub.add_parser("schema", help="Print the bundled PR delivery metadata JSON Schema")
+    pr_meta_sub.add_parser("template", help="Print the canonical pr-delivery-metadata JSON block")
+    pr_meta_validate = pr_meta_sub.add_parser(
+        "validate",
+        help="Validate a PR body markdown file against the bundled PR delivery metadata schema",
+    )
+    pr_meta_validate.add_argument("--body-file", required=True, help="Path to the PR body markdown file, or '-' for stdin")
+    pr_meta_validate.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Command output format (default: text)",
     )
 
     # Evidence subcommands (PR-A5)
@@ -2226,6 +2298,17 @@ def main(argv: list[str] | None = None) -> int:
         if ctx_cmd == "packet":
             return _cmd_context_packet(args)
         print("Usage: ao-kernel context {ingest,packet} [--root PATH] [--repo PATH]", file=sys.stderr)
+        return 1
+
+    if cmd == "pr-metadata":
+        pr_meta_cmd = getattr(args, "pr_metadata_command", None)
+        if pr_meta_cmd == "schema":
+            return _cmd_pr_metadata_schema(args)
+        if pr_meta_cmd == "template":
+            return _cmd_pr_metadata_template(args)
+        if pr_meta_cmd == "validate":
+            return _cmd_pr_metadata_validate(args)
+        print("Usage: ao-kernel pr-metadata {schema|template|validate}", file=sys.stderr)
         return 1
 
     # Executor subcommand (PR-C6)

--- a/ao_kernel/pr_metadata.py
+++ b/ao_kernel/pr_metadata.py
@@ -1,0 +1,188 @@
+"""Portable PR delivery metadata validation helpers.
+
+PR delivery metadata is an untrusted PR-author declaration. This module
+validates the declaration for product portability and diagnostics, but it does
+not make PR-author text release authority. The release authority remains the
+repo-owned ao-release-gate decision plus GitHub enforcement.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.config import load_default
+
+PR_DELIVERY_METADATA_SCHEMA_NAME = "pr-delivery-metadata.schema.v1.json"
+PR_DELIVERY_METADATA_SCHEMA_ID = "urn:ao:pr-delivery-metadata:v1"
+
+_FENCE_RE = re.compile(
+    r"```(?P<info>[^\n`]*)\n(?P<body>.*?)\n```",
+    flags=re.DOTALL,
+)
+
+PrMetadataFinding = Literal[
+    "pr_delivery_metadata_ok",
+    "pr_delivery_metadata_absent",
+    "pr_delivery_metadata_malformed_json",
+    "pr_delivery_metadata_schema_invalid",
+]
+
+
+@dataclass(frozen=True)
+class PrDeliveryMetadataValidation:
+    """Sanitized PR delivery metadata validation result."""
+
+    present: bool
+    valid: bool
+    finding_code: PrMetadataFinding
+    message: str
+    metadata: dict[str, Any] | None = None
+    risk_class: str | None = None
+    release_authority_impact: str | None = None
+    work_package: str | None = None
+    issue: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable sanitized result."""
+
+        return {
+            "schema_id": PR_DELIVERY_METADATA_SCHEMA_ID,
+            "present": self.present,
+            "valid": self.valid,
+            "finding_code": self.finding_code,
+            "message": self.message,
+            "risk_class": self.risk_class,
+            "release_authority_impact": self.release_authority_impact,
+            "work_package": self.work_package,
+            "issue": self.issue,
+        }
+
+
+def load_pr_delivery_metadata_schema() -> dict[str, Any]:
+    """Load the bundled PR delivery metadata JSON Schema."""
+
+    schema = load_default("schemas", PR_DELIVERY_METADATA_SCHEMA_NAME)
+    Draft202012Validator.check_schema(schema)
+    return schema
+
+
+def extract_pr_delivery_metadata_block(markdown: str) -> str | None:
+    """Extract the first fenced ``pr-delivery-metadata`` JSON block.
+
+    Accepted info strings are intentionally narrow and explicit:
+
+    - ``json pr-delivery-metadata``
+    - ``pr-delivery-metadata json``
+    - ``pr-delivery-metadata``
+
+    A plain ``json`` fence is ignored so unrelated examples in the PR body
+    cannot be treated as the delivery declaration by accident.
+    """
+
+    for match in _FENCE_RE.finditer(markdown):
+        info = " ".join(match.group("info").strip().lower().split())
+        tokens = set(info.split())
+        if info == "pr-delivery-metadata" or {"json", "pr-delivery-metadata"}.issubset(tokens):
+            return match.group("body").strip()
+    return None
+
+
+def validate_pr_delivery_metadata_object(metadata: object) -> PrDeliveryMetadataValidation:
+    """Validate an already-parsed metadata object."""
+
+    if not isinstance(metadata, dict):
+        return PrDeliveryMetadataValidation(
+            present=True,
+            valid=False,
+            finding_code="pr_delivery_metadata_schema_invalid",
+            message="PR delivery metadata must be a JSON object.",
+        )
+
+    schema = load_pr_delivery_metadata_schema()
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(metadata),
+        key=lambda error: list(error.absolute_path),
+    )
+    if errors:
+        first = errors[0]
+        path = ".".join(str(item) for item in first.absolute_path) or "<root>"
+        return PrDeliveryMetadataValidation(
+            present=True,
+            valid=False,
+            finding_code="pr_delivery_metadata_schema_invalid",
+            message=(
+                "PR delivery metadata schema validation failed "
+                f"at {path} (validator={first.validator})."
+            ),
+        )
+
+    return PrDeliveryMetadataValidation(
+        present=True,
+        valid=True,
+        finding_code="pr_delivery_metadata_ok",
+        message="PR delivery metadata validates against pr-delivery-metadata.schema.v1.json.",
+        metadata=cast(dict[str, Any], metadata),
+        risk_class=cast(str | None, metadata.get("risk_class")),
+        release_authority_impact=cast(str | None, metadata.get("release_authority_impact")),
+        work_package=cast(str | None, metadata.get("work_package")),
+        issue=cast(str | None, metadata.get("issue")),
+    )
+
+
+def validate_pr_delivery_metadata_markdown(markdown: str) -> PrDeliveryMetadataValidation:
+    """Extract and validate PR delivery metadata from a PR body."""
+
+    block = extract_pr_delivery_metadata_block(markdown)
+    if block is None:
+        return PrDeliveryMetadataValidation(
+            present=False,
+            valid=False,
+            finding_code="pr_delivery_metadata_absent",
+            message="No fenced pr-delivery-metadata JSON block found in the PR body.",
+        )
+    try:
+        parsed = json.loads(block)
+    except json.JSONDecodeError:
+        return PrDeliveryMetadataValidation(
+            present=True,
+            valid=False,
+            finding_code="pr_delivery_metadata_malformed_json",
+            message="PR delivery metadata block is not valid JSON.",
+        )
+    return validate_pr_delivery_metadata_object(parsed)
+
+
+def pr_delivery_metadata_template_json() -> str:
+    """Return the canonical JSON block used by the GitHub PR template."""
+
+    payload = {
+        "issue": "N/A",
+        "tracked_by": "N/A",
+        "work_package": "AO-MA-or-GPP-id",
+        "risk_class": "normal",
+        "release_authority_impact": "none",
+        "critical_fix": False,
+        "boundary_declaration": {
+            "credential_read": False,
+            "credential_write": False,
+            "state_mutation_test": False,
+            "state_mutation_production": False,
+            "boundary_cross": False,
+            "user_communication": False,
+            "none_of_the_above": True,
+            "user_approval_evidence": "N/A",
+        },
+        "cross_ai_review": {
+            "implementer_provider": "openai",
+            "reviewer_providers": ["anthropic"],
+            "review_artifacts": ["N/A"],
+            "verdict": "N/A",
+            "same_provider_exception": "N/A",
+        },
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)

--- a/docs/operator-runbooks/06-pr-delivery-metadata.md
+++ b/docs/operator-runbooks/06-pr-delivery-metadata.md
@@ -16,11 +16,33 @@ changing release authority.
 - This contract does not authorize support widening, production-platform claim,
   live-adapter execution, ruleset bypass actors, or admin merge.
 
+## Portable product commands
+
+The metadata contract is now exposed through `ao-kernel`, not only through this
+repository's PR template:
+
+```bash
+ao-kernel pr-metadata schema
+ao-kernel pr-metadata template
+ao-kernel pr-metadata validate --body-file pr-body.md
+ao-kernel pr-metadata validate --body-file pr-body.md --output json
+```
+
+`validate` exits `0` only when the PR body contains a fenced
+`json pr-delivery-metadata` block that validates against the bundled schema. It
+exits non-zero for missing, malformed, or schema-invalid metadata.
+
+The release gate also carries a sanitized `untrusted_pr_delivery_metadata`
+summary in its payload when the GitHub Actions workflow supplies the PR body.
+Metadata-only PR body gate: this is the metadata-only PR body gate surface for
+this release. It is diagnostic only, not enforcement. PR-author text never
+becomes release authority and never weakens trusted diff/API/GPP checks.
+
 ## What the PR template must declare
 
 Every PR should expose the following fields in a predictable form:
 
-- primary issue and optional `Tracked by` issue;
+- primary issue and optional `tracked_by` issue;
 - work package identifier;
 - risk class;
 - release-authority impact;
@@ -30,8 +52,9 @@ Every PR should expose the following fields in a predictable form:
 - validation evidence;
 - merge and post-merge cleanup notes.
 
-The future metadata gate can parse this body and validate it against
-`ao_kernel/defaults/schemas/pr-delivery-metadata.schema.v1.json`.
+The canonical form is a single fenced `json pr-delivery-metadata` block. Human
+mirror sections may remain in the template for reviewer scanning, but the product
+validator and release-gate diagnostic read only the JSON block.
 
 ## `Tracked by` versus `Closes`
 
@@ -54,7 +77,8 @@ If the PR includes credential read/write, production state mutation,
 boundary-crossing behavior, or user communication, user/operator approval
 evidence must not be `N/A`.
 
-The template's `Critical-Fix: no` value is intended to be parsed with YAML boolean semantics, where `no` maps to `false`.
+The JSON block uses `"critical_fix": false`. YAML boolean parsing is no longer
+part of the machine-readable contract.
 
 ## Cross-AI evidence semantics
 
@@ -72,10 +96,11 @@ decides whether any exception is acceptable for the PR risk class.
 
 ## Adoption sequence
 
-1. PR template and schema contract.
-2. Metadata-only PR body gate.
-3. Merge-to-issue evidence workflow.
-4. Lightweight issue/board helper CLI.
-5. Critical-fix trailer and label automation.
+1. PR template and schema contract. Done.
+2. Portable `ao-kernel pr-metadata` schema/template/validate commands. Done.
+3. Metadata-only release-gate diagnostic from GitHub API PR body. Done.
+4. Merge-to-issue evidence workflow.
+5. Lightweight issue/board helper CLI.
+6. Critical-fix trailer and label automation.
 
 Each step should be a separate PR so the gate remains observable and reversible.

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -9,17 +9,29 @@
       "status": "pass"
     },
     {
-      "name": "governance_boundary_review",
+      "name": "schema_design",
+      "status": "pass"
+    },
+    {
+      "name": "trust_boundary",
+      "status": "pass"
+    },
+    {
+      "name": "release_gate_integration",
       "status": "pass"
     }
   ],
   "findings": [
-    "MiniMax/Mavis returned VERDICT: AGREE for PR #1008 after reviewing the delivery metadata contract and final exact-allowlist delta.",
-    "Delivery metadata template, schema, runbook, and changelog adapt platform-k8s delivery discipline without changing release authority.",
-    "Release authority remains ao-release-gate required check plus GitHub branch protection; AI output remains evidence only.",
-    "The final branch no longer has to bootstrap .github/PULL_REQUEST_TEMPLATE.md allowlist or provider-aware high-risk selector; those are landed in protected base by PR #1009.",
-    "No secret material, support widening, production platform claim, live adapter execution, admin bypass, branch protection mutation, CODEOWNERS mutation, or ruleset mutation was found.",
-    "Schema and tests cover boundary declaration, sensitive-boundary approval evidence, AGREE/REVISE/BLOCK review artifact requirements, same-provider handling, and slice-scoped zero-touch guards."
+    "Anthropic Claude returned AGREE after final post-hardening review of PR delivery metadata productization.",
+    "Anthropic Claude returned AGREE after post-CI Python 3.11 localized workspace-not-found test fix; runtime code and release authority were unchanged.",
+    "Anthropic Claude returned AGREE after protected-base workflow compatibility fix: --pr-body-file is feature-detected before being passed to the base checkout payload builder.",
+    "PR delivery metadata is untrusted PR-author input: payload key is untrusted_pr_delivery_metadata and the release-gate check is diagnostic-only with no finding_code or allow/deny influence.",
+    "Schema-invalid metadata diagnostics use generic path plus validator output and do not echo raw user-supplied invalid values; regression test covers secret-like invalid values.",
+    "Packaged ao-kernel pr-metadata CLI provides schema/template/validate outside repo-local docs, with stdin and text/json validation output.",
+    "PR template migrated to explicit fenced JSON pr-delivery-metadata block, preventing accidental extraction from unrelated JSON code fences.",
+    "Workflow integration fetches PR body via GitHub API and passes it to the trusted-base payload builder as sanitized diagnostics only.",
+    "Dry-run killswitch preload fix is narrow and preserves network blocking while avoiding optional-client import-time socket patch breakage.",
+    "No secret material, support widening, production platform claim, live adapter execution, admin bypass, branch-protection mutation, CODEOWNERS mutation, or release-authority drift was found."
   ],
   "implementer": {
     "agent": "codex",
@@ -29,27 +41,36 @@
   "production_platform_claim": false,
   "repo": "Halildeu/ao-kernel",
   "reviewer": {
-    "agent": "mavis-verifier",
-    "provider": "minimax",
+    "agent": "anthropic-claude-reviewer",
+    "provider": "anthropic",
     "verdict": "AGREE"
   },
   "schema_version": "local-ai-review-evidence.v1",
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
+      ".claude/plans/GPP-2B-AO-RELEASE-GATE-REQUIRED-CHECK-MAPPING.md",
       ".github/PULL_REQUEST_TEMPLATE.md",
+      ".github/workflows/test.yml",
       "CHANGELOG.md",
-      "ao-ma-10-high-risk-reviews/minimax.local-ai-review-evidence.v1.json",
-      "ao_kernel/defaults/schemas/pr-delivery-metadata.schema.v1.json",
+      "ao_kernel/_internal/live_adapter_dryrun.py",
+      "ao_kernel/ao_release_gate.py",
+      "ao_kernel/cli.py",
+      "ao_kernel/pr_metadata.py",
       "docs/operator-runbooks/06-pr-delivery-metadata.md",
       "local-ai-review-evidence.v1.json",
-      "tests/test_changelog_enforcement_workflow_shape.py",
-      "tests/test_issue_forms_shape.py",
-      "tests/test_pr_delivery_metadata_contract.py"
+      "scripts/ao_release_gate_build_payload.py",
+      "tests/test_ao_release_gate.py",
+      "tests/test_ao_release_gate_build_payload.py",
+      "tests/test_ao_release_gate_enforce_job.py",
+      "tests/test_gpp2b_mapping_drift_guard.py",
+      "tests/test_migrate_cmd.py",
+      "tests/test_pr_delivery_metadata_contract.py",
+      "tests/test_pr_metadata_product.py"
     ],
-    "head_ref": "refs/heads/codex/delivery-metadata-pr-template"
+    "head_ref": "refs/heads/codex/pr-metadata-productization"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-delivery-ceremony-PR1"
+  "work_package": "AO-PR-METADATA-PRODUCTIZATION"
 }

--- a/scripts/ao_release_gate_build_payload.py
+++ b/scripts/ao_release_gate_build_payload.py
@@ -35,6 +35,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from ao_kernel.pr_metadata import validate_pr_delivery_metadata_markdown
+
 # A repo-owned, base-ref-trusted path allowlist for the diff_scope check.
 # Hard-coded here rather than read from gpp_status.current_wp.allowed_scope
 # because that field carries narrative scope statements, not file-path
@@ -223,6 +225,21 @@ def _review_context(pr_reviews_json_path: Path | None) -> tuple[str | None, list
             }
         )
     return author if isinstance(author, str) else None, reviews
+
+
+def _pr_delivery_metadata_summary(pr_body_path: Path | None) -> dict[str, Any]:
+    """Return sanitized, untrusted PR delivery metadata diagnostics.
+
+    The PR body is authored by the PR submitter, so this summary is never
+    release authority and never feeds scope/risk decisions. It is carried for
+    product diagnostics only; release-gate policy remains derived from
+    trusted API/diff/GPP inputs.
+    """
+
+    if pr_body_path is None:
+        return validate_pr_delivery_metadata_markdown("").to_dict()
+    body = pr_body_path.read_text(encoding="utf-8")
+    return validate_pr_delivery_metadata_markdown(body).to_dict()
 
 
 def _check_run_sort_key(entry: dict[str, Any]) -> tuple[str, str, int]:
@@ -416,6 +433,7 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
         "codex_or_claude_release_authority": False,
         "live_adapter_execution_requested": False,
         "low_risk_autonomous_merge_requested": args.ao_ma10_autonomous_merge_requested,
+        "untrusted_pr_delivery_metadata": _pr_delivery_metadata_summary(args.pr_body_file),
     }
 
 
@@ -449,6 +467,15 @@ def build_parser() -> argparse.ArgumentParser:
             "Optional output of `gh pr view <N> --json reviews,author`. "
             "When supplied, the payload carries only normalized review metadata "
             "for the path-sensitive high-risk human gate."
+        ),
+    )
+    parser.add_argument(
+        "--pr-body-file",
+        type=Path,
+        default=None,
+        help=(
+            "Optional PR body markdown fetched from the GitHub API. The builder parses only a sanitized "
+            "untrusted PR delivery metadata diagnostic summary; PR body text is never release authority."
         ),
     )
     parser.add_argument(

--- a/tests/test_ao_release_gate.py
+++ b/tests/test_ao_release_gate.py
@@ -338,6 +338,55 @@ def _find_check(decision: dict[str, object], name: str) -> dict[str, object]:
     raise AssertionError(f"missing check: {name}")
 
 
+def test_release_gate_surfaces_pr_delivery_metadata_as_diagnostic_only() -> None:
+    payload = _allow_payload()
+    payload["untrusted_pr_delivery_metadata"] = {
+        "schema_id": "urn:ao:pr-delivery-metadata:v1",
+        "present": True,
+        "valid": False,
+        "finding_code": "pr_delivery_metadata_schema_invalid",
+        "message": "schema failed",
+        "risk_class": None,
+        "release_authority_impact": None,
+        "work_package": None,
+        "issue": None,
+    }
+
+    decision = build_ao_release_gate_decision(payload, _gpp_status(), review_evidence=_review_evidence())
+
+    assert decision["decision"] == ALLOW_AUTONOMOUS_MERGE_DECISION
+    assert "pr_delivery_metadata_schema_invalid" not in decision["findings"]
+    diagnostic = _find_check(decision, "pr_delivery_metadata_diagnostic")
+    assert diagnostic["status"] == "pass"
+    assert diagnostic["finding_code"] is None
+    assert "diagnostic only" in str(diagnostic["detail"])
+
+
+def test_release_gate_context_records_valid_pr_delivery_metadata_summary() -> None:
+    payload = _allow_payload()
+    payload["untrusted_pr_delivery_metadata"] = {
+        "schema_id": "urn:ao:pr-delivery-metadata:v1",
+        "present": True,
+        "valid": True,
+        "finding_code": "pr_delivery_metadata_ok",
+        "message": "ok",
+        "risk_class": "governance",
+        "release_authority_impact": "ao-release-gate-input-only",
+        "work_package": "AO-MA-delivery-metadata",
+        "issue": "#1008",
+    }
+
+    decision = build_ao_release_gate_decision(payload, _gpp_status(), review_evidence=_review_evidence())
+
+    assert decision["decision"] == ALLOW_AUTONOMOUS_MERGE_DECISION
+    context = decision["context"]
+    assert context["pr_delivery_metadata_present"] is True
+    assert context["pr_delivery_metadata_valid"] is True
+    assert context["pr_delivery_metadata_risk_class"] == "governance"
+    diagnostic = _find_check(decision, "pr_delivery_metadata_diagnostic")
+    assert diagnostic["status"] == "pass"
+
+
 def _stale_branch_payload() -> dict[str, object]:
     payload = _allow_payload()
     payload["branch_up_to_date"] = False

--- a/tests/test_ao_release_gate_build_payload.py
+++ b/tests/test_ao_release_gate_build_payload.py
@@ -7,6 +7,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from ao_kernel.pr_metadata import pr_delivery_metadata_template_json
+
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
@@ -55,6 +57,14 @@ def _write_pr_reviews(path: Path) -> None:
                 ],
             }
         ),
+        encoding="utf-8",
+    )
+
+
+def _write_pr_body(path: Path, *, valid: bool = True) -> None:
+    block = pr_delivery_metadata_template_json() if valid else '{"issue": "not-valid"}'
+    path.write_text(
+        "## Delivery metadata\n\n```json pr-delivery-metadata\n" + block + "\n```\n",
         encoding="utf-8",
     )
 
@@ -173,6 +183,44 @@ def test_build_payload_can_request_ao_ma10_autonomous_merge_from_trusted_cli(tmp
     assert rc == 0
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert payload["low_risk_autonomous_merge_requested"] is True
+
+
+def test_build_payload_carries_sanitized_untrusted_pr_delivery_metadata(tmp_path: Path) -> None:
+    mod = _load_module()
+    output = tmp_path / "payload.json"
+    body = tmp_path / "pr-body.md"
+    _write_pr_body(body)
+    argv = _build_argv(tmp_path, output=output)
+    argv.extend(["--pr-body-file", str(body)])
+
+    rc = mod.main(argv)
+
+    assert rc == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    metadata = payload["untrusted_pr_delivery_metadata"]
+    assert metadata["present"] is True
+    assert metadata["valid"] is True
+    assert metadata["risk_class"] == "normal"
+    assert "body" not in metadata
+    assert "metadata" not in metadata
+
+
+def test_build_payload_carries_invalid_pr_delivery_metadata_as_diagnostic_only(tmp_path: Path) -> None:
+    mod = _load_module()
+    output = tmp_path / "payload.json"
+    body = tmp_path / "pr-body.md"
+    _write_pr_body(body, valid=False)
+    argv = _build_argv(tmp_path, output=output)
+    argv.extend(["--pr-body-file", str(body)])
+
+    rc = mod.main(argv)
+
+    assert rc == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    metadata = payload["untrusted_pr_delivery_metadata"]
+    assert metadata["present"] is True
+    assert metadata["valid"] is False
+    assert metadata["finding_code"] == "pr_delivery_metadata_schema_invalid"
 
 
 def test_build_payload_sorts_and_carries_changed_paths(tmp_path: Path) -> None:

--- a/tests/test_ao_release_gate_enforce_job.py
+++ b/tests/test_ao_release_gate_enforce_job.py
@@ -218,6 +218,11 @@ def test_enforce_job_builds_payload_from_api_not_pr_committed_json() -> None:
     assert "gh api" in block and "/check-runs" in block
     assert "--pr-files-json pr-files.json" in block
     assert "--check-runs-json check-runs.json" in block
+    assert "gh pr view \"$PR_NUMBER\" --repo \"$REPO_FULL\" --json body" in block
+    assert "PR_BODY_ARGS=()" in block
+    assert 'grep -q -- "--pr-body-file"' in block
+    assert "--pr-body-file pr-body.md" in block
+    assert '"${PR_BODY_ARGS[@]}"' in block
     assert "--gpp-status .claude/plans/gpp_status.v1.json" in block
     assert "Detect AO-MA-10l low-risk autonomous smoke request" in block
     assert 'prefix = "docs/evidence/ao-ma-10l-autonomous-smoke/"' in block

--- a/tests/test_gpp2b_mapping_drift_guard.py
+++ b/tests/test_gpp2b_mapping_drift_guard.py
@@ -7,9 +7,10 @@ pin that table to both gates' *actual* check sets so the mapping cannot
 silently drift:
 
 - the 8 local-gate checks declared in ``local-gpp-gate-evidence.schema.v1.json``
-- the 33 ao-release-gate checks produced by ``build_ao_release_gate_decision``
+- the 34 ao-release-gate checks produced by ``build_ao_release_gate_decision``
   (GPP-2D-2b added ``review_evidence`` and ``review_evidence_context_bound``;
-  AO-MA-10b added six ``ao_ma10_*`` checks)
+  AO-MA-10b added six ``ao_ma10_*`` checks; the PR metadata productization
+  slice added ``pr_delivery_metadata_diagnostic``)
 
 If either gate gains, loses, or renames a check without the table being
 updated, these tests fail. This is a documentation-integrity test only: it
@@ -157,7 +158,7 @@ def test_section_3_1_table_anchor() -> None:
 
 
 def test_section_3_1_header_counts_match_actual_check_sets() -> None:
-    """The (8) and (20) counts in the table header match the live gates."""
+    """The table header counts match the live gates."""
     table = _parse_section_3_1()
     local_total = len(_schema_local_check_names())
     ao_total = len(_runtime_ao_release_gate_check_names())

--- a/tests/test_migrate_cmd.py
+++ b/tests/test_migrate_cmd.py
@@ -27,7 +27,7 @@ class TestMigrateCmd:
         rc = run()
         assert rc == 1
         out = capsys.readouterr().out.lower()
-        assert "not found" in out or "no workspace" in out
+        assert "not found" in out or "no workspace" in out or "workspace bulunamad" in out
 
     def test_version_mismatch_triggers_migration(self, tmp_workspace: Path, capsys):
         ws_json = tmp_workspace / "workspace.json"

--- a/tests/test_pr_delivery_metadata_contract.py
+++ b/tests/test_pr_delivery_metadata_contract.py
@@ -12,6 +12,11 @@ from pathlib import Path
 
 from jsonschema import Draft202012Validator
 
+from ao_kernel.pr_metadata import (
+    extract_pr_delivery_metadata_block,
+    validate_pr_delivery_metadata_markdown,
+)
+
 
 ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE = ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
@@ -33,12 +38,13 @@ def test_pr_template_exposes_delivery_metadata_fields() -> None:
     text = TEMPLATE.read_text(encoding="utf-8")
     required = [
         "## Delivery metadata",
-        "Issue:",
-        "Tracked by:",
-        "Work package:",
-        "Risk class:",
-        "Release authority impact:",
-        "Critical-Fix:",
+        "```json pr-delivery-metadata",
+        '"issue"',
+        '"tracked_by"',
+        '"work_package"',
+        '"risk_class"',
+        '"release_authority_impact"',
+        '"critical_fix"',
         "## Boundary declaration",
         "credential-read",
         "credential-write",
@@ -48,11 +54,11 @@ def test_pr_template_exposes_delivery_metadata_fields() -> None:
         "user-communication",
         "none of the above",
         "## Cross-AI review evidence",
-        "Implementer provider:",
-        "Reviewer provider(s):",
-        "Review artifact(s):",
-        "Verdict:",
-        "Same-provider exception:",
+        '"implementer_provider"',
+        '"reviewer_providers"',
+        '"review_artifacts"',
+        '"verdict"',
+        '"same_provider_exception"',
     ]
     for item in required:
         assert item in text, f"missing PR template contract field: {item}"
@@ -64,6 +70,24 @@ def test_pr_template_preserves_release_authority_boundary() -> None:
     assert "Release authority remains `ao-release-gate` plus" in text
     assert "No support widening, production-platform claim, live-adapter execution" in text
     assert "admin merge" in text
+
+
+def test_pr_template_metadata_block_validates_against_bundled_schema() -> None:
+    text = TEMPLATE.read_text(encoding="utf-8")
+    block = extract_pr_delivery_metadata_block(text)
+    assert block is not None
+    payload = json.loads(block)
+    schema = _load_schema()
+    errors = list(Draft202012Validator(schema).iter_errors(payload))
+    assert errors == [], [error.message for error in errors]
+
+
+def test_pr_template_metadata_block_validates_with_product_helper() -> None:
+    text = TEMPLATE.read_text(encoding="utf-8")
+    result = validate_pr_delivery_metadata_markdown(text)
+    assert result.valid is True
+    assert result.finding_code == "pr_delivery_metadata_ok"
+    assert result.risk_class == "normal"
 
 
 def test_schema_validates_minimal_low_risk_metadata() -> None:
@@ -258,5 +282,5 @@ def test_runbook_documents_adoption_sequence_and_non_goals() -> None:
     assert "This contract does not authorize support widening" in text
     assert "Metadata-only PR body gate" in text
     assert "Merge-to-issue evidence workflow" in text
-    assert "YAML boolean semantics" in text
+    assert "YAML boolean parsing is no longer" in text
     assert "same-provider implementer/reviewer overlap" in text

--- a/tests/test_pr_metadata_product.py
+++ b/tests/test_pr_metadata_product.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+
+from ao_kernel.cli import main as cli_main
+from ao_kernel.pr_metadata import (
+    extract_pr_delivery_metadata_block,
+    pr_delivery_metadata_template_json,
+    validate_pr_delivery_metadata_markdown,
+)
+
+
+def _valid_body() -> str:
+    return "## Delivery metadata\n\n```json pr-delivery-metadata\n" + pr_delivery_metadata_template_json() + "\n```\n"
+
+
+def test_extract_pr_delivery_metadata_requires_explicit_info_string() -> None:
+    assert extract_pr_delivery_metadata_block("```json\n{\"issue\":\"N/A\"}\n```") is None
+    assert extract_pr_delivery_metadata_block(_valid_body()) is not None
+
+
+def test_validate_pr_delivery_metadata_markdown_accepts_valid_body() -> None:
+    result = validate_pr_delivery_metadata_markdown(_valid_body())
+    assert result.present is True
+    assert result.valid is True
+    assert result.finding_code == "pr_delivery_metadata_ok"
+    assert result.risk_class == "normal"
+    assert result.release_authority_impact == "none"
+
+
+def test_validate_pr_delivery_metadata_markdown_reports_missing_block_without_echoing_body() -> None:
+    result = validate_pr_delivery_metadata_markdown("## Summary\nno metadata here\n")
+    assert result.present is False
+    assert result.valid is False
+    assert result.finding_code == "pr_delivery_metadata_absent"
+    assert "no metadata here" not in result.message
+
+
+def test_validate_pr_delivery_metadata_markdown_reports_malformed_json_without_echoing_body() -> None:
+    body = "```json pr-delivery-metadata\n{\"issue\": SECRET_TOKEN\n```\n"
+    result = validate_pr_delivery_metadata_markdown(body)
+    assert result.present is True
+    assert result.valid is False
+    assert result.finding_code == "pr_delivery_metadata_malformed_json"
+    assert "SECRET_TOKEN" not in result.message
+
+
+def test_validate_pr_delivery_metadata_markdown_rejects_schema_invalid_payload() -> None:
+    body = '```json pr-delivery-metadata\n{"issue":"not-an-issue"}\n```\n'
+    result = validate_pr_delivery_metadata_markdown(body)
+    assert result.present is True
+    assert result.valid is False
+    assert result.finding_code == "pr_delivery_metadata_schema_invalid"
+    assert "not-an-issue" not in result.message
+
+
+def test_validate_pr_delivery_metadata_schema_error_does_not_echo_invalid_values() -> None:
+    body = '```json pr-delivery-metadata\n{"risk_class":"invalid-sensitive-value-redacted-check"}\n```\n'
+    result = validate_pr_delivery_metadata_markdown(body)
+    assert result.present is True
+    assert result.valid is False
+    assert result.finding_code == "pr_delivery_metadata_schema_invalid"
+    assert "invalid-sensitive-value-redacted-check" not in result.message
+    assert "validator=" in result.message
+
+
+def test_pr_metadata_cli_schema_outputs_bundled_schema(capsys) -> None:
+    rc = cli_main(["pr-metadata", "schema"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    schema = json.loads(captured.out)
+    assert schema["$id"] == "urn:ao:pr-delivery-metadata:v1"
+
+
+def test_pr_metadata_cli_template_outputs_valid_block(capsys) -> None:
+    rc = cli_main(["pr-metadata", "template"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "```json pr-delivery-metadata" in captured.out
+    assert validate_pr_delivery_metadata_markdown(captured.out).valid is True
+
+
+def test_pr_metadata_cli_validate_json_success(tmp_path: Path, capsys) -> None:
+    body_path = tmp_path / "pr-body.md"
+    body_path.write_text(_valid_body(), encoding="utf-8")
+
+    rc = cli_main(["pr-metadata", "validate", "--body-file", str(body_path), "--output", "json"])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(captured.out)
+    assert payload["valid"] is True
+    assert payload["finding_code"] == "pr_delivery_metadata_ok"
+
+
+def test_pr_metadata_cli_validate_accepts_stdin(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(sys, "stdin", StringIO(_valid_body()))
+
+    rc = cli_main(["pr-metadata", "validate", "--body-file", "-", "--output", "json"])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(captured.out)
+    assert payload["valid"] is True
+
+
+def test_pr_metadata_cli_validate_text_failure(tmp_path: Path, capsys) -> None:
+    body_path = tmp_path / "pr-body.md"
+    body_path.write_text("no metadata", encoding="utf-8")
+
+    rc = cli_main(["pr-metadata", "validate", "--body-file", str(body_path)])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "INVALID: pr_delivery_metadata_absent" in captured.out


### PR DESCRIPTION
## Summary
- Productizes PR delivery metadata as a packaged `ao-kernel pr-metadata` CLI surface (`schema`, `template`, `validate`) instead of repo-local docs only.
- Migrates the PR template to one explicit fenced JSON metadata block and wires PR body parsing into the trusted-base release-gate payload builder as sanitized diagnostics.
- Keeps PR body metadata untrusted: it never changes allow/deny, never becomes release authority, and invalid metadata stays diagnostic-only.

```json pr-delivery-metadata
{
  "boundary_declaration": {
    "boundary_cross": false,
    "credential_read": false,
    "credential_write": false,
    "none_of_the_above": true,
    "state_mutation_production": false,
    "state_mutation_test": false,
    "user_approval_evidence": "N/A",
    "user_communication": false
  },
  "critical_fix": false,
  "cross_ai_review": {
    "implementer_provider": "openai",
    "review_artifacts": [
      "local-ai-review-evidence.v1.json"
    ],
    "reviewer_providers": [
      "anthropic"
    ],
    "same_provider_exception": "N/A",
    "verdict": "AGREE"
  },
  "issue": "N/A",
  "release_authority_impact": "ao-release-gate-input-only",
  "risk_class": "governance",
  "tracked_by": "N/A",
  "work_package": "AO-PR-METADATA-PRODUCTIZATION"
}
```

## Validation
- `pytest -q` -> 7107 passed, 114 skipped
- `pytest -q tests/test_pr_metadata_product.py tests/test_pr_delivery_metadata_contract.py` -> 23 passed
- `ruff check` targeted -> pass
- `mypy ao_kernel/pr_metadata.py` -> pass
- `python3 -m ao_kernel.cli pr-metadata schema | python3 -m json.tool >/dev/null` -> pass
- `python3 -m ao_kernel.cli pr-metadata template | python3 -m ao_kernel.cli pr-metadata validate --body-file - --output json` -> pass
- `bash .claude/scripts/ops.sh preflight` -> pass with unrelated dirty-worktree warnings only
- `python3 scripts/gpp_next.py` -> program closed, no blocked work packages
- `python3 scripts/local_gpp_gate.py ...` -> `operator_may_merge` (8/8 pass)

## Cross-AI Review
- Claude (`anthropic`) plan review returned REVISE; findings absorbed before implementation.
- Claude post-hardening review returned AGREE; evidence recorded in `local-ai-review-evidence.v1.json`.
- MiniMax/Mavis did not return a fresh current verdict for this slice; no MiniMax evidence was fabricated.

## Release Authority Boundary
- AI review output and PR body metadata remain evidence/diagnostics only.
- Release authority remains the repo-owned `ao-release-gate` required check plus GitHub branch/ruleset enforcement.
- No support widening, production platform claim, live adapter execution, admin bypass, branch-protection mutation, CODEOWNERS mutation, or secret material change is included.
