### PR TITLE
docs(ri): close promotion decision as beta onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **Repo-intelligence productization closeout**: recorded the existing RI-7.8c
+  final non-promotion decision in the V5 gap audit and release-planning docs. The
+  productized surface is beta read-only onboarding only: GitHub App
+  installation plus repository selection. It does not widen support, claim
+  production-platform readiness, execute live adapters, change guard flags, or
+  reopen v5.0.0 tag/publish authority.
 - **PR delivery metadata productization**: added the packaged
   `ao-kernel pr-metadata` CLI (`schema`, `template`, and `validate`) so any
   installed `ao-kernel` runtime can generate and validate the canonical PR

--- a/ao_kernel/defaults/schemas/v5-governed-control-plane-gap-audit.schema.v1.json
+++ b/ao_kernel/defaults/schemas/v5-governed-control-plane-gap-audit.schema.v1.json
@@ -180,7 +180,13 @@
         "title": { "type": "string", "minLength": 1 },
         "status": {
           "type": "string",
-          "enum": ["open", "blocked_external", "operator_bound", "done"]
+          "enum": [
+            "open",
+            "blocked_external",
+            "operator_bound",
+            "closed_non_promotion",
+            "done"
+          ]
         },
         "owner_boundary": {
           "type": "string",

--- a/docs/V4-GOVERNED-CONTROL-PLANE-RELEASE-CHECKLIST.md
+++ b/docs/V4-GOVERNED-CONTROL-PLANE-RELEASE-CHECKLIST.md
@@ -63,7 +63,10 @@ Before an operator tags a v4.x release, collect and record:
    - `ao-release-gate-technical`.
 3. `python3 scripts/repo_intelligence_tier_promotion_readiness.py --output json
    --evidence-manifest .claude/plans/RI-7-EVIDENCE-MANIFEST.v1.json` output
-   remains `ready_for_operator_promotion_decision` with guard flags false.
+   remains `ready_for_operator_promotion_decision` with guard flags false, and
+   `.claude/plans/RI-7.8c-FINAL-PROMOTE-DECISION.v1.json` remains the current
+   closed non-promotion outcome: repo-intelligence is beta read-only product
+   onboarding, not a support-tier or production-platform promotion.
 4. `CHANGELOG.md` has a release entry that frames the release as governed
    control-plane hardening, not production platform promotion.
 5. `pyproject.toml` version and any release notes agree on the same v4.x

--- a/docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json
+++ b/docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json
@@ -29,12 +29,12 @@
     },
     {
       "id": "repo-intelligence-promotion-decision",
-      "title": "Operator-bound repo-intelligence promotion or non-promotion decision",
-      "status": "operator_bound",
+      "title": "Repo-intelligence non-promotion decision and beta read-only product onboarding",
+      "status": "closed_non_promotion",
       "owner_boundary": "operator",
-      "evidence_required": "An explicit operator decision consuming the committed RI-7 evidence manifest and preserving or changing support boundaries through a separate authority path.",
-      "current_evidence": "The manifest-backed readiness report is ready_for_operator_decision, but it is evidence only and does not authorize autonomous support widening.",
-      "blocking_for_v5_tag_publish": true
+      "evidence_required": "RI-7.8c final operator non-promotion decision consuming the committed RI-7 evidence manifest while preserving CLI-only, no support widening, no production claim, and no live adapter execution boundaries.",
+      "current_evidence": ".claude/plans/RI-7.8c-FINAL-PROMOTE-DECISION.v1.json records the final non-promotion outcome: repo-intelligence is productized only as beta read-only onboarding, not a general-purpose production promotion.",
+      "blocking_for_v5_tag_publish": false
     },
     {
       "id": "v5-major-release-supersession",
@@ -69,7 +69,7 @@
   "next_safe_actions": [
     "Keep #997 fail-closed until real MiniMax AGREE evidence exists.",
     "Use the v4.x governed-control-plane release checklist for any near-term release preparation.",
-    "Treat RI-7 readiness as input to a later operator-bound promotion or non-promotion decision.",
+    "Treat RI-7.8c as the closed repo-intelligence non-promotion decision; keep repo-intelligence productized only as beta read-only onboarding.",
     "Do not tag or publish v5.0.0 without an explicit operator-bound supersession PR."
   ]
 }

--- a/docs/V5-GOVERNED-CONTROL-PLANE-READINESS-GAP.md
+++ b/docs/V5-GOVERNED-CONTROL-PLANE-READINESS-GAP.md
@@ -47,6 +47,13 @@ The safe release framing is therefore:
   control-plane GA, with changelog/PyPI/docs stating that all three guard flags
   remain false and that no production-platform promotion happened.
 
+Repo-intelligence has its own closed decision record. `RI-7.8c` consumed the
+manifest-backed readiness package and chose **non-promotion** under the current
+CLI-only/monthly-subscription operating mode. The resulting product surface is
+beta read-only onboarding: GitHub App installation plus repository selection,
+without end-user Cloud Run, Vault, webhook, private-key, live-adapter, support
+widening, or production-platform setup.
+
 ## Machine-Enforced Gap Audit
 
 `docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json` is the machine-readable
@@ -61,7 +68,10 @@ The audit artifact pins:
 - release authority to `ao-release-gate` plus GitHub branch protection;
 - AI review output as evidence only, not release authority;
 - fake MiniMax `AGREE` evidence as forbidden;
-- the remaining V5 blockers as MiniMax/environment and operator-bound items.
+- the remaining V5 blockers as MiniMax/environment and major-release
+  supersession items;
+- the repo-intelligence promotion decision as closed by `RI-7.8c` as
+  non-promotion, not as a support-tier promotion.
 
 The same test file also audits the PR diff for
 `.claude/plans/gpp_status.v1.json` using `origin/main...HEAD` and fails if any
@@ -116,9 +126,10 @@ live_adapter_execution: false
 ```
 
 That manifest-backed ready state means the RI-7 evidence package is prepared
-for a later operator-bound promotion decision PR. It does not itself authorize
-support widening, a production-platform claim, live adapter execution, a
-`v5.0.0` tag, or publication.
+for a promotion decision, and `RI-7.8c` has now recorded the decision outcome:
+**non-promotion**. It does not authorize support widening, a
+production-platform claim, live adapter execution, a `v5.0.0` tag, or
+publication. The productized outcome is beta read-only onboarding only.
 
 Manifest-backed coverage for the completed agent-preparable RI-7 rows:
 
@@ -162,7 +173,7 @@ The correct completion path for `#985` is:
 |---:|---|---|---|
 | 1 | MiniMax provider/tooling unblock for `#997` | Operator/environment + agent verification | Real MiniMax `AGREE` evidence replaces `BLOCK`; `ao-release-gate` passes. |
 | 2 | Governed-control-plane v4.x release checklist | Agent planning only | Done by PR #1002: `docs/V4-GOVERNED-CONTROL-PLANE-RELEASE-CHECKLIST.md` records packaging, docs, changelog, version, and publish preflight without tag/publish or guard flips. |
-| 3 | Repo-intelligence promotion decision PR | Operator-bound | Consumes the manifest-backed readiness report and explicitly chooses promotion or non-promotion. No autonomous guard flip. |
+| 3 | Repo-intelligence promotion decision | Closed non-promotion | Done by `RI-7.8c`: manifest-backed readiness was consumed and the outcome is beta read-only product onboarding, not promotion. No guard flip. |
 | 4 | Separate major-release supersession, if ever desired | Operator-bound | Explicitly renames the release target as governed control-plane GA; no general-purpose production-platform claim unless separately authorized. |
 
 ## v5.0.0 Release No-Go
@@ -176,8 +187,8 @@ The current safe release preparation surface is:
 1. keep all three guard flags false;
 2. prepare a conservative v4.x governed-control-plane release checklist;
 3. keep #997 fail-closed until real MiniMax `AGREE` evidence exists;
-4. treat the RI-7 manifest-backed ready state as input to a later
-   operator-bound decision, not as autonomous release authority;
+4. treat the RI-7.8c non-promotion decision as closed beta read-only
+   productization, not as autonomous release authority;
 5. avoid public wording that can be read as a general-purpose production
    platform claim.
 
@@ -202,9 +213,8 @@ Recommended follow-up slices:
 1. `fix(#985): replace fail-closed MiniMax blocker with real MiniMax evidence`
    after the external MiniMax credential/tooling issue is resolved.
 2. `docs(release): prepare governed-control-plane v4.x release checklist`.
-3. `decision(ri): operator-bound repo-intelligence promotion or non-promotion
-   decision`, if the operator chooses to consume the manifest-backed
-   `ready_for_operator_decision` report.
+3. `supersession(release): operator-bound major-release decision`, only if a
+   future operator explicitly reopens the major-release path.
 
 None of these slices should tag, publish, widen support, claim production
 platform readiness, or execute live adapters.

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -22,16 +22,12 @@
     }
   ],
   "findings": [
-    "Anthropic Claude returned AGREE after final post-hardening review of PR delivery metadata productization.",
-    "Anthropic Claude returned AGREE after post-CI Python 3.11 localized workspace-not-found test fix; runtime code and release authority were unchanged.",
-    "Anthropic Claude returned AGREE after protected-base workflow compatibility fix: --pr-body-file is feature-detected before being passed to the base checkout payload builder.",
-    "PR delivery metadata is untrusted PR-author input: payload key is untrusted_pr_delivery_metadata and the release-gate check is diagnostic-only with no finding_code or allow/deny influence.",
-    "Schema-invalid metadata diagnostics use generic path plus validator output and do not echo raw user-supplied invalid values; regression test covers secret-like invalid values.",
-    "Packaged ao-kernel pr-metadata CLI provides schema/template/validate outside repo-local docs, with stdin and text/json validation output.",
-    "PR template migrated to explicit fenced JSON pr-delivery-metadata block, preventing accidental extraction from unrelated JSON code fences.",
-    "Workflow integration fetches PR body via GitHub API and passes it to the trusted-base payload builder as sanitized diagnostics only.",
-    "Dry-run killswitch preload fix is narrow and preserves network blocking while avoiding optional-client import-time socket patch breakage.",
-    "No secret material, support widening, production platform claim, live adapter execution, admin bypass, branch-protection mutation, CODEOWNERS mutation, or release-authority drift was found."
+    "Anthropic Claude returned AGREE after post-implementation review of the repo-intelligence productization closeout diff.",
+    "The V5 gap audit records repo-intelligence-promotion-decision as closed_non_promotion and no longer a V5 tag blocker.",
+    "The remaining V5 blockers are still MiniMax provider evidence for #997 and major-release supersession.",
+    "RI-7.8c remains the final operator non-promotion authority and keeps repo-intelligence as beta read-only onboarding.",
+    "The productized user path is GitHub App installation plus repository selection, with no end-user Cloud Run, Vault, webhook, private key, deployment protection callback, or hosted gate setup.",
+    "No gpp_status mutation, guard flag flip, support widening, production platform claim, live adapter execution, admin bypass, branch-protection mutation, or release-authority drift was found."
   ],
   "implementer": {
     "agent": "codex",
@@ -49,28 +45,17 @@
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
     "changed_files": [
-      ".claude/plans/GPP-2B-AO-RELEASE-GATE-REQUIRED-CHECK-MAPPING.md",
-      ".github/PULL_REQUEST_TEMPLATE.md",
-      ".github/workflows/test.yml",
       "CHANGELOG.md",
-      "ao_kernel/_internal/live_adapter_dryrun.py",
-      "ao_kernel/ao_release_gate.py",
-      "ao_kernel/cli.py",
-      "ao_kernel/pr_metadata.py",
-      "docs/operator-runbooks/06-pr-delivery-metadata.md",
+      "ao_kernel/defaults/schemas/v5-governed-control-plane-gap-audit.schema.v1.json",
+      "docs/V4-GOVERNED-CONTROL-PLANE-RELEASE-CHECKLIST.md",
+      "docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json",
+      "docs/V5-GOVERNED-CONTROL-PLANE-READINESS-GAP.md",
       "local-ai-review-evidence.v1.json",
-      "scripts/ao_release_gate_build_payload.py",
-      "tests/test_ao_release_gate.py",
-      "tests/test_ao_release_gate_build_payload.py",
-      "tests/test_ao_release_gate_enforce_job.py",
-      "tests/test_gpp2b_mapping_drift_guard.py",
-      "tests/test_migrate_cmd.py",
-      "tests/test_pr_delivery_metadata_contract.py",
-      "tests/test_pr_metadata_product.py"
+      "tests/test_v5_governed_control_plane_gap_audit.py"
     ],
-    "head_ref": "refs/heads/codex/pr-metadata-productization"
+    "head_ref": "refs/heads/codex/repo-intelligence-promotion-productization"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "AO-PR-METADATA-PRODUCTIZATION"
+  "work_package": "RI-PROMOTION-PRODUCTIZATION"
 }

--- a/tests/test_v5_governed_control_plane_gap_audit.py
+++ b/tests/test_v5_governed_control_plane_gap_audit.py
@@ -86,7 +86,7 @@ def test_gap_audit_keeps_release_boundary_closed() -> None:
 
 
 def test_gap_audit_records_remaining_v5_tag_blockers() -> None:
-    """V5 publish remains blocked by real MiniMax and operator-bound decisions."""
+    """V5 publish remains blocked while RI productization stays non-promotional."""
     items = {item["id"]: item for item in _artifact()["gap_items"]}
 
     assert items["minimax-provider-evidence-for-997"]["status"] == "blocked_external"
@@ -97,7 +97,16 @@ def test_gap_audit_records_remaining_v5_tag_blockers() -> None:
     assert "fake MiniMax AGREE evidence is forbidden" in (
         items["minimax-provider-evidence-for-997"]["current_evidence"]
     )
-    assert items["repo-intelligence-promotion-decision"]["status"] == "operator_bound"
+    ri_item = items["repo-intelligence-promotion-decision"]
+    assert ri_item["status"] == "closed_non_promotion"
+    assert ri_item["owner_boundary"] == "operator"
+    assert ri_item["blocking_for_v5_tag_publish"] is False
+    assert "RI-7.8c" in ri_item["evidence_required"]
+    assert "RI-7.8c-FINAL-PROMOTE-DECISION.v1.json" in ri_item["current_evidence"]
+    assert "non-promotion" in ri_item["current_evidence"]
+    assert "beta read-only onboarding" in ri_item["current_evidence"]
+    assert "not a general-purpose production promotion" in ri_item["current_evidence"]
+
     assert items["v5-major-release-supersession"]["status"] == "operator_bound"
     assert items["v4-governed-control-plane-release-checklist"]["status"] == "done"
 
@@ -108,7 +117,6 @@ def test_gap_audit_records_remaining_v5_tag_blockers() -> None:
     ]
     assert blockers == [
         "minimax-provider-evidence-for-997",
-        "repo-intelligence-promotion-decision",
         "v5-major-release-supersession",
     ]
 


### PR DESCRIPTION
## Summary
- Closes the stale repo-intelligence promotion-decision gap as `closed_non_promotion`, bound to the existing RI-7.8c final non-promotion decision.
- Productizes repo-intelligence only as beta read-only onboarding: GitHub App install + repository selection, with no end-user Cloud Run, Vault, webhook, private key, deployment-protection callback, or hosted gate setup.
- Keeps V5 tag/publish no-go intact: remaining blockers are real MiniMax evidence for #997 and major-release supersession.

## Guardrails
- No `.claude/plans/gpp_status.v1.json` mutation.
- `support_widening=false`, `production_platform_claim=false`, `live_adapter_execution=false` preserved.
- No support-tier promotion, production-platform claim, live adapter execution, admin bypass, branch-protection mutation, or release-authority change.
- Release authority remains `ao-release-gate` plus GitHub branch protection; Claude/Codex output is evidence only.

## Cross-AI review
- Plan-time Claude: AGREE with 3 corrections absorbed (`closed_non_promotion`, work-order drift cleanup, positive non-promotion assertions).
- Post-implementation Claude: AGREE; no overclaim, no support-boundary drift, no hidden production/general-purpose claim.
- `local-ai-review-evidence.v1.json` updated for this exact PR scope.

## Local validation
- `python3 -m json.tool docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json`
- `python3 -m json.tool ao_kernel/defaults/schemas/v5-governed-control-plane-gap-audit.schema.v1.json`
- `python3 -m json.tool local-ai-review-evidence.v1.json`
- `pytest -q tests/test_v5_governed_control_plane_gap_audit.py tests/test_repo_intelligence_product_onboarding.py tests/test_repo_intelligence_workflow_surface.py tests/test_repo_intelligence_tier_promotion_readiness.py` -> 25 passed
- `python3 scripts/repo_intelligence_tier_promotion_readiness.py --evidence-manifest .claude/plans/RI-7-EVIDENCE-MANIFEST.v1.json --output json | python3 -m json.tool >/dev/null`
- `python3 scripts/local_gpp_gate.py ... --work-package RI-PROMOTION-PRODUCTIZATION` -> `decision: operator_may_merge`, 8/8 checks pass
- `python3 scripts/gpp_next.py` -> guard flags false, GPP program closed
- `git diff --check HEAD~1..HEAD`
