### PR TITLE
docs(v5): close minimax provider evidence blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **V5 MiniMax provider-evidence closeout**: updated the governed-control-plane
+  gap audit after PR #997 merged through repo-owned `ao-release-gate`
+  acceptance. The MiniMax provider-evidence item is no longer a V5 tag/publish
+  blocker, while fake MiniMax evidence remains forbidden and the V5 major-release
+  supersession blocker, support-widening guard, production-platform-claim guard,
+  and live-adapter-execution guard all remain closed.
 - **Repo-intelligence productization closeout**: recorded the existing RI-7.8c
   final non-promotion decision in the V5 gap audit and release-planning docs. The
   productized surface is beta read-only onboarding only: GitHub App

--- a/docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json
+++ b/docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json
@@ -21,11 +21,11 @@
     {
       "id": "minimax-provider-evidence-for-997",
       "title": "Real MiniMax provider review evidence for high-risk provider separation",
-      "status": "blocked_external",
-      "owner_boundary": "operator_environment",
+      "status": "done",
+      "owner_boundary": "repo_owned_gate",
       "evidence_required": "A real MiniMax AGREE review for the exact #997 PR scope, produced by working MiniMax tooling and accepted by ao-release-gate.",
-      "current_evidence": "#997 remains fail-closed because MiniMax evidence is BLOCK or unavailable; fake MiniMax AGREE evidence is forbidden.",
-      "blocking_for_v5_tag_publish": true
+      "current_evidence": "PR #997 merged as 12e26204 after ao-release-gate, ao-release-gate-review, and ao-release-gate-technical accepted the committed Anthropic plus MiniMax review evidence for the narrowed evidence-closeout scope. Fake MiniMax AGREE evidence remains forbidden.",
+      "blocking_for_v5_tag_publish": false
     },
     {
       "id": "repo-intelligence-promotion-decision",
@@ -67,7 +67,7 @@
     "machine_enforced_by": "tests/test_v5_governed_control_plane_gap_audit.py"
   },
   "next_safe_actions": [
-    "Keep #997 fail-closed until real MiniMax AGREE evidence exists.",
+    "Treat the #997 MiniMax provider-evidence blocker as closed by repo-owned ao-release-gate acceptance; do not fabricate future MiniMax evidence.",
     "Use the v4.x governed-control-plane release checklist for any near-term release preparation.",
     "Treat RI-7.8c as the closed repo-intelligence non-promotion decision; keep repo-intelligence productized only as beta read-only onboarding.",
     "Do not tag or publish v5.0.0 without an explicit operator-bound supersession PR."

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,4 +1,26 @@
 {
+  "schema_version": "local-ai-review-evidence.v1",
+  "repo": "Halildeu/ao-kernel",
+  "work_package": "GPP-9",
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
+  "reviewer": {
+    "agent": "claude",
+    "provider": "anthropic",
+    "verdict": "AGREE"
+  },
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "head_ref": "refs/heads/codex/v5-minimax-evidence-closeout",
+    "changed_files": [
+      "CHANGELOG.md",
+      "docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json",
+      "local-ai-review-evidence.v1.json",
+      "tests/test_v5_governed_control_plane_gap_audit.py"
+    ]
+  },
   "checks_considered": [
     {
       "name": "tests",
@@ -13,42 +35,19 @@
       "status": "pass"
     },
     {
-      "name": "provider_separation",
+      "name": "release_authority_boundary",
       "status": "pass"
     }
   ],
   "findings": [
-    "Reviewed PR #997 after rebasing onto current main; the remaining scope is AO-MA-10 high-risk provider separation evidence closeout.",
-    "Current protected base already contains the provider-aware high-risk reviewer selector that excludes the OpenAI implementer from the required reviewer quorum.",
-    "For implementer provider openai, the required high-risk reviewer providers are anthropic plus minimax; OpenAI same-provider review is not release authority.",
-    "The final changed_files binding is limited to CHANGELOG.md, the raw Anthropic evidence file, the raw MiniMax evidence file, and the root local AI review evidence file.",
-    "The MiniMax evidence records a real Mavis/MiniMax AGREE review from session mvs_079b1e6ab14b4744ae6bd4c62180b562 for the original broader PR #997 provider-separation implementation; this rebased PR narrows that work to evidence closeout.",
-    "No support widening, production platform claim, live adapter execution, admin bypass, branch-protection weakening, or AI-as-release-authority is introduced."
+    "Reviewed PR #1012 after #997 merged as 12e26204; the change is a V5 gap-audit SSOT sync only.",
+    "The MiniMax provider-evidence gap item moves from blocked_external to done because repo-owned ao-release-gate accepted PR #997; fake MiniMax evidence remains explicitly forbidden.",
+    "The only remaining v5 tag/publish blocker is v5-major-release-supersession, so v5.0.0 tag or publish remains disallowed without an explicit operator-bound supersession PR.",
+    "The change does not flip support_widening_allowed, production_platform_claim_allowed, or live_adapter_execution_allowed; all three remain false.",
+    "The changed scope is limited to CHANGELOG.md, docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json, local-ai-review-evidence.v1.json, and tests/test_v5_governed_control_plane_gap_audit.py."
   ],
-  "implementer": {
-    "agent": "codex",
-    "provider": "openai"
-  },
-  "live_adapter_execution": false,
-  "production_platform_claim": false,
-  "repo": "Halildeu/ao-kernel",
-  "reviewer": {
-    "agent": "anthropic-claude-reviewer",
-    "provider": "anthropic",
-    "verdict": "AGREE"
-  },
-  "schema_version": "local-ai-review-evidence.v1",
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "changed_files": [
-      "CHANGELOG.md",
-      "ao-ma-10-high-risk-reviews/anthropic.local-ai-review-evidence.v1.json",
-      "ao-ma-10-high-risk-reviews/minimax.local-ai-review-evidence.v1.json",
-      "local-ai-review-evidence.v1.json"
-    ],
-    "head_ref": "refs/heads/codex/issue-985-high-risk-provider-separation"
-  },
   "secrets_recorded": false,
+  "live_adapter_execution": false,
   "support_widening": false,
-  "work_package": "AO-MA-985-HIGH-RISK-PROVIDER-SEPARATION"
+  "production_platform_claim": false
 }

--- a/tests/test_v5_governed_control_plane_gap_audit.py
+++ b/tests/test_v5_governed_control_plane_gap_audit.py
@@ -89,14 +89,18 @@ def test_gap_audit_records_remaining_v5_tag_blockers() -> None:
     """V5 publish remains blocked while RI productization stays non-promotional."""
     items = {item["id"]: item for item in _artifact()["gap_items"]}
 
-    assert items["minimax-provider-evidence-for-997"]["status"] == "blocked_external"
+    assert items["minimax-provider-evidence-for-997"]["status"] == "done"
     assert (
         items["minimax-provider-evidence-for-997"]["owner_boundary"]
-        == "operator_environment"
+        == "repo_owned_gate"
     )
-    assert "fake MiniMax AGREE evidence is forbidden" in (
+    assert "PR #997 merged as 12e26204" in (
         items["minimax-provider-evidence-for-997"]["current_evidence"]
     )
+    assert "Fake MiniMax AGREE evidence remains forbidden" in (
+        items["minimax-provider-evidence-for-997"]["current_evidence"]
+    )
+    assert items["minimax-provider-evidence-for-997"]["blocking_for_v5_tag_publish"] is False
     ri_item = items["repo-intelligence-promotion-decision"]
     assert ri_item["status"] == "closed_non_promotion"
     assert ri_item["owner_boundary"] == "operator"
@@ -115,10 +119,7 @@ def test_gap_audit_records_remaining_v5_tag_blockers() -> None:
         for item in items.values()
         if item["blocking_for_v5_tag_publish"] is True
     ]
-    assert blockers == [
-        "minimax-provider-evidence-for-997",
-        "v5-major-release-supersession",
-    ]
+    assert blockers == ["v5-major-release-supersession"]
 
 
 def test_gap_audit_schema_rejects_guard_or_release_authority_drift() -> None:


### PR DESCRIPTION
## Summary
- mark the #997 MiniMax provider-evidence gap item as closed by repo-owned ao-release-gate acceptance
- keep fake MiniMax evidence forbidden and keep v5.0.0 tag/publish blocked by the operator-bound major-release supersession item
- update the invariant test and changelog to match the post-#997 state

## Validation
- python3 -m json.tool docs/V5-GOVERNED-CONTROL-PLANE-GAP-AUDIT.v1.json >/dev/null
- pytest -q tests/test_v5_governed_control_plane_gap_audit.py
- git diff --check
- python3 scripts/gpp_next.py | sed -n '1,30p'\n\n## Cross-AI review\n- Claude advisory review: AGREE\n\n## Guardrails\n- no support widening\n- no production platform claim\n- no live adapter execution\n- no v5 tag or publish authority\n- release authority remains ao-release-gate plus GitHub branch protection\n