### PR TITLE
feat(product): close v4.3.1 local workflow productization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **Productization closeout for local governed workflows**: extended the
+  wheel-installed `packaging-smoke` gate and added
+  `scripts/fresh_install_product_smoke.py` so the built wheel and sdist are
+  installed into clean virtualenvs and the productized `repo onboarding`,
+  `pr-metadata`, `orchestration run-wrapper`, and new
+  `orchestration run-wrapper-async` surfaces are exercised from outside the
+  source checkout. Added `docs/PRODUCT-QUICKSTART.md` as the install-to-first
+  artifact path. The async wrapper v2 invokes pinned deterministic local worker
+  fixtures through a bounded worker pool and reports reviewer/verifier phases
+  as external evidence required instead of fabricating approvals. No GitHub,
+  Vault, webhook, branch-protection, support-widening, production-platform
+  claim, or live-adapter execution boundary is opened.
 - **Productized local workflows for repo onboarding, PR metadata, and AO-MA
   wrapper execution**: added `ao-kernel repo onboarding
   {template,init-config,validate,doctor}` for beta read-only repo-intelligence

--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ workflows. They do not install GitHub Apps, call GitHub, configure Vault,
 configure webhooks, mutate branch protection, enable live adapter execution, or
 make any platform-readiness claim.
 
+Start from the end-to-end guide:
+[`docs/PRODUCT-QUICKSTART.md`](docs/PRODUCT-QUICKSTART.md).
+
 **Repo-intelligence onboarding (read-only):**
 
 ```bash
@@ -258,11 +261,21 @@ ao-kernel orchestration run-wrapper \
   --goal "bounded local slice" \
   --declared-spec task-001:src/a.py:"bounded write scope" \
   --execute-local-fixture
+
+ao-kernel orchestration run-wrapper-async \
+  --goal "bounded parallel local slice" \
+  --declared-spec task-001:src/a.py:"worker one" \
+  --declared-spec task-002:src/b.py:"worker two" \
+  --execute-local-fixture \
+  --max-workers 2
 ```
 
 The wrapper chains `plan -> spawn` in dry-run mode or
 `plan -> spawn -> invoke` with the pinned deterministic local worker fixture.
-It requires explicit declared write scopes and keeps `support_widening`,
+The async wrapper v2 emits one task graph, invokes pinned local fixtures through
+a bounded worker pool, collects artifacts, and reports review/verification as
+external evidence required rather than fabricating AI approval. Both wrappers
+require explicit declared write scopes and keep `support_widening`,
 `production_platform_claim`, and `live_adapter_execution` closed.
 
 ## Context Management

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -2935,6 +2935,7 @@ def main(argv: list[str] | None = None) -> int:
             cmd_orchestration_plan,
             cmd_orchestration_review,
             cmd_orchestration_run_wrapper,
+            cmd_orchestration_run_wrapper_async,
             cmd_orchestration_spawn,
             cmd_orchestration_verify,
         )
@@ -2944,6 +2945,8 @@ def main(argv: list[str] | None = None) -> int:
             return cmd_orchestration_plan(args)
         if orchestration_cmd == "run-wrapper":
             return cmd_orchestration_run_wrapper(args)
+        if orchestration_cmd == "run-wrapper-async":
+            return cmd_orchestration_run_wrapper_async(args)
         if orchestration_cmd == "spawn":
             return cmd_orchestration_spawn(args)
         if orchestration_cmd == "cleanup":
@@ -2960,7 +2963,7 @@ def main(argv: list[str] | None = None) -> int:
             return cmd_orchestration_verify(args)
         print(
             "Usage: ao-kernel orchestration "
-            "{plan|run-wrapper|spawn|cleanup|invoke|native-import|integrate|review|verify}",
+            "{plan|run-wrapper|run-wrapper-async|spawn|cleanup|invoke|native-import|integrate|review|verify}",
             file=sys.stderr,
         )
         return 1

--- a/ao_kernel/orchestration/async_runner.py
+++ b/ao_kernel/orchestration/async_runner.py
@@ -1,0 +1,36 @@
+"""Bounded async helpers for productized AO-MA local wrappers.
+
+This module owns the concurrency primitive used by
+``orchestration run-wrapper-async``. It is deliberately tiny: callers supply
+already-validated, no-network, local callables; this helper only schedules them
+through a bounded thread pool and returns results in input order.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import TypeVar
+
+
+T = TypeVar("T")
+
+
+def invoke_callables_concurrently(calls: list[Callable[[], T]], *, max_workers: int) -> list[T]:
+    """Run callables with bounded concurrency and preserve input order."""
+
+    if max_workers <= 0:
+        raise ValueError("max_workers must be a positive integer")
+    if not calls:
+        return []
+    ordered: list[T | None] = [None] * len(calls)
+    with ThreadPoolExecutor(max_workers=min(max_workers, len(calls))) as pool:
+        futures = {pool.submit(call): index for index, call in enumerate(calls)}
+        for future in as_completed(futures):
+            ordered[futures[future]] = future.result()
+    results: list[T] = []
+    for item in ordered:
+        if item is None:
+            raise RuntimeError("concurrent invocation finished with a missing result")
+        results.append(item)
+    return results

--- a/ao_kernel/orchestration/cli_handlers.py
+++ b/ao_kernel/orchestration/cli_handlers.py
@@ -291,6 +291,176 @@ def cmd_orchestration_run_wrapper(args: argparse.Namespace) -> int:
     return 1 if failed_spawn or failed_invoke else 0
 
 
+def cmd_orchestration_run_wrapper_async(args: argparse.Namespace) -> int:
+    """Handle ``ao-kernel orchestration run-wrapper-async``.
+
+    Product-facing wrapper v2 for a bounded multi-worker local run. It emits a
+    single task graph for all declared specs, prepares workers, invokes the
+    pinned deterministic local worker fixture concurrently when requested, and
+    returns a fail-closed summary. It deliberately does not fabricate reviewer
+    or verifier AGREE artifacts; those phases are reported as external evidence
+    required unless a future command wires real review/verification inputs.
+    """
+
+    if bool(args.dry_run) == bool(args.execute_local_fixture):
+        print(
+            "orchestration run-wrapper-async requires exactly one of --dry-run or --execute-local-fixture",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        max_workers = int(args.max_workers)
+    except (TypeError, ValueError):
+        print("orchestration run-wrapper-async --max-workers must be a positive integer", file=sys.stderr)
+        return 2
+    if max_workers <= 0:
+        print("orchestration run-wrapper-async --max-workers must be a positive integer", file=sys.stderr)
+        return 2
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else Path.cwd()
+    output_dir = Path(args.output_dir).resolve() if args.output_dir else repo_root / ".ao" / "orchestration"
+    worktree_base = _resolve_worktree_base(args.worktree_base)
+    try:
+        declared_specs = _parse_declared_specs(args.declared_spec)
+    except SystemExit as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    if not declared_specs:
+        print(
+            "orchestration run-wrapper-async requires at least one --declared-spec so worker write scope is explicit",
+            file=sys.stderr,
+        )
+        return 2
+
+    orchestrator = Orchestrator(
+        repo_root=repo_root,
+        ssot=SSOTPaths.default(repo_root),
+        output_dir=output_dir,
+    )
+    try:
+        manifest = orchestrator.plan(
+            goal=args.goal,
+            declared_specs=declared_specs,
+            base_sha=args.base_sha,
+            base_ref=args.base_ref,
+            repo=args.repo,
+        )
+    except OrchestrationError as exc:
+        print(f"orchestration run-wrapper-async plan failed: {exc}", file=sys.stderr)
+        return 1
+
+    manifest_path = Path(str(manifest["base_dir"])) / "manifest.v1.json"
+    runner = WorkerRunner(repo_root=repo_root, worktree_base=worktree_base, dry_run=bool(args.dry_run))
+    try:
+        runner_report = runner.spawn(manifest_path=manifest_path)
+    except WorkerRunnerError as exc:
+        print(f"orchestration run-wrapper-async spawn failed: {exc}", file=sys.stderr)
+        return 1
+
+    invocation_report: dict[str, object] | None = None
+    if args.execute_local_fixture:
+        invoker = WorkerInvoker(repo_root=repo_root)
+        try:
+            invocation_report = invoker.invoke_concurrent(
+                manifest_path=manifest_path,
+                max_workers=max_workers,
+            )
+        except WorkerInvocationError as exc:
+            print(f"orchestration run-wrapper-async invoke failed: {exc}", file=sys.stderr)
+            return 2
+
+    raw_workers = runner_report.get("workers", [])
+    workers = [worker for worker in raw_workers if isinstance(worker, dict)]
+    worker_statuses = [
+        {"task_id": worker.get("task_id"), "status": worker.get("status")} for worker in workers
+    ]
+    invoked_by_task: dict[str, dict[str, object]] = {}
+    if invocation_report is not None:
+        raw_invoked = invocation_report.get("invoked", [])
+        if isinstance(raw_invoked, list):
+            for entry in raw_invoked:
+                if isinstance(entry, dict) and isinstance(entry.get("task_id"), str):
+                    invoked_by_task[str(entry["task_id"])] = entry
+
+    invocation_statuses = [
+        {
+            "task_id": worker.get("task_id"),
+            "status": invoked_by_task.get(str(worker.get("task_id")), {}).get(
+                "status",
+                "not_run_dry_run" if args.dry_run else "not_run",
+            ),
+            "worker_result_path": invoked_by_task.get(str(worker.get("task_id")), {}).get("worker_result_path"),
+            "integrated_worker_result_path": invoked_by_task.get(str(worker.get("task_id")), {}).get(
+                "integrated_worker_result_path"
+            ),
+        }
+        for worker in workers
+    ]
+    review_statuses = [
+        {
+            "task_id": worker.get("task_id"),
+            "status": "external_review_evidence_required",
+            "reason": "run-wrapper-async does not fabricate AI review verdicts",
+        }
+        for worker in workers
+    ]
+    verifier_statuses = [
+        {
+            "task_id": worker.get("task_id"),
+            "status": "external_verification_evidence_required",
+            "reason": "run-wrapper-async does not fabricate verification reports",
+        }
+        for worker in workers
+    ]
+
+    failed_spawn = any(str(worker.get("status", "")).startswith("failed_") for worker in workers)
+    failed_invoke = any(entry.get("status") == "failed" for entry in invocation_statuses)
+    payload: dict[str, object] = {
+        "status": "failed" if failed_spawn or failed_invoke else "ok",
+        "mode": "dry_run" if args.dry_run else "execute_local_fixture",
+        "async_wrapper_version": "v2",
+        "max_workers": max_workers,
+        "manifest_path": str(manifest_path),
+        "runner_report_path": str(manifest_path.parent / "runner_report.v1.json"),
+        "invocation_report_path": (
+            str(manifest_path.parent / "worker_invocation_report.v1.json") if invocation_report is not None else None
+        ),
+        "task_graph_id": manifest["task_graph_id"],
+        "worker_statuses": worker_statuses,
+        "invocation_statuses": invocation_statuses,
+        "review_statuses": review_statuses,
+        "verifier_statuses": verifier_statuses,
+        "guard_flags": {
+            "support_widening": False,
+            "production_platform_claim": False,
+            "live_adapter_execution": False,
+        },
+    }
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"status: {payload['status']}")
+        print(f"mode: {payload['mode']}")
+        print(f"async_wrapper_version: {payload['async_wrapper_version']}")
+        print(f"max_workers: {payload['max_workers']}")
+        print(f"manifest_path: {payload['manifest_path']}")
+        print(f"runner_report_path: {payload['runner_report_path']}")
+        if payload["invocation_report_path"]:
+            print(f"invocation_report_path: {payload['invocation_report_path']}")
+        print("invocation_statuses:")
+        for entry in invocation_statuses:
+            print(f"- {entry['task_id']}: {entry['status']}")
+        print("review_statuses:")
+        for entry in review_statuses:
+            print(f"- {entry['task_id']}: {entry['status']}")
+        print("verifier_statuses:")
+        for entry in verifier_statuses:
+            print(f"- {entry['task_id']}: {entry['status']}")
+
+    return 1 if failed_spawn or failed_invoke else 0
+
+
 def _parse_declared_specs(raw: list[str] | None) -> list[TaskSpec] | None:
     """Parse ``--declared-spec`` CLI repeats into TaskSpec objects.
 
@@ -414,6 +584,51 @@ def add_orchestration_subparser(sub: argparse._SubParsersAction[argparse.Argumen
     run_wrapper_p.add_argument("--base-ref", default="refs/heads/main", help="Base ref label")
     run_wrapper_p.add_argument("--repo", default=None, help="owner/repo (default: inferred from origin remote URL)")
     run_wrapper_p.add_argument("--format", choices=["text", "json"], default="text")
+
+    run_wrapper_async_p = orchestration_sub.add_parser(
+        "run-wrapper-async",
+        help=(
+            "Product wrapper v2: plan one bounded task graph, spawn workers, "
+            "invoke the pinned local fixture concurrently, and emit a fail-closed summary"
+        ),
+    )
+    run_wrapper_async_p.add_argument("--goal", required=True, help="Operator goal in free-form text")
+    run_wrapper_async_p.add_argument(
+        "--declared-spec",
+        action="append",
+        default=None,
+        help=(
+            "Required bounded slice in the form <task_id>:<comma-paths>[:<desc>]; "
+            "repeat for each concurrent worker"
+        ),
+    )
+    async_mode = run_wrapper_async_p.add_mutually_exclusive_group(required=True)
+    async_mode.add_argument("--dry-run", action="store_true", help="Plan + spawn dry-run only")
+    async_mode.add_argument(
+        "--execute-local-fixture",
+        action="store_true",
+        help="Plan + spawn real worktrees + invoke pinned deterministic local fixtures concurrently",
+    )
+    run_wrapper_async_p.add_argument(
+        "--max-workers",
+        default="4",
+        help="Maximum concurrent local fixture worker invocations (default: 4)",
+    )
+    run_wrapper_async_p.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output dir (default: <repo_root>/.ao/orchestration)",
+    )
+    run_wrapper_async_p.add_argument("--repo-root", default=None, help="Repository root path (default: cwd)")
+    run_wrapper_async_p.add_argument(
+        "--worktree-base",
+        default=None,
+        help="Override base directory for worktrees (also honors AO_MA_WORKTREE_BASE)",
+    )
+    run_wrapper_async_p.add_argument("--base-sha", default=None, help="40-char base SHA (default: origin/main)")
+    run_wrapper_async_p.add_argument("--base-ref", default="refs/heads/main", help="Base ref label")
+    run_wrapper_async_p.add_argument("--repo", default=None, help="owner/repo (default: inferred from origin remote URL)")
+    run_wrapper_async_p.add_argument("--format", choices=["text", "json"], default="text")
 
     # AO-MA-4: spawn parallel worktrees from a manifest
     spawn_p = orchestration_sub.add_parser(

--- a/ao_kernel/orchestration/worker_invoker.py
+++ b/ao_kernel/orchestration/worker_invoker.py
@@ -35,7 +35,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import ValidationError
@@ -155,6 +155,36 @@ class WorkerInvoker:
                 f"operator-bound GPP supersession with live_adapter_execution=true."
             )
 
+        return self._invoke_manifest(manifest_path=manifest_path, fixture_id=fixture_id, max_workers=1)
+
+    def invoke_concurrent(
+        self,
+        manifest_path: Path,
+        *,
+        fixture_id: str = PINNED_FIXTURE_ID,
+        max_workers: int = 4,
+    ) -> dict[str, Any]:
+        """Run the pinned worker fixture concurrently for prepared workers.
+
+        This is the product-facing AO-MA wrapper v2 execution primitive. It
+        keeps the same trust boundary as :meth:`invoke`: no arbitrary adapters,
+        no live adapter execution, no GitHub writes, and the same manifest /
+        runner_report / assignment / worktree verification before any fixture
+        write. The only semantic difference is that eligible worker fixture
+        subprocesses are scheduled through a bounded thread pool and the final
+        report is emitted in the runner_report worker order.
+        """
+
+        if max_workers <= 0:
+            raise WorkerInvocationError("max_workers must be a positive integer")
+        if fixture_id != PINNED_FIXTURE_ID:
+            raise WorkerInvocationError(
+                f"AO-MA wrapper v2 only invokes the pinned deterministic local worker fixture "
+                f"{PINNED_FIXTURE_ID!r}; arbitrary adapter {fixture_id!r} is rejected fail-closed."
+            )
+        return self._invoke_manifest(manifest_path=manifest_path, fixture_id=fixture_id, max_workers=max_workers)
+
+    def _invoke_manifest(self, *, manifest_path: Path, fixture_id: str, max_workers: int) -> dict[str, Any]:
         manifest_path = manifest_path.resolve()
         manifest = _load_json(manifest_path)
 
@@ -197,7 +227,7 @@ class WorkerInvoker:
                 f"runner_report manifest_sha256 {report_manifest_sha!r} != on-disk manifest sha256 "
                 f"{actual_manifest_sha!r}; re-run AO-MA-4 spawn before invoke"
             )
-        workers = runner_report.get("workers", [])
+        workers: list[dict[str, Any]] = runner_report.get("workers", [])
         if not workers:
             raise WorkerInvocationError("runner_report has no workers; nothing to invoke")
         base_sha = runner_report["base_sha"]
@@ -206,20 +236,42 @@ class WorkerInvoker:
         assignment_validator = Draft202012Validator(_load_schema(_ASSIGNMENT_SCHEMA))
         manifest_artifacts = {entry["path"]: entry for entry in manifest["artifacts"]}
 
-        # 6. Invoke the pinned fixture for each eligible worker entry.
+        # 6. Invoke the pinned fixture for each eligible worker entry. Preserve
+        # runner_report order in the emitted report even when execution is
+        # concurrent, so downstream artifact diffs remain deterministic.
         invoked: list[dict[str, Any]] = []
-        for worker in workers:
-            invoked.append(
-                self._invoke_one(
-                    worker=worker,
-                    manifest_dir=manifest_dir,
-                    manifest_artifacts=manifest_artifacts,
-                    task_graph_id=task_graph_id,
-                    base_sha=base_sha,
-                    worker_result_validator=worker_result_validator,
-                    assignment_validator=assignment_validator,
+        if max_workers == 1 or len(workers) <= 1:
+            for worker in workers:
+                invoked.append(
+                    self._invoke_one(
+                        worker=worker,
+                        manifest_dir=manifest_dir,
+                        manifest_artifacts=manifest_artifacts,
+                        task_graph_id=task_graph_id,
+                        base_sha=base_sha,
+                        worker_result_validator=worker_result_validator,
+                        assignment_validator=assignment_validator,
+                    )
                 )
-            )
+        else:
+            from ao_kernel.orchestration.async_runner import invoke_callables_concurrently
+
+            def make_invocation_call(worker: dict[str, Any]) -> Callable[[], dict[str, Any]]:
+                def call() -> dict[str, Any]:
+                    return self._invoke_one(
+                        worker=worker,
+                        manifest_dir=manifest_dir,
+                        manifest_artifacts=manifest_artifacts,
+                        task_graph_id=task_graph_id,
+                        base_sha=base_sha,
+                        worker_result_validator=worker_result_validator,
+                        assignment_validator=assignment_validator,
+                    )
+
+                return call
+
+            calls = [make_invocation_call(worker) for worker in workers]
+            invoked = invoke_callables_concurrently(calls, max_workers=max_workers)
 
         # 5. Emit the schema-valid invocation report.
         return self._emit_report(

--- a/docs/PRODUCT-QUICKSTART.md
+++ b/docs/PRODUCT-QUICKSTART.md
@@ -1,0 +1,142 @@
+# Product Quickstart — Local Governed Workflow
+
+This guide takes a fresh install from zero to the first local evidence
+artifacts for the productized `ao-kernel` workflow:
+
+1. repo-intelligence onboarding,
+2. PR delivery metadata,
+3. bounded multi-agent local orchestration.
+
+It is intentionally local and fail-closed. It does **not** configure GitHub
+Apps, Vault, webhooks, branch protection, Cloud Run, live adapters, support
+widening, or a production-platform claim.
+
+## 1. Install
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install ao-kernel==4.3.1
+ao-kernel version
+```
+
+For a checkout smoke before publishing, use:
+
+```bash
+python scripts/fresh_install_product_smoke.py --mode both
+```
+
+The smoke builds the checkout, installs the wheel and sdist into separate
+clean virtualenvs, and writes evidence under:
+
+```text
+build/fresh-install-product-smoke/
+```
+
+## 2. Prepare A Project
+
+Run these commands from the repository you want to onboard.
+
+```bash
+ao-kernel init
+ao-kernel repo onboarding init-config \
+  --project-root . \
+  --path .ao/repo-intelligence.yml
+ao-kernel repo onboarding doctor --project-root . --output json
+```
+
+Expected boundary:
+
+- `status` should become `ready` once the `.ao` workspace and onboarding
+  config are present.
+- The generated config records GitHub App installation and repository
+  selection as the user-managed setup boundary.
+- End users are not asked to host `ao-release-gate`, Vault, Cloud Run,
+  deployment-protection callbacks, or webhooks.
+
+## 3. Add PR Delivery Metadata
+
+Generate a metadata block:
+
+```bash
+ao-kernel pr-metadata generate \
+  --work-package PRODUCT-SLICE-1 \
+  --issue '#123' \
+  --reviewer-provider anthropic > /tmp/pr-metadata.md
+```
+
+Insert or update it in a PR body:
+
+```bash
+ao-kernel pr-metadata fix \
+  --body-file pr-body.md \
+  --write \
+  --work-package PRODUCT-SLICE-1 \
+  --issue '#123' \
+  --reviewer-provider anthropic
+
+ao-kernel pr-metadata validate --body-file pr-body.md --output json
+```
+
+The PR metadata block is a structured declaration. It is not release authority.
+Release authority remains the repo-owned `ao-release-gate` required check plus
+GitHub branch protection.
+
+## 4. Run A Bounded Local Multi-Agent Wrapper
+
+Dry-run one declared write scope:
+
+```bash
+BASE_SHA="$(git rev-parse origin/main)"
+
+ao-kernel orchestration run-wrapper \
+  --goal "bounded local slice" \
+  --repo-root . \
+  --base-sha "$BASE_SHA" \
+  --repo Halildeu/ao-kernel \
+  --declared-spec task-001:src/example.py:"bounded local change" \
+  --dry-run \
+  --format json
+```
+
+Run multiple deterministic local worker fixtures concurrently:
+
+```bash
+ao-kernel orchestration run-wrapper-async \
+  --goal "bounded parallel local slice" \
+  --repo-root . \
+  --worktree-base ../ao-kernel-workers \
+  --base-sha "$BASE_SHA" \
+  --repo Halildeu/ao-kernel \
+  --declared-spec task-001:src/a.py:"worker one" \
+  --declared-spec task-002:src/b.py:"worker two" \
+  --execute-local-fixture \
+  --max-workers 2 \
+  --format json
+```
+
+The async wrapper:
+
+- emits one task graph for all declared specs,
+- prepares one worker worktree per declared task,
+- invokes the pinned deterministic local worker fixture concurrently,
+- collects `manifest.v1.json`, `runner_report.v1.json`, and
+  `worker_invocation_report.v1.json`,
+- reports review and verification phases as external evidence required rather
+  than fabricating AI review or verifier approval.
+
+## 5. Acceptance Boundary
+
+This quickstart proves the local governed-control-plane workflow is installed
+and operational. It does not prove or claim:
+
+- support widening,
+- production-platform readiness,
+- live adapter execution,
+- GitHub ruleset mutation,
+- webhook callback delivery,
+- cloud hosting,
+- provider API execution.
+
+Those remain separate operator-bound supersession decisions.

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "P2-P3-P5-productization",
+  "work_package": "PRODUCTIZATION-CLOSEOUT-V4.3.1",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,18 +13,20 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/productize-p2-p3-p5",
+    "head_ref": "refs/heads/codex/productization-closeout",
     "changed_files": [
       "CHANGELOG.md",
       "README.md",
-      "ao_kernel/_internal/repo_intelligence/product_onboarding.py",
       "ao_kernel/cli.py",
+      "ao_kernel/orchestration/async_runner.py",
       "ao_kernel/orchestration/cli_handlers.py",
-      "ao_kernel/pr_metadata.py",
-      "ao_kernel/repo_intelligence/__init__.py",
+      "ao_kernel/orchestration/worker_invoker.py",
+      "docs/PRODUCT-QUICKSTART.md",
       "local-ai-review-evidence.v1.json",
-      "tests/test_productized_p2_p3_p5_cli.py",
-      "tests/test_repo_intelligence_no_mcp_root_export_guard.py"
+      "scripts/fresh_install_product_smoke.py",
+      "scripts/packaging_smoke.py",
+      "tests/test_productization_closeout.py",
+      "tests/test_productized_p2_p3_p5_cli.py"
     ]
   },
   "checks_considered": [
@@ -43,15 +45,23 @@
     {
       "name": "release_authority_boundary",
       "status": "pass"
+    },
+    {
+      "name": "fresh_install_smoke",
+      "status": "pass"
+    },
+    {
+      "name": "packaging_smoke",
+      "status": "pass"
     }
   ],
   "findings": [
-    "Claude reviewed PR 1013 diff for P2 repo-intelligence onboarding CLI, P3 PR metadata UX, and P5 AO-MA run wrapper.",
-    "Verdict AGREE: no GitHub, Vault, webhook, branch-protection mutation, live adapter execution, support widening, or platform-readiness claim.",
-    "Release authority remains repo-owned ao-release-gate; PR metadata is declaration only.",
-    "Repo-intelligence onboarding template, validate, doctor, and init-config are local and guard fields stay false.",
-    "PR metadata generate and fix cover sensitive boundary declarations with test coverage.",
-    "Run wrapper requires explicit declared spec and exactly one of dry-run or deterministic local fixture execution."
+    "Claude reviewed the productization closeout diff for v4.3.1 release readiness, packaging smoke, fresh install smoke, product quickstart, and run-wrapper-async v2.",
+    "Verdict AGREE: no blocking issue found in release readiness, bounded concurrency, CLI wiring, smoke evidence, or documentation scope.",
+    "Guard flags remain false: no support widening, no production platform claim, and no live adapter execution.",
+    "run-wrapper-async reports external review and verifier evidence required; it does not fabricate AGREE, PASS, or release authority.",
+    "Fresh install smoke installs wheel and sdist into clean virtual environments and runs onboarding, PR metadata, run-wrapper, and run-wrapper-async from outside the source checkout.",
+    "Packaging smoke extends the installed-wheel check with productized local workflows while preserving release authority under the repo-owned ao-release-gate."
   ],
   "secrets_recorded": false,
   "live_adapter_execution": false,

--- a/scripts/fresh_install_product_smoke.py
+++ b/scripts/fresh_install_product_smoke.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Fresh-install smoke for the productized local workflow surface.
+
+Builds the current checkout, installs the wheel and sdist into separate clean
+virtualenvs, and runs the user-facing product workflow commands from a temp cwd
+outside the source checkout:
+
+- ``repo onboarding`` template/init/doctor
+- ``pr-metadata`` generate/fix/validate
+- ``orchestration run-wrapper`` dry-run
+- ``orchestration run-wrapper-async`` local fixture execution
+
+No GitHub, Vault, webhook, branch-protection, live adapter, support widening,
+or production-platform claim is touched. Evidence is written under
+``build/fresh-install-product-smoke/`` so ``dist/`` remains distribution-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=["wheel", "sdist", "both"],
+        default="both",
+        help="Distribution artifact(s) to install and smoke (default: both)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="build/fresh-install-product-smoke",
+        help="Evidence output directory (default: build/fresh-install-product-smoke)",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    output_dir = (repo_root / args.output_dir).resolve()
+    dist_dir = repo_root / "dist"
+
+    shutil.rmtree(dist_dir, ignore_errors=True)
+    # Keep the parent build dir but reset only this script's evidence subdir.
+    shutil.rmtree(output_dir, ignore_errors=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    _run([sys.executable, "-m", "build"], cwd=repo_root)
+    wheel = _single(dist_dir, "ao_kernel-*.whl", "wheel")
+    sdist = _single(dist_dir, "ao_kernel-*.tar.gz", "sdist")
+    artifacts: list[tuple[str, Path]] = []
+    if args.mode in ("wheel", "both"):
+        artifacts.append(("wheel", wheel))
+    if args.mode in ("sdist", "both"):
+        artifacts.append(("sdist", sdist))
+
+    scenario_results = []
+    with tempfile.TemporaryDirectory(prefix="ao-kernel-fresh-install-smoke-") as tmp:
+        tmp_root = Path(tmp)
+        for artifact_kind, artifact_path in artifacts:
+            scenario_results.append(
+                _smoke_one_distribution(
+                    artifact_kind=artifact_kind,
+                    artifact_path=artifact_path,
+                    tmp_root=tmp_root,
+                    output_dir=output_dir,
+                )
+            )
+
+    evidence = {
+        "schema_version": "fresh-install-product-smoke.v1",
+        "artifact_kind": "fresh_install_product_smoke",
+        "decision": "productized_local_workflows_fresh_install_ready",
+        "package_version": _package_version(repo_root),
+        "distribution_modes": [kind for kind, _ in artifacts],
+        "scenarios": scenario_results,
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+        "notes": [
+            "Each scenario installs a built distribution into a clean virtualenv.",
+            "Smoke commands run from a temp cwd outside the source checkout.",
+            "No network or external service calls are required by the product workflow smoke.",
+        ],
+    }
+    evidence_path = output_dir / "fresh-install-product-smoke.v1.json"
+    evidence_path.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"+ wrote fresh-install product smoke evidence -> {evidence_path}")
+    return 0
+
+
+def _smoke_one_distribution(
+    *,
+    artifact_kind: str,
+    artifact_path: Path,
+    tmp_root: Path,
+    output_dir: Path,
+) -> dict[str, Any]:
+    scenario_root = tmp_root / artifact_kind
+    scenario_root.mkdir()
+    venv_dir = scenario_root / "venv"
+    smoke_cwd = scenario_root / "cwd"
+    smoke_cwd.mkdir()
+
+    _run([sys.executable, "-m", "venv", str(venv_dir)], cwd=scenario_root)
+    bin_dir = _venv_bin_dir(venv_dir)
+    venv_pip = bin_dir / ("pip.exe" if os.name == "nt" else "pip")
+    console = bin_dir / ("ao-kernel.exe" if os.name == "nt" else "ao-kernel")
+    _run([str(venv_pip), "install", str(artifact_path)], cwd=smoke_cwd)
+
+    project_root = smoke_cwd / "product-project"
+    base_sha = _init_product_project(project_root)
+    scenario_evidence = output_dir / f"{artifact_kind}-productized-local-workflows.v1.json"
+
+    commands: list[dict[str, Any]] = []
+
+    def run_step(step_id: str, command: list[str], *, cwd: Path = smoke_cwd) -> subprocess.CompletedProcess[str]:
+        result = _run_capture(command, cwd=cwd)
+        commands.append(
+            {
+                "id": step_id,
+                "returncode": result.returncode,
+                "stdout_excerpt": result.stdout.strip()[:500],
+                "stderr_excerpt": result.stderr.strip()[:300],
+            }
+        )
+        if result.returncode != 0:
+            raise SystemExit(f"{artifact_kind} smoke step {step_id} failed with exit {result.returncode}")
+        return result
+
+    run_step("console_version", [str(console), "version"])
+    run_step(
+        "repo_onboarding_template",
+        [str(console), "repo", "onboarding", "template", "--output", "json"],
+    )
+    run_step(
+        "repo_onboarding_init_config",
+        [
+            str(console),
+            "repo",
+            "onboarding",
+            "init-config",
+            "--project-root",
+            str(project_root),
+            "--output",
+            "json",
+        ],
+    )
+    doctor = run_step(
+        "repo_onboarding_doctor",
+        [str(console), "repo", "onboarding", "doctor", "--project-root", str(project_root), "--output", "json"],
+    )
+    doctor_payload = json.loads(doctor.stdout)
+    if doctor_payload.get("status") != "ready":
+        raise SystemExit(f"{artifact_kind} repo onboarding doctor did not report ready")
+
+    pr_body = smoke_cwd / "pr-body.md"
+    pr_body.write_text("## Summary\n\nFresh install smoke.\n", encoding="utf-8")
+    metadata = run_step(
+        "pr_metadata_generate",
+        [
+            str(console),
+            "pr-metadata",
+            "generate",
+            "--work-package",
+            "PRODUCT-SMOKE",
+            "--issue",
+            "#123",
+            "--reviewer-provider",
+            "anthropic",
+        ],
+    )
+    pr_body.write_text("## Summary\n\nFresh install smoke.\n\n" + metadata.stdout, encoding="utf-8")
+    run_step(
+        "pr_metadata_fix",
+        [
+            str(console),
+            "pr-metadata",
+            "fix",
+            "--body-file",
+            str(pr_body),
+            "--write",
+            "--output",
+            "json",
+            "--work-package",
+            "PRODUCT-SMOKE",
+            "--issue",
+            "#123",
+            "--reviewer-provider",
+            "anthropic",
+        ],
+    )
+    run_step(
+        "pr_metadata_validate",
+        [str(console), "pr-metadata", "validate", "--body-file", str(pr_body), "--output", "json"],
+    )
+
+    run_step(
+        "orchestration_run_wrapper_dry_run",
+        [
+            str(console),
+            "orchestration",
+            "run-wrapper",
+            "--goal",
+            "fresh install dry-run wrapper smoke",
+            "--repo-root",
+            str(project_root),
+            "--base-sha",
+            base_sha,
+            "--repo",
+            "Halildeu/ao-kernel",
+            "--declared-spec",
+            "task-001:src/a.py:fresh install dry run",
+            "--dry-run",
+            "--format",
+            "json",
+        ],
+    )
+    async_result = run_step(
+        "orchestration_run_wrapper_async_execute",
+        [
+            str(console),
+            "orchestration",
+            "run-wrapper-async",
+            "--goal",
+            "fresh install async wrapper smoke",
+            "--repo-root",
+            str(project_root),
+            "--worktree-base",
+            str(smoke_cwd / "worktrees"),
+            "--base-sha",
+            base_sha,
+            "--repo",
+            "Halildeu/ao-kernel",
+            "--declared-spec",
+            "task-001:src/a.py:fresh install async worker one",
+            "--declared-spec",
+            "task-002:src/b.py:fresh install async worker two",
+            "--execute-local-fixture",
+            "--max-workers",
+            "2",
+            "--format",
+            "json",
+        ],
+    )
+    async_payload = json.loads(async_result.stdout)
+    if async_payload.get("status") != "ok":
+        raise SystemExit(f"{artifact_kind} async wrapper did not report ok")
+
+    payload = {
+        "schema_version": "productized-local-workflows-smoke.v1",
+        "artifact_kind": "productized_local_workflows_smoke",
+        "distribution_mode": artifact_kind,
+        "artifact_name": artifact_path.name,
+        "decision": "productized_local_workflows_ready",
+        "commands": commands,
+        "async_wrapper_status": async_payload.get("status"),
+        "async_invocation_report_path": async_payload.get("invocation_report_path"),
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+    }
+    scenario_evidence.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return {
+        "distribution_mode": artifact_kind,
+        "artifact_name": artifact_path.name,
+        "status": "pass",
+        "evidence_path": str(scenario_evidence),
+        "command_count": len(commands),
+    }
+
+
+def _init_product_project(project_root: Path) -> str:
+    project_root.mkdir(parents=True)
+    _run(["git", "init", "--initial-branch=main", str(project_root)], cwd=project_root.parent)
+    _run(["git", "-C", str(project_root), "config", "user.email", "test@example.com"], cwd=project_root)
+    _run(["git", "-C", str(project_root), "config", "user.name", "test"], cwd=project_root)
+    (project_root / "AGENTS.md").write_text("# AGENTS\nFresh install product smoke.\n", encoding="utf-8")
+    plans_dir = project_root / ".claude" / "plans"
+    plans_dir.mkdir(parents=True, exist_ok=True)
+    (project_root / "src").mkdir()
+    (project_root / "src" / "a.py").write_text("def a():\n    return 1\n", encoding="utf-8")
+    (project_root / "src" / "b.py").write_text("def b():\n    return 2\n", encoding="utf-8")
+    (plans_dir / "gpp_status.v1.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "gpp_status.v1",
+                "current_wp": {"id": "fresh-install-product-smoke"},
+                "support_widening_allowed": False,
+                "production_platform_claim_allowed": False,
+                "live_adapter_execution_allowed": False,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _run(["git", "-C", str(project_root), "add", "."], cwd=project_root)
+    _run(["git", "-C", str(project_root), "commit", "-m", "initial"], cwd=project_root)
+    sha = _run_capture(["git", "-C", str(project_root), "rev-parse", "HEAD"], cwd=project_root).stdout.strip()
+    _run(["git", "-C", str(project_root), "update-ref", "refs/remotes/origin/main", sha], cwd=project_root)
+    return sha
+
+
+def _single(dist_dir: Path, pattern: str, label: str) -> Path:
+    matches = sorted(dist_dir.glob(pattern))
+    if len(matches) != 1:
+        raise SystemExit(f"expected exactly one {label} matching {pattern} in {dist_dir}, found {len(matches)}")
+    return matches[0]
+
+
+def _package_version(repo_root: Path) -> str:
+    import tomllib
+
+    data = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    if not isinstance(project, dict) or not isinstance(project.get("version"), str):
+        raise SystemExit("pyproject.toml project.version missing")
+    return str(project["version"])
+
+
+def _venv_bin_dir(venv_dir: Path) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts"
+    return venv_dir / "bin"
+
+
+def _run(command: list[str], *, cwd: Path) -> None:
+    result = _run_capture(command, cwd=cwd)
+    if result.returncode != 0:
+        if result.stdout.strip():
+            print(result.stdout.strip(), file=sys.stderr)
+        if result.stderr.strip():
+            print(result.stderr.strip(), file=sys.stderr)
+        raise SystemExit(result.returncode)
+
+
+def _run_capture(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    print(f"+ {shlex.join(command)}")
+    result = subprocess.run(
+        command,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=180,
+    )
+    if result.stdout.strip():
+        print(result.stdout.strip())
+    if result.stderr.strip() and result.returncode != 0:
+        print(result.stderr.strip(), file=sys.stderr)
+    return result
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/packaging_smoke.py
+++ b/scripts/packaging_smoke.py
@@ -15,6 +15,11 @@ The smoke is intentionally wheel-first:
    documented fail-closed contract for missing backend / missing API
    key. Writes a schema-valid JSON evidence artifact next to the smoke
    output.
+7. Drive the productized local workflow commands added after v4.3.1
+   prep: ``repo onboarding``, ``pr-metadata``, ``orchestration
+   run-wrapper``, and ``orchestration run-wrapper-async``. Evidence is
+   written under ``build/packaging-smoke/`` so ``dist/`` remains
+   distribution-only.
 """
 
 from __future__ import annotations
@@ -76,8 +81,222 @@ def main() -> int:
             outside_cwd=smoke_cwd,
             evidence_out=repo_root / "build" / "packaging-smoke" / "ri7-packaging-smoke-evidence.v1.json",
         )
+        _smoke_productized_local_workflows(
+            venv_python=venv_python,
+            console_script=console_script,
+            outside_cwd=smoke_cwd,
+            evidence_out=repo_root / "build" / "packaging-smoke" / "productized-local-workflows-smoke.v1.json",
+        )
 
     return 0
+
+
+def _smoke_productized_local_workflows(
+    *,
+    venv_python: Path,
+    console_script: Path,
+    outside_cwd: Path,
+    evidence_out: Path,
+) -> None:
+    """Smoke productized local workflows from the wheel-installed CLI."""
+
+    project = outside_cwd / "productized-workflows-project"
+    base_sha = _init_productized_smoke_project(project)
+    commands: list[dict[str, object]] = []
+
+    def _scenario(scenario_id: str, args: list[str]) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            args,
+            cwd=str(outside_cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=180,
+        )
+        commands.append(
+            {
+                "id": scenario_id,
+                "returncode": result.returncode,
+                "stdout_excerpt": result.stdout.strip()[:500],
+                "stderr_excerpt": result.stderr.strip()[:300],
+            }
+        )
+        if result.returncode != 0:
+            raise SystemExit(
+                f"productized workflow smoke {scenario_id} failed with exit "
+                f"{result.returncode}: {result.stderr.strip() or result.stdout.strip()}"
+            )
+        return result
+
+    _scenario("repo_onboarding_template", [str(console_script), "repo", "onboarding", "template", "--output", "json"])
+    _scenario(
+        "repo_onboarding_init_config",
+        [
+            str(console_script),
+            "repo",
+            "onboarding",
+            "init-config",
+            "--project-root",
+            str(project),
+            "--output",
+            "json",
+        ],
+    )
+    doctor = _scenario(
+        "repo_onboarding_doctor",
+        [str(console_script), "repo", "onboarding", "doctor", "--project-root", str(project), "--output", "json"],
+    )
+    if json.loads(doctor.stdout).get("status") != "ready":
+        raise SystemExit("productized workflow smoke repo onboarding doctor did not report ready")
+
+    body_path = outside_cwd / "product-pr-body.md"
+    body_path.write_text("## Summary\n\nPackaging smoke.\n", encoding="utf-8")
+    generated = _scenario(
+        "pr_metadata_generate",
+        [
+            str(console_script),
+            "pr-metadata",
+            "generate",
+            "--work-package",
+            "PRODUCT-SMOKE",
+            "--issue",
+            "#123",
+        ],
+    )
+    body_path.write_text(body_path.read_text(encoding="utf-8") + "\n" + generated.stdout, encoding="utf-8")
+    _scenario(
+        "pr_metadata_fix",
+        [
+            str(console_script),
+            "pr-metadata",
+            "fix",
+            "--body-file",
+            str(body_path),
+            "--write",
+            "--output",
+            "json",
+            "--work-package",
+            "PRODUCT-SMOKE",
+            "--issue",
+            "#123",
+        ],
+    )
+    _scenario(
+        "pr_metadata_validate",
+        [str(console_script), "pr-metadata", "validate", "--body-file", str(body_path), "--output", "json"],
+    )
+
+    _scenario(
+        "orchestration_run_wrapper_dry_run",
+        [
+            str(console_script),
+            "orchestration",
+            "run-wrapper",
+            "--goal",
+            "packaging smoke run wrapper",
+            "--repo-root",
+            str(project),
+            "--base-sha",
+            base_sha,
+            "--repo",
+            "Halildeu/ao-kernel",
+            "--declared-spec",
+            "task-001:src/a.py:packaging smoke dry run",
+            "--dry-run",
+            "--format",
+            "json",
+        ],
+    )
+    async_result = _scenario(
+        "orchestration_run_wrapper_async_execute",
+        [
+            str(console_script),
+            "orchestration",
+            "run-wrapper-async",
+            "--goal",
+            "packaging smoke async wrapper",
+            "--repo-root",
+            str(project),
+            "--worktree-base",
+            str(outside_cwd / "product-worktrees"),
+            "--base-sha",
+            base_sha,
+            "--repo",
+            "Halildeu/ao-kernel",
+            "--declared-spec",
+            "task-001:src/a.py:packaging smoke async one",
+            "--declared-spec",
+            "task-002:src/b.py:packaging smoke async two",
+            "--execute-local-fixture",
+            "--max-workers",
+            "2",
+            "--format",
+            "json",
+        ],
+    )
+    async_payload = json.loads(async_result.stdout)
+    if async_payload.get("status") != "ok":
+        raise SystemExit("productized workflow smoke async wrapper did not report ok")
+
+    artifact = {
+        "schema_version": "productized-local-workflows-smoke.v1",
+        "artifact_kind": "productized_local_workflows_smoke",
+        "decision": "productized_local_workflows_packaging_smoke_ready",
+        "entrypoint": {
+            "console_script": str(console_script),
+            "module": str(venv_python),
+        },
+        "scenarios": [
+            {"id": item["id"], "status": "pass", "returncode": item["returncode"]} for item in commands
+        ],
+        "async_wrapper_version": async_payload.get("async_wrapper_version"),
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+    }
+    evidence_out.parent.mkdir(parents=True, exist_ok=True)
+    evidence_out.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"+ wrote productized workflow smoke evidence -> {evidence_out}")
+
+
+def _init_productized_smoke_project(project: Path) -> str:
+    project.mkdir(parents=True)
+    _run(["git", "init", "--initial-branch=main", str(project)], cwd=project.parent)
+    _run(["git", "-C", str(project), "config", "user.email", "test@example.com"], cwd=project)
+    _run(["git", "-C", str(project), "config", "user.name", "test"], cwd=project)
+    (project / "AGENTS.md").write_text("# AGENTS\nProductized workflow packaging smoke.\n", encoding="utf-8")
+    plans = project / ".claude" / "plans"
+    plans.mkdir(parents=True)
+    (project / "src").mkdir()
+    (project / "src" / "a.py").write_text("def a():\n    return 1\n", encoding="utf-8")
+    (project / "src" / "b.py").write_text("def b():\n    return 2\n", encoding="utf-8")
+    (plans / "gpp_status.v1.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "gpp_status.v1",
+                "current_wp": {"id": "productized-workflow-packaging-smoke"},
+                "support_widening_allowed": False,
+                "production_platform_claim_allowed": False,
+                "live_adapter_execution_allowed": False,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _run(["git", "-C", str(project), "add", "."], cwd=project)
+    _run(["git", "-C", str(project), "commit", "-m", "initial"], cwd=project)
+    sha = subprocess.run(
+        ["git", "-C", str(project), "rev-parse", "HEAD"],
+        cwd=str(project),
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    ).stdout.strip()
+    _run(["git", "-C", str(project), "update-ref", "refs/remotes/origin/main", sha], cwd=project)
+    return sha
 
 
 def _smoke_repo_intelligence_cli(

--- a/tests/test_productization_closeout.py
+++ b/tests/test_productization_closeout.py
@@ -1,0 +1,61 @@
+"""Productization closeout invariants for release + install + quickstart."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_fresh_install_product_smoke_script_covers_wheel_sdist_and_product_commands() -> None:
+    text = (ROOT / "scripts" / "fresh_install_product_smoke.py").read_text(encoding="utf-8")
+
+    assert "--mode" in text
+    assert '"wheel", "sdist", "both"' in text
+    assert "repo_onboarding_doctor" in text
+    assert "pr_metadata_validate" in text
+    assert "orchestration_run_wrapper_dry_run" in text
+    assert "orchestration_run_wrapper_async_execute" in text
+    assert "build/fresh-install-product-smoke" in text
+    assert "support_widening" in text
+    assert "production_platform_claim" in text
+    assert "live_adapter_execution" in text
+
+
+def test_packaging_smoke_now_gates_productized_local_workflows_without_dist_pollution() -> None:
+    text = (ROOT / "scripts" / "packaging_smoke.py").read_text(encoding="utf-8")
+
+    assert "_smoke_productized_local_workflows" in text
+    assert "productized-local-workflows-smoke.v1.json" in text
+    assert "build\" / \"packaging-smoke\"" in text
+    assert "orchestration_run_wrapper_async_execute" in text
+    assert "dist/`` remains" in text
+
+
+def test_product_quickstart_is_end_to_end_and_keeps_guard_boundary() -> None:
+    text = (ROOT / "docs" / "PRODUCT-QUICKSTART.md").read_text(encoding="utf-8")
+
+    required_tokens = (
+        "python -m pip install ao-kernel==4.3.1",
+        "ao-kernel repo onboarding init-config",
+        "ao-kernel repo onboarding doctor",
+        "ao-kernel pr-metadata generate",
+        "ao-kernel pr-metadata fix",
+        "ao-kernel orchestration run-wrapper",
+        "ao-kernel orchestration run-wrapper-async",
+        "support widening",
+        "production-platform readiness",
+        "live adapter execution",
+    )
+    for token in required_tokens:
+        assert token in text
+
+
+def test_readme_links_product_quickstart_and_async_wrapper_v2() -> None:
+    text = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "docs/PRODUCT-QUICKSTART.md" in text
+    assert "ao-kernel orchestration run-wrapper-async" in text
+    assert "external evidence required" in text
+    assert "live_adapter_execution" in text

--- a/tests/test_productized_p2_p3_p5_cli.py
+++ b/tests/test_productized_p2_p3_p5_cli.py
@@ -21,7 +21,8 @@ def _git_init_repo(repo: Path) -> str:
     (repo / "README.md").write_text("initial\n", encoding="utf-8")
     (repo / "src").mkdir(parents=True, exist_ok=True)
     (repo / "src" / "a.py").write_text("def a():\n    return 1\n", encoding="utf-8")
-    _run(["git", "-C", str(repo), "add", "README.md", "src/a.py"])
+    (repo / "src" / "b.py").write_text("def b():\n    return 2\n", encoding="utf-8")
+    _run(["git", "-C", str(repo), "add", "README.md", "src/a.py", "src/b.py"])
     _run(["git", "-C", str(repo), "commit", "-m", "initial"])
     sha = _run(["git", "-C", str(repo), "rev-parse", "HEAD"])
     _run(["git", "-C", str(repo), "update-ref", "refs/remotes/origin/main", sha])
@@ -261,3 +262,88 @@ def test_orchestration_run_wrapper_executes_pinned_local_fixture(tmp_path: Path,
     assert Path(payload["manifest_path"]).is_file()
     assert Path(payload["runner_report_path"]).is_file()
     assert Path(payload["invocation_report_path"]).is_file()
+
+
+def test_orchestration_run_wrapper_async_executes_two_local_fixtures(tmp_path: Path, capsys) -> None:
+    repo = tmp_path / "repo"
+    base_sha = _git_init_repo(repo)
+    _write_synthetic_ssot(repo)
+
+    rc = cli_main(
+        [
+            "orchestration",
+            "run-wrapper-async",
+            "--goal",
+            "P5 async wrapper smoke",
+            "--repo-root",
+            str(repo),
+            "--worktree-base",
+            str(tmp_path / "worktrees"),
+            "--base-sha",
+            base_sha,
+            "--repo",
+            "Halildeu/ao-kernel",
+            "--declared-spec",
+            "task-001:src/a.py:P5 async one",
+            "--declared-spec",
+            "task-002:src/b.py:P5 async two",
+            "--execute-local-fixture",
+            "--max-workers",
+            "2",
+            "--format",
+            "json",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    payload = json.loads(captured.out)
+    assert payload["status"] == "ok"
+    assert payload["async_wrapper_version"] == "v2"
+    assert payload["max_workers"] == 2
+    assert {entry["task_id"] for entry in payload["invocation_statuses"]} == {"task-001", "task-002"}
+    assert {entry["status"] for entry in payload["invocation_statuses"]} == {"invoked"}
+    assert {entry["status"] for entry in payload["review_statuses"]} == {"external_review_evidence_required"}
+    assert {entry["status"] for entry in payload["verifier_statuses"]} == {"external_verification_evidence_required"}
+    assert Path(payload["manifest_path"]).is_file()
+    assert Path(payload["runner_report_path"]).is_file()
+    assert Path(payload["invocation_report_path"]).is_file()
+    assert payload["guard_flags"]["support_widening"] is False
+
+
+def test_orchestration_run_wrapper_async_dry_run_reports_not_run_invocations(tmp_path: Path, capsys) -> None:
+    repo = tmp_path / "repo"
+    base_sha = _git_init_repo(repo)
+    _write_synthetic_ssot(repo)
+
+    rc = cli_main(
+        [
+            "orchestration",
+            "run-wrapper-async",
+            "--goal",
+            "P5 async dry-run wrapper smoke",
+            "--repo-root",
+            str(repo),
+            "--base-sha",
+            base_sha,
+            "--repo",
+            "Halildeu/ao-kernel",
+            "--declared-spec",
+            "task-001:src/a.py:P5 async dry one",
+            "--declared-spec",
+            "task-002:src/b.py:P5 async dry two",
+            "--dry-run",
+            "--max-workers",
+            "2",
+            "--format",
+            "json",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    payload = json.loads(captured.out)
+    assert payload["mode"] == "dry_run"
+    assert payload["invocation_report_path"] is None
+    assert {entry["status"] for entry in payload["worker_statuses"]} == {"skipped_dry_run"}
+    assert {entry["status"] for entry in payload["invocation_statuses"]} == {"not_run_dry_run"}


### PR DESCRIPTION
## Summary

Close the v4.3.1 local workflow productization slice in one PR:

- add `orchestration run-wrapper-async` as a separate v2 CLI surface for bounded N-worker local fixture execution
- extend release packaging smoke to cover installed-wheel onboarding, PR metadata, run-wrapper, and run-wrapper-async workflows
- add `scripts/fresh_install_product_smoke.py` for clean wheel/sdist install smoke from outside the source checkout
- add `docs/PRODUCT-QUICKSTART.md` covering install -> repo onboarding -> PR metadata -> run-wrapper artifact
- update README + CHANGELOG and productization tests

## Authority boundary

- no support widening
- no production platform claim
- no live adapter execution
- no branch-protection / GitHub ruleset mutation
- no fabricated AI approval: async wrapper records review/verifier evidence as externally required
- release authority remains repo-owned `ao-release-gate` + GitHub branch protection

## Validation

- `ruff check ao_kernel/orchestration/async_runner.py ao_kernel/orchestration/worker_invoker.py ao_kernel/orchestration/cli_handlers.py ao_kernel/cli.py scripts/packaging_smoke.py scripts/fresh_install_product_smoke.py tests/test_productized_p2_p3_p5_cli.py tests/test_productization_closeout.py`
- `mypy --follow-imports=skip ao_kernel/orchestration/async_runner.py ao_kernel/orchestration/worker_invoker.py ao_kernel/orchestration/cli_handlers.py scripts/fresh_install_product_smoke.py scripts/packaging_smoke.py`
- `pytest -q tests/test_productized_p2_p3_p5_cli.py tests/test_productization_closeout.py` -> 13 passed
- `python3 scripts/fresh_install_product_smoke.py --mode both` -> pass; writes `build/fresh-install-product-smoke/fresh-install-product-smoke.v1.json`
- `python3 scripts/packaging_smoke.py` -> pass; writes `build/packaging-smoke/productized-local-workflows-smoke.v1.json`
- `python3 scripts/gpp_next.py` -> GPP-9 closed; guard flags false
- `python3 scripts/local_gpp_gate.py ...` -> `operator_may_merge`, changed_files_count=12, diff_digest=`sha256:a6d643fae840887994539dc3f875379905e53e912fbaf55f7d9f0a4333ac2413`

## Cross-AI review

Claude post-implementation adversarial review: `AGREE`; no blocking findings.

## Delivery metadata

Not included. This productization closeout was not tied to a single issue id, and I did not fabricate one for PR metadata.
