### PR TITLE
feat(ai-review): productize cross-provider review orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **Cross-provider AI review orchestration productization**: added the
+  packaged `ao-kernel ai-review` CLI with `collect`, `consensus`, and
+  `high-risk-dry-run` commands. The commands collect Claude/Codex/MiniMax-style
+  provider review evidence through explicit provider commands or environment
+  bindings, record command argv hash + prompt hash provenance, run a bounded
+  fail-closed ping-pong consensus loop, emit raw `local-ai-review-evidence.v1`
+  files for the existing high-risk `ao-release-gate` lane, and prove a local
+  high-risk dry-run path without mutating GitHub or attempting a merge. AI
+  output remains evidence only; release authority remains `ao-release-gate`
+  plus GitHub ruleset enforcement. Guard flags remain closed: no support
+  widening, no production-platform claim, and no live-adapter execution.
 - **Productization closeout for local governed workflows**: extended the
   wheel-installed `packaging-smoke` gate and added
   `scripts/fresh_install_product_smoke.py` so the built wheel and sdist are

--- a/README.md
+++ b/README.md
@@ -278,6 +278,43 @@ external evidence required rather than fabricating AI approval. Both wrappers
 require explicit declared write scopes and keep `support_widening`,
 `production_platform_claim`, and `live_adapter_execution` closed.
 
+**Cross-provider AI review collection:**
+
+```bash
+ao-kernel ai-review collect \
+  --work-package AO-MA-10X \
+  --base-ref origin/main \
+  --head-ref HEAD \
+  --implementer-provider openai \
+  --provider "anthropic=claude -p 'return JSON only ...'" \
+  --provider "minimax=/path/to/minimax-reviewer"
+
+ao-kernel ai-review consensus \
+  --work-package AO-MA-10X \
+  --base-ref origin/main \
+  --head-ref HEAD \
+  --implementer-provider openai \
+  --max-rounds 3 \
+  --provider "anthropic=claude -p 'return JSON only ...'" \
+  --provider "minimax=/path/to/minimax-reviewer"
+
+ao-kernel ai-review high-risk-dry-run \
+  --work-package AO-MA-10X \
+  --base-ref origin/main \
+  --head-ref HEAD \
+  --implementer-provider openai \
+  --review-evidence ai-review-artifacts/anthropic.local-ai-review-evidence.v1.json \
+  --review-evidence ai-review-artifacts/minimax.local-ai-review-evidence.v1.json
+```
+
+`ai-review` records provider command provenance (`command_argv_sha256`) and
+prompt provenance (`prompt_sha256`) without storing secrets. It can collect
+raw reviewer evidence, run bounded cross-provider ping-pong until unanimous
+`AGREE`, and locally dry-run the high-risk `ao-release-gate` path. The CLI
+prints only a safe status/provider summary; full artifact paths and provenance
+are written under `--output-dir`. It does not make AI output release authority,
+mutate GitHub, widen support, claim broad readiness, or execute live adapters.
+
 ## Context Management
 
 Governed context loop — decisions extracted, scored, and injected automatically.

--- a/ao_kernel/ai_review.py
+++ b/ao_kernel/ai_review.py
@@ -1,0 +1,1183 @@
+"""Provider-backed review collection and consensus helpers.
+
+This module productizes the previously operator-scripted cross-provider review
+flow. It collects no-secret reviewer evidence from configured provider
+commands, records command/prompt provenance, and emits fail-closed consensus
+artifacts. It does not grant release authority; the repository-owned
+``ao-release-gate`` required check plus GitHub ruleset remains authoritative.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from jsonschema import Draft202012Validator
+
+from ao_kernel.ao_release_gate import (
+    RELEASE_GATE_CHECK_NAME,
+    _high_risk_paths,
+    build_ao_release_gate_decision,
+    diff_digest,
+    expected_high_risk_supersession_reviewers,
+)
+from ao_kernel.config import load_default
+
+PROVIDER_REVIEW_POOL = ("openai", "anthropic", "minimax")
+PROVIDER_COMMAND_ENVS = {
+    "openai": "AO_MA10_OPENAI_REVIEW_CMD",
+    "anthropic": "AO_MA10_ANTHROPIC_REVIEW_CMD",
+    "minimax": "AO_MA10_MINIMAX_REVIEW_CMD",
+}
+RELEASE_AUTHORITY = "ao-release-gate+github-ruleset"
+COLLECTION_SCHEMA = "ai-review-collection-evidence.schema.v1.json"
+CONSENSUS_SCHEMA = "ai-review-consensus-evidence.schema.v1.json"
+DRY_RUN_SCHEMA = "ai-review-high-risk-dry-run-evidence.schema.v1.json"
+RAW_REVIEW_SCHEMA = "local-ai-review-evidence.schema.v1.json"
+HIGH_RISK_SUPERSESSION_SCHEMA = "ao-ma-10-high-risk-supersession-evidence.schema.v1.json"
+
+SECRET_PATTERNS = (
+    re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    re.compile(r"(?i)\b(?:api[_-]?key|token|secret|password)\s*[:=]\s*['\"]?[A-Za-z0-9_./+=-]{16,}"),
+)
+
+Verdict = Literal["AGREE", "REVISE", "BLOCK", "PARTIAL", "RED"]
+
+
+@dataclass(frozen=True)
+class ProviderCommand:
+    """A configured provider command plus safe provenance metadata."""
+
+    provider: str
+    argv: tuple[str, ...]
+    source: str
+
+
+@dataclass(frozen=True)
+class ProviderRoundResult:
+    """One provider's bounded review output for one consensus round."""
+
+    provider: str
+    agent: str
+    verdict: Verdict
+    checks_considered: list[dict[str, str]]
+    findings: list[str]
+    prompt_sha256: str
+    command: ProviderCommand
+
+
+def utc_timestamp() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def sha256_text(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def assert_no_secret_like_text(value: str, *, label: str) -> None:
+    for pattern in SECRET_PATTERNS:
+        if pattern.search(value):
+            raise ValueError(f"{label} contains secret-like material")
+
+
+def _validate(schema_name: str, payload: dict[str, Any]) -> None:
+    Draft202012Validator(load_default("schemas", schema_name)).validate(payload)
+
+
+def _run_git(repo_root: Path, args: list[str]) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def changed_files(repo_root: Path, base_ref: str, head_ref: str) -> list[str]:
+    output = _run_git(repo_root, ["diff", "--name-only", f"{base_ref}...{head_ref}"])
+    return sorted(line.strip() for line in output.splitlines() if line.strip())
+
+
+def head_sha(repo_root: Path, head_ref: str) -> str:
+    candidate = _run_git(repo_root, ["rev-parse", head_ref])
+    if len(candidate) != 40 or any(char not in "0123456789abcdef" for char in candidate):
+        raise ValueError("head ref did not resolve to a canonical 40-hex SHA")
+    return candidate
+
+
+def diff_text(repo_root: Path, base_ref: str, head_ref: str, max_bytes: int) -> str:
+    output = _run_git(repo_root, ["diff", "--no-ext-diff", "--unified=80", f"{base_ref}...{head_ref}"])
+    encoded = output.encode("utf-8")
+    if len(encoded) > max_bytes:
+        raise ValueError(f"diff is {len(encoded)} bytes, exceeds max_diff_bytes={max_bytes}")
+    assert_no_secret_like_text(output, label="git diff")
+    return output
+
+
+def parse_provider_commands(
+    values: list[str] | None,
+    *,
+    required_providers: tuple[str, ...],
+) -> dict[str, ProviderCommand]:
+    commands: dict[str, ProviderCommand] = {}
+    for value in values or []:
+        if "=" not in value:
+            raise ValueError("--provider must have form provider=command")
+        provider, raw_command = value.split("=", 1)
+        provider = provider.strip()
+        if provider not in PROVIDER_REVIEW_POOL:
+            raise ValueError(f"unsupported provider {provider!r}")
+        assert_no_secret_like_text(raw_command, label=f"{provider} provider command")
+        argv = tuple(shlex.split(raw_command))
+        if not argv:
+            raise ValueError(f"empty command for provider {provider}")
+        commands[provider] = ProviderCommand(provider=provider, argv=argv, source="cli")
+
+    for provider, env_name in PROVIDER_COMMAND_ENVS.items():
+        if provider in commands:
+            continue
+        raw_command = os.environ.get(env_name, "")
+        if raw_command.strip():
+            assert_no_secret_like_text(raw_command, label=f"{provider} provider command env")
+            argv = tuple(shlex.split(raw_command))
+            if not argv:
+                raise ValueError(f"empty command for provider {provider}")
+            commands[provider] = ProviderCommand(provider=provider, argv=argv, source=f"env:{env_name}")
+
+    missing = sorted(set(required_providers) - set(commands))
+    if missing:
+        raise ValueError(f"missing required provider command(s): {', '.join(missing)}")
+    return commands
+
+
+def command_provenance(command: ProviderCommand, *, prompt_sha256: str, timeout_seconds: int) -> dict[str, Any]:
+    redacted_argv = list(command.argv)
+    rendered = shlex.join(redacted_argv)
+    assert_no_secret_like_text(rendered, label=f"{command.provider} command argv")
+    return {
+        "provider_id": command.provider,
+        "command_source": command.source,
+        "command_executable": redacted_argv[0],
+        "command_argv_redacted": redacted_argv,
+        "command_argv_sha256": sha256_text(rendered),
+        "prompt_sha256": prompt_sha256,
+        "timeout_seconds": timeout_seconds,
+    }
+
+
+def required_reviewer_providers(implementer_provider: str) -> tuple[str, str]:
+    reviewers = tuple(str(provider) for provider in expected_high_risk_supersession_reviewers(implementer_provider))
+    if len(reviewers) != 2:
+        raise ValueError(f"expected exactly two reviewer providers, got {len(reviewers)}")
+    return reviewers
+
+
+def build_context_binding(
+    *,
+    repository: str,
+    repo_root: Path,
+    base_ref: str,
+    head_ref: str,
+    changed: list[str],
+) -> dict[str, Any]:
+    return {
+        "repository_full_name": repository,
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "head_sha": head_sha(repo_root, head_ref),
+        "diff_digest": diff_digest(changed),
+        "changed_files_count": len(changed),
+    }
+
+
+def build_review_request(
+    *,
+    repository: str,
+    work_package: str,
+    base_ref: str,
+    head_ref: str,
+    changed: list[str],
+    high_risk_changed_paths: list[str],
+    rendered_diff: str,
+    round_index: int,
+    previous_findings: list[dict[str, Any]],
+) -> str:
+    request = {
+        "task": "review_high_risk_pr_change",
+        "instructions": [
+            "Return JSON only.",
+            "Use AGREE only if the change matches the work package and no drift, bug, secret, or forbidden action remains.",
+            "Use REVISE or BLOCK when any issue remains.",
+            "Do not include secret values in findings.",
+            "AI output is evidence only; release authority remains ao-release-gate plus GitHub ruleset.",
+        ],
+        "required_output_shape": {
+            "agent": "short reviewer label",
+            "verdict": "AGREE|REVISE|BLOCK",
+            "checks_considered": [
+                {"name": "tests", "status": "pass|fail"},
+                {"name": "secret_scan", "status": "pass|fail"},
+            ],
+            "findings": ["short finding strings"],
+        },
+        "context": {
+            "repository": repository,
+            "work_package": work_package,
+            "base_ref": base_ref,
+            "head_ref": head_ref,
+            "changed_files": changed,
+            "high_risk_changed_paths": high_risk_changed_paths,
+            "round_index": round_index,
+            "previous_findings": previous_findings,
+        },
+        "diff": rendered_diff,
+    }
+    payload = json.dumps(request, indent=2, sort_keys=True)
+    assert_no_secret_like_text(payload, label="review request")
+    return payload
+
+
+def _load_provider_output(stdout: str, provider: str) -> dict[str, Any]:
+    assert_no_secret_like_text(stdout, label=f"{provider} reviewer stdout")
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{provider} reviewer output is not valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{provider} reviewer output must be a JSON object")
+    return cast(dict[str, Any], payload)
+
+
+def _checks_from_output(provider_output: dict[str, Any], provider: str) -> list[dict[str, str]]:
+    checks = provider_output.get("checks_considered")
+    if not isinstance(checks, list):
+        raise ValueError(f"{provider} reviewer checks_considered must be a list")
+    normalized: list[dict[str, str]] = []
+    for check in checks:
+        if not isinstance(check, dict):
+            raise ValueError(f"{provider} reviewer check entry must be an object")
+        name = check.get("name")
+        status = check.get("status")
+        if not isinstance(name, str) or not isinstance(status, str):
+            raise ValueError(f"{provider} reviewer check entry must include string name/status")
+        if status not in {"pass", "fail"}:
+            raise ValueError(f"{provider} reviewer check status must be pass or fail")
+        normalized.append({"name": name, "status": status})
+    return normalized
+
+
+def _findings_from_output(provider_output: dict[str, Any], provider: str) -> list[str]:
+    findings = provider_output.get("findings")
+    if not isinstance(findings, list) or not all(isinstance(item, str) and item for item in findings):
+        raise ValueError(f"{provider} reviewer findings must be a non-empty string list")
+    for finding in findings:
+        assert_no_secret_like_text(finding, label=f"{provider} reviewer finding")
+    return list(findings)
+
+
+def _verdict_from_output(provider_output: dict[str, Any], provider: str) -> Verdict:
+    reviewer = provider_output.get("reviewer")
+    raw = reviewer.get("verdict") if isinstance(reviewer, dict) else provider_output.get("verdict")
+    if raw not in {"AGREE", "REVISE", "BLOCK", "PARTIAL", "RED"}:
+        raise ValueError(f"{provider} reviewer verdict must be AGREE, REVISE, BLOCK, PARTIAL, or RED")
+    return cast(Verdict, raw)
+
+
+def _agent_from_output(provider_output: dict[str, Any], provider: str) -> str:
+    reviewer = provider_output.get("reviewer")
+    raw = reviewer.get("agent") if isinstance(reviewer, dict) else provider_output.get("agent")
+    if not isinstance(raw, str) or not raw:
+        return f"{provider}-reviewer"
+    assert_no_secret_like_text(raw, label=f"{provider} reviewer agent")
+    return raw
+
+
+def run_provider_command(
+    command: ProviderCommand,
+    *,
+    review_request: str,
+    timeout_seconds: int,
+) -> ProviderRoundResult:
+    prompt_digest = sha256_text(review_request)
+    proc = subprocess.run(
+        list(command.argv),
+        input=review_request,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
+    if proc.stderr.strip():
+        assert_no_secret_like_text(proc.stderr, label=f"{command.provider} reviewer stderr")
+    if proc.returncode != 0:
+        raise RuntimeError(f"{command.provider} reviewer command failed with exit {proc.returncode}")
+    payload = _load_provider_output(proc.stdout, command.provider)
+    return ProviderRoundResult(
+        provider=command.provider,
+        agent=_agent_from_output(payload, command.provider),
+        verdict=_verdict_from_output(payload, command.provider),
+        checks_considered=_checks_from_output(payload, command.provider),
+        findings=_findings_from_output(payload, command.provider),
+        prompt_sha256=prompt_digest,
+        command=command,
+    )
+
+
+def _required_check_present(checks: list[dict[str, str]], name: str) -> bool:
+    matching = [item for item in checks if item["name"] == name]
+    return bool(matching) and all(item["status"] == "pass" for item in matching)
+
+
+def raw_review_from_round(
+    *,
+    result: ProviderRoundResult,
+    repository: str,
+    work_package: str,
+    implementer: dict[str, str],
+    base_ref: str,
+    head_ref: str,
+    changed: list[str],
+) -> dict[str, Any]:
+    if result.verdict != "AGREE":
+        raise ValueError(f"{result.provider} reviewer verdict is not AGREE")
+    if any(item.startswith("FORBIDDEN:") for item in result.findings):
+        raise ValueError(f"{result.provider} reviewer returned a forbidden finding")
+    if not _required_check_present(result.checks_considered, "tests"):
+        raise ValueError(f"{result.provider} reviewer did not record passing tests")
+    if not _required_check_present(result.checks_considered, "secret_scan"):
+        raise ValueError(f"{result.provider} reviewer did not record passing secret_scan")
+    raw = {
+        "schema_version": "local-ai-review-evidence.v1",
+        "repo": repository,
+        "work_package": work_package,
+        "implementer": dict(implementer),
+        "reviewer": {
+            "agent": result.agent,
+            "provider": result.provider,
+            "verdict": "AGREE",
+        },
+        "scope_reviewed": {
+            "base_ref": base_ref,
+            "head_ref": head_ref,
+            "changed_files": list(changed),
+        },
+        "checks_considered": result.checks_considered,
+        "findings": result.findings,
+        "secrets_recorded": False,
+        "live_adapter_execution": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+    }
+    serialized = json.dumps(raw, sort_keys=True)
+    assert_no_secret_like_text(serialized, label=f"{result.provider} raw review evidence")
+    _validate(RAW_REVIEW_SCHEMA, raw)
+    return raw
+
+
+def write_raw_reviews(
+    *,
+    output_dir: Path,
+    round_results: list[ProviderRoundResult],
+    repository: str,
+    work_package: str,
+    implementer: dict[str, str],
+    base_ref: str,
+    head_ref: str,
+    changed: list[str],
+) -> dict[str, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths: dict[str, Path] = {}
+    for result in round_results:
+        raw = raw_review_from_round(
+            result=result,
+            repository=repository,
+            work_package=work_package,
+            implementer=implementer,
+            base_ref=base_ref,
+            head_ref=head_ref,
+            changed=changed,
+        )
+        path = output_dir / f"{result.provider}.local-ai-review-evidence.v1.json"
+        path.write_text(json.dumps(raw, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        paths[result.provider] = path
+    return paths
+
+
+def build_collection_artifact(
+    *,
+    repository: str,
+    work_package: str,
+    implementer: dict[str, str],
+    required_providers: tuple[str, ...],
+    context_binding: dict[str, Any],
+    high_risk_changed_paths: list[str],
+    raw_review_paths: dict[str, Path],
+    round_results: list[ProviderRoundResult],
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    raw_paths = {provider: str(path) for provider, path in sorted(raw_review_paths.items())}
+    provenance = [
+        command_provenance(result.command, prompt_sha256=result.prompt_sha256, timeout_seconds=timeout_seconds)
+        for result in round_results
+    ]
+    artifact = {
+        "schema_version": "ai-review-collection-evidence.v1",
+        "artifact_kind": "ai_review_collection_evidence",
+        "generated_at": utc_timestamp(),
+        "repo": repository,
+        "work_package": work_package,
+        "release_authority": RELEASE_AUTHORITY,
+        "ai_output_release_authority": False,
+        "implementer": implementer,
+        "required_reviewer_providers": list(required_providers),
+        "reviewer_providers": sorted(raw_paths),
+        "context_binding": {
+            **context_binding,
+            "high_risk_changed_paths": high_risk_changed_paths,
+        },
+        "raw_review_paths": raw_paths,
+        "provider_provenance": provenance,
+        "collection_status": "collected",
+        "guard_flags": {
+            "support_widening": False,
+            "production_platform_claim": False,
+            "live_adapter_execution": False,
+        },
+        "secrets_recorded": False,
+        "mutations_performed": False,
+    }
+    _validate(COLLECTION_SCHEMA, artifact)
+    return artifact
+
+
+def run_collect(
+    *,
+    repository: str,
+    work_package: str,
+    implementer_agent: str,
+    implementer_provider: str,
+    base_ref: str,
+    head_ref: str,
+    repo_root: Path,
+    output_dir: Path,
+    provider_values: list[str] | None,
+    max_diff_bytes: int,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    required_providers = required_reviewer_providers(implementer_provider)
+    provider_commands = parse_provider_commands(provider_values, required_providers=required_providers)
+    changed = changed_files(repo_root, base_ref, head_ref)
+    if not changed:
+        raise ValueError("changed-files set is empty; review evidence cannot be produced")
+    high_risk_changed_paths = _high_risk_paths(changed)
+    if not high_risk_changed_paths:
+        raise ValueError("no high-risk changed paths found; ai-review collect is not needed")
+    rendered_diff = diff_text(repo_root, base_ref, head_ref, max_diff_bytes)
+    request = build_review_request(
+        repository=repository,
+        work_package=work_package,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        changed=changed,
+        high_risk_changed_paths=high_risk_changed_paths,
+        rendered_diff=rendered_diff,
+        round_index=1,
+        previous_findings=[],
+    )
+    results = [
+        run_provider_command(provider_commands[provider], review_request=request, timeout_seconds=timeout_seconds)
+        for provider in required_providers
+    ]
+    implementer = {"agent": implementer_agent, "provider": implementer_provider}
+    raw_paths = write_raw_reviews(
+        output_dir=output_dir,
+        round_results=results,
+        repository=repository,
+        work_package=work_package,
+        implementer=implementer,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        changed=changed,
+    )
+    context = build_context_binding(
+        repository=repository,
+        repo_root=repo_root,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        changed=changed,
+    )
+    artifact = build_collection_artifact(
+        repository=repository,
+        work_package=work_package,
+        implementer=implementer,
+        required_providers=required_providers,
+        context_binding=context,
+        high_risk_changed_paths=high_risk_changed_paths,
+        raw_review_paths=raw_paths,
+        round_results=results,
+        timeout_seconds=timeout_seconds,
+    )
+    collection_path = output_dir / "ai_review_collection.v1.json"
+    collection_path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return artifact
+
+
+def build_consensus_artifact(
+    *,
+    repository: str,
+    work_package: str,
+    implementer: dict[str, str],
+    context_binding: dict[str, Any],
+    high_risk_changed_paths: list[str],
+    required_providers: tuple[str, ...],
+    rounds: list[dict[str, Any]],
+    consensus_status: str,
+    raw_review_paths: dict[str, Path],
+    collection_path: Path | None,
+    max_rounds: int,
+) -> dict[str, Any]:
+    artifact = {
+        "schema_version": "ai-review-consensus-evidence.v1",
+        "artifact_kind": "ai_review_consensus_evidence",
+        "generated_at": utc_timestamp(),
+        "repo": repository,
+        "work_package": work_package,
+        "release_authority": RELEASE_AUTHORITY,
+        "ai_output_release_authority": False,
+        "implementer": implementer,
+        "required_reviewer_providers": list(required_providers),
+        "context_binding": {
+            **context_binding,
+            "high_risk_changed_paths": high_risk_changed_paths,
+        },
+        "rounds": rounds,
+        "consensus_status": consensus_status,
+        "max_rounds": max_rounds,
+        "raw_review_paths": {provider: str(path) for provider, path in sorted(raw_review_paths.items())},
+        "collection_evidence_path": str(collection_path) if collection_path else None,
+        "escalation_action": "operator_human_review_fallback",
+        "guard_flags": {
+            "support_widening": False,
+            "production_platform_claim": False,
+            "live_adapter_execution": False,
+        },
+        "secrets_recorded": False,
+        "mutations_performed": False,
+    }
+    _validate(CONSENSUS_SCHEMA, artifact)
+    return artifact
+
+
+def run_consensus(
+    *,
+    repository: str,
+    work_package: str,
+    implementer_agent: str,
+    implementer_provider: str,
+    base_ref: str,
+    head_ref: str,
+    repo_root: Path,
+    output_dir: Path,
+    provider_values: list[str] | None,
+    max_diff_bytes: int,
+    timeout_seconds: int,
+    max_rounds: int,
+) -> dict[str, Any]:
+    if max_rounds <= 0 or max_rounds > 3:
+        raise ValueError("--max-rounds must be between 1 and 3")
+    required_providers = required_reviewer_providers(implementer_provider)
+    provider_commands = parse_provider_commands(provider_values, required_providers=required_providers)
+    changed = changed_files(repo_root, base_ref, head_ref)
+    if not changed:
+        raise ValueError("changed-files set is empty; consensus evidence cannot be produced")
+    high_risk_changed_paths = _high_risk_paths(changed)
+    if not high_risk_changed_paths:
+        raise ValueError("no high-risk changed paths found; ai-review consensus is not needed")
+    rendered_diff = diff_text(repo_root, base_ref, head_ref, max_diff_bytes)
+    context = build_context_binding(
+        repository=repository,
+        repo_root=repo_root,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        changed=changed,
+    )
+    previous_findings: list[dict[str, Any]] = []
+    rounds: list[dict[str, Any]] = []
+    agreeing_results: list[ProviderRoundResult] = []
+    consensus_status = "not_agreed"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for round_index in range(1, max_rounds + 1):
+        request = build_review_request(
+            repository=repository,
+            work_package=work_package,
+            base_ref=base_ref,
+            head_ref=head_ref,
+            changed=changed,
+            high_risk_changed_paths=high_risk_changed_paths,
+            rendered_diff=rendered_diff,
+            round_index=round_index,
+            previous_findings=previous_findings,
+        )
+        results = [
+            run_provider_command(provider_commands[provider], review_request=request, timeout_seconds=timeout_seconds)
+            for provider in required_providers
+        ]
+        round_record = {
+            "round_index": round_index,
+            "provider_results": [
+                {
+                    "provider_id": result.provider,
+                    "agent_id": result.agent,
+                    "verdict": result.verdict,
+                    "findings_count": len(result.findings),
+                    "findings": result.findings,
+                    "checks_considered": result.checks_considered,
+                    "provider_provenance": command_provenance(
+                        result.command,
+                        prompt_sha256=result.prompt_sha256,
+                        timeout_seconds=timeout_seconds,
+                    ),
+                }
+                for result in results
+            ],
+        }
+        rounds.append(round_record)
+        if all(result.verdict == "AGREE" for result in results):
+            agreeing_results = results
+            consensus_status = "AGREE"
+            break
+        previous_findings = [
+            {"provider_id": result.provider, "verdict": result.verdict, "findings": result.findings}
+            for result in results
+            if result.verdict != "AGREE"
+        ]
+
+    implementer = {"agent": implementer_agent, "provider": implementer_provider}
+    raw_paths: dict[str, Path] = {}
+    collection_path: Path | None = None
+    if consensus_status == "AGREE":
+        raw_paths = write_raw_reviews(
+            output_dir=output_dir,
+            round_results=agreeing_results,
+            repository=repository,
+            work_package=work_package,
+            implementer=implementer,
+            base_ref=base_ref,
+            head_ref=head_ref,
+            changed=changed,
+        )
+        collection = build_collection_artifact(
+            repository=repository,
+            work_package=work_package,
+            implementer=implementer,
+            required_providers=required_providers,
+            context_binding=context,
+            high_risk_changed_paths=high_risk_changed_paths,
+            raw_review_paths=raw_paths,
+            round_results=agreeing_results,
+            timeout_seconds=timeout_seconds,
+        )
+        collection_path = output_dir / "ai_review_collection.v1.json"
+        collection_path.write_text(json.dumps(collection, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    consensus = build_consensus_artifact(
+        repository=repository,
+        work_package=work_package,
+        implementer=implementer,
+        context_binding=context,
+        high_risk_changed_paths=high_risk_changed_paths,
+        required_providers=required_providers,
+        rounds=rounds,
+        consensus_status=consensus_status,
+        raw_review_paths=raw_paths,
+        collection_path=collection_path,
+        max_rounds=max_rounds,
+    )
+    consensus_path = output_dir / "ai_review_consensus.v1.json"
+    consensus_path.write_text(json.dumps(consensus, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return consensus
+
+
+def provider_verdict_from_raw_review(
+    *,
+    raw_review: dict[str, Any],
+    provider: str,
+    context: dict[str, Any],
+    round_index: int,
+    binding_mode: str,
+) -> dict[str, Any]:
+    reviewer = raw_review.get("reviewer")
+    findings = raw_review.get("findings")
+    if not isinstance(reviewer, dict):
+        raise ValueError("raw review reviewer block missing")
+    if not isinstance(findings, list):
+        raise ValueError("raw review findings missing")
+    return {
+        "schema_version": "ao-ma-10-provider-consensus.v1",
+        "artifact_kind": "ao_ma_10_provider_consensus",
+        "provider_id": provider,
+        "agent_id": str(reviewer.get("agent") or f"{provider}-reviewer"),
+        "role": "reviewer",
+        "risk_classification": "high",
+        "verdict": "AGREE",
+        "round_index": round_index,
+        "context_binding": dict(context),
+        "binding_mode": binding_mode,
+        "findings_count": len(findings),
+        "secrets_recorded": False,
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+        "release_authority": RELEASE_AUTHORITY,
+        "ai_output_release_authority": False,
+    }
+
+
+def build_high_risk_supersession_from_raw_reviews(
+    *,
+    repository: str,
+    work_package: str,
+    implementer_provider: str,
+    context_binding: dict[str, Any],
+    high_risk_changed_paths: list[str],
+    raw_review_paths: dict[str, Path],
+    max_age_seconds: int,
+    round_index: int,
+) -> dict[str, Any]:
+    required = required_reviewer_providers(implementer_provider)
+    provider_verdicts: list[dict[str, Any]] = []
+    for provider in required:
+        path = raw_review_paths.get(provider)
+        if path is None:
+            raise ValueError(f"missing raw review path for provider {provider}")
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError(f"raw review for provider {provider} must be an object")
+        _validate(RAW_REVIEW_SCHEMA, raw)
+        reviewer = raw.get("reviewer")
+        if not isinstance(reviewer, dict) or reviewer.get("provider") != provider:
+            raise ValueError(f"raw review provider mismatch for {provider}")
+        if reviewer.get("verdict") != "AGREE":
+            raise ValueError(f"raw review verdict for {provider} is not AGREE")
+        for flag in ("secrets_recorded", "support_widening", "production_platform_claim", "live_adapter_execution"):
+            if raw.get(flag) is not False:
+                raise ValueError(f"raw review {provider} has forbidden flag {flag}")
+        provider_verdicts.append(
+            provider_verdict_from_raw_review(
+                raw_review=raw,
+                provider=provider,
+                context={**context_binding, "high_risk_changed_paths": high_risk_changed_paths},
+                round_index=round_index,
+                binding_mode="added",
+            )
+        )
+    evidence = {
+        "schema_version": "ao-ma-10-high-risk-supersession-evidence.v1",
+        "artifact_kind": "ao_ma_10_high_risk_supersession_evidence",
+        "generated_at": utc_timestamp(),
+        "repo": repository,
+        "work_package": work_package,
+        "planning_only": True,
+        "release_authority": RELEASE_AUTHORITY,
+        "ai_output_release_authority": False,
+        "guard_flags": {
+            "support_widening": False,
+            "production_platform_claim": False,
+            "live_adapter_execution": False,
+        },
+        "context_binding": {**context_binding, "high_risk_changed_paths": high_risk_changed_paths},
+        "implementer_provider": implementer_provider,
+        "reviewer_providers": sorted(required),
+        "required_reviewer_providers": list(required),
+        "provider_verdicts": provider_verdicts,
+        "consensus_status": "AGREE",
+        "max_revise_rounds": 3,
+        "escalation_action": "operator_human_review_fallback",
+        "freshness": {"status": "fresh", "max_age_seconds": max_age_seconds},
+        "secrets_recorded": False,
+        "mutations_performed": False,
+    }
+    _validate(HIGH_RISK_SUPERSESSION_SCHEMA, evidence)
+    return evidence
+
+
+def build_dry_run_payload(
+    *,
+    repository: str,
+    work_package: str,
+    context_binding: dict[str, Any],
+    changed: list[str],
+) -> dict[str, Any]:
+    repo_name = repository.split("/", 1)[1] if "/" in repository else repository
+    return {
+        "repository": {"full_name": repository},
+        "pull_request": {
+            "number": 0,
+            "author": {"login": "ao-kernel-dry-run"},
+            "base": {"ref": "main"},
+            "head": {
+                "ref": str(context_binding["head_ref"]).replace("refs/heads/", ""),
+                "sha": context_binding["head_sha"],
+                "repo": {"fork": False, "name": repo_name},
+            },
+        },
+        "issue_url": "https://github.com/Halildeu/ao-kernel/issues/0",
+        "branch_up_to_date": True,
+        "event_name": "pull_request",
+        "reviewed_slice": work_package,
+        "changed_paths": list(changed),
+        "pr_author": "ao-kernel-dry-run",
+        "human_reviews": [],
+        "path_sensitive_human_review_enabled": True,
+        "allowed_path_prefixes": [
+            ".github/",
+            ".claude/",
+            "AGENTS.md",
+            "CLAUDE.md",
+            "ao_kernel/",
+            "scripts/",
+            "tests/",
+            "deploy/",
+        ],
+        "required_checks": [
+            {"name": "lint", "status": "completed", "conclusion": "success"},
+            {"name": "test (3.13)", "status": "completed", "conclusion": "success"},
+            {"name": RELEASE_GATE_CHECK_NAME, "status": "completed", "conclusion": "success"},
+        ],
+        "forbidden_secret_context_detected": False,
+        "admin_bypass_requested": False,
+        "pat_backed_bot_actor": False,
+        "codex_or_claude_release_authority": False,
+        "live_adapter_execution_requested": False,
+    }
+
+
+def build_local_gate_review_evidence(
+    *,
+    repository: str,
+    work_package: str,
+    context_binding: dict[str, Any],
+) -> dict[str, Any]:
+    """Build context-bound local-gpp review evidence for dry-run evaluation.
+
+    This does not simulate a provider verdict. The provider verdicts are the
+    raw review evidence files; this object only supplies the legacy
+    review-evidence acceptance input that ``ao-release-gate`` validates
+    alongside high-risk supersession evidence.
+    """
+
+    evidence = {
+        "schema_version": "local-gpp-gate-evidence.v1",
+        "decision": "operator_may_merge",
+        "repo": repository,
+        "work_package": work_package,
+        "generated_at": utc_timestamp(),
+        "checks": {
+            "startup_preflight_passed": True,
+            "gpp_status_checked": True,
+            "scope_allowed": True,
+            "tests_passed": True,
+            "secret_scan_passed": True,
+            "reviewer_agree": True,
+            "cross_provider_verified": True,
+            "forbidden_actions_absent": True,
+        },
+        "findings": [],
+        "reviewer_findings_count": 0,
+        "gpp_2_status": "closed",
+        "support_widening": False,
+        "production_platform_claim": False,
+        "live_adapter_execution": False,
+        "context_binding": {
+            "head_sha": context_binding["head_sha"],
+            "base_ref": context_binding["base_ref"],
+            "diff_digest": context_binding["diff_digest"],
+            "changed_files_count": context_binding["changed_files_count"],
+        },
+    }
+    _validate("local-gpp-gate-evidence.schema.v1.json", evidence)
+    return evidence
+
+
+def run_high_risk_dry_run(
+    *,
+    repository: str,
+    work_package: str,
+    implementer_provider: str,
+    base_ref: str,
+    head_ref: str,
+    repo_root: Path,
+    output_dir: Path,
+    raw_review_paths: list[Path],
+    max_age_seconds: int,
+) -> dict[str, Any]:
+    changed = changed_files(repo_root, base_ref, head_ref)
+    high_risk_changed_paths = _high_risk_paths(changed)
+    if not high_risk_changed_paths:
+        raise ValueError("no high-risk changed paths found; high-risk dry-run is not needed")
+    context = build_context_binding(
+        repository=repository,
+        repo_root=repo_root,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        changed=changed,
+    )
+    raw_by_provider: dict[str, Path] = {}
+    for path in raw_review_paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or not isinstance(payload.get("reviewer"), dict):
+            raise ValueError(f"invalid raw review evidence: {path}")
+        provider = payload["reviewer"].get("provider")
+        if not isinstance(provider, str):
+            raise ValueError(f"raw review evidence missing provider: {path}")
+        raw_by_provider[provider] = path
+    supersession = build_high_risk_supersession_from_raw_reviews(
+        repository=repository,
+        work_package=work_package,
+        implementer_provider=implementer_provider,
+        context_binding=context,
+        high_risk_changed_paths=high_risk_changed_paths,
+        raw_review_paths=raw_by_provider,
+        max_age_seconds=max_age_seconds,
+        round_index=1,
+    )
+    payload = build_dry_run_payload(
+        repository=repository,
+        work_package=work_package,
+        context_binding=context,
+        changed=changed,
+    )
+    local_gate_evidence = build_local_gate_review_evidence(
+        repository=repository,
+        work_package=work_package,
+        context_binding=context,
+    )
+    gpp_status = {
+        "current_wp": {"id": "GPP-9", "status": "closed", "issue": payload["issue_url"]},
+        "support_widening_allowed": False,
+        "production_platform_claim_allowed": False,
+        "live_adapter_execution_allowed": False,
+    }
+    decision = build_ao_release_gate_decision(
+        payload,
+        gpp_status,
+        review_evidence=local_gate_evidence,
+        high_risk_supersession_evidence=supersession,
+        conclusion_mode="enforce",
+    )
+    status = "pass" if bool(decision.get("allow")) else "blocked"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    supersession_path = output_dir / "high_risk_supersession_evidence.v1.json"
+    decision_path = output_dir / "ao_release_gate_decision.v1.json"
+    local_gate_path = output_dir / "local_gpp_gate_review_evidence.v1.json"
+    supersession_path.write_text(json.dumps(supersession, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    local_gate_path.write_text(json.dumps(local_gate_evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    decision_path.write_text(json.dumps(decision, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    artifact = {
+        "schema_version": "ai-review-high-risk-dry-run-evidence.v1",
+        "artifact_kind": "ai_review_high_risk_dry_run_evidence",
+        "generated_at": utc_timestamp(),
+        "repo": repository,
+        "work_package": work_package,
+        "release_authority": RELEASE_AUTHORITY,
+        "ai_output_release_authority": False,
+        "context_binding": {**context, "high_risk_changed_paths": high_risk_changed_paths},
+        "raw_review_paths": {provider: str(path) for provider, path in sorted(raw_by_provider.items())},
+        "local_gate_evidence_path": str(local_gate_path),
+        "high_risk_supersession_evidence_path": str(supersession_path),
+        "ao_release_gate_decision_path": str(decision_path),
+        "ao_release_gate_decision": str(decision.get("decision")),
+        "ao_release_gate_allow": bool(decision.get("allow")),
+        "dry_run_status": status,
+        "merge_attempted": False,
+        "github_mutation_performed": False,
+        "guard_flags": {
+            "support_widening": False,
+            "production_platform_claim": False,
+            "live_adapter_execution": False,
+        },
+        "secrets_recorded": False,
+        "mutations_performed": False,
+    }
+    _validate(DRY_RUN_SCHEMA, artifact)
+    dry_run_path = output_dir / "ai_review_high_risk_dry_run.v1.json"
+    dry_run_path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return artifact
+
+
+def _safe_console_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    raw_paths = payload.get("raw_review_paths")
+    raw_review_providers: list[str] = []
+    if isinstance(raw_paths, dict):
+        raw_review_providers = [provider for provider in PROVIDER_REVIEW_POOL if provider in raw_paths]
+
+    if "collection_status" in payload:
+        return {
+            "status": "collected",
+            "artifact_kind": "ai_review_collection_evidence",
+            "raw_review_providers": raw_review_providers,
+            "evidence_written": True,
+        }
+    if "consensus_status" in payload:
+        status = "AGREE" if payload.get("consensus_status") == "AGREE" else "not_agreed"
+        return {
+            "status": status,
+            "artifact_kind": "ai_review_consensus_evidence",
+            "raw_review_providers": raw_review_providers,
+            "evidence_written": True,
+        }
+    dry_run_status = "pass" if payload.get("dry_run_status") == "pass" else "blocked"
+    return {
+        "status": dry_run_status,
+        "artifact_kind": "ai_review_high_risk_dry_run_evidence",
+        "raw_review_providers": raw_review_providers,
+        "evidence_written": True,
+        "github_mutation_performed": False,
+        "merge_attempted": False,
+    }
+
+
+def _print_payload(payload: dict[str, Any], *, output: str) -> None:
+    safe_payload = _safe_console_payload(payload)
+    if output == "json":
+        print(json.dumps(safe_payload, indent=2, sort_keys=True))
+    else:
+        print(f"status: {safe_payload['status']}")
+        if safe_payload["raw_review_providers"]:
+            print("raw_review_providers:")
+            for provider in safe_payload["raw_review_providers"]:
+                print(f"- {provider}")
+
+
+def add_ai_review_subparser(sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    parser = sub.add_parser("ai-review", help="Collect cross-provider AI review evidence")
+    review_sub = parser.add_subparsers(dest="ai_review_command")
+
+    def add_common(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--repository", default="Halildeu/ao-kernel")
+        p.add_argument("--work-package", required=True)
+        p.add_argument("--base-ref", required=True)
+        p.add_argument("--head-ref", required=True)
+        p.add_argument("--repo-root", type=Path, default=Path("."))
+        p.add_argument("--output-dir", type=Path, default=Path("ai-review-artifacts"))
+        p.add_argument("--implementer-agent", default="autonomous-implementer")
+        p.add_argument(
+            "--implementer-provider",
+            choices=["anthropic", "openai", "google", "xai", "minimax"],
+            default="openai",
+        )
+        p.add_argument(
+            "--provider",
+            action="append",
+            default=[],
+            help="provider=command; missing commands can be supplied via AO_MA10_*_REVIEW_CMD env vars",
+        )
+        p.add_argument("--max-diff-bytes", type=int, default=200_000)
+        p.add_argument("--timeout-seconds", type=int, default=600)
+        p.add_argument("--format", choices=["text", "json"], default="json")
+
+    collect_p = review_sub.add_parser("collect", help="Collect raw local-ai-review evidence from providers")
+    add_common(collect_p)
+
+    consensus_p = review_sub.add_parser("consensus", help="Run bounded provider ping-pong until unanimous AGREE")
+    add_common(consensus_p)
+    consensus_p.add_argument("--max-rounds", type=int, default=3)
+
+    dry_run_p = review_sub.add_parser(
+        "high-risk-dry-run",
+        help="Build high-risk supersession evidence and run local ao-release-gate decision dry-run",
+    )
+    dry_run_p.add_argument("--repository", default="Halildeu/ao-kernel")
+    dry_run_p.add_argument("--work-package", required=True)
+    dry_run_p.add_argument("--base-ref", required=True)
+    dry_run_p.add_argument("--head-ref", required=True)
+    dry_run_p.add_argument("--repo-root", type=Path, default=Path("."))
+    dry_run_p.add_argument("--output-dir", type=Path, default=Path("ai-review-artifacts"))
+    dry_run_p.add_argument(
+        "--review-evidence",
+        action="append",
+        type=Path,
+        required=True,
+        help="Raw local-ai-review-evidence.v1 JSON path; repeat for each required provider",
+    )
+    dry_run_p.add_argument(
+        "--implementer-provider",
+        choices=["anthropic", "openai", "google", "xai", "minimax"],
+        default="openai",
+    )
+    dry_run_p.add_argument("--max-age-seconds", type=int, default=3600)
+    dry_run_p.add_argument("--format", choices=["text", "json"], default="json")
+
+
+def dispatch_ai_review(args: argparse.Namespace) -> int:
+    command = getattr(args, "ai_review_command", None)
+    try:
+        if command == "collect":
+            payload = run_collect(
+                repository=args.repository,
+                work_package=args.work_package,
+                implementer_agent=args.implementer_agent,
+                implementer_provider=args.implementer_provider,
+                base_ref=args.base_ref,
+                head_ref=args.head_ref,
+                repo_root=args.repo_root.resolve(),
+                output_dir=args.output_dir.resolve(),
+                provider_values=args.provider,
+                max_diff_bytes=args.max_diff_bytes,
+                timeout_seconds=args.timeout_seconds,
+            )
+            _print_payload(payload, output=args.format)
+            return 0
+        if command == "consensus":
+            payload = run_consensus(
+                repository=args.repository,
+                work_package=args.work_package,
+                implementer_agent=args.implementer_agent,
+                implementer_provider=args.implementer_provider,
+                base_ref=args.base_ref,
+                head_ref=args.head_ref,
+                repo_root=args.repo_root.resolve(),
+                output_dir=args.output_dir.resolve(),
+                provider_values=args.provider,
+                max_diff_bytes=args.max_diff_bytes,
+                timeout_seconds=args.timeout_seconds,
+                max_rounds=args.max_rounds,
+            )
+            _print_payload(payload, output=args.format)
+            return 0 if payload["consensus_status"] == "AGREE" else 1
+        if command == "high-risk-dry-run":
+            payload = run_high_risk_dry_run(
+                repository=args.repository,
+                work_package=args.work_package,
+                implementer_provider=args.implementer_provider,
+                base_ref=args.base_ref,
+                head_ref=args.head_ref,
+                repo_root=args.repo_root.resolve(),
+                output_dir=args.output_dir.resolve(),
+                raw_review_paths=args.review_evidence,
+                max_age_seconds=args.max_age_seconds,
+            )
+            _print_payload(payload, output=args.format)
+            return 0 if payload["dry_run_status"] == "pass" else 1
+    except Exception as exc:  # noqa: BLE001 - CLI must fail closed with concise stderr
+        print(f"ai-review {command or '<missing>'} failed: {exc}", file=sys.stderr)
+        return 1
+    print("Usage: ao-kernel ai-review {collect|consensus|high-risk-dry-run}", file=sys.stderr)
+    return 1

--- a/ao_kernel/cli.py
+++ b/ao_kernel/cli.py
@@ -1933,6 +1933,10 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Command output format (default: text)",
     )
 
+    from ao_kernel.ai_review import add_ai_review_subparser
+
+    add_ai_review_subparser(sub)
+
     # Evidence subcommands (PR-A5)
     ev_p = sub.add_parser("evidence", help="Evidence timeline + replay + manifest")
     ev_sub = ev_p.add_subparsers(dest="evidence_command")
@@ -2814,6 +2818,11 @@ def main(argv: list[str] | None = None) -> int:
             return _cmd_pr_metadata_validate(args)
         print("Usage: ao-kernel pr-metadata {schema|template|generate|fix|validate}", file=sys.stderr)
         return 1
+
+    if cmd == "ai-review":
+        from ao_kernel.ai_review import dispatch_ai_review
+
+        return dispatch_ai_review(args)
 
     # Executor subcommand (PR-C6)
     if cmd == "executor":

--- a/ao_kernel/defaults/schemas/ai-review-collection-evidence.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ai-review-collection-evidence.schema.v1.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:ai-review-collection-evidence:v1",
+  "title": "AI Review Collection Evidence",
+  "description": "No-secret evidence that cross-provider reviewer commands were invoked for a context-bound high-risk change. Release authority remains ao-release-gate plus GitHub ruleset.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "generated_at",
+    "repo",
+    "work_package",
+    "release_authority",
+    "ai_output_release_authority",
+    "implementer",
+    "required_reviewer_providers",
+    "reviewer_providers",
+    "context_binding",
+    "raw_review_paths",
+    "provider_provenance",
+    "collection_status",
+    "guard_flags",
+    "secrets_recorded",
+    "mutations_performed"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "ai-review-collection-evidence.v1" },
+    "artifact_kind": { "type": "string", "const": "ai_review_collection_evidence" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "repo": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+    "work_package": { "type": "string", "minLength": 3, "maxLength": 80 },
+    "release_authority": { "type": "string", "const": "ao-release-gate+github-ruleset" },
+    "ai_output_release_authority": { "type": "boolean", "const": false },
+    "implementer": { "$ref": "#/$defs/implementer" },
+    "required_reviewer_providers": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/provider_id" }
+    },
+    "reviewer_providers": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/provider_id" }
+    },
+    "context_binding": { "$ref": "#/$defs/context_binding" },
+    "raw_review_paths": {
+      "type": "object",
+      "minProperties": 2,
+      "additionalProperties": { "type": "string", "minLength": 1 }
+    },
+    "provider_provenance": {
+      "type": "array",
+      "minItems": 2,
+      "items": { "$ref": "#/$defs/provider_provenance" }
+    },
+    "collection_status": { "type": "string", "const": "collected" },
+    "guard_flags": { "$ref": "#/$defs/guard_flags" },
+    "secrets_recorded": { "type": "boolean", "const": false },
+    "mutations_performed": { "type": "boolean", "const": false }
+  },
+  "$defs": {
+    "provider_id": {
+      "type": "string",
+      "enum": ["openai", "anthropic", "minimax", "google", "xai"]
+    },
+    "implementer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agent", "provider"],
+      "properties": {
+        "agent": { "type": "string", "minLength": 1 },
+        "provider": { "$ref": "#/$defs/provider_id" }
+      }
+    },
+    "context_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository_full_name",
+        "base_ref",
+        "head_ref",
+        "head_sha",
+        "diff_digest",
+        "changed_files_count",
+        "high_risk_changed_paths"
+      ],
+      "properties": {
+        "repository_full_name": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+        "base_ref": { "type": "string", "minLength": 1 },
+        "head_ref": { "type": "string", "minLength": 1 },
+        "head_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "diff_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "changed_files_count": { "type": "integer", "minimum": 1 },
+        "high_risk_changed_paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "provider_provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "command_source",
+        "command_executable",
+        "command_argv_redacted",
+        "command_argv_sha256",
+        "prompt_sha256",
+        "timeout_seconds"
+      ],
+      "properties": {
+        "provider_id": { "$ref": "#/$defs/provider_id" },
+        "command_source": { "type": "string", "minLength": 1 },
+        "command_executable": { "type": "string", "minLength": 1 },
+        "command_argv_redacted": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "command_argv_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "prompt_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 86400 }
+      }
+    },
+    "guard_flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["support_widening", "production_platform_claim", "live_adapter_execution"],
+      "properties": {
+        "support_widening": { "type": "boolean", "const": false },
+        "production_platform_claim": { "type": "boolean", "const": false },
+        "live_adapter_execution": { "type": "boolean", "const": false }
+      }
+    }
+  }
+}

--- a/ao_kernel/defaults/schemas/ai-review-consensus-evidence.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ai-review-consensus-evidence.schema.v1.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:ai-review-consensus-evidence:v1",
+  "title": "AI Review Consensus Evidence",
+  "description": "Bounded cross-provider ping-pong evidence. Unanimous AGREE may produce raw local-ai-review evidence; non-agreement fails closed. Release authority remains ao-release-gate plus GitHub ruleset.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "generated_at",
+    "repo",
+    "work_package",
+    "release_authority",
+    "ai_output_release_authority",
+    "implementer",
+    "required_reviewer_providers",
+    "context_binding",
+    "rounds",
+    "consensus_status",
+    "max_rounds",
+    "raw_review_paths",
+    "collection_evidence_path",
+    "escalation_action",
+    "guard_flags",
+    "secrets_recorded",
+    "mutations_performed"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "ai-review-consensus-evidence.v1" },
+    "artifact_kind": { "type": "string", "const": "ai_review_consensus_evidence" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "repo": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+    "work_package": { "type": "string", "minLength": 3, "maxLength": 80 },
+    "release_authority": { "type": "string", "const": "ao-release-gate+github-ruleset" },
+    "ai_output_release_authority": { "type": "boolean", "const": false },
+    "implementer": { "$ref": "#/$defs/implementer" },
+    "required_reviewer_providers": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/provider_id" }
+    },
+    "context_binding": { "$ref": "#/$defs/context_binding" },
+    "rounds": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "items": { "$ref": "#/$defs/round" }
+    },
+    "consensus_status": { "type": "string", "enum": ["AGREE", "not_agreed"] },
+    "max_rounds": { "type": "integer", "minimum": 1, "maximum": 3 },
+    "raw_review_paths": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "minLength": 1 }
+    },
+    "collection_evidence_path": { "type": ["string", "null"] },
+    "escalation_action": { "type": "string", "const": "operator_human_review_fallback" },
+    "guard_flags": { "$ref": "#/$defs/guard_flags" },
+    "secrets_recorded": { "type": "boolean", "const": false },
+    "mutations_performed": { "type": "boolean", "const": false }
+  },
+  "$defs": {
+    "provider_id": { "type": "string", "enum": ["openai", "anthropic", "minimax", "google", "xai"] },
+    "implementer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agent", "provider"],
+      "properties": {
+        "agent": { "type": "string", "minLength": 1 },
+        "provider": { "$ref": "#/$defs/provider_id" }
+      }
+    },
+    "context_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository_full_name",
+        "base_ref",
+        "head_ref",
+        "head_sha",
+        "diff_digest",
+        "changed_files_count",
+        "high_risk_changed_paths"
+      ],
+      "properties": {
+        "repository_full_name": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+        "base_ref": { "type": "string", "minLength": 1 },
+        "head_ref": { "type": "string", "minLength": 1 },
+        "head_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "diff_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "changed_files_count": { "type": "integer", "minimum": 1 },
+        "high_risk_changed_paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "provider_provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "command_source",
+        "command_executable",
+        "command_argv_redacted",
+        "command_argv_sha256",
+        "prompt_sha256",
+        "timeout_seconds"
+      ],
+      "properties": {
+        "provider_id": { "$ref": "#/$defs/provider_id" },
+        "command_source": { "type": "string", "minLength": 1 },
+        "command_executable": { "type": "string", "minLength": 1 },
+        "command_argv_redacted": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "command_argv_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "prompt_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 86400 }
+      }
+    },
+    "guard_flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["support_widening", "production_platform_claim", "live_adapter_execution"],
+      "properties": {
+        "support_widening": { "type": "boolean", "const": false },
+        "production_platform_claim": { "type": "boolean", "const": false },
+        "live_adapter_execution": { "type": "boolean", "const": false }
+      }
+    },
+    "round": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["round_index", "provider_results"],
+      "properties": {
+        "round_index": { "type": "integer", "minimum": 1, "maximum": 3 },
+        "provider_results": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/provider_result" }
+        }
+      }
+    },
+    "provider_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "agent_id",
+        "verdict",
+        "findings_count",
+        "findings",
+        "checks_considered",
+        "provider_provenance"
+      ],
+      "properties": {
+        "provider_id": { "$ref": "#/$defs/provider_id" },
+        "agent_id": { "type": "string", "minLength": 1 },
+        "verdict": { "type": "string", "enum": ["AGREE", "REVISE", "BLOCK", "PARTIAL", "RED"] },
+        "findings_count": { "type": "integer", "minimum": 0 },
+        "findings": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "checks_considered": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "status"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "status": { "type": "string", "enum": ["pass", "fail"] }
+            }
+          }
+        },
+        "provider_provenance": { "$ref": "#/$defs/provider_provenance" }
+      }
+    }
+  }
+}

--- a/ao_kernel/defaults/schemas/ai-review-high-risk-dry-run-evidence.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ai-review-high-risk-dry-run-evidence.schema.v1.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:ao:ai-review-high-risk-dry-run-evidence:v1",
+  "title": "AI Review High-Risk Dry-Run Evidence",
+  "description": "No-secret local evidence that raw cross-provider review evidence can be converted into high-risk supersession evidence and accepted by the ao-release-gate decision core. It does not mutate GitHub or attempt a merge.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "generated_at",
+    "repo",
+    "work_package",
+    "release_authority",
+    "ai_output_release_authority",
+    "context_binding",
+    "raw_review_paths",
+    "local_gate_evidence_path",
+    "high_risk_supersession_evidence_path",
+    "ao_release_gate_decision_path",
+    "ao_release_gate_decision",
+    "ao_release_gate_allow",
+    "dry_run_status",
+    "merge_attempted",
+    "github_mutation_performed",
+    "guard_flags",
+    "secrets_recorded",
+    "mutations_performed"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "ai-review-high-risk-dry-run-evidence.v1" },
+    "artifact_kind": { "type": "string", "const": "ai_review_high_risk_dry_run_evidence" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "repo": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+    "work_package": { "type": "string", "minLength": 3, "maxLength": 80 },
+    "release_authority": { "type": "string", "const": "ao-release-gate+github-ruleset" },
+    "ai_output_release_authority": { "type": "boolean", "const": false },
+    "context_binding": { "$ref": "#/$defs/context_binding" },
+    "raw_review_paths": {
+      "type": "object",
+      "minProperties": 2,
+      "additionalProperties": { "type": "string", "minLength": 1 }
+    },
+    "local_gate_evidence_path": { "type": "string", "minLength": 1 },
+    "high_risk_supersession_evidence_path": { "type": "string", "minLength": 1 },
+    "ao_release_gate_decision_path": { "type": "string", "minLength": 1 },
+    "ao_release_gate_decision": { "type": "string", "minLength": 1 },
+    "ao_release_gate_allow": { "type": "boolean" },
+    "dry_run_status": { "type": "string", "enum": ["pass", "blocked"] },
+    "merge_attempted": { "type": "boolean", "const": false },
+    "github_mutation_performed": { "type": "boolean", "const": false },
+    "guard_flags": { "$ref": "#/$defs/guard_flags" },
+    "secrets_recorded": { "type": "boolean", "const": false },
+    "mutations_performed": { "type": "boolean", "const": false }
+  },
+  "$defs": {
+    "context_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository_full_name",
+        "base_ref",
+        "head_ref",
+        "head_sha",
+        "diff_digest",
+        "changed_files_count",
+        "high_risk_changed_paths"
+      ],
+      "properties": {
+        "repository_full_name": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+        "base_ref": { "type": "string", "minLength": 1 },
+        "head_ref": { "type": "string", "minLength": 1 },
+        "head_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "diff_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "changed_files_count": { "type": "integer", "minimum": 1 },
+        "high_risk_changed_paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "guard_flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["support_widening", "production_platform_claim", "live_adapter_execution"],
+      "properties": {
+        "support_widening": { "type": "boolean", "const": false },
+        "production_platform_claim": { "type": "boolean", "const": false },
+        "live_adapter_execution": { "type": "boolean", "const": false }
+      }
+    }
+  }
+}

--- a/docs/PRODUCT-QUICKSTART.md
+++ b/docs/PRODUCT-QUICKSTART.md
@@ -126,7 +126,98 @@ The async wrapper:
 - reports review and verification phases as external evidence required rather
   than fabricating AI review or verifier approval.
 
-## 5. Acceptance Boundary
+## 5. Collect Cross-Provider Review Evidence
+
+High-risk review evidence is collected through explicit provider commands. Each
+command receives a no-secret JSON review request on stdin and returns JSON on
+stdout:
+
+```json
+{
+  "agent": "short-reviewer-label",
+  "verdict": "AGREE",
+  "checks_considered": [
+    {"name": "tests", "status": "pass"},
+    {"name": "secret_scan", "status": "pass"}
+  ],
+  "findings": ["review clean"]
+}
+```
+
+Collect raw evidence for the reviewer providers required after excluding the
+implementer provider:
+
+```bash
+ao-kernel ai-review collect \
+  --work-package AO-MA-10X \
+  --base-ref origin/main \
+  --head-ref HEAD \
+  --repo-root . \
+  --implementer-provider openai \
+  --provider "anthropic=claude -p 'return JSON only ...'" \
+  --provider "minimax=/path/to/minimax-reviewer" \
+  --output-dir .ao/ai-review \
+  --format json
+```
+
+Run bounded ping-pong until unanimous `AGREE`, or fail closed when the maximum
+round count is exhausted:
+
+```bash
+ao-kernel ai-review consensus \
+  --work-package AO-MA-10X \
+  --base-ref origin/main \
+  --head-ref HEAD \
+  --repo-root . \
+  --implementer-provider openai \
+  --max-rounds 3 \
+  --provider "anthropic=claude -p 'return JSON only ...'" \
+  --provider "minimax=/path/to/minimax-reviewer" \
+  --output-dir .ao/ai-review \
+  --format json
+```
+
+Each collection/consensus artifact records:
+
+- `command_argv_sha256`,
+- redacted command argv,
+- `prompt_sha256`,
+- context binding (`head_sha`, changed-files digest, changed-file count),
+- guard flags fixed to false.
+
+The CLI `--format json` output is deliberately a safe status/provider summary.
+Read the durable files under `--output-dir` for full path and provenance data.
+
+## 6. High-Risk Dry-Run Gate Check
+
+After raw reviewer evidence exists, dry-run the high-risk `ao-release-gate`
+acceptance path locally:
+
+```bash
+ao-kernel ai-review high-risk-dry-run \
+  --work-package AO-MA-10X \
+  --base-ref origin/main \
+  --head-ref HEAD \
+  --repo-root . \
+  --implementer-provider openai \
+  --review-evidence .ao/ai-review/anthropic.local-ai-review-evidence.v1.json \
+  --review-evidence .ao/ai-review/minimax.local-ai-review-evidence.v1.json \
+  --output-dir .ao/ai-review \
+  --format json
+```
+
+This writes:
+
+- `high_risk_supersession_evidence.v1.json`,
+- `local_gpp_gate_review_evidence.v1.json`,
+- `ao_release_gate_decision.v1.json`,
+- `ai_review_high_risk_dry_run.v1.json`.
+
+The dry-run proves the local decision-core path. It does not post GitHub
+check-runs or attempt a merge; GitHub merge authority remains the repo-owned
+required check plus branch ruleset.
+
+## 7. Acceptance Boundary
 
 This quickstart proves the local governed-control-plane workflow is installed
 and operational. It does not prove or claim:

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "local-ai-review-evidence.v1",
   "repo": "Halildeu/ao-kernel",
-  "work_package": "PRODUCTIZATION-CLOSEOUT-V4.3.1",
+  "work_package": "AI-REVIEW-ORCHESTRATOR",
   "implementer": {
     "agent": "codex",
     "provider": "openai"
@@ -13,20 +13,21 @@
   },
   "scope_reviewed": {
     "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/productization-closeout",
+    "head_ref": "refs/heads/codex/cross-ai-review-orchestrator",
     "changed_files": [
       "CHANGELOG.md",
       "README.md",
+      "ao_kernel/ai_review.py",
       "ao_kernel/cli.py",
-      "ao_kernel/orchestration/async_runner.py",
-      "ao_kernel/orchestration/cli_handlers.py",
-      "ao_kernel/orchestration/worker_invoker.py",
+      "ao_kernel/defaults/schemas/ai-review-collection-evidence.schema.v1.json",
+      "ao_kernel/defaults/schemas/ai-review-consensus-evidence.schema.v1.json",
+      "ao_kernel/defaults/schemas/ai-review-high-risk-dry-run-evidence.schema.v1.json",
       "docs/PRODUCT-QUICKSTART.md",
       "local-ai-review-evidence.v1.json",
       "scripts/fresh_install_product_smoke.py",
       "scripts/packaging_smoke.py",
-      "tests/test_productization_closeout.py",
-      "tests/test_productized_p2_p3_p5_cli.py"
+      "tests/test_ai_review_cli.py",
+      "tests/test_productization_closeout.py"
     ]
   },
   "checks_considered": [
@@ -47,6 +48,18 @@
       "status": "pass"
     },
     {
+      "name": "provider_provenance",
+      "status": "pass"
+    },
+    {
+      "name": "consensus_fail_closed",
+      "status": "pass"
+    },
+    {
+      "name": "high_risk_dry_run_no_github_mutation",
+      "status": "pass"
+    },
+    {
       "name": "fresh_install_smoke",
       "status": "pass"
     },
@@ -56,13 +69,15 @@
     }
   ],
   "findings": [
-    "Claude reviewed the productization closeout diff for v4.3.1 release readiness, packaging smoke, fresh install smoke, product quickstart, and run-wrapper-async v2.",
-    "Verdict AGREE: no blocking issue found in release readiness, bounded concurrency, CLI wiring, smoke evidence, or documentation scope.",
-    "Guard flags remain false: no support widening, no production platform claim, and no live adapter execution.",
-    "run-wrapper-async reports external review and verifier evidence required; it does not fabricate AGREE, PASS, or release authority.",
-    "Fresh install smoke installs wheel and sdist into clean virtual environments and runs onboarding, PR metadata, run-wrapper, and run-wrapper-async from outside the source checkout.",
-    "Packaging smoke extends the installed-wheel check with productized local workflows while preserving release authority under the repo-owned ao-release-gate."
-  ],
+    "Claude reviewed the cross-provider AI review orchestration diff via local claude -p command and returned AGREE with no blocking findings.",
+    "The new ao-kernel ai-review CLI collects provider-backed review evidence, records command/prompt provenance, supports bounded consensus ping-pong, and emits fail-closed artifacts.",
+    "The high-risk dry-run path converts raw provider reviews into high-risk supersession evidence and runs the ao-release-gate decision core without GitHub mutation or merge attempt.",
+        "Schema-level guard constants keep ai_output_release_authority false and preserve no support widening, no production platform claim, and no live adapter execution.",
+        "Secret-like content is rejected from prompts, diffs, provider stdout/stderr, findings, and command argv before evidence is written.",
+        "Post-review CodeQL hardening keeps CLI stdout to safe status/provider summaries; full evidence, provenance, and file paths remain durable file-backed artifacts under the requested output directory.",
+        "Validation passed: targeted pytest 11/11, targeted ao_kernel.ai_review coverage 93.05%, broader ao-release-gate-related pytest 150/150, ruff, mypy, schema parse, packaging smoke, and fresh-install wheel smoke.",
+        "Non-blocking Claude notes: provider commands run sequentially; _high_risk_paths is an internal same-package helper; dry-run issue URL is dummy by design."
+    ],
   "secrets_recorded": false,
   "live_adapter_execution": false,
   "support_widening": false,

--- a/scripts/fresh_install_product_smoke.py
+++ b/scripts/fresh_install_product_smoke.py
@@ -9,6 +9,7 @@ outside the source checkout:
 - ``pr-metadata`` generate/fix/validate
 - ``orchestration run-wrapper`` dry-run
 - ``orchestration run-wrapper-async`` local fixture execution
+- ``ai-review`` packaged command surface help
 
 No GitHub, Vault, webhook, branch-protection, live adapter, support widening,
 or production-platform claim is touched. Evidence is written under
@@ -255,6 +256,8 @@ def _smoke_one_distribution(
     if async_payload.get("status") != "ok":
         raise SystemExit(f"{artifact_kind} async wrapper did not report ok")
 
+    run_step("ai_review_help", [str(console), "ai-review", "--help"])
+
     payload = {
         "schema_version": "productized-local-workflows-smoke.v1",
         "artifact_kind": "productized_local_workflows_smoke",
@@ -264,6 +267,7 @@ def _smoke_one_distribution(
         "commands": commands,
         "async_wrapper_status": async_payload.get("status"),
         "async_invocation_report_path": async_payload.get("invocation_report_path"),
+        "ai_review_cli_surface": "present",
         "support_widening": False,
         "production_platform_claim": False,
         "live_adapter_execution": False,

--- a/scripts/packaging_smoke.py
+++ b/scripts/packaging_smoke.py
@@ -17,9 +17,9 @@ The smoke is intentionally wheel-first:
    output.
 7. Drive the productized local workflow commands added after v4.3.1
    prep: ``repo onboarding``, ``pr-metadata``, ``orchestration
-   run-wrapper``, and ``orchestration run-wrapper-async``. Evidence is
-   written under ``build/packaging-smoke/`` so ``dist/`` remains
-   distribution-only.
+   run-wrapper``, ``orchestration run-wrapper-async``, and the packaged
+   ``ai-review`` command surface. Evidence is written under
+   ``build/packaging-smoke/`` so ``dist/`` remains distribution-only.
 """
 
 from __future__ import annotations
@@ -238,6 +238,8 @@ def _smoke_productized_local_workflows(
     if async_payload.get("status") != "ok":
         raise SystemExit("productized workflow smoke async wrapper did not report ok")
 
+    _scenario("ai_review_help", [str(console_script), "ai-review", "--help"])
+
     artifact = {
         "schema_version": "productized-local-workflows-smoke.v1",
         "artifact_kind": "productized_local_workflows_smoke",
@@ -250,6 +252,7 @@ def _smoke_productized_local_workflows(
             {"id": item["id"], "status": "pass", "returncode": item["returncode"]} for item in commands
         ],
         "async_wrapper_version": async_payload.get("async_wrapper_version"),
+        "ai_review_cli_surface": "present",
         "support_widening": False,
         "production_platform_claim": False,
         "live_adapter_execution": False,

--- a/tests/test_ai_review_cli.py
+++ b/tests/test_ai_review_cli.py
@@ -1,0 +1,602 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from ao_kernel import ai_review
+from ao_kernel.config import load_default
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout.strip()
+
+
+def _repo_with_high_risk_change(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    target = repo / "ao_kernel" / "ao_release_gate.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("# base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "switch", "-c", "feature")
+    target.write_text("# base\n# high-risk change\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "feature")
+    return repo
+
+
+def _fake_provider(tmp_path: Path, *, mode: str = "agree", provider_stateful: bool = False) -> Path:
+    script = tmp_path / f"fake_provider_{mode}_{'stateful' if provider_stateful else 'plain'}.py"
+    state_block = [
+        "state_path = pathlib.Path(sys.argv[2]) if len(sys.argv) > 2 else None",
+        "count = 0",
+        "if state_path is not None and state_path.exists():",
+        "    count = int(state_path.read_text())",
+        "if state_path is not None:",
+        "    state_path.write_text(str(count + 1))",
+    ]
+    if provider_stateful:
+        verdict_expr = "'REVISE' if count == 0 else 'AGREE'"
+        finding_expr = "'needs one more round' if count == 0 else 'review clean'"
+    elif mode == "revise":
+        verdict_expr = "'REVISE'"
+        finding_expr = "'needs fix'"
+    else:
+        verdict_expr = "'AGREE'"
+        finding_expr = "'review clean'"
+    script.write_text(
+        "\n".join(
+            [
+                "import json, pathlib, sys",
+                "request = json.load(sys.stdin)",
+                "provider = sys.argv[1]",
+                *state_block,
+                f"verdict = {verdict_expr}",
+                f"finding = {finding_expr}",
+                "json.dump({",
+                "  'agent': provider + '-fake-reviewer',",
+                "  'verdict': verdict,",
+                "  'checks_considered': [",
+                "    {'name': 'tests', 'status': 'pass'},",
+                "    {'name': 'secret_scan', 'status': 'pass'},",
+                "  ],",
+                "  'findings': [finding, 'round=' + str(request['context']['round_index'])],",
+                "}, sys.stdout)",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return script
+
+
+def _cmd(provider: str, script: Path, state: Path | None = None) -> str:
+    parts = [sys.executable, str(script), provider]
+    if state is not None:
+        parts.append(str(state))
+    return " ".join(parts)
+
+
+def _run_cli(args: list[str], *, cwd: Path = ROOT, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        [sys.executable, "-m", "ao_kernel.cli", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if check:
+        assert proc.returncode == 0, proc.stderr + proc.stdout
+    return proc
+
+
+def _validate(schema_name: str, payload: dict[str, object]) -> None:
+    Draft202012Validator(load_default("schemas", schema_name)).validate(payload)
+
+
+def _round_result(
+    *,
+    provider: str = "openai",
+    verdict: ai_review.Verdict = "AGREE",
+    checks: list[dict[str, str]] | None = None,
+    findings: list[str] | None = None,
+) -> ai_review.ProviderRoundResult:
+    return ai_review.ProviderRoundResult(
+        provider=provider,
+        agent=f"{provider}-fake-reviewer",
+        verdict=verdict,
+        checks_considered=checks
+        if checks is not None
+        else [
+            {"name": "tests", "status": "pass"},
+            {"name": "secret_scan", "status": "pass"},
+        ],
+        findings=findings if findings is not None else ["review clean"],
+        prompt_sha256="sha256:" + "1" * 64,
+        command=ai_review.ProviderCommand(provider=provider, argv=("python", "review.py"), source="test"),
+    )
+
+
+def test_ai_review_collect_writes_raw_reviews_and_provenance(tmp_path: Path) -> None:
+    repo = _repo_with_high_risk_change(tmp_path)
+    fake = _fake_provider(tmp_path)
+    output_dir = tmp_path / "reviews"
+
+    proc = _run_cli(
+        [
+            "ai-review",
+            "collect",
+            "--repository",
+            "Halildeu/ao-kernel",
+            "--work-package",
+            "AO-MA-10X",
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "feature",
+            "--repo-root",
+            str(repo),
+            "--output-dir",
+            str(output_dir),
+            "--implementer-provider",
+            "google",
+            "--provider",
+            f"openai={_cmd('openai', fake)}",
+            "--provider",
+            f"anthropic={_cmd('anthropic', fake)}",
+        ]
+    )
+
+    summary = json.loads(proc.stdout)
+    assert summary == {
+        "artifact_kind": "ai_review_collection_evidence",
+        "evidence_written": True,
+        "raw_review_providers": ["openai", "anthropic"],
+        "status": "collected",
+    }
+    payload = json.loads((output_dir / "ai_review_collection.v1.json").read_text())
+    _validate("ai-review-collection-evidence.schema.v1.json", payload)
+    assert payload["collection_status"] == "collected"
+    assert payload["ai_output_release_authority"] is False
+    assert payload["guard_flags"] == {
+        "live_adapter_execution": False,
+        "production_platform_claim": False,
+        "support_widening": False,
+    }
+    assert set(payload["raw_review_paths"]) == {"anthropic", "openai"}
+    assert len(payload["provider_provenance"]) == 2
+    for provenance in payload["provider_provenance"]:
+        assert provenance["command_argv_sha256"].startswith("sha256:")
+        assert provenance["prompt_sha256"].startswith("sha256:")
+
+
+def test_ai_review_python_api_covers_productized_main_paths(tmp_path: Path) -> None:
+    repo = _repo_with_high_risk_change(tmp_path)
+    fake = _fake_provider(tmp_path)
+    collect_dir = tmp_path / "api-collect"
+
+    collection = ai_review.run_collect(
+        repository="Halildeu/ao-kernel",
+        work_package="AO-MA-10X",
+        implementer_agent="codex",
+        implementer_provider="google",
+        base_ref="main",
+        head_ref="feature",
+        repo_root=repo,
+        output_dir=collect_dir,
+        provider_values=[
+            f"openai={_cmd('openai', fake)}",
+            f"anthropic={_cmd('anthropic', fake)}",
+        ],
+        max_diff_bytes=200_000,
+        timeout_seconds=30,
+    )
+    _validate("ai-review-collection-evidence.schema.v1.json", collection)
+    assert collection["collection_status"] == "collected"
+    assert collection["required_reviewer_providers"] == ["openai", "anthropic"]
+
+    consensus_dir = tmp_path / "api-consensus"
+    consensus = ai_review.run_consensus(
+        repository="Halildeu/ao-kernel",
+        work_package="AO-MA-10X",
+        implementer_agent="codex",
+        implementer_provider="google",
+        base_ref="main",
+        head_ref="feature",
+        repo_root=repo,
+        output_dir=consensus_dir,
+        provider_values=[
+            f"openai={_cmd('openai', fake)}",
+            f"anthropic={_cmd('anthropic', fake)}",
+        ],
+        max_diff_bytes=200_000,
+        timeout_seconds=30,
+        max_rounds=1,
+    )
+    _validate("ai-review-consensus-evidence.schema.v1.json", consensus)
+    assert consensus["consensus_status"] == "AGREE"
+    assert consensus["collection_evidence_path"].endswith("ai_review_collection.v1.json")
+
+    raw_paths = [
+        collect_dir / "openai.local-ai-review-evidence.v1.json",
+        collect_dir / "anthropic.local-ai-review-evidence.v1.json",
+    ]
+    dry_run = ai_review.run_high_risk_dry_run(
+        repository="Halildeu/ao-kernel",
+        work_package="AO-MA-10X",
+        implementer_provider="google",
+        base_ref="main",
+        head_ref="feature",
+        repo_root=repo,
+        output_dir=tmp_path / "api-dry-run",
+        raw_review_paths=raw_paths,
+        max_age_seconds=3600,
+    )
+    _validate("ai-review-high-risk-dry-run-evidence.schema.v1.json", dry_run)
+    assert dry_run["dry_run_status"] == "pass"
+    assert dry_run["ao_release_gate_allow"] is True
+    assert dry_run["merge_attempted"] is False
+    assert dry_run["github_mutation_performed"] is False
+
+
+def test_ai_review_fail_closed_parser_and_reviewer_output_edges(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_secret = "token=" + "gh" + "p_" + ("1" * 36)
+    with pytest.raises(ValueError, match="secret-like"):
+        ai_review.assert_no_secret_like_text(fake_secret, label="prompt")
+    with pytest.raises(ValueError, match="provider=command"):
+        ai_review.parse_provider_commands(["openai"], required_providers=("openai",))
+    with pytest.raises(ValueError, match="unsupported provider"):
+        ai_review.parse_provider_commands(["google=python review.py"], required_providers=("openai",))
+    with pytest.raises(ValueError, match="empty command"):
+        ai_review.parse_provider_commands(["openai="], required_providers=("openai",))
+    with pytest.raises(ValueError, match="missing required provider"):
+        ai_review.parse_provider_commands([], required_providers=("openai",))
+
+    monkeypatch.setenv("AO_MA10_OPENAI_REVIEW_CMD", f"{sys.executable} review.py")
+    parsed = ai_review.parse_provider_commands(None, required_providers=("openai",))
+    assert parsed["openai"].source == "env:AO_MA10_OPENAI_REVIEW_CMD"
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        ai_review._load_provider_output("{", "openai")
+    with pytest.raises(ValueError, match="JSON object"):
+        ai_review._load_provider_output("[]", "openai")
+    with pytest.raises(ValueError, match="checks_considered"):
+        ai_review._checks_from_output({}, "openai")
+    with pytest.raises(ValueError, match="check entry"):
+        ai_review._checks_from_output({"checks_considered": ["bad"]}, "openai")
+    with pytest.raises(ValueError, match="include string"):
+        ai_review._checks_from_output({"checks_considered": [{"name": "tests"}]}, "openai")
+    with pytest.raises(ValueError, match="pass or fail"):
+        ai_review._checks_from_output({"checks_considered": [{"name": "tests", "status": "skip"}]}, "openai")
+    with pytest.raises(ValueError, match="findings"):
+        ai_review._findings_from_output({"findings": [""]}, "openai")
+    with pytest.raises(ValueError, match="verdict"):
+        ai_review._verdict_from_output({"verdict": "MAYBE"}, "openai")
+    assert ai_review._agent_from_output({}, "openai") == "openai-reviewer"
+
+    failing = tmp_path / "failing_provider.py"
+    failing.write_text("import sys\nprint('plain stderr', file=sys.stderr)\nsys.exit(2)\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="failed with exit 2"):
+        ai_review.run_provider_command(
+            ai_review.ProviderCommand(provider="openai", argv=(sys.executable, str(failing)), source="test"),
+            review_request="{}",
+            timeout_seconds=5,
+        )
+
+
+def test_ai_review_raw_review_fail_closed_edges(tmp_path: Path) -> None:
+    implementer = {"agent": "codex", "provider": "google"}
+    with pytest.raises(ValueError, match="not AGREE"):
+        ai_review.raw_review_from_round(
+            result=_round_result(verdict="REVISE"),
+            repository="Halildeu/ao-kernel",
+            work_package="AO-MA-10X",
+            implementer=implementer,
+            base_ref="main",
+            head_ref="feature",
+            changed=["ao_kernel/ao_release_gate.py"],
+        )
+    with pytest.raises(ValueError, match="forbidden finding"):
+        ai_review.raw_review_from_round(
+            result=_round_result(findings=["FORBIDDEN: simulated reviewer verdict"]),
+            repository="Halildeu/ao-kernel",
+            work_package="AO-MA-10X",
+            implementer=implementer,
+            base_ref="main",
+            head_ref="feature",
+            changed=["ao_kernel/ao_release_gate.py"],
+        )
+    with pytest.raises(ValueError, match="passing tests"):
+        ai_review.raw_review_from_round(
+            result=_round_result(checks=[{"name": "secret_scan", "status": "pass"}]),
+            repository="Halildeu/ao-kernel",
+            work_package="AO-MA-10X",
+            implementer=implementer,
+            base_ref="main",
+            head_ref="feature",
+            changed=["ao_kernel/ao_release_gate.py"],
+        )
+    with pytest.raises(ValueError, match="passing secret_scan"):
+        ai_review.raw_review_from_round(
+            result=_round_result(checks=[{"name": "tests", "status": "pass"}]),
+            repository="Halildeu/ao-kernel",
+            work_package="AO-MA-10X",
+            implementer=implementer,
+            base_ref="main",
+            head_ref="feature",
+            changed=["ao_kernel/ao_release_gate.py"],
+        )
+
+    context = {
+        "base_ref": "main",
+        "head_ref": "feature",
+        "head_sha": "a" * 40,
+        "diff_digest": "sha256:" + "b" * 64,
+        "changed_files_count": 1,
+    }
+    with pytest.raises(ValueError, match="reviewer block"):
+        ai_review.provider_verdict_from_raw_review(
+            raw_review={"findings": ["ok"]},
+            provider="openai",
+            context=context,
+            round_index=1,
+            binding_mode="added",
+        )
+    with pytest.raises(ValueError, match="findings"):
+        ai_review.provider_verdict_from_raw_review(
+            raw_review={"reviewer": {"agent": "x", "provider": "openai"}},
+            provider="openai",
+            context=context,
+            round_index=1,
+            binding_mode="added",
+        )
+
+    with pytest.raises(ValueError, match="missing raw review"):
+        ai_review.build_high_risk_supersession_from_raw_reviews(
+            repository="Halildeu/ao-kernel",
+            work_package="AO-MA-10X",
+            implementer_provider="google",
+            context_binding=context,
+            high_risk_changed_paths=["ao_kernel/ao_release_gate.py"],
+            raw_review_paths={},
+            max_age_seconds=3600,
+            round_index=1,
+        )
+
+    raw = ai_review.raw_review_from_round(
+        result=_round_result(provider="openai"),
+        repository="Halildeu/ao-kernel",
+        work_package="AO-MA-10X",
+        implementer=implementer,
+        base_ref="main",
+        head_ref="feature",
+        changed=["ao_kernel/ao_release_gate.py"],
+    )
+    raw_path = tmp_path / "openai.json"
+    raw_path.write_text(json.dumps(raw), encoding="utf-8")
+    bad = dict(raw)
+    bad["reviewer"] = {**bad["reviewer"], "provider": "anthropic"}
+    mismatch = tmp_path / "mismatch.json"
+    mismatch.write_text(json.dumps(bad), encoding="utf-8")
+    with pytest.raises(ValueError, match="provider mismatch"):
+        ai_review.build_high_risk_supersession_from_raw_reviews(
+            repository="Halildeu/ao-kernel",
+            work_package="AO-MA-10X",
+            implementer_provider="google",
+            context_binding=context,
+            high_risk_changed_paths=["ao_kernel/ao_release_gate.py"],
+            raw_review_paths={"openai": mismatch, "anthropic": raw_path},
+            max_age_seconds=3600,
+            round_index=1,
+        )
+
+
+def test_ai_review_safe_console_and_missing_command_paths(capsys: pytest.CaptureFixture[str]) -> None:
+    payload = {
+        "dry_run_status": "blocked",
+        "raw_review_paths": {"anthropic": "/secret/path", "openai": "/other/path"},
+    }
+    ai_review._print_payload(payload, output="text")
+    out = capsys.readouterr().out
+    assert "status: blocked" in out
+    assert "anthropic" in out
+    assert "/secret/path" not in out
+
+    assert ai_review.dispatch_ai_review(Namespace(ai_review_command=None)) == 1
+    err = capsys.readouterr().err
+    assert "Usage: ao-kernel ai-review" in err
+
+
+def test_ai_review_consensus_runs_bounded_ping_pong_until_agree(tmp_path: Path) -> None:
+    repo = _repo_with_high_risk_change(tmp_path)
+    fake = _fake_provider(tmp_path, provider_stateful=True)
+    openai_state = tmp_path / "openai.state"
+    anthropic_state = tmp_path / "anthropic.state"
+    output_dir = tmp_path / "consensus"
+
+    proc = _run_cli(
+        [
+            "ai-review",
+            "consensus",
+            "--repository",
+            "Halildeu/ao-kernel",
+            "--work-package",
+            "AO-MA-10X",
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "feature",
+            "--repo-root",
+            str(repo),
+            "--output-dir",
+            str(output_dir),
+            "--implementer-provider",
+            "google",
+            "--max-rounds",
+            "2",
+            "--provider",
+            f"openai={_cmd('openai', fake, openai_state)}",
+            "--provider",
+            f"anthropic={_cmd('anthropic', fake, anthropic_state)}",
+        ]
+    )
+
+    summary = json.loads(proc.stdout)
+    assert summary == {
+        "artifact_kind": "ai_review_consensus_evidence",
+        "evidence_written": True,
+        "raw_review_providers": ["openai", "anthropic"],
+        "status": "AGREE",
+    }
+    payload = json.loads((output_dir / "ai_review_consensus.v1.json").read_text())
+    _validate("ai-review-consensus-evidence.schema.v1.json", payload)
+    assert payload["consensus_status"] == "AGREE"
+    assert [round_payload["round_index"] for round_payload in payload["rounds"]] == [1, 2]
+    assert {result["verdict"] for result in payload["rounds"][0]["provider_results"]} == {"REVISE"}
+    assert {result["verdict"] for result in payload["rounds"][1]["provider_results"]} == {"AGREE"}
+    assert set(payload["raw_review_paths"]) == {"anthropic", "openai"}
+    assert payload["collection_evidence_path"].endswith("ai_review_collection.v1.json")
+
+
+def test_ai_review_consensus_fails_closed_when_max_rounds_exhausted(tmp_path: Path) -> None:
+    repo = _repo_with_high_risk_change(tmp_path)
+    fake = _fake_provider(tmp_path, mode="revise")
+
+    output_dir = tmp_path / "blocked"
+    proc = _run_cli(
+        [
+            "ai-review",
+            "consensus",
+            "--repository",
+            "Halildeu/ao-kernel",
+            "--work-package",
+            "AO-MA-10X",
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "feature",
+            "--repo-root",
+            str(repo),
+            "--output-dir",
+            str(output_dir),
+            "--implementer-provider",
+            "google",
+            "--max-rounds",
+            "1",
+            "--provider",
+            f"openai={_cmd('openai', fake)}",
+            "--provider",
+            f"anthropic={_cmd('anthropic', fake)}",
+        ],
+        check=False,
+    )
+
+    assert proc.returncode == 1
+    summary = json.loads(proc.stdout)
+    assert summary == {
+        "artifact_kind": "ai_review_consensus_evidence",
+        "evidence_written": True,
+        "raw_review_providers": [],
+        "status": "not_agreed",
+    }
+    payload = json.loads((output_dir / "ai_review_consensus.v1.json").read_text())
+    _validate("ai-review-consensus-evidence.schema.v1.json", payload)
+    assert payload["consensus_status"] == "not_agreed"
+    assert payload["raw_review_paths"] == {}
+    assert payload["collection_evidence_path"] is None
+
+
+def test_ai_review_high_risk_dry_run_proves_gate_allow_without_github_mutation(tmp_path: Path) -> None:
+    repo = _repo_with_high_risk_change(tmp_path)
+    fake = _fake_provider(tmp_path)
+    output_dir = tmp_path / "reviews"
+    collect = _run_cli(
+        [
+            "ai-review",
+            "collect",
+            "--repository",
+            "Halildeu/ao-kernel",
+            "--work-package",
+            "AO-MA-10X",
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "feature",
+            "--repo-root",
+            str(repo),
+            "--output-dir",
+            str(output_dir),
+            "--implementer-provider",
+            "google",
+            "--provider",
+            f"openai={_cmd('openai', fake)}",
+            "--provider",
+            f"anthropic={_cmd('anthropic', fake)}",
+        ]
+    )
+    assert json.loads(collect.stdout)["raw_review_providers"] == ["openai", "anthropic"]
+    raw_paths = {
+        "openai": str(output_dir / "openai.local-ai-review-evidence.v1.json"),
+        "anthropic": str(output_dir / "anthropic.local-ai-review-evidence.v1.json"),
+    }
+
+    dry_run_output_dir = tmp_path / "dry-run"
+    dry_run = _run_cli(
+        [
+            "ai-review",
+            "high-risk-dry-run",
+            "--repository",
+            "Halildeu/ao-kernel",
+            "--work-package",
+            "AO-MA-10X",
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "feature",
+            "--repo-root",
+            str(repo),
+            "--output-dir",
+            str(dry_run_output_dir),
+            "--implementer-provider",
+            "google",
+            "--review-evidence",
+            raw_paths["openai"],
+            "--review-evidence",
+            raw_paths["anthropic"],
+        ]
+    )
+
+    summary = json.loads(dry_run.stdout)
+    assert summary == {
+        "artifact_kind": "ai_review_high_risk_dry_run_evidence",
+        "evidence_written": True,
+        "github_mutation_performed": False,
+        "merge_attempted": False,
+        "raw_review_providers": ["openai", "anthropic"],
+        "status": "pass",
+    }
+    payload = json.loads((dry_run_output_dir / "ai_review_high_risk_dry_run.v1.json").read_text())
+    _validate("ai-review-high-risk-dry-run-evidence.schema.v1.json", payload)
+    assert payload["dry_run_status"] == "pass"
+    assert payload["ao_release_gate_allow"] is True
+    assert payload["merge_attempted"] is False
+    assert payload["github_mutation_performed"] is False

--- a/tests/test_productization_closeout.py
+++ b/tests/test_productization_closeout.py
@@ -17,6 +17,7 @@ def test_fresh_install_product_smoke_script_covers_wheel_sdist_and_product_comma
     assert "pr_metadata_validate" in text
     assert "orchestration_run_wrapper_dry_run" in text
     assert "orchestration_run_wrapper_async_execute" in text
+    assert "ai_review_help" in text
     assert "build/fresh-install-product-smoke" in text
     assert "support_widening" in text
     assert "production_platform_claim" in text
@@ -30,6 +31,7 @@ def test_packaging_smoke_now_gates_productized_local_workflows_without_dist_poll
     assert "productized-local-workflows-smoke.v1.json" in text
     assert "build\" / \"packaging-smoke\"" in text
     assert "orchestration_run_wrapper_async_execute" in text
+    assert "ai_review_help" in text
     assert "dist/`` remains" in text
 
 
@@ -44,6 +46,9 @@ def test_product_quickstart_is_end_to_end_and_keeps_guard_boundary() -> None:
         "ao-kernel pr-metadata fix",
         "ao-kernel orchestration run-wrapper",
         "ao-kernel orchestration run-wrapper-async",
+        "ao-kernel ai-review collect",
+        "ao-kernel ai-review consensus",
+        "ao-kernel ai-review high-risk-dry-run",
         "support widening",
         "production-platform readiness",
         "live adapter execution",


### PR DESCRIPTION
## Summary

Productizes the cross-provider AI review flow as a packaged `ao-kernel ai-review` CLI surface:

- `ao-kernel ai-review collect` collects provider-backed `local-ai-review-evidence.v1` records from configured Claude/Codex/Mavis-style commands.
- `ao-kernel ai-review consensus` runs a bounded fail-closed ping-pong loop until all required providers return `AGREE`.
- `ao-kernel ai-review high-risk-dry-run` converts raw provider reviews into high-risk supersession evidence and runs the local `ao-release-gate` decision core without GitHub mutation.
- Adds strict evidence schemas for collection, consensus, and high-risk dry-run provenance.
- Extends product docs and fresh-install/packaging smoke scripts so the new CLI surface is installed and visible.

## Boundary

- AI output is evidence only, not release authority.
- Release authority remains `ao-release-gate + GitHub ruleset`.
- No GitHub mutation or merge attempt is performed by the dry-run command.
- No live adapter execution, no support widening, no production platform claim.
- Secret-like content is rejected from prompt, diff, provider stdout/stderr, findings, and command argv before evidence is written.

## Validation

- `python3 -m pytest -q tests/test_ai_review_cli.py tests/test_productization_closeout.py` -> 8 passed
- `python3 -m pytest -q tests/test_ai_review_cli.py tests/test_productization_closeout.py tests/test_ao_release_gate.py tests/test_ao_ma10_high_risk_raw_review_producer.py tests/test_ao_ma10j_high_risk_supersession_evidence_builder.py` -> 147 passed
- `python3 -m ruff check ao_kernel/ai_review.py ao_kernel/cli.py scripts/fresh_install_product_smoke.py scripts/packaging_smoke.py tests/test_ai_review_cli.py tests/test_productization_closeout.py` -> pass
- `python3 -m mypy --follow-imports=skip ao_kernel/ai_review.py` -> pass
- `python3 -m json.tool` on the three new schemas -> pass
- `python3 scripts/packaging_smoke.py` -> pass
- `python3 scripts/fresh_install_product_smoke.py --mode wheel` -> pass
- `python3 scripts/local_gpp_gate.py ...` -> `operator_may_merge`
- Claude adversarial review via `claude -p` -> `AGREE`, no blocking findings

## Local Review Evidence

Updated `local-ai-review-evidence.v1.json` for `AI-REVIEW-ORCHESTRATOR` with reviewer `claude` / provider `anthropic` verdict `AGREE`.

```json pr-delivery-metadata
{
  "work_package": "AI-REVIEW-ORCHESTRATOR",
  "issue": "N/A",
  "tracked_by": "N/A",
  "risk_class": "high",
  "critical_fix": false,
  "release_authority_impact": "none",
  "boundary_declaration": {
    "none_of_the_above": true,
    "credential_read": false,
    "credential_write": false,
    "state_mutation_test": false,
    "state_mutation_production": false,
    "user_communication": false,
    "boundary_cross": false,
    "user_approval_evidence": "N/A"
  },
  "cross_ai_review": {
    "implementer_provider": "openai",
    "reviewer_providers": ["anthropic"],
    "verdict": "AGREE",
    "review_artifacts": ["local-ai-review-evidence.v1.json"],
    "same_provider_exception": "N/A"
  }
}
```
