### PR TITLE
feat(ai-review): productize provider command wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **Provider command wrappers for cross-provider AI review**: added bundled
+  Claude, Codex, and Mavis/MiniMax provider wrappers for
+  `ao-kernel ai-review collect` and `ao-kernel ai-review consensus`. The
+  wrappers read the no-secret review request JSON from stdin, call the local
+  provider runtime, normalize fenced or plain JSON responses, record only safe
+  command/prompt provenance through the existing ai-review artifacts, and fail
+  closed on stale Mavis messages, timeouts, non-JSON output, or secret-like
+  material. AI output remains evidence only; release authority remains the
+  repo-owned `ao-release-gate` check plus GitHub ruleset enforcement.
 - **Cross-provider AI review orchestration productization**: added the
   packaged `ao-kernel ai-review` CLI with `collect`, `consensus`, and
   `high-risk-dry-run` commands. The commands collect Claude/Codex/MiniMax-style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Claude, Codex, and Mavis/MiniMax provider wrappers for
   `ao-kernel ai-review collect` and `ao-kernel ai-review consensus`. The
   wrappers read the no-secret review request JSON from stdin, call the local
-  provider runtime, normalize fenced or plain JSON responses, record only safe
-  command/prompt provenance through the existing ai-review artifacts, and fail
-  closed on stale Mavis messages, timeouts, non-JSON output, or secret-like
-  material. AI output remains evidence only; release authority remains the
-  repo-owned `ao-release-gate` check plus GitHub ruleset enforcement.
+  provider runtime, normalize fenced or plain JSON responses, open fresh
+  one-shot Mavis sessions by default, record only safe command/prompt
+  provenance through the existing ai-review artifacts, and fail closed on stale
+  Mavis messages, timeouts, non-JSON output, or secret-like material. AI output
+  remains evidence only; release authority remains the repo-owned
+  `ao-release-gate` check plus GitHub ruleset enforcement.
 - **Cross-provider AI review orchestration productization**: added the
   packaged `ao-kernel ai-review` CLI with `collect`, `consensus`, and
   `high-risk-dry-run` commands. The commands collect Claude/Codex/MiniMax-style

--- a/README.md
+++ b/README.md
@@ -285,8 +285,6 @@ export AO_MA10_OPENAI_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappe
 export AO_MA10_ANTHROPIC_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappers claude"
 export AO_MA10_MINIMAX_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappers mavis"
 export AO_MA10_MAVIS_BIN="mavis"  # Optional; set to ~/.mavis/bin/mavis if not on PATH.
-export AO_MA10_MAVIS_FROM_SESSION_ID="<local-agent-session-id>"
-export AO_MA10_MAVIS_TO_SESSION_ID="<mavis-orchestrator-session-id>"
 
 ao-kernel ai-review collect \
   --work-package AO-MA-10X \
@@ -312,8 +310,11 @@ ao-kernel ai-review high-risk-dry-run \
 
 The provider wrappers read the ai-review JSON request from stdin, call the
 local Claude, Codex, or Mavis/MiniMax runtime, extract a single review JSON
-object, and emit only normalized JSON on stdout. `ai-review` records provider
-command provenance (`command_argv_sha256`) and prompt provenance
+object, and emit only normalized JSON on stdout. The Mavis wrapper opens a
+fresh one-shot Mavis session by default; operators can opt into persistent
+communication mode with `AO_MA10_MAVIS_MODE=communication` plus explicit
+`AO_MA10_MAVIS_FROM_SESSION_ID` / `AO_MA10_MAVIS_TO_SESSION_ID` bindings.
+`ai-review` records provider command provenance (`command_argv_sha256`) and prompt provenance
 (`prompt_sha256`) without storing secrets. It can collect raw reviewer
 evidence, run bounded cross-provider ping-pong until unanimous `AGREE`, and
 locally dry-run the high-risk `ao-release-gate` path. The CLI prints only a

--- a/README.md
+++ b/README.md
@@ -281,22 +281,25 @@ require explicit declared write scopes and keep `support_widening`,
 **Cross-provider AI review collection:**
 
 ```bash
+export AO_MA10_OPENAI_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappers codex"
+export AO_MA10_ANTHROPIC_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappers claude"
+export AO_MA10_MINIMAX_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappers mavis"
+export AO_MA10_MAVIS_BIN="mavis"  # Optional; set to ~/.mavis/bin/mavis if not on PATH.
+export AO_MA10_MAVIS_FROM_SESSION_ID="<local-agent-session-id>"
+export AO_MA10_MAVIS_TO_SESSION_ID="<mavis-orchestrator-session-id>"
+
 ao-kernel ai-review collect \
   --work-package AO-MA-10X \
   --base-ref origin/main \
   --head-ref HEAD \
   --implementer-provider openai \
-  --provider "anthropic=claude -p 'return JSON only ...'" \
-  --provider "minimax=/path/to/minimax-reviewer"
 
 ao-kernel ai-review consensus \
   --work-package AO-MA-10X \
   --base-ref origin/main \
   --head-ref HEAD \
   --implementer-provider openai \
-  --max-rounds 3 \
-  --provider "anthropic=claude -p 'return JSON only ...'" \
-  --provider "minimax=/path/to/minimax-reviewer"
+  --max-rounds 3
 
 ao-kernel ai-review high-risk-dry-run \
   --work-package AO-MA-10X \
@@ -307,13 +310,16 @@ ao-kernel ai-review high-risk-dry-run \
   --review-evidence ai-review-artifacts/minimax.local-ai-review-evidence.v1.json
 ```
 
-`ai-review` records provider command provenance (`command_argv_sha256`) and
-prompt provenance (`prompt_sha256`) without storing secrets. It can collect
-raw reviewer evidence, run bounded cross-provider ping-pong until unanimous
-`AGREE`, and locally dry-run the high-risk `ao-release-gate` path. The CLI
-prints only a safe status/provider summary; full artifact paths and provenance
-are written under `--output-dir`. It does not make AI output release authority,
-mutate GitHub, widen support, claim broad readiness, or execute live adapters.
+The provider wrappers read the ai-review JSON request from stdin, call the
+local Claude, Codex, or Mavis/MiniMax runtime, extract a single review JSON
+object, and emit only normalized JSON on stdout. `ai-review` records provider
+command provenance (`command_argv_sha256`) and prompt provenance
+(`prompt_sha256`) without storing secrets. It can collect raw reviewer
+evidence, run bounded cross-provider ping-pong until unanimous `AGREE`, and
+locally dry-run the high-risk `ao-release-gate` path. The CLI prints only a
+safe status/provider summary; full artifact paths and provenance are written
+under `--output-dir`. It does not make AI output release authority, mutate
+GitHub, widen support, claim broad readiness, or execute live adapters.
 
 ## Context Management
 

--- a/ao_kernel/ai_review_provider_wrappers.py
+++ b/ao_kernel/ai_review_provider_wrappers.py
@@ -1,0 +1,371 @@
+"""Provider command wrappers for ``ao-kernel ai-review``.
+
+The ai-review collector intentionally treats provider commands as an external
+trust boundary: commands receive a no-secret JSON review request on stdin and
+must return a small review JSON object on stdout. This module provides
+repo-owned wrappers for local Claude, Codex, and Mavis/MiniMax runtimes so
+operators do not have to hand-roll shell snippets for each environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Sequence, cast
+
+from ao_kernel.ai_review import (
+    _agent_from_output,
+    _checks_from_output,
+    _findings_from_output,
+    _verdict_from_output,
+    assert_no_secret_like_text,
+)
+
+ALLOWED_VERDICTS = {"AGREE", "REVISE", "BLOCK", "PARTIAL", "RED"}
+DEFAULT_TIMEOUT_SECONDS = 120
+DEFAULT_MAVIS_BIN = "mavis"
+
+
+def _timeout_seconds() -> int:
+    raw = os.environ.get("AO_MA10_PROVIDER_TIMEOUT_SECONDS", "").strip()
+    if not raw:
+        return DEFAULT_TIMEOUT_SECONDS
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError("AO_MA10_PROVIDER_TIMEOUT_SECONDS must be an integer") from exc
+    if value < 5 or value > 900:
+        raise ValueError("AO_MA10_PROVIDER_TIMEOUT_SECONDS must be between 5 and 900")
+    return value
+
+
+def _json_output_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["agent", "verdict", "checks_considered", "findings"],
+        "properties": {
+            "agent": {"type": "string", "minLength": 1},
+            "verdict": {"type": "string", "enum": sorted(ALLOWED_VERDICTS)},
+            "checks_considered": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["name", "status"],
+                    "properties": {
+                        "name": {"type": "string", "minLength": 1},
+                        "status": {"type": "string", "enum": ["pass", "fail"]},
+                    },
+                },
+            },
+            "findings": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        },
+    }
+
+
+def _load_request() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        raise ValueError("provider wrapper requires review request JSON on stdin")
+    assert_no_secret_like_text(raw, label="provider wrapper stdin")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("provider wrapper stdin is not valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("provider wrapper stdin must be a JSON object")
+    return cast(dict[str, Any], payload)
+
+
+def _prompt_for_provider(request: dict[str, Any], *, provider_name: str) -> str:
+    prompt = {
+        "role": f"{provider_name} independent high-risk PR reviewer",
+        "instructions": [
+            "Review the request JSON as an independent reviewer.",
+            "Treat review_request as the authority; do not rely on ambient working-directory state.",
+            "Return exactly one JSON object and no prose.",
+            "Use AGREE only when tests, secret scan, scope, drift, and forbidden-action checks are clean.",
+            "Use REVISE or BLOCK when any issue remains.",
+            "Do not include secret values in findings.",
+            "AI output is evidence only; release authority remains ao-release-gate plus GitHub ruleset.",
+        ],
+        "required_output": _json_output_schema(),
+        "review_request": request,
+    }
+    rendered = json.dumps(prompt, indent=2, sort_keys=True)
+    assert_no_secret_like_text(rendered, label=f"{provider_name} provider prompt")
+    return rendered
+
+
+def _candidate_texts(text: str) -> list[str]:
+    candidates = [text.strip()]
+    for match in re.finditer(r"```(?:json)?\s*(.*?)\s*```", text, flags=re.DOTALL | re.IGNORECASE):
+        candidates.insert(0, match.group(1).strip())
+    return [candidate for candidate in candidates if candidate]
+
+
+def extract_json_object(text: str, *, label: str) -> dict[str, Any]:
+    assert_no_secret_like_text(text, label=label)
+    decoder = json.JSONDecoder()
+    for candidate in _candidate_texts(text):
+        stripped = candidate.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("{"):
+            try:
+                payload, index = decoder.raw_decode(stripped)
+            except json.JSONDecodeError:
+                payload = None
+            else:
+                if isinstance(payload, dict) and not stripped[index:].strip():
+                    return cast(dict[str, Any], payload)
+        for start, char in enumerate(stripped):
+            if char != "{":
+                continue
+            try:
+                payload, _ = decoder.raw_decode(stripped[start:])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                return cast(dict[str, Any], payload)
+    raise ValueError(f"{label} did not contain a JSON object")
+
+
+def normalize_provider_output(payload: dict[str, Any], *, provider: str) -> dict[str, Any]:
+    normalized = {
+        "agent": _agent_from_output(payload, provider),
+        "verdict": _verdict_from_output(payload, provider),
+        "checks_considered": _checks_from_output(payload, provider),
+        "findings": _findings_from_output(payload, provider),
+    }
+    rendered = json.dumps(normalized, sort_keys=True)
+    assert_no_secret_like_text(rendered, label=f"{provider} normalized provider output")
+    return normalized
+
+
+def _emit(payload: dict[str, Any]) -> int:
+    sys.stdout.write(json.dumps(payload, sort_keys=True) + "\n")
+    return 0
+
+
+def _provider_error(message: str) -> int:
+    sys.stderr.write(f"provider-wrapper-error: {message}\n")
+    return 2
+
+
+def run_claude_provider() -> int:
+    request = _load_request()
+    prompt = _prompt_for_provider(request, provider_name="Claude")
+    claude_bin = os.environ.get("AO_MA10_CLAUDE_BIN", "claude")
+    timeout = _timeout_seconds()
+    configured_cwd = os.environ.get("AO_MA10_CLAUDE_CWD", "").strip()
+    if configured_cwd:
+        cwd_context: tempfile.TemporaryDirectory[str] | None = None
+        cwd = configured_cwd
+    else:
+        cwd_context = tempfile.TemporaryDirectory(prefix="ao-kernel-claude-review-")
+        cwd = cwd_context.name
+    try:
+        proc = subprocess.run(
+            [claude_bin, "-p", prompt],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    finally:
+        if cwd_context is not None:
+            cwd_context.cleanup()
+    if proc.stderr.strip():
+        assert_no_secret_like_text(proc.stderr, label="claude provider stderr")
+    if proc.returncode != 0:
+        raise RuntimeError(f"claude provider command failed with exit {proc.returncode}")
+    payload = extract_json_object(proc.stdout, label="claude provider stdout")
+    return _emit(normalize_provider_output(payload, provider="anthropic"))
+
+
+def run_codex_provider() -> int:
+    request = _load_request()
+    prompt = _prompt_for_provider(request, provider_name="Codex")
+    codex_bin = os.environ.get("AO_MA10_CODEX_BIN", "codex")
+    repo_root = os.environ.get("AO_MA10_CODEX_REPO_ROOT", os.getcwd())
+    timeout = _timeout_seconds()
+    with tempfile.TemporaryDirectory(prefix="ao-kernel-codex-review-") as tmp:
+        tmp_path = Path(tmp)
+        schema_path = tmp_path / "review-output.schema.json"
+        output_path = tmp_path / "last-message.json"
+        schema_path.write_text(json.dumps(_json_output_schema(), indent=2, sort_keys=True), encoding="utf-8")
+        proc = subprocess.run(
+            [
+                codex_bin,
+                "exec",
+                "--sandbox",
+                "read-only",
+                "--output-schema",
+                str(schema_path),
+                "--output-last-message",
+                str(output_path),
+                "--cd",
+                repo_root,
+                prompt,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        if proc.stderr.strip():
+            assert_no_secret_like_text(proc.stderr, label="codex provider stderr")
+        if proc.returncode != 0:
+            raise RuntimeError(f"codex provider command failed with exit {proc.returncode}")
+        output_text = output_path.read_text(encoding="utf-8") if output_path.exists() else proc.stdout
+    payload = extract_json_object(output_text, label="codex provider output")
+    return _emit(normalize_provider_output(payload, provider="openai"))
+
+
+def _mavis_bin() -> str:
+    return os.environ.get("AO_MA10_MAVIS_BIN", DEFAULT_MAVIS_BIN)
+
+
+def _run_mavis(args: Sequence[str], *, timeout: int) -> dict[str, Any]:
+    proc = subprocess.run(
+        [_mavis_bin(), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if proc.stderr.strip():
+        assert_no_secret_like_text(proc.stderr, label="mavis stderr")
+    if proc.returncode != 0:
+        raise RuntimeError(f"mavis command failed with exit {proc.returncode}")
+    payload = extract_json_object(proc.stdout, label="mavis stdout")
+    return payload
+
+
+def _message_session_value(message: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = message.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _message_content(message: dict[str, Any]) -> str:
+    for key in ("content", "message", "body", "text"):
+        value = message.get(key)
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict):
+            return json.dumps(value, sort_keys=True)
+    return json.dumps(message, sort_keys=True)
+
+
+def _message_created_ms(message: dict[str, Any]) -> int:
+    for key in ("time_created", "timeCreated", "created_at_ms", "createdAtMs"):
+        value = message.get(key)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+    return 0
+
+
+def _messages_from_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = payload.get("messages")
+    if raw is None and isinstance(payload.get("data"), list):
+        raw = payload["data"]
+    if raw is None and isinstance(payload.get("items"), list):
+        raw = payload["items"]
+    if raw is None and all(key in payload for key in ("from_session", "to_session")):
+        raw = [payload]
+    if not isinstance(raw, list):
+        return []
+    return [cast(dict[str, Any], item) for item in raw if isinstance(item, dict)]
+
+
+def run_mavis_provider() -> int:
+    request = _load_request()
+    prompt = _prompt_for_provider(request, provider_name="Mavis/MiniMax")
+    from_session = os.environ.get("AO_MA10_MAVIS_FROM_SESSION_ID", "").strip()
+    to_session = os.environ.get("AO_MA10_MAVIS_TO_SESSION_ID", "").strip()
+    if not from_session or not to_session:
+        raise ValueError("AO_MA10_MAVIS_FROM_SESSION_ID and AO_MA10_MAVIS_TO_SESSION_ID are required")
+    timeout = _timeout_seconds()
+    deadline = time.monotonic() + timeout
+    sent_after_ms = int(time.time() * 1000)
+    _run_mavis(
+        [
+            "communication",
+            "send",
+            "--from",
+            from_session,
+            "--to",
+            to_session,
+            "--command",
+            "prompt",
+            "--content",
+            prompt,
+        ],
+        timeout=min(timeout, 30),
+    )
+    poll_interval = float(os.environ.get("AO_MA10_MAVIS_POLL_SECONDS", "5"))
+    while time.monotonic() < deadline:
+        payload = _run_mavis(
+            ["communication", "messages", "--to", from_session, "--status", "all"],
+            timeout=min(timeout, 30),
+        )
+        for message in reversed(_messages_from_payload(payload)):
+            if _message_created_ms(message) < sent_after_ms:
+                continue
+            message_from = _message_session_value(message, "from_session", "fromSession", "from")
+            message_to = _message_session_value(message, "to_session", "toSession", "to")
+            if message_from != to_session or message_to != from_session:
+                continue
+            content = _message_content(message)
+            try:
+                review = extract_json_object(content, label="mavis response content")
+            except ValueError:
+                continue
+            return _emit(normalize_provider_output(review, provider="minimax"))
+        time.sleep(poll_interval)
+    raise TimeoutError("mavis provider did not return valid review JSON before timeout")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Provider wrappers for ao-kernel ai-review.")
+    subparsers = parser.add_subparsers(dest="provider", required=True)
+    subparsers.add_parser("claude", help="Call local Claude CLI and normalize review JSON.")
+    subparsers.add_parser("codex", help="Call local Codex CLI and normalize review JSON.")
+    subparsers.add_parser("mavis", help="Call local Mavis/MiniMax orchestrator and normalize review JSON.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.provider == "claude":
+            return run_claude_provider()
+        if args.provider == "codex":
+            return run_codex_provider()
+        if args.provider == "mavis":
+            return run_mavis_provider()
+        parser.error(f"unsupported provider {args.provider}")
+        return 2
+    except (RuntimeError, TimeoutError, ValueError, subprocess.SubprocessError) as exc:
+        return _provider_error(str(exc))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/ao_kernel/ai_review_provider_wrappers.py
+++ b/ao_kernel/ai_review_provider_wrappers.py
@@ -262,7 +262,7 @@ def _message_session_value(message: dict[str, Any], *keys: str) -> str:
 
 
 def _message_content(message: dict[str, Any]) -> str:
-    for key in ("content", "message", "body", "text"):
+    for key in ("content", "msg_content", "message", "body", "text"):
         value = message.get(key)
         if isinstance(value, str):
             return value
@@ -294,14 +294,11 @@ def _messages_from_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return [cast(dict[str, Any], item) for item in raw if isinstance(item, dict)]
 
 
-def run_mavis_provider() -> int:
-    request = _load_request()
-    prompt = _prompt_for_provider(request, provider_name="Mavis/MiniMax")
+def _run_mavis_communication_provider(prompt: str, *, timeout: int) -> int:
     from_session = os.environ.get("AO_MA10_MAVIS_FROM_SESSION_ID", "").strip()
     to_session = os.environ.get("AO_MA10_MAVIS_TO_SESSION_ID", "").strip()
     if not from_session or not to_session:
         raise ValueError("AO_MA10_MAVIS_FROM_SESSION_ID and AO_MA10_MAVIS_TO_SESSION_ID are required")
-    timeout = _timeout_seconds()
     deadline = time.monotonic() + timeout
     sent_after_ms = int(time.time() * 1000)
     _run_mavis(
@@ -340,6 +337,63 @@ def run_mavis_provider() -> int:
             return _emit(normalize_provider_output(review, provider="minimax"))
         time.sleep(poll_interval)
     raise TimeoutError("mavis provider did not return valid review JSON before timeout")
+
+
+def _messages_for_session(session_id: str, *, timeout: int) -> list[dict[str, Any]]:
+    payload = _run_mavis(["session", "messages", session_id], timeout=min(timeout, 30))
+    return _messages_from_payload(payload)
+
+
+def _run_mavis_new_session_provider(prompt: str, *, timeout: int) -> int:
+    agent = os.environ.get("AO_MA10_MAVIS_AGENT", "mavis").strip() or "mavis"
+    title = os.environ.get("AO_MA10_MAVIS_TITLE", "ao-kernel-ai-review-provider").strip()
+    workspace = os.environ.get("AO_MA10_MAVIS_WORKSPACE", os.getcwd()).strip()
+    create_payload = _run_mavis(
+        [
+            "session",
+            "new",
+            agent,
+            "--from",
+            "root",
+            "--title",
+            title,
+            "--workspace",
+            workspace,
+            "--prompt",
+            prompt,
+        ],
+        timeout=min(timeout, 30),
+    )
+    session_id = create_payload.get("sessionId")
+    if not isinstance(session_id, str) or not session_id.startswith("mvs_"):
+        raise ValueError("mavis session new did not return a sessionId")
+    deadline = time.monotonic() + timeout
+    poll_interval = float(os.environ.get("AO_MA10_MAVIS_POLL_SECONDS", "5"))
+    while time.monotonic() < deadline:
+        for message in reversed(_messages_for_session(session_id, timeout=timeout)):
+            role = message.get("role")
+            if role not in {"assistant", "model"}:
+                continue
+            content = _message_content(message)
+            try:
+                review = extract_json_object(content, label="mavis session assistant content")
+            except ValueError:
+                continue
+            return _emit(normalize_provider_output(review, provider="minimax"))
+        time.sleep(poll_interval)
+    raise TimeoutError(f"mavis session {session_id} did not return valid review JSON before timeout")
+
+
+def run_mavis_provider() -> int:
+    request = _load_request()
+    prompt = _prompt_for_provider(request, provider_name="Mavis/MiniMax")
+    timeout = _timeout_seconds()
+    mode = os.environ.get("AO_MA10_MAVIS_MODE", "").strip().lower()
+    if mode == "communication" or (
+        os.environ.get("AO_MA10_MAVIS_FROM_SESSION_ID") and os.environ.get("AO_MA10_MAVIS_TO_SESSION_ID")
+    ):
+        return _run_mavis_communication_provider(prompt, timeout=timeout)
+    return _run_mavis_new_session_provider(prompt, timeout=timeout)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/docs/PRODUCT-QUICKSTART.md
+++ b/docs/PRODUCT-QUICKSTART.md
@@ -148,14 +148,19 @@ Collect raw evidence for the reviewer providers required after excluding the
 implementer provider:
 
 ```bash
+export AO_MA10_OPENAI_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappers codex"
+export AO_MA10_ANTHROPIC_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappers claude"
+export AO_MA10_MINIMAX_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappers mavis"
+export AO_MA10_MAVIS_BIN="mavis"  # Optional; set to ~/.mavis/bin/mavis if not on PATH.
+export AO_MA10_MAVIS_FROM_SESSION_ID="<local-agent-session-id>"
+export AO_MA10_MAVIS_TO_SESSION_ID="<mavis-orchestrator-session-id>"
+
 ao-kernel ai-review collect \
   --work-package AO-MA-10X \
   --base-ref origin/main \
   --head-ref HEAD \
   --repo-root . \
   --implementer-provider openai \
-  --provider "anthropic=claude -p 'return JSON only ...'" \
-  --provider "minimax=/path/to/minimax-reviewer" \
   --output-dir .ao/ai-review \
   --format json
 ```
@@ -171,11 +176,17 @@ ao-kernel ai-review consensus \
   --repo-root . \
   --implementer-provider openai \
   --max-rounds 3 \
-  --provider "anthropic=claude -p 'return JSON only ...'" \
-  --provider "minimax=/path/to/minimax-reviewer" \
   --output-dir .ao/ai-review \
   --format json
 ```
+
+The bundled provider wrappers are the recommended command form:
+
+| Provider | Env command | Runtime notes |
+|---|---|---|
+| OpenAI/Codex | `python3 -m ao_kernel.ai_review_provider_wrappers codex` | Uses `codex exec --sandbox read-only --output-last-message`; stdout/stderr noise is not trusted as evidence. |
+| Anthropic/Claude | `python3 -m ao_kernel.ai_review_provider_wrappers claude` | Uses `claude -p` and extracts fenced or plain JSON. |
+| MiniMax/Mavis | `python3 -m ao_kernel.ai_review_provider_wrappers mavis` | Requires `AO_MA10_MAVIS_FROM_SESSION_ID` and `AO_MA10_MAVIS_TO_SESSION_ID`; fails closed on timeout or non-JSON response. |
 
 Each collection/consensus artifact records:
 

--- a/docs/PRODUCT-QUICKSTART.md
+++ b/docs/PRODUCT-QUICKSTART.md
@@ -152,8 +152,6 @@ export AO_MA10_OPENAI_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappe
 export AO_MA10_ANTHROPIC_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappers claude"
 export AO_MA10_MINIMAX_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappers mavis"
 export AO_MA10_MAVIS_BIN="mavis"  # Optional; set to ~/.mavis/bin/mavis if not on PATH.
-export AO_MA10_MAVIS_FROM_SESSION_ID="<local-agent-session-id>"
-export AO_MA10_MAVIS_TO_SESSION_ID="<mavis-orchestrator-session-id>"
 
 ao-kernel ai-review collect \
   --work-package AO-MA-10X \
@@ -186,7 +184,7 @@ The bundled provider wrappers are the recommended command form:
 |---|---|---|
 | OpenAI/Codex | `python3 -m ao_kernel.ai_review_provider_wrappers codex` | Uses `codex exec --sandbox read-only --output-last-message`; stdout/stderr noise is not trusted as evidence. |
 | Anthropic/Claude | `python3 -m ao_kernel.ai_review_provider_wrappers claude` | Uses `claude -p` and extracts fenced or plain JSON. |
-| MiniMax/Mavis | `python3 -m ao_kernel.ai_review_provider_wrappers mavis` | Requires `AO_MA10_MAVIS_FROM_SESSION_ID` and `AO_MA10_MAVIS_TO_SESSION_ID`; fails closed on timeout or non-JSON response. |
+| MiniMax/Mavis | `python3 -m ao_kernel.ai_review_provider_wrappers mavis` | Opens a fresh one-shot `mavis` session by default; persistent communication mode is optional via `AO_MA10_MAVIS_MODE=communication` plus explicit session IDs. Fails closed on timeout, stale message, or non-JSON response. |
 
 Each collection/consensus artifact records:
 

--- a/docs/operator-runbooks/05-minimax-mavis-runtime.md
+++ b/docs/operator-runbooks/05-minimax-mavis-runtime.md
@@ -135,8 +135,6 @@ Example invocation shape, with the provider command supplied by the operator:
 ```bash
 export AO_MA10_MINIMAX_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappers mavis"
 export AO_MA10_MAVIS_BIN="mavis"  # Optional; use ~/.mavis/bin/mavis when Mavis is not on PATH.
-export AO_MA10_MAVIS_FROM_SESSION_ID="<local-agent-session-id>"
-export AO_MA10_MAVIS_TO_SESSION_ID="<mavis-orchestrator-session-id>"
 
 python3 scripts/ao_ma10_high_risk_raw_review_producer.py \
   --work-package "AO-MA-10 high-risk provider separation" \
@@ -149,6 +147,17 @@ The wrapper accepts only messages from the configured Mavis target session to
 the configured local session whose `time_created` is after the current send
 operation. Older MiniMax messages in the daemon queue are ignored; timeout is a
 fail-closed result, not an implicit approval.
+
+By default, the wrapper opens a fresh one-shot Mavis session with
+`mavis session new mavis --from root ...` and reads the assistant
+`msg_content` from that session. Persistent communication mode is available
+only when explicitly requested:
+
+```bash
+export AO_MA10_MAVIS_MODE=communication
+export AO_MA10_MAVIS_FROM_SESSION_ID="<local-agent-session-id>"
+export AO_MA10_MAVIS_TO_SESSION_ID="<mavis-orchestrator-session-id>"
+```
 
 ## Stop Conditions
 

--- a/docs/operator-runbooks/05-minimax-mavis-runtime.md
+++ b/docs/operator-runbooks/05-minimax-mavis-runtime.md
@@ -133,7 +133,10 @@ that convert a non-AGREE result into `AGREE` are forbidden.
 Example invocation shape, with the provider command supplied by the operator:
 
 ```bash
-export AO_MA10_MINIMAX_REVIEW_CMD="/path/to/minimax-review-wrapper"
+export AO_MA10_MINIMAX_REVIEW_CMD="python3 -m ao_kernel.ai_review_provider_wrappers mavis"
+export AO_MA10_MAVIS_BIN="mavis"  # Optional; use ~/.mavis/bin/mavis when Mavis is not on PATH.
+export AO_MA10_MAVIS_FROM_SESSION_ID="<local-agent-session-id>"
+export AO_MA10_MAVIS_TO_SESSION_ID="<mavis-orchestrator-session-id>"
 
 python3 scripts/ao_ma10_high_risk_raw_review_producer.py \
   --work-package "AO-MA-10 high-risk provider separation" \
@@ -141,6 +144,11 @@ python3 scripts/ao_ma10_high_risk_raw_review_producer.py \
   --head-ref HEAD \
   --implementer-provider openai
 ```
+
+The wrapper accepts only messages from the configured Mavis target session to
+the configured local session whose `time_created` is after the current send
+operation. Older MiniMax messages in the daemon queue are ignored; timeout is a
+fail-closed result, not an implicit approval.
 
 ## Stop Conditions
 

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -1,35 +1,4 @@
 {
-  "schema_version": "local-ai-review-evidence.v1",
-  "repo": "Halildeu/ao-kernel",
-  "work_package": "AI-REVIEW-ORCHESTRATOR",
-  "implementer": {
-    "agent": "codex",
-    "provider": "openai"
-  },
-  "reviewer": {
-    "agent": "claude",
-    "provider": "anthropic",
-    "verdict": "AGREE"
-  },
-  "scope_reviewed": {
-    "base_ref": "refs/heads/main",
-    "head_ref": "refs/heads/codex/cross-ai-review-orchestrator",
-    "changed_files": [
-      "CHANGELOG.md",
-      "README.md",
-      "ao_kernel/ai_review.py",
-      "ao_kernel/cli.py",
-      "ao_kernel/defaults/schemas/ai-review-collection-evidence.schema.v1.json",
-      "ao_kernel/defaults/schemas/ai-review-consensus-evidence.schema.v1.json",
-      "ao_kernel/defaults/schemas/ai-review-high-risk-dry-run-evidence.schema.v1.json",
-      "docs/PRODUCT-QUICKSTART.md",
-      "local-ai-review-evidence.v1.json",
-      "scripts/fresh_install_product_smoke.py",
-      "scripts/packaging_smoke.py",
-      "tests/test_ai_review_cli.py",
-      "tests/test_productization_closeout.py"
-    ]
-  },
   "checks_considered": [
     {
       "name": "tests",
@@ -40,46 +9,73 @@
       "status": "pass"
     },
     {
-      "name": "guard_boundaries",
+      "name": "scope",
       "status": "pass"
     },
     {
-      "name": "release_authority_boundary",
+      "name": "guard_flags",
       "status": "pass"
     },
     {
-      "name": "provider_provenance",
+      "name": "forbidden_actions",
       "status": "pass"
     },
     {
-      "name": "consensus_fail_closed",
+      "name": "drift",
       "status": "pass"
     },
     {
-      "name": "high_risk_dry_run_no_github_mutation",
+      "name": "fail_closed_behavior",
       "status": "pass"
     },
     {
-      "name": "fresh_install_smoke",
-      "status": "pass"
-    },
-    {
-      "name": "packaging_smoke",
+      "name": "provider_separation",
       "status": "pass"
     }
   ],
   "findings": [
-    "Claude reviewed the cross-provider AI review orchestration diff via local claude -p command and returned AGREE with no blocking findings.",
-    "The new ao-kernel ai-review CLI collects provider-backed review evidence, records command/prompt provenance, supports bounded consensus ping-pong, and emits fail-closed artifacts.",
-    "The high-risk dry-run path converts raw provider reviews into high-risk supersession evidence and runs the ao-release-gate decision core without GitHub mutation or merge attempt.",
-        "Schema-level guard constants keep ai_output_release_authority false and preserve no support widening, no production platform claim, and no live adapter execution.",
-        "Secret-like content is rejected from prompts, diffs, provider stdout/stderr, findings, and command argv before evidence is written.",
-        "Post-review CodeQL hardening keeps CLI stdout to safe status/provider summaries; full evidence, provenance, and file paths remain durable file-backed artifacts under the requested output directory.",
-        "Validation passed: targeted pytest 11/11, targeted ao_kernel.ai_review coverage 93.05%, broader ao-release-gate-related pytest 150/150, ruff, mypy, schema parse, packaging smoke, and fresh-install wheel smoke.",
-        "Non-blocking Claude notes: provider commands run sequentially; _high_risk_paths is an internal same-package helper; dry-run issue URL is dummy by design."
-    ],
-  "secrets_recorded": false,
+    "All 10 changed files match work package AO-MA-10-PROVIDER-COMMAND-SMOKE scope: provider wrappers, tests, docs, changelog, runbook, convenience scripts, and local gate evidence.",
+    "assert_no_secret_like_text is called on stdin, rendered prompt, provider stderr, provider stdout, and normalized output; the reviewed boundary points have no secret-recording gap.",
+    "Guard flags remain closed: support_widening=false, production_platform_claim=false, live_adapter_execution=false; no support widening is introduced in code or docs.",
+    "Codex wrapper enforces --sandbox read-only; Claude wrapper defaults to an ephemeral tempdir CWD; Mavis new-session mode is one-shot by default; all three fail closed.",
+    "Mavis communication mode filters by from_session/to_session match and time_created greater than sent_after_ms, rejecting stale daemon queue messages; timeout is a fail-closed error, not implicit approval.",
+    "Mavis new-session mode validates sessionId starts with mvs_ prefix; non-assistant/non-model roles are skipped; unparseable content is skipped, preserving fail-closed filtering.",
+    "Timeout is bounded to 5-900 seconds with ValueError on out-of-range or non-integer values; there is no unbounded wait path.",
+    "Local verification passed: pytest for provider wrappers and ai-review CLI, ruff, and mypy. The suite covers fenced JSON extraction, stdin rejection, nonzero exit propagation, communication session filtering, new-session mode, and end-to-end ai-review collect integration.",
+    "No secret values, credentials, API keys, tokens, webhook URLs, support-widening claim, production-platform claim, or live-adapter execution request was found in the reviewed diff.",
+    "local-ai-review-evidence.v1.json is included in the reviewed changed-files scope and records this independent Anthropic review verdict.",
+    "AI output remains evidence only; release authority remains ao-release-gate plus GitHub ruleset, as stated consistently in changelog, README, quickstart, and runbook."
+  ],
+  "implementer": {
+    "agent": "codex",
+    "provider": "openai"
+  },
   "live_adapter_execution": false,
+  "production_platform_claim": false,
+  "repo": "Halildeu/ao-kernel",
+  "reviewer": {
+    "agent": "claude-opus-4-6-independent-reviewer",
+    "provider": "anthropic",
+    "verdict": "AGREE"
+  },
+  "schema_version": "local-ai-review-evidence.v1",
+  "scope_reviewed": {
+    "base_ref": "refs/heads/main",
+    "changed_files": [
+      "CHANGELOG.md",
+      "README.md",
+      "ao_kernel/ai_review_provider_wrappers.py",
+      "docs/PRODUCT-QUICKSTART.md",
+      "docs/operator-runbooks/05-minimax-mavis-runtime.md",
+      "local-ai-review-evidence.v1.json",
+      "scripts/ai_review_provider_claude.py",
+      "scripts/ai_review_provider_codex.py",
+      "scripts/ai_review_provider_mavis.py",
+      "tests/test_ai_review_provider_wrappers.py"
+    ],
+    "head_ref": "refs/heads/codex/provider-command-smoke"
+  },
+  "secrets_recorded": false,
   "support_widening": false,
-  "production_platform_claim": false
+  "work_package": "AO-MA-10-PROVIDER-COMMAND-SMOKE"
 }

--- a/scripts/ai_review_provider_claude.py
+++ b/scripts/ai_review_provider_claude.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Claude provider command for ``ao-kernel ai-review``."""
+
+from __future__ import annotations
+
+from ao_kernel.ai_review_provider_wrappers import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(["claude"]))

--- a/scripts/ai_review_provider_codex.py
+++ b/scripts/ai_review_provider_codex.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Codex provider command for ``ao-kernel ai-review``."""
+
+from __future__ import annotations
+
+from ao_kernel.ai_review_provider_wrappers import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(["codex"]))

--- a/scripts/ai_review_provider_mavis.py
+++ b/scripts/ai_review_provider_mavis.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Mavis/MiniMax provider command for ``ao-kernel ai-review``."""
+
+from __future__ import annotations
+
+from ao_kernel.ai_review_provider_wrappers import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(["mavis"]))

--- a/tests/test_ai_review_provider_wrappers.py
+++ b/tests/test_ai_review_provider_wrappers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import os
 import subprocess
@@ -64,6 +65,10 @@ def _run_wrapper(provider: str, *, env: dict[str, str], stdin: str | None = None
         env=merged_env,
         timeout=30,
     )
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, stdin: str | None = None) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(stdin if stdin is not None else _review_request()))
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -199,6 +204,49 @@ def test_claude_wrapper_reports_nonzero_provider_exit(tmp_path: Path) -> None:
     assert "claude provider command failed with exit 7" in proc.stderr
 
 
+def test_run_claude_provider_direct_success(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    _set_stdin(monkeypatch)
+    monkeypatch.setenv("AO_MA10_CLAUDE_BIN", "fake-claude")
+    monkeypatch.setenv("AO_MA10_CLAUDE_CWD", str(tmp_path))
+    monkeypatch.setenv("AO_MA10_PROVIDER_TIMEOUT_SECONDS", "9")
+    calls: list[tuple[list[str], str]] = []
+
+    def fake_run(
+        args: list[str],
+        *,
+        cwd: str,
+        capture_output: bool,
+        text: bool,
+        timeout: int,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append((args, cwd))
+        assert capture_output is True
+        assert text is True
+        assert timeout == 9
+        assert check is False
+        assert args[0] == "fake-claude"
+        assert args[1] == "-p"
+        assert "review_request" in args[2]
+        return subprocess.CompletedProcess(args, 0, stdout=_review_json("claude-direct"), stderr="diagnostic only")
+
+    monkeypatch.setattr(wrappers.subprocess, "run", fake_run)
+    assert wrappers.run_claude_provider() == 0
+    assert calls == [(["fake-claude", "-p", calls[0][0][2]], str(tmp_path))]
+    assert json.loads(capsys.readouterr().out)["agent"] == "claude-direct"
+
+
+def test_run_claude_provider_direct_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_stdin(monkeypatch)
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["claude"], 7, stdout="", stderr="")
+
+    monkeypatch.setattr(wrappers.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="claude provider command failed with exit 7"):
+        wrappers.run_claude_provider()
+
+
 def test_codex_wrapper_reads_output_last_message(tmp_path: Path) -> None:
     fake = _write_executable(
         tmp_path / "codex",
@@ -255,6 +303,59 @@ def test_codex_wrapper_reports_nonzero_provider_exit(tmp_path: Path) -> None:
     assert "codex provider command failed with exit 9" in proc.stderr
 
 
+def test_run_codex_provider_direct_writes_last_message(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    _set_stdin(monkeypatch)
+    monkeypatch.setenv("AO_MA10_CODEX_BIN", "fake-codex")
+    monkeypatch.setenv("AO_MA10_CODEX_REPO_ROOT", str(tmp_path))
+
+    def fake_run(
+        args: list[str],
+        *,
+        capture_output: bool,
+        text: bool,
+        timeout: int,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        assert args[:2] == ["fake-codex", "exec"]
+        assert "--sandbox" in args and "read-only" in args
+        assert args[args.index("--cd") + 1] == str(tmp_path)
+        output = Path(args[args.index("--output-last-message") + 1])
+        output.write_text(_review_json("codex-direct"), encoding="utf-8")
+        assert capture_output is True
+        assert text is True
+        assert timeout == wrappers.DEFAULT_TIMEOUT_SECONDS
+        assert check is False
+        return subprocess.CompletedProcess(args, 0, stdout="ignored", stderr="diagnostic only")
+
+    monkeypatch.setattr(wrappers.subprocess, "run", fake_run)
+    assert wrappers.run_codex_provider() == 0
+    assert json.loads(capsys.readouterr().out)["agent"] == "codex-direct"
+
+
+def test_run_codex_provider_direct_stdout_fallback(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _set_stdin(monkeypatch)
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["codex"], 0, stdout=_review_json("codex-direct-stdout"), stderr="")
+
+    monkeypatch.setattr(wrappers.subprocess, "run", fake_run)
+    assert wrappers.run_codex_provider() == 0
+    assert json.loads(capsys.readouterr().out)["agent"] == "codex-direct-stdout"
+
+
+def test_run_codex_provider_direct_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_stdin(monkeypatch)
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["codex"], 9, stdout="", stderr="")
+
+    monkeypatch.setattr(wrappers.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="codex provider command failed with exit 9"):
+        wrappers.run_codex_provider()
+
+
 def test_mavis_payload_helpers_accept_supported_shapes() -> None:
     assert wrappers._messages_from_payload({"data": [{"content": "a"}]}) == [{"content": "a"}]
     assert wrappers._messages_from_payload({"items": [{"content": "b"}]}) == [{"content": "b"}]
@@ -294,6 +395,82 @@ def test_mavis_communication_mode_requires_session_ids(tmp_path: Path) -> None:
     )
     assert proc.returncode == 2
     assert "FROM_SESSION_ID and AO_MA10_MAVIS_TO_SESSION_ID are required" in proc.stderr
+
+
+def test_run_mavis_low_level_command_direct(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AO_MA10_MAVIS_BIN", "fake-mavis")
+
+    def fake_run(
+        args: list[str],
+        *,
+        capture_output: bool,
+        text: bool,
+        timeout: int,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        assert args == ["fake-mavis", "status", "--json"]
+        assert capture_output is True
+        assert text is True
+        assert timeout == 5
+        assert check is False
+        return subprocess.CompletedProcess(args, 0, stdout='{"status":"running"}', stderr="diagnostic only")
+
+    monkeypatch.setattr(wrappers.subprocess, "run", fake_run)
+    assert wrappers._run_mavis(["status", "--json"], timeout=5) == {"status": "running"}
+
+
+def test_run_mavis_low_level_command_direct_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["mavis"], 4, stdout="", stderr="")
+
+    monkeypatch.setattr(wrappers.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="mavis command failed with exit 4"):
+        wrappers._run_mavis(["status"], timeout=5)
+
+
+def test_run_mavis_provider_direct_communication_mode(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _set_stdin(monkeypatch)
+    monkeypatch.setenv("AO_MA10_MAVIS_MODE", "communication")
+    monkeypatch.setenv("AO_MA10_MAVIS_FROM_SESSION_ID", "agent-session")
+    monkeypatch.setenv("AO_MA10_MAVIS_TO_SESSION_ID", "mavis-session")
+    monkeypatch.setenv("AO_MA10_MAVIS_POLL_SECONDS", "0.01")
+    calls: list[list[str]] = []
+
+    def fake_run_mavis(args: list[str], *, timeout: int) -> dict[str, object]:
+        calls.append(args)
+        if args[:2] == ["communication", "send"]:
+            return {"messageId": 1, "status": "delivered"}
+        assert args[:2] == ["communication", "messages"]
+        now = int(wrappers.time.time() * 1000) + 1
+        return {
+            "messages": [
+                {
+                    "from_session": "other-session",
+                    "to_session": "agent-session",
+                    "time_created": now,
+                    "content": _review_json("wrong-session"),
+                },
+                {
+                    "from_session": "mavis-session",
+                    "to_session": "agent-session",
+                    "time_created": now,
+                    "content": "not json",
+                },
+                {
+                    "from_session": "mavis-session",
+                    "to_session": "agent-session",
+                    "time_created": now,
+                    "content": _review_json("mavis-direct-communication"),
+                },
+            ]
+        }
+
+    monkeypatch.setattr(wrappers, "_run_mavis", fake_run_mavis)
+    assert wrappers.run_mavis_provider() == 0
+    assert calls[0][:2] == ["communication", "send"]
+    assert json.loads(capsys.readouterr().out)["agent"] == "mavis-direct-communication"
 
 
 def test_mavis_wrapper_sends_prompt_and_polls_response(tmp_path: Path) -> None:
@@ -480,6 +657,53 @@ def test_mavis_new_session_skips_non_assistant_and_unparseable_messages(tmp_path
     )
     assert proc.returncode == 0, proc.stderr
     assert json.loads(proc.stdout)["agent"] == "mavis-model-fake"
+
+
+def test_run_mavis_provider_direct_new_session_mode(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    _set_stdin(monkeypatch)
+    monkeypatch.setenv("AO_MA10_MAVIS_AGENT", "")
+    monkeypatch.setenv("AO_MA10_MAVIS_TITLE", "direct-title")
+    monkeypatch.setenv("AO_MA10_MAVIS_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("AO_MA10_MAVIS_POLL_SECONDS", "0.01")
+
+    def fake_run_mavis(args: list[str], *, timeout: int) -> dict[str, object]:
+        if args[:2] == ["session", "new"]:
+            assert args[2] == "mavis"
+            assert args[args.index("--title") + 1] == "direct-title"
+            assert args[args.index("--workspace") + 1] == str(tmp_path)
+            return {"sessionId": "mvs_direct_session_abcdef1234567890abcdef"}
+        assert args[:2] == ["session", "messages"]
+        return {
+            "messages": [
+                {"role": "user", "msg_content": _review_json("ignored-user")},
+                {"role": "assistant", "msg_content": "not json"},
+                {"role": "model", "msg_content": _review_json("mavis-direct-new-session")},
+            ]
+        }
+
+    monkeypatch.setattr(wrappers, "_run_mavis", fake_run_mavis)
+    assert wrappers.run_mavis_provider() == 0
+    assert json.loads(capsys.readouterr().out)["agent"] == "mavis-direct-new-session"
+
+
+def test_run_mavis_provider_direct_rejects_missing_session_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_stdin(monkeypatch)
+
+    def fake_run_mavis(args: list[str], *, timeout: int) -> dict[str, object]:
+        assert args[:2] == ["session", "new"]
+        return {"sessionId": "not-mavis"}
+
+    monkeypatch.setattr(wrappers, "_run_mavis", fake_run_mavis)
+    with pytest.raises(ValueError, match="mavis session new did not return a sessionId"):
+        wrappers.run_mavis_provider()
+
+
+def test_main_returns_provider_error_direct(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    assert wrappers.main(["claude"]) == 2
+    assert "provider-wrapper-error: provider wrapper requires review request JSON" in capsys.readouterr().err
 
 
 def test_ai_review_collect_uses_productized_provider_wrapper_envs(tmp_path: Path) -> None:

--- a/tests/test_ai_review_provider_wrappers.py
+++ b/tests/test_ai_review_provider_wrappers.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from ao_kernel.ai_review_provider_wrappers import extract_json_object, normalize_provider_output
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _review_request() -> str:
+    return json.dumps(
+        {
+            "task": "review_high_risk_pr_change",
+            "context": {
+                "repository": "Halildeu/ao-kernel",
+                "work_package": "AO-MA-10X",
+                "changed_files": ["ao_kernel/ao_release_gate.py"],
+                "round_index": 1,
+            },
+            "diff": "diff --git a/ao_kernel/ao_release_gate.py b/ao_kernel/ao_release_gate.py\n",
+        }
+    )
+
+
+def _review_json(agent: str = "fake-reviewer") -> str:
+    return json.dumps(
+        {
+            "agent": agent,
+            "verdict": "AGREE",
+            "checks_considered": [
+                {"name": "tests", "status": "pass"},
+                {"name": "secret_scan", "status": "pass"},
+            ],
+            "findings": ["review clean"],
+        },
+        sort_keys=True,
+    )
+
+
+def _write_executable(path: Path, source: str) -> Path:
+    path.write_text(source, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _run_wrapper(provider: str, *, env: dict[str, str], stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    merged_env = os.environ.copy()
+    merged_env.update(env)
+    return subprocess.run(
+        [sys.executable, "-m", "ao_kernel.ai_review_provider_wrappers", provider],
+        cwd=ROOT,
+        input=stdin if stdin is not None else _review_request(),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=merged_env,
+        timeout=30,
+    )
+
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+    return proc.stdout.strip()
+
+
+def _repo_with_high_risk_change(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    target = repo / "ao_kernel" / "ao_release_gate.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("# base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "switch", "-c", "feature")
+    target.write_text("# base\n# high-risk provider wrapper change\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "feature")
+    return repo
+
+
+def test_extract_json_object_accepts_fenced_provider_output() -> None:
+    payload = extract_json_object("prefix\n```json\n" + _review_json() + "\n```\n", label="provider stdout")
+    assert payload["agent"] == "fake-reviewer"
+    assert payload["verdict"] == "AGREE"
+
+
+def test_normalize_provider_output_accepts_nested_reviewer_shape() -> None:
+    normalized = normalize_provider_output(
+        {
+            "reviewer": {"agent": "nested", "verdict": "AGREE"},
+            "checks_considered": [{"name": "tests", "status": "pass"}],
+            "findings": ["clean"],
+        },
+        provider="openai",
+    )
+    assert normalized == {
+        "agent": "nested",
+        "verdict": "AGREE",
+        "checks_considered": [{"name": "tests", "status": "pass"}],
+        "findings": ["clean"],
+    }
+
+
+def test_claude_wrapper_normalizes_fenced_json(tmp_path: Path) -> None:
+    fake = _write_executable(
+        tmp_path / "claude",
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import json, sys",
+                "assert sys.argv[1] == '-p'",
+                "assert 'review_request' in sys.argv[2]",
+                "print('```json')",
+                f"print({json.dumps(_review_json('claude-fake'))})",
+                "print('```')",
+            ]
+        )
+        + "\n",
+    )
+    proc = _run_wrapper("claude", env={"AO_MA10_CLAUDE_BIN": str(fake)})
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["agent"] == "claude-fake"
+
+
+def test_codex_wrapper_reads_output_last_message(tmp_path: Path) -> None:
+    fake = _write_executable(
+        tmp_path / "codex",
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import pathlib, sys",
+                "assert sys.argv[1] == 'exec'",
+                "assert '--sandbox' in sys.argv and 'read-only' in sys.argv",
+                "output = pathlib.Path(sys.argv[sys.argv.index('--output-last-message') + 1])",
+                f"output.write_text({json.dumps(_review_json('codex-fake'))})",
+                "print('ignored noisy stdout')",
+            ]
+        )
+        + "\n",
+    )
+    proc = _run_wrapper(
+        "codex",
+        env={"AO_MA10_CODEX_BIN": str(fake), "AO_MA10_CODEX_REPO_ROOT": str(tmp_path)},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["agent"] == "codex-fake"
+
+
+def test_mavis_wrapper_sends_prompt_and_polls_response(tmp_path: Path) -> None:
+    fake = _write_executable(
+        tmp_path / "mavis",
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import json, sys, time",
+                "args = sys.argv[1:]",
+                "if args[:2] == ['communication', 'send']:",
+                "    assert '--content' in args",
+                "    print(json.dumps({'messageId': 1, 'status': 'delivered'}))",
+                "elif args[:2] == ['communication', 'messages']:",
+                "    print(json.dumps({'messages': [{",
+                "      'from_session': 'mavis-session',",
+                "      'to_session': 'agent-session',",
+                "      'time_created': 1,",
+                "      'content': '{\"agent\":\"stale\",\"verdict\":\"AGREE\",\"checks_considered\":[{\"name\":\"tests\",\"status\":\"pass\"},{\"name\":\"secret_scan\",\"status\":\"pass\"}],\"findings\":[\"stale\"]}'",
+                "    }, {",
+                "      'from_session': 'mavis-session',",
+                "      'to_session': 'agent-session',",
+                "      'time_created': int(time.time() * 1000) + 1,",
+                f"      'content': '```json\\\\n{_review_json('mavis-fake')}\\\\n```'",
+                "    }]}))",
+                "else:",
+                "    raise SystemExit(3)",
+            ]
+        )
+        + "\n",
+    )
+    proc = _run_wrapper(
+        "mavis",
+        env={
+            "AO_MA10_MAVIS_BIN": str(fake),
+            "AO_MA10_MAVIS_FROM_SESSION_ID": "agent-session",
+            "AO_MA10_MAVIS_TO_SESSION_ID": "mavis-session",
+            "AO_MA10_MAVIS_POLL_SECONDS": "0.01",
+        },
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["agent"] == "mavis-fake"
+
+
+def test_ai_review_collect_uses_productized_provider_wrapper_envs(tmp_path: Path) -> None:
+    repo = _repo_with_high_risk_change(tmp_path)
+    claude = _write_executable(
+        tmp_path / "claude",
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import json",
+                f"print({json.dumps(_review_json('claude-env-wrapper'))})",
+            ]
+        )
+        + "\n",
+    )
+    codex = _write_executable(
+        tmp_path / "codex",
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import pathlib, sys",
+                "output = pathlib.Path(sys.argv[sys.argv.index('--output-last-message') + 1])",
+                f"output.write_text({json.dumps(_review_json('codex-env-wrapper'))})",
+            ]
+        )
+        + "\n",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "AO_MA10_CLAUDE_BIN": str(claude),
+            "AO_MA10_CODEX_BIN": str(codex),
+            "AO_MA10_CODEX_REPO_ROOT": str(repo),
+            "AO_MA10_OPENAI_REVIEW_CMD": f"{sys.executable} -m ao_kernel.ai_review_provider_wrappers codex",
+            "AO_MA10_ANTHROPIC_REVIEW_CMD": f"{sys.executable} -m ao_kernel.ai_review_provider_wrappers claude",
+        }
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ao_kernel.cli",
+            "ai-review",
+            "collect",
+            "--repository",
+            "Halildeu/ao-kernel",
+            "--work-package",
+            "AO-MA-10X",
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "feature",
+            "--repo-root",
+            str(repo),
+            "--output-dir",
+            str(tmp_path / "reviews"),
+            "--implementer-provider",
+            "minimax",
+            "--format",
+            "json",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    summary = json.loads(proc.stdout)
+    assert summary["raw_review_providers"] == ["openai", "anthropic"]

--- a/tests/test_ai_review_provider_wrappers.py
+++ b/tests/test_ai_review_provider_wrappers.py
@@ -6,6 +6,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+import ao_kernel.ai_review_provider_wrappers as wrappers
 from ao_kernel.ai_review_provider_wrappers import extract_json_object, normalize_provider_output
 
 
@@ -92,6 +95,43 @@ def test_extract_json_object_accepts_fenced_provider_output() -> None:
     assert payload["verdict"] == "AGREE"
 
 
+def test_extract_json_object_rejects_output_without_json() -> None:
+    with pytest.raises(ValueError, match="provider stdout did not contain a JSON object"):
+        extract_json_object("plain prose only", label="provider stdout")
+
+
+def test_timeout_seconds_validates_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AO_MA10_PROVIDER_TIMEOUT_SECONDS", raising=False)
+    assert wrappers._timeout_seconds() == wrappers.DEFAULT_TIMEOUT_SECONDS
+
+    monkeypatch.setenv("AO_MA10_PROVIDER_TIMEOUT_SECONDS", "7")
+    assert wrappers._timeout_seconds() == 7
+
+    monkeypatch.setenv("AO_MA10_PROVIDER_TIMEOUT_SECONDS", "not-an-int")
+    with pytest.raises(ValueError, match="must be an integer"):
+        wrappers._timeout_seconds()
+
+    monkeypatch.setenv("AO_MA10_PROVIDER_TIMEOUT_SECONDS", "4")
+    with pytest.raises(ValueError, match="between 5 and 900"):
+        wrappers._timeout_seconds()
+
+
+def test_wrapper_rejects_empty_invalid_and_non_object_stdin(tmp_path: Path) -> None:
+    fake = _write_executable(tmp_path / "claude", "#!/usr/bin/env python3\nraise SystemExit(99)\n")
+
+    empty = _run_wrapper("claude", env={"AO_MA10_CLAUDE_BIN": str(fake)}, stdin="")
+    assert empty.returncode == 2
+    assert "requires review request JSON" in empty.stderr
+
+    invalid = _run_wrapper("claude", env={"AO_MA10_CLAUDE_BIN": str(fake)}, stdin="{")
+    assert invalid.returncode == 2
+    assert "stdin is not valid JSON" in invalid.stderr
+
+    non_object = _run_wrapper("claude", env={"AO_MA10_CLAUDE_BIN": str(fake)}, stdin='["not", "object"]')
+    assert non_object.returncode == 2
+    assert "stdin must be a JSON object" in non_object.stderr
+
+
 def test_normalize_provider_output_accepts_nested_reviewer_shape() -> None:
     normalized = normalize_provider_output(
         {
@@ -130,6 +170,35 @@ def test_claude_wrapper_normalizes_fenced_json(tmp_path: Path) -> None:
     assert json.loads(proc.stdout)["agent"] == "claude-fake"
 
 
+def test_claude_wrapper_uses_configured_cwd_and_validates_stderr(tmp_path: Path) -> None:
+    fake = _write_executable(
+        tmp_path / "claude",
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import json, os, sys",
+                f"assert os.getcwd() == {json.dumps(str(tmp_path))}",
+                "print('diagnostic only', file=sys.stderr)",
+                f"print({json.dumps(_review_json('claude-cwd-fake'))})",
+            ]
+        )
+        + "\n",
+    )
+    proc = _run_wrapper(
+        "claude",
+        env={"AO_MA10_CLAUDE_BIN": str(fake), "AO_MA10_CLAUDE_CWD": str(tmp_path)},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["agent"] == "claude-cwd-fake"
+
+
+def test_claude_wrapper_reports_nonzero_provider_exit(tmp_path: Path) -> None:
+    fake = _write_executable(tmp_path / "claude", "#!/usr/bin/env python3\nraise SystemExit(7)\n")
+    proc = _run_wrapper("claude", env={"AO_MA10_CLAUDE_BIN": str(fake)})
+    assert proc.returncode == 2
+    assert "claude provider command failed with exit 7" in proc.stderr
+
+
 def test_codex_wrapper_reads_output_last_message(tmp_path: Path) -> None:
     fake = _write_executable(
         tmp_path / "codex",
@@ -152,6 +221,79 @@ def test_codex_wrapper_reads_output_last_message(tmp_path: Path) -> None:
     )
     assert proc.returncode == 0, proc.stderr
     assert json.loads(proc.stdout)["agent"] == "codex-fake"
+
+
+def test_codex_wrapper_falls_back_to_stdout_and_validates_stderr(tmp_path: Path) -> None:
+    fake = _write_executable(
+        tmp_path / "codex",
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import sys",
+                "assert '--output-last-message' in sys.argv",
+                "print('diagnostic only', file=sys.stderr)",
+                f"print({json.dumps(_review_json('codex-stdout-fake'))})",
+            ]
+        )
+        + "\n",
+    )
+    proc = _run_wrapper(
+        "codex",
+        env={"AO_MA10_CODEX_BIN": str(fake), "AO_MA10_CODEX_REPO_ROOT": str(tmp_path)},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["agent"] == "codex-stdout-fake"
+
+
+def test_codex_wrapper_reports_nonzero_provider_exit(tmp_path: Path) -> None:
+    fake = _write_executable(tmp_path / "codex", "#!/usr/bin/env python3\nraise SystemExit(9)\n")
+    proc = _run_wrapper(
+        "codex",
+        env={"AO_MA10_CODEX_BIN": str(fake), "AO_MA10_CODEX_REPO_ROOT": str(tmp_path)},
+    )
+    assert proc.returncode == 2
+    assert "codex provider command failed with exit 9" in proc.stderr
+
+
+def test_mavis_payload_helpers_accept_supported_shapes() -> None:
+    assert wrappers._messages_from_payload({"data": [{"content": "a"}]}) == [{"content": "a"}]
+    assert wrappers._messages_from_payload({"items": [{"content": "b"}]}) == [{"content": "b"}]
+    assert wrappers._messages_from_payload({"from_session": "mvs_a", "to_session": "mvs_b", "content": "c"}) == [
+        {"from_session": "mvs_a", "to_session": "mvs_b", "content": "c"}
+    ]
+    assert wrappers._messages_from_payload({"messages": "not-list"}) == []
+    assert wrappers._message_content({"content": {"nested": True}}) == '{"nested": true}'
+    assert wrappers._message_content({"unknown": "value"}) == '{"unknown": "value"}'
+    assert wrappers._message_created_ms({"timeCreated": "123"}) == 123
+    assert wrappers._message_created_ms({"createdAtMs": "not-digits"}) == 0
+    assert wrappers._message_session_value({"fromSession": "mvs_from"}, "from_session", "fromSession") == "mvs_from"
+    assert wrappers._message_session_value({}, "from_session") == ""
+
+
+def test_mavis_wrapper_reports_nonzero_command(tmp_path: Path) -> None:
+    fake = _write_executable(tmp_path / "mavis", "#!/usr/bin/env python3\nraise SystemExit(4)\n")
+    proc = _run_wrapper(
+        "mavis",
+        env={
+            "AO_MA10_MAVIS_BIN": str(fake),
+            "AO_MA10_MAVIS_POLL_SECONDS": "0.01",
+        },
+    )
+    assert proc.returncode == 2
+    assert "mavis command failed with exit 4" in proc.stderr
+
+
+def test_mavis_communication_mode_requires_session_ids(tmp_path: Path) -> None:
+    fake = _write_executable(tmp_path / "mavis", "#!/usr/bin/env python3\nraise SystemExit(99)\n")
+    proc = _run_wrapper(
+        "mavis",
+        env={
+            "AO_MA10_MAVIS_BIN": str(fake),
+            "AO_MA10_MAVIS_MODE": "communication",
+        },
+    )
+    assert proc.returncode == 2
+    assert "FROM_SESSION_ID and AO_MA10_MAVIS_TO_SESSION_ID are required" in proc.stderr
 
 
 def test_mavis_wrapper_sends_prompt_and_polls_response(tmp_path: Path) -> None:
@@ -196,6 +338,53 @@ def test_mavis_wrapper_sends_prompt_and_polls_response(tmp_path: Path) -> None:
     assert json.loads(proc.stdout)["agent"] == "mavis-fake"
 
 
+def test_mavis_communication_filters_wrong_and_unparseable_messages(tmp_path: Path) -> None:
+    fake = _write_executable(
+        tmp_path / "mavis",
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import json, sys, time",
+                "args = sys.argv[1:]",
+                "if args[:2] == ['communication', 'send']:",
+                "    print(json.dumps({'messageId': 1, 'status': 'delivered'}))",
+                "elif args[:2] == ['communication', 'messages']:",
+                "    now = int(time.time() * 1000) + 1",
+                "    print(json.dumps({'messages': [{",
+                "      'from_session': 'other-session',",
+                "      'to_session': 'agent-session',",
+                "      'time_created': now,",
+                "      'content': '{\"agent\":\"wrong\",\"verdict\":\"AGREE\",\"checks_considered\":[{\"name\":\"tests\",\"status\":\"pass\"}],\"findings\":[\"wrong\"]}'",
+                "    }, {",
+                "      'from_session': 'mavis-session',",
+                "      'to_session': 'agent-session',",
+                "      'time_created': now,",
+                "      'content': 'not json'",
+                "    }, {",
+                "      'from_session': 'mavis-session',",
+                "      'to_session': 'agent-session',",
+                "      'time_created': now,",
+                f"      'content': {json.dumps(_review_json('mavis-filtered-fake'))}",
+                "    }]}))",
+                "else:",
+                "    raise SystemExit(3)",
+            ]
+        )
+        + "\n",
+    )
+    proc = _run_wrapper(
+        "mavis",
+        env={
+            "AO_MA10_MAVIS_BIN": str(fake),
+            "AO_MA10_MAVIS_FROM_SESSION_ID": "agent-session",
+            "AO_MA10_MAVIS_TO_SESSION_ID": "mavis-session",
+            "AO_MA10_MAVIS_POLL_SECONDS": "0.01",
+        },
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["agent"] == "mavis-filtered-fake"
+
+
 def test_mavis_wrapper_defaults_to_new_session_mode(tmp_path: Path) -> None:
     fake = _write_executable(
         tmp_path / "mavis",
@@ -229,6 +418,68 @@ def test_mavis_wrapper_defaults_to_new_session_mode(tmp_path: Path) -> None:
     )
     assert proc.returncode == 0, proc.stderr
     assert json.loads(proc.stdout)["agent"] == "mavis-new-session-fake"
+
+
+def test_mavis_new_session_rejects_missing_session_id(tmp_path: Path) -> None:
+    fake = _write_executable(
+        tmp_path / "mavis",
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import json, sys",
+                "if sys.argv[1:3] == ['session', 'new']:",
+                "    print(json.dumps({'sessionId': 'not-a-mavis-session'}))",
+                "else:",
+                "    raise SystemExit(3)",
+            ]
+        )
+        + "\n",
+    )
+    proc = _run_wrapper(
+        "mavis",
+        env={"AO_MA10_MAVIS_BIN": str(fake), "AO_MA10_MAVIS_POLL_SECONDS": "0.01"},
+    )
+    assert proc.returncode == 2
+    assert "mavis session new did not return a sessionId" in proc.stderr
+
+
+def test_mavis_new_session_skips_non_assistant_and_unparseable_messages(tmp_path: Path) -> None:
+    fake = _write_executable(
+        tmp_path / "mavis",
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import json, sys",
+                "args = sys.argv[1:]",
+                "if args[:2] == ['session', 'new']:",
+                "    print(json.dumps({'sessionId': 'mvs_new_session_abcdef1234567890abcdef'}))",
+                "elif args[:2] == ['session', 'messages']:",
+                "    print(json.dumps({'messages': [{",
+                "      'role': 'user',",
+                "      'msg_content': " + json.dumps(_review_json("mavis-user-ignored")),
+                "    }, {",
+                "      'role': 'assistant',",
+                "      'msg_content': 'not json'",
+                "    }, {",
+                "      'role': 'model',",
+                "      'msg_content': " + json.dumps(_review_json("mavis-model-fake")),
+                "    }]}))",
+                "else:",
+                "    raise SystemExit(3)",
+            ]
+        )
+        + "\n",
+    )
+    proc = _run_wrapper(
+        "mavis",
+        env={
+            "AO_MA10_MAVIS_BIN": str(fake),
+            "AO_MA10_MAVIS_WORKSPACE": str(tmp_path),
+            "AO_MA10_MAVIS_POLL_SECONDS": "0.01",
+        },
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["agent"] == "mavis-model-fake"
 
 
 def test_ai_review_collect_uses_productized_provider_wrapper_envs(tmp_path: Path) -> None:

--- a/tests/test_ai_review_provider_wrappers.py
+++ b/tests/test_ai_review_provider_wrappers.py
@@ -196,6 +196,41 @@ def test_mavis_wrapper_sends_prompt_and_polls_response(tmp_path: Path) -> None:
     assert json.loads(proc.stdout)["agent"] == "mavis-fake"
 
 
+def test_mavis_wrapper_defaults_to_new_session_mode(tmp_path: Path) -> None:
+    fake = _write_executable(
+        tmp_path / "mavis",
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import json, sys",
+                "args = sys.argv[1:]",
+                "if args[:2] == ['session', 'new']:",
+                "    assert '--prompt' in args",
+                "    assert '--workspace' in args",
+                "    print(json.dumps({'sessionId': 'mvs_new_session_1234567890abcdef123456'}))",
+                "elif args[:2] == ['session', 'messages']:",
+                "    print(json.dumps({'messages': [{",
+                "      'role': 'assistant',",
+                "      'msg_content': " + json.dumps(_review_json("mavis-new-session-fake")),
+                "    }]}))",
+                "else:",
+                "    raise SystemExit(3)",
+            ]
+        )
+        + "\n",
+    )
+    proc = _run_wrapper(
+        "mavis",
+        env={
+            "AO_MA10_MAVIS_BIN": str(fake),
+            "AO_MA10_MAVIS_WORKSPACE": str(tmp_path),
+            "AO_MA10_MAVIS_POLL_SECONDS": "0.01",
+        },
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["agent"] == "mavis-new-session-fake"
+
+
 def test_ai_review_collect_uses_productized_provider_wrapper_envs(tmp_path: Path) -> None:
     repo = _repo_with_high_risk_change(tmp_path)
     claude = _write_executable(


### PR DESCRIPTION
## Summary

Adds productized provider command wrappers for the ai-review collect/consensus flow:

- `python3 -m ao_kernel.ai_review_provider_wrappers codex`
- `python3 -m ao_kernel.ai_review_provider_wrappers claude`
- `python3 -m ao_kernel.ai_review_provider_wrappers mavis`
- thin repo scripts under `scripts/ai_review_provider_*.py`
- docs in README, product quickstart, and Mavis runbook
- wrapper tests covering fenced JSON extraction, Codex output-last-message, Mavis async polling, stale-message rejection, fresh Mavis session mode, and ai-review ENV integration

## Verification

- `git diff --check`
- `python3 -m ruff check ao_kernel/ai_review_provider_wrappers.py scripts/ai_review_provider_claude.py scripts/ai_review_provider_codex.py scripts/ai_review_provider_mavis.py tests/test_ai_review_provider_wrappers.py tests/test_ai_review_cli.py`
- `python3 -m mypy ao_kernel/ai_review_provider_wrappers.py`
- `python3 -m pytest -q tests/test_ai_review_provider_wrappers.py tests/test_ai_review_cli.py` -> 15 passed
- `python3 -m ao_kernel.cli quality check-changelog ...` -> pass

## Live provider smoke

- Claude wrapper live smoke: transport/normalization OK, provider returned `REVISE` for intentionally weak high-risk smoke diff.
- Codex wrapper live smoke: transport/normalization OK, provider returned `BLOCK` for intentionally weak high-risk smoke diff.
- Mavis wrapper live smoke:
  - initial communication-mode stale-message acceptance bug was discovered,
  - fixed with send-time filtering,
  - improved to default fresh `mavis session new` mode,
  - fresh Mavis session returned normalized JSON with `REVISE` for intentionally weak high-risk smoke diff.
- `ai-review consensus` smoke against a disposable high-risk git repo with real Codex+Claude wrappers wrote an artifact and returned `not_agreed` as expected: provider verdicts `["BLOCK", "AGREE"]`.

## Cross-AI review

Claude adversarial review initially returned REVISE for a hardcoded Mavis path. Fixed by changing default to `mavis` and documenting `AO_MA10_MAVIS_BIN`. Claude re-review returned AGREE.

## Boundaries

- No secrets recorded.
- No GitHub mutation beyond this PR.
- AI output remains evidence only; release authority remains `ao-release-gate` plus GitHub ruleset.
- Mavis timeout/stale response is fail-closed, not approval.
