### PR TITLE
fix(ai-review): bind preflight evidence and final Mavis output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **AI-review preflight binding and Mavis final-message hardening**: require
+  explicit trusted test argv for `ai-review collect` and `consensus` (executed
+  directly without `shell=True`; the operator/config remains the trust boundary),
+  bind their no-output pass result plus the built-in diff secret scan to the
+  reviewed head SHA and diff digest, and ignore Mavis intermediate tool-call
+  envelopes until a schema-valid final review arrives. The v1 schemas accept
+  the new field additively for old-artifact compatibility while the current
+  emitter requires it. Release authority and all support/live-execution guard
+  flags remain unchanged.
 - **v4.3.1 changelog finalization**: consolidated landed productization and
   AI-review entries under the v4.3.1 release section without tagging,
   publishing, widening support, claiming production-platform readiness, or

--- a/ao_kernel/ai_review.py
+++ b/ao_kernel/ai_review.py
@@ -86,6 +86,17 @@ def sha256_text(value: str) -> str:
     return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
+def redacted_command_argv(argv: tuple[str, ...]) -> list[str]:
+    """Preserve only the executable name in persisted command provenance."""
+
+    return [argv[0], *("<redacted>" for _ in argv[1:])]
+
+
+def validate_timeout_seconds(value: int, *, label: str) -> None:
+    if value < 1 or value > 86400:
+        raise ValueError(f"{label} must be between 1 and 86400")
+
+
 def assert_no_secret_like_text(value: str, *, label: str) -> None:
     for pattern in SECRET_PATTERNS:
         if pattern.search(value):
@@ -167,8 +178,8 @@ def parse_provider_commands(
 
 
 def command_provenance(command: ProviderCommand, *, prompt_sha256: str, timeout_seconds: int) -> dict[str, Any]:
-    redacted_argv = list(command.argv)
-    rendered = shlex.join(redacted_argv)
+    redacted_argv = redacted_command_argv(command.argv)
+    rendered = shlex.join(list(command.argv))
     assert_no_secret_like_text(rendered, label=f"{command.provider} command argv")
     return {
         "provider_id": command.provider,
@@ -206,6 +217,89 @@ def build_context_binding(
     }
 
 
+def run_preflight_checks(
+    *,
+    repo_root: Path,
+    test_commands: list[str],
+    context_binding: dict[str, Any],
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    """Run trusted operator-configured argv and bind the result to the diff.
+
+    Commands execute directly without ``shell=True``. This is not a sandbox or
+    executable allowlist: whoever configures the gate is trusted to choose safe
+    test executables and must not place credentials in command arguments.
+    """
+
+    if not test_commands:
+        raise ValueError("at least one --test-command is required")
+    validate_timeout_seconds(timeout_seconds, label="--test-timeout-seconds")
+
+    command_results: list[dict[str, Any]] = []
+    for raw_command in test_commands:
+        assert_no_secret_like_text(raw_command, label="test command")
+        argv = tuple(shlex.split(raw_command))
+        if not argv:
+            raise ValueError("test command cannot be empty")
+        rendered = shlex.join(list(argv))
+        proc = subprocess.run(
+            list(argv),
+            cwd=repo_root,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f"test command failed with exit {proc.returncode}: {argv[0]}")
+        command_results.append(
+            {
+                "command_executable": argv[0],
+                "command_argv_redacted": redacted_command_argv(argv),
+                "command_argv_sha256": sha256_text(rendered),
+                "timeout_seconds": timeout_seconds,
+                "exit_code": 0,
+            }
+        )
+
+    return {
+        "head_sha": context_binding["head_sha"],
+        "diff_digest": context_binding["diff_digest"],
+        "tests": {"status": "pass", "commands": command_results},
+        "secret_scan": {
+            "status": "pass",
+            "scanner": "ao-kernel-diff-secret-patterns-v1",
+        },
+        "stdout_recorded": False,
+        "stderr_recorded": False,
+    }
+
+
+def assert_preflight_binding(preflight_evidence: dict[str, Any], context_binding: dict[str, Any]) -> None:
+    if preflight_evidence.get("head_sha") != context_binding.get("head_sha"):
+        raise ValueError("preflight head_sha does not match review context")
+    if preflight_evidence.get("diff_digest") != context_binding.get("diff_digest"):
+        raise ValueError("preflight diff_digest does not match review context")
+
+
+def assert_review_context_stable(
+    *,
+    repo_root: Path,
+    base_ref: str,
+    head_ref: str,
+    expected_head_sha: str,
+    expected_diff_sha256: str,
+    max_diff_bytes: int,
+) -> None:
+    """Fail closed if refs or reviewed diff move during a bounded review run."""
+
+    if head_sha(repo_root, head_ref) != expected_head_sha:
+        raise RuntimeError("review head changed while provider review was running")
+    current_diff = diff_text(repo_root, base_ref, head_ref, max_diff_bytes)
+    if sha256_text(current_diff) != expected_diff_sha256:
+        raise RuntimeError("review diff changed while provider review was running")
+
+
 def build_review_request(
     *,
     repository: str,
@@ -215,6 +309,7 @@ def build_review_request(
     changed: list[str],
     high_risk_changed_paths: list[str],
     rendered_diff: str,
+    preflight_evidence: dict[str, Any],
     round_index: int,
     previous_findings: list[dict[str, Any]],
 ) -> str:
@@ -245,6 +340,7 @@ def build_review_request(
             "high_risk_changed_paths": high_risk_changed_paths,
             "round_index": round_index,
             "previous_findings": previous_findings,
+            "preflight_evidence": preflight_evidence,
         },
         "diff": rendered_diff,
     }
@@ -426,11 +522,13 @@ def build_collection_artifact(
     implementer: dict[str, str],
     required_providers: tuple[str, ...],
     context_binding: dict[str, Any],
+    preflight_evidence: dict[str, Any],
     high_risk_changed_paths: list[str],
     raw_review_paths: dict[str, Path],
     round_results: list[ProviderRoundResult],
     timeout_seconds: int,
 ) -> dict[str, Any]:
+    assert_preflight_binding(preflight_evidence, context_binding)
     raw_paths = {provider: str(path) for provider, path in sorted(raw_review_paths.items())}
     provenance = [
         command_provenance(result.command, prompt_sha256=result.prompt_sha256, timeout_seconds=timeout_seconds)
@@ -451,6 +549,7 @@ def build_collection_artifact(
             **context_binding,
             "high_risk_changed_paths": high_risk_changed_paths,
         },
+        "preflight_evidence": preflight_evidence,
         "raw_review_paths": raw_paths,
         "provider_provenance": provenance,
         "collection_status": "collected",
@@ -477,9 +576,12 @@ def run_collect(
     repo_root: Path,
     output_dir: Path,
     provider_values: list[str] | None,
+    test_commands: list[str],
+    test_timeout_seconds: int,
     max_diff_bytes: int,
     timeout_seconds: int,
 ) -> dict[str, Any]:
+    validate_timeout_seconds(timeout_seconds, label="--timeout-seconds")
     required_providers = required_reviewer_providers(implementer_provider)
     provider_commands = parse_provider_commands(provider_values, required_providers=required_providers)
     changed = changed_files(repo_root, base_ref, head_ref)
@@ -489,6 +591,28 @@ def run_collect(
     if not high_risk_changed_paths:
         raise ValueError("no high-risk changed paths found; ai-review collect is not needed")
     rendered_diff = diff_text(repo_root, base_ref, head_ref, max_diff_bytes)
+    context = build_context_binding(
+        repository=repository,
+        repo_root=repo_root,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        changed=changed,
+    )
+    rendered_diff_sha256 = sha256_text(rendered_diff)
+    preflight = run_preflight_checks(
+        repo_root=repo_root,
+        test_commands=test_commands,
+        context_binding=context,
+        timeout_seconds=test_timeout_seconds,
+    )
+    assert_review_context_stable(
+        repo_root=repo_root,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        expected_head_sha=str(context["head_sha"]),
+        expected_diff_sha256=rendered_diff_sha256,
+        max_diff_bytes=max_diff_bytes,
+    )
     request = build_review_request(
         repository=repository,
         work_package=work_package,
@@ -497,6 +621,7 @@ def run_collect(
         changed=changed,
         high_risk_changed_paths=high_risk_changed_paths,
         rendered_diff=rendered_diff,
+        preflight_evidence=preflight,
         round_index=1,
         previous_findings=[],
     )
@@ -504,6 +629,14 @@ def run_collect(
         run_provider_command(provider_commands[provider], review_request=request, timeout_seconds=timeout_seconds)
         for provider in required_providers
     ]
+    assert_review_context_stable(
+        repo_root=repo_root,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        expected_head_sha=str(context["head_sha"]),
+        expected_diff_sha256=rendered_diff_sha256,
+        max_diff_bytes=max_diff_bytes,
+    )
     implementer = {"agent": implementer_agent, "provider": implementer_provider}
     raw_paths = write_raw_reviews(
         output_dir=output_dir,
@@ -515,19 +648,13 @@ def run_collect(
         head_ref=head_ref,
         changed=changed,
     )
-    context = build_context_binding(
-        repository=repository,
-        repo_root=repo_root,
-        base_ref=base_ref,
-        head_ref=head_ref,
-        changed=changed,
-    )
     artifact = build_collection_artifact(
         repository=repository,
         work_package=work_package,
         implementer=implementer,
         required_providers=required_providers,
         context_binding=context,
+        preflight_evidence=preflight,
         high_risk_changed_paths=high_risk_changed_paths,
         raw_review_paths=raw_paths,
         round_results=results,
@@ -544,6 +671,7 @@ def build_consensus_artifact(
     work_package: str,
     implementer: dict[str, str],
     context_binding: dict[str, Any],
+    preflight_evidence: dict[str, Any],
     high_risk_changed_paths: list[str],
     required_providers: tuple[str, ...],
     rounds: list[dict[str, Any]],
@@ -552,6 +680,7 @@ def build_consensus_artifact(
     collection_path: Path | None,
     max_rounds: int,
 ) -> dict[str, Any]:
+    assert_preflight_binding(preflight_evidence, context_binding)
     artifact = {
         "schema_version": "ai-review-consensus-evidence.v1",
         "artifact_kind": "ai_review_consensus_evidence",
@@ -566,6 +695,7 @@ def build_consensus_artifact(
             **context_binding,
             "high_risk_changed_paths": high_risk_changed_paths,
         },
+        "preflight_evidence": preflight_evidence,
         "rounds": rounds,
         "consensus_status": consensus_status,
         "max_rounds": max_rounds,
@@ -595,12 +725,15 @@ def run_consensus(
     repo_root: Path,
     output_dir: Path,
     provider_values: list[str] | None,
+    test_commands: list[str],
+    test_timeout_seconds: int,
     max_diff_bytes: int,
     timeout_seconds: int,
     max_rounds: int,
 ) -> dict[str, Any]:
     if max_rounds <= 0 or max_rounds > 3:
         raise ValueError("--max-rounds must be between 1 and 3")
+    validate_timeout_seconds(timeout_seconds, label="--timeout-seconds")
     required_providers = required_reviewer_providers(implementer_provider)
     provider_commands = parse_provider_commands(provider_values, required_providers=required_providers)
     changed = changed_files(repo_root, base_ref, head_ref)
@@ -617,6 +750,13 @@ def run_consensus(
         head_ref=head_ref,
         changed=changed,
     )
+    rendered_diff_sha256 = sha256_text(rendered_diff)
+    preflight = run_preflight_checks(
+        repo_root=repo_root,
+        test_commands=test_commands,
+        context_binding=context,
+        timeout_seconds=test_timeout_seconds,
+    )
     previous_findings: list[dict[str, Any]] = []
     rounds: list[dict[str, Any]] = []
     agreeing_results: list[ProviderRoundResult] = []
@@ -624,6 +764,14 @@ def run_consensus(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     for round_index in range(1, max_rounds + 1):
+        assert_review_context_stable(
+            repo_root=repo_root,
+            base_ref=base_ref,
+            head_ref=head_ref,
+            expected_head_sha=str(context["head_sha"]),
+            expected_diff_sha256=rendered_diff_sha256,
+            max_diff_bytes=max_diff_bytes,
+        )
         request = build_review_request(
             repository=repository,
             work_package=work_package,
@@ -632,6 +780,7 @@ def run_consensus(
             changed=changed,
             high_risk_changed_paths=high_risk_changed_paths,
             rendered_diff=rendered_diff,
+            preflight_evidence=preflight,
             round_index=round_index,
             previous_findings=previous_findings,
         )
@@ -639,6 +788,14 @@ def run_consensus(
             run_provider_command(provider_commands[provider], review_request=request, timeout_seconds=timeout_seconds)
             for provider in required_providers
         ]
+        assert_review_context_stable(
+            repo_root=repo_root,
+            base_ref=base_ref,
+            head_ref=head_ref,
+            expected_head_sha=str(context["head_sha"]),
+            expected_diff_sha256=rendered_diff_sha256,
+            max_diff_bytes=max_diff_bytes,
+        )
         round_record = {
             "round_index": round_index,
             "provider_results": [
@@ -669,6 +826,14 @@ def run_consensus(
             if result.verdict != "AGREE"
         ]
 
+    assert_review_context_stable(
+        repo_root=repo_root,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        expected_head_sha=str(context["head_sha"]),
+        expected_diff_sha256=rendered_diff_sha256,
+        max_diff_bytes=max_diff_bytes,
+    )
     implementer = {"agent": implementer_agent, "provider": implementer_provider}
     raw_paths: dict[str, Path] = {}
     collection_path: Path | None = None
@@ -689,6 +854,7 @@ def run_consensus(
             implementer=implementer,
             required_providers=required_providers,
             context_binding=context,
+            preflight_evidence=preflight,
             high_risk_changed_paths=high_risk_changed_paths,
             raw_review_paths=raw_paths,
             round_results=agreeing_results,
@@ -702,6 +868,7 @@ def run_consensus(
         work_package=work_package,
         implementer=implementer,
         context_binding=context,
+        preflight_evidence=preflight,
         high_risk_changed_paths=high_risk_changed_paths,
         required_providers=required_providers,
         rounds=rounds,
@@ -1093,6 +1260,16 @@ def add_ai_review_subparser(sub: argparse._SubParsersAction[argparse.ArgumentPar
             default=[],
             help="provider=command; missing commands can be supplied via AO_MA10_*_REVIEW_CMD env vars",
         )
+        p.add_argument(
+            "--test-command",
+            action="append",
+            required=True,
+            help=(
+                "Trusted operator-configured test argv, executed without shell=True; repeat for multiple suites. "
+                "Output is never recorded."
+            ),
+        )
+        p.add_argument("--test-timeout-seconds", type=int, default=600)
         p.add_argument("--max-diff-bytes", type=int, default=200_000)
         p.add_argument("--timeout-seconds", type=int, default=600)
         p.add_argument("--format", choices=["text", "json"], default="json")
@@ -1144,6 +1321,8 @@ def dispatch_ai_review(args: argparse.Namespace) -> int:
                 repo_root=args.repo_root.resolve(),
                 output_dir=args.output_dir.resolve(),
                 provider_values=args.provider,
+                test_commands=args.test_command,
+                test_timeout_seconds=args.test_timeout_seconds,
                 max_diff_bytes=args.max_diff_bytes,
                 timeout_seconds=args.timeout_seconds,
             )
@@ -1160,6 +1339,8 @@ def dispatch_ai_review(args: argparse.Namespace) -> int:
                 repo_root=args.repo_root.resolve(),
                 output_dir=args.output_dir.resolve(),
                 provider_values=args.provider,
+                test_commands=args.test_command,
+                test_timeout_seconds=args.test_timeout_seconds,
                 max_diff_bytes=args.max_diff_bytes,
                 timeout_seconds=args.timeout_seconds,
                 max_rounds=args.max_rounds,

--- a/ao_kernel/ai_review_provider_wrappers.py
+++ b/ao_kernel/ai_review_provider_wrappers.py
@@ -93,7 +93,8 @@ def _prompt_for_provider(request: dict[str, Any], *, provider_name: str) -> str:
             "Review the request JSON as an independent reviewer.",
             "Treat review_request as the authority; do not rely on ambient working-directory state.",
             "Return exactly one JSON object and no prose.",
-            "Use AGREE only when tests, secret scan, scope, drift, and forbidden-action checks are clean.",
+            "Use AGREE only when the context-bound preflight evidence records tests and secret_scan as pass, and scope, drift, and forbidden-action checks are clean.",
+            "When preflight evidence passes, include checks named exactly tests and secret_scan with status pass.",
             "Use REVISE or BLOCK when any issue remains.",
             "Do not include secret values in findings.",
             "AI output is evidence only; release authority remains ao-release-gate plus GitHub ruleset.",
@@ -268,7 +269,18 @@ def _message_content(message: dict[str, Any]) -> str:
             return value
         if isinstance(value, dict):
             return json.dumps(value, sort_keys=True)
-    return json.dumps(message, sort_keys=True)
+    return ""
+
+
+def _normalized_review_from_message(message: dict[str, Any], *, label: str) -> dict[str, Any] | None:
+    content = _message_content(message)
+    if not content:
+        return None
+    try:
+        review = extract_json_object(content, label=label)
+        return normalize_provider_output(review, provider="minimax")
+    except ValueError:
+        return None
 
 
 def _message_created_ms(message: dict[str, Any]) -> int:
@@ -329,12 +341,10 @@ def _run_mavis_communication_provider(prompt: str, *, timeout: int) -> int:
             message_to = _message_session_value(message, "to_session", "toSession", "to")
             if message_from != to_session or message_to != from_session:
                 continue
-            content = _message_content(message)
-            try:
-                review = extract_json_object(content, label="mavis response content")
-            except ValueError:
+            review = _normalized_review_from_message(message, label="mavis response content")
+            if review is None:
                 continue
-            return _emit(normalize_provider_output(review, provider="minimax"))
+            return _emit(review)
         time.sleep(poll_interval)
     raise TimeoutError("mavis provider did not return valid review JSON before timeout")
 
@@ -374,12 +384,10 @@ def _run_mavis_new_session_provider(prompt: str, *, timeout: int) -> int:
             role = message.get("role")
             if role not in {"assistant", "model"}:
                 continue
-            content = _message_content(message)
-            try:
-                review = extract_json_object(content, label="mavis session assistant content")
-            except ValueError:
+            review = _normalized_review_from_message(message, label="mavis session assistant content")
+            if review is None:
                 continue
-            return _emit(normalize_provider_output(review, provider="minimax"))
+            return _emit(review)
         time.sleep(poll_interval)
     raise TimeoutError(f"mavis session {session_id} did not return valid review JSON before timeout")
 

--- a/ao_kernel/defaults/schemas/ai-review-collection-evidence.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ai-review-collection-evidence.schema.v1.json
@@ -48,6 +48,7 @@
       "items": { "$ref": "#/$defs/provider_id" }
     },
     "context_binding": { "$ref": "#/$defs/context_binding" },
+    "preflight_evidence": { "$ref": "#/$defs/preflight_evidence" },
     "raw_review_paths": {
       "type": "object",
       "minProperties": 2,
@@ -127,6 +128,51 @@
         "command_argv_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
         "prompt_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
         "timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 86400 }
+      }
+    },
+    "preflight_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["head_sha", "diff_digest", "tests", "secret_scan", "stdout_recorded", "stderr_recorded"],
+      "properties": {
+        "head_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "diff_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "tests": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "commands"],
+          "properties": {
+            "status": { "type": "string", "const": "pass" },
+            "commands": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/preflight_command" }
+            }
+          }
+        },
+        "secret_scan": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "scanner"],
+          "properties": {
+            "status": { "type": "string", "const": "pass" },
+            "scanner": { "type": "string", "const": "ao-kernel-diff-secret-patterns-v1" }
+          }
+        },
+        "stdout_recorded": { "type": "boolean", "const": false },
+        "stderr_recorded": { "type": "boolean", "const": false }
+      }
+    },
+    "preflight_command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command_executable", "command_argv_redacted", "command_argv_sha256", "timeout_seconds", "exit_code"],
+      "properties": {
+        "command_executable": { "type": "string", "minLength": 1 },
+        "command_argv_redacted": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "command_argv_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 86400 },
+        "exit_code": { "type": "integer", "const": 0 }
       }
     },
     "guard_flags": {

--- a/ao_kernel/defaults/schemas/ai-review-consensus-evidence.schema.v1.json
+++ b/ao_kernel/defaults/schemas/ai-review-consensus-evidence.schema.v1.json
@@ -43,6 +43,7 @@
       "items": { "$ref": "#/$defs/provider_id" }
     },
     "context_binding": { "$ref": "#/$defs/context_binding" },
+    "preflight_evidence": { "$ref": "#/$defs/preflight_evidence" },
     "rounds": {
       "type": "array",
       "minItems": 1,
@@ -122,6 +123,51 @@
         "command_argv_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
         "prompt_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
         "timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 86400 }
+      }
+    },
+    "preflight_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["head_sha", "diff_digest", "tests", "secret_scan", "stdout_recorded", "stderr_recorded"],
+      "properties": {
+        "head_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "diff_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "tests": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "commands"],
+          "properties": {
+            "status": { "type": "string", "const": "pass" },
+            "commands": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/preflight_command" }
+            }
+          }
+        },
+        "secret_scan": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "scanner"],
+          "properties": {
+            "status": { "type": "string", "const": "pass" },
+            "scanner": { "type": "string", "const": "ao-kernel-diff-secret-patterns-v1" }
+          }
+        },
+        "stdout_recorded": { "type": "boolean", "const": false },
+        "stderr_recorded": { "type": "boolean", "const": false }
+      }
+    },
+    "preflight_command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command_executable", "command_argv_redacted", "command_argv_sha256", "timeout_seconds", "exit_code"],
+      "properties": {
+        "command_executable": { "type": "string", "minLength": 1 },
+        "command_argv_redacted": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "command_argv_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 86400 },
+        "exit_code": { "type": "integer", "const": 0 }
       }
     },
     "guard_flags": {

--- a/docs/PRODUCT-QUICKSTART.md
+++ b/docs/PRODUCT-QUICKSTART.md
@@ -159,6 +159,7 @@ ao-kernel ai-review collect \
   --head-ref HEAD \
   --repo-root . \
   --implementer-provider openai \
+  --test-command 'python3 -m pytest -q' \
   --output-dir .ao/ai-review \
   --format json
 ```
@@ -173,6 +174,7 @@ ao-kernel ai-review consensus \
   --head-ref HEAD \
   --repo-root . \
   --implementer-provider openai \
+  --test-command 'python3 -m pytest -q' \
   --max-rounds 3 \
   --output-dir .ao/ai-review \
   --format json
@@ -188,11 +190,20 @@ The bundled provider wrappers are the recommended command form:
 
 Each collection/consensus artifact records:
 
+- a head-SHA and diff-digest-bound test preflight whose command output is never recorded,
 - `command_argv_sha256`,
 - redacted command argv,
 - `prompt_sha256`,
 - context binding (`head_sha`, changed-files digest, changed-file count),
 - guard flags fixed to false.
+
+`--test-command` is trusted operator or repository configuration. ao-kernel
+parses it into argv and executes it directly without `shell=True`, but it does
+not sandbox or allowlist the selected executable. Do not put credentials in
+command arguments; persisted provenance keeps only the executable, fully
+redacted argument placeholders, and a SHA-256 command binding. The built-in
+secret scan is pattern-based and fail-closed for the recognized credential
+formats; it is not a general secret-discovery substitute.
 
 The CLI `--format json` output is deliberately a safe status/provider summary.
 Read the durable files under `--output-dir` for full path and provenance data.

--- a/local-ai-review-evidence.v1.json
+++ b/local-ai-review-evidence.v1.json
@@ -30,13 +30,13 @@
     }
   ],
   "findings": [
-    "Claude independent review returned AGREE for the final staged scope: CHANGELOG.md and local-ai-review-evidence.v1.json.",
-    "The changed files match release-readiness work package V431-CHANGELOG-FINALIZE with no out-of-scope files.",
-    "CHANGELOG.md moves landed entries into the dated 4.3.1 section and adds an Unreleased bullet explicitly stating no tag push, no PyPI publish dispatch, no support widening, no production-platform claim, and no live-adapter execution.",
-    "local-ai-review-evidence.v1.json updates scope_reviewed.changed_files, head_ref, and work_package to match this PR while keeping secrets_recorded, support_widening, production_platform_claim, and live_adapter_execution false.",
-    "Local verification supplied to the reviewer: 8 targeted tests passed, packaging_smoke passed, fresh_install_product_smoke passed, and changelog enforcement passed.",
-    "No secret material, credentials, tokens, private keys, credential-bearing URLs, admin bypass, branch-protection weakening, gate weakening, tag push, PyPI publish dispatch, support widening, production-platform claim, live-adapter execution, or AI-as-release-authority drift was introduced.",
-    "Release authority remains ao-release-gate plus GitHub ruleset; this AI review is evidence only."
+    "Claude independent post-implementation review returned REVISE, the findings were absorbed, and the unchanged final implementation returned AGREE with no blocking findings.",
+    "The exact scope hardens ai-review preflight provenance, head and diff stability, Mavis final-message parsing, schemas, tests, documentation, changelog, and this bound review evidence only.",
+    "Full regression supplied to the reviewer passed with 7166 tests and 114 skips; focused AI-review tests, ruff, mypy, JSON validation, and diff checks also passed.",
+    "The v1 schema extension is additive for old-artifact compatibility while the current emitter always writes context-bound preflight evidence.",
+    "Persisted command provenance exposes only the executable, redacted argument placeholders, and cryptographic hashes; test output and credential material are not recorded.",
+    "No credential read or write, production or test state mutation, GitHub ruleset change, admin bypass, support widening, production-platform claim, or live-adapter execution is introduced.",
+    "AI output remains evidence only; release authority remains ao-release-gate plus GitHub ruleset."
   ],
   "implementer": {
     "agent": "codex",
@@ -55,11 +55,18 @@
     "base_ref": "refs/heads/main",
     "changed_files": [
       "CHANGELOG.md",
-      "local-ai-review-evidence.v1.json"
+      "ao_kernel/ai_review.py",
+      "ao_kernel/ai_review_provider_wrappers.py",
+      "ao_kernel/defaults/schemas/ai-review-collection-evidence.schema.v1.json",
+      "ao_kernel/defaults/schemas/ai-review-consensus-evidence.schema.v1.json",
+      "docs/PRODUCT-QUICKSTART.md",
+      "local-ai-review-evidence.v1.json",
+      "tests/test_ai_review_cli.py",
+      "tests/test_ai_review_provider_wrappers.py"
     ],
-    "head_ref": "refs/heads/codex/release-4.3.1-readiness"
+    "head_ref": "refs/heads/codex/ai-review-preflight-mavis-final"
   },
   "secrets_recorded": false,
   "support_widening": false,
-  "work_package": "V431-CHANGELOG-FINALIZE"
+  "work_package": "AI-REVIEW-PREFLIGHT-HARDENING"
 }

--- a/tests/test_ai_review_cli.py
+++ b/tests/test_ai_review_cli.py
@@ -154,6 +154,73 @@ def _round_result(
     )
 
 
+def test_preflight_checks_are_context_bound_and_fail_closed(tmp_path: Path) -> None:
+    context = {
+        "head_sha": "a" * 40,
+        "diff_digest": "sha256:" + "b" * 64,
+    }
+    preflight = ai_review.run_preflight_checks(
+        repo_root=tmp_path,
+        test_commands=[f"{sys.executable} -c pass short-sensitive-value"],
+        context_binding=context,
+        timeout_seconds=10,
+    )
+    assert preflight["head_sha"] == context["head_sha"]
+    assert preflight["diff_digest"] == context["diff_digest"]
+    assert preflight["tests"]["status"] == "pass"
+    assert preflight["tests"]["commands"][0]["command_argv_redacted"] == [
+        sys.executable,
+        "<redacted>",
+        "<redacted>",
+        "<redacted>",
+    ]
+    assert "short-sensitive-value" not in json.dumps(preflight)
+    assert preflight["secret_scan"] == {
+        "status": "pass",
+        "scanner": "ao-kernel-diff-secret-patterns-v1",
+    }
+    assert preflight["stdout_recorded"] is False
+    assert preflight["stderr_recorded"] is False
+
+    with pytest.raises(ValueError, match="at least one --test-command"):
+        ai_review.run_preflight_checks(
+            repo_root=tmp_path,
+            test_commands=[],
+            context_binding=context,
+            timeout_seconds=10,
+        )
+    for timeout_seconds in (0, 86401):
+        with pytest.raises(ValueError, match="--test-timeout-seconds"):
+            ai_review.run_preflight_checks(
+                repo_root=tmp_path,
+                test_commands=["true"],
+                context_binding=context,
+                timeout_seconds=timeout_seconds,
+            )
+    with pytest.raises(RuntimeError, match="test command failed"):
+        ai_review.run_preflight_checks(
+            repo_root=tmp_path,
+            test_commands=["false"],
+            context_binding=context,
+            timeout_seconds=10,
+        )
+    secret_like = "token=" + "gh" + "p_" + ("1" * 36)
+    with pytest.raises(ValueError, match="secret-like"):
+        ai_review.run_preflight_checks(
+            repo_root=tmp_path,
+            test_commands=[secret_like],
+            context_binding=context,
+            timeout_seconds=10,
+        )
+    with pytest.raises(ValueError, match="head_sha"):
+        ai_review.assert_preflight_binding({**preflight, "head_sha": "c" * 40}, context)
+    with pytest.raises(ValueError, match="diff_digest"):
+        ai_review.assert_preflight_binding(
+            {**preflight, "diff_digest": "sha256:" + "d" * 64},
+            context,
+        )
+
+
 def test_ai_review_collect_writes_raw_reviews_and_provenance(tmp_path: Path) -> None:
     repo = _repo_with_high_risk_change(tmp_path)
     fake = _fake_provider(tmp_path)
@@ -177,6 +244,8 @@ def test_ai_review_collect_writes_raw_reviews_and_provenance(tmp_path: Path) -> 
             str(output_dir),
             "--implementer-provider",
             "google",
+            "--test-command",
+            "true",
             "--provider",
             f"openai={_cmd('openai', fake)}",
             "--provider",
@@ -193,8 +262,14 @@ def test_ai_review_collect_writes_raw_reviews_and_provenance(tmp_path: Path) -> 
     }
     payload = json.loads((output_dir / "ai_review_collection.v1.json").read_text())
     _validate("ai-review-collection-evidence.schema.v1.json", payload)
+    legacy_payload = dict(payload)
+    legacy_payload.pop("preflight_evidence")
+    _validate("ai-review-collection-evidence.schema.v1.json", legacy_payload)
     assert payload["collection_status"] == "collected"
     assert payload["ai_output_release_authority"] is False
+    assert payload["preflight_evidence"]["tests"]["status"] == "pass"
+    assert payload["preflight_evidence"]["head_sha"] == payload["context_binding"]["head_sha"]
+    assert payload["preflight_evidence"]["diff_digest"] == payload["context_binding"]["diff_digest"]
     assert payload["guard_flags"] == {
         "live_adapter_execution": False,
         "production_platform_claim": False,
@@ -204,7 +279,58 @@ def test_ai_review_collect_writes_raw_reviews_and_provenance(tmp_path: Path) -> 
     assert len(payload["provider_provenance"]) == 2
     for provenance in payload["provider_provenance"]:
         assert provenance["command_argv_sha256"].startswith("sha256:")
+        assert provenance["command_argv_redacted"][0] == sys.executable
+        assert set(provenance["command_argv_redacted"][1:]) == {"<redacted>"}
         assert provenance["prompt_sha256"].startswith("sha256:")
+
+
+def test_command_provenance_redacts_every_non_executable_argument() -> None:
+    command = ai_review.ProviderCommand(
+        provider="anthropic",
+        argv=("review-provider", "--profile", "short-sensitive-value"),
+        source="test",
+    )
+    provenance = ai_review.command_provenance(
+        command,
+        prompt_sha256="sha256:" + "a" * 64,
+        timeout_seconds=30,
+    )
+    assert provenance["command_executable"] == "review-provider"
+    assert provenance["command_argv_redacted"] == ["review-provider", "<redacted>", "<redacted>"]
+    assert "short-sensitive-value" not in json.dumps(provenance)
+
+
+def test_review_context_stability_fails_closed_when_head_moves(tmp_path: Path) -> None:
+    repo = _repo_with_high_risk_change(tmp_path)
+    rendered_diff = ai_review.diff_text(repo, "main", "feature", 200_000)
+    expected_head = ai_review.head_sha(repo, "feature")
+    ai_review.assert_review_context_stable(
+        repo_root=repo,
+        base_ref="main",
+        head_ref="feature",
+        expected_head_sha=expected_head,
+        expected_diff_sha256=ai_review.sha256_text(rendered_diff),
+        max_diff_bytes=200_000,
+    )
+    (repo / "ao_kernel" / "ao_release_gate.py").write_text("# moved\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "move reviewed head")
+    with pytest.raises(RuntimeError, match="review head changed"):
+        ai_review.assert_review_context_stable(
+            repo_root=repo,
+            base_ref="main",
+            head_ref="feature",
+            expected_head_sha=expected_head,
+            expected_diff_sha256=ai_review.sha256_text(rendered_diff),
+            max_diff_bytes=200_000,
+        )
+
+
+def test_collection_and_consensus_preflight_schema_defs_cannot_drift() -> None:
+    collection = load_default("schemas", "ai-review-collection-evidence.schema.v1.json")
+    consensus = load_default("schemas", "ai-review-consensus-evidence.schema.v1.json")
+    for definition in ("preflight_evidence", "preflight_command"):
+        assert collection["$defs"][definition] == consensus["$defs"][definition]
 
 
 def test_ai_review_python_api_covers_productized_main_paths(tmp_path: Path) -> None:
@@ -225,6 +351,8 @@ def test_ai_review_python_api_covers_productized_main_paths(tmp_path: Path) -> N
             f"openai={_cmd('openai', fake)}",
             f"anthropic={_cmd('anthropic', fake)}",
         ],
+        test_commands=["true"],
+        test_timeout_seconds=30,
         max_diff_bytes=200_000,
         timeout_seconds=30,
     )
@@ -246,6 +374,8 @@ def test_ai_review_python_api_covers_productized_main_paths(tmp_path: Path) -> N
             f"openai={_cmd('openai', fake)}",
             f"anthropic={_cmd('anthropic', fake)}",
         ],
+        test_commands=["true"],
+        test_timeout_seconds=30,
         max_diff_bytes=200_000,
         timeout_seconds=30,
         max_rounds=1,
@@ -471,6 +601,8 @@ def test_ai_review_consensus_runs_bounded_ping_pong_until_agree(tmp_path: Path) 
             "google",
             "--max-rounds",
             "2",
+            "--test-command",
+            "true",
             "--provider",
             f"openai={_cmd('openai', fake, openai_state)}",
             "--provider",
@@ -487,6 +619,9 @@ def test_ai_review_consensus_runs_bounded_ping_pong_until_agree(tmp_path: Path) 
     }
     payload = json.loads((output_dir / "ai_review_consensus.v1.json").read_text())
     _validate("ai-review-consensus-evidence.schema.v1.json", payload)
+    legacy_payload = dict(payload)
+    legacy_payload.pop("preflight_evidence")
+    _validate("ai-review-consensus-evidence.schema.v1.json", legacy_payload)
     assert payload["consensus_status"] == "AGREE"
     assert [round_payload["round_index"] for round_payload in payload["rounds"]] == [1, 2]
     assert {result["verdict"] for result in payload["rounds"][0]["provider_results"]} == {"REVISE"}
@@ -520,6 +655,8 @@ def test_ai_review_consensus_fails_closed_when_max_rounds_exhausted(tmp_path: Pa
             "google",
             "--max-rounds",
             "1",
+            "--test-command",
+            "true",
             "--provider",
             f"openai={_cmd('openai', fake)}",
             "--provider",
@@ -565,6 +702,8 @@ def test_ai_review_high_risk_dry_run_proves_gate_allow_without_github_mutation(t
             str(output_dir),
             "--implementer-provider",
             "google",
+            "--test-command",
+            "true",
             "--provider",
             f"openai={_cmd('openai', fake)}",
             "--provider",

--- a/tests/test_ai_review_provider_wrappers.py
+++ b/tests/test_ai_review_provider_wrappers.py
@@ -364,7 +364,7 @@ def test_mavis_payload_helpers_accept_supported_shapes() -> None:
     ]
     assert wrappers._messages_from_payload({"messages": "not-list"}) == []
     assert wrappers._message_content({"content": {"nested": True}}) == '{"nested": true}'
-    assert wrappers._message_content({"unknown": "value"}) == '{"unknown": "value"}'
+    assert wrappers._message_content({"unknown": "value"}) == ""
     assert wrappers._message_created_ms({"timeCreated": "123"}) == 123
     assert wrappers._message_created_ms({"createdAtMs": "not-digits"}) == 0
     assert wrappers._message_session_value({"fromSession": "mvs_from"}, "from_session", "fromSession") == "mvs_from"
@@ -471,6 +471,53 @@ def test_run_mavis_provider_direct_communication_mode(
     assert wrappers.run_mavis_provider() == 0
     assert calls[0][:2] == ["communication", "send"]
     assert json.loads(capsys.readouterr().out)["agent"] == "mavis-direct-communication"
+
+
+def test_mavis_communication_ignores_tool_call_envelopes_before_final_review(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _set_stdin(monkeypatch)
+    monkeypatch.setenv("AO_MA10_MAVIS_MODE", "communication")
+    monkeypatch.setenv("AO_MA10_MAVIS_FROM_SESSION_ID", "agent-session")
+    monkeypatch.setenv("AO_MA10_MAVIS_TO_SESSION_ID", "mavis-session")
+    monkeypatch.setenv("AO_MA10_MAVIS_POLL_SECONDS", "0.01")
+    poll_count = 0
+
+    def fake_run_mavis(args: list[str], *, timeout: int) -> dict[str, object]:
+        nonlocal poll_count
+        if args[:2] == ["communication", "send"]:
+            return {"messageId": 1, "status": "delivered"}
+        poll_count += 1
+        now = int(wrappers.time.time() * 1000) + 1
+        messages: list[dict[str, object]] = [
+            {
+                "from_session": "mavis-session",
+                "to_session": "agent-session",
+                "time_created": now,
+                "tool_calls": [{"tool_name": "bash", "arguments": {"verdict": "AGREE"}}],
+            },
+            {
+                "from_session": "mavis-session",
+                "to_session": "agent-session",
+                "time_created": now,
+                "content": '{"event":"tool-call-complete"}',
+            },
+        ]
+        if poll_count > 1:
+            messages.append(
+                {
+                    "from_session": "mavis-session",
+                    "to_session": "agent-session",
+                    "time_created": now,
+                    "content": _review_json("mavis-communication-final-review"),
+                }
+            )
+        return {"messages": messages}
+
+    monkeypatch.setattr(wrappers, "_run_mavis", fake_run_mavis)
+    assert wrappers.run_mavis_provider() == 0
+    assert poll_count == 2
+    assert json.loads(capsys.readouterr().out)["agent"] == "mavis-communication-final-review"
 
 
 def test_mavis_wrapper_sends_prompt_and_polls_response(tmp_path: Path) -> None:
@@ -688,6 +735,37 @@ def test_run_mavis_provider_direct_new_session_mode(
     assert json.loads(capsys.readouterr().out)["agent"] == "mavis-direct-new-session"
 
 
+def test_mavis_new_session_ignores_tool_call_envelopes_before_final_review(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    _set_stdin(monkeypatch)
+    monkeypatch.setenv("AO_MA10_MAVIS_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("AO_MA10_MAVIS_POLL_SECONDS", "0.01")
+    poll_count = 0
+
+    def fake_run_mavis(args: list[str], *, timeout: int) -> dict[str, object]:
+        nonlocal poll_count
+        if args[:2] == ["session", "new"]:
+            return {"sessionId": "mvs_tool_call_then_final_abcdef1234567890"}
+        assert args[:2] == ["session", "messages"]
+        poll_count += 1
+        messages: list[dict[str, object]] = [
+            {
+                "role": "assistant",
+                "tool_calls": [{"tool_name": "bash", "arguments": {"verdict": "AGREE"}}],
+            },
+            {"role": "assistant", "msg_content": '{"event":"tool-call-complete"}'},
+        ]
+        if poll_count > 1:
+            messages.append({"role": "assistant", "msg_content": _review_json("mavis-final-review")})
+        return {"messages": messages}
+
+    monkeypatch.setattr(wrappers, "_run_mavis", fake_run_mavis)
+    assert wrappers.run_mavis_provider() == 0
+    assert poll_count == 2
+    assert json.loads(capsys.readouterr().out)["agent"] == "mavis-final-review"
+
+
 def test_run_mavis_provider_direct_rejects_missing_session_id(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_stdin(monkeypatch)
 
@@ -762,6 +840,8 @@ def test_ai_review_collect_uses_productized_provider_wrapper_envs(tmp_path: Path
             str(tmp_path / "reviews"),
             "--implementer-provider",
             "minimax",
+            "--test-command",
+            "true",
             "--format",
             "json",
         ],


### PR DESCRIPTION
## Summary

Harden the productized `ai-review collect` and `ai-review consensus` paths after a real Claude + Mavis smoke exposed two fail-closed usability defects: reviewers had no bound test evidence to evaluate, and the Mavis wrapper could consume an intermediate tool-call envelope instead of the final review.

This patch runs trusted, explicitly configured test argv before review; binds the no-output result and pattern-based diff secret scan to the reviewed head/diff; redacts persisted argv; rejects head/diff movement during provider rounds; and waits for a schema-valid Mavis final message in both supported modes. Existing v1 artifacts remain schema-valid while the current emitter always includes preflight evidence.

## Delivery metadata

```json pr-delivery-metadata
{
  "boundary_declaration": {
    "boundary_cross": false,
    "credential_read": false,
    "credential_write": false,
    "none_of_the_above": true,
    "state_mutation_production": false,
    "state_mutation_test": false,
    "user_approval_evidence": "N/A",
    "user_communication": false
  },
  "critical_fix": false,
  "cross_ai_review": {
    "implementer_provider": "openai",
    "review_artifacts": [
      "Claude CLI independent review: REVISE round 1, AGREE round 2"
    ],
    "reviewer_providers": [
      "anthropic"
    ],
    "same_provider_exception": "N/A",
    "verdict": "AGREE"
  },
  "issue": "N/A",
  "release_authority_impact": "ao-release-gate-input-only",
  "risk_class": "governance",
  "tracked_by": "N/A",
  "work_package": "AI-REVIEW-PREFLIGHT-HARDENING"
}
```

## Scope

- Add SHA/diff-bound test and secret-scan preflight evidence.
- Persist only the command executable, redacted argv placeholders, and command hash.
- Fail closed if the reviewed head or diff moves during collection/consensus.
- Ignore Mavis intermediate envelopes until a complete review is available.
- Keep v1 artifact compatibility and add schema drift guards.
- Document the trusted operator/config command boundary.

## Boundary declaration (human mirror)

- [ ] credential-read
- [ ] credential-write
- [ ] state-mutation (test/sandbox)
- [ ] state-mutation (production)
- [ ] boundary-cross
- [ ] user-communication
- [x] none of the above

User/operator approval evidence: `N/A`

## Cross-AI review evidence (human mirror)

- Implementer: OpenAI Codex.
- Independent reviewer: Anthropic Claude CLI.
- Verdict chain: `REVISE` (three blocking findings) -> findings absorbed -> `AGREE` with no blockers.
- AI output remains evidence only. Release authority remains `ao-release-gate` plus GitHub ruleset.

## Validation

- [x] `python3 -m pytest -q` -> `7166 passed, 114 skipped`.
- [x] Focused AI-review/provider tests -> `45 passed`.
- [x] `ruff` and `mypy` -> clean.
- [x] JSON schemas and `git diff --check` -> clean.
- [x] Real Claude + Mavis smoke against the Actions maintenance batch produced two `AGREE` raw reviews with bound passing tests and secret scan.
- [x] No release-authority, GitHub workflow, ruleset, support-tier, production-claim, or live-adapter mutation.

## Merge notes

- Squash merge through normal repository automation; no admin bypass.
- After merge, rebase the Actions maintenance batch and regenerate its provider evidence from the landed product code.
